### PR TITLE
fix(insights): Improving recommended issues header optics

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -1,7 +1,6 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -114,12 +113,6 @@ const IssuesContainer = styled('div')`
     min-width: 0;
     overflow-y: auto;
     margin-bottom: 0 !important;
-  }
-
-  & ${PanelHeader} {
-    position: sticky;
-    top: 0;
-    z-index: ${p => p.theme.zIndex.header};
   }
 `;
 

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -1,7 +1,6 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -116,12 +115,6 @@ const IssuesContainer = styled('div')`
     min-width: 0;
     overflow-y: auto;
     margin-bottom: 0 !important;
-  }
-
-  & ${PanelHeader} {
-    position: sticky;
-    top: 0;
-    z-index: ${p => p.theme.zIndex.header};
   }
 `;
 

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -242,13 +242,15 @@ class IssuesGroupList extends Component<Props, State> {
     return (
       <Fragment>
         <PanelContainer>
-          <SuperHeader disablePadding>
-            <SuperHeaderLabel hideDivider>{t('Recommended Issues')}</SuperHeaderLabel>
-            <LinkButton to={this.getIssuesUrl(queryParams)} size="xs">
-              All Issues
-            </LinkButton>
-          </SuperHeader>
-          <GroupListHeader withChart={!!withChart} withColumns={columns} />
+          <HeaderContainer>
+            <SuperHeader disablePadding>
+              <SuperHeaderLabel hideDivider>{t('Recommended Issues')}</SuperHeaderLabel>
+              <LinkButton to={this.getIssuesUrl(queryParams)} size="xs">
+                All Issues
+              </LinkButton>
+            </SuperHeader>
+            <GroupListHeader withChart={!!withChart} withColumns={columns} />
+          </HeaderContainer>
           <PanelBody>
             {loading
               ? [
@@ -313,6 +315,9 @@ const SuperHeaderLabel = styled(IssueStreamHeaderLabel)`
 const SuperHeader = styled(PanelHeader)`
   background-color: ${p => p.theme.headerBackground};
   padding: ${space(1)};
+`;
+
+const HeaderContainer = styled('div')`
   position: sticky;
   top: 0;
   z-index: 1001;

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -302,13 +302,20 @@ const PanelContainer = styled(Panel)`
 `;
 
 const SuperHeaderLabel = styled(IssueStreamHeaderLabel)`
+  color: ${p => p.theme.headingColor};
+  font-size: 1rem;
+  line-height: 1.2;
   padding-left: ${space(1)};
   text-transform: capitalize;
+  font-weight: ${p => p.theme.fontWeightBold};
 `;
 
 const SuperHeader = styled(PanelHeader)`
-  background: ${p => p.theme.background};
+  background-color: ${p => p.theme.headerBackground};
   padding: ${space(1)};
+  position: sticky;
+  top: 0;
+  z-index: 1001;
 `;
 
 export function IssuesWidget({query = ''}: {query?: string}) {

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -320,7 +320,7 @@ const SuperHeader = styled(PanelHeader)`
 const HeaderContainer = styled('div')`
   position: sticky;
   top: 0;
-  z-index: ${p => p.theme.zIndex.header};;
+  z-index: ${p => p.theme.zIndex.header};
 `;
 
 export function IssuesWidget({query = ''}: {query?: string}) {

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -320,7 +320,7 @@ const SuperHeader = styled(PanelHeader)`
 const HeaderContainer = styled('div')`
   position: sticky;
   top: 0;
-  z-index: 1001;
+  z-index: ${p => p.theme.zIndex.header};;
 `;
 
 export function IssuesWidget({query = ''}: {query?: string}) {


### PR DESCRIPTION
Making it sticky, overriding the table header stickyness.
Improving font.

Closes https://linear.app/getsentry/issue/TET-352/issues-table-recommended-issues-should-be-more-prominent-larger-darker
Closes https://linear.app/getsentry/issue/TET-351/issues-table-header-should-stay-fixed

<img width="1071" alt="Bildschirmfoto 2025-04-30 um 14 50 08" src="https://github.com/user-attachments/assets/f95fae2a-d771-4673-9568-8180bf4cbcfa" />


https://github.com/user-attachments/assets/727838a1-a7a1-4798-b7f8-991ef465d136

