### PR TITLE
feat(feedback): add release hover to tags

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {Fragment, useEffect, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -27,7 +28,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 interface Props {
   eventData: Event | undefined;
   feedbackItem: FeedbackIssue;
-  tags: Record<string, string>;
+  tags: Record<string, string | ReactNode>;
 }
 
 export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {

--- a/static/app/components/feedback/feedbackItem/tagsSection.tsx
+++ b/static/app/components/feedback/feedbackItem/tagsSection.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import Collapsible from 'sentry/components/collapsible';
@@ -9,7 +10,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface Props {
-  tags: Record<string, string>;
+  tags: Record<string, string | ReactNode>;
 }
 
 export default function TagsSection({tags}: Props) {

--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -33,8 +33,8 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
   );
 
   const tags = useMemo(
-    () => hydrateFeedbackTags(eventData, issueData),
-    [eventData, issueData]
+    () => hydrateFeedbackTags(eventData, issueData, organization),
+    [eventData, issueData, organization]
   );
 
   const {markAsRead} = useMutateFeedback({


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/90631

<img width="792" alt="SCR-20250430-kirm" src="https://github.com/user-attachments/assets/9da7ab9d-519a-4865-9000-85bf890b94f6" />


adds a release hovercard to the release tag, but clicking still links to old release details (default behavior of the hovercard anywhere it exists right now).