### PR TITLE
fix(taskworker) Remove pickle parameters from relocation tasks

### DIFF
--- a/src/sentry/relocation/api/endpoints/index.py
+++ b/src/sentry/relocation/api/endpoints/index.py
@@ -287,7 +287,7 @@ class RelocationIndexEndpoint(Endpoint):
         relocation_link_promo_code.send_robust(
             relocation_uuid=relocation.uuid, promo_code=promo_code, sender=self.__class__
         )
-        uploading_start.apply_async(args=[relocation.uuid, None, None])
+        uploading_start.apply_async(args=[str(relocation.uuid), None, None])
         try:
             analytics.record(
                 "relocation.created",

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -171,7 +171,9 @@ ERR_COMPLETED_INTERNAL = "Internal error during relocation wrap-up."
         ),
     ),
 )
-def uploading_start(uuid: UUID, replying_region_name: str | None, org_slug: str | None) -> None:
+def uploading_start(
+    uuid: UUID | str, replying_region_name: str | None, org_slug: str | None
+) -> None:
     """
     The very first action in the relocation pipeline. In the case of a `SAAS_TO_SAAS` relocation, it
     will trigger the export of the requested organization from the region it currently live in. If
@@ -258,6 +260,7 @@ def uploading_start(uuid: UUID, replying_region_name: str | None, org_slug: str 
         control_relocation_export_service,
     )
 
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.UPLOADING_START,
@@ -395,7 +398,7 @@ def fulfill_cross_region_export_request(
         fp,
         encryptor=LocalFileEncryptor(BytesIO(encrypt_with_public_key)),
         org_filter={org_slug},
-        printer=LoggingPrinter(uuid),
+        printer=LoggingPrinter(uuid_str),
         checkpointer=StorageBackedCheckpointExporter(
             crypto=EncryptorDecryptorPair(
                 encryptor=GCPKMSEncryptor.from_crypto_key_version(get_default_crypto_key_version()),
@@ -455,12 +458,13 @@ def fulfill_cross_region_export_request(
     ),
 )
 def cross_region_export_timeout_check(
-    uuid: UUID,
+    uuid: UUID | str,
 ) -> None:
     """
     Not part of the primary `OrderedTask` queue. This task is only used to ensure that cross-region
     export requests don't hang indefinitely.
     """
+    uuid = str(uuid)
 
     try:
         relocation = Relocation.objects.get(uuid=uuid)
@@ -468,7 +472,7 @@ def cross_region_export_timeout_check(
         logger.exception("Could not locate Relocation model by UUID: %s", uuid)
         return
 
-    logger_data = {"uuid": str(relocation.uuid), "task": "cross_region_export_timeout_check"}
+    logger_data = {"uuid": uuid, "task": "cross_region_export_timeout_check"}
     logger.info(
         "cross_region_export_timeout_check: started",
         extra=logger_data,
@@ -518,12 +522,12 @@ def cross_region_export_timeout_check(
         ),
     ),
 )
-def uploading_complete(uuid: UUID) -> None:
+def uploading_complete(uuid: UUID | str) -> None:
     """
     Just check to ensure that uploading the (potentially very large!) backup file has completed
     before we try to do all sorts of fun stuff with it.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.UPLOADING_COMPLETE,
@@ -572,7 +576,7 @@ def uploading_complete(uuid: UUID) -> None:
         ),
     ),
 )
-def preprocessing_scan(uuid: UUID) -> None:
+def preprocessing_scan(uuid: UUID | str) -> None:
     """
     Performs the very first part of the `PREPROCESSING` step of a `Relocation`, which involves
     decrypting the user-supplied tarball and picking out some useful information for it. This let's
@@ -590,7 +594,7 @@ def preprocessing_scan(uuid: UUID) -> None:
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.PREPROCESSING_SCAN,
@@ -753,14 +757,14 @@ def preprocessing_scan(uuid: UUID) -> None:
         ),
     ),
 )
-def preprocessing_transfer(uuid: UUID) -> None:
+def preprocessing_transfer(uuid: UUID | str) -> None:
     """
     We currently have the user's relocation data stored in the main filestore bucket, but we need to
     move it to the relocation bucket. This task handles that transfer.
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.PREPROCESSING_TRANSFER,
@@ -848,13 +852,13 @@ def preprocessing_transfer(uuid: UUID) -> None:
         ),
     ),
 )
