### PR TITLE
fix(issue-details): Add back analytics when clicking pull request link in suspect commit

### DIFF
--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -122,8 +122,6 @@ describe('commitRow', () => {
     const prLink = screen.getByRole('link', {name: /ref\(commitRow\):/i});
     expect(prLink).toHaveAttribute('href', 'https://github.com/getsentry/sentry/pull/1');
     await userEvent.click(prLink);
-
-    // XXX: Does not get called in Streamline UI, it's just a link
-    expect(handlePullRequestClick).not.toHaveBeenCalled();
+    expect(handlePullRequestClick).toHaveBeenCalled();
   });
 });

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -82,7 +82,10 @@ function CommitRow({
   return hasStreamlinedUI ? (
     <StreamlinedCommitRow data-test-id="commit-row">
       {commit.pullRequest?.externalUrl ? (
-        <StyledExternalLink href={commit.pullRequest?.externalUrl}>
+        <StyledExternalLink
+          href={commit.pullRequest?.externalUrl}
+          onClick={onPullRequestClick}
+        >
           <Message>{formatCommitMessage(commit.message)}</Message>
         </StyledExternalLink>
       ) : (


### PR DESCRIPTION
The new issue details UI didn't call `onPullRequestClick` when the PR link was clicked so we lost the analytics.