### PR TITLE
fix(releases): Fix when project not yet loaded yet and drawer is opened

### DIFF
--- a/static/app/views/releases/utils/useReleaseDeploys.tsx
+++ b/static/app/views/releases/utils/useReleaseDeploys.tsx
@@ -1,3 +1,7 @@
+import {useEffect, useRef} from 'react';
+import {logger} from '@sentry/react';
+
+import type {Project} from 'sentry/types/project';
 import type {Deploy} from 'sentry/types/release';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -12,12 +16,24 @@ export function useReleaseDeploys({
 }) {
   const organization = useOrganization();
   const project = useProjectFromSlug({organization, projectSlug});
+  const prevProject = useRef<Project | undefined>(undefined);
+
+  useEffect(() => {
+    if (!project) {
+      logger.warn('Release: project undefined in useReleaseDeploys', {projectSlug});
+    }
+    if (project && !prevProject.current) {
+      logger.warn('Release: project is now defined in useReleaseDeploys', {projectSlug});
+    }
+    prevProject.current = project;
+  }, [project, projectSlug]);
+
   return useApiQuery<Deploy[]>(
     [
       `/organizations/${organization.slug}/releases/${encodeURIComponent(release)}/deploys/`,
       {
         query: {
-          project: project!.id, // Should be disabled if project is undefined
+          project: project?.id, // Should be disabled if project is undefined
         },
       },
     ],


### PR DESCRIPTION
Fix when project is undefined, I *believe* this happens when we load the page and drawer immediately opens before projects are fetched.
