### PR TITLE
fix(taskworker): Pass simple types to prepare_organization_report task in tests

### DIFF
--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -634,7 +634,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
         # TODO(RyanSkonnord): Make sure this doesn't cause false negatives after
         #  batch IDs are also used to prevent duplicate sends
-        batch_id = UUID("ea18c80c-d44f-48a4-8973-b0daa3169c44")
+        batch_id = str(UUID("ea18c80c-d44f-48a4-8973-b0daa3169c44"))
 
         with (
             mock.patch(
@@ -887,6 +887,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_email_override_simple(self, message_builder, record):
         user = self.create_user(email="itwasme@dio.xyz")
+        user_id = user.id
         self.create_member(teams=[self.team], user=user, organization=self.organization)
         extra_team = self.create_team(organization=self.organization)
         # create an extra project to ensure our email only gets the user's project
@@ -902,7 +903,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             self.organization.id,
             self._dummy_batch_id,
             dry_run=False,
-            target_user=user,
+            target_user=user_id,
             email_override="joseph@speedwagon.org",
         )
 
@@ -932,7 +933,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         project = self.create_project(organization=organization)
 
         user = self.create_user(email="itwasme@dio.xyz")
-
+        user_id = user.id
         extra_team = self.create_team(organization=organization, members=[])
         self.create_member(teams=[extra_team], user=user, organization=organization)
 
@@ -944,7 +945,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             organization.id,
             self._dummy_batch_id,
             dry_run=False,
-            target_user=user,
+            target_user=user_id,
         )
 
         for call_args in message_builder.call_args_list:
@@ -1001,7 +1002,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         # fill with data so report not skipped
         self.store_event_outcomes(org.id, proj.id, self.two_days_ago, num_times=2)
 
-        batch_id = UUID("ef61f1d1-41a3-4530-8160-615466937076")
+        batch_id = str(UUID("ef61f1d1-41a3-4530-8160-615466937076"))
         prepare_organization_report(
             self.timestamp,
             ONE_DAY * 7,

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from typing import cast
 from unittest import mock
-from uuid import UUID
 
 import pytest
 from django.core import mail
@@ -58,7 +57,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         self.two_days_ago = self.now - timedelta(days=2)
         self.three_days_ago = self.now - timedelta(days=3)
 
-    _dummy_batch_id = str(UUID("20bd6c5b-7fac-4f31-9548-d6f8bb63226d"))
+    _dummy_batch_id = "20bd6c5b-7fac-4f31-9548-d6f8bb63226d"
 
     def store_event_outcomes(
         self,
@@ -180,7 +179,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         user_project_ownership(ctx)
         template_context = prepare_template_context(ctx, [self.user.id])
         mock_prepare_template_context.return_value = template_context
-        batch_id = str(UUID("77a1d368-33d5-47cd-88cf-d66c97b38333"))
+        batch_id = "77a1d368-33d5-47cd-88cf-d66c97b38333"
 
         # disabled
         self._set_option_value("never")
@@ -634,7 +633,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
 
         # TODO(RyanSkonnord): Make sure this doesn't cause false negatives after
         #  batch IDs are also used to prevent duplicate sends
-        batch_id = str(UUID("ea18c80c-d44f-48a4-8973-b0daa3169c44"))
+        batch_id = "ea18c80c-d44f-48a4-8973-b0daa3169c44"
 
         with (
             mock.patch(
@@ -1002,7 +1001,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         # fill with data so report not skipped
         self.store_event_outcomes(org.id, proj.id, self.two_days_ago, num_times=2)
 
-        batch_id = str(UUID("ef61f1d1-41a3-4530-8160-615466937076"))
+        batch_id = "ef61f1d1-41a3-4530-8160-615466937076"
         prepare_organization_report(
             self.timestamp,
             ONE_DAY * 7,
@@ -1064,8 +1063,8 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         user_project_ownership(ctx)
         template_context = prepare_template_context(ctx, [self.user.id])
         mock_prepare_template_context.return_value = template_context
-        batch1_id = str(UUID("abe8ba3e-90af-4a98-b925-5f30250ae6a0"))
-        batch2_id = str(UUID("abe8ba3e-90af-4a98-b925-5f30250ae6a1"))
+        batch1_id = "abe8ba3e-90af-4a98-b925-5f30250ae6a0"
+        batch2_id = "abe8ba3e-90af-4a98-b925-5f30250ae6a1"
         self._set_option_value("always")
 
         # First send


### PR DESCRIPTION
### Testing
```
export TASK_TYPE_CHECKING=1 && pytest tests/sentry/tasks/test_weekly_reports.py -s -vv
============================================================ test session starts =============================================================
platform darwin -- Python 3.13.1, pytest-8.1.2, pluggy-1.5.0 -- /Users/enochtang/code/sentry/.venv/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.13.1', 'Platform': 'macOS-15.3.1-arm64-arm-64bit-Mach-O', 'Packages': {'pytest': '8.1.2', 'pluggy': '1.5.0'}, 'Plugins': {'fail-slow': '0.3.0', 'time-machine': '2.16.0', 'json-report': '1.5.0', 'metadata': '3.1.1', 'xdist': '3.0.2', 'django': '4.9.0', 'pytest_sentry': '0.3.0', 'anyio': '3.7.1', 'rerunfailures': '15.0', 'cov': '4.0.0'}}
django: version: 5.1.7
rootdir: /Users/enochtang/code/sentry
configfile: pyproject.toml
plugins: fail-slow-0.3.0, time-machine-2.16.0, json-report-1.5.0, metadata-3.1.1, xdist-3.0.2, django-4.9.0, pytest_sentry-0.3.0, anyio-3.7.1, rerunfailures-15.0, cov-4.0.0
collected 28 items

tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_deliver_reports_respects_settings Creating test database for alias 'default' ('test_region')...
Creating test database for alias 'control' ('test_control')...
Creating test database for alias 'secondary' ('test_secondary')...
PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_dry_run_simple PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_duplicate_detection PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_email_override_invalid_target_user PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_email_override_no_target_user PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_email_override_simple PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_empty_report PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_group_status_to_color_obj_correct_length PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_integration PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_invited_member PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_member_disabled PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_advanced PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_filter_resolved PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_filter_to_error_level PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_multiple_users_prevent_resend PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_replays PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_simple PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_builder_substatus_simple PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_message_links_customer_domains PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_organization_project_issue_status PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_organization_project_issue_substatus_summaries PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_schedule_organizations_starts_from_beginning_when_no_redis_key PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_schedule_organizations_updates_redis_during_processing PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_schedule_organizations_with_redis_tracking PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_transferred_project PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_user_inactive PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_user_with_team_and_no_projects PASSED
tests/sentry/tasks/test_weekly_reports.py::WeeklyReportsTest::test_with_empty_string_user_option PASSEDDestroying test database for alias 'default' ('test_region')...
Destroying test database for alias 'control' ('test_control')...
Destroying test database for alias 'secondary' ('test_secondary')...


============================================================ 28 passed in 22.27s =============================================================
%4|1746129607.823|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 1 message (211 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```