### PR TITLE
feat(ui): Add `error.cause` to `<ErrorHandler>`

### DIFF
--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -55,15 +55,18 @@ class ErrorBoundary extends Component<Props, State> {
         Object.keys(errorTag).forEach(tag => scope.setTag(tag, errorTag[tag]));
       }
 
-      // Based on https://github.com/getsentry/sentry-javascript/blob/6f4ad562c469f546f1098136b65583309d03487b/packages/react/src/errorboundary.tsx#L75-L85
-      const errorBoundaryError = new Error(error.message);
-      errorBoundaryError.name = `React ErrorBoundary ${errorBoundaryError.name}`;
-      errorBoundaryError.stack = errorInfo.componentStack!;
-
-      error.cause = errorBoundaryError;
-
-      scope.setExtra('errorInfo', errorInfo);
-      Sentry.captureException(error);
+      try {
+        // Based on https://github.com/getsentry/sentry-javascript/blob/6f4ad562c469f546f1098136b65583309d03487b/packages/react/src/errorboundary.tsx#L75-L85
+        const errorBoundaryError = new Error(error.message);
+        errorBoundaryError.name = `React ErrorBoundary ${errorBoundaryError.name}`;
+        errorBoundaryError.stack = errorInfo.componentStack!;
+        error.cause = errorBoundaryError;
+      } catch {
+        // Some browsers won't let you write to Error instance
+        scope.setExtra('errorInfo', errorInfo);
+      } finally {
+        Sentry.captureException(error);
+      }
     });
   }
 

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -76,8 +76,20 @@ class ErrorBoundary extends Component<{children: React.ReactNode}, ErrorBoundary
       if (isWebpackChunkLoadingError(error)) {
         scope.setFingerprint(['webpack', 'error loading chunk']);
       }
-      scope.setExtra('errorInfo', errorInfo);
-      Sentry.captureException(error);
+      try {
+        // Based on https://github.com/getsentry/sentry-javascript/blob/6f4ad562c469f546f1098136b65583309d03487b/packages/react/src/errorboundary.tsx#L75-L85
+        const errorBoundaryError = new Error(error.message);
+        errorBoundaryError.name = `React ErrorBoundary ${errorBoundaryError.name}`;
+        errorBoundaryError.stack = errorInfo.componentStack!;
+
+        // This will mutate `error` and get captured to Sentry in `RouteError`
+        error.cause = errorBoundaryError;
+      } catch {
+        // Some browsers won't let you write to Error instance
+        scope.setExtra('errorInfo', errorInfo);
+      } finally {
+        Sentry.captureException(error);
+      }
     });
 
     // eslint-disable-next-line no-console

--- a/static/app/utils/errorHandler.tsx
+++ b/static/app/utils/errorHandler.tsx
@@ -24,12 +24,24 @@ export default function errorHandler<P>(WrappedComponent: React.ComponentType<P>
       error: undefined,
     };
 
-    componentDidCatch(_error: Error, info: React.ErrorInfo) {
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
       // eslint-disable-next-line no-console
       console.error(
         'Component stack trace caught in <ErrorHandler />:',
         info.componentStack
       );
+
+      try {
+        // Based on https://github.com/getsentry/sentry-javascript/blob/6f4ad562c469f546f1098136b65583309d03487b/packages/react/src/errorboundary.tsx#L75-L85
+        const errorBoundaryError = new Error(error.message);
+        errorBoundaryError.name = `React ErrorBoundary ${errorBoundaryError.name}`;
+        errorBoundaryError.stack = info.componentStack!;
+
+        // This will mutate `error` and get captured to Sentry in `RouteError`
+        error.cause = errorBoundaryError;
+      } catch {
+        // Some browsers won't let you write to Error instance
+      }
     }
 
     render() {

--- a/static/app/utils/errorHandler.tsx
+++ b/static/app/utils/errorHandler.tsx
@@ -24,18 +24,18 @@ export default function errorHandler<P>(WrappedComponent: React.ComponentType<P>
       error: undefined,
     };
 
-    componentDidCatch(error: Error, info: React.ErrorInfo) {
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
       // eslint-disable-next-line no-console
       console.error(
         'Component stack trace caught in <ErrorHandler />:',
-        info.componentStack
+        errorInfo.componentStack
       );
 
       try {
         // Based on https://github.com/getsentry/sentry-javascript/blob/6f4ad562c469f546f1098136b65583309d03487b/packages/react/src/errorboundary.tsx#L75-L85
         const errorBoundaryError = new Error(error.message);
         errorBoundaryError.name = `React ErrorBoundary ${errorBoundaryError.name}`;
-        errorBoundaryError.stack = info.componentStack!;
+        errorBoundaryError.stack = errorInfo.componentStack!;
 
         // This will mutate `error` and get captured to Sentry in `RouteError`
         error.cause = errorBoundaryError;


### PR DESCRIPTION
This PR fixes `<ErrorHandler>` to add a `cause` error to when we catch an error with a React Error Boundary. This will help us debug [this error](https://sentry.sentry.io/issues/6333431167/events/ecf1545d92834ceba543c2b62af63171/?project=11276) (and future ones that hit `<ErrorHandler>`).

See [this issue](https://sentry-emerging-tech.sentry.io/issues/6580362564/?project=6326737&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0) for what it will look like.
