### PR TITLE
feat(grouping): Add feature flag and sample rate for split enhancements

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -329,6 +329,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:insights-session-health-tab-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    # Enable the split enhancements experiment
+    manager.add("organizations:run-split-enhancements", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable SAML2 Single-logout
     manager.add("organizations:sso-saml2-slo", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Show links and upsells to Insights modules

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -16,7 +16,7 @@ from sentry.grouping.component import (
     DefaultGroupingComponent,
     SystemGroupingComponent,
 )
-from sentry.grouping.enhancer import LATEST_VERSION, Enhancements
+from sentry.grouping.enhancer import LATEST_VERSION, Enhancements, get_enhancements_version
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.strategies.base import DEFAULT_GROUPING_ENHANCEMENTS_BASE, GroupingContext
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
@@ -122,7 +122,9 @@ class GroupingConfigLoader:
                     else derived_enhancements
                 )
             enhancements = Enhancements.from_rules_text(
-                enhancements_string, bases=[enhancements_base] if enhancements_base else []
+                enhancements_string,
+                bases=[enhancements_base] if enhancements_base else [],
+                version=get_enhancements_version(project, config_id),
             ).base64_string
         except InvalidEnhancerConfig:
             enhancements = get_default_enhancements()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2549,6 +2549,15 @@ register(
     default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Rate at which to run split enhancements and compare the results to the default enhancements
+register(
+    "grouping.split_enhancements.sample_rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "metrics.sample-list.sample-rate",
     type=Float,


### PR DESCRIPTION
This adds both a feature flag (`organizations:run-split-enhancements`) and a sample rate option (`grouping.split_enhancements.sample_rate`) to control the running of split enhancements. It also adds a helper, `get_enhancements_version`, which uses the two to determine if the enhancements created should be version 2 (the current version, with no split enhancements) or version 3 (the new version, which does have them). Finally, it calls the helper when loading enhancements from project options, so that once orgs are opted in and the sample rate is set to something other than 0, the experiment will be enabled.