### PR TITLE
feat(explore): High Accuracy request continues pending state

### DIFF
--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -172,12 +172,10 @@ function _checkCanQueryForMoreData(
   visualizes: Visualize[],
   isTopN: boolean
 ) {
-  return visualizes
-    .map(visualize => {
-      const dedupedYAxes = dedupeArray(visualize.yAxes);
-      const series = dedupedYAxes.flatMap(yAxis => data[yAxis]).filter(defined);
-      const {dataScanned} = determineSeriesSampleCountAndIsSampled(series, isTopN);
-      return dataScanned === 'partial';
-    })
-    .some(Boolean);
+  return visualizes.some(visualize => {
+    const dedupedYAxes = dedupeArray(visualize.yAxes);
+    const series = dedupedYAxes.flatMap(yAxis => data[yAxis]).filter(defined);
+    const {dataScanned} = determineSeriesSampleCountAndIsSampled(series, isTopN);
+    return dataScanned === 'partial';
+  });
 }

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -39,6 +39,7 @@ interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {
     result: ReturnType<TQueryFn>['result'] & {
       data: any;
       isFetched: boolean;
+      isPending: boolean;
     };
   };
   queryOptions?: QueryOptions<TQueryFn>;
@@ -137,7 +138,10 @@ export function useProgressiveQuery<
   // End of NORMAL -> HIGH_ACCURACY flow
 
   if (canUseNormalSamplingMode) {
-    if (highAccuracyRequest?.result?.isFetched) {
+    if (
+      highAccuracyRequest?.result?.isPending ||
+      highAccuracyRequest?.result?.isFetched
+    ) {
       return {
         ...highAccuracyRequest,
         samplingMode: SAMPLING_MODE.HIGH_ACCURACY,


### PR DESCRIPTION
Without this, the first normal mode results get rendered and there is no loading UI for loading the unsampled request. I still need to add more messaging to the UI saying the high accuracy request is kicking off but for now this prevents an unexpected experience with the second request.