### PR TITLE
fix(ourlogs): Remove unused flexbox causing width problems

### DIFF
--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -47,7 +47,7 @@ import {
   DetailsContent,
   DetailsWrapper,
   getLogColors,
-  LogDetailPanelItem,
+  LogAttributeTreeWrapper,
   LogDetailTableBodyCell,
   LogFirstCellContent,
   LogsTableBodyFirstCell,
@@ -315,7 +315,7 @@ function LogRowDetails({
                   },
                 })}
               </DetailsBody>
-              <LogDetailPanelItem>
+              <LogAttributeTreeWrapper>
                 <AttributesTree<RendererExtra>
                   attributes={data.attributes}
                   hiddenAttributes={HiddenLogDetailFields}
@@ -332,7 +332,7 @@ function LogRowDetails({
                     theme,
                   }}
                 />
-              </LogDetailPanelItem>
+              </LogAttributeTreeWrapper>
             </DetailsContent>
           </Fragment>
         )}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -5,7 +5,6 @@ import {Button} from 'sentry/components/core/button';
 import {GRID_BODY_ROW_HEIGHT} from 'sentry/components/gridEditable/styles';
 import {HighlightComponent} from 'sentry/components/highlight';
 import Panel from 'sentry/components/panels/panel';
-import PanelItem from 'sentry/components/panels/panelItem';
 import {space} from 'sentry/styles/space';
 import {unreachable} from 'sentry/utils/unreachable';
 import {
@@ -20,11 +19,6 @@ const StyledPanel = styled(Panel)`
   margin-bottom: 0;
 `;
 
-export const LogDetailPanelItem = styled(PanelItem)`
-  padding: ${space(1)} ${space(1)};
-  display: auto;
-`;
-
 export const LogTableRow = styled(TableRow)`
   &:not(thead > &) {
     cursor: pointer;
@@ -37,6 +31,11 @@ export const LogTableRow = styled(TableRow)`
       border-bottom: 0;
     }
   }
+`;
+
+export const LogAttributeTreeWrapper = styled('div')`
+  padding: ${space(1)} ${space(1)};
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
 `;
 
 export const LogTableBodyCell = styled(TableBodyCell)`
@@ -101,7 +100,14 @@ export const LogFirstCellContent = styled('div')`
   align-items: center;
 `;
 
-export const DetailsBody = styled(LogDetailPanelItem)`
+export const DetailsBody = styled('div')`
+  display: flex;
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
   padding: ${space(1)} 0;
   font-family: ${p => p.theme.text.familyMono};
 `;


### PR DESCRIPTION
### Summary
Fixes tree layout problems for log table row (table ref needs to be 100% for column calculation to be correct).

Fixes LOGS-78