### PR TITLE
fix(taskworker) Remove pickle parameters from delete_groups

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -79,7 +79,7 @@ def delete_group_list(
     delete_groups_task.apply_async(
         kwargs={
             "object_ids": group_ids,
-            "transaction_id": transaction_id,
+            "transaction_id": str(transaction_id),
             "eventstream_state": eventstream_state,
         },
         countdown=countdown,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -208,7 +208,7 @@ class SnubaProtocolEventStream(EventStream):
             raise ValueError("expected groups to delete!")
 
         state = {
-            "transaction_id": uuid4().hex,
+            "transaction_id": str(uuid4().hex),
             "project_id": project_id,
             "group_ids": list(group_ids),
             "datetime": json.datetime_to_str(datetime.now(tz=timezone.utc)),

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -5613,7 +5613,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.eventstream.backend")
     def test_delete_by_id(self, mock_eventstream: MagicMock) -> None:
-        eventstream_state = {"event_stream_state": uuid4()}
+        eventstream_state = {"event_stream_state": str(uuid4())}
         mock_eventstream.start_delete_groups = Mock(return_value=eventstream_state)
 
         group1 = self.create_group(status=GroupStatus.RESOLVED)
@@ -5686,7 +5686,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
     @patch("sentry.eventstream.backend")
     def test_delete_performance_issue_by_id(self, mock_eventstream: MagicMock) -> None:
-        eventstream_state = {"event_stream_state": uuid4()}
+        eventstream_state = {"event_stream_state": str(uuid4())}
         mock_eventstream.start_delete_groups = Mock(return_value=eventstream_state)
 
         group1 = self.create_group(


### PR DESCRIPTION
Don't put uuid() objects into evenstream_state, as they require pickle.

Fixes #90765