### PR TITLE
Update sentry-python SDK to 2.27.0

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -192,7 +192,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.72
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.8
-sentry-sdk==2.25.1
+sentry-sdk==2.27.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -130,7 +130,7 @@ sentry-ophio==1.0.0
 sentry-protos==0.1.72
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.8
-sentry-sdk==2.25.1
+sentry-sdk==2.27.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
 six==1.16.0


### PR DESCRIPTION
This release includes feature flags on spans. 