### PR TITLE
feat(seer): Add project flag to auto run issue summaries

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1099,6 +1099,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             },
             "symbolSources": serialized_sources,
             "isDynamicallySampled": sample_rate is not None and sample_rate < 1.0,
+            "autoRunIssueSummaries": bool(
+                self.get_value_with_default(attrs, "sentry:auto_run_issue_summaries")
+            ),
         }
 
         if has_tempest_access(obj.organization, user):
@@ -1149,6 +1152,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 self.get_value_with_default(attrs, "sentry:toolbar_allowed_origins") or []
             ),
             "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
+            "sentry:auto_run_issue_summaries": bool(
+                self.get_value_with_default(attrs, "sentry:auto_run_issue_summaries")
+            ),
         }
 
     def get_value_with_default(self, attrs, key):

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -74,6 +74,7 @@ OPTION_KEYS = frozenset(
         "filters:react-hydration-errors",
         "filters:chunk-load-error",
         "relay.cardinality-limiter.limits",
+        "sentry:auto_run_issue_summaries",
     ]
 )
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -196,3 +196,6 @@ register(key="sentry:tempest_fetch_screenshots", default=False)
 
 # Should tempest fetch dumps for this project
 register(key="sentry:tempest_fetch_dumps", default=False)
+
+# Auto-enable issue summaries for projects
+register(key="sentry:auto_run_issue_summaries", default=True)

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -797,6 +797,17 @@ class DetailedProjectSerializerTest(TestCase):
         result = serialize(self.project, self.user, DetailedProjectSerializer())
         assert result["options"]["sentry:replay_hydration_error_issues"] is False
 
+    def test_auto_run_issue_summaries_flag(self):
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        # default should be true
+        assert result["options"]["sentry:auto_run_issue_summaries"] is True
+        assert result["autoRunIssueSummaries"] is True
+
+        self.project.update_option("sentry:auto_run_issue_summaries", False)
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        assert result["options"]["sentry:auto_run_issue_summaries"] is False
+        assert result["autoRunIssueSummaries"] is False
+
     def test_toolbar_allowed_origins(self):
         # Does not allow trailing newline or extra whitespace.
         # Default is empty:


### PR DESCRIPTION
default: always run issue summaries
when disabled: summaries will not run by default.

part of https://linear.app/getsentry/issue/AIML-93/autofix-add-automation-toggles
