### PR TITLE
ref(workflow_engine): Rename the StatefulDetectorHandler to StatefulGroupingDetectorHandler

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -12,8 +12,11 @@ from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.handlers.detector import DetectorOccurrence, StatefulDetectorHandler
 from sentry.workflow_engine.handlers.detector.base import EvidenceData
+from sentry.workflow_engine.handlers.detector import (
+    DetectorOccurrence,
+    StatefulGroupingDetectorHandler,
+)
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorSettings
 
@@ -26,7 +29,7 @@ class MetricIssueEvidenceData(EvidenceData):
     alert_id: int
 
 
-class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate]):
+class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate]):
     def build_occurrence_and_event_data(
         self, group_key: DetectorGroupKey, new_status: PriorityLevel
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -12,11 +12,11 @@ from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.handlers.detector.base import EvidenceData
 from sentry.workflow_engine.handlers.detector import (
     DetectorOccurrence,
     StatefulGroupingDetectorHandler,
 )
+from sentry.workflow_engine.handlers.detector.base import EvidenceData
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorSettings
 

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -3,8 +3,8 @@ __all__ = [
     "DetectorHandler",
     "DetectorOccurrence",
     "DetectorStateData",
-    "StatefulDetectorHandler",
+    "StatefulGroupingDetectorHandler",
 ]
 
 from .base import DetectorEvaluationResult, DetectorHandler, DetectorOccurrence, DetectorStateData
-from .stateful import StatefulDetectorHandler
+from .stateful import StatefulGroupingDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -32,7 +32,7 @@ def get_redis_client() -> RetryingRedisCluster:
     return redis.redis_clusters.get(cluster_key)  # type: ignore[return-value]
 
 
-class StatefulDetectorHandler(DetectorHandler[T], abc.ABC):
+class StatefulGroupingDetectorHandler(DetectorHandler[T], abc.ABC):
     def __init__(self, detector: Detector):
         super().__init__(detector)
         self.dedupe_updates: dict[DetectorGroupKey, int] = {}

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -12,7 +12,7 @@ from sentry.workflow_engine.handlers.detector import (
     DetectorHandler,
     DetectorOccurrence,
 )
-from sentry.workflow_engine.handlers.detector.stateful import StatefulDetectorHandler
+from sentry.workflow_engine.handlers.detector.stateful import StatefulGroupingDetectorHandler
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorSettings
@@ -20,7 +20,7 @@ from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
 
 
 def build_mock_occurrence_and_event(
-    handler: StatefulDetectorHandler,
+    handler: StatefulGroupingDetectorHandler,
     group_key: DetectorGroupKey,
     new_status: PriorityLevel,
 ) -> tuple[DetectorOccurrence, dict[str, Any]]:
@@ -47,7 +47,7 @@ def status_change_comparator(self: StatusChangeMessage, other: StatusChangeMessa
     )
 
 
-class MockDetectorStateHandler(StatefulDetectorHandler[dict]):
+class MockDetectorStateHandler(StatefulGroupingDetectorHandler[dict]):
     counter_names = ["test1", "test2"]
 
     def get_dedupe_value(self, data_packet: DataPacket[dict]) -> int:


### PR DESCRIPTION
## Description
Updating the handler to be a little more descriptive, this will help in the refactor work to let me create a generic stateful handler in isolation, then a generic grouping one, and finally update this handler to be a composed version of the two.