### PR TITLE
fix(ui): use a lighter color for overviewRow animation

### DIFF
--- a/static/app/components/checkInTimeline/checkInPlaceholder.tsx
+++ b/static/app/components/checkInTimeline/checkInPlaceholder.tsx
@@ -41,10 +41,10 @@ const AnimatedGradient = styled('div')`
   height: 100%;
   background-image: linear-gradient(
     90deg,
-    ${p => p.theme.border} 0%,
+    ${p => p.theme.tokens.content.muted} 0%,
     rgba(255, 255, 255, 0) 20%,
     rgba(255, 255, 255, 0) 80%,
-    ${p => p.theme.border} 100%
+    ${p => p.theme.tokens.content.muted} 100%
   );
   background-size: 200% 100%;
   animation: ${gradientAnimation} 2s linear infinite;


### PR DESCRIPTION
after (old theme):
![Screenshot 2025-04-30 at 14 18 27](https://github.com/user-attachments/assets/b995f71a-38e7-49e0-819b-d4f48cfb54f7)

after (chonk theme):

![Screenshot 2025-04-30 at 14 20 29](https://github.com/user-attachments/assets/7509bc80-c4fa-4a9e-9df0-8927522e3249)
