### PR TITLE
chore(schema-hints): Clean up test with new router configs

### DIFF
--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -31,11 +31,6 @@ jest.mock('sentry/components/searchQueryBuilder/context', () => ({
   SearchQueryBuilderProvider: ({children}: {children: React.ReactNode}) => children,
 }));
 
-const searchQueryBuilderModule = jest.requireMock(
-  'sentry/components/searchQueryBuilder/context'
-);
-const originalUseSearchQueryBuilder = searchQueryBuilderModule.useSearchQueryBuilder;
-
 function Subject(
   props: Omit<
     Parameters<typeof SchemaHintsList>[0],
@@ -87,10 +82,6 @@ jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(fu
 describe('SchemaHintsList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    searchQueryBuilderModule.useSearchQueryBuilder = originalUseSearchQueryBuilder;
   });
 
   it('should render', () => {
@@ -287,12 +278,17 @@ describe('SchemaHintsList', () => {
   });
 
   it('should set focus override propely on duplicate filters', async () => {
-    searchQueryBuilderModule.useSearchQueryBuilder = () => ({
-      query: 'stringTag1:"something"',
-      getTagValues: () => Promise.resolve(['tagValue1', 'tagValue2']),
-      dispatch: mockDispatch,
-      wrapperRef: {current: null},
-    });
+    const mockUseSearchQueryBuilder = jest
+      .spyOn(
+        require('sentry/components/searchQueryBuilder/context'),
+        'useSearchQueryBuilder'
+      )
+      .mockImplementation(() => ({
+        query: 'stringTag1:"something"',
+        getTagValues: () => Promise.resolve(['tagValue1', 'tagValue2']),
+        dispatch: mockDispatch,
+        wrapperRef: {current: null},
+      }));
 
     render(
       <Subject
@@ -313,5 +309,7 @@ describe('SchemaHintsList', () => {
         part: 'value',
       },
     });
+
+    mockUseSearchQueryBuilder.mockRestore();
   });
 });

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import type {TagCollection} from 'sentry/types/group';
@@ -86,15 +85,6 @@ jest.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(fu
 });
 
 describe('SchemaHintsList', () => {
-  const {organization, router} = initializeOrg({
-    router: {
-      location: {
-        query: {
-          query: '',
-        },
-      },
-    },
-  });
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -171,12 +161,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -199,12 +184,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -232,23 +212,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-
-        router: {
-          ...router,
-          location: {
-            ...router.location,
-            query: {
-              query: '!stringTag1:"" numberTag1:>0',
-              field: ['stringTag1', 'numberTag1'],
-            },
-          },
-        },
-
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -269,16 +233,19 @@ describe('SchemaHintsList', () => {
   });
 
   it('should keep drawer open when query is updated', async () => {
-    render(
+    const {router} = render(
       <Subject
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
       />,
       {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: {
+          location: {
+            pathname: '/test/path',
+            query: {query: ''},
+          },
+        },
       }
     );
 
@@ -289,9 +256,9 @@ describe('SchemaHintsList', () => {
     const stringTag1Checkbox = withinDrawer.getByText('stringTag1');
     await userEvent.click(stringTag1Checkbox);
 
-    router.push({
-      ...router.location,
-      query: {query: '!stringTag1:""'},
+    router.navigate({
+      pathname: '/test/path',
+      search: '?query=stringTag1:""',
     });
 
     expect(screen.getByLabelText('Schema Hints Drawer')).toBeInTheDocument();
@@ -303,12 +270,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-        router,
-        deprecatedRouterMocks: true,
-      }
+      />
     );
 
     const seeFullList = screen.getByText('See full list');
@@ -337,10 +299,7 @@ describe('SchemaHintsList', () => {
         stringTags={mockStringTags}
         numberTags={mockNumberTags}
         supportedAggregates={[]}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     const stringTag1Hint = screen.getByText('stringTag1');

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -1702,7 +1702,9 @@ describe('trace view', () => {
       await assertHighlightedRowAtIndex(container, 1);
     });
 
-    it('clicking a row that is also a search result updates the result index', async () => {
+    // TODO Abdullah Khan: This is flaky, and when it flakes it takes over 90s to run
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('clicking a row that is also a search result updates the result index', async () => {
       const {container, virtualizedContainer} = await searchTestSetup();
 
       const searchInput = await screen.findByPlaceholderText('Search in trace');
@@ -2002,7 +2004,9 @@ describe('trace view', () => {
       });
     });
 
-    it('clicking a node that is already open in a tab switches to that tab and persists the previous node', async () => {
+    // TODO Abdullah Khan: This is flaky, and when it flakes it takes over 90s to run
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('clicking a node that is already open in a tab switches to that tab and persists the previous node', async () => {
       const {virtualizedContainer} = await simpleTestSetup();
       const rows = getVirtualizedRows(virtualizedContainer);
       expect(screen.queryAllByTestId(DRAWER_TABS_TEST_ID)).toHaveLength(0);


### PR DESCRIPTION
let's try this again :) The router prop in render has been deprecated so I've changed it accordingly to use the new initialRouterConfig. Also turns out a lot of these tests didn't need the router prop anymore 🤩. Just a bunch of cleanup in this test file.