### PR TITLE
fix(insights): Fix prevent same chart from being picked twice in Session Health when names have changed

### DIFF
--- a/static/app/views/insights/sessions/components/chartMap.tsx
+++ b/static/app/views/insights/sessions/components/chartMap.tsx
@@ -76,7 +76,7 @@ export const PAGE_CHART_OPTIONS: Record<
 
 export const DEFAULT_LAYOUTS: Record<
   DomainView,
-  ReadonlyArray<keyof typeof CHART_MAP>
+  ReadonlyArray<keyof typeof CHART_MAP | undefined>
 > = {
   frontend: [
     // ORDER MATTERS HERE

--- a/static/app/views/insights/sessions/components/chartPlacement.tsx
+++ b/static/app/views/insights/sessions/components/chartPlacement.tsx
@@ -41,19 +41,17 @@ export function ChartPlacementSlot({view, index}: Props) {
 
   const chartsByIndex = useMemo(() => {
     return chartsByIndexAnyName.map(name => {
-      // We didn't get a valid name, so use the default (which might be empty too)
-      if (!name) {
-        return PAGE_CHART_OPTIONS[view][index];
-      }
       // This is a proper chart name, we can just use it
-      if (PAGE_CHART_OPTIONS[view].includes(name)) {
+      if (name && PAGE_CHART_OPTIONS[view].includes(name)) {
         return name;
       }
       // The chart was renamed, use the new name
-      if (CHART_RENAMES[name]) {
+      if (name && CHART_RENAMES[name]) {
         return CHART_RENAMES[name];
       }
-      // The name wasn't found, so use the default
+      // The name wasn't found, so use the default if the index is valid.
+      // If `index` is invalid then we'll see the 'None' chart and the dropdown
+      // will still work to pick another
       // This might cause the chart to be rendered twice on the screen
       return PAGE_CHART_OPTIONS[view][index];
     });

--- a/static/app/views/insights/sessions/components/chartPlacement.tsx
+++ b/static/app/views/insights/sessions/components/chartPlacement.tsx
@@ -1,4 +1,4 @@
-import {createContext, useCallback, useContext} from 'react';
+import {createContext, useCallback, useContext, useMemo} from 'react';
 
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -35,9 +35,29 @@ interface Props {
 export function ChartPlacementSlot({view, index}: Props) {
   const organization = useOrganization();
 
-  const [chartsByIndex, setChartsByIndex] = useSyncedLocalStorageState<
+  const [chartsByIndexAnyName, setChartsByIndex] = useSyncedLocalStorageState<
     (typeof DEFAULT_LAYOUTS)[DomainView]
   >(`insights-sessions-layout-${organization.slug}-${view}`, DEFAULT_LAYOUTS[view]);
+
+  const chartsByIndex = useMemo(() => {
+    return chartsByIndexAnyName.map(name => {
+      // We didn't get a valid name, so use the default (which might be empty too)
+      if (!name) {
+        return PAGE_CHART_OPTIONS[view][index];
+      }
+      // This is a proper chart name, we can just use it
+      if (PAGE_CHART_OPTIONS[view].includes(name)) {
+        return name;
+      }
+      // The chart was renamed, use the new name
+      if (CHART_RENAMES[name]) {
+        return CHART_RENAMES[name];
+      }
+      // The name wasn't found, so use the default
+      // This might cause the chart to be rendered twice on the screen
+      return PAGE_CHART_OPTIONS[view][index];
+    });
+  }, [chartsByIndexAnyName, index, view]);
 
   const chartOptions = PAGE_CHART_OPTIONS[view].map(opt => ({
     value: opt,
@@ -53,7 +73,7 @@ export function ChartPlacementSlot({view, index}: Props) {
     [chartsByIndex, index, setChartsByIndex]
   );
 
-  const chartName = CHART_RENAMES[chartsByIndex[index] as string] ?? chartsByIndex[index];
+  const chartName = chartsByIndex[index];
   const Chart = chartName && CHART_MAP[chartName];
   if (Chart) {
     return (


### PR DESCRIPTION
Fixes an issue where, if localStorage contains a random string instead of a known chart name, we show the None chart. The situation is improved, but if `index` is out of bounds then we have no decent thing to fallback on.

Also, fixes an issue where `CHART_RENAMES` was not considered when we generated `chartOptions`. This meant that we didn't properly set the `disabled` prop, allowing duplicate charts to be picked.