### PR TITLE
fix(eap-spans): incorrect alias used for mobile frames attributes

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -234,17 +234,17 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="second",
         ),
         ResolvedAttribute(
-            public_alias="mobile.frames_slow",
+            public_alias="mobile.slow_frames",
             internal_name="frames.slow",
             search_type="number",
         ),
         ResolvedAttribute(
-            public_alias="mobile.frames_frozen",
+            public_alias="mobile.frozen_frames",
             internal_name="frames.frozen",
             search_type="number",
         ),
         ResolvedAttribute(
-            public_alias="mobile.frames_total",
+            public_alias="mobile.total_frames",
             internal_name="frames.total",
             search_type="number",
         ),

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3092,8 +3092,8 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         response = self.do_request(
             {
                 "field": [
-                    "division(mobile.frames_slow,mobile.frames_total)",
-                    "division(mobile.frames_frozen,mobile.frames_total)",
+                    "division(mobile.slow_frames,mobile.total_frames)",
+                    "division(mobile.frozen_frames,mobile.total_frames)",
                 ],
                 "project": self.project.id,
                 "dataset": self.dataset,
@@ -3104,8 +3104,8 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         data = response.data["data"]
         meta = response.data["meta"]
         assert len(data) == 1
-        assert data[0]["division(mobile.frames_slow,mobile.frames_total)"] == 10 / 100
-        assert data[0]["division(mobile.frames_frozen,mobile.frames_total)"] == 20 / 100
+        assert data[0]["division(mobile.slow_frames,mobile.total_frames)"] == 10 / 100
+        assert data[0]["division(mobile.frozen_frames,mobile.total_frames))"] == 20 / 100
         assert meta["dataset"] == self.dataset
 
     def test_opportunity_score_zero_scores(self):

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3105,7 +3105,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         meta = response.data["meta"]
         assert len(data) == 1
         assert data[0]["division(mobile.slow_frames,mobile.total_frames)"] == 10 / 100
-        assert data[0]["division(mobile.frozen_frames,mobile.total_frames))"] == 20 / 100
+        assert data[0]["division(mobile.frozen_frames,mobile.total_frames)"] == 20 / 100
         assert meta["dataset"] == self.dataset
 
     def test_opportunity_score_zero_scores(self):


### PR DESCRIPTION
`mobile.frames_slow`, `mobile.frames_frozen`, and `mobile.frames_total` are all not used at all (you can cmd+f the repo to verify), these we're incorrectly set as aliases in `attributes.py`. Instead they should be `mobile.slow_frames`, `mobile.frozen_frames` and `mobile.total_frames` respectively