-def preprocessing_baseline_config(uuid: UUID) -> None:
+def preprocessing_baseline_config(uuid: UUID | str) -> None:
     """
     Pulls down the global config data we'll need to check for collisions and global data integrity.
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.PREPROCESSING_BASELINE_CONFIG,
@@ -906,14 +910,14 @@ def preprocessing_baseline_config(uuid: UUID) -> None:
         ),
     ),
 )
-def preprocessing_colliding_users(uuid: UUID) -> None:
+def preprocessing_colliding_users(uuid: UUID | str) -> None:
     """
     Pulls down any already existing users whose usernames match those found in the import - we'll
     need to validate that none of these are mutated during import.
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.PREPROCESSING_COLLIDING_USERS,
@@ -962,7 +966,7 @@ def preprocessing_colliding_users(uuid: UUID) -> None:
         ),
     ),
 )
-def preprocessing_complete(uuid: UUID) -> None:
+def preprocessing_complete(uuid: UUID | str) -> None:
     """
     This task ensures that every file CloudBuild will need to do its work is actually present and
     available. Even if we've "finished" our uploads from the previous step, they may still not (yet)
@@ -971,7 +975,7 @@ def preprocessing_complete(uuid: UUID) -> None:
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.PREPROCESSING_COMPLETE,
@@ -1084,7 +1088,6 @@ def _update_relocation_validation_attempt(
         )
     ):
         uuid_str = str(relocation.uuid)
-        uuid = UUID(uuid_str)
 
         # If no interesting status updates occurred, check again in a minute.
         if status == ValidationStatus.IN_PROGRESS:
@@ -1094,7 +1097,7 @@ def _update_relocation_validation_attempt(
             )
             return NextTask(
                 task=validating_poll,
-                args=[uuid, str(relocation_validation_attempt.build_id)],
+                args=[uuid_str, str(relocation_validation_attempt.build_id)],
                 countdown=60,
             )
 
@@ -1118,7 +1121,7 @@ def _update_relocation_validation_attempt(
                     extra={"uuid": uuid_str, "task": task.name},
                 )
 
-                return NextTask(task=validating_start, args=[uuid])
+                return NextTask(task=validating_start, args=[uuid_str])
 
             # Always accept the numerically higher `ValidationStatus`, since that is a more definite
             # result.
@@ -1167,7 +1170,7 @@ def _update_relocation_validation_attempt(
             extra={"uuid": uuid_str, "task": task.name},
         )
 
-        return NextTask(task=importing, args=[uuid])
+        return NextTask(task=importing, args=[uuid_str])
 
 
 @instrumented_task(
@@ -1187,13 +1190,13 @@ def _update_relocation_validation_attempt(
         ),
     ),
 )
-def validating_start(uuid: UUID) -> None:
+def validating_start(uuid: UUID | str) -> None:
     """
     Calls into Google CloudBuild and kicks off a validation run.
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.VALIDATING_START,
@@ -1271,13 +1274,13 @@ def validating_start(uuid: UUID) -> None:
         retry=Retry(times=MAX_VALIDATION_POLLS, on=(Exception,), times_exceeded=LastAction.Discard),
     ),
 )
-def validating_poll(uuid: UUID, build_id: str) -> None:
+def validating_poll(uuid: UUID | str, build_id: str) -> None:
     """
     Checks the progress of a Google CloudBuild validation run.
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.VALIDATING_POLL,
@@ -1299,7 +1302,7 @@ def validating_poll(uuid: UUID, build_id: str) -> None:
     logger.info(
         "Validation polling: active",
         extra={
-            "uuid": str(relocation.uuid),
+            "uuid": uuid,
             "task": OrderedTask.VALIDATING_POLL.name,
             "build_id": build_id,
         },
@@ -1376,7 +1379,7 @@ def validating_poll(uuid: UUID, build_id: str) -> None:
         ),
     ),
 )
-def validating_complete(uuid: UUID, build_id: str) -> None:
+def validating_complete(uuid: UUID | str, build_id: str) -> None:
     """
     Wraps up a validation run, and reports on what we found. If this task is being called, the
     CloudBuild run as completed successfully, so we just need to figure out if there were any
