### PR TITLE
feat(autofix): Display autofix summary while waiting for seer

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -32,12 +32,7 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const isAutofixEnabled = issueTypeConfig.autofix;
   const hasResources = !!issueTypeConfig.resources;
 
-  const hasGenAIAcknowledgement =
-    autofixSetupData?.setupAcknowledgement.orgHasAcknowledged;
-
-  const hasSummary = Boolean(
-    hasGenAIAcknowledgement && isSummaryEnabled && areAiFeaturesAllowed
-  );
+  const hasSummary = Boolean(isSummaryEnabled && areAiFeaturesAllowed);
   const hasAutofix = isAutofixEnabled && areAiFeaturesAllowed && !isSampleError;
   const hasGithubIntegration = !!autofixSetupData?.integration.ok;
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -101,7 +101,7 @@ describe('SeerSection', () => {
   });
 
   describe('Seer button text', () => {
-    it('shows "Set Up Seer" when AI needs setup', async () => {
+    it('shows "Set Up Seer" with summary when Seer needs setup', async () => {
       const customOrganization = OrganizationFixture({
         hideAiFeatures: false,
         features: ['gen-ai-features'],
@@ -119,18 +119,17 @@ describe('SeerSection', () => {
         }),
       });
 
+      MockApiClient.addMockResponse({
+        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/summarize/`,
+        method: 'POST',
+        body: {whatsWrong: 'Test summary'},
+      });
+
       render(<SeerSection event={mockEvent} group={mockGroup} project={mockProject} />, {
         organization: customOrganization,
       });
 
-      await waitFor(() => {
-        expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
-      });
-
-      expect(
-        screen.getByText('Explore potential root causes and solutions with Autofix.')
-      ).toBeInTheDocument();
-
+      expect(await screen.findByText('Test summary')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Set Up Seer'})).toBeInTheDocument();
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -125,31 +125,31 @@ export default function SeerSection({
       !aiConfig.hasAutofix &&
       aiConfig.hasResources);
 
-  const titleComponent = (
+  const titleComponent = onlyHasResources ? (
+    <HeaderContainer>{t('Resources')}</HeaderContainer>
+  ) : (
     <HeaderContainer>
-      {onlyHasResources ? t('Resources') : t('Seer')}
-      {aiConfig.hasSummary && (
-        <FeatureBadge
-          type="beta"
-          tooltipProps={{
-            title: tct(
-              'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
-              {
-                email: (
-                  <a
-                    href="mailto:autofix@sentry.io"
-                    onClick={clickEvent => {
-                      // Prevent header from collapsing
-                      clickEvent.stopPropagation();
-                    }}
-                  />
-                ),
-              }
-            ),
-            isHoverable: true,
-          }}
-        />
-      )}
+      {t('Seer')}
+      <FeatureBadge
+        type="beta"
+        tooltipProps={{
+          title: tct(
+            'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
+            {
+              email: (
+                <a
+                  href="mailto:autofix@sentry.io"
+                  onClick={clickEvent => {
+                    // Prevent header from collapsing
+                    clickEvent.stopPropagation();
+                  }}
+                />
+              ),
+            }
+          ),
+          isHoverable: true,
+        }}
+      />
     </HeaderContainer>
   );
 
@@ -161,7 +161,7 @@ export default function SeerSection({
       preventCollapse={!hasStreamlinedUI}
     >
       <SeerSectionContainer>
-        {aiConfig.needsGenAiAcknowledgement ? (
+        {aiConfig.needsGenAiAcknowledgement && !aiConfig.hasSummary ? (
           <Summary>
             {t('Explore potential root causes and solutions with Autofix.')}
           </Summary>

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
@@ -76,6 +76,11 @@ describe('StreamlinedSidebar', function () {
       url: `/organizations/${organization.slug}/issues/1/external-issues/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/summarize/`,
+      method: 'POST',
+      body: {whatsWrong: 'Test summary'},
+    });
 
     mockExternalIssues = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,


### PR DESCRIPTION
Displays the autofix summary and the beta badge while waiting for Seer to be acknowledged.

![image](https://github.com/user-attachments/assets/7959df7c-0cca-402f-8297-098a1b62f064)
