### PR TITLE
chore(aci milestone 3): update dual delete

### DIFF
--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -34,6 +34,7 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
         from sentry.models.repository import Repository
         from sentry.models.team import Team
         from sentry.models.transaction_threshold import ProjectTransactionThreshold
+        from sentry.workflow_engine.models import Workflow
 
         # Team must come first
         relations: list[BaseRelation] = [ModelRelation(Team, {"organization_id": instance.id})]
@@ -63,6 +64,7 @@ class OrganizationDeletionTask(ModelDeletionTask[Organization]):
                 task=DiscoverSavedQueryDeletionTask,
             )
         )
+        relations.append(ModelRelation(Workflow, {"organization_id": instance.id}))
 
         return relations
 

--- a/src/sentry/incidents/models/alert_rule.py
+++ b/src/sentry/incidents/models/alert_rule.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.db.models.signals import post_delete, post_save, pre_delete
+from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
 
@@ -151,23 +151,6 @@ class AlertRuleManager(BaseManager["AlertRule"]):
                         "rule_id": instance.id,
                     },
                 )
-
-    @classmethod
-    def dual_delete_alert_rule(cls, instance: AlertRule, **kwargs: Any) -> None:
-        from sentry.workflow_engine.migration_helpers.alert_rule import (
-            dual_delete_migrated_alert_rule,
-        )
-
-        try:
-            dual_delete_migrated_alert_rule(instance)
-        except Exception as e:
-            logger.exception(
-                "Error when dual deleting alert rule",
-                extra={
-                    "rule_id": instance.id,
-                    "error": str(e),
-                },
-            )
 
 
 @region_silo_model
@@ -638,8 +621,6 @@ class AlertRuleActivity(Model):
         app_label = "sentry"
         db_table = "sentry_alertruleactivity"
 
