### PR TITLE
feat(insights): update eap overview table to link to transaction summary

### DIFF
--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -17,6 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {EAPSpanResponse} from 'sentry/views/insights/types';
 
 type Row = Pick<
@@ -190,6 +191,16 @@ function renderBodyCell(
 ) {
   if (!meta?.fields) {
     return row[column.key];
+  }
+
+  if (column.key === 'transaction') {
+    return (
+      <TransactionCell
+        project={row.project}
+        transaction={row.transaction}
+        transactionMethod={row['span.op']}
+      />
+    );
   }
 
   const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -17,6 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {EAPSpanResponse} from 'sentry/views/insights/types';
 
 type Row = Pick<
@@ -182,6 +183,16 @@ function renderBodyCell(
 ) {
   if (!meta?.fields) {
     return row[column.key];
+  }
+
+  if (column.key === 'transaction') {
+    return (
+      <TransactionCell
+        project={row.project}
+        transaction={row.transaction}
+        transactionMethod={row['span.op']}
+      />
+    );
   }
 
   const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -17,6 +17,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {EAPSpanResponse} from 'sentry/views/insights/types';
 
 type Row = Pick<
@@ -182,6 +183,16 @@ function renderBodyCell(
 ) {
   if (!meta?.fields) {
     return row[column.key];
+  }
+
+  if (column.key === 'transaction') {
+    return (
+      <TransactionCell
+        project={row.project}
+        transaction={row.transaction}
+        transactionMethod={row['span.op']}
+      />
+    );
   }
 
   const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/insights/pages/transactionCell.tsx
+++ b/static/app/views/insights/pages/transactionCell.tsx
@@ -1,0 +1,55 @@
+import * as qs from 'query-string';
+
+import Link from 'sentry/components/links/link';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {generateTransactionSummaryRoute} from 'sentry/views/performance/transactionSummary/utils';
+
+interface Props {
+  project?: string;
+  transaction?: string;
+  transactionMethod?: string;
+}
+
+export function TransactionCell({project, transaction, transactionMethod}: Props) {
+  const projects = useProjects();
+  const organization = useOrganization();
+  const location = useLocation();
+  const {view} = useDomainViewFilters();
+
+  const projectId = projects.projects.find(p => p.slug === project)?.id;
+
+  const searchQuery = new MutableSearch('');
+  if (transactionMethod) {
+    searchQuery.addFilterValue('transaction.op', transactionMethod);
+  }
+
+  if (!transaction || !projectId) {
+    return NULL_DESCRIPTION;
+  }
+
+  const pathname = generateTransactionSummaryRoute({
+    organization,
+    view,
+  });
+
+  const query = {
+    project: projectId,
+    transaction,
+    query: searchQuery.formatString(),
+    referrer: `insights-${view}-overview`,
+    ...location.query,
+  };
+
+  return (
+    <OverflowEllipsisTextContainer>
+      <Link to={`${pathname}/?${qs.stringify(query)}`}>{transaction}</Link>
+    </OverflowEllipsisTextContainer>
+  );
+}
+
+const NULL_DESCRIPTION = <span>&lt;null&gt;</span>;


### PR DESCRIPTION
The eap overview table now has a transaction body cell which links to the transaction summary, before it displayed as plain text.
![image](https://github.com/user-attachments/assets/f64823b8-91d4-40e9-856e-95eb1c8ff136)
