### PR TITLE
:sparkles: feat(cursor): add cursor rule for python tests

### DIFF
--- a/.cursor/rules/python_tests.mdc
+++ b/.cursor/rules/python_tests.mdc
@@ -1,0 +1,27 @@
+---
+description: Guidelines for writing python tests
+globs: tests/**/*.py,**/test_*.py
+alwaysApply: false
+---
+
+# Python tests
+
+
+## Use factories instead of directly calling `Model.objects.create`
+
+In Sentry Python tests, prefer using factory methods from `sentry.testutils.factories.Factories` @factories.py or fixture methods (e.g., `self.create_model`) provided by base classes like `sentry.testutils.fixtures.Fixtures` @fixtures.py  instead of directly calling `Model.objects.create`. This promotes consistency, reduces boilerplate, and leverages shared test setup logic defined in the factories.
+
+For example, a diff that uses a fixture instead of the directly calling `Model.objects.create`  would look like:
+
+```diff
+    -        direct_project = Project.objects.create(
+    -            organization=self.organization,
+    -            name="Directly Created",
+    -            slug="directly-created"
+    -        )
+    +        direct_project = self.create_project(
+    +            organization=self.organization,
+    +            name="Directly Created",
+    +            slug="directly-created" # Note: Ensure factory args match
+    +        )
+```


### PR DESCRIPTION
cursor has been pretty useful when generating boilerplate for tests. 

one pet-peeve i have with some of the tests it makes is it prefers to use the model itself when creating an instance. 

this is not a pattern we use often in our codebase and makes things more brittle as the fixtures we have let us abstract silo boundaries as an example.

this rules tries to encourage the agent to use the fixtures we have defined when it can