### PR TITLE
feat(codecov): Add TA CI efficiency panel

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -2,8 +2,10 @@ import {RateUnit} from 'sentry/utils/discover/fields';
 import {
   formatAbbreviatedNumber,
   formatAbbreviatedNumberWithDynamicPrecision,
+  formatPercentRate,
   formatRate,
   formatSpanOperation,
+  formatTimeDuration,
   userDisplayName,
 } from 'sentry/utils/formatters';
 
@@ -212,5 +214,55 @@ describe('formatSpanOperation', () => {
     ['resource.img', 'image'],
   ])('formats long description for %s span operation', (operation, description) => {
     expect(formatSpanOperation(operation, 'long')).toEqual(description);
+  });
+});
+
+describe('formatPercentRate', () => {
+  it('formats positive numbers', () => {
+    expect(formatPercentRate(0.1)).toBe('+0.10%');
+    expect(formatPercentRate(1)).toBe('+1.00%');
+    expect(formatPercentRate(10)).toBe('+10.00%');
+  });
+
+  it('formats negative numbers', () => {
+    expect(formatPercentRate(-0.1)).toBe('-0.10%');
+    expect(formatPercentRate(-1)).toBe('-1.00%');
+    expect(formatPercentRate(-10)).toBe('-10.00%');
+  });
+
+  it('formats zero', () => {
+    expect(formatPercentRate(0)).toBe('0.00%');
+  });
+});
+
+describe('formatTimeDuration', () => {
+  describe('numbers less than 1 second', () => {
+    it('formats 0', () => {
+      expect(formatTimeDuration(0)).toBe('0s');
+    });
+  });
+
+  describe('numbers greater than 1 second', () => {
+    it('formats 1', () => {
+      expect(formatTimeDuration(1000)).toBe('1s');
+    });
+  });
+
+  describe('numbers greater than 1 minute', () => {
+    it('formats 1', () => {
+      expect(formatTimeDuration(60000)).toBe('1m 0s');
+    });
+  });
+
+  describe('numbers greater than 1 hour', () => {
+    it('formats 1', () => {
+      expect(formatTimeDuration(3600000)).toBe('1h 0m 0s');
+    });
+  });
+
+  describe('numbers greater than 1 day', () => {
+    it('formats 1', () => {
+      expect(formatTimeDuration(86400000)).toBe('1d 0h 0m 0s');
+    });
   });
 });

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -243,25 +243,25 @@ describe('formatTimeDuration', () => {
   });
 
   describe('numbers greater than 1 second', () => {
-    it('formats 1', () => {
+    it('formats 1 second', () => {
       expect(formatTimeDuration(1000)).toBe('1s');
     });
   });
 
   describe('numbers greater than 1 minute', () => {
-    it('formats 1', () => {
+    it('formats 1 minute', () => {
       expect(formatTimeDuration(60000)).toBe('1m 0s');
     });
   });
 
   describe('numbers greater than 1 hour', () => {
-    it('formats 1', () => {
+    it('formats 1 hour', () => {
       expect(formatTimeDuration(3600000)).toBe('1h 0m 0s');
     });
   });
 
   describe('numbers greater than 1 day', () => {
-    it('formats 1', () => {
+    it('formats 1 day', () => {
       expect(formatTimeDuration(86400000)).toBe('1d 0h 0m 0s');
     });
   });

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -239,3 +239,47 @@ function getShortSpanOperationDescription(operation?: string) {
 
   return t('span');
 }
+
+/**
+ * Formats a change rate with a sign (+/-) and 2 decimal places.
+ *
+ * e.g. `0.46 -> '+0.46%'`, `-0.46 -> '-0.46%'`, `0 -> '0%'`
+ *
+ * @param change the change rate to format
+ */
+export function formatPercentRate(change: number) {
+  if (change > 0) {
+    return `+${change.toFixed(2)}%`;
+  }
+
+  if (change < 0) {
+    return `${change.toFixed(2)}%`;
+  }
+
+  return '0.00%';
+}
+
+/**
+ * Formats a duration in milliseconds into a human readable string. This function will
+ * filter out "units" that are larger than the duration i.e. if the duration is 1000ms,
+ * it will return `'1s'` instead of `'0d 0h 0m 1s'`.
+ *
+ * e.g. 12345678 -> `'12d 12h 34m 56s'`
+ *
+ * @param duration the duration in milliseconds to format
+ */
+export function formatTimeDuration(duration: number) {
+  const d = Math.floor(duration / DAY);
+  const h = Math.floor((duration % DAY) / HOUR);
+  const m = Math.floor((duration % HOUR) / MINUTE);
+  const s = Math.floor((duration % MINUTE) / SECOND);
+
+  return [
+    duration >= DAY ? t('%sd', d) : undefined,
+    duration >= HOUR ? t('%sh', h) : undefined,
+    duration >= MINUTE ? t('%sm', m) : undefined,
+    t('%ss', s),
+  ]
+    .filter(Boolean)
+    .join(' ');
+}

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.spec.tsx
@@ -1,0 +1,52 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {CIEfficiency} from 'sentry/views/codecov/tests/summaries/ciEfficiency';
+
+const testCIEfficiencyData = {
+  slowestTests: 100,
+  slowestTestsDuration: 10000,
+  totalTestsRunTime: 12300000,
+  totalTestsRunTimeChange: 0.46,
+};
+
+describe('CIEfficiency', () => {
+  it('renders formatted total tests run time', () => {
+    render(<CIEfficiency {...testCIEfficiencyData} />);
+
+    const formattedTotalTestsRunTime = screen.getByText('3h 25m 0s');
+    expect(formattedTotalTestsRunTime).toBeInTheDocument();
+  });
+
+  it('renders the slowest tests with a filter link', () => {
+    render(<CIEfficiency {...testCIEfficiencyData} />);
+
+    const formattedSlowestTests = screen.getByRole('link', {name: '100'});
+    expect(formattedSlowestTests).toBeInTheDocument();
+    expect(formattedSlowestTests).toHaveAttribute(
+      'href',
+      '/mock-pathname/?f_b_type=slowest_tests'
+    );
+  });
+
+  describe('rendering the total tests run time change', () => {
+    describe('total tests run time is negative', () => {
+      it('renders success tag', () => {
+        render(
+          <CIEfficiency {...testCIEfficiencyData} totalTestsRunTimeChange={-0.46} />
+        );
+
+        const changeTag = screen.getByText('-0.46%');
+        expect(changeTag.parentElement).toHaveAttribute('type', 'success');
+      });
+    });
+
+    describe('total tests run time is positive', () => {
+      it('renders error tag', () => {
+        render(<CIEfficiency {...testCIEfficiencyData} totalTestsRunTimeChange={0.46} />);
+
+        const changeTag = screen.getByText('+0.46%');
+        expect(changeTag.parentElement).toHaveAttribute('type', 'error');
+      });
+    });
+  });
+});

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.spec.tsx
@@ -11,14 +11,14 @@ const testCIEfficiencyData = {
 
 describe('CIEfficiency', () => {
   it('renders formatted total tests run time', () => {
-    render(<CIEfficiency {...testCIEfficiencyData} />);
+    render(<CIEfficiency {...testCIEfficiencyData} isLoading={false} />);
 
     const formattedTotalTestsRunTime = screen.getByText('3h 25m 0s');
     expect(formattedTotalTestsRunTime).toBeInTheDocument();
   });
 
   it('renders the slowest tests with a filter link', () => {
-    render(<CIEfficiency {...testCIEfficiencyData} />);
+    render(<CIEfficiency {...testCIEfficiencyData} isLoading={false} />);
 
     const formattedSlowestTests = screen.getByRole('link', {name: '100'});
     expect(formattedSlowestTests).toBeInTheDocument();
@@ -32,7 +32,11 @@ describe('CIEfficiency', () => {
     describe('total tests run time is negative', () => {
       it('renders success tag', () => {
         render(
-          <CIEfficiency {...testCIEfficiencyData} totalTestsRunTimeChange={-0.46} />
+          <CIEfficiency
+            {...testCIEfficiencyData}
+            totalTestsRunTimeChange={-0.46}
+            isLoading={false}
+          />
         );
 
         const changeTag = screen.getByText('-0.46%');
@@ -42,7 +46,13 @@ describe('CIEfficiency', () => {
 
     describe('total tests run time is positive', () => {
       it('renders error tag', () => {
-        render(<CIEfficiency {...testCIEfficiencyData} totalTestsRunTimeChange={0.46} />);
+        render(
+          <CIEfficiency
+            {...testCIEfficiencyData}
+            totalTestsRunTimeChange={0.46}
+            isLoading={false}
+          />
+        );
 
         const changeTag = screen.getByText('+0.46%');
         expect(changeTag.parentElement).toHaveAttribute('type', 'error');

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
@@ -1,0 +1,111 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {
+  SummaryEntries,
+  SummaryEntry,
+  SummaryEntryLabel,
+  SummaryEntryValue,
+  SummaryEntryValueLink,
+} from 'sentry/components/codecov/summary';
+import {Tag} from 'sentry/components/core/badge/tag';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import {t} from 'sentry/locale';
+import {formatPercentRate, formatTimeDuration} from 'sentry/utils/formatters';
+
+function TotalTestsRunTimeTooltip() {
+  return (
+    <Fragment>
+      <p>
+        <ToolTipTitle>Impact:</ToolTipTitle>
+        The cumulative CI time spent running tests over the last 30 days.
+      </p>
+      <p>
+        <ToolTipTitle>What is it:</ToolTipTitle>
+        The total time it takes to run all your tests.
+      </p>
+    </Fragment>
+  );
+}
+
+interface SlowestTestsTooltipProps {
+  slowestTestsDuration: number;
+}
+
+function SlowestTestsTooltip({slowestTestsDuration}: SlowestTestsTooltipProps) {
+  return (
+    <Fragment>
+      <p>
+        <ToolTipTitle>Impact:</ToolTipTitle>
+        The slowest 100 tests take {formatTimeDuration(slowestTestsDuration)} to run.
+      </p>
+      <p>
+        <ToolTipTitle>What is it:</ToolTipTitle>
+        Lists the tests that take more than the 95th percentile run time to complete.
+        Showing a max of 100 tests.
+      </p>
+    </Fragment>
+  );
+}
+
+const ToolTipTitle = styled('strong')`
+  display: block;
+`;
+
+interface CIEfficiencyProps {
+  slowestTests: number;
+  slowestTestsDuration: number;
+  totalTestsRunTime: number;
+  totalTestsRunTimeChange: number;
+}
+
+export function CIEfficiency({
+  slowestTests,
+  slowestTestsDuration,
+  totalTestsRunTime,
+  totalTestsRunTimeChange,
+}: CIEfficiencyProps) {
+  return (
+    <CIEfficiencyPanel>
+      <PanelHeader>{t('CI Efficiency')}</PanelHeader>
+      <PanelBody>
+        <SummaryEntries largeColumnSpan={2} smallColumnSpan={1}>
+          <SummaryEntry>
+            <SummaryEntryLabel showUnderline body={<TotalTestsRunTimeTooltip />}>
+              {t('Total Tests Run Time')}
+            </SummaryEntryLabel>
+            <div>
+              <SummaryEntryValue>
+                {formatTimeDuration(totalTestsRunTime)}
+                <Tag type={totalTestsRunTimeChange > 0 ? 'error' : 'success'}>
+                  {formatPercentRate(totalTestsRunTimeChange)}
+                </Tag>
+              </SummaryEntryValue>
+            </div>
+          </SummaryEntry>
+          <SummaryEntry>
+            <SummaryEntryLabel
+              showUnderline
+              body={<SlowestTestsTooltip slowestTestsDuration={slowestTestsDuration} />}
+            >
+              {t('Slowest Tests')}
+            </SummaryEntryLabel>
+            <SummaryEntryValueLink filterBy="slowest_tests">
+              {slowestTests}
+            </SummaryEntryValueLink>
+          </SummaryEntry>
+        </SummaryEntries>
+      </PanelBody>
+    </CIEfficiencyPanel>
+  );
+}
+
+const CIEfficiencyPanel = styled(Panel)`
+  grid-column: span 24;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    grid-column: span 9;
+  }
+`;

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
@@ -21,7 +21,7 @@ function TotalTestsRunTimeTooltip() {
     <Fragment>
       <p>
         <ToolTipTitle>Impact:</ToolTipTitle>
-        The cumulative CI time spent running tests over the last 30 days.
+        The cumulative CI time spent running tests over the last <strong>30 days</strong>.
       </p>
       <p>
         <ToolTipTitle>What is it:</ToolTipTitle>
@@ -40,7 +40,8 @@ function SlowestTestsTooltip({slowestTestsDuration}: SlowestTestsTooltipProps) {
     <Fragment>
       <p>
         <ToolTipTitle>Impact:</ToolTipTitle>
-        The slowest 100 tests take {formatTimeDuration(slowestTestsDuration)} to run.
+        The slowest 100 tests take{' '}
+        <strong>{formatTimeDuration(slowestTestsDuration)}</strong> to run.
       </p>
       <p>
         <ToolTipTitle>What is it:</ToolTipTitle>

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
@@ -9,6 +9,7 @@ import {
   SummaryEntryValueLink,
 } from 'sentry/components/codecov/summary';
 import {Tag} from 'sentry/components/core/badge/tag';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -54,49 +55,63 @@ const ToolTipTitle = styled('strong')`
   display: block;
 `;
 
-interface CIEfficiencyProps {
+interface CIEfficiencyBodyProps {
   slowestTests: number;
   slowestTestsDuration: number;
   totalTestsRunTime: number;
   totalTestsRunTimeChange: number;
 }
 
-export function CIEfficiency({
-  slowestTests,
-  slowestTestsDuration,
+function CIEfficiencyBody({
   totalTestsRunTime,
   totalTestsRunTimeChange,
-}: CIEfficiencyProps) {
+  slowestTestsDuration,
+  slowestTests,
+}: CIEfficiencyBodyProps) {
+  return (
+    <SummaryEntries largeColumnSpan={2} smallColumnSpan={1}>
+      <SummaryEntry>
+        <SummaryEntryLabel showUnderline body={<TotalTestsRunTimeTooltip />}>
+          {t('Total Tests Run Time')}
+        </SummaryEntryLabel>
+        <div>
+          <SummaryEntryValue>
+            {formatTimeDuration(totalTestsRunTime)}
+            <Tag type={totalTestsRunTimeChange > 0 ? 'error' : 'success'}>
+              {formatPercentRate(totalTestsRunTimeChange)}
+            </Tag>
+          </SummaryEntryValue>
+        </div>
+      </SummaryEntry>
+      <SummaryEntry>
+        <SummaryEntryLabel
+          showUnderline
+          body={<SlowestTestsTooltip slowestTestsDuration={slowestTestsDuration} />}
+        >
+          {t('Slowest Tests')}
+        </SummaryEntryLabel>
+        <SummaryEntryValueLink filterBy="slowest_tests">
+          {slowestTests}
+        </SummaryEntryValueLink>
+      </SummaryEntry>
+    </SummaryEntries>
+  );
+}
+
+interface CIEfficiencyProps {
+  isLoading: boolean;
+  slowestTests: number;
+  slowestTestsDuration: number;
+  totalTestsRunTime: number;
+  totalTestsRunTimeChange: number;
+}
+
+export function CIEfficiency({isLoading, ...bodyProps}: CIEfficiencyProps) {
   return (
     <CIEfficiencyPanel>
       <PanelHeader>{t('CI Efficiency')}</PanelHeader>
       <PanelBody>
-        <SummaryEntries largeColumnSpan={2} smallColumnSpan={1}>
-          <SummaryEntry>
-            <SummaryEntryLabel showUnderline body={<TotalTestsRunTimeTooltip />}>
-              {t('Total Tests Run Time')}
-            </SummaryEntryLabel>
-            <div>
-              <SummaryEntryValue>
-                {formatTimeDuration(totalTestsRunTime)}
-                <Tag type={totalTestsRunTimeChange > 0 ? 'error' : 'success'}>
-                  {formatPercentRate(totalTestsRunTimeChange)}
-                </Tag>
-              </SummaryEntryValue>
-            </div>
-          </SummaryEntry>
-          <SummaryEntry>
-            <SummaryEntryLabel
-              showUnderline
-              body={<SlowestTestsTooltip slowestTestsDuration={slowestTestsDuration} />}
-            >
-              {t('Slowest Tests')}
-            </SummaryEntryLabel>
-            <SummaryEntryValueLink filterBy="slowest_tests">
-              {slowestTests}
-            </SummaryEntryValueLink>
-          </SummaryEntry>
-        </SummaryEntries>
+        {isLoading ? <LoadingIndicator /> : <CIEfficiencyBody {...bodyProps} />}
       </PanelBody>
     </CIEfficiencyPanel>
   );

--- a/static/app/views/codecov/tests/summaries/summaries.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/summaries.spec.tsx
@@ -1,0 +1,12 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Summaries} from 'sentry/views/codecov/tests/summaries/summaries';
+
+describe('Summaries', () => {
+  it('renders the CIEfficiency component', () => {
+    render(<Summaries />);
+
+    const ciEfficiencyPanel = screen.getByText('CI Efficiency');
+    expect(ciEfficiencyPanel).toBeInTheDocument();
+  });
+});

--- a/static/app/views/codecov/tests/summaries/summaries.tsx
+++ b/static/app/views/codecov/tests/summaries/summaries.tsx
@@ -11,7 +11,7 @@ const testCIEfficiencyData = {
 export function Summaries() {
   return (
     <SummaryContainer columns={24}>
-      <CIEfficiency {...testCIEfficiencyData} />
+      <CIEfficiency {...testCIEfficiencyData} isLoading={false} />
     </SummaryContainer>
   );
 }

--- a/static/app/views/codecov/tests/summaries/summaries.tsx
+++ b/static/app/views/codecov/tests/summaries/summaries.tsx
@@ -1,0 +1,17 @@
+import {SummaryContainer} from 'sentry/components/codecov/summary';
+import {CIEfficiency} from 'sentry/views/codecov/tests/summaries/ciEfficiency';
+
+const testCIEfficiencyData = {
+  totalTestsRunTime: 12300000,
+  totalTestsRunTimeChange: 0.46,
+  slowestTests: 100,
+  slowestTestsDuration: 10000,
+};
+
+export function Summaries() {
+  return (
+    <SummaryContainer columns={24}>
+      <CIEfficiency {...testCIEfficiencyData} />
+    </SummaryContainer>
+  );
+}

--- a/static/app/views/codecov/tests/tests.tsx
+++ b/static/app/views/codecov/tests/tests.tsx
@@ -4,6 +4,7 @@ import {DatePicker} from 'sentry/components/codecov/datePicker/datePicker';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {space} from 'sentry/styles/space';
+import {Summaries} from 'sentry/views/codecov/tests/summaries/summaries';
 
 const DEFAULT_CODECOV_DATETIME_SELECTION = {
   start: null,
@@ -23,6 +24,7 @@ export default function TestsPage() {
           <DatePicker />
         </PageFilterBar>
       </PageFiltersContainer>
+      <Summaries />
     </LayoutGap>
   );
 }


### PR DESCRIPTION
This PR adds in some helpful formatter utils for our summary panels that we'll be adding in to the various Codecov pages. As well, this PR adds in the CI efficiency panel for the test analytics page. 

![Screenshot 2025-04-29 at 14 23 21](https://github.com/user-attachments/assets/adc42cda-4096-49fd-a249-774d440a3c05)