### PR TITLE
fix(releases): Lazy update release bubble series

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -468,28 +468,33 @@ export function useReleaseBubbles({
         // rectangular area of the "release bucket" that was hovered over (in
         // the release bubbles). This is drawn on the main chart so that users
         // can visualize the time block of the set of relases.
-        echartsInstance.setOption({
-          series: [
-            {
-              id: BUBBLE_AREA_SERIES_ID,
-              type: 'custom',
-              renderItem: () => {},
-              markArea: {
-                itemStyle: {color: theme.blue400, opacity: 0.1},
-                data: [
-                  [
-                    {
-                      xAxis: data.start - xAxisShift,
-                    },
-                    {
-                      xAxis: data.end - xAxisShift,
-                    },
+        echartsInstance.setOption(
+          {
+            series: [
+              {
+                id: BUBBLE_AREA_SERIES_ID,
+                type: 'custom',
+                renderItem: () => {},
+                markArea: {
+                  itemStyle: {color: theme.blue400, opacity: 0.1},
+                  data: [
+                    [
+                      {
+                        xAxis: data.start - xAxisShift,
+                      },
+                      {
+                        xAxis: data.end - xAxisShift,
+                      },
+                    ],
                   ],
-                ],
+                },
               },
-            },
-          ],
-        });
+            ],
+          },
+          {
+            lazyUpdate: true,
+          }
+        );
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
@@ -498,9 +503,14 @@ export function useReleaseBubbles({
         }
 
         // Clear the `markArea` that was drawn during mouse over
-        echartsInstance.setOption({
-          series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
-        });
+        echartsInstance.setOption(
+          {
+            series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
+          },
+          {
+            lazyUpdate: true,
+          }
+        );
       };
 
       // This fixes a bug where if you hover over a bubble and mouseout via xaxis

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -468,33 +468,25 @@ export function useReleaseBubbles({
         // rectangular area of the "release bucket" that was hovered over (in
         // the release bubbles). This is drawn on the main chart so that users
         // can visualize the time block of the set of relases.
-        echartsInstance.setOption(
-          {
-            series: [
-              {
-                id: BUBBLE_AREA_SERIES_ID,
-                type: 'custom',
-                renderItem: () => {},
-                markArea: {
-                  itemStyle: {color: theme.blue400, opacity: 0.1},
-                  data: [
-                    [
-                      {
-                        xAxis: data.start - xAxisShift,
-                      },
-                      {
-                        xAxis: data.end - xAxisShift,
-                      },
-                    ],
-                  ],
+        const customSeries: CustomSeriesOption = {
+          id: BUBBLE_AREA_SERIES_ID,
+          type: 'custom',
+          renderItem: () => null,
+          markArea: {
+            itemStyle: {color: theme.blue400, opacity: 0.1},
+            data: [
+              [
+                {
+                  xAxis: data.start - xAxisShift,
                 },
-              },
+                {
+                  xAxis: data.end - xAxisShift,
+                },
+              ],
             ],
           },
-          {
-            lazyUpdate: true,
-          }
-        );
+        };
+        echartsInstance.setOption({series: [customSeries]}, {lazyUpdate: true});
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {


### PR DESCRIPTION
Waits for the next animation frame to make an update. Improves performance when rendering MarkArea quickly.