### PR TITLE
chore(alerts): Add more logging in fire_rules

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -459,7 +459,9 @@ def fire_rules(
         group_to_groupevent = get_group_to_groupevent(
             parsed_rulegroup_to_event_data, project.id, group_ids
         )
-        if features.has("organizations:workflow-engine-process-workflows", project.organization):
+        if features.has(
+            "organizations:workflow-engine-process-workflows", project.organization
+        ) or features.has("projects:num-events-issue-debugging", project):
             serialized_groups = {
                 group.id: group_event.event_id for group, group_event in group_to_groupevent.items()
             }


### PR DESCRIPTION
Add another flag here to enable extra logs to figure out where an alert is falling off.