### PR TITLE
fix(org member invite): fix signal param

### DIFF
--- a/src/sentry/api/endpoints/organization_member_invite/index.py
+++ b/src/sentry/api/endpoints/organization_member_invite/index.py
@@ -158,7 +158,7 @@ class OrganizationMemberInviteIndexEndpoint(OrganizationEndpoint):
         referrer = request.query_params.get("referrer")
         omi.send_invite_email(referrer)
         member_invited.send_robust(
-            invited_member=omi,
+            member=omi,
             user=request.user,
             sender=self,
             referrer=request.data.get("referrer"),

--- a/src/sentry/models/organizationmemberinvite.py
+++ b/src/sentry/models/organizationmemberinvite.py
@@ -189,9 +189,7 @@ class OrganizationMemberInvite(DefaultFieldsModel):
             self.save()
 
         self.send_invite_email(referrer)
-        member_invited.send_robust(
-            invited_member=self, user=approving_user, sender=self, referrer=referrer
-        )
+        member_invited.send_robust(member=self, user=approving_user, sender=self, referrer=referrer)
         create_audit_entry_from_user(
             approving_user,
             api_key,


### PR DESCRIPTION
The `member_invited` signal takes a `member` param, not `invited_member`.