### PR TITLE
chore(autofix): Restyle insight cards

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -292,7 +292,6 @@ function CollapsibleChainLink({
         className="rethink-button-container"
         parentAlignment={alignment}
       >
-        {/* Render Collapse Controls */}
         {showCollapseControl && onToggleCollapse && (
           <CollapseButtonWrapper
             onClick={onToggleCollapse}
@@ -319,7 +318,6 @@ function CollapsibleChainLink({
             />
           </CollapseButtonWrapper>
         )}
-        {/* Render Add Controls */}
         {showAddControl &&
           !isCollapsed &&
           !isEmpty &&
@@ -417,7 +415,6 @@ function AutofixInsightCards({
       <CardsColumn>
         {insights.length > 0 ? (
           <Fragment>
-            {/* Render collapse link above cards if hasStepAbove */}
             {hasStepAbove && (
               <CollapsibleChainLink
                 isCollapsed={isCollapsed}
@@ -456,7 +453,6 @@ function AutofixInsightCards({
                 </motion.div>
               )}
             </AnimatePresence>
-            {/* Render AddLink below cards if not collapsed and hasStepBelow */}
             {!isCollapsed && hasStepBelow && (
               <CollapsibleChainLink
                 isEmpty={insights.length === 0}

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -104,10 +104,7 @@ function AutofixInsightCard({
     <ContentWrapper>
       <AnimatePresence initial={isNewInsight}>
         <AnimationWrapper key="content">
-          <InsightContainer
-            data-new-insight={isNewInsight ? 'true' : 'false'}
-            expanded={expanded}
-          >
+          <InsightContainer data-new-insight={isNewInsight ? 'true' : 'false'}>
             {isEditing ? (
               <EditContainer>
                 <form onSubmit={handleSubmit}>
@@ -159,7 +156,10 @@ function AutofixInsightCard({
                   stepIndex={stepIndex}
                   retainInsightCardIndex={insightCardAboveIndex}
                 >
-                  <MiniHeader dangerouslySetInnerHTML={truncatedTitleHtml} />
+                  <MiniHeader
+                    dangerouslySetInnerHTML={truncatedTitleHtml}
+                    expanded={expanded}
+                  />
                 </AutofixHighlightWrapper>
 
                 <RightSection>
@@ -553,7 +553,7 @@ const CardsStack = styled('div')`
   gap: 0;
 `;
 
-const InsightContainer = styled(motion.div)<{expanded?: boolean}>`
+const InsightContainer = styled(motion.div)`
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
   margin-bottom: 0;
@@ -640,7 +640,7 @@ const RethinkButtonContainer = styled('div')<{parentAlignment?: 'start' | 'cente
 
 const ContentWrapper = styled('div')``;
 
-const MiniHeader = styled('p')`
+const MiniHeader = styled('p')<{expanded?: boolean}>`
   padding-top: ${space(0.25)};
   padding-bottom: ${space(0.25)};
   padding-left: ${space(1)};
@@ -648,7 +648,7 @@ const MiniHeader = styled('p')`
   margin: 0;
   flex: 1;
   word-break: break-word;
-  color: ${p => p.theme.subText};
+  color: ${p => (p.expanded ? p.theme.textColor : p.theme.subText)};
 `;
 
 const ContextBody = styled('div')`

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -149,7 +149,7 @@ function AutofixInsightCard({
                 </form>
               </EditContainer>
             ) : (
-              <InsightCardRow onClick={toggleExpand}>
+              <InsightCardRow onClick={toggleExpand} expanded={expanded}>
                 <AutofixHighlightWrapper
                   groupId={groupId}
                   runId={runId}
@@ -506,11 +506,13 @@ function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: string}
   });
 }
 
-const InsightCardRow = styled('div')<{isUserMessage?: boolean}>`
+const InsightCardRow = styled('div')<{expanded?: boolean; isUserMessage?: boolean}>`
   display: flex;
   justify-content: space-between;
   align-items: stretch;
   cursor: pointer;
+  background-color: ${p => (p.expanded ? p.theme.backgroundSecondary : 'transparent')};
+
   &:hover {
     background-color: ${p => p.theme.backgroundSecondary};
   }

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -115,7 +115,7 @@ export function AutofixOutputStream({
 
   const displayedActiveLog = useTypingAnimation({
     text: activeLog,
-    speed: 100,
+    speed: 200,
     enabled: !!activeLog,
   });
 
@@ -237,7 +237,6 @@ const Wrapper = styled(motion.div)`
   flex-direction: column;
   align-items: flex-start;
   margin-bottom: ${space(1)};
-  margin-right: ${space(2)};
   gap: ${space(1)};
 `;
 
@@ -247,7 +246,6 @@ const ScaleContainer = styled(motion.div)`
   flex-direction: column;
   align-items: flex-start;
   transform-origin: top left;
-  padding-left: ${space(2)};
 `;
 
 const shimmer = keyframes`
@@ -314,7 +312,7 @@ const VerticalLine = styled('div')`
   width: 0;
   height: ${space(4)};
   border-left: 2px dashed ${p => p.theme.subText};
-  margin-left: 17px;
+  margin-left: 16px;
   margin-bottom: -1px;
 `;
 

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -64,7 +64,6 @@ function Step({
   hasStepBelow,
   hasStepAbove,
   hasErroredStepBefore,
-  shouldCollapseByDefault,
   previousDefaultStepIndex,
   previousInsightCount,
   feedback,
@@ -91,7 +90,6 @@ function Step({
                   stepIndex={step.index}
                   groupId={groupId}
                   runId={runId}
-                  shouldCollapseByDefault={shouldCollapseByDefault}
                 />
               )}
               {step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && (


### PR DESCRIPTION
Auto-collapsing was confusing people so this PR removes it. To compensate, this PR restyles the insight cards to take up less space.

<img width="961" alt="Screenshot 2025-05-01 at 10 38 21 AM" src="https://github.com/user-attachments/assets/c60ec123-e816-4b5d-bfbe-edc25fb227fc" />
<img width="842" alt="Screenshot 2025-05-01 at 10 39 11 AM" src="https://github.com/user-attachments/assets/8e513fed-3d43-4464-b0a6-079284abee4a" />
<img width="820" alt="Screenshot 2025-05-01 at 10 39 21 AM" src="https://github.com/user-attachments/assets/8db2de93-7124-4986-a258-86971494b8b3" />
