### PR TITLE
fix(api): Make trace item details rename type=double to type=float

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -44,6 +44,8 @@ def convert_rpc_attribute_to_json(
                     column_type = "string"
                 elif val_type in ["int", "float", "double"]:
                     column_type = "number"
+                    if val_type == "double":
+                        val_type = "float"
                 else:
                     raise BadRequest(f"unknown column type in protobuf: {val_type}")
 


### PR DESCRIPTION
Related to https://github.com/getsentry/snuba/pull/7145 (needs to be done before that can be merged) - we use 'double' in the wire for float64 accuracy