### PR TITLE
fix(taskworker) Increase processing deadlines for assemble tasks

### DIFF
--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -228,6 +228,7 @@ def delete_assemble_status(task, scope, checksum):
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=attachments_tasks,
+        processing_deadline_duration=30,
     ),
 )
 def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
@@ -597,6 +598,7 @@ class ArtifactBundlePostAssembler:
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=attachments_tasks,
+        processing_deadline_duration=30,
     ),
 )
 def assemble_artifacts(


### PR DESCRIPTION
We've seen a few deadline exception for these tasks in s4s. Bumping the deadline should resolve the failures.

Refs SENTRY-FOR-SENTRY-ARH
