### PR TITLE
ref(✂️): make flamegraphRendererDOM used in tests

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -4,6 +4,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {FlamegraphRendererDOM as mockFlameGraphRenderer} from 'sentry/utils/profiling/renderers/testUtils';
 import {useParams} from 'sentry/utils/useParams';
 import ProfileFlamegraph from 'sentry/views/profiling/profileFlamechart';
 import ProfilesAndTransactionProvider from 'sentry/views/profiling/transactionProfileProvider';
@@ -24,12 +25,8 @@ Element.prototype.scrollTo = () => {};
 
 // Replace the webgl renderer with a dom renderer for tests
 jest.mock('sentry/utils/profiling/renderers/flamegraphRendererWebGL', () => {
-  const {
-    FlamegraphRendererDOM,
-  } = require('sentry/utils/profiling/renderers/flamegraphRendererDOM');
-
   return {
-    FlamegraphRendererWebGL: FlamegraphRendererDOM,
+    FlamegraphRendererWebGL: mockFlameGraphRenderer,
   };
 });
 

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -122,11 +122,10 @@ export abstract class FlamegraphRenderer {
     return hoveredNode;
   }
 
-  // @ts-expect-error TS(7010): 'setSearchResults', which lacks return-type annota... Remove this comment to see the full error message
   abstract setSearchResults(
     _query: string,
     _searchResults: FlamegraphSearch['results']['frames']
-  );
+  ): void;
 
   abstract draw(_configViewToPhysicalSpace: mat3): void;
 }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
@@ -1,5 +1,6 @@
 import type {mat3} from 'gl-matrix';
 
+import {colorComponentsToRGBA} from 'sentry/utils/profiling/colors/utils';
 import type {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import type {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch';
 import type {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
@@ -12,12 +13,6 @@ import {
   FlamegraphRenderer,
 } from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {Rect} from 'sentry/utils/profiling/speedscope';
-
-function colorComponentsToRgba(color: number[]): string {
-  return `rgba(${Math.floor(color[0]! * 255)}, ${Math.floor(color[1]! * 255)}, ${Math.floor(
-    color[2]! * 255
-  )}, ${color[3] ?? 1})`;
-}
 
 export class FlamegraphRenderer2D extends FlamegraphRenderer {
   ctx: CanvasRenderingContext2D | null = null;
@@ -81,8 +76,8 @@ export class FlamegraphRenderer2D extends FlamegraphRenderer {
 
       this.ctx.fillStyle =
         this.isSearching && !this.searchResults.has(getFlamegraphFrameSearchId(frame))
-          ? colorComponentsToRgba(this.theme.COLORS.FRAME_FALLBACK_COLOR)
-          : colorComponentsToRgba(color);
+          ? colorComponentsToRGBA(this.theme.COLORS.FRAME_FALLBACK_COLOR)
+          : colorComponentsToRGBA(color);
 
       this.ctx.fillRect(
         rect.x + border,

--- a/static/app/utils/profiling/renderers/testUtils.tsx
+++ b/static/app/utils/profiling/renderers/testUtils.tsx
@@ -1,5 +1,6 @@
 import type {mat3} from 'gl-matrix';
 
+import {colorComponentsToRGBA} from 'sentry/utils/profiling/colors/utils';
 import type {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import type {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch';
 import type {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
@@ -10,13 +11,6 @@ import {
   FlamegraphRenderer,
 } from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {Rect} from 'sentry/utils/profiling/speedscope';
-
-// Convert color component from 0-1 to 0-255 range
-function colorComponentsToRgba(color: number[]): string {
-  return `rgba(${Math.floor(color[0]! * 255)}, ${Math.floor(color[1]! * 255)}, ${Math.floor(
-    color[2]! * 255
-  )}, ${color[3] ?? 1})`;
-}
 
 export class FlamegraphRendererDOM extends FlamegraphRenderer {
   ctx: CanvasRenderingContext2D | null = null;
@@ -61,7 +55,7 @@ export class FlamegraphRendererDOM extends FlamegraphRenderer {
 
       const colors =
         this.colorMap.get(frame.key) ?? this.theme.COLORS.FRAME_FALLBACK_COLOR;
-      const color = colorComponentsToRgba(colors);
+      const color = colorComponentsToRGBA(colors);
 
       const div = document.createElement('div');
       div.style.pointerEvents = 'absolute';

--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -22,17 +22,6 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-// Replace the webgl renderer with a dom renderer for tests
-jest.mock('sentry/utils/profiling/renderers/flamegraphRendererWebGL', () => {
-  const {
-    FlamegraphRendererDOM,
-  } = require('sentry/utils/profiling/renderers/flamegraphRendererDOM');
-
-  return {
-    FlamegraphRendererWebGL: FlamegraphRendererDOM,
-  };
-});
-
 window.ResizeObserver =
   window.ResizeObserver ||
   jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
- `flamegraphRendererDOM` is only used in tests, but it was conditionally imported. We can import it directly if the name starts with `mock`, as jest allows that.
- since it’s only used in tests, we need a way to distinguish unused code that has tests and can be deleted, and things like this that is a necessary test util. The current naming convention that’s mostly used is a file called `testUtils.tsx`, and `knip` also has an exception for these files. Ideally, I think tests and their utils should live in a separate adjacent directory (like `__tests__`), but that’s a broader topic.