### PR TITLE
feat(trace-explorer-ai): Add setup endpoint to create LLM state

### DIFF
--- a/src/sentry/api/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/api/endpoints/trace_explorer_ai_setup.py
@@ -60,7 +60,7 @@ class TraceExplorerAISetup(OrganizationEndpoint):
         """
         Checks if we are able to run Autofix on the given group.
         """
-        project_ids = [int(x) for x in request.data.get("project_ids")]
+        project_ids = [int(x) for x in request.data.get("project_ids", [])]
 
         if not features.has(
             "organizations:gen-ai-explore-traces", organization=organization, actor=request.user

--- a/src/sentry/api/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/api/endpoints/trace_explorer_ai_setup.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+
+import orjson
+import requests
+from django.conf import settings
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import ProjectEndpoint
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+
+logger = logging.getLogger(__name__)
+
+from rest_framework.request import Request
+
+
+def fire_setup_request(org_id: int, project_ids: list[int]) -> None:
+    """
+    Sends a request to seer to create the initial cached prompt / setup the AI models
+    """
+    body = orjson.dumps(
+        {
+            "org_id": org_id,
+            "project_ids": project_ids,
+        }
+    )
+
+    response = requests.post(
+        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/create-cache",
+        data=body,
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            **sign_with_seer_secret(body),
+        },
+    )
+    response.raise_for_status()
+
+
+@region_silo_endpoint
+class TraceExplorerAISetup(ProjectEndpoint):
+    """
+    This endpoint is called when a user visits the trace explorer with the correct flags enabled.
+    """
+
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+
+    def get(self, request: Request, project: Project) -> Response:
+        """
+        Checks if we are able to run Autofix on the given group.
+        """
+        org: Organization = request.organization
+
+        user_acknowledgement = get_seer_user_acknowledgement(user_id=request.user.id, org_id=org.id)
+        org_acknowledgement = user_acknowledgement or get_seer_org_acknowledgement(org_id=org.id)
+
+        if not org_acknowledgement:
+            return Response(
+                {"detail": "Organization has not opted in to this feature."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        fire_setup_request(org.id, [project.id])
+
+        return Response({"status": "ok"})

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -64,6 +64,7 @@ from sentry.api.endpoints.seer_rpc import SeerRpcServiceEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
+from sentry.api.endpoints.trace_explorer_ai_setup import TraceExplorerAISetup
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.data_secrecy.api.waive_data_secrecy import WaiveDataSecrecyEndpoint
@@ -2463,6 +2464,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/files/dsyms/associate/$",
         AssociateDSymFilesEndpoint.as_view(),
         name="sentry-api-0-associate-dsym-files",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/trace-explorer-ai/setup/$",
+        TraceExplorerAISetup.as_view(),
+        name="sentry-api-0-trace-explorer-ai-setup",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/filters/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2048,6 +2048,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-sentry-apps",
     ),
     re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/trace-explorer-ai/setup/$",
+        TraceExplorerAISetup.as_view(),
+        name="sentry-api-0-trace-explorer-ai-setup",
+    ),
+    re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/sentry-app-components/$",
         OrganizationSentryAppComponentsEndpoint.as_view(),
         name="sentry-api-0-organization-sentry-app-components",
@@ -2464,11 +2469,6 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/files/dsyms/associate/$",
         AssociateDSymFilesEndpoint.as_view(),
         name="sentry-api-0-associate-dsym-files",
-    ),
-    re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/trace-explorer-ai/setup/$",
-        TraceExplorerAISetup.as_view(),
-        name="sentry-api-0-trace-explorer-ai-setup",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/filters/$",


### PR DESCRIPTION
This endpoint will be used to add AI to the trace explorer page, it initializes the LLM on page load.