### PR TITLE
fix(taskworker) Switch cluster_projects to use project_ids

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -71,6 +71,17 @@ def get_active_projects(namespace: ClustererNamespace) -> Iterator[Project]:
             logger.debug("Could not find project %s in db", project_id)
 
 
+def get_active_project_ids(namespace: ClustererNamespace) -> Iterator[int]:
+    """
+    Scan redis for projects and fetch their ids.
+
+    Unlike get_active_projects(), this will include ids for projects
+    that have been deleted since clustering was scheduled.
+    """
+    for key in _get_all_keys(namespace):
+        yield int(key)
+
+
 def _record_sample(namespace: ClustererNamespace, project: Project, sample: str) -> None:
     with sentry_sdk.start_span(op=f"cluster.{namespace.value.name}.record_sample"):
         client = get_redis_client()

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -55,10 +55,10 @@ def spawn_clusterers(**kwargs: Any) -> None:
     """Look for existing transaction name sets in redis and spawn clusterers for each"""
     with sentry_sdk.start_span(op="txcluster_spawn"):
         project_count = 0
-        project_iter = redis.get_active_projects(ClustererNamespace.TRANSACTIONS)
+        project_iter = redis.get_active_project_ids(ClustererNamespace.TRANSACTIONS)
         while batch := list(islice(project_iter, PROJECTS_PER_TASK)):
             project_count += len(batch)
-            cluster_projects.delay(batch)
+            cluster_projects.delay(project_ids=batch)
 
         metrics.incr("txcluster.spawned_projects", amount=project_count, sample_rate=1.0)
 

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -9,6 +9,7 @@ from sentry.ingest.transaction_clusterer.datasource.redis import (
     _get_redis_key,
     _record_sample,
     clear_samples,
+    get_active_project_ids,
     get_active_projects,
     get_redis_client,
     get_transaction_names,
@@ -366,8 +367,7 @@ def test_run_clusterer_spawn_cluster_projects(cluster_projects_delay, default_or
     spawn_clusterers()
 
     assert cluster_projects_delay.call_count == 1
-    # TODO(taskworker) This should use project_ids to avoid pickle
-    cluster_projects_delay.assert_called_once_with([project1, project2])
+    cluster_projects_delay.assert_called_once_with(project_ids=[project1.id, project2.id])
 
 
 @mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
@@ -379,7 +379,7 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
 
     _record_sample(ClustererNamespace.TRANSACTIONS, project, "/transaction/number/1")
-    cluster_projects([project])
+    cluster_projects(project_ids=[project.id])
     # Clusterer didn't create rules. Still, it updates the stores.
     assert mock_update_rules.call_count == 1
     assert mock_update_rules.call_args == mock.call(ClustererNamespace.TRANSACTIONS, project, [])
@@ -395,11 +395,27 @@ def test_clusterer_only_runs_when_enough_transactions(mock_update_rules, default
     )
 
 
+@mock.patch("sentry.ingest.transaction_clusterer.datasource.redis.MAX_SET_SIZE", 2)
+@mock.patch("sentry.ingest.transaction_clusterer.tasks.MERGE_THRESHOLD", 2)
+@mock.patch("sentry.ingest.transaction_clusterer.rules.update_rules")
+@django_db_all
+def test_clusterer_skips_deleted_projects(mock_update_rules, default_project):
+    project = default_project
+    assert get_rules(ClustererNamespace.TRANSACTIONS, project) == {}
+
+    _record_sample(ClustererNamespace.TRANSACTIONS, project, "/transaction/number/1")
+    # The 6666 record doesn't exist, the task should not fail
+    cluster_projects(project_ids=[project.id, 6666])
+    assert mock_update_rules.call_count == 1
+    mock_update_rules.assert_called_once_with(ClustererNamespace.TRANSACTIONS, project, [])
+
+
 @django_db_all
 def test_get_deleted_project():
     deleted_project = Project(pk=666, organization=Organization(pk=666))
     _record_sample(ClustererNamespace.TRANSACTIONS, deleted_project, "foo")
     assert list(get_active_projects(ClustererNamespace.TRANSACTIONS)) == []
+    assert list(get_active_project_ids(ClustererNamespace.TRANSACTIONS)) == [666]
 
 
 @django_db_all


### PR DESCRIPTION
Pass lists of ids instead of entire project models through task parameters. This continues changes started in #90681