### PR TITLE
feat(deletion): Create audit entries get created earlier

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -65,6 +65,11 @@ def delete_group_list(
     eventstream_state = eventstream.backend.start_delete_groups(project.id, group_ids)
     transaction_id = uuid4().hex
 
+    # The moment groups are marked as pending deletion, we create audit entries
+    # so that we can see who requested the deletion. Even if anything after this point
+    # fails, we will still have a record of who requested the deletion.
+    create_audit_entries(request, project, group_list, delete_type, transaction_id)
+
     # Tell seer to delete grouping records for these groups
     call_delete_seer_grouping_records_by_hash(group_ids)
 
@@ -84,8 +89,6 @@ def delete_group_list(
         },
         countdown=countdown,
     )
-
-    create_audit_entries(request, project, group_list, delete_type, transaction_id)
 
 
 def create_audit_entries(

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1521,8 +1521,16 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             assert Group.objects.get(id=g.id).status != GroupStatus.PENDING_DELETION
             assert GroupHash.objects.filter(group_id=g.id).exists()
 
+    def assert_audit_log_entry(self, groups: Sequence[Group], mock_record_audit_log: Mock) -> None:
+        calls = mock_record_audit_log.call_args_list
+        assert len(calls) > 0
+        for i, group in enumerate(groups):
+            assert calls[i].kwargs["event"].actor_user_id == self.user.id
+            assert calls[i].kwargs["event"].data["issue_id"] == group.id
+
     @patch("sentry.eventstream.backend")
-    def test_delete_by_id(self, mock_eventstream):
+    @patch("sentry.utils.audit.log_service.record_audit_log")
+    def test_delete_by_id(self, mock_record_audit_log, mock_eventstream):
         eventstream_state = {"event_stream_state": uuid4().hex}
         mock_eventstream.start_delete_groups = Mock(return_value=eventstream_state)
 
@@ -1562,6 +1570,8 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             call(eventstream_state),
             call(eventstream_state),
         ]
+
+        self.assert_audit_log_entry([group1, group2], mock_record_audit_log)
 
         assert response.status_code == 204
 
@@ -1625,3 +1635,25 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             response = self.client.delete(url, format="json")
             assert response.status_code == 204
             self.assert_groups_are_gone(groups)
+
+    @patch("sentry.api.helpers.group_index.delete.call_delete_seer_grouping_records_by_hash")
+    @patch("sentry.utils.audit.log_service.record_audit_log")
+    def test_audit_log_even_if_exception_raised(
+        self, mock_record_audit_log: Mock, mock_seer_delete: Mock
+    ):
+        """
+        Test that audit log is created even if an exception is raised after the audit log is created.
+        """
+        # Calling seer happens after creating the audit log entry
+        mock_seer_delete.side_effect = Exception("Seer error!")
+        group1 = self.create_group()
+        self.login_as(user=self.user)
+        url = f"{self.path}?id={group1.id}"
+        with self.tasks():
+            response = self.client.delete(url, format="json")
+            assert response.status_code == 500
+
+        self.assert_audit_log_entry([group1], mock_record_audit_log)
+
+        # They have been marked as pending deletion but the exception prevented their complete deletion
+        assert Group.objects.get(id=group1.id).status == GroupStatus.PENDING_DELETION


### PR DESCRIPTION
We found no audits of who did it when investigating a group deletion. This will increase the chances that we will have the entries.