### PR TITLE
chore(perf-issues): Increase rollout to 0.5 for HTTP Detectors

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1641,12 +1641,12 @@ register(
 )
 register(
     "performance.issues.consecutive_http.problem-creation",
-    default=0.25,
+    default=0.5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "performance.issues.large_http_payload.problem-creation",
-    default=0.25,
+    default=0.5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/90538