### PR TITLE
feat(ui): Fix error in `SeerDrawer` when moving to settings

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -210,7 +210,10 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
                   {tct('Seer can be turned off in [settingsDocs:Settings].', {
                     settingsDocs: (
                       <Link
-                        to={`/settings/${organization.slug}/general-settings/#hideAiFeatures`}
+                        to={{
+                          pathname: `/settings/${organization.slug}/`,
+                          hash: '#hideAiFeatures',
+                        }}
                       />
                     ),
                   })}


### PR DESCRIPTION
This fixes the URL in the SeerDrawer tooltip to link to turn off Seer, it was redirecting to a URL where I guess organization context was being lost and becoming null while redirecting to the correct URL

![image](https://github.com/user-attachments/assets/db58d948-70ed-4a79-9f6a-a4db673cee10)


Fixes JAVASCRIPT-2WMG
