### PR TITLE
fix(widget-builder): Add tooltip around project filters

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -1,9 +1,11 @@
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {t} from 'sentry/locale';
 import {ReleasesProvider} from 'sentry/utils/releases/releasesProvider';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -25,18 +27,22 @@ function WidgetBuilderFilterBar() {
         },
       }}
     >
-      <PageFilterBar>
-        <ProjectPageFilter disabled onChange={() => {}} />
-        <EnvironmentPageFilter disabled onChange={() => {}} />
-        <DatePageFilter disabled onChange={() => {}} />
-        <ReleasesProvider organization={organization} selection={selection}>
-          <ReleasesSelectControl
-            isDisabled
-            handleChangeFilter={() => {}}
-            selectedReleases={[]}
-          />
-        </ReleasesProvider>
-      </PageFilterBar>
+      <Tooltip
+        title={t('Changes to these filters can only be made at the dashboard level')}
+      >
+        <PageFilterBar>
+          <ProjectPageFilter disabled onChange={() => {}} />
+          <EnvironmentPageFilter disabled onChange={() => {}} />
+          <DatePageFilter disabled onChange={() => {}} />
+          <ReleasesProvider organization={organization} selection={selection}>
+            <ReleasesSelectControl
+              isDisabled
+              handleChangeFilter={() => {}}
+              selectedReleases={[]}
+            />
+          </ReleasesProvider>
+        </PageFilterBar>
+      </Tooltip>
     </PageFiltersContainer>
   );
 }


### PR DESCRIPTION
It isn't clear to the users why these filters are disabled, so add a tooltip to explain why.

<img width="510" alt="Screenshot 2025-05-01 at 3 04 23 PM" src="https://github.com/user-attachments/assets/d5e45123-10f2-4425-a875-a45ed20b8266" />
