### PR TITLE
fix(eap): Meta tier defaults to unspecified

### DIFF
--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -138,14 +138,4 @@ def can_expose_attribute(attribute: str, item_type: SupportedTraceItemType) -> b
 
 
 def handle_downsample_meta(meta: DownsampledStorageMeta) -> bool:
-    if (
-        meta.tier
-        in {
-            DownsampledStorageMeta.SELECTED_TIER_1,
-            DownsampledStorageMeta.SELECTED_TIER_UNSPECIFIED,
-        }
-        or not meta.can_go_to_higher_accuracy_tier
-    ):
-        return True
-    else:
-        return False
+    return not meta.can_go_to_higher_accuracy_tier


### PR DESCRIPTION
The default value is unspecified so the condition was always evaluating to True.