### PR TITLE
fix(taskworker) Update cluster_projects so it can not use pickle

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -76,7 +76,13 @@ def spawn_clusterers(**kwargs: Any) -> None:
         retry=Retry(times=5),
     ),
 )
-def cluster_projects(projects: Sequence[Project]) -> None:
+def cluster_projects(
+    projects: Sequence[Project] | None = None, project_ids: Sequence[int] | None = None
+) -> None:
+    if project_ids:
+        projects = Project.objects.get_many_from_cache(project_ids)
+    assert projects is not None, "Either projects or project_ids must be provided"
+
     pending = set(projects)
     num_clustered = 0
     try:


### PR DESCRIPTION
Currently, we invoke this task with a list of `Project` models that are pickled. This has escaped our existing pickle detection logic as all calls to the task are mocked.

This set of changes introduces a new `project_ids` parameter that will let us not need pickle. Once this has deployed, I'll change the callsites to pass `project_ids` and deprecate `projects` usage.

Refs #90681