### PR TITLE
chore(shared-views): fix alignment of sort save container

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -123,7 +123,7 @@ const StyledPageFilterBar = styled(PageFilterBar)`
 
 const SortSaveContainer = styled('div')`
   display: flex;
-  align-items: center;
+  align-items: start;
   gap: ${space(1)};
   grid-area: sort-save;
 


### PR DESCRIPTION
Before: 

<img width="900" alt="image" src="https://github.com/user-attachments/assets/366c4804-0017-4475-a5d2-cecb440f0620" />


After:

<img width="904" alt="image" src="https://github.com/user-attachments/assets/33c2bec8-493b-47f4-b996-a2ddd6f9787a" />

(look at the right side) 
