### PR TITLE
fix(issue-views): Fix issue page document titles

### DIFF
--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -22,6 +22,7 @@ import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/se
 
 type Props = {
   children: React.ReactNode;
+  title?: string;
 };
 
 function useUpdateViewLastVisited({view}: {view: GroupSearchView | undefined}) {
@@ -103,19 +104,23 @@ function IssueViewWrapper({children}: Props) {
     return <NotFound />;
   }
 
-  return (
-    <SentryDocumentTitle title={groupSearchView?.name} orgSlug={organization.slug}>
-      <StreamWrapper>{children}</StreamWrapper>
-    </SentryDocumentTitle>
-  );
+  if (groupSearchView) {
+    return (
+      <SentryDocumentTitle title={groupSearchView.name} orgSlug={organization.slug}>
+        <StreamWrapper>{children}</StreamWrapper>
+      </SentryDocumentTitle>
+    );
+  }
+
+  return <StreamWrapper>{children}</StreamWrapper>;
 }
 
-function IssueListContainer({children}: Props) {
+function IssueListContainer({children, title = t('Issues')}: Props) {
   const organization = useOrganization();
   const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
 
   return (
-    <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={title} orgSlug={organization.slug}>
       {hasIssueViewSharing ? (
         <IssueViewWrapper>{children}</IssueViewWrapper>
       ) : (

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -8,6 +8,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import Pagination from 'sentry/components/pagination';
 import Redirect from 'sentry/components/redirect';
 import SearchBar from 'sentry/components/searchBar';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd, IconMegaphone, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -258,106 +259,110 @@ export default function IssueViewsList() {
   }
 
   return (
-    <Layout.Page>
-      <Layout.Header unified>
-        <Layout.HeaderContent>
-          <Layout.Title>{t('All Views')}</Layout.Title>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>
-          <ButtonBar gap={1}>
-            {openFeedbackForm ? (
+    <SentryDocumentTitle title={t('All Views')} orgSlug={organization.slug}>
+      <Layout.Page>
+        <Layout.Header unified>
+          <Layout.HeaderContent>
+            <Layout.Title>{t('All Views')}</Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            <ButtonBar gap={1}>
+              {openFeedbackForm ? (
+                <Button
+                  icon={<IconMegaphone />}
+                  size="sm"
+                  onClick={() => {
+                    openFeedbackForm({
+                      formTitle: t('Give Feedback'),
+                      messagePlaceholder: t(
+                        'How can we make issue views better for you?'
+                      ),
+                      tags: {
+                        ['feedback.source']: 'custom_views',
+                        ['feedback.owner']: 'issues',
+                      },
+                    });
+                  }}
+                >
+                  {t('Give Feedback')}
+                </Button>
+              ) : null}
               <Button
-                icon={<IconMegaphone />}
+                priority="primary"
+                icon={<IconAdd />}
                 size="sm"
+                disabled={isCreatingView}
+                busy={isCreatingView}
                 onClick={() => {
-                  openFeedbackForm({
-                    formTitle: t('Give Feedback'),
-                    messagePlaceholder: t('How can we make issue views better for you?'),
-                    tags: {
-                      ['feedback.source']: 'custom_views',
-                      ['feedback.owner']: 'issues',
-                    },
+                  trackAnalytics('issue_views.table.create_view_clicked', {
+                    organization,
                   });
+                  createGroupSearchView(
+                    {
+                      name: t('New View'),
+                      query: 'is:unresolved',
+                      projects: defaultProject,
+                      environments: DEFAULT_ENVIRONMENTS,
+                      timeFilters: DEFAULT_TIME_FILTERS,
+                      querySort: IssueSortOptions.DATE,
+                      starred: true,
+                    },
+                    {
+                      onSuccess: data => {
+                        navigate({
+                          pathname: normalizeUrl(
+                            `/organizations/${organization.slug}/issues/views/${data.id}/`
+                          ),
+                          query: {
+                            ...getIssueViewQueryParams({view: data}),
+                            new: 'true',
+                          },
+                        });
+                      },
+                    }
+                  );
                 }}
               >
-                {t('Give Feedback')}
+                {t('Create View')}
               </Button>
-            ) : null}
-            <Button
-              priority="primary"
-              icon={<IconAdd />}
-              size="sm"
-              disabled={isCreatingView}
-              busy={isCreatingView}
-              onClick={() => {
-                trackAnalytics('issue_views.table.create_view_clicked', {
-                  organization,
-                });
-                createGroupSearchView(
-                  {
-                    name: t('New View'),
-                    query: 'is:unresolved',
-                    projects: defaultProject,
-                    environments: DEFAULT_ENVIRONMENTS,
-                    timeFilters: DEFAULT_TIME_FILTERS,
-                    querySort: IssueSortOptions.DATE,
-                    starred: true,
-                  },
-                  {
-                    onSuccess: data => {
-                      navigate({
-                        pathname: normalizeUrl(
-                          `/organizations/${organization.slug}/issues/views/${data.id}/`
-                        ),
-                        query: {
-                          ...getIssueViewQueryParams({view: data}),
-                          new: 'true',
-                        },
-                      });
-                    },
-                  }
-                );
-              }}
-            >
-              {t('Create View')}
-            </Button>
-          </ButtonBar>
-        </Layout.HeaderActions>
-      </Layout.Header>
-      <Layout.Body>
-        <MainTableLayout fullWidth>
-          <FilterSortBar>
-            <SearchBar
-              defaultQuery={query}
-              onSearch={newQuery => {
-                navigate({
-                  pathname: location.pathname,
-                  query: {...location.query, query: newQuery},
-                });
-                trackAnalytics('issue_views.table.search', {
-                  organization,
-                  query: newQuery,
-                });
-              }}
-              placeholder={t('Search views by name or query')}
+            </ButtonBar>
+          </Layout.HeaderActions>
+        </Layout.Header>
+        <Layout.Body>
+          <MainTableLayout fullWidth>
+            <FilterSortBar>
+              <SearchBar
+                defaultQuery={query}
+                onSearch={newQuery => {
+                  navigate({
+                    pathname: location.pathname,
+                    query: {...location.query, query: newQuery},
+                  });
+                  trackAnalytics('issue_views.table.search', {
+                    organization,
+                    query: newQuery,
+                  });
+                }}
+                placeholder={t('Search views by name or query')}
+              />
+              <SortDropdown />
+            </FilterSortBar>
+            <TableHeading>{t('My Views')}</TableHeading>
+            <IssueViewSection
+              createdBy={GroupSearchViewCreatedBy.ME}
+              limit={20}
+              cursorQueryParam="mc"
             />
-            <SortDropdown />
-          </FilterSortBar>
-          <TableHeading>{t('My Views')}</TableHeading>
-          <IssueViewSection
-            createdBy={GroupSearchViewCreatedBy.ME}
-            limit={20}
-            cursorQueryParam="mc"
-          />
-          <TableHeading>{t('Created by Others')}</TableHeading>
-          <IssueViewSection
-            createdBy={GroupSearchViewCreatedBy.OTHERS}
-            limit={20}
-            cursorQueryParam="sc"
-          />
-        </MainTableLayout>
-      </Layout.Body>
-    </Layout.Page>
+            <TableHeading>{t('Created by Others')}</TableHeading>
+            <IssueViewSection
+              createdBy={GroupSearchViewCreatedBy.OTHERS}
+              limit={20}
+              cursorQueryParam="sc"
+            />
+          </MainTableLayout>
+        </Layout.Body>
+      </Layout.Page>
+    </SentryDocumentTitle>
   );
 }
 

--- a/static/app/views/issueList/pages/bestPractices.tsx
+++ b/static/app/views/issueList/pages/bestPractices.tsx
@@ -1,7 +1,6 @@
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Redirect from 'sentry/components/redirect';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -22,14 +21,12 @@ export default function ErrorsOutagesPage(props: Props) {
   }
 
   return (
-    <SentryDocumentTitle title={TITLE} orgSlug={organization.slug}>
-      <IssueListContainer>
-        <PageFiltersContainer>
-          <NoProjectMessage organization={organization}>
-            <IssueListOverview {...props} initialQuery={QUERY} title={TITLE} />
-          </NoProjectMessage>
-        </PageFiltersContainer>
-      </IssueListContainer>
-    </SentryDocumentTitle>
+    <IssueListContainer title={TITLE}>
+      <PageFiltersContainer>
+        <NoProjectMessage organization={organization}>
+          <IssueListOverview {...props} initialQuery={QUERY} title={TITLE} />
+        </NoProjectMessage>
+      </PageFiltersContainer>
+    </IssueListContainer>
   );
 }

--- a/static/app/views/issueList/pages/errorsOutages.tsx
+++ b/static/app/views/issueList/pages/errorsOutages.tsx
@@ -1,7 +1,6 @@
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Redirect from 'sentry/components/redirect';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -22,14 +21,12 @@ export default function ErrorsOutagesPage(props: Props) {
   }
 
   return (
-    <SentryDocumentTitle title={TITLE} orgSlug={organization.slug}>
-      <IssueListContainer>
-        <PageFiltersContainer>
-          <NoProjectMessage organization={organization}>
-            <IssueListOverview {...props} initialQuery={QUERY} title={TITLE} />
-          </NoProjectMessage>
-        </PageFiltersContainer>
-      </IssueListContainer>
-    </SentryDocumentTitle>
+    <IssueListContainer title={TITLE}>
+      <PageFiltersContainer>
+        <NoProjectMessage organization={organization}>
+          <IssueListOverview {...props} initialQuery={QUERY} title={TITLE} />
+        </NoProjectMessage>
+      </PageFiltersContainer>
+    </IssueListContainer>
   );
 }

--- a/static/app/views/issueList/pages/metrics.tsx
+++ b/static/app/views/issueList/pages/metrics.tsx
@@ -1,7 +1,6 @@
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Redirect from 'sentry/components/redirect';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -21,14 +20,12 @@ export default function ErrorsOutagesPage(props: Props) {
   }
 
   return (
-    <SentryDocumentTitle title={TITLE} orgSlug={organization.slug}>
-      <IssueListContainer>
-        <PageFiltersContainer>
-          <NoProjectMessage organization={organization}>
-            <IssueListOverview {...props} initialQuery={QUERY} title={TITLE} />
-          </NoProjectMessage>
-        </PageFiltersContainer>
-      </IssueListContainer>
-    </SentryDocumentTitle>
+    <IssueListContainer title={TITLE}>
+      <PageFiltersContainer>
+        <NoProjectMessage organization={organization}>
+          <IssueListOverview {...props} initialQuery={QUERY} title={TITLE} />
+        </NoProjectMessage>
+      </PageFiltersContainer>
+    </IssueListContainer>
   );
 }


### PR DESCRIPTION
Fixes a couple issues:

- When issue view sharing is enabled, and on a page that doesn't have a view, the document title would be `- orgslug - Sentry`
- "All views" page didn't have a document title

I'm still seeing some issues with the title being overridden by the organization layout one (which just says "Sentry"), but that is a different problem which I haven't tracked down yet.