### PR TITLE
 chore(perf-issues): Fully rollout HTTP Detectors

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1625,12 +1625,12 @@ register(
 )
 register(
     "performance.issues.consecutive_http.problem-creation",
-    default=0.75,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "performance.issues.large_http_payload.problem-creation",
-    default=0.75,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(


### PR DESCRIPTION
Fully rollout HTTP detectors, follow up to https://github.com/getsentry/sentry/pull/90723