### PR TITLE
chore(devservices): Add label to devservices containers

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -129,6 +129,8 @@ services:
       - devservices
     extra_hosts:
       - host.docker.internal:host-gateway
+    labels:
+      - orchestrator=devservices
   redis-cluster:
     image: ghcr.io/getsentry/docker-redis-cluster:7.0.10
     ports:
@@ -144,6 +146,8 @@ services:
       - host.docker.internal:host-gateway
     environment:
       - IP=0.0.0.0
+    labels:
+      - orchestrator=devservices
   rabbitmq:
     image: ghcr.io/getsentry/image-mirror-library-rabbitmq:3-management
     ports:
@@ -155,6 +159,8 @@ services:
       - host.docker.internal:host-gateway
     environment:
       - IP=0.0.0.0
+    labels:
+      - orchestrator=devservices
   memcached:
     image: ghcr.io/getsentry/image-mirror-library-memcached:1.5-alpine
     ports:
@@ -163,6 +169,8 @@ services:
       - devservices
     extra_hosts:
       - host.docker.internal:host-gateway
+    labels:
+      - orchestrator=devservices
   spotlight:
     image: ghcr.io/getsentry/spotlight:latest
     healthcheck:


### PR DESCRIPTION
This label is needed in order for purging the containers to work properly