### PR TITLE
feat: Track alert misfires on EAP

### DIFF
--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -201,7 +201,7 @@ def get_mismatch_type(mismatches: dict[int, dict[str, float]], total_buckets: in
     if all_rpc_values_zero:
         return MismatchType.RPC_ALWAYS_ZERO, many_low_conf_buckets, many_low_sample_rate_buckets
 
-    if snql_always_lower and total_buckets - (mismatches) < 2:
+    if snql_always_lower and total_buckets - len(mismatches) < 2:
         return MismatchType.SNQL_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
 
     if rpc_always_lower and total_buckets - len(mismatches) < 2:

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -201,10 +201,10 @@ def get_mismatch_type(mismatches: dict[int, dict[str, float]], total_buckets: in
     if all_rpc_values_zero:
         return MismatchType.RPC_ALWAYS_ZERO, many_low_conf_buckets, many_low_sample_rate_buckets
 
-    if snql_always_lower and total_buckets == len(mismatches):
+    if snql_always_lower and total_buckets - (mismatches) < 2:
         return MismatchType.SNQL_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
 
-    if rpc_always_lower and total_buckets == len(mismatches):
+    if rpc_always_lower and total_buckets - len(mismatches) < 2:
         return MismatchType.RPC_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
 
     if has_high_diff:

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -9,7 +9,6 @@ import sentry_sdk
 from django.urls import reverse
 
 from sentry import features
-from sentry.api.bases.organization import NoProjects
 from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_eap
 from sentry.exceptions import IncompatibleMetricsQuery
 from sentry.incidents.models.alert_rule import (
@@ -343,9 +342,9 @@ def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
     snuba_query: SnubaQuery = alert_rule.snuba_query
     project = alert_rule.projects.first()
     if not project:
-        raise NoProjects
+        return {"is_close": False, "skipped": True, "mismatches": {}}
 
-    if snuba_query.aggregate in ["apdex()"]:
+    if "apdex" in snuba_query.aggregate:
         logger.info(
             "Skipping alert %s, %s aggregate not yet supported by RPC",
             alert_rule.id,

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -12,7 +12,12 @@ from sentry import features
 from sentry.api.bases.organization import NoProjects
 from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_eap
 from sentry.exceptions import IncompatibleMetricsQuery
-from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.models.alert_rule import (
+    AlertRule,
+    AlertRuleDetectionType,
+    AlertRuleThresholdType,
+    AlertRuleTrigger,
+)
 from sentry.models.organization import Organization
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.fields import get_function_alias
@@ -148,7 +153,7 @@ def make_snql_request(
     return TSResultForComparison(result=results, agg_alias=get_function_alias(aggregate))
 
 
-def get_mismatch_type(mismatches: dict[int, dict[str, float]]):
+def get_mismatch_type(mismatches: dict[int, dict[str, float]], total_buckets: int):
     all_snql_values_zero = True
     all_rpc_values_zero = True
     snql_always_lower = True
@@ -178,7 +183,7 @@ def get_mismatch_type(mismatches: dict[int, dict[str, float]]):
         if snql_value >= rpc_value:
             snql_always_lower = False
 
-        if snql_value > 0 and rpc_value > 0 and diff > 0.2:
+        if diff > 0.2:
             has_high_diff = True
 
         if confidence == "low":
@@ -196,10 +201,10 @@ def get_mismatch_type(mismatches: dict[int, dict[str, float]]):
     if all_rpc_values_zero:
         return MismatchType.RPC_ALWAYS_ZERO, many_low_conf_buckets, many_low_sample_rate_buckets
 
-    if snql_always_lower:
+    if snql_always_lower and total_buckets == len(mismatches):
         return MismatchType.SNQL_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
 
-    if rpc_always_lower:
+    if rpc_always_lower and total_buckets == len(mismatches):
         return MismatchType.RPC_ALWAYS_LOWER, many_low_conf_buckets, many_low_sample_rate_buckets
 
     if has_high_diff:
@@ -235,6 +240,9 @@ def align_timeseries(snql_result: TSResultForComparison, rpc_result: TSResultFor
 
 def assert_timeseries_close(aligned_timeseries, alert_rule):
     mismatches: dict[int, dict[str, float]] = {}
+    false_positive_misfire = 0
+    false_negative_misfire = 0
+    rule_triggers = AlertRuleTrigger.objects.get_for_alert_rule(alert_rule)
     missing_buckets = 0
     all_zeros = True
     for timestamp, values in aligned_timeseries.items():
@@ -243,6 +251,42 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
         if rpc_value is None or snql_value is None:
             missing_buckets += 1
             continue
+
+        if alert_rule.detection_type == AlertRuleDetectionType.STATIC:
+            for trigger in rule_triggers:
+                would_fire = False
+                threshold = trigger.alert_threshold
+                comparison_type = (
+                    alert_rule.threshold_type
+                    if alert_rule.threshold_type is not None
+                    else trigger.threshold_type
+                )  # greater or less than
+
+                if (
+                    comparison_type == AlertRuleThresholdType.ABOVE.value and snql_value > threshold
+                ) or (
+                    comparison_type == AlertRuleThresholdType.BELOW.value and snql_value < threshold
+                ):
+                    would_fire = True
+
+                if would_fire:
+                    if (
+                        comparison_type == AlertRuleThresholdType.ABOVE.value
+                        and rpc_value < threshold
+                    ) or (
+                        comparison_type == AlertRuleThresholdType.BELOW.value
+                        and rpc_value > threshold
+                    ):
+                        false_negative_misfire += 1
+                else:
+                    if (
+                        comparison_type == AlertRuleThresholdType.ABOVE.value
+                        and rpc_value > threshold
+                    ) or (
+                        comparison_type == AlertRuleThresholdType.BELOW.value
+                        and rpc_value < threshold
+                    ):
+                        false_positive_misfire += 1
 
         # If the sum is 0, we assume that the numbers must be 0, since we have all positive integers. We still do
         # check the sum in order to protect the division by zero in case for some reason we have -x + x inside of
@@ -264,6 +308,9 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
                 "confidence": values["confidence"],
             }
 
+    sentry_sdk.set_tag("false_positive_misfires", false_positive_misfire)
+    sentry_sdk.set_tag("false_negative_misfires", false_negative_misfire)
+
     if mismatches:
         with sentry_sdk.isolation_scope() as scope:
             scope.set_extra("mismatches", mismatches)
@@ -274,24 +321,21 @@ def assert_timeseries_close(aligned_timeseries, alert_rule):
             scope.set_tag("buckets_mismatch.count", len(mismatches))
 
             mismatch_type, many_low_conf_buckets, many_low_sample_rate_buckets = get_mismatch_type(
-                mismatches
+                mismatches, len(aligned_timeseries)
             )
             scope.set_tag("mismatch_type", mismatch_type.value)
             scope.set_tag("many_low_conf_buckets", many_low_conf_buckets)
             scope.set_tag("many_low_sample_rate_buckets", many_low_sample_rate_buckets)
 
             sentry_sdk.capture_message("Timeseries mismatch", level="info")
-            logger.info("Alert %s has too many mismatches", alert_rule.id)
 
             return False, mismatches, all_zeros
 
     if missing_buckets > 1:
         sentry_sdk.capture_message("Multiple missing buckets", level="info")
-        logger.info("Alert %s has multiple missing buckets", alert_rule.id)
 
         return False, mismatches, all_zeros
 
-    logger.info("Alert %s timeseries is close", alert_rule.id)
     return True, mismatches, all_zeros
 
 
@@ -321,6 +365,7 @@ def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
 
     sentry_sdk.set_tag("organization", organization.slug)
     sentry_sdk.set_tag("alert_id", alert_rule.id)
+    sentry_sdk.set_tag("detection_type", alert_rule.detection_type)
 
     on_demand_metrics_enabled = features.has(
         "organizations:on-demand-metrics-extraction",


### PR DESCRIPTION
Add some logic to track false positives and false negatives on alert misfires.