### PR TITLE
ref(trace): Add alias for lineno

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -319,6 +319,11 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.sampling_factor",
             search_type="number",
         ),
+        ResolvedAttribute(
+            public_alias="code.lineno",
+            internal_name="code.lineno",
+            search_type="number",
+        ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("device.family"),
         simple_sentry_field("device.arch"),

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -197,6 +197,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
     def test_simple_using_spans_item_type(self):
         span_1 = self.create_span(
             {"description": "foo", "sentry_tags": {"status": "success"}},
+            measurements={"code.lineno": {"value": 420}},
             start_ts=self.one_min_ago,
         )
         span_1["trace_id"] = self.trace_uuid
@@ -208,6 +209,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
         assert trace_details_response.status_code == 200, trace_details_response.content
         assert trace_details_response.data["attributes"] == [
             {"name": "is_segment", "type": "bool", "value": False},
+            {"name": "code.lineno", "type": "float", "value": 420.0},
             {"name": "is_transaction", "type": "float", "value": 0.0},
             {
                 "name": "received",


### PR DESCRIPTION
- Add an alias for lineno so the field doesn't come back as `tags[code.lineno, number]`