### PR TITLE
:wrench: chore(aci): use evidence data for notification data classes

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -27,8 +27,6 @@ COMPARISON_DELTA_CHOICES.append(None)
 @dataclass
 class MetricIssueEvidenceData(EvidenceData):
     alert_id: int
-    # Used for anomaly detection
-    sensitivity: str | None = None
 
 
 class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate, int]):

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -27,6 +27,8 @@ COMPARISON_DELTA_CHOICES.append(None)
 @dataclass
 class MetricIssueEvidenceData(EvidenceData):
     alert_id: int
+    # Used for anomaly detection
+    sensitivity: str | None = None
 
 
 class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate, int]):

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -187,10 +187,10 @@ class MetricIssueContext:
 
     @classmethod
     def _get_subscription(cls, evidence_data: MetricIssueEvidenceData) -> QuerySubscription:
-        data_sources = evidence_data.data_sources
-        if len(data_sources) != 1:
+        data_source_ids = evidence_data.data_source_ids
+        if len(data_source_ids) != 1:
             raise ValueError("Only one data source is supported for alert context")
-        data_source = DataSource.objects.get(id=data_sources[0])
+        data_source = DataSource.objects.get(id=data_source_ids[0])
 
         subscription = QuerySubscription.objects.get(id=data_source.source_id)
         return subscription

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -198,14 +198,12 @@ class MetricIssueContext:
     @classmethod
     def _get_subscription(cls, evidence_data: MetricIssueEvidenceData) -> QuerySubscription:
         data_source_ids = evidence_data.data_source_ids
-        data_sources = DataSource.objects.filter(
+        data_source = DataSource.objects.filter(
             id__in=data_source_ids, type=DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
-        )
+        ).first()
 
-        if len(data_sources) == 0:
+        if data_source is None:
             raise ValueError("No data sources found for alert context")
