### PR TITLE
feat(gitlab): Suspect PR comments - Frontend

### DIFF
--- a/static/app/components/core/avatar/index.stories.tsx
+++ b/static/app/components/core/avatar/index.stories.tsx
@@ -107,6 +107,7 @@ export default storyBook('Avatar', (story, APIReference) => {
             githubNudgeInvite: false,
             githubOpenPRBot: false,
             githubPRBot: false,
+            gitlabPRBot: false,
             hideAiFeatures: false,
             isEarlyAdopter: false,
             issueAlertsThreadFlag: false,

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -24,6 +24,7 @@ export interface OrganizationSummary {
   githubNudgeInvite: boolean;
   githubOpenPRBot: boolean;
   githubPRBot: boolean;
+  gitlabPRBot: boolean;
   hideAiFeatures: boolean;
   id: string;
   isEarlyAdopter: boolean;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -250,4 +250,36 @@ describe('IntegrationDetailedView', function () {
       );
     });
   });
+
+  it('can enable gitlab features', async function () {
+    const router = RouterFixture({
+      params: {integrationSlug: 'gitlab'},
+    });
+    render(<IntegrationDetailedView />, {
+      organization,
+      router,
+      deprecatedRouterMocks: true,
+    });
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('features'));
+
+    const mock = MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      method: 'PUT',
+    });
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {name: /Enable Comments on Suspect Pull Requests/})
+    );
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          data: {gitlabPRBot: true},
+        })
+      );
+    });
+  });
 });

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -1,5 +1,7 @@
 import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
+import {GitLabIntegrationFixture} from 'sentry-fixture/gitlabIntegration';
+import {GitLabIntegrationProviderFixture} from 'sentry-fixture/gitlabIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
@@ -87,6 +89,18 @@ describe('IntegrationDetailedView', function () {
       url: `/organizations/${organization.slug}/integrations/`,
       match: [MockApiClient.matchQuery({provider_key: 'github', includeConfig: 0})],
       body: [GitHubIntegrationFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/config/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'gitlab'})],
+      body: {
+        providers: [GitLabIntegrationProviderFixture()],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      match: [MockApiClient.matchQuery({provider_key: 'gitlab', includeConfig: 0})],
+      body: [GitLabIntegrationFixture()],
     });
   });
 

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -44,7 +44,7 @@ import IntegrationButton from 'sentry/views/settings/organizationIntegrations/in
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 // Show the features tab if the org has features for the integration
-const integrationFeatures = ['github', 'slack'];
+const integrationFeatures = ['github', 'gitlab', 'slack'];
 
 const FirstPartyIntegrationAlert = HookOrDefault({
   hookName: 'component:first-party-integration-alert',
@@ -484,6 +484,35 @@ export default function IntegrationDetailedView() {
     return [forms, initialData];
   }, [organization, configurations]);
 
+  const getGitlabFeatures = useCallback((): [JsonFormObject[], Data] => {
+    const hasIntegration = configurations ? configurations.length > 0 : false;
+
+    const forms: JsonFormObject[] = [
+      {
+        fields: [
+          {
+            name: 'gitlabPRBot',
+            type: 'boolean',
+            label: t('Enable Comments on Suspect Pull Requests'),
+            help: t(
+              'Allow Sentry to comment on recent pull requests suspected of causing issues.'
+            ),
+            disabled: !hasIntegration,
+            disabledReason: t(
+              'You must have a GitLab integration to enable this feature.'
+            ),
+          },
+        ],
+      },
+    ];
+
+    const initialData = {
+      gitlabPRBot: organization.gitlabPRBot,
+    };
+
+    return [forms, initialData];
+  }, [organization, configurations]);
+
   const renderFeatures = useCallback(() => {
     const endpoint = `/organizations/${organization.slug}/`;
     const hasOrgWrite = organization.access.includes('org:write');
@@ -492,6 +521,10 @@ export default function IntegrationDetailedView() {
     switch (provider?.key) {
       case 'github': {
         [forms, initialData] = getGithubFeatures();
+        break;
+      }
+      case 'gitlab': {
+        [forms, initialData] = getGitlabFeatures();
         break;
       }
       case 'slack': {
@@ -518,7 +551,7 @@ export default function IntegrationDetailedView() {
         />
       </Form>
     );
-  }, [organization, provider, getGithubFeatures, getSlackFeatures]);
+  }, [organization, provider, getGithubFeatures, getGitlabFeatures, getSlackFeatures]);
 
   if (isInformationPending || isConfigurationsPending) {
     return <LoadingIndicator />;

--- a/tests/js/fixtures/gitlabIntegration.ts
+++ b/tests/js/fixtures/gitlabIntegration.ts
@@ -1,0 +1,34 @@
+import {GroupIntegration} from 'sentry/types/integrations';
+
+export function GitLabIntegrationFixture(
+  params: Partial<GroupIntegration> = {}
+): GroupIntegration {
+  return {
+    domainName: 'gitlab.com/test-integration',
+    icon: 'http://example.com/integration_icon.png',
+    id: '1',
+    name: 'Test Integration',
+    provider: {
+      name: 'GitLab',
+      key: 'gitlab',
+      canAdd: true,
+      features: [],
+      aspects: {
+        alerts: [
+          {
+            type: 'warning',
+            text: 'This is a an alert example',
+          },
+        ],
+      },
+      canDisable: false,
+      slug: '',
+    },
+    externalIssues: [],
+    accountType: '',
+    gracePeriodEnd: '',
+    organizationIntegrationStatus: 'active',
+    status: 'active',
+    ...params,
+  };
+}

--- a/tests/js/fixtures/gitlabIntegrationProvider.ts
+++ b/tests/js/fixtures/gitlabIntegrationProvider.ts
@@ -1,0 +1,42 @@
+import { IntegrationProvider } from "sentry/types/integrations";
+
+export function GitLabIntegrationProviderFixture(
+  params: Partial<IntegrationProvider> = {}
+): IntegrationProvider {
+  return {
+    key: 'gitlab',
+    slug: 'gitlab',
+    name: 'GitLab',
+    canAdd: true,
+    features: [],
+    setupDialog: {
+      url: '/gitlab-integration-setup-uri/',
+      width: 100,
+      height: 100,
+    },
+    canDisable: true,
+    metadata: {
+      description: '*markdown* formatted _description_',
+      features: [
+        {
+          description: '*markdown* feature description',
+          featureGate: 'integrations-commits',
+          featureId: 3,
+        },
+      ],
+      author: 'Morty',
+      noun: 'Installation',
+      issue_url: 'http://example.com/integration_issue_url',
+      source_url: 'http://example.com/integration_source_url',
+      aspects: {
+        alerts: [
+          {
+            type: 'warning',
+            text: 'This is a an alert example',
+          },
+        ],
+      },
+    },
+    ...params,
+  }
+}

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -58,6 +58,7 @@ export function OrganizationFixture( params: Partial<Organization> = {}): Organi
     githubNudgeInvite: false,
     githubOpenPRBot: false,
     githubPRBot: false,
+    gitlabPRBot: false,
     hideAiFeatures: false,
     isDefault: false,
     isDynamicallySampled: true,


### PR DESCRIPTION
Implement suspect PR comments for GitLab - Frontend toggles.
<img width="1787" alt="Screenshot 2025-05-06 at 22 49 46" src="https://github.com/user-attachments/assets/e9f4cfa4-6134-4921-9707-08f068d14789" />
