### PR TITLE
feat(story): add story for SearchQueryBuilderProvider

### DIFF
--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -809,7 +809,7 @@ function OpenDropdownButton() {
   const handleClick = () => {
     dispatch({
       type: "UPDATE_QUERY",
-      query: 'key:""',
+      query: 'browser.name:""',
       focusOverride: {
         // Focuses the filter with index 0
         itemKey: 'filter:0',

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -1,8 +1,14 @@
 import {Fragment, useState} from 'react';
 
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {Button} from 'sentry/components/core/button';
 import {ItemType} from 'sentry/components/deprecatedSmartSearchBar/types';
 import MultipleCheckbox from 'sentry/components/forms/controls/multipleCheckbox';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import {
+  SearchQueryBuilderProvider,
+  useSearchQueryBuilder,
+} from 'sentry/components/searchQueryBuilder/context';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import type {
   FieldDefinitionGetter,
@@ -732,6 +738,105 @@ export default storyBook('SearchQueryBuilder', story => {
           query="count():>1 AND (browser.name:[Firefox,Chrome] OR lastSeen:-7d) TypeError"
           filterKeys={FILTER_KEYS}
         />
+      </Fragment>
+    );
+  });
+
+  story('SearchQueryBuilderProvider', () => {
+    function OpenDropdownButton() {
+      const {dispatch} = useSearchQueryBuilder();
+
+      return (
+        <Button
+          style={{marginTop: '16px'}}
+          onClick={() =>
+            dispatch({
+              type: 'UPDATE_QUERY',
+              query: 'browser.name:""',
+              focusOverride: {
+                itemKey: 'filter:0',
+                part: 'value',
+              },
+            })
+          }
+        >
+          Open Dropdown
+        </Button>
+      );
+    }
+
+    function SearchQueryBuilderExample() {
+      const props = {
+        initialQuery: 'browser.name:""',
+        filterKeys: FILTER_KEYS,
+        getTagValues,
+        searchSource: 'storybook',
+      };
+      return (
+        <SearchQueryBuilderProvider {...props}>
+          <SearchQueryBuilder {...props} />
+          <OpenDropdownButton />
+        </SearchQueryBuilderProvider>
+      );
+    }
+
+    return (
+      <Fragment>
+        <p>
+          The <JSXNode name="SearchQueryBuilder" /> component already comes pre-wrapped
+          with the <JSXNode name="SearchQueryBuilderProvider" />. However, in the event
+          that you need to control the inner state of the{' '}
+          <JSXNode name="SearchQueryBuilder" />, you can wrap it in the provider yourself.
+          When passed this way, the search bar will ditch its original provider and use
+          the one you defined. The provider accepts the same props as the{' '}
+          <JSXNode name="SearchQueryBuilder" /> component.
+        </p>
+        <p>
+          The provider will give you access to the context values within the search bar.
+          Access these values using the <code>useSearchQueryBuilder</code> hook within any
+          of the provider's child components.
+        </p>
+        <p>
+          Here is an example of a custom component that uses the provider. In this
+          implementation, clicking the button will open the dropdown for the first filter
+          with the <code>focusOverride</code> prop.
+        </p>
+        <CodeSnippet language="tsx">
+          {`
+function OpenDropdownButton() {
+  const {dispatch} = useSearchQueryBuilder();
+
+  const handleClick = () => {
+    dispatch({
+      type: "UPDATE_QUERY",
+      query: 'key:""',
+      focusOverride: {
+        // Focuses the filter with index 0
+        itemKey: 'filter:0',
+        part: 'value',
+      },
+    })
+  }
+
+  return (
+    <Button onClick={handleClick}>
+      {'Open Dropdown'}
+    </Button>
+  );
+};
+
+function SearchQueryBuilderExample(queryBuilderProps: SearchQueryBuilderProps) {
+  return (
+    <SearchQueryBuilderProvider {...queryBuilderProps}>
+      <SearchQueryBuilder {...queryBuilderProps} />
+      <OpenDropdownButton />
+    </SearchQueryBuilderProvider>
+  )
+}
+      `}
+        </CodeSnippet>
+        <p>The following is the above code in action:</p>
+        <SearchQueryBuilderExample />
       </Fragment>
     );
   });


### PR DESCRIPTION
I added a section to the `SearchQueryBuilder` story for the provider. I've provided a short description of the use case and some direction on how to use it. I've also put in a working example similar to how its being used within sentry.
