### PR TITLE
fix(taskworker): Pass report_id to user report task

### DIFF
--- a/src/sentry/models/userreport.py
+++ b/src/sentry/models/userreport.py
@@ -32,14 +32,9 @@ class UserReport(Model):
     __repr__ = sane_repr("event_id", "name", "email")
 
     def notify(self):
-        from django.contrib.auth.models import AnonymousUser
-
-        from sentry.api.serializers import UserReportWithGroupSerializer, serialize
         from sentry.tasks.user_report import user_report
-
-        report = serialize(self, AnonymousUser(), UserReportWithGroupSerializer())
 
         user_report.delay(
             project_id=self.project_id,
-            report=report,
+            report=self.id,
         )

--- a/src/sentry/models/userreport.py
+++ b/src/sentry/models/userreport.py
@@ -36,5 +36,5 @@ class UserReport(Model):
 
         user_report.delay(
             project_id=self.project_id,
-            report=self.id,
+            report_id=self.id,
         )


### PR DESCRIPTION
Now that the user report tasks support report_id: https://github.com/getsentry/sentry/pull/90535. Update the callsite to pass id instead of pickle object.