### PR TITLE
fix(reserved budgets): Omit percentage in usage history for now

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -665,9 +665,7 @@ describe('Subscription > UsageHistory', () => {
         name: /spans/i,
       })
     ).toBeInTheDocument();
-    expect(screen.getByText('N/A')).toBeInTheDocument();
-    expect(screen.queryByText(/accepted spans/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/stored spans/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText('N/A')).toHaveLength(2);
     expect(mockCall).toHaveBeenCalled();
   });
 
@@ -712,7 +710,7 @@ describe('Subscription > UsageHistory', () => {
         name: /stored spans/i,
       })
     ).toBeInTheDocument();
-    expect(screen.getAllByText('N/A')).toHaveLength(2);
+    expect(screen.getAllByText('N/A')).toHaveLength(4);
     expect(mockCall).toHaveBeenCalled();
   });
 

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -23,7 +23,12 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import withSubscription from 'getsentry/components/withSubscription';
-import {GIGABYTE, UNLIMITED, UNLIMITED_ONDEMAND} from 'getsentry/constants';
+import {
+  GIGABYTE,
+  RESERVED_BUDGET_QUOTA,
+  UNLIMITED,
+  UNLIMITED_ONDEMAND,
+} from 'getsentry/constants';
 import type {
   BillingHistory,
   BillingMetricHistory,
@@ -331,12 +336,14 @@ function UsageHistoryRow({history, subscription}: RowProps) {
                       </td>
                     )}
                     <td>
-                      {usagePercentage(
-                        metricHistory.category === DataCategory.ATTACHMENTS
-                          ? metricHistory.usage / GIGABYTE
-                          : metricHistory.usage,
-                        metricHistory.prepaid
-                      )}
+                      {metricHistory.reserved === RESERVED_BUDGET_QUOTA
+                        ? 'N/A'
+                        : usagePercentage(
+                            metricHistory.category === DataCategory.ATTACHMENTS
+                              ? metricHistory.usage / GIGABYTE
+                              : metricHistory.usage,
+                            metricHistory.prepaid
+                          )}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Just a temporary fix since we'll see the first of these customers soon for DS

# before 
![Screenshot 2025-04-30 at 4 18 50 PM](https://github.com/user-attachments/assets/186c2446-f6ee-4040-9ec6-f4d52ec19f49)


# after
![Screenshot 2025-04-30 at 4 19 16 PM](https://github.com/user-attachments/assets/68649688-a141-4a4c-9146-de9b4dd671a3)
