### PR TITLE
fix(saved-searches): Fix custom search button styles

### DIFF
--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -81,12 +81,9 @@ const StyledButton = styled(Button)`
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-right: none;
-    ${p => p.theme.overflowEllipsis};
 
-    > span {
+    & > span {
       ${p => p.theme.overflowEllipsis};
-      height: auto;
-      display: block;
     }
   }
 `;


### PR DESCRIPTION
Probably due to recent changes to the button component, but the "custom search" button that is shown when you do not have issue views was messed up:

![CleanShot 2025-05-01 at 09 16 40@2x](https://github.com/user-attachments/assets/bbd9830d-78b4-42ed-973f-adc386cfbb0d)
