### PR TITLE
fix(schema-hints): Duplicate hint opens wrong dropdown

### DIFF
--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -270,6 +270,10 @@ export class MutableSearch {
     return Object.keys(this.filters);
   }
 
+  getTokenKeys() {
+    return this.tokens.map(t => t.key);
+  }
+
   hasFilter(key: string): boolean {
     return this.getFilterValues(key).length > 0;
   }

--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -111,7 +111,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
         type: 'UPDATE_QUERY',
         query: filterQuery.formatString(),
         focusOverride: {
-          itemKey: `filter:${filterQuery.getFilterKeys().indexOf(hint.key)}`,
+          itemKey: `filter:${filterQuery.getTokenKeys().lastIndexOf(hint.key)}`,
           part: 'value',
         },
       });

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -32,6 +32,11 @@ jest.mock('sentry/components/searchQueryBuilder/context', () => ({
   SearchQueryBuilderProvider: ({children}: {children: React.ReactNode}) => children,
 }));
 
+const searchQueryBuilderModule = jest.requireMock(
+  'sentry/components/searchQueryBuilder/context'
+);
+const originalUseSearchQueryBuilder = searchQueryBuilderModule.useSearchQueryBuilder;
+
 function Subject(
   props: Omit<
     Parameters<typeof SchemaHintsList>[0],
@@ -92,6 +97,10 @@ describe('SchemaHintsList', () => {
   });
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    searchQueryBuilderModule.useSearchQueryBuilder = originalUseSearchQueryBuilder;
   });
 
   it('should render', () => {
@@ -313,5 +322,37 @@ describe('SchemaHintsList', () => {
     expect(withinDrawer.getByText('stringTag2')).toBeInTheDocument();
     expect(withinDrawer.queryByText('numberTag1')).not.toBeInTheDocument();
     expect(withinDrawer.queryByText('numberTag2')).not.toBeInTheDocument();
+  });
+
+  it('should set focus override propely on duplicate filters', async () => {
+    searchQueryBuilderModule.useSearchQueryBuilder = () => ({
+      query: 'stringTag1:"something"',
+      getTagValues: () => Promise.resolve(['tagValue1', 'tagValue2']),
+      dispatch: mockDispatch,
+      wrapperRef: {current: null},
+    });
+
+    render(
+      <Subject
+        stringTags={mockStringTags}
+        numberTags={mockNumberTags}
+        supportedAggregates={[]}
+      />,
+      {
+        organization,
+      }
+    );
+
+    const stringTag1Hint = screen.getByText('stringTag1');
+    await userEvent.click(stringTag1Hint);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'UPDATE_QUERY',
+      query: 'stringTag1:something stringTag1:""',
+      focusOverride: {
+        itemKey: 'filter:1',
+        part: 'value',
+      },
+    });
   });
 });

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -325,7 +325,7 @@ function SchemaHintsList({
         type: 'UPDATE_QUERY',
         query: newQuery,
         focusOverride: {
-          itemKey: `filter:${newSearchQuery.getFilterKeys().indexOf(hint.key)}`,
+          itemKey: `filter:${newSearchQuery.getTokenKeys().lastIndexOf(hint.key)}`,
           part: 'value',
         },
       });


### PR DESCRIPTION
Originally when you clicked on a hint from the visible list that is already in the search bar, it would add the hint but open the dropdown of the the first hint. This was happening for two reasons:
1. `getFilterKeys()` was returning a reduced version of all the tokens in the search bar; any tokens of the same key would get grouped together and would only show the first key.
2. The logic to open the dropdown was focusing on the first token of the specified key instead of the last token.

This is how it looks now:

https://github.com/user-attachments/assets/1a970d00-0f53-4cf3-84e9-551eaf2c29d8
