### PR TITLE
feat(group_deletion): Ask Seer to only delete error ids

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -47,15 +47,15 @@ def delete_group_list(
     # delete the "smaller" groups first
     group_list.sort(key=lambda g: (g.times_seen, g.id))
     group_ids = []
-    error_group_found = False
+    error_ids = []
     for g in group_list:
         group_ids.append(g.id)
         if g.issue_category == GroupCategory.ERROR:
-            error_group_found = True
+            error_ids.append(g.id)
 
     countdown = 3600
     # With ClickHouse light deletes we want to get rid of the long delay
-    if not error_group_found:
+    if not error_ids:
         countdown = 0
 
     Group.objects.filter(id__in=group_ids).exclude(
@@ -66,7 +66,7 @@ def delete_group_list(
     transaction_id = uuid4().hex
 
     # Tell seer to delete grouping records for these groups
-    call_delete_seer_grouping_records_by_hash(group_ids)
+    call_delete_seer_grouping_records_by_hash(error_ids)
 
     # Removing GroupHash rows prevents new events from associating to the groups
     # we just deleted.


### PR DESCRIPTION
No need to pass all IDs since Seer does not store issue platform issues.