### PR TITLE
chore(shared-views): Register flag to enforce stacked side navigation

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -450,6 +450,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:visibility-explore-tabs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable explore multi query page
     manager.add("organizations:explore-multi-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enforce stacked navigation feature (with ability to opt out)
+    manager.add("organizations:enforce-stacked-navigation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable dual writing for issue alert issues (see: alerts create issues)
     manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow processing for metric issues


### PR DESCRIPTION
Registers the `enforce-stacked-navigation` flag. Created in flagpole [here](https://github.com/getsentry/sentry-options-automator/pull/3731) 