### PR TITLE
feat(explore): Add pagination analytics

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -37,6 +37,11 @@ export type TracingEventParameters = {
   'trace.explorer.schema_hints_drawer': {
     drawer_open: boolean;
   };
+  'trace.explorer.table_pagination': {
+    direction: string;
+    num_results: number;
+    type: 'samples' | 'traces' | 'aggregates';
+  };
   'trace.load.empty_state': {
     source: TraceWaterFallSource;
   };
@@ -184,6 +189,7 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
     'Improved Trace Explorer: Schema Hints Click Events',
   'trace.explorer.schema_hints_drawer':
     'Improved Trace Explorer: Schema Hints Drawer Events',
+  'trace.explorer.table_pagination': 'Trace Explorer Table Pagination',
   'trace.trace_layout.change': 'Changed Trace Layout',
   'trace.trace_layout.drawer_minimize': 'Minimized Trace Drawer',
   'trace.trace_drawer_explore_search': 'Searched Trace Explorer',

--- a/static/app/views/explore/hooks/usePaginationAnalytics.tsx
+++ b/static/app/views/explore/hooks/usePaginationAnalytics.tsx
@@ -1,0 +1,20 @@
+import {useCallback} from 'react';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function usePaginationAnalytics(numResults: number) {
+  const organization = useOrganization();
+
+  return useCallback(
+    (direction: string) => {
+      trackAnalytics('trace.explorer.table_pagination', {
+        direction,
+        type: 'traces',
+        num_results: numResults,
+        organization,
+      });
+    },
+    [organization, numResults]
+  );
+}

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -40,6 +40,7 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
+import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 import {TOP_EVENTS_LIMIT, useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
 import {viewSamplesTarget} from 'sentry/views/explore/utils';
 
@@ -83,6 +84,8 @@ export function AggregatesTable({
   const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
 
   const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 2); // -2 because getColorPalette artificially adds 1, I'm not sure why
+
+  const paginationAnalyticsEvent = usePaginationAnalytics(result.data?.length ?? 0);
 
   return (
     <Fragment>
@@ -207,7 +210,10 @@ export function AggregatesTable({
           )}
         </TableBody>
       </Table>
-      <Pagination pageLinks={result.pageLinks} />
+      <Pagination
+        pageLinks={result.pageLinks}
+        paginationAnalyticsEvent={paginationAnalyticsEvent}
+      />
     </Fragment>
   );
 }

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -28,6 +28,7 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
+import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 
 import {FieldRenderer} from './fieldRenderer';
 
@@ -60,6 +61,8 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
 
   const {tags: numberTags} = useSpanTags('number');
   const {tags: stringTags} = useSpanTags('string');
+
+  const paginationAnalyticsEvent = usePaginationAnalytics(result.data?.length ?? 0);
 
   return (
     <Fragment>
@@ -154,7 +157,10 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
           )}
         </TableBody>
       </Table>
-      <Pagination pageLinks={result.pageLinks} />
+      <Pagination
+        pageLinks={result.pageLinks}
+        paginationAnalyticsEvent={paginationAnalyticsEvent}
+      />
     </Fragment>
   );
 }

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -24,6 +24,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {useExploreQuery} from 'sentry/views/explore/contexts/pageParamsContext';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
+import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
 import {
   Description,
@@ -58,6 +59,8 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
 
   const showErrorState = !isPending && isError;
   const showEmptyState = !isPending && !showErrorState && (data?.data?.length ?? 0) === 0;
+
+  const paginationAnalyticsEvent = usePaginationAnalytics(data?.data?.length ?? 0);
 
   return (
     <Fragment>
@@ -124,7 +127,10 @@ export function TracesTable({tracesTableResult}: TracesTableProps) {
           ))}
         </TracePanelContent>
       </StyledPanel>
-      <Pagination pageLinks={getResponseHeader?.('Link')} />
+      <Pagination
+        pageLinks={getResponseHeader?.('Link')}
+        paginationAnalyticsEvent={paginationAnalyticsEvent}
+      />
     </Fragment>
   );
 }


### PR DESCRIPTION
Record an analytics event for pagination clicks. The data we store are:
- the type of table (samples, traces, aggregates)
- the number of results being rendered
- the direction of the pagination (next vs previous, defined by the pagination component)