### PR TITLE
feat(insights): eap starred transaction column updates

### DIFF
--- a/static/app/views/insights/common/utils/useStarredSegment.tsx
+++ b/static/app/views/insights/common/utils/useStarredSegment.tsx
@@ -34,25 +34,25 @@ export function useStarredSegment({initialIsStarred, projectId, segmentName}: Pr
     segment_name: segmentName,
   };
 
-  const onError = () => {
-    addErrorMessage(t('Failed to star transaction'));
+  const onError = (message: string) => {
+    addErrorMessage(message);
     setIsStarred(!isStarred);
   };
 
-  const onSuccess = () => {
-    addSuccessMessage(t('Transaction starred'));
+  const onSuccess = (message: string) => {
+    addSuccessMessage(message);
   };
 
   const {mutate: starTransaction, ...starTransactionResult} = useMutation({
     mutationFn: () => api.requestPromise(url, {method: 'POST', data}),
-    onSuccess,
-    onError,
+    onSuccess: () => onSuccess(t('Transaction starred')),
+    onError: () => onError(t('Failed to star transaction')),
   });
 
   const {mutate: unstarTransaction, ...unstarTransactionResult} = useMutation({
     mutationFn: () => api.requestPromise(url, {method: 'DELETE', data}),
-    onSuccess,
-    onError,
+    onSuccess: () => onSuccess(t('Transaction unstarred')),
+    onError: () => onError(t('Failed to unstar transaction')),
   });
 
   const isPending =

--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -5,6 +5,7 @@ import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
+import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -15,6 +16,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
+import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
@@ -50,11 +52,6 @@ type Column = GridColumnHeader<
 >;
 
 const COLUMN_ORDER: Column[] = [
-  {
-    key: 'is_starred_transaction',
-    name: t('Starred'),
-    width: COL_WIDTH_UNDEFINED,
-  },
   {
     key: 'request.method',
     name: t('HTTP Method'),
@@ -166,6 +163,8 @@ export function BackendOverviewTable({response, sort}: Props) {
           },
         ]}
         grid={{
+          renderPrependColumns,
+          prependColumnWidths: ['max-content'],
           renderHeadCell: column =>
             renderHeadCell({
               column,
@@ -179,6 +178,24 @@ export function BackendOverviewTable({response, sort}: Props) {
       <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
     </VisuallyCompleteWithData>
   );
+}
+
+function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
+  if (isHeader) {
+    return [<IconStar key="star" color="yellow300" isSolid />];
+  }
+
+  if (!row) {
+    return [];
+  }
+  return [
+    <StarredSegmentCell
+      key={row.transaction}
+      initialIsStarred={row.is_starred_transaction}
+      projectSlug={row.project}
+      segmentName={row.transaction}
+    />,
+  ];
 }
 
 function renderBodyCell(

--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -1,4 +1,5 @@
 import {type Theme, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import type {GridColumnHeader} from 'sentry/components/gridEditable';
@@ -7,6 +8,7 @@ import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
 import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -182,7 +184,7 @@ export function BackendOverviewTable({response, sort}: Props) {
 
 function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
   if (isHeader) {
-    return [<IconStar key="star" color="yellow300" isSolid />];
+    return [<StyledIconStar key="star" color="yellow300" isSolid />];
   }
 
   if (!row) {
@@ -229,3 +231,7 @@ function renderBodyCell(
     theme,
   });
 }
+
+export const StyledIconStar = styled(IconStar)`
+  margin-left: ${space(0.25)};
+`;

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -5,7 +5,6 @@ import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
-import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -19,6 +18,7 @@ import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells
 import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {StyledIconStar} from 'sentry/views/insights/pages/backend/backendTable';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {EAPSpanResponse} from 'sentry/views/insights/types';
 
@@ -174,7 +174,7 @@ export function FrontendOverviewTable({response, sort}: Props) {
 
 function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
   if (isHeader) {
-    return [<IconStar key="star" color="yellow300" isSolid />];
+    return [<StyledIconStar key="star" color="yellow300" isSolid />];
   }
 
   if (!row) {

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -5,6 +5,7 @@ import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
+import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -15,6 +16,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
+import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
@@ -158,6 +160,8 @@ export function FrontendOverviewTable({response, sort}: Props) {
           },
         ]}
         grid={{
+          prependColumnWidths: ['max-content'],
+          renderPrependColumns,
           renderHeadCell: column =>
             renderHeadCell({
               column,
@@ -171,6 +175,24 @@ export function FrontendOverviewTable({response, sort}: Props) {
       <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
     </VisuallyCompleteWithData>
   );
+}
+
+function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
+  if (isHeader) {
+    return [<IconStar key="star" color="yellow300" isSolid />];
+  }
+
+  if (!row) {
+    return [];
+  }
+  return [
+    <StarredSegmentCell
+      key={row.transaction}
+      initialIsStarred={row.is_starred_transaction}
+      projectSlug={row.project}
+      segmentName={row.transaction}
+    />,
+  ];
 }
 
 function renderBodyCell(

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -51,11 +51,6 @@ type Column = GridColumnHeader<
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: 'is_starred_transaction',
-    name: t('Starred'),
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
     key: 'transaction',
     name: t('Transaction'),
     width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -51,11 +51,6 @@ type Column = GridColumnHeader<
 
 const COLUMN_ORDER: Column[] = [
   {
-    key: 'is_starred_transaction',
-    name: t('Starred'),
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
     key: 'transaction',
     name: t('Transaction'),
     width: COL_WIDTH_UNDEFINED,

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -5,7 +5,6 @@ import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
-import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -19,6 +18,7 @@ import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells
 import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {StyledIconStar} from 'sentry/views/insights/pages/backend/backendTable';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
 import type {EAPSpanResponse} from 'sentry/views/insights/types';
 
@@ -174,7 +174,7 @@ export function MobileOverviewTable({response, sort}: Props) {
 
 function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
   if (isHeader) {
-    return [<IconStar key="star" color="yellow300" isSolid />];
+    return [<StyledIconStar key="star" color="yellow300" isSolid />];
   }
 
   if (!row) {

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -5,6 +5,7 @@ import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
+import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -15,6 +16,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
+import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {TransactionCell} from 'sentry/views/insights/pages/transactionCell';
@@ -158,6 +160,8 @@ export function MobileOverviewTable({response, sort}: Props) {
           },
         ]}
         grid={{
+          prependColumnWidths: ['max-content'],
+          renderPrependColumns,
           renderHeadCell: column =>
             renderHeadCell({
               column,
@@ -171,6 +175,24 @@ export function MobileOverviewTable({response, sort}: Props) {
       <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
     </VisuallyCompleteWithData>
   );
+}
+
+function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
+  if (isHeader) {
+    return [<IconStar key="star" color="yellow300" isSolid />];
+  }
+
+  if (!row) {
+    return [];
+  }
+  return [
+    <StarredSegmentCell
+      key={row.transaction}
+      initialIsStarred={row.is_starred_transaction}
+      projectSlug={row.project}
+      segmentName={row.transaction}
+    />,
+  ];
 }
 
 function renderBodyCell(

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -643,9 +643,8 @@ class _Table extends Component<Props, State> {
                               tableData?.meta
                             ) as any,
                             renderBodyCell: this.renderBodyCellWithData(tableData) as any,
-                            renderPrependColumns: this.renderPrependCellWithData(
-                              tableData
-                            ) as any,
+                            renderPrependColumns:
+                              this.renderPrependCellWithData(tableData),
                             prependColumnWidths,
                           }}
                         />

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -537,7 +537,9 @@ class _Table extends Component<Props, State> {
             </TeamKeyTransactionWrapper>
           );
           return [
-            this.renderHeadCell(tableData?.meta, teamKeyTransactionColumn, {title: star}),
+            this.renderHeadCell(tableData?.meta, teamKeyTransactionColumn, {
+              title: star,
+            }) as any,
           ];
         }
         return [this.renderBodyCell(tableData, teamKeyTransactionColumn, dataRow)];
@@ -643,8 +645,9 @@ class _Table extends Component<Props, State> {
                               tableData?.meta
                             ) as any,
                             renderBodyCell: this.renderBodyCellWithData(tableData) as any,
-                            renderPrependColumns:
-                              this.renderPrependCellWithData(tableData),
+                            renderPrependColumns: this.renderPrependCellWithData(
+                              tableData
+                            ) as any,
                             prependColumnWidths,
                           }}
                         />

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -537,9 +537,7 @@ class _Table extends Component<Props, State> {
             </TeamKeyTransactionWrapper>
           );
           return [
-            this.renderHeadCell(tableData?.meta, teamKeyTransactionColumn, {
-              title: star,
-            }) as any,
+            this.renderHeadCell(tableData?.meta, teamKeyTransactionColumn, {title: star}),
           ];
         }
         return [this.renderBodyCell(tableData, teamKeyTransactionColumn, dataRow)];


### PR DESCRIPTION
1. Correct error messages when starring/un-starring transactions
2. Update the starred transaction header to be a star and non-resizable
Before
![image](https://github.com/user-attachments/assets/ab9ad3e1-9a51-4144-a80f-afdb5c211e3f)

After
![image](https://github.com/user-attachments/assets/1bf6e453-6c53-450c-8149-2f507f157137)
