### PR TITLE
chore(eap): Trace item attributes snake to camel case

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -138,6 +138,10 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
             serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
             if not serializer.is_valid():
                 return Response(serializer.errors, status=400)
+            else:
+                sentry_sdk.set_tag("param.casing", "camel")
+        else:
+            sentry_sdk.set_tag("param.casing", "snake")
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -225,6 +229,10 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
             serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
             if not serializer.is_valid():
                 return Response(serializer.errors, status=400)
+            else:
+                sentry_sdk.set_tag("param.casing", "camel")
+        else:
+            sentry_sdk.set_tag("param.casing", "snake")
 
         try:
             snuba_params = self.get_snuba_params(request, organization)


### PR DESCRIPTION
Just migrating this endpoint to use camel case instead of snake case.

requires getsentry/snuba#7142 or the tests can be flaky