### PR TITLE
chore(schema-hints): Remove router from render props in tests

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import type {TagCollection} from 'sentry/types/group';
@@ -81,15 +80,6 @@ jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(fu
 });
 
 describe('SchemaHintsList', () => {
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {
-        query: {
-          query: '',
-        },
-      },
-    },
-  });
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -100,10 +90,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const container = screen.getByLabelText('Schema Hints List');
@@ -126,10 +113,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const stringTag1Hint = screen.getByText('stringTag1');
@@ -147,10 +131,7 @@ describe('SchemaHintsList', () => {
 
   it('should render loading indicator when isLoading is true', () => {
     render(
-      <Subject stringTags={{}} numberTags={{}} supportedAggregates={[]} isLoading />,
-      {
-        deprecatedRouterMocks: true,
-      }
+      <Subject stringTags={{}} numberTags={{}} supportedAggregates={[]} isLoading />
     );
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -162,12 +143,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -190,12 +166,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -223,23 +194,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-
-        router: {
-          ...router,
-          location: {
-            ...router.location,
-            query: {
-              query: '!stringTag1:"" numberTag1:>0',
-              field: ['stringTag1', 'numberTag1'],
-            },
-          },
-        },
-
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -260,19 +215,21 @@ describe('SchemaHintsList', () => {
   });
 
   it('should keep drawer open when query is updated', async () => {
-    render(
+    const {router: newRouter} = render(
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
       />,
       {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/test/path',
+            query: {query: ''},
+          },
+        },
       }
     );
-
     const seeFullList = screen.getByText('See full list');
     await userEvent.click(seeFullList);
 
@@ -280,9 +237,9 @@ describe('SchemaHintsList', () => {
     const stringTag1Checkbox = withinDrawer.getByText('stringTag1');
     await userEvent.click(stringTag1Checkbox);
 
-    router.push({
-      ...router.location,
-      query: {query: '!stringTag1:""'},
+    newRouter.navigate({
+      pathname: '/test/path',
+      search: '?query=stringTag1:""',
     });
 
     expect(screen.getByLabelText('Schema Hints Drawer')).toBeInTheDocument();
@@ -294,12 +251,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');


### PR DESCRIPTION
The router prop in `render` has been deprecated so I've changed it accordingly to use the new `initialRouterConfig`. Also turns out a lot of these tests didn't need the router prop anymore 🤩. Just a bunch of cleanup in this test file.