### PR TITLE
style(flags): fix alignment on ff section in issues

### DIFF
--- a/static/app/components/events/featureFlags/featureFlagDrawer.tsx
+++ b/static/app/components/events/featureFlags/featureFlagDrawer.tsx
@@ -157,18 +157,12 @@ export const CardContainer = styled('div')<{numCols: number}>`
     :not(:last-child) {
       border-right: 1.5px solid ${p => p.theme.innerBorder};
       padding-right: ${space(2)};
-      div {
-        padding-left: ${space(0.5)};
-      }
     }
     :not(:first-child) {
       border-left: 1.5px solid ${p => p.theme.innerBorder};
       padding-left: ${space(2)};
       padding-right: 0;
       margin-left: -1px;
-      div {
-        padding-left: ${space(0.5)};
-      }
     }
   }
 `;


### PR DESCRIPTION
before:
<img width="785" alt="SCR-20250501-macq" src="https://github.com/user-attachments/assets/625192cb-c090-49c2-8d2c-5e912116b659" />

after:
<img width="910" alt="SCR-20250501-lzyc" src="https://github.com/user-attachments/assets/5dcfd519-c550-483f-839b-8f8e04cd124f" />

don't know when the misalignment happened (and i know the suspect labels will go away soon), but let's fix it for now