### PR TITLE
fix(ui): optIn banner styling in chonk

### DIFF
--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -110,7 +110,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                     );
                   }}
                 >
-                  {t('Try New Navigation')} <Badge type="alpha">{t('Alpha')}</Badge>
+                  {t('Try New Navigation')} <Badge type="beta">{t('Beta')}</Badge>
                 </SidebarMenuItem>
               )}
               {organization?.features?.includes('chonk-ui') ? (

--- a/static/app/views/nav/optInBanner.tsx
+++ b/static/app/views/nav/optInBanner.tsx
@@ -65,7 +65,7 @@ const TranslucentBackgroundPanel = styled(Panel)<{isDarkMode: boolean}>`
   background: rgba(245, 243, 247, ${p => (p.isDarkMode ? 0.05 : 0.1)});
   border: 1px solid rgba(245, 243, 247, ${p => (p.isDarkMode ? 0.1 : 0.15)});
   padding: ${space(1)};
-  color: ${p => (p.isDarkMode ? p.theme.textColor : '#ebe6ef')};
+  color: ${p => (p.theme.isChonk || p.isDarkMode ? p.theme.textColor : '#ebe6ef')};
 
   margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
before:

![image (34)](https://github.com/user-attachments/assets/0208a805-a153-4b15-a604-b0cd2834016f)

after:

![Screenshot 2025-05-01 at 18 05 01](https://github.com/user-attachments/assets/6e618d3e-137c-4bb4-91da-2d746cf89e9e)

