### PR TITLE
fix(autofix): Track first user in org to setup seer

### DIFF
--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -78,6 +78,10 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
           disabled={autofixAcknowledgeMutation.isPending}
           analyticsEventKey="gen_ai_consent.in_drawer_clicked"
           analyticsEventName="Gen AI Consent: Clicked In Drawer"
+          analyticsParams={{
+            is_first_user_in_org:
+              !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged,
+          }}
           size="sm"
         >
           {autofixAcknowledgeMutation.isPending ? (


### PR DESCRIPTION
`is_first_user_in_org` is true if they are the first user in the org to setup seer