@@ -1384,7 +1387,7 @@ def validating_complete(uuid: UUID, build_id: str) -> None:
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.VALIDATING_COMPLETE,
@@ -1471,14 +1474,14 @@ def validating_complete(uuid: UUID, build_id: str) -> None:
         ),
     ),
 )
-def importing(uuid: UUID) -> None:
+def importing(uuid: UUID | str) -> None:
     """
     Perform the import on the actual live instance we are targeting.
 
     This function is NOT idempotent - if an import breaks, we should just abandon it rather than
     trying it again!
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.IMPORTING,
@@ -1540,11 +1543,11 @@ def importing(uuid: UUID) -> None:
         ),
     ),
 )
-def postprocessing(uuid: UUID) -> None:
+def postprocessing(uuid: UUID | str) -> None:
     """
     Make the owner of this relocation an owner of all of the organizations we just imported.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.POSTPROCESSING,
@@ -1559,10 +1562,9 @@ def postprocessing(uuid: UUID) -> None:
         attempts_left,
         ERR_POSTPROCESSING_INTERNAL,
     ):
-        uuid_str = str(uuid)
         imported_org_ids: set[int] = set()
         for chunk in RegionImportChunk.objects.filter(
-            import_uuid=uuid_str, model="sentry.organization"
+            import_uuid=uuid, model="sentry.organization"
         ):
             imported_org_ids = imported_org_ids.union(set(chunk.inserted_map.values()))
 
@@ -1594,7 +1596,7 @@ def postprocessing(uuid: UUID) -> None:
         # Last, but certainly not least: trigger signals, so that interested subscribers in eg:
         # getsentry can do whatever postprocessing they need to. If even a single one fails, we fail
         # the entire task.
-        for _, result in relocated.send_robust(sender=postprocessing, relocation_uuid=uuid_str):
+        for _, result in relocated.send_robust(sender=postprocessing, relocation_uuid=uuid):
             if isinstance(result, Exception):
                 raise result
 
@@ -1603,7 +1605,7 @@ def postprocessing(uuid: UUID) -> None:
         relocation_redeem_promo_code.send_robust(
             sender=postprocessing,
             user_id=relocation.owner_id,
-            relocation_uuid=uuid_str,
+            relocation_uuid=uuid,
             orgs=list(imported_orgs),
         )
 
@@ -1612,7 +1614,7 @@ def postprocessing(uuid: UUID) -> None:
                 analytics.record(
                     "relocation.organization_imported",
                     organization_id=org.id,
-                    relocation_uuid=uuid_str,
+                    relocation_uuid=uuid,
                     slug=org.slug,
                     owner_id=relocation.owner_id,
                 )
@@ -1639,11 +1641,11 @@ def postprocessing(uuid: UUID) -> None:
         ),
     ),
 )
-def notifying_unhide(uuid: UUID) -> None:
+def notifying_unhide(uuid: UUID | str) -> None:
     """
     Un-hide the just-imported organizations, making them visible to users in the UI.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.NOTIFYING_UNHIDE,
@@ -1692,11 +1694,11 @@ def notifying_unhide(uuid: UUID) -> None:
         ),
     ),
 )
-def notifying_users(uuid: UUID) -> None:
+def notifying_users(uuid: UUID | str) -> None:
     """
     Send an email to all users that have been imported, telling them to claim their accounts.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.NOTIFYING_USERS,
@@ -1711,15 +1713,14 @@ def notifying_users(uuid: UUID) -> None:
         attempts_left,
         ERR_NOTIFYING_INTERNAL,
     ):
-        uuid_str = str(uuid)
         imported_user_ids: set[int] = set()
