### PR TITLE
feat(ourlogs): Change period limits based on plan

### DIFF
--- a/static/app/views/explore/logs/index.tsx
+++ b/static/app/views/explore/logs/index.tsx
@@ -44,7 +44,8 @@ function FeedbackButton() {
 
 export default function LogsPage() {
   const organization = useOrganization();
-  const {defaultPeriod, maxPickableDays, relativeOptions} = logsPickableDays();
+  const {defaultPeriod, maxPickableDays, relativeOptions} =
+    logsPickableDays(organization);
 
   const prefersStackedNav = usePrefersStackedNav();
 

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react';
 
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
+import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {
@@ -190,13 +191,16 @@ export function adjustLogTraceID(traceID: string) {
   return traceID.replace(/-/g, '');
 }
 
-export function logsPickableDays(): PickableDays {
+export function logsPickableDays(organization: Organization): PickableDays {
   const relativeOptions: Array<[string, React.ReactNode]> = [
     ['1h', t('Last hour')],
     ['24h', t('Last 24 hours')],
     ['7d', t('Last 7 days')],
-    ['14d', t('Last 14 days')],
   ];
+
+  if (organization.features.includes('visibility-explore-range-high')) {
+    relativeOptions.push(['14d', t('Last 14 days')]);
+  }
 
   return {
     defaultPeriod: '24h',


### PR DESCRIPTION
### Summary
High visibility plans get longer periods for logs.

Closes LOGS-75