### PR TITLE
fix(eap-spans): `failure_rate_if` function return boolean as meta instead of percentage

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -633,6 +633,7 @@ SPAN_FORMULA_DEFINITIONS = {
     ),
     "failure_rate_if": FormulaDefinition(
         default_search_type="percentage",
+        infer_search_type_from_arguments=False,
         arguments=[
             AttributeArgumentDefinition(attribute_types={"string", "boolean"}),
             ValueArgumentDefinition(argument_types={"string"}),

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2889,6 +2889,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["failure_rate_if(is_transaction, true)"] == 0.25
         assert meta["dataset"] == self.dataset
+        assert meta["fields"] == {
+            "failure_rate_if(is_transaction, true)": "percentage",
+        }
+        assert meta["units"] == {
+            "failure_rate_if(is_transaction, true)": None,
+        }
 
     def test_count_op(self):
         self.store_spans(


### PR DESCRIPTION
`failure_rate_if` was returning boolean as it's meta instead of percentage with conditions like `failure_rate_if(is_transaction,true)`. This is because by default we infer the return type from the first argument, this works for functions like `sum(x)`. For example if `x = span.duration` you want the meta to be milliseconds, but if `x = http.response_body_size` you want the meta to be bytes.

Because failure rate always returns percentage regardless of the params, we want to ignore this default behaviour