### PR TITLE
ref(ourlogs): Change default (24h) and max (14d) period for logs

### DIFF
--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -12,8 +12,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsTabContent} from 'sentry/views/explore/logs/logsTab';
+import {logsPickableDays} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import {usePrefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 
 function FeedbackButton() {
@@ -44,11 +44,9 @@ function FeedbackButton() {
 
 export default function LogsPage() {
   const organization = useOrganization();
-  const {relativeOptions} = limitMaxPickableDays(organization);
+  const {defaultPeriod, maxPickableDays, relativeOptions} = logsPickableDays();
 
   const prefersStackedNav = usePrefersStackedNav();
-  const maxPickableDays = 14;
-  const defaultPeriod = '24h';
 
   return (
     <SentryDocumentTitle title={t('Logs')} orgSlug={organization?.slug}>

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -50,7 +50,17 @@ export default function LogsPage() {
 
   return (
     <SentryDocumentTitle title={t('Logs')} orgSlug={organization?.slug}>
-      <PageFiltersContainer maxPickableDays={maxPickableDays}>
+      <PageFiltersContainer
+        maxPickableDays={maxPickableDays}
+        defaultSelection={{
+          datetime: {
+            period: defaultPeriod,
+            start: null,
+            end: null,
+            utc: null,
+          },
+        }}
+      >
         <Layout.Page>
           <Layout.Header unified={prefersStackedNav}>
             <Layout.HeaderContent unified={prefersStackedNav}>

--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -44,10 +44,11 @@ function FeedbackButton() {
 
 export default function LogsPage() {
   const organization = useOrganization();
-  const {defaultPeriod, maxPickableDays, relativeOptions} =
-    limitMaxPickableDays(organization);
+  const {relativeOptions} = limitMaxPickableDays(organization);
 
   const prefersStackedNav = usePrefersStackedNav();
+  const maxPickableDays = 14;
+  const defaultPeriod = '24h';
 
   return (
     <SentryDocumentTitle title={t('Logs')} orgSlug={organization?.slug}>

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -43,14 +43,10 @@ import {useExploreLogsTable} from 'sentry/views/explore/logs/useLogsQuery';
 import {usePersistentLogsPageParameters} from 'sentry/views/explore/logs/usePersistentLogsPageParameters';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import type {DefaultPeriod, MaxPickableDays} from 'sentry/views/explore/utils';
+import type {PickableDays} from 'sentry/views/explore/utils';
 import {useSortedTimeSeries} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
-type LogsTabProps = {
-  defaultPeriod: DefaultPeriod;
-  maxPickableDays: MaxPickableDays;
-  relativeOptions: Record<string, React.ReactNode>;
-};
+type LogsTabProps = PickableDays;
 
 export function LogsTabContent({
   defaultPeriod,

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -21,6 +21,7 @@ import {
   OurLogKnownFieldKey,
   type OurLogsResponseItem,
 } from 'sentry/views/explore/logs/types';
+import type {PickableDays} from 'sentry/views/explore/utils';
 
 const {warn, fmt} = Sentry.logger;
 
@@ -187,4 +188,19 @@ export function getLogRowItem(
 
 export function adjustLogTraceID(traceID: string) {
   return traceID.replace(/-/g, '');
+}
+
+export function logsPickableDays(): PickableDays {
+  const relativeOptions: Array<[string, React.ReactNode]> = [
+    ['1h', t('Last hour')],
+    ['24h', t('Last 24 hours')],
+    ['7d', t('Last 7 days')],
+    ['14d', t('Last 14 days')],
+  ];
+
+  return {
+    defaultPeriod: '24h',
+    maxPickableDays: 14,
+    relativeOptions: Object.fromEntries(relativeOptions),
+  };
 }

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -66,22 +66,14 @@ import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
 import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/spans/tour';
 import {ExploreTables} from 'sentry/views/explore/tables';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
-import {
-  combineConfidenceForSeries,
-  type DefaultPeriod,
-  type MaxPickableDays,
-} from 'sentry/views/explore/utils';
+import {combineConfidenceForSeries, type PickableDays} from 'sentry/views/explore/utils';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {Onboarding} from 'sentry/views/performance/onboarding';
 
 // eslint-disable-next-line no-restricted-imports
 import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
 
-type SpanTabProps = {
-  defaultPeriod: DefaultPeriod;
-  maxPickableDays: MaxPickableDays;
-  relativeOptions: Record<string, React.ReactNode>;
-};
+type SpanTabProps = PickableDays;
 
 function SpansTabContentImpl({
   defaultPeriod,
@@ -417,7 +409,7 @@ export function SpansTabContent(props: SpanTabProps) {
 
 function checkIsAllowedSelection(
   selection: PageFilters,
-  maxPickableDays: MaxPickableDays
+  maxPickableDays: PickableDays['maxPickableDays']
 ) {
   const maxPickableMinutes = maxPickableDays * 24 * 60;
   const selectedMinutes = getDiffInMinutes(selection.datetime);

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -238,14 +238,16 @@ export function viewSamplesTarget(
   });
 }
 
-export type MaxPickableDays = 7 | 14 | 30;
-export type DefaultPeriod = '7d' | '14d' | '30d';
+type MaxPickableDays = 7 | 14 | 30;
+type DefaultPeriod = '24h' | '7d' | '14d' | '30d';
 
-export function limitMaxPickableDays(organization: Organization): {
+export interface PickableDays {
   defaultPeriod: DefaultPeriod;
   maxPickableDays: MaxPickableDays;
   relativeOptions: Record<string, React.ReactNode>;
-} {
+}
+
+export function limitMaxPickableDays(organization: Organization): PickableDays {
   const defaultPeriods: Record<MaxPickableDays, DefaultPeriod> = {
     7: '7d',
     14: '14d',


### PR DESCRIPTION
The default of 14d is resulting in some slow-ish loading for some orgs. We also want to limit the number of very slow queries when looking at larger periods (at least for now).

Closes LOGS-76