### PR TITLE
fix(explore): Add loading indicator messaging

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -19,6 +19,7 @@ import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingM
 import {useChartZoom} from 'sentry/components/charts/useChartZoom';
 import {isChartHovered, truncationFormatter} from 'sentry/components/charts/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {space} from 'sentry/styles/space';
 import type {
   EChartClickHandler,
   EChartDataZoomHandler,
@@ -639,11 +640,24 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   );
 }
 
-function LoadingPanel() {
+function LoadingPanel({
+  loadingMessage,
+  expectMessage,
+}: {
+  // If we expect that a message will be provided, we can render a non-visible element that will
+  // be replaced with the message to prevent layout shift.
+  expectMessage?: boolean;
+  loadingMessage?: string;
+}) {
   return (
     <LoadingPlaceholder>
       <LoadingMask visible />
       <LoadingIndicator mini />
+      {(expectMessage || loadingMessage) && (
+        <LoadingMessage visible={Boolean(loadingMessage)}>
+          {loadingMessage}
+        </LoadingMessage>
+      )}
     </LoadingPlaceholder>
   );
 }
@@ -694,8 +708,15 @@ const LoadingPlaceholder = styled('div')`
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
+  gap: ${space(1)};
 
   padding: ${Y_GUTTER} ${X_GUTTER};
+`;
+
+const LoadingMessage = styled('div')<{visible: boolean}>`
+  opacity: ${p => (p.visible ? 1 : 0)};
+  height: ${p => p.theme.fontSizeSmall};
 `;
 
 const LoadingMask = styled(TransparentLoadingMask)`

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -29,7 +29,10 @@ import type {
   Visualize,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
-import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {
+  SAMPLING_MODE,
+  type SamplingMode,
+} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {CHART_HEIGHT, INGESTION_DELAY} from 'sentry/views/explore/settings';
 import {
@@ -200,12 +203,27 @@ export function ExploreCharts({
           );
 
           if (chartInfo.loading) {
+            const loadingMessage =
+              organization.features.includes(
+                'visibility-explore-progressive-loading-normal-sampling-mode'
+              ) &&
+              timeseriesResult.isFetching &&
+              samplingMode === SAMPLING_MODE.HIGH_ACCURACY
+                ? t(
+                    "Hey, we're gonna try scanning all data we can to get your query answered so just wait a bit more"
+                  )
+                : undefined;
             return (
               <Widget
                 key={index}
                 height={CHART_HEIGHT}
                 Title={Title}
-                Visualization={<TimeSeriesWidgetVisualization.LoadingPlaceholder />}
+                Visualization={
+                  <TimeSeriesWidgetVisualization.LoadingPlaceholder
+                    loadingMessage={loadingMessage}
+                    expectMessage
+                  />
+                }
                 revealActions="always"
                 Footer={
                   organization.features.includes(


### PR DESCRIPTION
Adds some parameters to define a loading message. Since I want to prevent some layout shift, I added a non-visible element that can be rendered below the loading spinner, then the message becomes visible when it's passed down.

<img width="1127" alt="Screenshot 2025-04-30 at 11 17 13 AM" src="https://github.com/user-attachments/assets/910bb74d-60ef-4a4d-988f-7c6b515fba27" />

Closes EXP-190