### PR TITLE
chore(sentry app slos): Add SLOs to alert rule action requester 

### DIFF
--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -47,7 +47,7 @@ class SentryAppAlertRuleActionRequester:
     http_method: str | None = "POST"
 
     def run(self) -> SentryAppAlertRuleActionResult:
-        event = SentryAppEventType("alert_rule_action.requested")
+        event = SentryAppEventType.ALERT_RULE_ACTION_REQUESTED
         with SentryAppInteractionEvent(
             operation_type=SentryAppInteractionType.EXTERNAL_REQUEST,
             event_type=event,

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -10,6 +10,13 @@ from requests import RequestException
 from requests.models import Response
 
 from sentry.sentry_apps.external_requests.utils import send_and_save_sentry_app_request
+from sentry.sentry_apps.metrics import (
+    SentryAppEventType,
+    SentryAppExternalRequestFailureReason,
+    SentryAppExternalRequestHaltReason,
+    SentryAppInteractionEvent,
+    SentryAppInteractionType,
+)
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
 from sentry.sentry_apps.utils.errors import SentryAppErrorType
@@ -17,6 +24,8 @@ from sentry.utils import json
 
 DEFAULT_SUCCESS_MESSAGE = "Success!"
 DEFAULT_ERROR_MESSAGE = "Something went wrong!"
+FAILURE_REASON_BASE = f"{SentryAppEventType.ALERT_RULE_ACTION_REQUESTED}.{{}}"
+
 
 logger = logging.getLogger("sentry.sentry_apps.external_requests")
 
@@ -38,41 +47,60 @@ class SentryAppAlertRuleActionRequester:
     http_method: str | None = "POST"
 
     def run(self) -> SentryAppAlertRuleActionResult:
-        try:
-            response = send_and_save_sentry_app_request(
-                url=self._build_url(),
-                sentry_app=self.sentry_app,
-                org_id=self.install.organization_id,
-                event="alert_rule_action.requested",
-                headers=self._build_headers(),
-                method=self.http_method,
-                data=self.body,
-            )
-
-        except RequestException as e:
-
-            error_type = "alert_rule_action.error"
-            extras = {
-                "sentry_app_slug": self.sentry_app.slug,
-                "installation_uuid": self.install.uuid,
+        event = SentryAppEventType("alert_rule_action.requested")
+        with SentryAppInteractionEvent(
+            operation_type=SentryAppInteractionType.EXTERNAL_REQUEST,
+            event_type=event,
+        ).capture() as lifecycle:
+            extras: dict[str, Any] = {
                 "uri": self.uri,
-                "error_message": str(e),
+                "installation_uuid": self.install.uuid,
+                "sentry_app_slug": self.sentry_app.slug,
             }
-            logger.info(
-                error_type,
-                extra={**extras},
-            )
+            try:
+
+                response = send_and_save_sentry_app_request(
+                    url=self._build_url(),
+                    sentry_app=self.sentry_app,
+                    org_id=self.install.organization_id,
+                    event=event,
+                    headers=self._build_headers(),
+                    method=self.http_method,
+                    data=self.body,
+                )
+
+            except RequestException as e:
+                halt_reason = FAILURE_REASON_BASE.format(
+                    SentryAppExternalRequestHaltReason.BAD_RESPONSE
+                )
+                lifecycle.record_halt(halt_reason=e, extra={"halt_reason": halt_reason, **extras})
+
+                return SentryAppAlertRuleActionResult(
+                    success=False,
+                    message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
+                    error_type=SentryAppErrorType.INTEGRATOR,
+                    webhook_context={"error_type": "alert_rule_action.error", **extras},
+                    status_code=500,
+                )
+            except Exception as e:
+                failure_reason = FAILURE_REASON_BASE.format(
+                    SentryAppExternalRequestFailureReason.UNEXPECTED_ERROR
+                )
+                lifecycle.record_failure(
+                    failure_reason=e, extra={"failure_reason": failure_reason, **extras}
+                )
+
+                return SentryAppAlertRuleActionResult(
+                    success=False,
+                    message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
+                    error_type=SentryAppErrorType.SENTRY,
+                    webhook_context={"error_type": failure_reason, **extras},
+                    status_code=500,
+                )
 
             return SentryAppAlertRuleActionResult(
-                success=False,
-                message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
-                error_type=SentryAppErrorType.INTEGRATOR,
-                webhook_context={"error_type": "alert_rule_action.error", **extras},
-                status_code=500,
+                success=True, message=self._get_response_message(response, DEFAULT_SUCCESS_MESSAGE)
             )
-        return SentryAppAlertRuleActionResult(
-            success=True, message=self._get_response_message(response, DEFAULT_SUCCESS_MESSAGE)
-        )
 
     def _build_url(self) -> str:
         urlparts = list(urlparse(self.sentry_app.webhook_url))

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -80,7 +80,7 @@ class SentryAppAlertRuleActionRequester:
                     message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
                     error_type=SentryAppErrorType.INTEGRATOR,
                     webhook_context={"error_type": halt_reason, **extras},
-                    status_code=400,
+                    status_code=500,
                 )
             except Exception as e:
                 failure_reason = FAILURE_REASON_BASE.format(

--- a/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/sentry_apps/external_requests/alert_rule_action_requester.py
@@ -79,8 +79,8 @@ class SentryAppAlertRuleActionRequester:
                     success=False,
                     message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
                     error_type=SentryAppErrorType.INTEGRATOR,
-                    webhook_context={"error_type": "alert_rule_action.error", **extras},
-                    status_code=500,
+                    webhook_context={"error_type": halt_reason, **extras},
+                    status_code=400,
                 )
             except Exception as e:
                 failure_reason = FAILURE_REASON_BASE.format(
@@ -92,7 +92,7 @@ class SentryAppAlertRuleActionRequester:
 
                 return SentryAppAlertRuleActionResult(
                     success=False,
-                    message=self._get_response_message(e.response, DEFAULT_ERROR_MESSAGE),
+                    message=DEFAULT_ERROR_MESSAGE,
                     error_type=SentryAppErrorType.SENTRY,
                     webhook_context={"error_type": failure_reason, **extras},
                     status_code=500,

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -153,3 +153,15 @@ def assert_many_halt_metrics(mock_record, messages_or_errors):
             assert isinstance(halt.args[1], type(error_msg))
         else:
             assert halt.args[1] == error_msg
+
+
+# Given messages_or_errors need to align 1:1 to the calls :bufo-big-eyes:
+def assert_many_failure_metrics(mock_record, messages_or_errors):
+    failures = (
+        call for call in mock_record.mock_calls if call.args[0] == EventLifecycleOutcome.FAILURE
+    )
+    for failure, error_msg in zip(failures, messages_or_errors):
+        if isinstance(error_msg, Exception):
+            assert isinstance(failure.args[1], type(error_msg))
+        else:
+            assert failure.args[1] == error_msg


### PR DESCRIPTION
Add SLOs to the alert rule action requester module/process.
This module is called when a person sets up an alert with a Sentry App as the action -> steps below

1. User sets up an alert with a Sentry App as the action
2. User configures the settings for the Sentry App and saves
3. When User hits save, Sentry reaches out to the integrator to let them know a user has set up an alert rule
4. Integrator can choose to respond with some custom message to be given back to the creator

Note:
The context manager doesn't capture the entire process for `AlertRuleActionRequester`(e.g this process is kicked off from an endpoint that then makes an RPC request to kick off the `AlertRuleActionRequester` dataclass). We only capture the dataclass part, but I think that's okay to begin with since if any other parts fail, we will be alerted loudly via Sentry errors. 
