### PR TITLE
fix(ourlogs): Fix trace id link in attributes being broken

### DIFF
--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -282,7 +282,9 @@ function LogRowDetails({
   const theme = useTheme();
   const logColors = getLogColors(level, theme);
   const attributes =
-    data?.attributes?.reduce((it, {name, value}) => ({...it, [name]: value}), {}) ?? {};
+    data?.attributes?.reduce((it, {name, value}) => ({...it, [name]: value}), {
+      [OurLogKnownFieldKey.TIMESTAMP]: dataRow[OurLogKnownFieldKey.TIMESTAMP],
+    }) ?? {};
 
   if (missingLogId) {
     return (


### PR DESCRIPTION
### Summary
'timestamp' doesn't exist in trace-item-details endpoint, we only have sentry.timestamp_nanos when mapping directly.

This broke when we moved to passing `attributes` to renderExtra instead of the table row.