### PR TITLE
feat(laravel-nextjs-insights): Show release bubbles

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -25,6 +25,7 @@ import {
 } from 'sentry/views/insights/pages/platform/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {HighestCacheMissRateTransactionsWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
@@ -125,8 +126,7 @@ export function CachesWidget({query, releases}: {query?: string; releases?: Rele
           (ts, index) =>
             new Line(convertSeriesToTimeseries(ts), {color: colorPalette[index]})
         ),
-        releases,
-        showReleaseAs: 'bubble',
+        ...useReleaseBubbleProps(releases),
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -9,6 +9,7 @@ import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -30,7 +31,7 @@ import {HighestCacheMissRateTransactionsWidgetEmptyStateWarning} from 'sentry/vi
 function isCacheHitError(error: QueryError | null) {
   return error?.message === 'Column cache.hit was not found in metrics indexer';
 }
-export function CachesWidget({query}: {query?: string}) {
+export function CachesWidget({query, releases}: {query?: string; releases?: Release[]}) {
   const theme = useTheme();
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
@@ -124,6 +125,8 @@ export function CachesWidget({query}: {query?: string}) {
           (ts, index) =>
             new Line(convertSeriesToTimeseries(ts), {color: colorPalette[index]})
         ),
+        releases,
+        showReleaseAs: 'bubble',
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -6,6 +6,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
 import {CachesWidget} from 'sentry/views/insights/pages/platform/laravel/cachesWidget';
 import {JobsWidget} from 'sentry/views/insights/pages/platform/laravel/jobsWidget';
@@ -19,6 +21,13 @@ import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shar
 
 export function LaravelOverviewPage() {
   const organization = useOrganization();
+  const pageFilters = usePageFilters();
+  const {releases: releasesWithDate} = useReleaseStats(pageFilters.selection);
+  const releases =
+    releasesWithDate?.map(({date, version}) => ({
+      timestamp: date,
+      version,
+    })) ?? [];
 
   useEffect(() => {
     trackAnalytics('laravel-insights.page-view', {
@@ -38,22 +47,23 @@ export function LaravelOverviewPage() {
             trafficSeriesName={t('Requests')}
             baseQuery={'span.op:http.server'}
             query={query}
+            releases={releases}
           />
         </RequestsContainer>
         <IssuesContainer>
           <IssuesWidget query={query} />
         </IssuesContainer>
         <DurationContainer>
-          <DurationWidget query={query} />
+          <DurationWidget query={query} releases={releases} />
         </DurationContainer>
         <JobsContainer>
-          <JobsWidget query={query} />
+          <JobsWidget query={query} releases={releases} />
         </JobsContainer>
         <QueriesContainer>
-          <QueriesWidget query={query} />
+          <QueriesWidget query={query} releases={releases} />
         </QueriesContainer>
         <CachesContainer>
-          <CachesWidget query={query} />
+          <CachesWidget query={query} releases={releases} />
         </CachesContainer>
       </WidgetGrid>
       <PathsTable handleAddTransactionFilter={setTransactionFilter} query={query} />

--- a/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
@@ -24,6 +24,7 @@ import {
 } from 'sentry/views/insights/pages/platform/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {QueuesWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
@@ -110,8 +111,7 @@ export function JobsWidget({query, releases}: {query?: string; releases?: Releas
       visualizationProps={{
         showLegend: 'never',
         plottables,
-        releases,
-        showReleaseAs: 'bubble',
+        ...useReleaseBubbleProps(releases),
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
@@ -7,7 +7,7 @@ import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {Release, TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -27,7 +27,7 @@ import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/la
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {QueuesWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
-export function JobsWidget({query}: {query?: string}) {
+export function JobsWidget({query, releases}: {query?: string; releases?: Release[]}) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({
     granularity: 'spans-low',
@@ -110,6 +110,8 @@ export function JobsWidget({query}: {query?: string}) {
       visualizationProps={{
         showLegend: 'never',
         plottables,
+        releases,
+        showReleaseAs: 'bubble',
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
@@ -8,6 +8,7 @@ import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -34,7 +35,7 @@ function getSeriesName(item: {'span.group': string; transaction: string}) {
   return `${item.transaction},${item['span.group']}`;
 }
 
-export function QueriesWidget({query}: {query?: string}) {
+export function QueriesWidget({query, releases}: {query?: string; releases?: Release[]}) {
   const theme = useTheme();
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({
@@ -141,6 +142,8 @@ export function QueriesWidget({query}: {query?: string}) {
               alias: aliases[ts.seriesName],
             })
         ),
+        releases,
+        showReleaseAs: 'bubble',
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
@@ -27,6 +27,7 @@ import {
 } from 'sentry/views/insights/pages/platform/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {ModuleName} from 'sentry/views/insights/types';
 import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
@@ -142,8 +143,7 @@ export function QueriesWidget({query, releases}: {query?: string; releases?: Rel
               alias: aliases[ts.seriesName],
             })
         ),
-        releases,
-        showReleaseAs: 'bubble',
+        ...useReleaseBubbleProps(releases),
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -6,6 +6,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {PathsTable} from 'sentry/views/insights/pages/platform/laravel/pathsTable';
 import {SlowSSRWidget} from 'sentry/views/insights/pages/platform/nextjs/slowSsrWidget';
@@ -21,6 +23,13 @@ function PlaceholderWidget() {
 
 export function NextJsOverviewPage({headerTitle}: {headerTitle: React.ReactNode}) {
   const organization = useOrganization();
+  const pageFilters = usePageFilters();
+  const {releases: releasesWithDate} = useReleaseStats(pageFilters.selection);
+  const releases =
+    releasesWithDate?.map(({date, version}) => ({
+      timestamp: date,
+      version,
+    })) ?? [];
 
   useEffect(() => {
     trackAnalytics('nextjs-insights.page-view', {
@@ -40,19 +49,20 @@ export function NextJsOverviewPage({headerTitle}: {headerTitle: React.ReactNode}
             trafficSeriesName={t('Page views')}
             baseQuery={'span.op:[navigation,pageload]'}
             query={query}
+            releases={releases}
           />
         </RequestsContainer>
         <IssuesContainer>
           <IssuesWidget query={query} />
         </IssuesContainer>
         <DurationContainer>
-          <DurationWidget query={query} />
+          <DurationWidget query={query} releases={releases} />
         </DurationContainer>
         <JobsContainer>
           <PlaceholderWidget />
         </JobsContainer>
         <QueriesContainer>
-          <SlowSSRWidget query={query} />
+          <SlowSSRWidget query={query} releases={releases} />
         </QueriesContainer>
         <CachesContainer>
           <PlaceholderWidget />

--- a/static/app/views/insights/pages/platform/nextjs/slowSsrWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/slowSsrWidget.tsx
@@ -29,6 +29,7 @@ import {
 } from 'sentry/views/insights/pages/platform/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
 function renameMeta(meta: EventsMetaType, from: string, to: string): EventsMetaType {
@@ -133,8 +134,7 @@ export function SlowSSRWidget({query, releases}: {query?: string; releases?: Rel
               alias: aliases[ts.seriesName],
             })
         ),
-        releases,
-        showReleaseAs: 'bubble',
+        ...useReleaseBubbleProps(releases),
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/nextjs/slowSsrWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/slowSsrWidget.tsx
@@ -10,6 +10,7 @@ import getDuration from 'sentry/utils/duration/getDuration';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -41,7 +42,7 @@ function renameMeta(meta: EventsMetaType, from: string, to: string): EventsMetaT
   };
 }
 
-export function SlowSSRWidget({query}: {query?: string}) {
+export function SlowSSRWidget({query, releases}: {query?: string; releases?: Release[]}) {
   const theme = useTheme();
   const {selection} = usePageFilters();
   const organization = useOrganization();
@@ -132,6 +133,8 @@ export function SlowSSRWidget({query}: {query?: string}) {
               alias: aliases[ts.seriesName],
             })
         ),
+        releases,
+        showReleaseAs: 'bubble',
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/durationWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/durationWidget.tsx
@@ -19,6 +19,7 @@ import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
 export function DurationWidget({
@@ -93,8 +94,7 @@ export function DurationWidget({
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables,
-        releases,
-        showReleaseAs: 'bubble',
+        ...useReleaseBubbleProps(releases),
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/durationWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/durationWidget.tsx
@@ -7,6 +7,7 @@ import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -20,7 +21,13 @@ import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/lar
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
-export function DurationWidget({query}: {query?: string}) {
+export function DurationWidget({
+  query,
+  releases,
+}: {
+  query?: string;
+  releases?: Release[];
+}) {
   const theme = useTheme();
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
@@ -86,6 +93,8 @@ export function DurationWidget({query}: {query?: string}) {
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables,
+        releases,
+        showReleaseAs: 'bubble',
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/getReleaseBubbleProps.tsx
+++ b/static/app/views/insights/pages/platform/shared/getReleaseBubbleProps.tsx
@@ -1,0 +1,9 @@
+import useOrganization from 'sentry/utils/useOrganization';
+import type {Release} from 'sentry/views/dashboards/widgets/common/types';
+
+export function useReleaseBubbleProps(releases: Release[] | undefined) {
+  const organization = useOrganization();
+  return organization.features.includes('release-bubbles-ui')
+    ? ({releases, showReleaseAs: 'bubble'} as const)
+    : {};
+}

--- a/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
@@ -18,6 +18,7 @@ import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/laravel/styles';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
 export function TrafficWidget({
@@ -111,8 +112,7 @@ export function TrafficWidget({
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables,
-        releases,
-        showReleaseAs: 'bubble',
+        ...useReleaseBubbleProps(releases),
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {Release, TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -25,11 +25,13 @@ export function TrafficWidget({
   trafficSeriesName,
   baseQuery,
   query,
+  releases,
 }: {
   title: string;
   trafficSeriesName: string;
   baseQuery?: string;
   query?: string;
+  releases?: Release[];
 }) {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({granularity: 'spans-low'});
@@ -109,6 +111,8 @@ export function TrafficWidget({
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables,
+        releases,
+        showReleaseAs: 'bubble',
       }}
     />
   );


### PR DESCRIPTION
Show release bubbles on laravel and nextjs insights.

![Screenshot 2025-04-29 at 12 25 03](https://github.com/user-attachments/assets/c57e0d7e-8db0-48db-88a7-c368c0d40c2e)
![Screenshot 2025-04-29 at 12 25 12](https://github.com/user-attachments/assets/c89783f9-d120-454f-b225-856440ba8774)

**Note:** They are only visible if the feature flag for release bubbles is enabled.

- closes [TET-287: Check if release bubbles work on Laravel landing page widgets](https://linear.app/getsentry/issue/TET-287/check-if-release-bubbles-work-on-laravel-landing-page-widgets)