### PR TITLE
fix(ui): make finalizeReleaseButton smaller in chonk

### DIFF
--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
@@ -29,6 +30,7 @@ type Props = {
 };
 
 function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
+  const theme = useTheme();
   const organization = useOrganization();
   const orgSlug = organization.slug;
 
@@ -92,7 +94,7 @@ function ProjectReleaseDetails({release, releaseMeta, projectSlug}: Props) {
                     )}
                   >
                     <Button
-                      size="xs"
+                      size={theme.isChonk ? 'zero' : 'xs'}
                       onClick={() => {
                         finalizeRelease.mutate([release], {
                           onSettled() {


### PR DESCRIPTION
as it doesn't fit the line properly

before:
![Screenshot 2025-04-30 at 10 46 09](https://github.com/user-attachments/assets/6eb749ff-7223-4295-98c8-03ba0ef1be55)

after:
![Screenshot 2025-04-30 at 10 45 52](https://github.com/user-attachments/assets/5cc739ce-05be-43a3-a79d-cfd45030ac70)

note that I didn’t change the current theme, as a `zero` button has a larger font-size than a `sm` button (why?) and that looked weird.
