### PR TITLE
🐛 fix(slack): fix slack metric alert threading behavior

### DIFF
--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -73,7 +73,7 @@ def _get_thread_config(
 
     reply_broadcast = False
     # If the incident is critical status, even if it's in a thread, send to main channel
-    if incident_status == IncidentStatus.CRITICAL.value:
+    if incident_status == IncidentStatus.CRITICAL:
         reply_broadcast = True
 
     return reply_broadcast, parent_notification_message.message_identifier

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -15,6 +15,7 @@ from sentry.constants import METRIC_ALERTS_THREAD_DEFAULT, ObjectStatus
 from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.endpoints.serializers.alert_rule import AlertRuleSerializerResponse
 from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializerResponse
+from sentry.incidents.models.incident import IncidentStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
     MetricIssueContext,
@@ -65,11 +66,17 @@ def _get_thread_config(
     parent_notification_message: (
         NotificationActionNotificationMessage | MetricAlertNotificationMessage | None
     ),
+    incident_status: IncidentStatus,
 ) -> tuple[bool, str | None]:
     if parent_notification_message is None:
         return False, None
 
-    return True, parent_notification_message.message_identifier
+    reply_broadcast = False
+    # If the incident is critical status, even if it's in a thread, send to main channel
+    if incident_status == IncidentStatus.CRITICAL.value:
+        reply_broadcast = True
+
+    return reply_broadcast, parent_notification_message.message_identifier
 
 
 def _fetch_parent_notification_message_for_incident(
@@ -336,7 +343,9 @@ def _handle_workflow_engine_notification(
         parent_notification_message=parent_notification_message,
     )
 
-    reply_broadcast, thread_ts = _get_thread_config(parent_notification_message)
+    reply_broadcast, thread_ts = _get_thread_config(
+        parent_notification_message, metric_issue_context.new_status
+    )
 
     return _send_notification(
         integration=integration,
@@ -377,7 +386,9 @@ def _handle_legacy_notification(
         parent_notification_message=parent_notification_message,
     )
 
-    reply_broadcast, thread_ts = _get_thread_config(parent_notification_message)
+    reply_broadcast, thread_ts = _get_thread_config(
+        parent_notification_message, metric_issue_context.new_status
+    )
 
     return _send_notification(
         integration=integration,

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -19,6 +19,7 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.utils import json
 from tests.sentry.integrations.slack.utils.test_mock_slack_response import mock_slack_response
 
@@ -26,6 +27,7 @@ from . import FireTest
 
 
 @freeze_time()
+@apply_feature_flag_on_cls("organizations:metric-alert-thread-flag")
 class SlackActionHandlerTest(FireTest):
     @pytest.fixture(autouse=True)
     def mock_chat_postEphemeral(self):
@@ -326,3 +328,92 @@ class SlackActionHandlerTest(FireTest):
             external_id=str(self.action.target_identifier),
             notification_uuid="",
         )
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
+    def test_update_metric_alert_in_thread(self, mock_post, mock_api_call, mock_record_event):
+        """
+        Tests that subsequent alerts for the same incident are posted as replies
+        in a thread, and that critical alerts broadcast to the channel.
+        """
+        # Mocking Slack responses
+        initial_ts = "12345.67890"
+        update_ts = "98765.43210"
+        mock_post.side_effect = [
+            SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="...",
+                req_args={},
+                data={"ok": True, "ts": initial_ts, "channel": self.channel_id},
+                headers={},
+                status_code=200,
+            ),
+            SlackResponse(
+                client=None,
+                http_verb="POST",
+                api_url="...",
+                req_args={},
+                data={"ok": True, "ts": update_ts, "channel": self.channel_id},
+                headers={},
+                status_code=200,
+            ),
+        ]
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        # 1. Fire initial warning alert
+        incident = self.create_incident(
+            alert_rule=self.alert_rule, status=IncidentStatus.WARNING.value
+        )
+        metric_value = 1000
+        with self.tasks():
+            self.handler.fire(
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                metric_value=metric_value,
+                new_status=IncidentStatus.WARNING,
+            )
+
+        # Assert initial post
+        assert mock_post.call_count == 1
+        first_call_args, first_call_kwargs = mock_post.call_args
+        assert first_call_kwargs.get("thread_ts") is None
+        assert first_call_kwargs.get("reply_broadcast") is False
+        assert NotificationMessage.objects.filter(incident=incident).count() == 1
+        parent_message = NotificationMessage.objects.get(incident=incident)
+        assert parent_message.message_identifier == initial_ts
+        assert parent_message.parent_notification_message_id is None
+
+        # 2. Update incident status to critical and fire again
+        update_incident_status(
+            incident, IncidentStatus.CRITICAL, status_method=IncidentStatusMethod.MANUAL
+        )
+        metric_value_update = 2000
+        with self.tasks():
+            self.handler.fire(
+                action=self.action,
+                incident=incident,
+                project=self.project,
+                metric_value=metric_value_update,
+                new_status=IncidentStatus.CRITICAL,
+            )
+
+        # Assert update post is in thread and broadcast
+        assert mock_post.call_count == 2
+        second_call_args, second_call_kwargs = mock_post.call_args
+        assert second_call_kwargs.get("thread_ts") == initial_ts
+        assert second_call_kwargs.get("reply_broadcast") is True
+
+        # Assert new notification message is saved correctly
+        assert NotificationMessage.objects.filter(incident=incident).count() == 2
+        update_message = NotificationMessage.objects.exclude(id=parent_message.id).get(
+            incident=incident
+        )
+        assert update_message.message_identifier == update_ts
+        assert update_message.parent_notification_message_id == parent_message.id


### PR DESCRIPTION
Fixes ECO-481
Fixes https://github.com/getsentry/sentry/issues/90689

i had deleted the `incident_status` check during my refactor, adding it back now

https://github.com/getsentry/sentry/blob/2df0a163f843ece35b9be01e4a72553ea846ac59/src/sentry/integrations/slack/utils/notifications.py#L74-L77