-
-pre_delete.connect(AlertRuleManager.dual_delete_alert_rule, sender=AlertRule)
 
 post_delete.connect(AlertRuleManager.clear_subscription_cache, sender=QuerySubscription)
 post_delete.connect(AlertRuleManager.delete_data_in_seer, sender=AlertRule)

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -5,6 +5,7 @@ from typing import Any
 from django.db import router, transaction
 from django.forms import ValidationError
 
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import (
     AlertRule,
@@ -814,39 +815,10 @@ def dual_delete_migrated_alert_rule(alert_rule: AlertRule) -> None:
 
     workflow: Workflow = alert_rule_workflow.workflow
     detector: Detector = alert_rule_detector.detector
-    data_condition_group: DataConditionGroup | None = detector.workflow_condition_group
 
-    data_source = get_data_source(alert_rule=alert_rule)
-    if data_source is None:
-        logger.info(
-            "DataSource does not exist",
-            extra={"alert_rule_id": alert_rule.id},
-        )
     with transaction.atomic(router.db_for_write(Detector)):
-        triggers_to_dual_delete = AlertRuleTrigger.objects.filter(alert_rule=alert_rule)
-        for trigger in triggers_to_dual_delete:
-            dual_delete_migrated_alert_rule_trigger(trigger)
-
-        if data_condition_group:
-            # we need to delete the "resolve" dataconditions here as well
-            data_conditions = DataCondition.objects.filter(condition_group=data_condition_group)
-            resolve_detector_trigger = data_conditions.get(
-                condition_result=DetectorPriorityLevel.OK
-            )
-
-            resolve_detector_trigger.delete()
-
-        # NOTE: for migrated alert rules, each workflow is associated with a single detector
-        # make sure there are no other detectors associated with the workflow, then delete it if so
-        if DetectorWorkflow.objects.filter(workflow=workflow).count() == 1:
-            # also deletes alert_rule_workflow
-            workflow.delete()
-        # also deletes alert_rule_detector, detector_workflow (if not already deleted), detector_state
-        detector.delete()
-        if data_condition_group:
-            data_condition_group.delete()
-        if data_source:
-            data_source.delete()
+        RegionScheduledDeletion.schedule(instance=detector, days=0)
+        RegionScheduledDeletion.schedule(instance=workflow, days=0)
 
     return
 

--- a/tests/sentry/deletions/test_alert_rule.py
+++ b/tests/sentry/deletions/test_alert_rule.py
@@ -121,39 +121,3 @@ class DeleteAlertRuleTest(BaseWorkflowTest, HybridCloudTestMixin):
         assert not Incident.objects.filter(id=incident.id).exists()
 
         assert mock_delete_request.call_count == 1
-
-    @patch("sentry.workflow_engine.migration_helpers.alert_rule.dual_delete_migrated_alert_rule")
-    def test_dual_delete(self, mock_dual_delete_call):
-        """
-        Test the that the pre delete signal deleting the ACI objects for a dual written alert rule is called.
-        """
-        organization = self.create_organization()
-        alert_rule = self.create_alert_rule(resolve_threshold=10, organization=organization)
-
-        self.ScheduledDeletion.schedule(instance=alert_rule, days=0)
-
-        with self.tasks():
-            run_scheduled_deletions()
-
-        assert mock_dual_delete_call.call_count == 1
-
-    @patch("sentry.incidents.models.alert_rule.logger")
-    @patch("sentry.workflow_engine.migration_helpers.alert_rule.dual_delete_migrated_alert_rule")
-    def test_dual_delete_error(self, mock_dual_delete_call, mock_logger):
-        """
-        Test that if an error happens in the dual delete helper, it is caught and logged.
-        """
-        mock_dual_delete_call.side_effect = Exception("bad stuff happened")
-        organization = self.create_organization()
-        alert_rule = self.create_alert_rule(resolve_threshold=10, organization=organization)
-
-        self.ScheduledDeletion.schedule(instance=alert_rule, days=0)
-
-        with self.tasks():
-            run_scheduled_deletions()
-
-        assert mock_dual_delete_call.call_count == 1
-        mock_logger.exception.assert_called_with(
-            "Error when dual deleting alert rule",
-            extra={"rule_id": alert_rule.id, "error": "bad stuff happened"},
-        )

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -32,7 +32,7 @@ from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
-from sentry.workflow_engine.models import Detector, Workflow
+from sentry.workflow_engine.models import DataCondition, DataConditionGroup, Detector, Workflow
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -372,10 +372,14 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
         org = self.create_organization(name="test")
         project = self.create_project(organization=org)
 
+        dcg = self.create_data_condition_group(organization=org)
+        dc = self.create_data_condition(condition_group=dcg)
+
         detector = self.create_detector(
             project_id=project.id,
             name="Test Detector",
             type=MetricIssue.slug,
+            workflow_condition_group=dcg,
         )
         workflow = self.create_workflow(organization=org, name="Test Workflow")
 
@@ -387,4 +391,6 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
 
         assert not Project.objects.filter(id=project.id).exists()
         assert not Detector.objects.filter(id=detector.id).exists()
+        assert not DataConditionGroup.objects.filter(id=dcg.id).exists()
+        assert not DataCondition.objects.filter(id=dc.id).exists()
         assert not Workflow.objects.filter(id=workflow.id).exists()

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -19,6 +19,7 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
+from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
@@ -384,5 +385,6 @@ class DeleteOrganizationTest(TransactionTestCase, HybridCloudTestMixin, BaseWork
         with self.tasks():
             run_scheduled_deletions()
 
+        assert not Project.objects.filter(id=project.id).exists()
         assert not Detector.objects.filter(id=detector.id).exists()
         assert not Workflow.objects.filter(id=workflow.id).exists()


### PR DESCRIPTION
1. When dual deleting a metric alert, use `RegionScheduledDeletion` to delete the alert rule and workflow. This will cleanly get all child relations and help guard against race conditions (scheduling an object for deletion is an idempotent operation)
2. Instead of a pre delete signal on the alert rule model, add `Workflow` to the organization deletion task. `Detector` is cleaned up in the project deletion task, which is scheduled when an organization is scheduled for deletion, so these two operations combined will clean up all dual written alert rules' ACI objects.

Requires https://github.com/getsentry/sentry/pull/90539 be merged first.