### PR TITLE
feat(insights): add user column to overview pages, remove slow op charts

### DIFF
--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -77,6 +77,7 @@ const SORTABLE_FIELDS = new Set([
   'p50(span.duration)',
   'p95(span.duration)',
   'failure_rate()',
+  'count_unique(user)',
 ]);
 
 const NUMERIC_FIELDS = new Set([

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -213,6 +213,7 @@ function EAPBackendOverviewPage() {
         'p50(span.duration)',
         'p95(span.duration)',
         'failure_rate()',
+        'count_unique(user)',
         'time_spent_percentage(span.duration)',
         'sum(span.duration)',
       ],

--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -35,6 +35,7 @@ type Row = Pick<
   | 'p50(span.duration)'
   | 'p95(span.duration)'
   | 'failure_rate()'
+  | 'count_unique(user)'
   | 'time_spent_percentage(span.duration)'
   | 'sum(span.duration)'
 >;
@@ -49,6 +50,7 @@ type Column = GridColumnHeader<
   | 'p50(span.duration)'
   | 'p95(span.duration)'
   | 'failure_rate()'
+  | 'count_unique(user)'
   | 'time_spent_percentage(span.duration)'
   | 'sum(span.duration)'
 >;
@@ -95,6 +97,11 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
+    key: 'count_unique(user)',
+    name: t('Users'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
     key: 'time_spent_percentage(span.duration)',
     name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
@@ -111,6 +118,7 @@ const SORTABLE_FIELDS = [
   'p50(span.duration)',
   'p95(span.duration)',
   'failure_rate()',
+  'count_unique(user)',
   'time_spent_percentage(span.duration)',
 ] as const;
 

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -127,8 +127,9 @@ function EAPOverviewPage() {
   const showOnboarding = onboardingProject !== undefined;
 
   const doubleChartRowCharts = [
-    PerformanceWidgetSetting.SLOW_HTTP_OPS,
-    PerformanceWidgetSetting.SLOW_RESOURCE_OPS,
+    PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS,
+    PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES,
+    PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES,
   ];
   const tripleChartRowCharts = filterAllowedChartsMetrics(
     organization,
@@ -143,12 +144,6 @@ function EAPOverviewPage() {
     ],
     mepSetting
   );
-
-  if (organization.features.includes('insights-initial-modules')) {
-    doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_TIME_CONSUMING_DOMAINS);
-    doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES);
-    doubleChartRowCharts.unshift(PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES);
-  }
 
   const getFreeTextFromQuery = (query: string) => {
     const conditions = new MutableSearch(query);
@@ -204,6 +199,7 @@ function EAPOverviewPage() {
         'p95(span.duration)',
         'failure_rate()',
         'time_spent_percentage(span.duration)',
+        'count_unique(user)',
         'sum(span.duration)',
       ],
     },

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -33,6 +33,7 @@ type Row = Pick<
   | 'p95(span.duration)'
   | 'failure_rate()'
   | 'time_spent_percentage(span.duration)'
+  | 'count_unique(user)'
   | 'sum(span.duration)'
 >;
 
@@ -46,6 +47,7 @@ type Column = GridColumnHeader<
   | 'p95(span.duration)'
   | 'failure_rate()'
   | 'time_spent_percentage(span.duration)'
+  | 'count_unique(user)'
   | 'sum(span.duration)'
 >;
 
@@ -86,6 +88,11 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
+    key: 'count_unique(user)',
+    name: t('Users'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
     key: 'time_spent_percentage(span.duration)',
     name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
@@ -101,6 +108,7 @@ const SORTABLE_FIELDS = [
   'p50(span.duration)',
   'p95(span.duration)',
   'failure_rate()',
+  'count_unique(user)',
   'time_spent_percentage(span.duration)',
 ] as const;
 

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -202,6 +202,7 @@ function EAPMobileOverviewPage() {
         'p50(span.duration)',
         'p95(span.duration)',
         'failure_rate()',
+        'count_unique(user)',
         'time_spent_percentage(span.duration)',
         'sum(span.duration)',
       ],

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -32,6 +32,7 @@ type Row = Pick<
   | 'p50(span.duration)'
   | 'p95(span.duration)'
   | 'failure_rate()'
+  | 'count_unique(user)'
   | 'time_spent_percentage(span.duration)'
   | 'sum(span.duration)'
 >;
@@ -45,6 +46,7 @@ type Column = GridColumnHeader<
   | 'p50(span.duration)'
   | 'p95(span.duration)'
   | 'failure_rate()'
+  | 'count_unique(user)'
   | 'time_spent_percentage(span.duration)'
   | 'sum(span.duration)'
 >;
@@ -86,6 +88,11 @@ const COLUMN_ORDER: Column[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
+    key: 'count_unique(user)',
+    name: t('Users'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  {
     key: 'time_spent_percentage(span.duration)',
     name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
@@ -101,6 +108,7 @@ const SORTABLE_FIELDS = [
   'p50(span.duration)',
   'p95(span.duration)',
   'failure_rate()',
+  'count_unique(user)',
   'time_spent_percentage(span.duration)',
 ] as const;
 

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -72,6 +72,7 @@ export enum SpanFields {
   CACHE_HIT = 'cache.hit',
   IS_STARRED_TRANSACTION = 'is_starred_transaction',
   SPAN_DURATION = 'span.duration',
+  USER = 'user',
 }
 
 type SpanBooleanFields =
@@ -244,6 +245,8 @@ export type EAPSpanResponse = {
       | `${Property}(${string},${string},${string})`]: number;
   } & {
     [SpanMetricsField.USER_GEO_SUBREGION]: SubregionCode;
+  } & {
+    [Property in SpanFields as `count_unique(${Property})`]: number;
   };
 
 export type EAPSpanProperty = keyof EAPSpanResponse;


### PR DESCRIPTION
1. Add user column to eap overview table
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/d8962e1c-5d71-411e-894b-d2bd1ddf5fa3" />

2. Remove Slow ops Charts to eap overview pages as we have better span based charts like slow assets, and most-time consuming domains