### PR TITLE
:wrench: chore(aci): use integration provider enum in config  definition

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_issue_alert_handler
 from sentry.workflow_engine.models import Action, Detector
@@ -10,8 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class IntegrationActionHandler(ActionHandler, ABC):
-    # TODO(iamrajjoshi): Switch this to an enum after we decide on what this enum will be
-    provider_slug: str
+    provider_slug: IntegrationProviderSlug
 
 
 class TicketingActionHandler(IntegrationActionHandler, ABC):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from unittest.mock import ANY, patch
 
 from sentry.constants import SentryAppStatus
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.action_handler_registry.base import (
     IntegrationActionHandler,
 )
@@ -57,7 +58,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
         @dataclass(frozen=True)
         class SlackActionHandler(IntegrationActionHandler):
             group = ActionHandler.Group.NOTIFICATION
-            provider_slug = "slack"
+            provider_slug = IntegrationProviderSlug.SLACK
             config_schema = {}
             data_schema = {}
 
@@ -74,7 +75,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
         @dataclass(frozen=True)
         class GithubActionHandler(IntegrationActionHandler):
             group = ActionHandler.Group.TICKET_CREATION
-            provider_slug = "github"
+            provider_slug = IntegrationProviderSlug.GITHUB
             config_schema = {}
             data_schema = {}
 
@@ -92,7 +93,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
         @dataclass(frozen=True)
         class MSTeamsActionHandler(IntegrationActionHandler):
             group = ActionHandler.Group.NOTIFICATION
-            provider_slug = "msteams"
+            provider_slug = IntegrationProviderSlug.MSTEAMS
             config_schema = {}
             data_schema = {}
 


### PR DESCRIPTION
cleaning up a todo. this has no impact on migrations or anything