### PR TITLE
chore(shared-views): Swap out issue-view-sharing flag for enforce-stacked-navigation

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -24,7 +24,9 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
   const hasIssueViews = organization.features.includes('issue-stream-custom-views');
-  const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
+  const hasIssueViewSharing = organization.features.includes(
+    'enforce-stacked-navigation'
+  );
 
   return (
     <FiltersContainer hasIssueViewSharing={hasIssueViewSharing}>

--- a/static/app/views/issueList/index.spec.tsx
+++ b/static/app/views/issueList/index.spec.tsx
@@ -13,7 +13,7 @@ describe('IssueListContainer', function () {
   };
 
   const organization = OrganizationFixture({
-    features: ['issue-view-sharing'],
+    features: ['enforce-stacked-navigation'],
   });
 
   const initialRouterConfig = {

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -112,7 +112,9 @@ function IssueViewWrapper({children}: Props) {
 
 function IssueListContainer({children}: Props) {
   const organization = useOrganization();
-  const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
+  const hasIssueViewSharing = organization.features.includes(
+    'enforce-stacked-navigation'
+  );
 
   return (
     <SentryDocumentTitle title={t('Issues')} orgSlug={organization.slug}>

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -14,7 +14,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import IssueViewsList from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsList';
 
 const organization = OrganizationFixture({
-  features: ['issue-view-sharing'],
+  features: ['enforce-stacked-navigation'],
 });
 
 describe('IssueViewsList', function () {

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -253,7 +253,7 @@ export default function IssueViewsList() {
     useCreateGroupSearchView();
   const defaultProject = useDefaultProject();
 
-  if (!organization.features.includes('issue-view-sharing')) {
+  if (!organization.features.includes('enforce-stacked-navigation')) {
     return <Redirect to={`/organizations/${organization.slug}/issues/`} />;
   }
 

--- a/static/app/views/issueList/leftNavViewsHeader.spec.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.spec.tsx
@@ -32,7 +32,7 @@ describe('LeftNavViewsHeader', function () {
 
   const organization = OrganizationFixture({
     access: ['org:read'],
-    features: ['issue-view-sharing'],
+    features: ['enforce-stacked-navigation'],
   });
 
   const onIssueViewRouterConfig = {

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -36,7 +36,9 @@ function PageTitle({title}: {title: ReactNode}) {
   const organization = useOrganization();
   const {data: groupSearchView} = useSelectedGroupSearchView();
   const user = useUser();
-  const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
+  const hasIssueViewSharing = organization.features.includes(
+    'enforce-stacked-navigation'
+  );
 
   if (
     hasIssueViewSharing &&
@@ -87,7 +89,7 @@ function IssueViewStarButton() {
     },
   });
 
-  if (!organization.features.includes('issue-view-sharing') || !groupSearchView) {
+  if (!organization.features.includes('enforce-stacked-navigation') || !groupSearchView) {
     return null;
   }
 
@@ -134,7 +136,7 @@ function IssueViewEditMenu() {
   const {mutate: deleteIssueView} = useDeleteGroupSearchView();
   const navigate = useNavigate();
 
-  if (!organization.features.includes('issue-view-sharing') || !groupSearchView) {
+  if (!organization.features.includes('enforce-stacked-navigation') || !groupSearchView) {
     return null;
   }
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1096,7 +1096,7 @@ function IssueListOverview({
         )}
         {!prefersStackedNav &&
           (organization.features.includes('issue-stream-custom-views') &&
-          !organization.features.includes('issue-view-sharing') ? (
+          !organization.features.includes('enforce-stacked-navigation') ? (
             <ErrorBoundary message={'Failed to load custom tabs'} mini>
               <IssueViewsIssueListHeader
                 router={router}

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewAddViewButton.tsx
@@ -63,7 +63,7 @@ export function IssueViewAddViewButton() {
     }
   };
 
-  if (organization.features.includes('issue-view-sharing')) {
+  if (organization.features.includes('enforce-stacked-navigation')) {
     return null;
   }
 

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItemContent.tsx
@@ -71,7 +71,9 @@ export function IssueViewNavItemContent({
   const organization = useOrganization();
   const {projects} = useProjects();
 
-  const hasIssueViewSharing = organization.features.includes('issue-view-sharing');
+  const hasIssueViewSharing = organization.features.includes(
+    'enforce-stacked-navigation'
+  );
 
   const controls = useDragControls();
 

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -89,7 +89,7 @@ export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps)
           />
         ))}
       </Reorder.Group>
-      {organization.features.includes('issue-view-sharing') && (
+      {organization.features.includes('enforce-stacked-navigation') && (
         <SecondaryNav.Item to={`${baseUrl}/views/`} end>
           {t('All Views')}
         </SecondaryNav.Item>


### PR DESCRIPTION
depends on #90609

replaces all instances of the `issue-view-sharing` flag with the `enforce-stacked-navigation` flag, which has the same conditions. 