### PR TITLE
feat(replay): Capture replays for users without org in context

### DIFF
--- a/static/gsApp/components/organizationHeader.tsx
+++ b/static/gsApp/components/organizationHeader.tsx
@@ -18,7 +18,7 @@ export function OrganizationHeader({organization}: Props) {
   const showEmployeeFeedbackButton = !showDevToolbar;
 
   useFeedbackInit();
-  useReplayInit({organization});
+  useReplayInit();
 
   return (
     <Fragment>

--- a/static/gsApp/utils/useReplayInit.tsx
+++ b/static/gsApp/utils/useReplayInit.tsx
@@ -4,24 +4,15 @@ import type {replayIntegration} from '@sentry/react';
 import {getClient} from '@sentry/react';
 
 import {isStaticString} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {useUser} from 'sentry/utils/useUser';
-
-interface Props {
-  organization: Organization | null;
-}
 
 // Single replayRef across the whole app, even if this hook is called multiple times
 let replayRef: ReturnType<typeof replayIntegration> | null;
 
 /**
  * Load the Sentry Replay integration based on the feature flag.
- *
- *  Can't use `useOrganization` because it throws on
- * `/settings/account/api/auth-token/` because organization is not *immediately*
- * set in context
  */
-export default function useReplayInit({organization}: Props) {
+export default function useReplayInit() {
   const user = useUser();
 
   useEffect(() => {
@@ -84,7 +75,7 @@ export default function useReplayInit({organization}: Props) {
       return;
     }
 
-    if (!organization || !user) {
+    if (!user) {
       return;
     }
 
@@ -95,5 +86,5 @@ export default function useReplayInit({organization}: Props) {
 
     // NOTE: if this component is unmounted (e.g. when org is switched), we will continue to record!
     // This can be changed by calling `stop/start()` on unmount/mount respectively.
-  }, [organization, user]);
+  }, [user]);
 }


### PR DESCRIPTION
We have some errors that do not have any replays bc the user does not have any orgs. Previously we checked feature flags before deciding to record a replay, but those have been removed, so there is no need to check the org at all.
