### PR TITLE
fix(eap-spans): span-samples endpoint always returns dataset=spansIndexed, set sampling mode

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -190,8 +190,10 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
 
         if use_eap:
             result = get_eap_span_samples(request, snuba_params, orderby)
+            dataset = spans_rpc
         else:
             result = get_span_samples(request, snuba_params, orderby)
+            dataset = spans_indexed
 
         return Response(
             self.handle_results_with_meta(
@@ -200,7 +202,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsV2EndpointBase):
                 snuba_params.project_ids,
                 {"data": result["data"], "meta": result["meta"]},
                 True,
-                spans_indexed,
+                dataset,
             )
         )
 
@@ -314,7 +316,7 @@ def get_eap_span_samples(request: Request, snuba_params: SnubaParams, orderby: l
         config=SearchResolverConfig(),
         offset=0,
         limit=100,
-        sampling_mode=None,
+        sampling_mode=snuba_params.sampling_mode,
         orderby=["-profile.id"],
         referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_IDS.value,
         selected_columns=[
@@ -346,7 +348,7 @@ def get_eap_span_samples(request: Request, snuba_params: SnubaParams, orderby: l
         config=SearchResolverConfig(use_aggregate_conditions=False),
         offset=0,
         limit=9,
-        sampling_mode=None,
+        sampling_mode=snuba_params.sampling_mode,
         query_string=samples_query_string,
         orderby=orderby,
         referrer=Referrer.API_SPAN_SAMPLE_GET_SPAN_DATA.value,

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -706,3 +706,4 @@ class OrganizationSpansSamplesEAPRPCEndpointTest(OrganizationEventsEndpointTestB
         meta = response.data["meta"]
         assert meta["fields"]["span.duration"] == "duration"
         assert meta["units"]["span.duration"] == "millisecond"
+        assert meta["dataset"] == "spans"


### PR DESCRIPTION
1. set sampling mode if provided by snuba params
2. ensure the dataset param is properly set in the meta of the response