### PR TITLE
fix(shared-views): Fix issue view sharing check in some places

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -32,7 +32,9 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
 
   return (
-    <FiltersContainer hasIssueViewSharing={prefersStackedNav}>
+    <FiltersContainer
+      hasIssueViewSharing={prefersStackedNav && !prefersOldNavWithEnforcement}
+    >
       <GuideAnchor
         target="issue_views_page_filters_persistence"
         disabled={!hasIssueViews}

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -12,10 +12,7 @@ import IssueListSortOptions from 'sentry/views/issueList/actions/sortOptions';
 import {IssueSearchWithSavedSearches} from 'sentry/views/issueList/issueSearchWithSavedSearches';
 import {IssueViewSaveButton} from 'sentry/views/issueList/issueViews/issueViewSaveButton';
 import type {IssueSortOptions} from 'sentry/views/issueList/utils';
-import {
-  usePrefersOldNavWithEnforcedStackedNav,
-  usePrefersStackedNav,
-} from 'sentry/views/nav/usePrefersStackedNav';
+import {useHasIssueViewSharing} from 'sentry/views/nav/usePrefersStackedNav';
 
 interface Props {
   onSearch: (query: string) => void;
@@ -28,13 +25,10 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
   const hasIssueViews = organization.features.includes('issue-stream-custom-views');
-  const prefersStackedNav = usePrefersStackedNav();
-  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
+  const hasIssueViewSharing = useHasIssueViewSharing();
 
   return (
-    <FiltersContainer
-      hasIssueViewSharing={prefersStackedNav && !prefersOldNavWithEnforcement}
-    >
+    <FiltersContainer hasIssueViewSharing={hasIssueViewSharing}>
       <GuideAnchor
         target="issue_views_page_filters_persistence"
         disabled={!hasIssueViews}
@@ -57,9 +51,7 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
           showIcon={false}
         />
 
-        {prefersStackedNav && !prefersOldNavWithEnforcement && (
-          <IssueViewSaveButton query={query} sort={sort} />
-        )}
+        {hasIssueViewSharing && <IssueViewSaveButton query={query} sort={sort} />}
       </SortSaveContainer>
     </FiltersContainer>
   );

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -12,6 +12,10 @@ import IssueListSortOptions from 'sentry/views/issueList/actions/sortOptions';
 import {IssueSearchWithSavedSearches} from 'sentry/views/issueList/issueSearchWithSavedSearches';
 import {IssueViewSaveButton} from 'sentry/views/issueList/issueViews/issueViewSaveButton';
 import type {IssueSortOptions} from 'sentry/views/issueList/utils';
+import {
+  usePrefersOldNavWithEnforcedStackedNav,
+  usePrefersStackedNav,
+} from 'sentry/views/nav/usePrefersStackedNav';
 
 interface Props {
   onSearch: (query: string) => void;
@@ -24,12 +28,11 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
   const organization = useOrganization();
 
   const hasIssueViews = organization.features.includes('issue-stream-custom-views');
-  const hasIssueViewSharing = organization.features.includes(
-    'enforce-stacked-navigation'
-  );
+  const prefersStackedNav = usePrefersStackedNav();
+  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
 
   return (
-    <FiltersContainer hasIssueViewSharing={hasIssueViewSharing}>
+    <FiltersContainer hasIssueViewSharing={prefersStackedNav}>
       <GuideAnchor
         target="issue_views_page_filters_persistence"
         disabled={!hasIssueViews}
@@ -52,7 +55,9 @@ function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
           showIcon={false}
         />
 
-        {hasIssueViewSharing && <IssueViewSaveButton query={query} sort={sort} />}
+        {prefersStackedNav && !prefersOldNavWithEnforcement && (
+          <IssueViewSaveButton query={query} sort={sort} />
+        )}
       </SortSaveContainer>
     </FiltersContainer>
   );

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -120,7 +120,6 @@ function IssueViewWrapper({children}: Props) {
 
 function IssueListContainer({children, title = t('Issues')}: Props) {
   const organization = useOrganization();
-  // Issue view sharing is tied to the release of the stacked nav
   const prefersStackedNav = usePrefersStackedNav();
   const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
   const hasIssueViewSharing = prefersStackedNav && !prefersOldNavWithEnforcement;

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -19,7 +19,7 @@ import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useS
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/sections/issues/issueViews/useUpdateGroupSearchViewLastVisited';
 import {
-  usePrefersOldNavWithEnforcedStackedNav,
+  useHasIssueViewSharing,
   usePrefersStackedNav,
 } from 'sentry/views/nav/usePrefersStackedNav';
 
@@ -120,9 +120,7 @@ function IssueViewWrapper({children}: Props) {
 
 function IssueListContainer({children, title = t('Issues')}: Props) {
   const organization = useOrganization();
-  const prefersStackedNav = usePrefersStackedNav();
-  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
-  const hasIssueViewSharing = prefersStackedNav && !prefersOldNavWithEnforcement;
+  const hasIssueViewSharing = useHasIssueViewSharing();
 
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -18,7 +18,10 @@ import {getIssueViewQueryParams} from 'sentry/views/issueList/issueViews/getIssu
 import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/sections/issues/issueViews/useUpdateGroupSearchViewLastVisited';
-import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
+import {
+  usePrefersOldNavWithEnforcedStackedNav,
+  usePrefersStackedNav,
+} from 'sentry/views/nav/usePrefersStackedNav';
 
 type Props = {
   children: React.ReactNode;
@@ -117,9 +120,10 @@ function IssueViewWrapper({children}: Props) {
 
 function IssueListContainer({children, title = t('Issues')}: Props) {
   const organization = useOrganization();
-  const hasIssueViewSharing = organization.features.includes(
-    'enforce-stacked-navigation'
-  );
+  // Issue view sharing is tied to the release of the stacked nav
+  const prefersStackedNav = usePrefersStackedNav();
+  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
+  const hasIssueViewSharing = prefersStackedNav && !prefersOldNavWithEnforcement;
 
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -18,10 +18,7 @@ import {getIssueViewQueryParams} from 'sentry/views/issueList/issueViews/getIssu
 import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {useUpdateGroupSearchViewLastVisited} from 'sentry/views/nav/secondary/sections/issues/issueViews/useUpdateGroupSearchViewLastVisited';
-import {
-  useHasIssueViewSharing,
-  usePrefersStackedNav,
-} from 'sentry/views/nav/usePrefersStackedNav';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 type Props = {
   children: React.ReactNode;
@@ -120,7 +117,9 @@ function IssueViewWrapper({children}: Props) {
 
 function IssueListContainer({children, title = t('Issues')}: Props) {
   const organization = useOrganization();
-  const hasIssueViewSharing = useHasIssueViewSharing();
+  const hasIssueViewSharing = organization?.features.includes(
+    'enforce-stacked-navigation'
+  );
 
   return (
     <SentryDocumentTitle title={title} orgSlug={organization.slug}>

--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -8,6 +8,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueList/utils';
 import {useSelectedSavedSearch} from 'sentry/views/issueList/utils/useSelectedSavedSearch';
+import {usePrefersOldNavWithEnforcedStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 import IssueListSearchBar from './searchBar';
 
@@ -23,11 +24,17 @@ export function IssueSearchWithSavedSearches({
   onSearch,
 }: IssueSearchWithSavedSearchesProps) {
   const organization = useOrganization();
+
   const selectedSavedSearch = useSelectedSavedSearch();
   const [isSavedSearchesOpen, setIsSavedSearchesOpen] = useSyncedLocalStorageState(
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
     false
   );
+  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
+
+  const shouldShowSavedSearchesButton =
+    !organization.features.includes('issue-stream-custom-views') ||
+    prefersOldNavWithEnforcement;
 
   function onSavedSearchesToggleClicked() {
     const newOpenState = !isSavedSearchesOpen;
@@ -40,7 +47,7 @@ export function IssueSearchWithSavedSearches({
 
   return (
     <SearchBarWithButtonContainer className={className}>
-      {!organization.features.includes('issue-stream-custom-views') && (
+      {shouldShowSavedSearchesButton && (
         <StyledButton onClick={onSavedSearchesToggleClicked}>
           {selectedSavedSearch?.name ?? t('Custom Search')}
         </StyledButton>
@@ -51,7 +58,7 @@ export function IssueSearchWithSavedSearches({
         initialQuery={query || ''}
         onSearch={onSearch}
         placeholder={t('Search for events, users, tags, and more')}
-        roundCorners={organization.features.includes('issue-stream-custom-views')}
+        roundCorners={!shouldShowSavedSearchesButton}
       />
     </SearchBarWithButtonContainer>
   );

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -36,10 +36,12 @@ function PageTitle({title}: {title: ReactNode}) {
   const organization = useOrganization();
   const {data: groupSearchView} = useSelectedGroupSearchView();
   const user = useUser();
-  const prefersStackedNav = usePrefersStackedNav();
+  const hasIssueViewSharing = organization.features.includes(
+    'enforce-stacked-navigation'
+  );
 
   if (
-    prefersStackedNav &&
+    hasIssueViewSharing &&
     groupSearchView &&
     canEditIssueView({groupSearchView, user, organization})
   ) {

--- a/static/app/views/issueList/leftNavViewsHeader.tsx
+++ b/static/app/views/issueList/leftNavViewsHeader.tsx
@@ -36,12 +36,10 @@ function PageTitle({title}: {title: ReactNode}) {
   const organization = useOrganization();
   const {data: groupSearchView} = useSelectedGroupSearchView();
   const user = useUser();
-  const hasIssueViewSharing = organization.features.includes(
-    'enforce-stacked-navigation'
-  );
+  const prefersStackedNav = usePrefersStackedNav();
 
   if (
-    hasIssueViewSharing &&
+    prefersStackedNav &&
     groupSearchView &&
     canEditIssueView({groupSearchView, user, organization})
   ) {

--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -24,7 +24,7 @@ import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageStat
 import {useDeleteSavedSearchOptimistic} from 'sentry/views/issueList/mutations/useDeleteSavedSearch';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueList/utils';
-import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
+import {usePrefersOldNavWithEnforcedStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 interface SavedIssueSearchesProps {
   onSavedSearchSelect: (savedSearch: SavedSearch) => void;
@@ -175,14 +175,13 @@ function SavedIssueSearches({
     refetch,
   } = useFetchSavedSearchesForOrg({orgSlug: organization.slug});
   const isMobile = useMedia(`(max-width: ${theme.breakpoints.small})`);
-  const prefersStackedNav = usePrefersStackedNav();
+  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
 
-  if (
-    !isOpen ||
-    isMobile ||
-    prefersStackedNav ||
-    organization.features.includes('issue-stream-custom-views')
-  ) {
+  const shouldShowSavedSearches =
+    !organization.features.includes('issue-stream-custom-views') ||
+    prefersOldNavWithEnforcement;
+
+  if (!isOpen || isMobile || !shouldShowSavedSearches) {
     return null;
   }
 

--- a/static/app/views/nav/usePrefersStackedNav.tsx
+++ b/static/app/views/nav/usePrefersStackedNav.tsx
@@ -19,3 +19,13 @@ export function usePrefersStackedNav() {
 
   return userStackedNavOption ?? false;
 }
+
+export function usePrefersOldNavWithEnforcedStackedNav() {
+  const organization = useOrganization({allowNull: true});
+  const user = useUser();
+
+  return (
+    !!organization?.features.includes('enforce-stacked-navigation') &&
+    user?.options?.prefersStackedNavigation === false
+  );
+}

--- a/static/app/views/nav/usePrefersStackedNav.tsx
+++ b/static/app/views/nav/usePrefersStackedNav.tsx
@@ -29,3 +29,13 @@ export function usePrefersOldNavWithEnforcedStackedNav() {
     user?.options?.prefersStackedNavigation === false
   );
 }
+
+export function useHasIssueViewSharing() {
+  const organization = useOrganization({allowNull: true});
+  const user = useUser();
+
+  return (
+    !!organization?.features.includes('enforce-stacked-navigation') &&
+    user?.options?.prefersStackedNavigation !== false
+  );
+}


### PR DESCRIPTION
Fixes an issue where certain ui elements were appearing when they shouldn't (save) and not appearing when they should (custom searches) due to misconfigured conditions. 

We need an additional condition to check if a user has the enforcement flag on, but has turned it off. 

Now, when the enforcement flag is on for your org but you opt out, you'll no longer see the save button, and you'll also see the custom seraches button. 