### PR TITLE
Add page filters fixtures to tests

### DIFF
--- a/static/app/stores/pageFiltersStore.tsx
+++ b/static/app/stores/pageFiltersStore.tsx
@@ -40,7 +40,7 @@ function datetimeHasSameValue(
   return true;
 }
 
-interface PageFiltersState {
+export interface PageFiltersState {
   /**
    * The set of page filters which have been pinned but do not match the current
    * URL state.

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -1,6 +1,6 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {GetPageFiltersStorageFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersStorageFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -488,7 +488,7 @@ describe('Discover > Homepage', () => {
     };
     jest
       .spyOn(pageFilterUtils, 'getPageFilterStorage')
-      .mockReturnValueOnce(GetPageFiltersStorageFixture({state}));
+      .mockReturnValueOnce(PageFiltersStorageFixture({state}));
 
     render(
       <Homepage

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -1,5 +1,6 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {GetPageFiltersStorageFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -476,17 +477,18 @@ describe('Discover > Homepage', () => {
 
   it('overrides homepage filters with pinned filters if they exist', async () => {
     ProjectsStore.loadInitialData([ProjectFixture({id: '1'}), ProjectFixture({id: '2'})]);
-    jest.spyOn(pageFilterUtils, 'getPageFilterStorage').mockReturnValueOnce({
-      pinnedFilters: new Set(['projects']),
-      state: {
-        project: [2],
-        environment: [],
-        start: null,
-        end: null,
-        period: '14d',
-        utc: null,
-      },
-    });
+    const state = {
+      project: [2],
+      environment: [],
+      start: null,
+      end: null,
+      period: '14d',
+      utc: null,
+      repository: null,
+    };
+    jest
+      .spyOn(pageFilterUtils, 'getPageFilterStorage')
+      .mockReturnValueOnce(GetPageFiltersStorageFixture({state}));
 
     render(
       <Homepage

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -1,6 +1,7 @@
 import {QueryClientProvider} from '@tanstack/react-query';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -33,22 +34,7 @@ describe('useExploreTimeseries', () => {
   beforeEach(() => {
     jest.mocked(useLocation).mockReturnValue(LocationFixture());
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
-      },
-    });
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     jest.clearAllMocks();
   });
 

--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -64,17 +64,7 @@ describe('useProgressiveQuery', function () {
         body: 'test',
       });
 
-      const selection = {
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
-      };
-      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     });
 
     it('makes a single request when the feature flag is disabled', function () {
@@ -275,17 +265,20 @@ describe('useProgressiveQuery', function () {
         body: 'test',
       });
 
-      const selection = {
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
-      };
-      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+      jest.mocked(usePageFilters).mockReturnValue(
+        PageFilterStateFixture({
+          selection: {
+            datetime: {
+              period: '14d',
+              start: null,
+              end: null,
+              utc: false,
+            },
+            environments: [],
+            projects: [2],
+          },
+        })
+      );
     });
 
     it('takes in a callback that determines if we can trigger the high accuracy request', async function () {

--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -1,5 +1,6 @@
 import {QueryClientProvider} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -63,22 +64,17 @@ describe('useProgressiveQuery', function () {
         body: 'test',
       });
 
-      jest.mocked(usePageFilters).mockReturnValue({
-        isReady: true,
-        desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
-        shouldPersist: true,
-        selection: {
-          datetime: {
-            period: '14d',
-            start: null,
-            end: null,
-            utc: false,
-          },
-          environments: [],
-          projects: [2],
+      const selection = {
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
         },
-      });
+        environments: [],
+        projects: [2],
+      };
+      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
     });
 
     it('makes a single request when the feature flag is disabled', function () {
@@ -279,22 +275,17 @@ describe('useProgressiveQuery', function () {
         body: 'test',
       });
 
-      jest.mocked(usePageFilters).mockReturnValue({
-        isReady: true,
-        desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
-        shouldPersist: true,
-        selection: {
-          datetime: {
-            period: '14d',
-            start: null,
-            end: null,
-            utc: false,
-          },
-          environments: [],
-          projects: [2],
+      const selection = {
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: false,
         },
-      });
+        environments: [],
+        projects: [2],
+      };
+      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
     });
 
     it('takes in a callback that determines if we can trigger the high accuracy request', async function () {

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.spec.tsx
@@ -1,6 +1,7 @@
 import {QueryClientProvider} from '@tanstack/react-query';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -36,22 +37,7 @@ describe('useMultiQueryTimeseries', () => {
   beforeEach(() => {
     jest.mocked(useLocation).mockReturnValue(LocationFixture());
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '14d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
-      },
-    });
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     jest.clearAllMocks();
   });
 

--- a/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
@@ -63,17 +63,7 @@ const setupMocks = () => {
   const mockProjects = [ProjectFixture()];
   ProjectsStore.loadInitialData(mockProjects);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -62,22 +63,17 @@ const setupMocks = () => {
   const mockProjects = [ProjectFixture()];
   ProjectsStore.loadInitialData(mockProjects);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [2],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -133,17 +133,20 @@ describe('ResourcesLandingPage', function () {
 });
 
 const setupMocks = () => {
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -132,22 +133,17 @@ describe('ResourcesLandingPage', function () {
 });
 
 const setupMocks = () => {
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -24,22 +25,17 @@ describe('PerformanceScoreBreakdownChartWidget', function () {
       action: 'PUSH',
       key: '',
     });
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/stats/`,

--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreBreakdownChart.spec.tsx
@@ -25,17 +25,7 @@ describe('PerformanceScoreBreakdownChartWidget', function () {
       action: 'PUSH',
       key: '',
     });
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/stats/`,

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
@@ -26,22 +27,17 @@ describe('PagePerformanceTable', function () {
   beforeEach(function () {
     jest.mocked(useLocation).mockReturnValue(router.location);
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     ProjectsStore.loadInitialData([
       ProjectFixture({

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -27,17 +27,7 @@ describe('PagePerformanceTable', function () {
   beforeEach(function () {
     jest.mocked(useLocation).mockReturnValue(router.location);
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
     ProjectsStore.loadInitialData([
       ProjectFixture({

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.spec.tsx
@@ -34,17 +34,7 @@ describe('WebVitalMeters', function () {
       action: 'PUSH',
       key: '',
     });
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
   });
 
   it('renders web vital meters with interaction to next paint', async () => {

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -33,22 +34,17 @@ describe('WebVitalMeters', function () {
       action: 'PUSH',
       key: '',
     });
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
   });
 
   it('renders web vital meters with interaction to next paint', async () => {

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -24,22 +25,17 @@ describe('WebVitalsDetailPanel', function () {
       action: 'PUSH',
       key: '',
     });
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.spec.tsx
@@ -25,17 +25,8 @@ describe('WebVitalsDetailPanel', function () {
       action: 'PUSH',
       key: '',
     });
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -27,17 +27,8 @@ describe('PageOverview', function () {
       action: 'PUSH',
       key: '',
     });
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -26,22 +27,17 @@ describe('PageOverview', function () {
       action: 'PUSH',
       key: '',
     });
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -32,22 +33,17 @@ describe('WebVitalsLandingPage', function () {
       action: 'PUSH',
       key: '',
     });
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.spec.tsx
@@ -33,17 +33,8 @@ describe('WebVitalsLandingPage', function () {
       action: 'PUSH',
       key: '',
     });
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
     eventsMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -32,17 +32,20 @@ const requestMocks = {
 describe('CacheLandingPage', function () {
   const organization = OrganizationFixture({features: ['insights-addon-modules']});
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {
@@ -31,22 +32,17 @@ const requestMocks = {
 describe('CacheLandingPage', function () {
   const organization = OrganizationFixture({features: ['insights-addon-modules']});
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -19,22 +20,17 @@ describe('FullSpanDescription', function () {
 
   const project = ProjectFixture();
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   const groupId = '2ed2abf6ce7e3577';
   const spanId = 'abfed2aabf';

--- a/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.spec.tsx
@@ -20,17 +20,7 @@ describe('FullSpanDescription', function () {
 
   const project = ProjectFixture();
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   const groupId = '2ed2abf6ce7e3577';
   const spanId = 'abfed2aabf';

--- a/static/app/views/insights/common/components/modulePageProviders.spec.tsx
+++ b/static/app/views/insights/common/components/modulePageProviders.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -13,22 +14,17 @@ jest.mock('sentry/views/insights/common/utils/useHasDataTrackAnalytics');
 
 describe('ModulePageProviders', () => {
   beforeEach(() => {
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [2],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
   });
 
   afterEach(() => {

--- a/static/app/views/insights/common/components/modulePageProviders.spec.tsx
+++ b/static/app/views/insights/common/components/modulePageProviders.spec.tsx
@@ -14,17 +14,7 @@ jest.mock('sentry/views/insights/common/utils/useHasDataTrackAnalytics');
 
 describe('ModulePageProviders', () => {
   beforeEach(() => {
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [2],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
   });
 
   afterEach(() => {

--- a/static/app/views/insights/common/components/modulesOnboarding.spec.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.spec.tsx
@@ -23,17 +23,7 @@ describe('ModulesOnboarding', () => {
 
     ProjectsStore.loadInitialData([project]);
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [2],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
     render(
       <ModulesOnboarding moduleName={ModuleName.CACHE}>
@@ -54,17 +44,20 @@ describe('ModulesOnboarding', () => {
       body: [project],
     });
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [Number(project.id)],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [Number(project.id)],
+        },
+      })
+    );
 
     render(
       <ModulesOnboarding moduleName={ModuleName.CACHE}>
@@ -80,17 +73,20 @@ describe('ModulesOnboarding', () => {
     project.hasInsightsCaches = true;
     ProjectsStore.loadInitialData([project]);
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [Number(project.id)],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [Number(project.id)],
+        },
+      })
+    );
 
     render(
       <ModulesOnboarding moduleName={ModuleName.CACHE}>

--- a/static/app/views/insights/common/components/modulesOnboarding.spec.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.spec.tsx
@@ -1,3 +1,4 @@
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -22,22 +23,17 @@ describe('ModulesOnboarding', () => {
 
     ProjectsStore.loadInitialData([project]);
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [2],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     render(
       <ModulesOnboarding moduleName={ModuleName.CACHE}>
@@ -58,22 +54,17 @@ describe('ModulesOnboarding', () => {
       body: [project],
     });
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [Number(project.id)],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [Number(project.id)],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     render(
       <ModulesOnboarding moduleName={ModuleName.CACHE}>
@@ -89,22 +80,17 @@ describe('ModulesOnboarding', () => {
     project.hasInsightsCaches = true;
     ProjectsStore.loadInitialData([project]);
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [Number(project.id)],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [Number(project.id)],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     render(
       <ModulesOnboarding moduleName={ModuleName.CACHE}>

--- a/static/app/views/insights/common/components/spanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/spanDescription.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -19,22 +20,17 @@ describe('DatabaseSpanDescription', function () {
 
   const project = ProjectFixture();
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   const groupId = '2ed2abf6ce7e3577';
   const spanId = 'abfed2aabf';

--- a/static/app/views/insights/common/components/spanDescription.spec.tsx
+++ b/static/app/views/insights/common/components/spanDescription.spec.tsx
@@ -20,17 +20,7 @@ describe('DatabaseSpanDescription', function () {
 
   const project = ProjectFixture();
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   const groupId = '2ed2abf6ce7e3577';
   const spanId = 'abfed2aabf';

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -1,6 +1,7 @@
 import type {ReactNode} from 'react';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -35,22 +36,17 @@ describe('useDiscover', () => {
   describe('useSpanMetrics', () => {
     const organization = OrganizationFixture();
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     jest.mocked(useLocation).mockReturnValue(
       LocationFixture({
@@ -159,22 +155,17 @@ describe('useDiscover', () => {
   describe('useSpanIndexed', () => {
     const organization = OrganizationFixture();
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     jest.mocked(useLocation).mockReturnValue(
       LocationFixture({

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -36,17 +36,7 @@ describe('useDiscover', () => {
   describe('useSpanMetrics', () => {
     const organization = OrganizationFixture();
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
     jest.mocked(useLocation).mockReturnValue(
       LocationFixture({
@@ -155,17 +145,20 @@ describe('useDiscover', () => {
   describe('useSpanIndexed', () => {
     const organization = OrganizationFixture();
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [],
+        },
+      })
+    );
 
     jest.mocked(useLocation).mockReturnValue(
       LocationFixture({

--- a/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
@@ -27,17 +27,20 @@ describe('useSpanMetricsSeries', () => {
     );
   }
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.spec.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -26,22 +27,17 @@ describe('useSpanMetricsSeries', () => {
     );
   }
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/common/queries/useSpanMetricsTopNSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useSpanMetricsTopNSeries.spec.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -26,22 +27,17 @@ describe('useSpanMetricsTopNSeries', () => {
     );
   }
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/common/queries/useSpanMetricsTopNSeries.spec.tsx
+++ b/static/app/views/insights/common/queries/useSpanMetricsTopNSeries.spec.tsx
@@ -27,17 +27,20 @@ describe('useSpanMetricsTopNSeries', () => {
     );
   }
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.spec.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.spec.tsx
@@ -19,17 +19,7 @@ jest.mock('sentry/utils/usePageFilters');
 describe('DomainSelector', function () {
   const organization = OrganizationFixture();
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   beforeEach(function () {
     MockApiClient.addMockResponse({

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.spec.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {
   render,
@@ -18,22 +19,17 @@ jest.mock('sentry/utils/usePageFilters');
 describe('DomainSelector', function () {
   const organization = OrganizationFixture();
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   beforeEach(function () {
     MockApiClient.addMockResponse({

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -24,17 +24,20 @@ describe('DatabaseLandingPage', function () {
     ProjectFixture({hasInsightsDb: true, firstTransactionEvent: true}),
   ]);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseLandingPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -23,22 +24,17 @@ describe('DatabaseLandingPage', function () {
     ProjectFixture({hasInsightsDb: true, firstTransactionEvent: true}),
   ]);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -25,17 +25,20 @@ describe('DatabaseSpanSummaryPage', function () {
   const group = GroupFixture();
   const groupId = '1756baf8fd19c116';
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useParams).mockReturnValue({
     groupId,

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.spec.tsx
@@ -12,6 +12,8 @@ import {DatabaseSpanSummaryPage} from 'sentry/views/insights/database/views/data
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/useParams');
 jest.mock('sentry/utils/usePageFilters');
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 
 jest.mock('sentry/utils/useReleaseStats');
@@ -23,22 +25,17 @@ describe('DatabaseSpanSummaryPage', function () {
   const group = GroupFixture();
   const groupId = '1756baf8fd19c116';
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: null,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useParams).mockReturnValue({
     groupId,

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {
   render,
@@ -19,22 +20,17 @@ describe('HTTPSamplesPanel', () => {
 
   let eventsRequestMock: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -20,17 +20,20 @@ describe('HTTPSamplesPanel', () => {
 
   let eventsRequestMock: jest.Mock;
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -26,22 +27,17 @@ describe('useSpanSamples', () => {
     );
   }
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: ['prod'],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: ['prod'],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     query: {},

--- a/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.spec.tsx
@@ -27,17 +27,20 @@ describe('useSpanSamples', () => {
     );
   }
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: ['prod'],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: ['prod'],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     query: {},

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -30,17 +30,20 @@ describe('HTTPDomainSummaryPage', function () {
   let domainMetricsRibbonRequestMock: jest.Mock;
   let regionFilterRequestMock: jest.Mock;
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.spec.tsx
@@ -13,6 +13,8 @@ import {HTTPDomainSummaryPage} from 'sentry/views/insights/http/views/httpDomain
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 
 jest.mock('sentry/utils/useReleaseStats');
@@ -28,22 +30,17 @@ describe('HTTPDomainSummaryPage', function () {
   let domainMetricsRibbonRequestMock: jest.Mock;
   let regionFilterRequestMock: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -26,18 +26,20 @@ describe('HTTPLandingPage', function () {
 
   let spanListRequestMock!: jest.Mock;
   let regionFilterRequestMock!: jest.Mock;
-
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   const useLocationMock = jest.mocked(useLocation);
 

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -26,22 +27,17 @@ describe('HTTPLandingPage', function () {
   let spanListRequestMock!: jest.Mock;
   let regionFilterRequestMock!: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   const useLocationMock = jest.mocked(useLocation);
 

--- a/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
@@ -21,17 +21,20 @@ describe('ScreenLoadEventSamples', function () {
 
   let mockEventsRequest!: jest.Mock;
   beforeEach(function () {
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [parseInt(project.id, 10)],
+        },
+      })
+    );
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: 'com.example.vu.android@2.10.5',
       isLoading: false,

--- a/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/eventSamples.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -20,22 +21,17 @@ describe('ScreenLoadEventSamples', function () {
 
   let mockEventsRequest!: jest.Mock;
   beforeEach(function () {
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [parseInt(project.id, 10)],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: 'com.example.vu.android@2.10.5',
       isLoading: false,

--- a/static/app/views/insights/mobile/appStarts/components/spanOpSelector.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/spanOpSelector.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -12,22 +13,17 @@ describe('SpanOpSelector', function () {
   const organization = OrganizationFixture();
   const project = ProjectFixture();
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/mobile/appStarts/components/spanOpSelector.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/spanOpSelector.spec.tsx
@@ -13,17 +13,20 @@ describe('SpanOpSelector', function () {
   const organization = OrganizationFixture();
   const project = ProjectFixture();
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/events/`,

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
@@ -1,6 +1,7 @@
 import type {Location} from 'history';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -23,22 +24,17 @@ describe('StartDurationWidget', () => {
   const project = ProjectFixture();
 
   beforeEach(function () {
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [parseInt(project.id, 10)],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/`,
       body: [

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
@@ -24,17 +24,20 @@ describe('StartDurationWidget', () => {
   const project = ProjectFixture();
 
   beforeEach(function () {
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [parseInt(project.id, 10)],
+        },
+      })
+    );
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/`,
       body: [

--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
@@ -1,5 +1,6 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -16,22 +17,17 @@ describe('SpanOpSelector', function () {
   const project = ProjectFixture();
   let mockEventsRequest: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue(LocationFixture());
 

--- a/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/tables/spanOperationTable.spec.tsx
@@ -17,17 +17,20 @@ describe('SpanOpSelector', function () {
   const project = ProjectFixture();
   let mockEventsRequest: jest.Mock;
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue(LocationFixture());
 

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
@@ -32,17 +32,20 @@ describe('Screen Summary', function () {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   describe('Native Project', function () {
     let eventsMock: jest.Mock;

--- a/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/views/screenSummaryPage.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
@@ -31,22 +32,17 @@ describe('Screen Summary', function () {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   describe('Native Project', function () {
     let eventsMock: jest.Mock;

--- a/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
+++ b/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
@@ -1,4 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
@@ -13,22 +14,17 @@ jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
 
 function mockPageFilters(projects: number[]) {
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects,
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects,
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 }
 
 describe('useCrossPlatformProject', () => {

--- a/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
+++ b/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
@@ -14,17 +14,20 @@ jest.mock('sentry/utils/usePageFilters');
 jest.mock('sentry/utils/useLocation');
 
 function mockPageFilters(projects: number[]) {
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects,
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects,
+      },
+    })
+  );
 }
 
 describe('useCrossPlatformProject', () => {

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
@@ -21,17 +21,20 @@ describe('ScreenLoadEventSamples', function () {
 
   let mockEventsRequest: jest.Mock;
   beforeEach(function () {
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [parseInt(project.id, 10)],
+        },
+      })
+    );
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: 'com.example.vu.android@2.10.5',
       isLoading: false,

--- a/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/eventSamples.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -20,22 +21,17 @@ describe('ScreenLoadEventSamples', function () {
 
   let mockEventsRequest: jest.Mock;
   beforeEach(function () {
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [parseInt(project.id, 10)],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
     jest.mocked(useReleaseSelection).mockReturnValue({
       primaryRelease: 'com.example.vu.android@2.10.5',
       isLoading: false,

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -14,22 +15,17 @@ describe('MetricsRibbon', function () {
   const organization = OrganizationFixture();
   const project = ProjectFixture();
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/releases/`,

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.spec.tsx
@@ -15,17 +15,20 @@ describe('MetricsRibbon', function () {
   const organization = OrganizationFixture();
   const project = ProjectFixture();
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/releases/`,

--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
@@ -26,17 +26,7 @@ describe('ScreenLoadSpansTable', function () {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   let eventsMock: jest.Mock;
   beforeEach(function () {

--- a/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/components/tables/screenLoadSpansTable.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
@@ -25,22 +26,17 @@ describe('ScreenLoadSpansTable', function () {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   let eventsMock: jest.Mock;
   beforeEach(function () {

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -34,17 +34,20 @@ function mockResponses(organization: Organization, project: Project) {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/releases/`,

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
@@ -33,22 +34,17 @@ function mockResponses(organization: Organization, project: Project) {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/releases/`,

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
@@ -37,17 +37,20 @@ describe('PageloadModule', function () {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   let eventsMock: jest.Mock;
   beforeEach(function () {

--- a/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenloadLandingPage.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -36,22 +37,17 @@ describe('PageloadModule', function () {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   let eventsMock: jest.Mock;
   beforeEach(function () {

--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -31,22 +32,17 @@ describe('ScreensOverview', () => {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useCrossPlatformProject).mockReturnValue({
     project,

--- a/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverview.spec.tsx
@@ -32,17 +32,20 @@ describe('ScreensOverview', () => {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   jest.mocked(useCrossPlatformProject).mockReturnValue({
     project,

--- a/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
@@ -33,17 +33,20 @@ describe('ScreensOverviewTable', () => {
   } as Location;
 
   jest.mocked(useLocation).mockReturnValue(location);
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   const mockEventView = EventView.fromLocation(location);
 

--- a/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
+++ b/static/app/views/insights/mobile/screens/components/screensOverviewTable.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -32,22 +33,17 @@ describe('ScreensOverviewTable', () => {
   } as Location;
 
   jest.mocked(useLocation).mockReturnValue(location);
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   const mockEventView = EventView.fromLocation(location);
 

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
@@ -31,17 +31,20 @@ describe('ScreenDetailsPage', function () {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   describe('Tabs', function () {
     beforeEach(() => {

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
@@ -30,22 +31,17 @@ describe('ScreenDetailsPage', function () {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   describe('Tabs', function () {
     beforeEach(() => {

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
@@ -32,22 +33,17 @@ describe('Screens Landing Page', function () {
     state: undefined,
   } as Location);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useCrossPlatformProject).mockReturnValue({
     project,

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -33,17 +33,20 @@ describe('Screens Landing Page', function () {
     state: undefined,
   } as Location);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   jest.mocked(useCrossPlatformProject).mockReturnValue({
     project,

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.spec.tsx
@@ -1,3 +1,5 @@
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -6,22 +8,17 @@ import {Referrer} from 'sentry/views/insights/mobile/ui/referrers';
 
 jest.mock('sentry/utils/usePageFilters');
 
-jest.mocked(usePageFilters).mockReturnValue({
-  isReady: true,
-  desyncedFilters: new Set(),
-  pinnedFilters: new Set(),
-  shouldPersist: true,
-  selection: {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
+const selection = {
+  datetime: {
+    period: '10d',
+    start: null,
+    end: null,
+    utc: false,
   },
-});
+  environments: [],
+  projects: [],
+};
+jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
 describe('SpanOperationTable', () => {
   it('renders and fetches the proper data', () => {

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.spec.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.spec.tsx
@@ -8,17 +8,7 @@ import {Referrer} from 'sentry/views/insights/mobile/ui/referrers';
 
 jest.mock('sentry/utils/usePageFilters');
 
-const selection = {
-  datetime: {
-    period: '10d',
-    start: null,
-    end: null,
-    utc: false,
-  },
-  environments: [],
-  projects: [],
-};
-jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
 describe('SpanOperationTable', () => {
   it('renders and fetches the proper data', () => {

--- a/static/app/views/insights/mobile/ui/components/uiScreens.spec.tsx
+++ b/static/app/views/insights/mobile/ui/components/uiScreens.spec.tsx
@@ -1,3 +1,4 @@
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -42,22 +43,17 @@ describe('Performance Mobile UI Screens', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
 
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [parseInt(project.id, 10)],
+    const selection = {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [parseInt(project.id, 10)],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
   });
 
   it('queries for the correct table data', async () => {

--- a/static/app/views/insights/mobile/ui/components/uiScreens.spec.tsx
+++ b/static/app/views/insights/mobile/ui/components/uiScreens.spec.tsx
@@ -43,17 +43,20 @@ describe('Performance Mobile UI Screens', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
 
-    const selection = {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '10d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [parseInt(project.id, 10)],
+        },
+      })
+    );
   });
 
   it('queries for the correct table data', async () => {

--- a/static/app/views/insights/pages/backend/backendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.spec.tsx
@@ -1,5 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture, PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -175,12 +175,8 @@ const setupMocks = () => {
     key: '',
   });
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: pageFilterSelection,
-  });
+  jest
+    .mocked(usePageFilters)
+    .mockReturnValue(PageFilterStateFixture({selection: pageFilterSelection}));
   ProjectsStore.loadInitialData(projects);
 };

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -54,12 +54,15 @@ describe('FrontendOverviewPage', () => {
     });
 
     it('fetches correct data with unknown platform', async () => {
-      const selection = {
-        datetime: pageFilterSelection.datetime,
-        environments: [],
-        projects: [2],
-      };
-      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+      jest.mocked(usePageFilters).mockReturnValue(
+        PageFilterStateFixture({
+          selection: {
+            datetime: pageFilterSelection.datetime,
+            environments: [],
+            projects: [2],
+          },
+        })
+      );
       render(<FrontendOverviewPage />, {organization});
 
       expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.spec.tsx
@@ -1,5 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture, PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -54,17 +54,12 @@ describe('FrontendOverviewPage', () => {
     });
 
     it('fetches correct data with unknown platform', async () => {
-      jest.mocked(usePageFilters).mockReturnValue({
-        isReady: true,
-        desyncedFilters: new Set(),
-        pinnedFilters: new Set(),
-        shouldPersist: true,
-        selection: {
-          projects: [2],
-          datetime: pageFilterSelection.datetime,
-          environments: [],
-        },
-      });
+      const selection = {
+        datetime: pageFilterSelection.datetime,
+        environments: [],
+        projects: [2],
+      };
+      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
       render(<FrontendOverviewPage />, {organization});
 
       expect(await screen.findByRole('heading', {level: 1})).toHaveTextContent(
@@ -188,12 +183,8 @@ const setupMocks = () => {
     key: '',
   });
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: pageFilterSelection,
-  });
+  jest
+    .mocked(usePageFilters)
+    .mockReturnValue(PageFilterStateFixture({selection: pageFilterSelection}));
   ProjectsStore.loadInitialData(projects);
 };

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
@@ -17,22 +18,17 @@ describe('messageSpanSamplesPanel', () => {
   let samplesRequestMock: jest.Mock;
   let spanFieldTagsMock: jest.Mock;
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -18,17 +18,20 @@ describe('messageSpanSamplesPanel', () => {
   let samplesRequestMock: jest.Mock;
   let spanFieldTagsMock: jest.Mock;
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    })
+  );
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -19,22 +20,17 @@ describe('destinationSummaryPage', () => {
   });
   const project = ProjectFixture({firstTransactionEvent: true});
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.spec.tsx
@@ -20,17 +20,7 @@ describe('destinationSummaryPage', () => {
   });
   const project = ProjectFixture({firstTransactionEvent: true});
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
@@ -22,17 +22,7 @@ describe('queuesLandingPage', () => {
   project.firstTransactionEvent = true;
   project.hasInsightsQueues = true;
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
+++ b/static/app/views/insights/queues/views/queuesLandingPage.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -21,22 +22,17 @@ describe('queuesLandingPage', () => {
   project.firstTransactionEvent = true;
   project.hasInsightsQueues = true;
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   jest.mocked(useLocation).mockReturnValue({
     pathname: '',

--- a/static/app/views/insights/uptime/views/overview.spec.tsx
+++ b/static/app/views/insights/uptime/views/overview.spec.tsx
@@ -27,17 +27,7 @@ describe('Uptime Overview', function () {
   const project = ProjectFixture();
   const team = TeamFixture();
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
 
   beforeEach(function () {
     OrganizationStore.init();

--- a/static/app/views/insights/uptime/views/overview.spec.tsx
+++ b/static/app/views/insights/uptime/views/overview.spec.tsx
@@ -1,4 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
@@ -26,22 +27,17 @@ describe('Uptime Overview', function () {
   const project = ProjectFixture();
   const team = TeamFixture();
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   beforeEach(function () {
     OrganizationStore.init();

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -30,17 +30,20 @@ describe('SpanSummaryPage', function () {
 
   ProjectsStore.loadInitialData([project]);
 
-  const selection = {
-    datetime: {
-      period: '10d',
-      start: null,
-      end: null,
-      utc: false,
-    },
-    environments: [],
-    projects: [parseInt(project.id, 10)],
-  };
-  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+  jest.mocked(usePageFilters).mockReturnValue(
+    PageFilterStateFixture({
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    })
+  );
 
   let headerDataMock: jest.Mock;
   let avgDurationChartMock: jest.Mock;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanSummary/content.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
@@ -29,22 +30,17 @@ describe('SpanSummaryPage', function () {
 
   ProjectsStore.loadInitialData([project]);
 
-  jest.mocked(usePageFilters).mockReturnValue({
-    isReady: true,
-    desyncedFilters: new Set(),
-    pinnedFilters: new Set(),
-    shouldPersist: true,
-    selection: {
-      datetime: {
-        period: '10d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [parseInt(project.id, 10)],
+  const selection = {
+    datetime: {
+      period: '10d',
+      start: null,
+      end: null,
+      utc: false,
     },
-  });
+    environments: [],
+    projects: [parseInt(project.id, 10)],
+  };
+  jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
   let headerDataMock: jest.Mock;
   let avgDurationChartMock: jest.Mock;

--- a/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
@@ -30,17 +30,20 @@ describe('Renders QuotaExceededAlert correctly', function () {
   });
   beforeEach(function () {
     setMockDate(new Date('2024-12-14').getTime());
-    const selection = {
-      datetime: {
-        period: '7d',
-        start: null,
-        end: null,
-        utc: false,
-      },
-      environments: [],
-      projects: [2],
-    };
-    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
+    jest.mocked(usePageFilters).mockReturnValue(
+      PageFilterStateFixture({
+        selection: {
+          datetime: {
+            period: '7d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+          environments: [],
+          projects: [2],
+        },
+      })
+    );
 
     jest.mocked(useLocation).mockReturnValue({
       pathname: '',

--- a/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
@@ -1,3 +1,5 @@
+import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -28,22 +30,17 @@ describe('Renders QuotaExceededAlert correctly', function () {
   });
   beforeEach(function () {
     setMockDate(new Date('2024-12-14').getTime());
-    jest.mocked(usePageFilters).mockReturnValue({
-      isReady: true,
-      desyncedFilters: new Set(),
-      pinnedFilters: new Set(),
-      shouldPersist: true,
-      selection: {
-        datetime: {
-          period: '7d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects: [2],
+    const selection = {
+      datetime: {
+        period: '7d',
+        start: null,
+        end: null,
+        utc: false,
       },
-    });
+      environments: [],
+      projects: [2],
+    };
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({selection}));
 
     jest.mocked(useLocation).mockReturnValue({
       pathname: '',

--- a/tests/js/fixtures/pageFilters.ts
+++ b/tests/js/fixtures/pageFilters.ts
@@ -16,7 +16,7 @@ export function PageFiltersFixture(params: Partial<PageFilters> = {}): PageFilte
   };
 }
 
-export function GetPageFiltersStorageFixture(params = {}) {
+export function PageFiltersStorageFixture(params = {}) {
   return {
     pinnedFilters: new Set<PinnedPageFilter>(['projects']),
     state: {
@@ -31,7 +31,7 @@ export function GetPageFiltersStorageFixture(params = {}) {
   };
 }
 
-export function PageFilterStateFixture(params: Partial<PageFiltersState> = {}) {
+export function PageFilterStateFixture(params: Partial<PageFiltersState> = {}): PageFiltersState {
   return {
     isReady: true,
     desyncedFilters: new Set<PinnedPageFilter>(),

--- a/tests/js/fixtures/pageFilters.ts
+++ b/tests/js/fixtures/pageFilters.ts
@@ -1,4 +1,6 @@
 import type {PageFilters} from 'sentry/types/core';
+import type {PageFiltersState} from 'sentry/stores/pageFiltersStore';
+import type {PinnedPageFilter} from 'sentry/types/core';
 
 export function PageFiltersFixture(params: Partial<PageFilters> = {}): PageFilters {
   return {
@@ -12,4 +14,30 @@ export function PageFiltersFixture(params: Partial<PageFilters> = {}): PageFilte
     projects: [],
     ...params,
   };
+}
+
+export function GetPageFiltersStorageFixture(params = {}) {
+  return {
+    pinnedFilters: new Set<PinnedPageFilter>(['projects']),
+    state: {
+      project: [],
+      environment: [],
+      start: null,
+      end: null,
+      period: '14d',
+      utc: null,
+    },
+    ...params
+  };
+}
+
+export function PageFilterStateFixture(params: Partial<PageFiltersState> = {}) {
+  return {
+    isReady: true,
+    desyncedFilters: new Set<PinnedPageFilter>(),
+    pinnedFilters: new Set<PinnedPageFilter>(),
+    shouldPersist: true,
+    selection: PageFiltersFixture(),
+    ...params
+  }
 }


### PR DESCRIPTION
Added page filter fixtures to replaced hardcoded objects. The value is provided in some cases if it derives from the default. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