-
-        data_source = data_sources.first()
 
         subscription = QuerySubscription.objects.get(id=data_source.source_id)
         return subscription

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from sentry.eventstore.models import GroupEvent
 from sentry.incidents.models.alert_rule import (
     AlertRule,
     AlertRuleDetectionType,
@@ -12,13 +11,50 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.incidents.models.incident import Incident, IncidentStatus
-from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupopenperiod import get_latest_open_period
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action, Detector
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.models.data_source import DataSource
+
+if TYPE_CHECKING:
+    from sentry.incidents.grouptype import MetricIssueEvidenceData
+
+CONDITION_TO_ALERT_RULE_THRESHOLD_TYPE = {
+    Condition.GREATER_OR_EQUAL: AlertRuleThresholdType.ABOVE,
+    Condition.GREATER: AlertRuleThresholdType.ABOVE,
+    Condition.LESS_OR_EQUAL: AlertRuleThresholdType.BELOW,
+    Condition.LESS: AlertRuleThresholdType.BELOW,
+}
+
+
+def fetch_threshold_type(evidence_data: MetricIssueEvidenceData) -> AlertRuleThresholdType:
+    return CONDITION_TO_ALERT_RULE_THRESHOLD_TYPE[evidence_data.data_condition_type]
+
+
+def fetch_alert_threshold(
+    evidence_data: MetricIssueEvidenceData, group_status: GroupStatus
+) -> float | None:
+    if group_status == GroupStatus.RESOLVED or group_status == GroupStatus.IGNORED:
+        return None
+    else:
+        return evidence_data.data_condition_comparison_value
+
+
+def fetch_resolve_threshold(
+    evidence_data: MetricIssueEvidenceData, group_status: GroupStatus
+) -> float | None:
+    """
+    This is the opposite of `fetch_alert_threshold`.
+    We keep it explicitly separate to make it clear that we are fetching the resolve threshold and to consolidate tech debt.
+    """
+    if group_status == GroupStatus.RESOLVED or group_status == GroupStatus.IGNORED:
+        return evidence_data.data_condition_comparison_value
+    else:
+        return None
 
 
 @dataclass
@@ -49,24 +85,21 @@ class AlertContext:
 
     @classmethod
     def from_workflow_engine_models(
-        cls, detector: Detector, issue_occurrence: IssueOccurrence
+        cls, detector: Detector, evidence_data: MetricIssueEvidenceData, group_status: GroupStatus
     ) -> AlertContext:
-        # TODO(iamrajjoshi): Finalize the fetch from issue_occurrence once we have evidence_data contract
-        threshold_type = issue_occurrence.evidence_data.get("threshold_type")
-        if threshold_type is not None:
-            threshold_type = AlertRuleThresholdType(threshold_type)
+        threshold_type = fetch_threshold_type(evidence_data)
+        resolve_threshold = fetch_resolve_threshold(evidence_data, group_status)
+        alert_threshold = fetch_alert_threshold(evidence_data, group_status)
+
         return cls(
             name=detector.name,
             action_identifier_id=detector.id,
             threshold_type=threshold_type,
             detection_type=detector.config.get("detection_type"),
             comparison_delta=detector.config.get("comparison_delta"),
-            # TODO(iamrajjoshi): Add sensitivity, alert_threshold, resolve_threshold
-            sensitivity=None,
-            resolve_threshold=None,
-            # Currently, i am hacking this so we don't have to fetch the alert_threshold, but we should
-            # remove this once we have the evidence_data contract
-            alert_threshold=1.0,
+            sensitivity=evidence_data.sensitivity,
+            resolve_threshold=resolve_threshold,
+            alert_threshold=alert_threshold,
         )
 
 
@@ -144,45 +177,37 @@ class MetricIssueContext:
     group: Group | None
 
     @classmethod
-    def _get_new_status(cls, group: Group, occurrence: IssueOccurrence) -> IncidentStatus:
+    def _get_new_status(cls, group: Group, priority_level: int) -> IncidentStatus:
         if group.status == GroupStatus.RESOLVED:
             return IncidentStatus.CLOSED
-        elif occurrence.priority == PriorityLevel.MEDIUM.value:
+        elif priority_level == PriorityLevel.MEDIUM.value:
             return IncidentStatus.WARNING
         else:
             return IncidentStatus.CRITICAL
 
     @classmethod
-    def _get_snuba_query(cls, occurrence: IssueOccurrence) -> SnubaQuery:
-        snuba_query_id = occurrence.evidence_data.get("snuba_query_id")
-        if not snuba_query_id:
-            raise ValueError("Snuba query ID is required for alert context")
-        try:
-            query = SnubaQuery.objects.get(id=snuba_query_id)
-        except SnubaQuery.DoesNotExist as e:
-            raise ValueError("Snuba query does not exist") from e
-        return query
+    def _get_subscription(cls, evidence_data: MetricIssueEvidenceData) -> QuerySubscription:
+        data_sources = evidence_data.data_sources
+        if len(data_sources) != 1:
+            raise ValueError("Only one data source is supported for alert context")
+        data_source = DataSource.objects.get(id=data_sources[0])
+
+        subscription = QuerySubscription.objects.get(id=data_source.source_id)
+        return subscription
 
     @classmethod
-    def _get_subscription(cls, occurrence: IssueOccurrence) -> QuerySubscription | None:
-        return occurrence.evidence_data.get("subscription_id")
-
-    @classmethod
-    def _get_metric_value(cls, occurrence: IssueOccurrence) -> float:
-        if (metric_value := occurrence.evidence_data.get("metric_value")) is None:
-            raise ValueError("Metric value is required for alert context")
-        return metric_value
-
-    @classmethod
-    def from_group_event(cls, group_event: GroupEvent) -> MetricIssueContext:
-        group = group_event.group
-        occurrence = group_event.occurrence
-        if occurrence is None:
-            raise ValueError("Occurrence is required for alert context")
+    def from_group_event(
+        cls, group: Group, evidence_data: MetricIssueEvidenceData, priority_level: int | None
+    ) -> MetricIssueContext:
+        if priority_level is None:
+            raise ValueError("Priority level is required for metric issues")
 
         open_period = get_latest_open_period(group)
         if open_period is None:
             raise ValueError("No open periods found for group")
+
+        subscription = cls._get_subscription(evidence_data)
+        snuba_query = subscription.snuba_query
 
         return cls(
             # TODO(iamrajjoshi): Replace with something once we know how we want to build the link
@@ -190,10 +215,10 @@ class MetricIssueContext:
             # Otherwise, we can use the issue id
             id=group.id,
             open_period_identifier=open_period.id,
-            snuba_query=cls._get_snuba_query(occurrence),
-            subscription=cls._get_subscription(occurrence),
-            new_status=cls._get_new_status(group, occurrence),
-            metric_value=cls._get_metric_value(occurrence),
+            snuba_query=snuba_query,
+            subscription=subscription,
+            new_status=cls._get_new_status(group, priority_level),
+            metric_value=evidence_data.value,
             group=group,
             title=group.title,
         )

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -9,6 +9,7 @@ import sentry_sdk
 from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.eventstore.models import GroupEvent
+from sentry.incidents.grouptype import MetricIssueEvidenceData
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -16,8 +17,7 @@ from sentry.incidents.typings.metric_detector import (
     NotificationContext,
     OpenPeriodContext,
 )
-from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.models.group import GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleSource
@@ -294,12 +294,16 @@ class BaseMetricAlertHandler(ABC):
         return NotificationContext.from_action_model(action)
 
     @classmethod
-    def build_alert_context(cls, detector: Detector, occurrence: IssueOccurrence) -> AlertContext:
-        return AlertContext.from_workflow_engine_models(detector, occurrence)
+    def build_alert_context(
+        cls, detector: Detector, evidence_data: MetricIssueEvidenceData, group_status: GroupStatus
+    ) -> AlertContext:
+        return AlertContext.from_workflow_engine_models(detector, evidence_data, group_status)
 
     @classmethod
-    def build_metric_issue_context(cls, event: GroupEvent) -> MetricIssueContext:
-        return MetricIssueContext.from_group_event(event)
+    def build_metric_issue_context(
+        cls, group: Group, evidence_data: MetricIssueEvidenceData, priority_level: int | None
+    ) -> MetricIssueContext:
+        return MetricIssueContext.from_group_event(group, evidence_data, priority_level)
 
     @classmethod
     def build_open_period_context(cls, event: GroupEvent) -> OpenPeriodContext:
@@ -339,9 +343,14 @@ class BaseMetricAlertHandler(ABC):
             if not event.occurrence:
                 raise ValueError("Event occurrence is required for alert context")
 
+            evidence_data = MetricIssueEvidenceData(**event.occurrence.evidence_data)
+
             notification_context = cls.build_notification_context(action)
-            alert_context = cls.build_alert_context(detector, event.occurrence)
-            metric_issue_context = cls.build_metric_issue_context(event)
+            alert_context = cls.build_alert_context(detector, evidence_data, event.group.status)
+
+            metric_issue_context = cls.build_metric_issue_context(
+                event.group, evidence_data, event.occurrence.priority
+            )
             open_period_context = cls.build_open_period_context(event)
 
             trigger_status = cls.get_trigger_status(event)

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -10,7 +10,7 @@ from sentry.issues.grouptype import GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.types.actor import Actor
-from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
+from sentry.workflow_engine.models import Condition, DataConditionGroup, DataPacket, Detector
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,10 @@ EvidenceValueT = TypeVar("EvidenceValueT")
 class EvidenceData(Generic[EvidenceValueT]):
     value: EvidenceValueT
     detector_id: int
+    data_sources: list[int]
     data_condition_ids: list[int]
+    data_condition_type: Condition
+    data_condition_comparison_value: T
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -23,7 +23,7 @@ EvidenceValueT = TypeVar("EvidenceValueT")
 class EvidenceData(Generic[EvidenceValueT]):
     value: EvidenceValueT
     detector_id: int
-    data_sources: list[int]
+    data_source_ids: list[int]
     data_condition_ids: list[int]
     data_condition_type: Condition
     data_condition_comparison_value: T

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -15,18 +15,20 @@ from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
 
+
 PacketT = TypeVar("PacketT")
 EvidenceValueT = TypeVar("EvidenceValueT")
 
 
 @dataclass
-class EvidenceData(Generic[EvidenceValueT]):
+class EvidenceData(Generic[EvidenceValueT, PacketT]):
     value: EvidenceValueT
     detector_id: int
     data_source_ids: list[int]
     data_condition_ids: list[int]
     data_condition_type: Condition
-    data_condition_comparison_value: T
+    # Represents the actual value that we are comparing against
+    data_condition_comparison_value: PacketT
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -41,9 +42,11 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -99,10 +102,10 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -113,6 +116,7 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
             metric_value=123.45,
             group=self.group_event.group,
             title=self.group_event.group.title,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_email_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -43,9 +44,11 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -103,11 +106,10 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            # TODO(iamrajjoshi): change this once we have the evidence_data contract
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -118,6 +120,7 @@ class TestEmailMetricAlertHandler(MetricAlertHandlerBase):
             metric_value=123.45,
             group=self.group_event.group,
             title=self.group_event.group.title,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_msteams_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -42,9 +43,11 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -100,10 +103,10 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -114,6 +117,7 @@ class TestMsteamsMetricAlertHandler(MetricAlertHandlerBase):
             metric_value=123.45,
             group=self.group_event.group,
             title=self.group_event.group.title,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_opsgenie_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -39,9 +40,11 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -96,10 +99,10 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -110,6 +113,7 @@ class TestOpsgenieMetricAlertHandler(MetricAlertHandlerBase):
             metric_value=123.45,
             group=self.group_event.group,
             title=self.group_event.group.title,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_pagerduty_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -37,9 +38,11 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -94,10 +97,10 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -108,6 +111,7 @@ class TestPagerDutyMetricAlertHandler(MetricAlertHandlerBase):
             metric_value=123.45,
             group=self.group_event.group,
             title=self.group_event.group.title,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -13,7 +14,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.sen
     SentryAppMetricAlertHandler,
 )
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_incident_serializer,
+    get_detailed_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import Action
@@ -52,9 +53,11 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -75,7 +78,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             organization=self.detector.project.organization,
             notification_uuid=notification_uuid,
