### PR TITLE
fix(projects): Fix race condition in project creation

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -385,7 +385,7 @@ class Project(Model):
             super().save(*args, **kwargs)
 
     def save(self, *args, **kwargs):
-        if self.id is not None:
+        if getattr(self, "id", None) is not None:
             # no need to acquire lock if we're updating an existing project
             self._save_project(*args, **kwargs)
             return


### PR DESCRIPTION
Previous implementation of getting a unique slug for a project had a race condition bug. This PR fixes it, by inserting a project into a `sentry_project` table while still holding an acquired lock.

### Race condition
Prev solution was doing:
1. acquire lock
2. generate slug by making sure it doesn't already exist in the DB
3. release lock **<--** **PROBLEM**: we release the lock before saving to DB, which means other thread could acquire the lock and get the same slug as valid
4. save to DB

If it ever happens that 2 threads at the same time would ask for a `slug` of a project with the same name (we generate the `slug` from a `name` field/attribute) at the same time, race condition could happen. This has been happening when user would quickly click on "Create project" in our UI, we would send multiple requests, and weird errors would happen. [This is now fixed in our UI](https://github.com/getsentry/sentry/pull/90471), but race condition should still be fixed in our code.

Fixes [TET-277: RequestError: POST /teams/{orgSlug}/{teamSlug}/projects/ 409](https://linear.app/getsentry/issue/TET-277/requesterror-post-teamsorgslugteamslugprojects-409)