### PR TITLE
fix(taskworker) Remove pickle parameters from buffer tasks

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -164,8 +164,13 @@ class Buffer(Service):
             update_kwargs: dict[str, Expression] = {c: F(c) + v for c, v in columns.items()}
 
             if extra:
+                # Because of the group.update() below, we need to parse
+                # datetime strings back into datetime objects. This ensures that
+                # the cache data contains the correct type.
+                for key in ("last_seen", "first_seen"):
+                    if key in extra:
+                        extra[key] = datetime.fromisoformat(extra[key])
                 update_kwargs.update(extra)
-
             # HACK(dcramer): this is gross, but we don't have a good hook to compute this property today
             # XXX(dcramer): remove once we can replace 'priority' with something reasonable via Snuba
             if model is Group:

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -121,6 +121,11 @@ class Buffer(Service):
         in cases where we need to do additional processing before writing to the database and opt to do
         it in a `buffer_incr_complete` receiver.
         """
+        if extra:
+            for key, value in extra.items():
+                if isinstance(value, datetime):
+                    extra[key] = value.isoformat()
+
         process_incr.apply_async(
             kwargs={
                 "model_name": f"{model._meta.app_label}.{model._meta.model_name}",

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -168,7 +168,7 @@ class Buffer(Service):
                 # datetime strings back into datetime objects. This ensures that
                 # the cache data contains the correct type.
                 for key in ("last_seen", "first_seen"):
-                    if key in extra:
+                    if key in extra and isinstance(extra[key], str):
                         extra[key] = datetime.fromisoformat(extra[key])
                 update_kwargs.update(extra)
             # HACK(dcramer): this is gross, but we don't have a good hook to compute this property today

--- a/tests/sentry/buffer/test_base.py
+++ b/tests/sentry/buffer/test_base.py
@@ -54,9 +54,9 @@ class BufferTest(TestCase):
         filters = {"id": group.id, "project_id": 1}
         the_date = timezone.now() + timedelta(days=5)
         self.buf.process(Group, columns, filters, {"last_seen": the_date})
-        group_ = Group.objects.get(id=group.id)
-        assert group_.times_seen == group.times_seen + 1
-        assert group_.last_seen == the_date
+        reload = Group.objects.get(id=group.id)
+        assert reload.times_seen == group.times_seen + 1
+        assert reload.last_seen == the_date
 
     def test_increments_when_null(self):
         org = Organization.objects.create(slug="test-org")


### PR DESCRIPTION
We were passing datetime objects into process_buffer tasks which require pickle. Taskworkers won't support pickling parameters, so we need to string cast datetime values.
