### PR TITLE
feat(seer): Add issue summary to post process

### DIFF
--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -45,7 +45,8 @@ def check_autofix_status(run_id: int):
         ),
     ),
 )
-def start_seer_automation(group: Group):
+def start_seer_automation(group_id: int):
     from sentry.seer.issue_summary import get_issue_summary
 
+    group = Group.objects.get(id=group_id)
     get_issue_summary(group=group, source="post_process")

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -5,7 +5,7 @@ from sentry.autofix.utils import AutofixStatus, get_autofix_state
 from sentry.models.group import Group
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import ingest_errors_tasks, issues_tasks
 from sentry.taskworker.retry import Retry
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ def check_autofix_status(run_id: int):
     name="sentry.tasks.autofix.start_seer_automation",
     max_retries=1,
     taskworker_config=TaskworkerConfig(
-        namespace=issues_tasks,
+        namespace=ingest_errors_tasks,
         retry=Retry(
             times=1,
         ),

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1566,7 +1566,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     ):
         return
 
-    start_seer_automation.delay(group)
+    start_seer_automation.delay(group.id)
 
 
 GROUP_CATEGORY_POST_PROCESS_PIPELINE = {

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1556,6 +1556,7 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
+    from sentry.seer.seer_setup import get_seer_org_acknowledgement
     from sentry.tasks.autofix import start_seer_automation
 
     event = job["event"]
@@ -1564,6 +1565,10 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     if not features.has("organizations:gen-ai-features", group.organization) or not features.has(
         "projects:trigger-issue-summary-on-alerts", group.project
     ):
+        return
+
+    seer_enabled = get_seer_org_acknowledgement(group.organization.id)
+    if not seer_enabled:
         return
 
     start_seer_automation.delay(group.id)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2486,7 +2486,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
             event=event,
         )
 
-        mock_start_seer_automation.assert_called_once_with(event.group)
+        mock_start_seer_automation.assert_called_once_with(event.group.id)
 
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     def test_kick_off_seer_automation_without_org_feature(self, mock_start_seer_automation):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2470,10 +2470,16 @@ class ProcessSimilarityTestMixin(BasePostProgressGroupMixin):
 
 
 class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
     @with_feature("organizations:gen-ai-features")
     @with_feature("projects:trigger-issue-summary-on-alerts")
-    def test_kick_off_seer_automation_with_features(self, mock_start_seer_automation):
+    def test_kick_off_seer_automation_with_features(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
@@ -2488,35 +2494,71 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
 
         mock_start_seer_automation.assert_called_once_with(event.group.id)
 
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
-    def test_kick_off_seer_automation_without_org_feature(self, mock_start_seer_automation):
+    @with_feature("projects:trigger-issue-summary-on-alerts")
+    def test_kick_off_seer_automation_without_org_feature(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
         )
-        with self.feature("projects:trigger-issue-summary-on-alerts"):
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=True,
-                event=event,
-            )
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
 
         mock_start_seer_automation.assert_not_called()
 
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
     @patch("sentry.tasks.autofix.start_seer_automation.delay")
-    def test_kick_off_seer_automation_without_proj_feature(self, mock_start_seer_automation):
+    @with_feature("organizations:gen-ai-features")
+    def test_kick_off_seer_automation_without_proj_feature(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
         )
-        with self.feature("organizations:gen-ai-features"):
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=True,
-                event=event,
-            )
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
+
+        mock_start_seer_automation.assert_not_called()
+
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=False,
+    )
+    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("projects:trigger-issue-summary-on-alerts")
+    def test_kick_off_seer_automation_without_seer_enabled(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
+        event = self.create_event(
+            data={"message": "testing"},
+            project_id=self.project.id,
+        )
+
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
 
         mock_start_seer_automation.assert_not_called()
 


### PR DESCRIPTION
Asynchronously kicks off issue summary in post process. The existing issue summary code should handle locking, caching results, and automatically triggering Autofix.

I put it in this location in the pipeline so that the summary generation has started before we start building and firing alerts.