### PR TITLE
chore(billing): Reduce hardcoding of data categories in ondemand budget utility functions

### DIFF
--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -146,11 +146,11 @@ function getBudgetMode(budget: OnDemandBudgets) {
 }
 
 export function getOnDemandBudget(budget: OnDemandBudgets, dataCategory: DataCategory) {
-  if (budget.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    if (dataCategory in budget.budgets) {
-      return budget.budgets[dataCategory] ?? 0;
-    }
-    return getTotalBudget(budget);
+  if (
+    budget.budgetMode === OnDemandBudgetMode.PER_CATEGORY &&
+    dataCategory in budget.budgets
+  ) {
+    return budget.budgets[dataCategory] ?? 0;
   }
   return getTotalBudget(budget);
 }
@@ -265,10 +265,12 @@ export function convertOnDemandBudget(
       newBudgets.transactions = transactionsBudget;
     }
 
-    const categoryBudgets: Partial<Record<string, number>> = {};
-    for (const category in newBudgets) {
-      categoryBudgets[`${category}Budget`] = newBudgets[category as DataCategory] ?? 0;
-    }
+    const categoryBudgets: Partial<Record<string, number>> = Object.fromEntries(
+      Object.entries(newBudgets).map(([category, value]) => [
+        `${category}Budget`,
+        value ?? 0,
+      ])
+    );
 
     return {
       budgetMode: OnDemandBudgetMode.PER_CATEGORY,

--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -39,27 +39,33 @@ export function parseOnDemandBudgets(
   onDemandBudgets: SubscriptionOnDemandBudgets | PendingOnDemandBudgets
 ): OnDemandBudgets {
   if (onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
+    const parsedBudgets: Partial<Record<DataCategory, number>> = {};
+    const categoryBudgets: Partial<
+      Omit<PerCategoryOnDemandBudget, 'budgetMode' | 'budgets'>
+    > = {};
+    for (const category in onDemandBudgets.budgets) {
+      parsedBudgets[category as DataCategory] =
+        onDemandBudgets.budgets[category as DataCategory] ?? 0;
+      const key = `${category}Budget`;
+      (categoryBudgets as Partial<Record<string, number>>)[key] =
+        onDemandBudgets.budgets[category as DataCategory] ?? 0;
+    }
+
     return {
-      // TODO(data categories): check if this can be parsed
       budgetMode: OnDemandBudgetMode.PER_CATEGORY,
-      errorsBudget: onDemandBudgets.budgets.errors ?? 0,
-      transactionsBudget: onDemandBudgets.budgets.transactions ?? 0,
-      attachmentsBudget: onDemandBudgets.budgets.attachments ?? 0,
-      replaysBudget: onDemandBudgets.budgets.replays ?? 0,
-      monitorSeatsBudget: onDemandBudgets.budgets.monitorSeats ?? 0,
-      uptimeBudget: onDemandBudgets.budgets.uptime ?? 0,
-      profileDurationBudget: onDemandBudgets.budgets.profileDuration ?? 0,
-      profileDurationUIBudget: onDemandBudgets.budgets.profileDurationUI ?? 0,
-      budgets: {
-        errors: onDemandBudgets.budgets.errors,
-        transactions: onDemandBudgets.budgets.transactions,
-        attachments: onDemandBudgets.budgets.attachments,
-        replays: onDemandBudgets.budgets.replays,
-        monitorSeats: onDemandBudgets.budgets.monitorSeats,
-        uptime: onDemandBudgets.budgets.uptime,
-        profileDuration: onDemandBudgets.budgets.profileDuration,
-        profileDurationUI: onDemandBudgets.budgets.profileDurationUI,
-      },
+      // Set defaults for all possible categories to satisfy the type.
+      // TODO: refactor this out later in the future.
+      errorsBudget: 0,
+      transactionsBudget: 0,
+      attachmentsBudget: 0,
+      replaysBudget: 0,
+      monitorSeatsBudget: 0,
+      profileDurationBudget: 0,
+      profileDurationUIBudget: 0,
+      uptimeBudget: 0,
+      // Spread the calculated values over the defaults
+      ...categoryBudgets,
+      budgets: parsedBudgets,
     };
   }
   return {
@@ -70,24 +76,9 @@ export function parseOnDemandBudgets(
 
 export function getTotalBudget(onDemandBudgets: OnDemandBudgets): number {
   if (onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    // TODO(data categories): check if this can be parsed
-    const errorsBudget = onDemandBudgets.budgets.errors ?? 0;
-    const transactionsBudget = onDemandBudgets.budgets.transactions ?? 0;
-    const attachmentsBudget = onDemandBudgets.budgets.attachments ?? 0;
-    const replaysBudget = onDemandBudgets.budgets.replays ?? 0;
-    const monitorSeatsBudget = onDemandBudgets.budgets.monitorSeats ?? 0;
-    const uptimeBudget = onDemandBudgets.budgets.uptime ?? 0;
-    const profileDurationBudget = onDemandBudgets.budgets.profileDuration ?? 0;
-    const profileDurationUIBudget = onDemandBudgets.budgets.profileDurationUI ?? 0;
-    return (
-      errorsBudget +
-      transactionsBudget +
-      attachmentsBudget +
-      replaysBudget +
-      monitorSeatsBudget +
-      uptimeBudget +
-      profileDurationBudget +
-      profileDurationUIBudget
+    return Object.values(onDemandBudgets.budgets).reduce(
+      (sum, budget) => sum + (budget ?? 0),
+      0
     );
   }
 
@@ -156,35 +147,10 @@ function getBudgetMode(budget: OnDemandBudgets) {
 
 export function getOnDemandBudget(budget: OnDemandBudgets, dataCategory: DataCategory) {
   if (budget.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    // TODO(data categories): check if this can be parsed
-    switch (dataCategory) {
-      case DataCategory.ERRORS: {
-        return budget.budgets.errors ?? 0;
-      }
-      case DataCategory.TRANSACTIONS: {
-        return budget.budgets.transactions ?? 0;
-      }
-      case DataCategory.ATTACHMENTS: {
-        return budget.budgets.attachments ?? 0;
-      }
-      case DataCategory.REPLAYS: {
-        return budget.budgets.replays ?? 0;
-      }
-      case DataCategory.MONITOR_SEATS: {
-        return budget.budgets.monitorSeats ?? 0;
-      }
-      case DataCategory.UPTIME: {
-        return budget.budgets.uptime ?? 0;
-      }
-      case DataCategory.PROFILE_DURATION: {
-        return budget.budgets.profileDuration ?? 0;
-      }
-      case DataCategory.PROFILE_DURATION_UI: {
-        return budget.budgets.profileDurationUI ?? 0;
-      }
-      default:
-        return getTotalBudget(budget);
+    if (dataCategory in budget.budgets) {
+      return budget.budgets[dataCategory] ?? 0;
     }
+    return getTotalBudget(budget);
   }
   return getTotalBudget(budget);
 }
@@ -276,51 +242,49 @@ export function convertOnDemandBudget(
   nextMode: OnDemandBudgetMode
 ): OnDemandBudgets {
   if (nextMode === OnDemandBudgetMode.PER_CATEGORY) {
-    // TODO(data categories): check if this can be parsed
-    let errorsBudget = 0;
-    let transactionsBudget = 0;
-    let attachmentsBudget = 0;
-    let replaysBudget = 0;
-    let monitorSeatsBudget = 0;
-    let uptimeBudget = 0;
-    let profileDurationBudget = 0;
-    let profileDurationUIBudget = 0;
+    const newBudgets: Partial<Record<DataCategory, number>> = {
+      // TODO: refactor this out later in the future.
+      errors: 0,
+      transactions: 0,
+      attachments: 0,
+      replays: 0,
+      monitorSeats: 0,
+      uptime: 0,
+      profileDuration: 0,
+      profileDurationUI: 0,
+    };
+
     if (currentOnDemandBudget.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-      errorsBudget = currentOnDemandBudget.budgets.errors ?? 0;
-      transactionsBudget = currentOnDemandBudget.budgets.transactions ?? 0;
-      attachmentsBudget = currentOnDemandBudget.budgets.attachments ?? 0;
-      replaysBudget = currentOnDemandBudget.budgets.replays ?? 0;
-      monitorSeatsBudget = currentOnDemandBudget.budgets.monitorSeats ?? 0;
-      uptimeBudget = currentOnDemandBudget.budgets.uptime ?? 0;
-      profileDurationBudget = currentOnDemandBudget.budgets.profileDuration ?? 0;
-      profileDurationUIBudget = currentOnDemandBudget.budgets.profileDurationUI ?? 0;
+      Object.assign(newBudgets, currentOnDemandBudget.budgets);
     } else {
       // should split 50:50 between transactions and errors (whole dollars, remainder added to errors)
       const total = getTotalBudget(currentOnDemandBudget);
-      errorsBudget = Math.ceil(total / 100 / 2) * 100;
-      transactionsBudget = Math.max(total - errorsBudget, 0);
+      const errorsBudget = Math.ceil(total / 100 / 2) * 100;
+      const transactionsBudget = Math.max(total - errorsBudget, 0);
+      newBudgets.errors = errorsBudget;
+      newBudgets.transactions = transactionsBudget;
+    }
+
+    const categoryBudgets: Partial<Record<string, number>> = {};
+    for (const category in newBudgets) {
+      categoryBudgets[`${category}Budget`] = newBudgets[category as DataCategory] ?? 0;
     }
 
     return {
       budgetMode: OnDemandBudgetMode.PER_CATEGORY,
-      errorsBudget,
-      transactionsBudget,
-      attachmentsBudget,
-      replaysBudget,
-      monitorSeatsBudget,
-      uptimeBudget,
-      profileDurationBudget,
-      profileDurationUIBudget,
-      budgets: {
-        errors: errorsBudget,
-        transactions: transactionsBudget,
-        attachments: attachmentsBudget,
-        replays: replaysBudget,
-        monitorSeats: monitorSeatsBudget,
-        uptime: uptimeBudget,
-        profileDuration: profileDurationBudget,
-        profileDurationUI: profileDurationUIBudget,
-      },
+      // Set defaults for all possible categories to satisfy the type.
+      // TODO: refactor this out later in the future.
+      errorsBudget: 0,
+      transactionsBudget: 0,
+      attachmentsBudget: 0,
+      replaysBudget: 0,
+      monitorSeatsBudget: 0,
+      uptimeBudget: 0,
+      profileDurationBudget: 0,
+      profileDurationUIBudget: 0,
+      // Spread the calculated values over the defaults
+      ...categoryBudgets,
+      budgets: newBudgets,
     };
   }
 


### PR DESCRIPTION

Part of https://linear.app/getsentry/issue/BIL-520/refactor-ondemandbudgetsutilstsx-to-iterate-through-per-category.

This is just a first pass in the refactor. 

Not all hardcoded data categories can be removed as they're hardcoded typescript types (e.g. `monitorSeatsBudget`). To be able to remove this limitation, we need to update the backend APIs to no longer use and consume them. Afterwards, we will be able to remove them.