### PR TITLE
chore(grouping): Upgrade `sentry-ophio` to 1.1.3

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.21.0
 sentry-kafka-schemas>=1.2.0
-sentry-ophio==1.0.0
+sentry-ophio>=1.1.3
 sentry-protos==0.1.72
 sentry-redis-tools>=0.5.0
 sentry-relay>=0.9.8

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -188,7 +188,7 @@ sentry-forked-django-stubs==5.1.3.post2
 sentry-forked-djangorestframework-stubs==3.15.3.post1
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.2.0
-sentry-ophio==1.0.0
+sentry-ophio==1.1.3
 sentry-protos==0.1.72
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.8

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -126,7 +126,7 @@ s3transfer==0.10.0
 sentry-arroyo==2.21.0
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.2.0
-sentry-ophio==1.0.0
+sentry-ophio==1.1.3
 sentry-protos==0.1.72
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.8


### PR DESCRIPTION
This upgrades `sentry-ophio` in order to take advantage of the fix in https://github.com/getsentry/ophio/pull/73.