### PR TITLE
feat(ourlogs): Lock columns to 1 in trace view

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -70,6 +70,8 @@ interface AttributesFieldRender<RendererExtra extends RenderFunctionBaggage> {
 interface AttributesTreeProps<RendererExtra extends RenderFunctionBaggage>
   extends AttributesFieldRender<RendererExtra> {
   attributes: TraceItemResponseAttribute[];
+  // If provided, locks the number of columns to this number. If not provided, the number of columns will be dynamic based on width.
+  columnCount?: number;
   config?: AttributesTreeRowConfig;
   getAdjustedAttributeKey?: (attribute: TraceItemResponseAttribute) => string;
   getCustomActions?: (content: AttributesTreeContent) => MenuItemProps[];
@@ -301,7 +303,8 @@ export function AttributesTree<RendererExtra extends RenderFunctionBaggage>(
   props: AttributesTreeProps<RendererExtra>
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const columnCount = useIssueDetailsColumnCount(containerRef);
+  const widthBasedColumnCount = useIssueDetailsColumnCount(containerRef);
+  const columnCount = props.columnCount ?? widthBasedColumnCount;
   return (
     <TreeContainer
       ref={containerRef}
@@ -523,7 +526,7 @@ const TreeContainer = styled('div')<{columnCount: number}>`
 
 const TreeColumn = styled('div')`
   display: grid;
-  grid-template-columns: minmax(auto, 175px) 1fr;
+  grid-template-columns: minmax(min-content, max-content) auto;
   grid-column-gap: ${space(3)};
   &:first-child {
     margin-left: -${space(1)};

--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -311,7 +311,7 @@ export function AttributesTree<RendererExtra extends RenderFunctionBaggage>(
       columnCount={columnCount}
       data-test-id="fields-tree"
     >
-      <AttributesTreeColumns columnCount={columnCount} {...props} />
+      <AttributesTreeColumns {...props} columnCount={columnCount} />
     </TreeContainer>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -381,6 +381,7 @@ function EAPSpanNodeDetails({
               disableCollapsePersistence
             >
               <AttributesTree
+                columnCount={1}
                 attributes={attributes}
                 rendererExtra={{
                   theme,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -42,6 +42,7 @@ import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceD
 import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
 
@@ -338,6 +339,8 @@ function EAPSpanNodeDetails({
 
   const avgSpanDuration = useAvgSpanDuration(node.value, location);
 
+  const traceState = useTraceState();
+
   if (isPending) {
     return <LoadingIndicator />;
   }
@@ -347,6 +350,11 @@ function EAPSpanNodeDetails({
   }
 
   const attributes = data?.attributes;
+  const columnCount =
+    traceState.preferences.layout === 'drawer left' ||
+    traceState.preferences.layout === 'drawer right'
+      ? 1
+      : undefined;
 
   return (
     <TraceDrawerComponents.DetailContainer>
@@ -381,7 +389,7 @@ function EAPSpanNodeDetails({
               disableCollapsePersistence
             >
               <AttributesTree
-                columnCount={1}
+                columnCount={columnCount}
                 attributes={attributes}
                 rendererExtra={{
                   theme,


### PR DESCRIPTION
### Summary
For the attribute tree, we want to constrain the tree to 1 column so that users can expand the pane to see more data. This PR also changes the column widths to auto size the column key and column value to at most 50/50, after which both key and value will start wrapping.

#### Screenshots
|larger without wrapping|still wrapping past 50%|
|-|-|
|![Screenshot 2025-05-01 at 2 34 01 PM](https://github.com/user-attachments/assets/226f9c32-251f-4390-a5bd-eebff62a209f)|![Screenshot 2025-05-01 at 2 34 16 PM](https://github.com/user-attachments/assets/6bef5ae7-03ad-40ce-a81d-21ae46b45c5c)|
