### PR TITLE
feat(issue-taxonomy): Recategorize warning categories in frontend config

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -99,6 +99,11 @@ export enum IssueCategory {
   USER_EXPERIENCE = 'user_experience',
   RESPONSIVENESS = 'responsiveness',
   PERFORMANCE_BEST_PRACTICE = 'performance_best_practice',
+
+  FRONTEND = 'frontend',
+  HTTP_CLIENT = 'http_client',
+  DB_QUERY = 'db_query',
+  MOBILE = 'mobile',
 }
 
 export enum IssueType {

--- a/static/app/utils/issueTypeConfig/dbQueryConfig.tsx
+++ b/static/app/utils/issueTypeConfig/dbQueryConfig.tsx
@@ -1,0 +1,105 @@
+import {t} from 'sentry/locale';
+import {IssueType} from 'sentry/types/group';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+
+const dbQueryConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {
+        enabled: false,
+        disabledReason: t('Not yet supported for performance issues'),
+      },
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for performance issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not yet supported for performance issues'),
+      },
+      ignore: {enabled: true},
+      resolve: {enabled: true},
+      resolveInRelease: {enabled: true},
+      share: {enabled: true},
+    },
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: true},
+      openPeriods: {enabled: false},
+      checkIns: {enabled: false},
+      uptimeChecks: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: false},
+      replays: {enabled: true},
+      tagsTab: {enabled: true},
+    },
+    autofix: false,
+    mergedIssues: {enabled: false},
+    similarIssues: {enabled: false},
+    stacktrace: {enabled: false},
+    spanEvidence: {enabled: true},
+    // Performance issues render a custom SpanEvidence component
+    evidence: null,
+    usesIssuePlatform: true,
+    issueSummary: {enabled: false},
+  },
+  [IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES]: {
+    resources: {
+      description: t(
+        'Consecutive DB Queries are a sequence of database spans where one or more have been identified as parallelizable, or in other words, spans that may be shifted to the start of the sequence. This often occurs when a db query performs no filtering on the data, for example a query without a WHERE clause. To learn more about how to fix consecutive DB queries, check out these resources:'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: Consecutive DB Queries'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/consecutive-db-queries/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES]: {
+    resources: {
+      description: t(
+        "N+1 queries are extraneous queries (N) caused by a single, initial query (+1). In the Span Evidence section, we've identified the parent span where the extraneous spans are located and the extraneous spans themselves. To learn more about how to fix N+1 problems, check out these resources:"
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: N+1 Queries'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/n-one-queries/',
+        },
+      ],
+      linksByPlatform: {
+        python: [
+          {
+            text: t('Finding and Fixing Django N+1 Problems'),
+            link: 'https://blog.sentry.io/2020/09/14/finding-and-fixing-django-n-1-problems',
+          },
+        ],
+        'python-django': [
+          {
+            text: t('Finding and Fixing Django N+1 Problems'),
+            link: 'https://blog.sentry.io/2020/09/14/finding-and-fixing-django-n-1-problems',
+          },
+        ],
+      },
+    },
+  },
+  [IssueType.PERFORMANCE_SLOW_DB_QUERY]: {
+    resources: {
+      description: t(
+        'Slow DB Queries are SELECT query spans that are consistently taking longer than 500ms. A quick method to understand why this may be the case is running an EXPLAIN command on the query itself. To learn more about how to fix slow DB queries, check out these resources:'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: Slow DB Queries'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/slow-db-queries/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+};
+
+export default dbQueryConfig;

--- a/static/app/utils/issueTypeConfig/frontendConfig.tsx
+++ b/static/app/utils/issueTypeConfig/frontendConfig.tsx
@@ -1,0 +1,80 @@
+import {t} from 'sentry/locale';
+import {IssueType} from 'sentry/types/group';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+
+const frontendConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {
+        enabled: false,
+        disabledReason: t('Not yet supported for user experience issues'),
+      },
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for user experience issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not supported for user experience issues'),
+      },
+      ignore: {enabled: true},
+      resolve: {enabled: true},
+      resolveInRelease: {enabled: true},
+      share: {enabled: true},
+    },
+    defaultTimePeriod: {sinceFirstSeen: false},
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: true},
+      openPeriods: {enabled: false},
+      uptimeChecks: {enabled: false},
+      checkIns: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: true},
+      replays: {enabled: true},
+      tagsTab: {enabled: true},
+    },
+    autofix: false,
+    mergedIssues: {enabled: false},
+    regression: {enabled: false},
+    stats: {enabled: true},
+    similarIssues: {enabled: false},
+    showFeedbackWidget: true,
+    discover: {enabled: true},
+    evidence: {title: t('Evidence')},
+    resources: null,
+    usesIssuePlatform: true,
+    issueSummary: {enabled: false},
+  },
+  [IssueType.PERFORMANCE_UNCOMPRESSED_ASSET]: {
+    spanEvidence: {enabled: true},
+    evidence: null,
+    resources: {
+      description: t(
+        'Uncompressed assets are asset spans that take over 300ms and are larger than 512kB which can usually be made faster with compression. Check that your server or CDN serving your assets is accepting the content encoding header from the browser and is returning them compressed.'
+      ),
+      links: [],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET]: {
+    spanEvidence: {enabled: true},
+    evidence: null,
+    resources: {
+      description: t(
+        'Large render blocking assets are a type of resource span delaying First Contentful Paint (FCP). Delaying FCP means it takes more time to initially load the page for the user. Spans that end after FCP are not as critical as those that end before it. The resource span may take form of a script, stylesheet, image, or other asset that requires optimization. To learn more about how to fix large render blocking assets, check out these resources:'
+      ),
+      links: [
+        {
+          text: t('Web Vital: First Contentful Paint'),
+          link: 'https://web.dev/fcp/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+};
+
+export default frontendConfig;

--- a/static/app/utils/issueTypeConfig/httpClientConfig.tsx
+++ b/static/app/utils/issueTypeConfig/httpClientConfig.tsx
@@ -1,0 +1,106 @@
+import {t} from 'sentry/locale';
+import {IssueType} from 'sentry/types/group';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+
+const httpClientConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {
+        enabled: false,
+        disabledReason: t('Not yet supported for performance issues'),
+      },
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for performance issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not yet supported for performance issues'),
+      },
+      ignore: {enabled: true},
+      resolve: {enabled: true},
+      resolveInRelease: {enabled: true},
+      share: {enabled: true},
+    },
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: true},
+      openPeriods: {enabled: false},
+      checkIns: {enabled: false},
+      uptimeChecks: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: false},
+      replays: {enabled: true},
+      tagsTab: {enabled: true},
+    },
+    autofix: false,
+    mergedIssues: {enabled: false},
+    similarIssues: {enabled: false},
+    stacktrace: {enabled: false},
+    spanEvidence: {enabled: true},
+    // Performance issues render a custom SpanEvidence component
+    evidence: null,
+    usesIssuePlatform: true,
+    issueSummary: {enabled: false},
+  },
+  [IssueType.PERFORMANCE_CONSECUTIVE_HTTP]: {
+    resources: {
+      description: t(
+        'A Consecutive HTTP issue occurs when at least 2000ms of time can be saved by parallelizing at least 3 consecutive HTTP calls occur sequentially.'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: Consecutive HTTP'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/consecutive-http/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_N_PLUS_ONE_API_CALLS]: {
+    resources: {
+      description: t(
+        'N+1 API Calls are repeated concurrent calls to fetch a resource. These spans will always begin at the same time and may potentially be combined to fetch everything at once to reduce server load. Alternatively, you may be able to lazily load the resources. To learn more about how and when to fix N+1 API Calls, check out these resources:'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: N+1 API Calls'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/n-one-api-calls/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_HTTP_OVERHEAD]: {
+    resources: {
+      description: t(
+        "HTTP/1.1 can cause overhead, with long request queue times in the browser due to max connection limits. In the Span Evidence section, we've identified the extent of the wait time and spans affected by request queueing. To learn more about how to fix HTTP Overhead, check out these resources:"
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: HTTP/1.1 Overhead'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/http-overhead/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD]: {
+    resources: {
+      description: t(
+        'A Large HTTP Payload issue occurs when an http payload size consistently exceeds a threshold of 300KB'
+      ),
+      links: [
+        {
+          text: t('Sentry Docs: Large HTTP Payload'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/large-http-payload/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+};
+
+export default httpClientConfig;

--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -2,12 +2,16 @@ import {t} from 'sentry/locale';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import cronConfig from 'sentry/utils/issueTypeConfig/cronConfig';
+import dbQueryConfig from 'sentry/utils/issueTypeConfig/dbQueryConfig';
 import {
   errorConfig,
   getErrorHelpResource,
 } from 'sentry/utils/issueTypeConfig/errorConfig';
 import feedbackConfig from 'sentry/utils/issueTypeConfig/feedbackConfig';
+import frontendConfig from 'sentry/utils/issueTypeConfig/frontendConfig';
+import httpClientConfig from 'sentry/utils/issueTypeConfig/httpClientConfig';
 import metricIssueConfig from 'sentry/utils/issueTypeConfig/metricIssueConfig';
+import mobileConfig from 'sentry/utils/issueTypeConfig/mobileConfig';
 import outageConfig from 'sentry/utils/issueTypeConfig/outageConfig';
 import performanceBestPracticeConfig from 'sentry/utils/issueTypeConfig/performanceBestPracticeConfig';
 import performanceConfig from 'sentry/utils/issueTypeConfig/performanceConfig';
@@ -100,6 +104,10 @@ const issueTypeConfig: Config = {
   [IssueCategory.RESPONSIVENESS]: responsivenessConfig,
   [IssueCategory.USER_EXPERIENCE]: userExperienceConfig,
   [IssueCategory.FEEDBACK]: feedbackConfig,
+  [IssueCategory.FRONTEND]: frontendConfig,
+  [IssueCategory.HTTP_CLIENT]: httpClientConfig,
+  [IssueCategory.DB_QUERY]: dbQueryConfig,
+  [IssueCategory.MOBILE]: mobileConfig,
 };
 
 /**

--- a/static/app/utils/issueTypeConfig/mobileConfig.tsx
+++ b/static/app/utils/issueTypeConfig/mobileConfig.tsx
@@ -1,0 +1,144 @@
+import {t} from 'sentry/locale';
+import {IssueType} from 'sentry/types/group';
+import type {IssueCategoryConfigMapping} from 'sentry/utils/issueTypeConfig/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+
+const mobileConfig: IssueCategoryConfigMapping = {
+  _categoryDefaults: {
+    actions: {
+      archiveUntilOccurrence: {enabled: true},
+      delete: {
+        enabled: false,
+        disabledReason: t('Not yet supported for mobile issues'),
+      },
+      deleteAndDiscard: {
+        enabled: false,
+        disabledReason: t('Not yet supported for mobile issues'),
+      },
+      merge: {
+        enabled: false,
+        disabledReason: t('Not yet supported for mobile issues'),
+      },
+      ignore: {enabled: true},
+      resolve: {enabled: true},
+      resolveInRelease: {enabled: true},
+      share: {enabled: true},
+    },
+    pages: {
+      landingPage: Tab.DETAILS,
+      events: {enabled: true},
+      openPeriods: {enabled: false},
+      checkIns: {enabled: false},
+      uptimeChecks: {enabled: false},
+      attachments: {enabled: false},
+      userFeedback: {enabled: false},
+      replays: {enabled: true},
+      tagsTab: {enabled: true},
+    },
+    autofix: false,
+    mergedIssues: {enabled: false},
+    similarIssues: {enabled: false},
+    stacktrace: {enabled: false},
+    spanEvidence: {enabled: true},
+    // Should render a custom SpanEvidence component
+    evidence: null,
+    usesIssuePlatform: true,
+    issueSummary: {enabled: false},
+  },
+  [IssueType.PERFORMANCE_FILE_IO_MAIN_THREAD]: {
+    resources: {
+      description: t('File IO operations on your main thread may lead to app hangs.'),
+      links: [
+        {
+          text: t('Sentry Docs: File IO on the Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/file-main-thread-io/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PERFORMANCE_DB_MAIN_THREAD]: {
+    resources: {
+      description: t('Database operations on your main thread may lead to app hangs.'),
+      links: [
+        {
+          text: t('Sentry Docs: Database on the Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/db-main-thread-io/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PROFILE_FILE_IO_MAIN_THREAD]: {
+    resources: {
+      description: t(
+        'File I/O can be a long running operation that blocks the main thread. This may result in app hangs and poor UI performance. To learn more, read our documentation:'
+      ),
+      links: [
+        {
+          text: t('File I/O on Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/main-thread-io/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PROFILE_JSON_DECODE_MAIN_THREAD]: {
+    resources: {
+      description: t(
+        'Decoding a JSON blob can be a long running operation that blocks the main thread. This may result in app hangs and poor UI performance. To learn more, read our documentation:'
+      ),
+      links: [
+        {
+          text: t('JSON Decode on Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/json-decoding-main-thread/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PROFILE_IMAGE_DECODE_MAIN_THREAD]: {
+    resources: {
+      description: t(
+        'Decoding a compressed image (e.g. JPEG, PNG) into a bitmap can be a long running operation that blocks the main thread. This may result in app hangs and poor UI performance. To learn more, read our documentation:'
+      ),
+      links: [
+        {
+          text: t('Image Decode on Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/image-decoding-main-thread/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PROFILE_REGEX_MAIN_THREAD]: {
+    resources: {
+      description: t(
+        'Evaluating matches between strings and regular expressions (regex) can be long-running operations that may impact app responsiveness. This may result in app hangs and poor UI performance. To learn more, read our documentation:'
+      ),
+      links: [
+        {
+          text: t('Regex on Main Thread'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/regex-main-thread/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+  [IssueType.PROFILE_FRAME_DROP]: {
+    resources: {
+      description: t(
+        'The main (or UI) thread in a mobile app is responsible for handling all user interaction and needs to be able to respond to gestures and taps in real time. If a long-running operation blocks the main thread, the app becomes unresponsive, impacting the quality of the user experience. To learn more, read our documentation:'
+      ),
+      links: [
+        {
+          text: t('Frame Drop'),
+          link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/frame-drop/',
+        },
+      ],
+      linksByPlatform: {},
+    },
+  },
+};
+
+export default mobileConfig;


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/90824, following the changes in this [spreadsheet](https://docs.google.com/spreadsheets/d/1PywKqFhpXtwTeevZnBV6As8z1CgkQtfxpIFToezP5C8/edit?gid=0#gid=0).

Here I need to maintain backwards compatibility, so I'm adding configs for the new categories while keeping the old ones. Will go back and clean up once we have the categories solidified. 

This is mostly just copy-pasting the old configs and breaking up into the new categories.

