### PR TITLE
fix(saved-searches): Fix saved search sidebar button styles

### DIFF
--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -373,11 +373,14 @@ const SearchListItem = styled('li')<{hasMenu?: boolean}>`
 const TitleDescriptionWrapper = styled('div')`
   overflow: hidden;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: start;
+  width: 100%;
 `;
 
 const SavedSearchItemTitle = styled('div')`
+  text-align: left;
   font-size: ${p => p.theme.fontSizeLarge};
   ${p => p.theme.overflowEllipsis}
 `;


### PR DESCRIPTION
More button styles that were recently broken

Before:

![CleanShot 2025-05-01 at 09 53 53@2x](https://github.com/user-attachments/assets/5c967fa3-93aa-41dd-8a8f-2eb1ff2b1e2a)

After:

![CleanShot 2025-05-01 at 09 54 02@2x](https://github.com/user-attachments/assets/c00a189f-df53-494e-8895-838a66ca2208)