-        chunks = ControlImportChunkReplica.objects.filter(import_uuid=uuid_str, model="sentry.user")
+        chunks = ControlImportChunkReplica.objects.filter(import_uuid=uuid, model="sentry.user")
         for control_chunk in chunks:
             imported_user_ids = imported_user_ids.union(set(control_chunk.inserted_map.values()))
 
         imported_org_slugs: set[str] = set()
         for region_chunk in RegionImportChunk.objects.filter(
-            import_uuid=uuid_str, model="sentry.organization"
+            import_uuid=uuid, model="sentry.organization"
         ):
             imported_org_slugs = imported_org_slugs.union(
                 set(region_chunk.inserted_identifiers.values())
@@ -1773,11 +1774,11 @@ def notifying_users(uuid: UUID) -> None:
         ),
     ),
 )
-def notifying_owner(uuid: UUID) -> None:
+def notifying_owner(uuid: UUID | str) -> None:
     """
     Send an email to the creator and owner, telling them that their relocation was successful.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.NOTIFYING_OWNER,
@@ -1792,10 +1793,9 @@ def notifying_owner(uuid: UUID) -> None:
         attempts_left,
         ERR_NOTIFYING_INTERNAL,
     ):
-        uuid_str = str(uuid)
         imported_org_slugs: set[int] = set()
         for chunk in RegionImportChunk.objects.filter(
-            import_uuid=uuid_str, model="sentry.organization"
+            import_uuid=uuid, model="sentry.organization"
         ):
             imported_org_slugs = imported_org_slugs.union(set(chunk.inserted_identifiers.values()))
 
@@ -1803,7 +1803,7 @@ def notifying_owner(uuid: UUID) -> None:
             relocation,
             Relocation.EmailKind.SUCCEEDED,
             {
-                "uuid": uuid_str,
+                "uuid": uuid,
                 "orgs": list(imported_org_slugs),
             },
         )
@@ -1828,11 +1828,11 @@ def notifying_owner(uuid: UUID) -> None:
         ),
     ),
 )
-def completed(uuid: UUID) -> None:
+def completed(uuid: UUID | str) -> None:
     """
     Finish up a relocation by marking it a success.
     """
-
+    uuid = str(uuid)
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
         task=OrderedTask.COMPLETED,

--- a/src/sentry/relocation/utils.py
+++ b/src/sentry/relocation/utils.py
@@ -405,7 +405,7 @@ class LoggingPrinter(Printer):
     and `export_*` backup methods rely on.
     """
 
-    def __init__(self, uuid: UUID):
+    def __init__(self, uuid: str):
         self.uuid = uuid
         super().__init__()
 
@@ -420,13 +420,13 @@ class LoggingPrinter(Printer):
             logger.error(
                 "Import failed: %s",
                 text,
-                extra={"uuid": str(self.uuid), "task": OrderedTask.IMPORTING.name},
+                extra={"uuid": self.uuid, "task": OrderedTask.IMPORTING.name},
             )
         else:
             logger.info(
                 "Import info: %s",
                 text,
-                extra={"uuid": str(self.uuid), "task": OrderedTask.IMPORTING.name},
+                extra={"uuid": self.uuid, "task": OrderedTask.IMPORTING.name},
             )
 
 
