### PR TITLE
feat(dashboards-eap): Enable NORMAL mode querying for dashboards

### DIFF
--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -399,4 +399,126 @@ describe('spansWidgetQueries', () => {
       })
     );
   });
+
+  it('triggers a normal mode request for charts', async () => {
+    widget = WidgetFixture({
+      queries: [
+        {
+          name: '',
+          aggregates: ['a'],
+          fields: ['a'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+      displayType: DisplayType.LINE,
+    });
+
+    const normalModeMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-stats/`,
+      body: {
+        data: [
+          [1, [{count: 1}]],
+          [2, [{count: 2}]],
+          [3, [{count: 3}]],
+        ],
+      },
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === 'NORMAL';
+        },
+      ],
+    });
+
+    render(
+      <OrganizationContext.Provider
+        value={OrganizationFixture({
+          features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
+        })}
+      >
+        <SpansWidgetQueries
+          api={api}
+          widget={widget}
+          selection={{
+            ...selection,
+            datetime: {period: '24hr', end: null, start: null, utc: null},
+          }}
+          dashboardFilters={{}}
+        >
+          {({timeseriesResults}) => <div>{timeseriesResults?.[0]?.data?.[0]?.value}</div>}
+        </SpansWidgetQueries>
+      </OrganizationContext.Provider>
+    );
+
+    expect(await screen.findByText('1')).toBeInTheDocument();
+
+    expect(normalModeMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          sampling: 'NORMAL',
+        }),
+      })
+    );
+  });
+
+  it('triggers a normal mode request for tables', async () => {
+    widget = WidgetFixture({
+      queries: [
+        {
+          name: '',
+          aggregates: ['a'],
+          fields: ['a'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+      displayType: DisplayType.TABLE,
+    });
+
+    const normalModeMock = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      body: {
+        data: [{a: 'normal mode'}],
+      },
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === 'NORMAL';
+        },
+      ],
+    });
+
+    render(
+      <OrganizationContext.Provider
+        value={OrganizationFixture({
+          features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
+        })}
+      >
+        <SpansWidgetQueries
+          api={api}
+          widget={widget}
+          selection={{
+            ...selection,
+            datetime: {period: '24hr', end: null, start: null, utc: null},
+          }}
+          dashboardFilters={{}}
+        >
+          {({tableResults}) => <div>{tableResults?.[0]?.data?.[0]?.a}</div>}
+        </SpansWidgetQueries>
+      </OrganizationContext.Provider>
+    );
+
+    expect(await screen.findByText('normal mode')).toBeInTheDocument();
+
+    expect(normalModeMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          sampling: 'NORMAL',
+        }),
+      })
+    );
+  });
 });

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -100,7 +100,12 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
     [props.widget.queries]
   );
 
-  if (organization.features.includes('visibility-explore-progressive-loading')) {
+  if (
+    organization.features.includes('visibility-explore-progressive-loading') &&
+    !organization.features.includes(
+      'visibility-explore-progressive-loading-normal-sampling-mode'
+    )
+  ) {
     return (
       <SpansWidgetQueriesProgressiveLoadingImpl
         {...props}
@@ -283,6 +288,13 @@ function SpansWidgetQueriesSingleRequestImpl({
         dashboardFilters={dashboardFilters}
         onDataFetched={onDataFetched}
         afterFetchSeriesData={afterFetchSeriesData}
+        samplingMode={
+          organization.features.includes(
+            'visibility-explore-progressive-loading-normal-sampling-mode'
+          )
+            ? SAMPLING_MODE.NORMAL
+            : undefined
+        }
       >
         {props =>
           children({


### PR DESCRIPTION
Reuses the old component for querying for span widgets and passes along a NORMAL mode param if the flag is enabled.

Closes EXP-186