### PR TITLE
fix(explore): Use old confidence footer for normal mode

### DIFF
--- a/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
+++ b/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
@@ -35,7 +35,10 @@ export function WidgetExtrapolationFooter({
   const organization = useOrganization();
   if (
     !organization.features.includes('visibility-explore-progressive-loading') ||
-    ![DiscoverDatasets.SPANS_EAP, DiscoverDatasets.SPANS_EAP_RPC].includes(dataset)
+    ![DiscoverDatasets.SPANS_EAP, DiscoverDatasets.SPANS_EAP_RPC].includes(dataset) ||
+    organization.features.includes(
+      'visibility-explore-progressive-loading-normal-sampling-mode'
+    )
   ) {
     return (
       <ConfidenceFooter


### PR DESCRIPTION
We don't want the loaders or icons with the extrapolation message in Explore. We can just use the confidence footer plainly.