### PR TITLE
chore(sentry_sdk): Include full stack for captured errors

### DIFF
--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -16,7 +16,7 @@ class SdkConfig(TypedDict):
     auto_enabling_integrations: bool
     keep_alive: NotRequired[bool]
     spotlight: NotRequired[str | bool | None]
-
+    add_full_stack: NotRequired[bool]
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     before_send: NotRequired[Callable[[Event, Hint], Event | None]]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2356,6 +2356,13 @@ register(
 
 # END: SDK Crash Detection
 
+# Whether to add the full stack trace to Python errors.
+register(
+    "sentry_sdk.add_full_stack",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     # Lists the shared resource ids we want to account usage for.
     "shared_resources_accounting_enabled",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -296,6 +296,7 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
         before_send_log=before_send_log,
         enable_logs=True,
     )
+    sdk_options["add_full_stack"] = options.get("sentry_sdk.add_full_stack", False)
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     dsns = Dsns(


### PR DESCRIPTION
This makes use of the Sentry SDK option added here: https://github.com/getsentry/sentry-python/pull/3673