### PR TITLE
ref(aci): clean up workflows via deletions

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -6,7 +6,9 @@ from sentry.deletions.base import (
     ModelDeletionTask,
     ModelRelation,
 )
+from sentry.deletions.defaults.rule import RuleDeletionTask
 from sentry.models.project import Project
+from sentry.models.rule import Rule
 
 
 class ProjectDeletionTask(ModelDeletionTask[Project]):
@@ -96,6 +98,13 @@ class ProjectDeletionTask(ModelDeletionTask[Project]):
             ModelRelation(
                 AlertRule,
                 {"snuba_query__subscriptions__project": instance},
+            )
+        )
+        relations.append(
+            ModelRelation(
+                Rule,
+                {"project_id": instance.id},
+                RuleDeletionTask,
             )
         )
 

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -13,7 +13,7 @@ class RuleDeletionTask(ModelDeletionTask[Rule]):
         from sentry.models.rulefirehistory import RuleFireHistory
         from sentry.workflow_engine.models import AlertRuleDetector, AlertRuleWorkflow
 
-        model_relations = [
+        model_relations: list[BaseRelation] = [
             ModelRelation(GroupRuleStatus, {"rule_id": instance.id}),
             ModelRelation(RuleFireHistory, {"rule_id": instance.id}),
             ModelRelation(RuleActivity, {"rule_id": instance.id}),

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
-from sentry.deletions.defaults.workflow import WorkflowDeletionTask
 from sentry.models.rule import Rule
 from sentry.workflow_engine.models import Workflow
 
@@ -24,11 +23,7 @@ class RuleDeletionTask(ModelDeletionTask[Rule]):
         alert_rule_workflow = AlertRuleWorkflow.objects.filter(rule_id=instance.id).first()
 
         if alert_rule_workflow:
-            model_relations.append(
-                ModelRelation(
-                    Workflow, {"id": alert_rule_workflow.workflow.id}, WorkflowDeletionTask
-                )
-            )
+            model_relations.append(ModelRelation(Workflow, {"id": alert_rule_workflow.workflow.id}))
 
         return model_relations
 

--- a/src/sentry/deletions/defaults/rule.py
+++ b/src/sentry/deletions/defaults/rule.py
@@ -1,7 +1,9 @@
 from collections.abc import Sequence
 
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.deletions.defaults.workflow import WorkflowDeletionTask
 from sentry.models.rule import Rule
+from sentry.workflow_engine.models import Workflow
 
 
 class RuleDeletionTask(ModelDeletionTask[Rule]):
@@ -11,13 +13,24 @@ class RuleDeletionTask(ModelDeletionTask[Rule]):
         from sentry.models.rulefirehistory import RuleFireHistory
         from sentry.workflow_engine.models import AlertRuleDetector, AlertRuleWorkflow
 
-        return [
+        model_relations = [
             ModelRelation(GroupRuleStatus, {"rule_id": instance.id}),
             ModelRelation(RuleFireHistory, {"rule_id": instance.id}),
             ModelRelation(RuleActivity, {"rule_id": instance.id}),
             ModelRelation(AlertRuleDetector, {"rule_id": instance.id}),
             ModelRelation(AlertRuleWorkflow, {"rule_id": instance.id}),
         ]
+
+        alert_rule_workflow = AlertRuleWorkflow.objects.filter(rule_id=instance.id).first()
+
+        if alert_rule_workflow:
+            model_relations.append(
+                ModelRelation(
+                    Workflow, {"id": alert_rule_workflow.workflow.id}, WorkflowDeletionTask
+                )
+            )
+
+        return model_relations
 
     def mark_deletion_in_progress(self, instance_list: Sequence[Rule]) -> None:
         from sentry.constants import ObjectStatus

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.db import router, transaction
-from django.db.models.signals import pre_delete
 
 from sentry import features
 from sentry.models.project import Project
@@ -9,9 +8,6 @@ from sentry.models.rule import Rule
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.signals import alert_rule_created, project_created
 from sentry.users.services.user.model import RpcUser
-from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
-    delete_migrated_issue_alert,
-)
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 
 logger = logging.getLogger("sentry")
@@ -79,17 +75,4 @@ def create_default_rules(project: Project, default_rules=True, RuleModel=Rule, *
     )
 
 
-def dual_delete_issue_alert(instance: Rule, **kwargs) -> None:
-    if features.has(
-        "organizations:workflow-engine-issue-alert-dual-write", instance.project.organization
-    ):
-        workflow_id = delete_migrated_issue_alert(instance)
-        if workflow_id:
-            logger.info(
-                "workflow_engine.issue_alert.deleted",
-                extra={"rule_id": instance.id, "workflow_id": workflow_id},
-            )
-
-
 project_created.connect(create_default_rules, dispatch_uid="create_default_rules", weak=False)
-pre_delete.connect(dual_delete_issue_alert, sender=Rule)

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -1,6 +1,9 @@
 import pytest
 from jsonschema.exceptions import ValidationError
 
+from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
+from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.age import AgeComparisonType
 from sentry.rules.conditions.event_frequency import (
@@ -35,7 +38,7 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import Condition
 
 
-class RuleMigrationHelpersTest(TestCase):
+class RuleMigrationHelpersTestBase(TestCase):
     def setUp(self):
         conditions = [
             {"id": ReappearedEventCondition.id},
@@ -109,6 +112,8 @@ class RuleMigrationHelpersTest(TestCase):
             },
         ]
 
+
+class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
     def test_rule_snooze_updates_workflow(self):
         IssueAlertMigrator(self.issue_alert, self.user.id).run()
         rule_snooze = RuleSnooze.objects.create(rule=self.issue_alert)
@@ -330,6 +335,21 @@ class RuleMigrationHelpersTest(TestCase):
         with pytest.raises(ValidationError):
             update_migrated_issue_alert(self.issue_alert)
 
+
+class IssueAlertDualWriteDeleteTest(RuleMigrationHelpersTestBase):
+    def setUp(self):
+        super().setUp()
+
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
+        self.workflow = alert_rule_workflow.workflow
+        self.when_dcg = self.workflow.when_condition_group
+        self.if_dcg = WorkflowDataConditionGroup.objects.get(workflow=self.workflow).condition_group
+
+        assert self.when_dcg is not None
+        assert self.if_dcg is not None
+
     def assert_issue_alert_deleted(self, workflow, when_dcg, if_dcg):
         assert not AlertRuleWorkflow.objects.filter(rule_id=self.issue_alert.id).exists()
         assert not Workflow.objects.filter(id=workflow.id).exists()
@@ -341,42 +361,36 @@ class RuleMigrationHelpersTest(TestCase):
         assert not Action.objects.all().exists()
 
     def test_delete_issue_alert(self):
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
-
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
-        workflow = alert_rule_workflow.workflow
-        when_dcg = workflow.when_condition_group
-        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
-
-        assert when_dcg is not None
-        assert if_dcg is not None
-
-        conditions = DataCondition.objects.filter(condition_group=when_dcg)
-        assert conditions.count() == 2
-        filters = DataCondition.objects.filter(condition_group=if_dcg)
-        assert filters.count() == 1
-
         delete_migrated_issue_alert(self.issue_alert)
 
-        self.assert_issue_alert_deleted(workflow, when_dcg, if_dcg)
+        self.assert_issue_alert_deleted(self.workflow, self.when_dcg, self.if_dcg)
 
     @with_feature("organizations:workflow-engine-issue-alert-dual-write")
-    def test_delete_issue_alert__receiver(self):
-        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+    def test_delete_issue_alert__rule_deletion_task(self):
+        self.issue_alert.update(status=ObjectStatus.PENDING_DELETION)
+        RegionScheduledDeletion.schedule(self.issue_alert, days=0)
 
-        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
-        workflow = alert_rule_workflow.workflow
-        when_dcg = workflow.when_condition_group
-        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        with self.tasks():
+            run_scheduled_deletions()
 
-        assert when_dcg is not None
-        assert if_dcg is not None
+        self.assert_issue_alert_deleted(self.workflow, self.when_dcg, self.if_dcg)
 
-        conditions = DataCondition.objects.filter(condition_group=when_dcg)
-        assert conditions.count() == 2
-        filters = DataCondition.objects.filter(condition_group=if_dcg)
-        assert filters.count() == 1
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    def test_delete_issue_alert__project_deletion_task(self):
+        self.project.update(status=ObjectStatus.PENDING_DELETION)
+        RegionScheduledDeletion.schedule(self.project, days=0)
 
-        self.project.delete()
+        with self.tasks():
+            run_scheduled_deletions()
 
-        self.assert_issue_alert_deleted(workflow, when_dcg, if_dcg)
+        self.assert_issue_alert_deleted(self.workflow, self.when_dcg, self.if_dcg)
+
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    def test_delete_issue_alert__org_deletion_task(self):
+        self.organization.update(status=ObjectStatus.PENDING_DELETION)
+        RegionScheduledDeletion.schedule(self.organization, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        self.assert_issue_alert_deleted(self.workflow, self.when_dcg, self.if_dcg)


### PR DESCRIPTION
Rules, projects, and organizations are deleted via scheduled deletions. Workflows should be deleted when any of these are deleted because they are tied to Rules (via the `AlertRuleWorkflow` lookup table). Rule FK's to Project, and Project FK's to Org.

If we tie these together with deletion tasks, they will be cleaned up correctly without the use of a Django signal.