### PR TITLE
ref(grouping): Add split enhancements to enhancement bases

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -508,7 +508,7 @@ def _load_configs() -> dict[str, Enhancements]:
                 # We cannot use `:` in filenames on Windows but we already have ids with
                 # `:` in their names hence this trickery.
                 filename = filename.replace("@", ":")
-                enhancements = Enhancements.from_rules_text(f.read(), id=filename)
+                enhancements = Enhancements.from_rules_text(f.read(), id=filename, version=3)
                 enhancement_bases[filename] = enhancements
     return enhancement_bases
 

--- a/src/sentry/grouping/enhancer/rules.py
+++ b/src/sentry/grouping/enhancer/rules.py
@@ -27,6 +27,15 @@ class EnhancementRule:
         self.has_classifier_actions = any(action.is_classifier for action in actions)
         self.has_contributes_actions = any(action.sets_contributes for action in actions)
 
+    def __repr__(self) -> str:
+        return f"<EnhancementRule {self.text}>"
+
+    def __hash__(self):
+        return hash(self.text)
+
+    def __eq__(self, other):
+        return self.text == other.text
+
     @property
     def text(self) -> str:
         matchers = " ".join(matcher.description for matcher in self.matchers)

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -9,6 +9,7 @@ import pytest
 
 from sentry.grouping.component import FrameGroupingComponent, StacktraceGroupingComponent
 from sentry.grouping.enhancer import (
+    ENHANCEMENT_BASES,
     Enhancements,
     is_valid_profiling_action,
     is_valid_profiling_matcher,
@@ -609,6 +610,18 @@ class EnhancementsTest(TestCase):
         enhancements = Enhancements.from_rules_text(self.rules_text, version=3)
         assert len(enhancements.classifier_rules) > 0
         assert len(enhancements.contributes_rules) > 0
+
+    def test_adds_split_rules_to_base_enhancements(self):
+        for base in ENHANCEMENT_BASES.values():
+            # Make these sets so checking in them is faster
+            classifier_rules = set(base.classifier_rules)
+            contributes_rules = set(base.contributes_rules)
+
+            for rule in base.rules:
+                if rule.has_classifier_actions:
+                    assert rule.as_classifier_rule() in classifier_rules
+                if rule.has_contributes_actions:
+                    assert rule.as_contributes_rule() in contributes_rules
 
 
 class AssembleStacktraceComponentTest(TestCase):


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/90505, which enabled enhancements (stacktrace rules) to be split up into classifier and contribtues types. In this PR, such split enhancements are added the default enhancements objects (the "bases," the ones representing the rules from each grouping config), to live alongside the regular enhancements, by forcing them to be created using version 3, rather than version 2.

This means that now if non-default enhancements were to be instantiated with version 3, their split rust enhancements would actually pull in the real default rules, rather than the empty rules provided by the `classifier_rust_enhancements` and `contributes_rust_enhancements` class variables. Nothing is actually doing that right now, but this means that once we turn it on, it'll have the right data.

This PR also adds some magic methods to the `EnhancementRule` class, to make testing easier.