### PR TITLE
fix(tests) Make quota test less flaky

### DIFF
--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from sentry import options
@@ -15,14 +17,17 @@ class QuotaTest(TestCase):
     def setUp(self):
         self.backend = Quota()
 
-    @pytest.mark.skip(reason="This test flakes often")
     def test_get_project_quota(self):
         org = self.create_organization()
         project = self.create_project(organization=org)
         # Read option to prime cache and make query count consistent
         options.get("taskworker.relay.rollout")
 
-        with self.assertNumQueries(7), self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0):
+        with (
+            self.assertNumQueries(5),
+            self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0),
+            mock.patch.object(OrganizationOption.objects, "reload_cache") as mock_reload_cache,
+        ):
             with self.options({"system.rate-limit": 0}):
                 assert self.backend.get_project_quota(project) == (None, 60)
 
@@ -33,6 +38,8 @@ class QuotaTest(TestCase):
 
             with self.options({"system.rate-limit": 0}):
                 assert self.backend.get_project_quota(project) == (None, 60)
+
+            assert mock_reload_cache.called
 
     def test_get_key_quota(self):
         key = ProjectKey.objects.create(


### PR DESCRIPTION
Remove the skip, and the source of non-deterministic queries. Setting an org option will trigger a cache rebuild for project config. Sometimes this will emit an additional db query if the option value has not already been cached. Mocking the reload_cache method should eliminate the option queries and make the test more consistent.