### PR TITLE
feat(eap-spans): add tpm function

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -497,9 +497,16 @@ def tpm(_: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormul
     return Column.BinaryFormula(
         default_value_double=0.0,
         left=Column(
-            aggregation=AttributeAggregation(
+            conditional_aggregation=AttributeConditionalAggregation(
                 aggregate=Function.FUNCTION_COUNT,
                 key=AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.is_segment"),
+                filter=TraceItemFilter(
+                    comparison_filter=ComparisonFilter(
+                        key=AttributeKey(type=AttributeKey.TYPE_BOOLEAN, name="sentry.is_segment"),
+                        op=ComparisonFilter.OP_EQUALS,
+                        value=AttributeValue(val_bool=True),
+                    )
+                ),
                 extrapolation_mode=extrapolation_mode,
             ),
         ),

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2034,6 +2034,9 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             }
         )
 
+        segment_span_count = 1
+        total_time = 90 * 24 * 60
+
         assert response.status_code == 200, response.content
         data = response.data["data"]
         meta = response.data["meta"]
@@ -2041,7 +2044,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data == [
             {
                 "description": "foo",
-                "tpm()": 1 / (90 * 24 * 60),
+                "tpm()": segment_span_count / total_time,
             },
         ]
         assert meta["dataset"] == self.dataset


### PR DESCRIPTION
We have a specialized use case which requires a dedicated tpm function. This is because we want a table that groups by transaction, displaying transaction per minute for each transaction, and also calculates performance score for each transaction (which is calculated with non-transaction spans, so we can't just apply a global is_transaction filter)