@@ -459,7 +459,7 @@ def send_relocation_update_email(
 
 
 def start_relocation_task(
-    uuid: UUID, task: OrderedTask, allowed_task_attempts: int
+    uuid: str, task: OrderedTask, allowed_task_attempts: int
 ) -> tuple[Relocation | None, int]:
     """
     All tasks for relocation are done sequentially, and take the UUID of the `Relocation` model as
@@ -468,7 +468,7 @@ def start_relocation_task(
     Returns a tuple of relocation model and the number of attempts remaining for this task.
     """
 
-    logger_data = {"uuid": str(uuid), "task": task.name}
+    logger_data = {"uuid": uuid, "task": task.name}
     try:
         relocation: Relocation = Relocation.objects.get(uuid=uuid)
     except Relocation.DoesNotExist:
@@ -805,10 +805,3 @@ def create_cloudbuild_validation_step(
         timeout=str(timeout) + "s",
         wait_for=make_cloudbuild_step_args(3, wait_for),
     )
-
-
-def uuid_to_identifier(uuid: UUID) -> int:
-    """
-    Take a UUID object and generated a unique-enough 64-bit identifier from it's final 64 bits.
-    """
-    return uuid.int & ((1 << 63) - 1)

--- a/tests/sentry/relocation/api/endpoints/test_index.py
+++ b/tests/sentry/relocation/api/endpoints/test_index.py
@@ -351,7 +351,7 @@ class PostRelocationsTest(APITestCase):
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
         assert uploading_start_mock.call_count == 1
-        uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+        uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
@@ -416,7 +416,7 @@ class PostRelocationsTest(APITestCase):
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
         assert uploading_start_mock.call_count == 1
-        uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+        uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
@@ -471,7 +471,7 @@ class PostRelocationsTest(APITestCase):
         assert response.data["scheduledPauseAtStep"] == Relocation.Step.IMPORTING.name
 
         assert uploading_start_mock.call_count == 1
-        uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+        uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
@@ -563,7 +563,7 @@ class PostRelocationsTest(APITestCase):
         assert response.data["scheduledPauseAtStep"] is None
 
         assert uploading_start_mock.call_count == 1
-        uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+        uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
@@ -627,7 +627,7 @@ class PostRelocationsTest(APITestCase):
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
         assert uploading_start_mock.call_count == 1
-        uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+        uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
@@ -689,7 +689,7 @@ class PostRelocationsTest(APITestCase):
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
         assert uploading_start_mock.call_count == 1
-        uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+        uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
@@ -805,7 +805,7 @@ class PostRelocationsTest(APITestCase):
             assert RelocationFile.objects.count() == relocation_file_count + 1
             assert Relocation.objects.get(owner_id=self.owner.id).want_org_slugs == expected
             assert uploading_start_mock.call_count == 1
-            uploading_start_mock.assert_called_with(args=[UUID(response.data["uuid"]), None, None])
+            uploading_start_mock.assert_called_with(args=[response.data["uuid"], None, None])
 
             assert analytics_record_mock.call_count == 1
             analytics_record_mock.assert_called_with(

--- a/tests/sentry/relocation/tasks/test_process.py
+++ b/tests/sentry/relocation/tasks/test_process.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from django.core.files.storage import Storage
@@ -136,7 +136,7 @@ class RelocationTaskTestCase(TestCase):
             file=self.file,
             kind=RelocationFile.Kind.RAW_USER_DATA.value,
         )
-        self.uuid = UUID(str(self.relocation.uuid))
+        self.uuid = str(self.relocation.uuid)
 
     @cached_property
     def file(self):
@@ -251,7 +251,7 @@ class UploadingStartTest(RelocationTaskTestCase):
                 latest_task=OrderedTask.UPLOADING_START.name,
                 provenance=Relocation.Provenance.SAAS_TO_SAAS,
             )
-            self.uuid = UUID(str(self.relocation.uuid))
+            self.uuid = str(self.relocation.uuid)
 
     @override_settings(
         SENTRY_MONOLITH_REGION=REQUESTING_TEST_REGION, SENTRY_REGION=REQUESTING_TEST_REGION
@@ -1638,7 +1638,7 @@ class ValidatingPollTest(RelocationTaskTestCase):
         assert relocation.failure_reason == ERR_VALIDATING_INTERNAL
 
 
-def mock_invalid_finding(storage: Storage, uuid: UUID):
+def mock_invalid_finding(storage: Storage, uuid: str):
     storage.save(
         f"runs/{uuid}/findings/import-baseline-config.json",
         BytesIO(

--- a/tests/sentry/relocation/test_utils.py
+++ b/tests/sentry/relocation/test_utils.py
@@ -39,7 +39,7 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
     def test_bad_relocation_not_found(self, fake_message_builder: Mock):
         self.mock_message_builder(fake_message_builder)
 
-        uuid = uuid4()
+        uuid = str(uuid4())
         (rel, attempts_left) = start_relocation_task(uuid, OrderedTask.UPLOADING_COMPLETE, 3)
 
         assert fake_message_builder.call_count == 0


### PR DESCRIPTION
Don't pass UUID instances (as they require pickle). Instead we can use the string form of UUIDs.

Fixes #90764