### PR TITLE
chore(fe): Convert `<IntegrationCodeMappings />` to an FC

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -148,7 +148,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
   }
 
   const onTabChange = (value: Tab) => {
-    // XXX: Omit the cursor to prevent paginating the new tabs queries.
+    // XXX: Omit the cursor to prevent paginating the next tab's queries.
     const {cursor: _, ...query} = location.query;
     router.push({
       pathname: location.pathname,

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -148,9 +148,11 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
   }
 
   const onTabChange = (value: Tab) => {
+    // XXX: Omit the cursor to prevent paginating the new tabs queries.
+    const {cursor: _, ...query} = location.query;
     router.push({
       pathname: location.pathname,
-      query: {...location.query, tab: value},
+      query: {...query, tab: value},
     });
   };
 

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
@@ -83,8 +83,9 @@ describe('IntegrationCodeMappings', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('shows the paths', () => {
-    render(<IntegrationCodeMappings organization={org} integration={integration} />);
+  it('shows the paths', async () => {
+    render(<IntegrationCodeMappings integration={integration} />);
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
 
     for (const repo of repos) {
       expect(screen.getByText(repo.name)).toBeInTheDocument();
@@ -108,7 +109,8 @@ describe('IntegrationCodeMappings', function () {
         defaultBranch,
       }),
     });
-    render(<IntegrationCodeMappings organization={org} integration={integration} />);
+    render(<IntegrationCodeMappings integration={integration} />);
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
     const {waitForModalToHide} = renderGlobalModal();
 
     await userEvent.click(screen.getByRole('button', {name: 'Add Code Mapping'}));
@@ -166,7 +168,8 @@ describe('IntegrationCodeMappings', function () {
         defaultBranch,
       }),
     });
-    render(<IntegrationCodeMappings organization={org} integration={integration} />);
+    render(<IntegrationCodeMappings integration={integration} />);
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
     const {waitForModalToHide} = renderGlobalModal();
 
     await userEvent.click(screen.getAllByRole('button', {name: 'edit'})[0]!);
@@ -206,7 +209,8 @@ describe('IntegrationCodeMappings', function () {
         ],
       },
     });
-    render(<IntegrationCodeMappings organization={org} integration={integration} />);
+    render(<IntegrationCodeMappings integration={integration} />);
+    expect(await screen.findByTestId('loading-indicator')).not.toBeInTheDocument();
     renderGlobalModal();
 
     await userEvent.click(screen.getByRole('button', {name: 'Add Code Mapping'}));

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -24,7 +24,7 @@ import type {
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {
-  ApiQueryKey,
+  type ApiQueryKey,
   useApiQuery,
   useMutation,
   useQueryClient,

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -1,14 +1,13 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button, LinkButton} from 'sentry/components/core/button';
-import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import ExternalLink from 'sentry/components/links/externalLink';
-import type {CursorHandler} from 'sentry/components/pagination';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -22,14 +21,21 @@ import type {
   Repository,
   RepositoryProjectPathConfig,
 } from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
-import type {WithRouteAnalyticsProps} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
-import withRouteAnalytics from 'sentry/utils/routeAnalytics/withRouteAnalytics';
-import withOrganization from 'sentry/utils/withOrganization';
-import withProjects from 'sentry/utils/withProjects';
+import {
+  ApiQueryKey,
+  useApiQuery,
+  useMutation,
+  useQueryClient,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import RepositoryProjectPathConfigForm from './repositoryProjectPathConfigForm';
@@ -40,268 +46,278 @@ import RepositoryProjectPathConfigRow, {
   OutputPathColumn,
 } from './repositoryProjectPathConfigRow';
 
-type Props = DeprecatedAsyncComponent['props'] &
-  WithRouteAnalyticsProps & {
-    integration: Integration;
-    organization: Organization;
-    projects: Project[];
-  };
-
-type State = DeprecatedAsyncComponent['state'] & {
-  pathConfigs: RepositoryProjectPathConfig[];
-  repos: Repository[];
-};
-
-class IntegrationCodeMappings extends DeprecatedAsyncComponent<Props, State> {
-  getDefaultState(): State {
-    return {
-      ...super.getDefaultState(),
-      pathConfigs: [],
-      repos: [],
-    };
+function getDocsLink(integration: Integration): string {
+  /** Accounts for some asymmetry between docs links and provider keys */
+  let docsKey = integration.provider.key;
+  switch (integration.provider.key) {
+    case 'vsts':
+      docsKey = 'azure-devops';
+      break;
+    case 'github_enterprise':
+      docsKey = 'github';
+      break;
+    default:
+      docsKey = integration.provider.key;
+      break;
   }
+  return `https://docs.sentry.io/product/integrations/source-code-mgmt/${docsKey}/#stack-trace-linking`;
+}
 
-  get integrationId() {
-    return this.props.integration.id;
-  }
+function makePathConfigQueryKey({
+  orgSlug,
+  integrationId,
+  cursor,
+}: {
+  integrationId: string;
+  orgSlug: string;
+  cursor?: string | string[] | null;
+}): ApiQueryKey {
+  return [`/organizations/${orgSlug}/code-mappings/`, {query: {integrationId, cursor}}];
+}
 
-  get pathConfigs() {
-    // we want to sort by the project slug and the
-    // id of the config
-    return sortBy(this.state.pathConfigs, [
+function useDeletePathConfig() {
+  const api = useApi({persistInFlight: false});
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const location = useLocation();
+  return useMutation<
+    RepositoryProjectPathConfig,
+    RequestError,
+    RepositoryProjectPathConfig
+  >({
+    mutationFn: pathConfig => {
+      return api.requestPromise(
+        `/organizations/${organization.slug}/code-mappings/${pathConfig.id}/`,
+        {
+          method: 'DELETE',
+        }
+      );
+    },
+    onMutate: pathConfig => {
+      if (pathConfig.integrationId) {
+        queryClient.setQueryData<RepositoryProjectPathConfig[]>(
+          makePathConfigQueryKey({
+            orgSlug: organization.slug,
+            integrationId: pathConfig.integrationId,
+            cursor: location.query.cursor,
+          }),
+          (data: RepositoryProjectPathConfig[] = []) => {
+            return data.filter(config => config.id !== pathConfig.id);
+          }
+        );
+      }
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('Successfully deleted code mapping'));
+    },
+    onError: error => {
+      addErrorMessage(`${error.statusText}: ${error.responseText}`);
+    },
+  });
+}
+
+export default function IntegrationCodeMappings({
+  integration,
+}: {
+  integration: Integration;
+}) {
+  useRouteAnalyticsEventNames(
+    'integrations.code_mappings_viewed',
+    'Integrations: Code Mappings Viewed'
+  );
+  useRouteAnalyticsParams({
+    integration: integration.provider.key,
+    integration_type: 'first_party',
+  });
+
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const location = useLocation();
+  const integrationId = integration.id;
+
+  const {
+    data: fetchedPathConfigs = [],
+    isPending: isPendingPathConfigs,
+    getResponseHeader: getPathConfigsResponseHeader,
+    refetch: refetchPathConfigs,
+  } = useApiQuery<RepositoryProjectPathConfig[]>(
+    makePathConfigQueryKey({
+      orgSlug: organization.slug,
+      integrationId,
+      cursor: location.query.cursor,
+    }),
+    {
+      staleTime: 30000,
+    }
+  );
+
+  const {data: fetchedRepos = [], isPending: isPendingRepos} = useApiQuery<Repository[]>(
+    [`/organizations/${organization.slug}/repos/`, {query: {status: 'active'}}],
+    {staleTime: 30000}
+  );
+
+  const pathConfigs = useMemo(() => {
+    return sortBy(fetchedPathConfigs, [
       ({projectSlug}) => projectSlug,
       ({id}) => parseInt(id, 10),
     ]);
-  }
+  }, [fetchedPathConfigs]);
 
-  get repos() {
-    // endpoint doesn't support loading only the repos for this integration
-    // but most people only have one source code repo so this should be fine
-    return this.state.repos.filter(repo => repo.integrationId === this.integrationId);
-  }
+  const repos = useMemo(
+    () => fetchedRepos.filter(repo => repo.integrationId === integrationId),
+    [fetchedRepos, integrationId]
+  );
 
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    const orgSlug = this.props.organization.slug;
-    return [
-      [
-        'pathConfigs',
-        `/organizations/${orgSlug}/code-mappings/`,
-        {query: {integrationId: this.integrationId}},
-      ],
-      ['repos', `/organizations/${orgSlug}/repos/`, {query: {status: 'active'}}],
-    ];
-  }
+  const getMatchingProject = useCallback(
+    (pathConfig: RepositoryProjectPathConfig) => {
+      return projects.find(project => project.id === pathConfig.projectId);
+    },
+    [projects]
+  );
 
-  getMatchingProject(pathConfig: RepositoryProjectPathConfig) {
-    return this.props.projects.find(project => project.id === pathConfig.projectId);
-  }
+  const {mutate: deletePathConfig} = useDeletePathConfig();
 
-  componentDidMount() {
-    super.componentDidMount();
-    this.props.setEventNames(
-      'integrations.code_mappings_viewed',
-      'Integrations: Code Mappings Viewed'
-    );
-    this.props.setRouteAnalyticsParams({
-      integration: this.props.integration.provider.key,
-      integration_type: 'first_party',
-    });
-  }
-
-  trackDocsClick = () => {
-    trackAnalytics('integrations.stacktrace_docs_clicked', {
-      view: 'integration_configuration_detail',
-      provider: this.props.integration.provider.key,
-      organization: this.props.organization,
-    });
-  };
-
-  handleDelete = async (pathConfig: RepositoryProjectPathConfig) => {
-    const {organization} = this.props;
-    const endpoint = `/organizations/${organization.slug}/code-mappings/${pathConfig.id}/`;
-    try {
-      await this.api.requestPromise(endpoint, {
-        method: 'DELETE',
+  const openCodeMappingModal = useCallback(
+    (pathConfig?: RepositoryProjectPathConfig) => {
+      trackAnalytics('integrations.stacktrace_start_setup', {
+        setup_type: 'manual',
+        view: 'integration_configuration_detail',
+        provider: integration.provider.key,
+        organization,
       });
-      // remove config and update state
-      let {pathConfigs} = this.state;
-      pathConfigs = pathConfigs.filter(config => config.id !== pathConfig.id);
-      this.setState({pathConfigs});
-      addSuccessMessage(t('Deletion successful'));
-    } catch (err) {
-      addErrorMessage(`${err.statusText}: ${err.responseText}`);
-    }
-  };
 
-  handleSubmitSuccess = (pathConfig: RepositoryProjectPathConfig) => {
-    trackAnalytics('integrations.stacktrace_complete_setup', {
-      setup_type: 'manual',
-      view: 'integration_configuration_detail',
-      provider: this.props.integration.provider.key,
-      organization: this.props.organization,
-    });
-    let {pathConfigs} = this.state;
-    pathConfigs = pathConfigs.filter(config => config.id !== pathConfig.id);
-    // our getter handles the order of the configs
-    pathConfigs = pathConfigs.concat([pathConfig]);
-    this.setState({pathConfigs});
-    this.setState({pathConfig: undefined});
-  };
+      openModal(({Body, Header, closeModal}) => (
+        <Fragment>
+          <Header closeButton>
+            <h4>{t('Configure code path mapping')}</h4>
+          </Header>
+          <Body>
+            <RepositoryProjectPathConfigForm
+              organization={organization}
+              integration={integration}
+              projects={projects}
+              repos={repos}
+              onSubmitSuccess={() => {
+                trackAnalytics('integrations.stacktrace_complete_setup', {
+                  setup_type: 'manual',
+                  view: 'integration_configuration_detail',
+                  provider: integration.provider.key,
+                  organization,
+                });
+                refetchPathConfigs();
+                closeModal();
+              }}
+              existingConfig={pathConfig}
+              onCancel={closeModal}
+            />
+          </Body>
+        </Fragment>
+      ));
+    },
+    [repos, projects, integration, organization, refetchPathConfigs]
+  );
 
-  openModal = (pathConfig?: RepositoryProjectPathConfig) => {
-    const {organization, projects, integration} = this.props;
-    trackAnalytics('integrations.stacktrace_start_setup', {
-      setup_type: 'manual',
-      view: 'integration_configuration_detail',
-      provider: this.props.integration.provider.key,
-      organization: this.props.organization,
-    });
+  const isLoading = isPendingPathConfigs || isPendingRepos;
 
-    openModal(({Body, Header, closeModal}) => (
-      <Fragment>
-        <Header closeButton>
-          <h4>{t('Configure code path mapping')}</h4>
-        </Header>
-        <Body>
-          <RepositoryProjectPathConfigForm
-            organization={organization}
-            integration={integration}
-            projects={projects}
-            repos={this.repos}
-            onSubmitSuccess={config => {
-              this.handleSubmitSuccess(config);
-              closeModal();
-            }}
-            existingConfig={pathConfig}
-            onCancel={closeModal}
-          />
-        </Body>
-      </Fragment>
-    ));
-  };
-
-  /**
-   * This is a workaround to paginate without affecting browserHistory or modifiying the URL
-   * It's necessary because we don't want to affect the pagination state of other tabs on the page.
-   */
-  handleCursor: CursorHandler = async (cursor, _path, query, _direction) => {
-    const orgSlug = this.props.organization.slug;
-    const [pathConfigs, _, responseMeta] = await this.api.requestPromise(
-      `/organizations/${orgSlug}/code-mappings/`,
-      {includeAllArgs: true, query: {...query, cursor}}
-    );
-    this.setState({
-      pathConfigs,
-      pathConfigsPageLinks: responseMeta?.getResponseHeader('link'),
-    });
-  };
-
-  getDocsLink(): string {
-    /** Accounts for some asymmetry between docs links and provider keys */
-    const {integration} = this.props;
-    let docsKey = integration.provider.key;
-    switch (integration.provider.key) {
-      case 'vsts':
-        docsKey = 'azure-devops';
-        break;
-      case 'github_enterprise':
-        docsKey = 'github';
-        break;
-      default:
-        docsKey = integration.provider.key;
-        break;
-    }
-    return `https://docs.sentry.io/product/integrations/source-code-mgmt/${docsKey}/#stack-trace-linking`;
+  if (isLoading) {
+    return <LoadingIndicator />;
   }
 
-  renderBody() {
-    const pathConfigs = this.pathConfigs;
-    const {integration} = this.props;
-    const {pathConfigsPageLinks} = this.state;
-    const docsLink = this.getDocsLink();
+  const pathConfigsPageLinks = getPathConfigsResponseHeader?.('Link');
+  const docsLink = getDocsLink(integration);
 
-    return (
-      <Fragment>
-        <TextBlock>
-          {tct(
-            `Code Mappings are used to map stack trace file paths to source code file paths. These mappings are the basis for features like Stack Trace Linking. To learn more, [link: read the docs].`,
-            {
-              link: <ExternalLink href={docsLink} onClick={this.trackDocsClick} />,
-            }
-          )}
-        </TextBlock>
-
-        <Panel>
-          <PanelHeader disablePadding hasButtons>
-            <HeaderLayout>
-              <NameRepoColumn>{t('Code Mappings')}</NameRepoColumn>
-              <InputPathColumn>{t('Stack Trace Root')}</InputPathColumn>
-              <OutputPathColumn>{t('Source Code Root')}</OutputPathColumn>
-              <ButtonWrapper>
-                <Button
-                  data-test-id="add-mapping-button"
-                  onClick={() => this.openModal()}
-                  size="xs"
-                  icon={<IconAdd isCircled />}
-                >
-                  {t('Add Code Mapping')}
-                </Button>
-              </ButtonWrapper>
-            </HeaderLayout>
-          </PanelHeader>
-          <PanelBody>
-            {pathConfigs.length === 0 && (
-              <EmptyMessage
-                icon={getIntegrationIcon(integration.provider.key, 'lg')}
-                action={
-                  <LinkButton
-                    href={docsLink}
-                    size="sm"
-                    external
-                    onClick={this.trackDocsClick}
-                  >
-                    {t('View Documentation')}
-                  </LinkButton>
-                }
-              >
-                {t('Set up stack trace linking by adding a code mapping.')}
-              </EmptyMessage>
-            )}
-            {pathConfigs
-              .map(pathConfig => {
-                const project = this.getMatchingProject(pathConfig);
-                // this should never happen since our pathConfig would be deleted
-                // if project was deleted
-                if (!project) {
-                  return null;
-                }
-                return (
-                  <ConfigPanelItem key={pathConfig.id}>
-                    <Layout>
-                      <RepositoryProjectPathConfigRow
-                        pathConfig={pathConfig}
-                        project={project}
-                        onEdit={this.openModal}
-                        onDelete={this.handleDelete}
-                      />
-                    </Layout>
-                  </ConfigPanelItem>
-                );
-              })
-              .filter(item => !!item)}
-          </PanelBody>
-        </Panel>
-        {pathConfigsPageLinks && (
-          <Pagination pageLinks={pathConfigsPageLinks} onCursor={this.handleCursor} />
+  return (
+    <Fragment>
+      <TextBlock>
+        {tct(
+          `Code Mappings are used to map stack trace file paths to source code file paths. These mappings are the basis for features like Stack Trace Linking. To learn more, [link: read the docs].`,
+          {
+            link: (
+              <ExternalLink
+                href={docsLink}
+                onClick={() => {
+                  trackAnalytics('integrations.stacktrace_docs_clicked', {
+                    view: 'integration_configuration_detail',
+                    provider: integration.provider.key,
+                    organization,
+                  });
+                }}
+              />
+            ),
+          }
         )}
-      </Fragment>
-    );
-  }
-}
+      </TextBlock>
 
-export default withRouteAnalytics(
-  withProjects(withOrganization(IntegrationCodeMappings))
-);
+      <Panel>
+        <PanelHeader disablePadding hasButtons>
+          <HeaderLayout>
+            <NameRepoColumn>{t('Code Mappings')}</NameRepoColumn>
+            <InputPathColumn>{t('Stack Trace Root')}</InputPathColumn>
+            <OutputPathColumn>{t('Source Code Root')}</OutputPathColumn>
+            <ButtonWrapper>
+              <Button
+                data-test-id="add-mapping-button"
+                onClick={() => openCodeMappingModal()}
+                size="xs"
+                icon={<IconAdd />}
+              >
+                {t('Add Code Mapping')}
+              </Button>
+            </ButtonWrapper>
+          </HeaderLayout>
+        </PanelHeader>
+        <PanelBody>
+          {pathConfigs.length === 0 && (
+            <EmptyMessage
+              icon={getIntegrationIcon(integration.provider.key, 'lg')}
+              action={
+                <LinkButton
+                  href={docsLink}
+                  size="sm"
+                  external
+                  onClick={() => {
+                    trackAnalytics('integrations.stacktrace_docs_clicked', {
+                      view: 'integration_configuration_detail',
+                      provider: integration.provider.key,
+                      organization,
+                    });
+                  }}
+                >
+                  {t('View Documentation')}
+                </LinkButton>
+              }
+            >
+              {t('Set up stack trace linking by adding a code mapping.')}
+            </EmptyMessage>
+          )}
+          {pathConfigs
+            .map(pathConfig => {
+              const project = getMatchingProject(pathConfig);
+              // this should never happen since our pathConfig would be deleted
+              // if project was deleted
+              if (!project) {
+                return null;
+              }
+              return (
+                <PanelItem key={pathConfig.id}>
+                  <Layout>
+                    <RepositoryProjectPathConfigRow
+                      pathConfig={pathConfig}
+                      project={project}
+                      onEdit={openCodeMappingModal}
+                      onDelete={() => deletePathConfig(pathConfig)}
+                    />
+                  </Layout>
+                </PanelItem>
+              );
+            })
+            .filter(item => !!item)}
+        </PanelBody>
+      </Panel>
+      {pathConfigsPageLinks && <Pagination pageLinks={pathConfigsPageLinks} />}
+    </Fragment>
+  );
+}
 
 const Layout = styled('div')`
   display: grid;
@@ -316,5 +332,3 @@ const HeaderLayout = styled(Layout)`
   align-items: center;
   margin: 0 ${space(1)} 0 ${space(2)};
 `;
-
-const ConfigPanelItem = styled(PanelItem)``;

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -7,6 +7,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
@@ -138,6 +139,7 @@ export default function IntegrationCodeMappings({
   const {
     data: fetchedPathConfigs = [],
     isPending: isPendingPathConfigs,
+    isError: isErrorPathConfigs,
     getResponseHeader: getPathConfigsResponseHeader,
     refetch: refetchPathConfigs,
   } = useApiQuery<RepositoryProjectPathConfig[]>(
@@ -151,7 +153,11 @@ export default function IntegrationCodeMappings({
     }
   );
 
-  const {data: fetchedRepos = [], isPending: isPendingRepos} = useApiQuery<Repository[]>(
+  const {
+    data: fetchedRepos = [],
+    isPending: isPendingRepos,
+    isError: isErrorRepos,
+  } = useApiQuery<Repository[]>(
     [`/organizations/${organization.slug}/repos/`, {query: {status: 'active'}}],
     {staleTime: 30000}
   );
@@ -221,6 +227,14 @@ export default function IntegrationCodeMappings({
 
   if (isLoading) {
     return <LoadingIndicator />;
+  }
+
+  if (isErrorPathConfigs) {
+    return <LoadingError message={t('Error loading code mappings')} />;
+  }
+
+  if (isErrorRepos) {
+    return <LoadingError message={t('Error loading repositories')} />;
   }
 
   const pathConfigsPageLinks = getPathConfigsResponseHeader?.('Link');


### PR DESCRIPTION
Pretty straight forward, the only two interesting changes are:
- All the special casing for handling the cursor has been removed. There were workarounds to handle the cursor in state and manually update the cache, but it's much simpler to just omit the cursor when a new tab is selected. it honestly didn't even make sense because refreshing the page after clicking a new tab would yield new results when we suddenly start respecting the cursor (I also introduced this workaround 3 years ago so i dont mind dogging on it lol)
- Instead of trying to update the list to include the newly created code mapping, just refetch. The list is sorted so if the codemapping started with an A, but was on page 10, the results would appear as [Aproj, Xproj, Yproj, Zproj] then refreshing would cause it to disappear. This means after manually creating a code mapping, you won't immediately see it in the list, though only if you have >100. TBH these pages should have search anyway.