-            incident_serialized_response=get_incident_serializer(self.open_period),
+            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
         )
 
     @mock.patch(
@@ -107,10 +110,10 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -121,6 +124,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             title=self.group_event.group.title,
             metric_value=123.45,
             group=self.group_event.group,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -14,7 +14,7 @@ from sentry.notifications.notification_action.metric_alert_registry.handlers.sen
     SentryAppMetricAlertHandler,
 )
 from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
-    get_detailed_incident_serializer,
+    get_incident_serializer,
 )
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import Action
@@ -78,7 +78,7 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             metric_issue_context=metric_issue_context,
             organization=self.detector.project.organization,
             notification_uuid=notification_uuid,
-            incident_serialized_response=get_detailed_incident_serializer(self.open_period),
+            incident_serialized_response=get_incident_serializer(self.open_period),
         )
 
     @mock.patch(

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest import mock
 
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -44,9 +45,11 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = NotificationContext.from_action_model(self.action)
         assert self.group_event.occurrence is not None
         alert_context = AlertContext.from_workflow_engine_models(
-            self.detector, self.group_event.occurrence
+            self.detector, self.evidence_data, self.group_event.group.status
         )
-        metric_issue_context = MetricIssueContext.from_group_event(self.group_event)
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
         open_period_context = OpenPeriodContext.from_group(self.group)
         notification_uuid = str(uuid.uuid4())
 
@@ -102,10 +105,10 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             alert_context,
             name=self.detector.name,
             action_identifier_id=self.detector.id,
-            threshold_type=None,
+            threshold_type=AlertRuleThresholdType.ABOVE,
             detection_type=None,
             comparison_delta=None,
-            alert_threshold=1.0,
+            alert_threshold=self.evidence_data.data_condition_comparison_value,
         )
 
         self.assert_metric_issue_context(
@@ -116,6 +119,7 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
             metric_value=123.45,
             group=self.group_event.group,
             title=self.group_event.group.title,
+            subscription=self.subscription,
         )
 
         self.assert_open_period_context(

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -282,7 +282,9 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert group_event.occurrence is not None
         assert group_event.occurrence.priority is not None
         assert (
-            MetricIssueContext._get_new_status(group, group_event.occurrence.priority)
+            MetricIssueContext._get_new_status(
+                group, PriorityLevel(group_event.occurrence.priority)
+            )
             == IncidentStatus.CRITICAL
         )
 
@@ -297,7 +299,9 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert group_event.occurrence is not None
         assert group_event.occurrence.priority is not None
         assert (
-            MetricIssueContext._get_new_status(group, group_event.occurrence.priority)
+            MetricIssueContext._get_new_status(
+                group, PriorityLevel(group_event.occurrence.priority)
+            )
             == IncidentStatus.WARNING
         )
 
@@ -314,7 +318,9 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         # Set the group to resolved -> incident is closed
         group.status = GroupStatus.RESOLVED
         assert (
-            MetricIssueContext._get_new_status(group, group_event.occurrence.priority)
+            MetricIssueContext._get_new_status(
+                group, PriorityLevel(group_event.occurrence.priority)
+            )
             == IncidentStatus.CLOSED
         )
 
@@ -340,7 +346,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert self.group_event.occurrence is not None
         assert self.group_event.occurrence.priority is not None
         status = MetricIssueContext._get_new_status(
-            self.group_event.group, self.group_event.occurrence.priority
+            self.group_event.group, PriorityLevel(self.group_event.occurrence.priority)
         )
         assert status == IncidentStatus.CRITICAL
 
@@ -355,7 +361,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         assert group_event.occurrence is not None
         assert group_event.occurrence.priority is not None
         status = MetricIssueContext._get_new_status(
-            group_event.group, group_event.occurrence.priority
+            group_event.group, PriorityLevel(group_event.occurrence.priority)
         )
         assert status == IncidentStatus.WARNING
 

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -105,7 +105,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
             data_condition_comparison_value=123,
             alert_id=self.alert_rule.id,
             detector_id=self.detector.id,
-            data_sources=[self.data_source.id],
+            data_source_ids=[self.data_source.id],
         )
         self.group, self.event, self.group_event = self.create_group_event(
             occurrence=self.create_issue_occurrence(

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -10,7 +10,7 @@ from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.snuba.models import SnubaQuery
+from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import EventType
 from sentry.utils.registry import AlreadyRegisteredError
@@ -79,6 +79,19 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
             aggregate="count()",
             time_window=60,
             resolution=60,
+            **kwargs,
+        )
+
+    def create_snuba_query_subscription(
+        self, project_id: int | None = None, snuba_query_id: int | None = None, **kwargs
+    ):
+        if snuba_query_id is None:
+            snuba_query_id = self.create_snuba_query().id
+        if project_id is None:
+            project_id = self.project.id
+        return QuerySubscription.objects.create(
+            project_id=project_id,
+            snuba_query_id=snuba_query_id,
             **kwargs,
         )
 


### PR DESCRIPTION
this pr updates the `MetricIssueEvidenceData` dataclass and uses the dataclasss to derive the data needed to send notifications for metric issues

## To make reviewing easier, I'd recommend the following order:
1. `src/sentry/workflow_engine/handlers/detector/base.py`
2. `src/sentry/incidents/grouptype.py`
3. `src/sentry/incidents/typings/metric_detector.py` and `src/sentry/notifications/notification_action/types.py`