### PR TITLE
chore: Use metricsEnhanced, address SENTRY-3T7B

### DIFF
--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -112,7 +112,7 @@ def make_rpc_request(
 def make_snql_request(
     query: str,
     aggregate: str,
-    granumarity_secs: int,
+    granularity_secs: int,
     on_demand_metrics_enabled: bool,
     snuba_params: SnubaParams,
     organization: Organization,
@@ -123,7 +123,7 @@ def make_snql_request(
         [aggregate],
         query,
         snuba_params=snuba_params,
-        rollup=granumarity_secs,
+        rollup=granularity_secs,
         referrer=Referrer.JOB_COMPARE_TIMESERIES.value,
         on_demand_metrics_enabled=on_demand_metrics_enabled,
         on_demand_metrics_type=MetricSpecType.SIMPLE_QUERY,

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -320,7 +320,7 @@ def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
     organization = Organization.objects.get_from_cache(id=project.organization_id)
 
     sentry_sdk.set_tag("organization", organization.slug)
-    sentry_sdk.set_extra("alert_id", alert_rule.id)
+    sentry_sdk.set_tag("alert_id", alert_rule.id)
 
     on_demand_metrics_enabled = features.has(
         "organizations:on-demand-metrics-extraction",


### PR DESCRIPTION
rename time_window -> granularity_secs so it's not confusing
fixes SENTRY-3T7B