### PR TITLE
feat(insights): add perf score column to frontend overview

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -57,6 +57,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {PercentChangeCell} from 'sentry/views/insights/common/components/tableCells/percentChangeCell';
 import {ResponseStatusCodeCell} from 'sentry/views/insights/common/components/tableCells/responseStatusCodeCell';
 import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
@@ -378,6 +379,7 @@ type SpecialFields = {
   issue: SpecialField;
   'issue.id': SpecialField;
   minidump: SpecialField;
+  'performance_score(measurements.score.total)': SpecialField;
   'profile.id': SpecialField;
   project: SpecialField;
   release: SpecialField;
@@ -401,6 +403,11 @@ const DownloadCount = styled('span')`
 const RightAlignedContainer = styled('span')`
   margin-left: auto;
   margin-right: 0;
+`;
+
+const CenterAlignedContainer = styled('span')`
+  text-align: center;
+  width: 100%;
 `;
 
 /**
@@ -826,6 +833,20 @@ const SPECIAL_FIELDS: SpecialFields = {
         )}
       </Container>
     ),
+  },
+  'performance_score(measurements.score.total)': {
+    sortField: 'performance_score(measurements.score.total)',
+    renderFunc: data => {
+      const score = data['performance_score(measurements.score.total)'];
+      if (typeof score !== 'number') {
+        return <Container>{emptyValue}</Container>;
+      }
+      return (
+        <CenterAlignedContainer>
+          <PerformanceBadge score={Math.round(score * 100)} />
+        </CenterAlignedContainer>
+      );
+    },
   },
 };
 

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -77,6 +77,7 @@ const SORTABLE_FIELDS = new Set([
   'p50(span.duration)',
   'p95(span.duration)',
   'failure_rate()',
+  'performance_score(measurements.score.total)',
 ]);
 
 const NUMERIC_FIELDS = new Set([

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -42,9 +42,9 @@ import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageH
 import {OldFrontendOverviewPage} from 'sentry/views/insights/pages/frontend/oldFrontendOverviewPage';
 import {
   DEFAULT_SORT,
+  EAP_OVERVIEW_PAGE_ALLOWED_OPS,
   FRONTEND_LANDING_TITLE,
   FRONTEND_PLATFORMS,
-  OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
 import {useIsNextJsInsightsEnabled} from 'sentry/views/insights/pages/platform/nextjs/features';
@@ -111,7 +111,7 @@ function EAPOverviewPage() {
   const existingQuery = new MutableSearch(eventView.query);
   // TODO - this query is getting complicated, once were on EAP, we should consider moving this to the backend
   existingQuery.addOp('(');
-  existingQuery.addFilterValues('span.op', OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addFilterValues('span.op', EAP_OVERVIEW_PAGE_ALLOWED_OPS);
   // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
   if (selectedFrontendProjects.length > 0) {
     existingQuery.addOp('OR');

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -111,7 +111,7 @@ function EAPOverviewPage() {
   const existingQuery = new MutableSearch(eventView.query);
   // TODO - this query is getting complicated, once were on EAP, we should consider moving this to the backend
   existingQuery.addOp('(');
-  existingQuery.addDisjunctionFilterValues('span.op', OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addFilterValues('span.op', OVERVIEW_PAGE_ALLOWED_OPS);
   // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
   if (selectedFrontendProjects.length > 0) {
     existingQuery.addOp('OR');
@@ -188,8 +188,6 @@ function EAPOverviewPage() {
     decodeSorts(location.query?.sort).find(isAValidSort) ?? DEFAULT_SORT,
   ];
 
-  existingQuery.addFilterValue('is_transaction', 'true');
-
   const response = useEAPSpans(
     {
       search: existingQuery,
@@ -197,13 +195,13 @@ function EAPOverviewPage() {
       fields: [
         'is_starred_transaction',
         'transaction',
-        'span.op',
         'project',
         'epm()',
         'p50(span.duration)',
         'p95(span.duration)',
         'failure_rate()',
         'time_spent_percentage(span.duration)',
+        'performance_score(measurements.score.total)',
         'sum(span.duration)',
       ],
     },

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -26,7 +26,6 @@ type Row = Pick<
   EAPSpanResponse,
   | 'is_starred_transaction'
   | 'transaction'
-  | 'span.op'
   | 'project'
   | 'epm()'
   | 'p50(span.duration)'
@@ -34,12 +33,12 @@ type Row = Pick<
   | 'failure_rate()'
   | 'time_spent_percentage(span.duration)'
   | 'sum(span.duration)'
+  | 'performance_score(measurements.score.total)'
 >;
 
 type Column = GridColumnHeader<
   | 'is_starred_transaction'
   | 'transaction'
-  | 'span.op'
   | 'project'
   | 'epm()'
   | 'p50(span.duration)'
@@ -47,17 +46,13 @@ type Column = GridColumnHeader<
   | 'failure_rate()'
   | 'time_spent_percentage(span.duration)'
   | 'sum(span.duration)'
+  | 'performance_score(measurements.score.total)'
 >;
 
 const COLUMN_ORDER: Column[] = [
   {
     key: 'transaction',
     name: t('Transaction'),
-    width: COL_WIDTH_UNDEFINED,
-  },
-  {
-    key: 'span.op',
-    name: t('Operation'),
     width: COL_WIDTH_UNDEFINED,
   },
   {
@@ -90,18 +85,23 @@ const COLUMN_ORDER: Column[] = [
     name: DataTitles.timeSpent,
     width: COL_WIDTH_UNDEFINED,
   },
+  {
+    key: 'performance_score(measurements.score.total)',
+    name: t('Perf Score'),
+    width: COL_WIDTH_UNDEFINED,
+  },
 ];
 
 const SORTABLE_FIELDS = [
   'is_starred_transaction',
   'transaction',
-  'span.op',
   'project',
   'epm()',
   'p50(span.duration)',
   'p95(span.duration)',
   'failure_rate()',
   'time_spent_percentage(span.duration)',
+  'performance_score(measurements.score.total)',
 ] as const;
 
 export type ValidSort = Sort & {
@@ -203,13 +203,7 @@ function renderBodyCell(
   }
 
   if (column.key === 'transaction') {
-    return (
-      <TransactionCell
-        project={row.project}
-        transaction={row.transaction}
-        transactionMethod={row['span.op']}
-      />
-    );
+    return <TransactionCell project={row.project} transaction={row.transaction} />;
   }
 
   const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -13,6 +13,13 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'navigation',
   'ui.render',
   'interaction',
+  'ui.interaction',
+  'ui.interaction.click',
+  'ui.interaction.hover',
+  'ui.interaction.drag',
+  'ui.interaction.press',
+  'ui.webvital.cls',
+  'ui.webvital.fcp',
 ];
 
 export const MODULES = [

--- a/static/app/views/insights/pages/frontend/settings.ts
+++ b/static/app/views/insights/pages/frontend/settings.ts
@@ -8,7 +8,7 @@ export const FRONTEND_LANDING_SUB_PATH = 'frontend';
 export const FRONTEND_LANDING_TITLE = t('Frontend');
 export const FRONTEND_SIDEBAR_LABEL = t('Frontend');
 
-export const OVERVIEW_PAGE_ALLOWED_OPS = [
+export const EAP_OVERVIEW_PAGE_ALLOWED_OPS = [
   'pageload',
   'navigation',
   'ui.render',
@@ -20,6 +20,13 @@ export const OVERVIEW_PAGE_ALLOWED_OPS = [
   'ui.interaction.press',
   'ui.webvital.cls',
   'ui.webvital.fcp',
+];
+
+export const OVERVIEW_PAGE_ALLOWED_OPS = [
+  'pageload',
+  'navigation',
+  'ui.render',
+  'interaction',
 ];
 
 export const MODULES = [

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -74,6 +74,14 @@ export enum SpanFields {
   SPAN_DURATION = 'span.duration',
 }
 
+type WebVitalsMeasurements =
+  | 'measurements.score.cls'
+  | 'measurements.score.fcp'
+  | 'measurements.score.inp'
+  | 'measurements.score.lcp'
+  | 'measurements.score.ttfb'
+  | 'measurements.score.total';
+
 type SpanBooleanFields =
   | SpanFields.CACHE_HIT
   | SpanFields.IS_TRANSACTION
@@ -172,6 +180,8 @@ export const SPAN_FUNCTIONS = [
   'failure_rate',
 ] as const;
 
+export const WEB_VITAL_FUNCTIONS = ['performance_score'] as const;
+
 type BreakpointCondition = 'less' | 'greater';
 
 type RegressionFunctions = [
@@ -183,6 +193,8 @@ type RegressionFunctions = [
 type SpanAnyFunction = `any(${string})`;
 
 export type SpanFunctions = (typeof SPAN_FUNCTIONS)[number];
+
+type WebVitalsFunctions = (typeof WEB_VITAL_FUNCTIONS)[number];
 
 export type SpanMetricsResponse = {
   [Property in SpanNumberFields as `${Aggregate}(${Property})`]: number;
@@ -225,6 +237,8 @@ export type EAPSpanResponse = {
   [Property in SpanNumberFields as `${Aggregate}(${Property})`]: number;
 } & {
   [Property in SpanFunctions as `${Property}()`]: number;
+} & {
+  [Property in WebVitalsMeasurements as `${WebVitalsFunctions}(${Property})`]: number;
 } & {
   [Property in SpanStringFields as `${Property}`]: string;
 } & {


### PR DESCRIPTION
1. Remove span.op column for frontend overview
2. Add performance score column
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/34959713-a21f-4b77-a15c-896dde9a891a" />
