### PR TITLE
fix(taskworker) Catch parameter errors in testing more easily

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -726,9 +726,6 @@ from kombu import Exchange, Queue
 BROKER_URL = "redis://127.0.0.1:6379"
 BROKER_TRANSPORT_OPTIONS: dict[str, int] = {}
 
-# Ensure workers run async by default
-# in Development you might want them to run in-process
-TASK_WORKER_ALWAYS_EAGER = False
 
 # Ensure workers run async by default
 # in Development you might want them to run in-process
@@ -1385,6 +1382,10 @@ BGTASKS: dict[str, BgTaskConfig] = {
 #######################
 # Taskworker settings #
 #######################
+
+# If true, tasks will be run immediately.
+# Used primarily in tests.
+TASKWORKER_ALWAYS_EAGER = False
 
 # Shared secrets used to sign RPC requests to taskbrokers
 # The first secret is used for signing.

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -17,7 +17,7 @@ def TaskRunner() -> Generator[None]:
     prev = settings.CELERY_ALWAYS_EAGER
     settings.CELERY_ALWAYS_EAGER = True
     current_app.conf.CELERY_ALWAYS_EAGER = True
-    with mock.patch.object(settings, "TASK_WORKER_ALWAYS_EAGER", True):
+    with mock.patch.object(settings, "TASKWORKER_ALWAYS_EAGER", True):
         try:
             yield
         finally:

--- a/tests/sentry/taskworker/test_task.py
+++ b/tests/sentry/taskworker/test_task.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -109,6 +110,31 @@ def test_delay_taskrunner_immediate_mode(task_namespace: TaskNamespace) -> None:
     assert calls[0] == {"args": ("arg",), "kwargs": {"org_id": 1}}
     assert calls[1] == {"args": ("arg2",), "kwargs": {"org_id": 2}}
     assert calls[2] == {"args": tuple(), "kwargs": {}}
+
+
+def test_delay_taskrunner_immediate_validate_activation(task_namespace: TaskNamespace) -> None:
+    calls = []
+
+    def test_func(mixed: Any) -> None:
+        calls.append({"mixed": mixed})
+
+    task = Task(
+        name="test.test_func",
+        func=test_func,
+        namespace=task_namespace,
+    )
+
+    with TaskRunner():
+        task.delay(mixed=None)
+        task.delay(mixed="str")
+
+        with pytest.raises(TypeError) as err:
+            task.delay(mixed=datetime.timedelta(days=1))
+            assert "not JSON serializable" in str(err)
+
+    assert len(calls) == 2
+    assert calls[0] == {"mixed": None}
+    assert calls[1] == {"mixed": "str"}
 
 
 def test_should_retry(task_namespace: TaskNamespace) -> None:


### PR DESCRIPTION
Should a task use parameters that cannot be JSON serialized, we should identify those problems in CI, instead of in production.