### PR TITLE
fix(explore): Ignore cursor for timeseries requests

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import omit from 'lodash/omit';
 
 import type {
   EventsStats,
@@ -103,7 +104,7 @@ export const useSortedTimeSeries = <
     location,
     orgSlug: organization.slug,
     getRequestPayload: () => ({
-      ...eventView.getEventsAPIPayload(location),
+      ...omit(eventView.getEventsAPIPayload(location), 'cursor'),
       yAxis: eventView.yAxis,
       topEvents: eventView.topEvents,
       excludeOther: 0,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import omit from 'lodash/omit';
 
 import type {
   EventsStats,
@@ -104,7 +103,7 @@ export const useSortedTimeSeries = <
     location,
     orgSlug: organization.slug,
     getRequestPayload: () => ({
-      ...omit(eventView.getEventsAPIPayload(location), 'cursor'),
+      ...eventView.getEventsAPIPayload(location),
       yAxis: eventView.yAxis,
       topEvents: eventView.topEvents,
       excludeOther: 0,
@@ -112,6 +111,9 @@ export const useSortedTimeSeries = <
       orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
       interval: eventView.interval,
       sampling: samplingMode,
+      // Timeseries requests do not support cursors, overwrite it to undefined so
+      // pagination does not cause extra requests
+      cursor: undefined,
     }),
     options: {
       enabled: enabled && pageFilters.isReady,


### PR DESCRIPTION
Pagination doesn't make sense in this request and it's causing a query to execute and re-render the chart.
