### PR TITLE
ref: avoid very old fixed dates in test_organization_stats_summary

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_stats_summary.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_summary.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from django.urls import reverse
@@ -9,13 +9,20 @@ from django.urls import reverse
 from sentry.constants import DataCategory
 from sentry.testutils.cases import APITestCase, OutcomesSnubaTest
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils.dates import floor_to_utc_day
 from sentry.utils.outcomes import Outcome
 
 
+def _iso_z(dt: datetime) -> str:
+    assert dt.tzinfo == UTC
+    return f"{dt.isoformat().removesuffix('+00:00')}Z"
+
+
 class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
+    _now = datetime.now(UTC).replace(hour=12, minute=27, second=28, microsecond=0)
+
     def setUp(self):
         super().setUp()
-        self.now = datetime(2021, 3, 14, 12, 27, 28, tzinfo=timezone.utc)
 
         self.login_as(user=self.user)
 
@@ -45,7 +52,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         self.store_outcomes(
             {
                 "org_id": self.org.id,
-                "timestamp": self.now - timedelta(hours=1),
+                "timestamp": self._now - timedelta(hours=1),
                 "project_id": self.project.id,
                 "outcome": Outcome.ACCEPTED,
                 "reason": "none",
@@ -57,7 +64,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         self.store_outcomes(
             {
                 "org_id": self.org.id,
-                "timestamp": self.now - timedelta(hours=1),
+                "timestamp": self._now - timedelta(hours=1),
                 "project_id": self.project.id,
                 "outcome": Outcome.ACCEPTED,
                 "reason": "none",
@@ -69,7 +76,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         self.store_outcomes(
             {
                 "org_id": self.org.id,
-                "timestamp": self.now - timedelta(hours=1),
+                "timestamp": self._now - timedelta(hours=1),
                 "project_id": self.project.id,
                 "outcome": Outcome.RATE_LIMITED,
                 "reason": "smart_rate_limit",
@@ -80,7 +87,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         self.store_outcomes(
             {
                 "org_id": self.org.id,
-                "timestamp": self.now - timedelta(hours=1),
+                "timestamp": self._now - timedelta(hours=1),
                 "project_id": self.project2.id,
                 "outcome": Outcome.RATE_LIMITED,
                 "reason": "smart_rate_limit",
@@ -142,27 +149,31 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
     def test_no_end_param(self):
         response = self.do_request(
-            {"field": ["sum(quantity)"], "interval": "1d", "start": "2021-03-14T00:00:00Z"}
+            {
+                "field": ["sum(quantity)"],
+                "interval": "1d",
+                "start": floor_to_utc_day(self._now).isoformat(),
+            }
         )
 
         assert response.status_code == 400, response.content
         assert response.data == {"detail": "start and end are both required"}
 
-    @freeze_time(datetime(2021, 3, 14, 12, 27, 28, tzinfo=timezone.utc))
+    @freeze_time(_now)
     def test_future_request(self):
         response = self.do_request(
             {
                 "field": ["sum(quantity)"],
                 "interval": "1h",
                 "category": ["error"],
-                "start": "2021-03-14T15:30:00",
-                "end": "2021-03-14T16:30:00",
+                "start": self._now.replace(hour=15, minute=30, second=0).isoformat(),
+                "end": self._now.replace(hour=16, minute=30, second=0).isoformat(),
             }
         )
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-14T12:00:00Z",
-            "end": "2021-03-14T17:00:00Z",
+            "start": _iso_z(self._now.replace(hour=12, minute=0, second=0)),
+            "end": _iso_z(self._now.replace(hour=17, minute=0, second=0)),
             "projects": [],
         }
 
@@ -212,7 +223,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 400, response.content
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_attachment_filter_only(self):
         response = self.do_request(
             {
@@ -229,7 +240,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             "detail": "if filtering by attachment no other category may be present"
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_user_all_accessible(self):
         response = self.do_request(
             {
@@ -256,12 +267,12 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200
         assert response.data == {
-            "start": "2021-03-13T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_no_project_access(self):
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=self.organization, role="member", teams=[])
@@ -281,7 +292,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         assert response.status_code == 403, response.content
         assert response.data == {"detail": "You do not have permission to perform this action."}
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_open_membership_semantics(self):
         self.org.flags.allow_joinleave = True
         self.org.save()
@@ -299,8 +310,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200
         assert response.data == {
-            "start": "2021-03-13T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -343,7 +354,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_org_simple(self):
         make_request = functools.partial(
             self.client.get,
@@ -359,8 +370,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-12T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=2)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -416,7 +427,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_org_multiple_fields(self):
         make_request = functools.partial(
             self.client.get,
@@ -432,8 +443,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-12T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=2)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -493,7 +504,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_org_project_totals_per_project(self):
         make_request = functools.partial(
             self.client.get,
@@ -510,8 +521,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response_per_group.status_code == 200, response_per_group.content
         assert response_per_group.data == {
-            "start": "2021-03-13T12:00:00Z",
-            "end": "2021-03-14T13:00:00Z",
+            "start": _iso_z((self._now - timedelta(days=1)).replace(hour=12, minute=0, second=0)),
+            "end": _iso_z(self._now.replace(hour=13, minute=0, second=0)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -554,7 +565,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_project_filter(self):
         make_request = functools.partial(
             self.client.get,
@@ -572,8 +583,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-13T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -597,7 +608,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_reason_filter(self):
         make_request = functools.partial(
             self.client.get,
@@ -615,8 +626,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-13T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -661,7 +672,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_outcome_filter(self):
         make_request = functools.partial(
             self.client.get,
@@ -678,8 +689,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         )
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-13T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,
@@ -697,7 +708,7 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
             ],
         }
 
-    @freeze_time("2021-03-14T12:27:28.303Z")
+    @freeze_time(_now)
     def test_category_filter(self):
         make_request = functools.partial(
             self.client.get,
@@ -713,8 +724,8 @@ class OrganizationStatsSummaryTest(APITestCase, OutcomesSnubaTest):
         )
         assert response.status_code == 200, response.content
         assert response.data == {
-            "start": "2021-03-13T00:00:00Z",
-            "end": "2021-03-15T00:00:00Z",
+            "start": _iso_z(floor_to_utc_day(self._now) - timedelta(days=1)),
+            "end": _iso_z(floor_to_utc_day(self._now) + timedelta(days=1)),
             "projects": [
                 {
                     "id": self.project.id,


### PR DESCRIPTION
this is currently the number one flaky test at sentry -- for some reason it only seems to fail from a blank database with a particular number of tests ahead of it (some timing issue? some periodic data cleanup task? unclear to me at least).  by modernizing the dates it seems to avoid that issue

<!-- Describe your PR here. -->
