### PR TITLE
ref(discover): Refactor SavedQueryAPI away from AsyncDeprecatedComponent

### DIFF
--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1603,6 +1603,10 @@ describe('Results', function () {
         deprecatedRouterMocks: true,
       });
 
+      await waitFor(() =>
+        expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()
+      );
+
       await userEvent.click(
         screen.getByPlaceholderText('Search for events, users, tags, and more')
       );
@@ -1714,6 +1718,10 @@ describe('Results', function () {
         organization,
         deprecatedRouterMocks: true,
       });
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument()
+      );
 
       await userEvent.click(
         screen.getByPlaceholderText('Search for events, users, tags, and more')

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -254,19 +254,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      render(
-        <Results
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // No request as eventview was invalid.
       expect(mockRequests.eventsStatsMock).not.toHaveBeenCalled();
@@ -303,20 +295,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // ensure cursor query string is initially present in the location
       expect(router.location).toEqual({
@@ -367,20 +350,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // Click the 'default' option.
       await selectEvent.select(
@@ -405,20 +379,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // Click the 'default' option.
       await selectEvent.select(
@@ -443,20 +408,11 @@ describe('Results', function () {
 
       renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await userEvent.click(await screen.findByRole('button', {name: /Display/}));
 
@@ -480,20 +436,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       expect(mockRequests.eventsResultsMock).toHaveBeenCalledTimes(0);
       await waitFor(() => {
@@ -523,20 +470,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       expect(mockRequests.eventsResultsMock).toHaveBeenCalledTimes(0);
       await waitFor(() => {
@@ -560,20 +498,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(mockRequests.measurementsMetaMock).toHaveBeenCalled();
@@ -603,20 +532,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(mockRequests.measurementsMetaMock).toHaveBeenCalled();
@@ -641,20 +561,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => expect(mockRequests.mockVisit).toHaveBeenCalled());
 
@@ -709,20 +620,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => expect(mockRequests.mockVisit).toHaveBeenCalled());
 
@@ -748,20 +650,11 @@ describe('Results', function () {
 
       const {eventsStatsMock, measurementsMetaMock} = renderMockRequests();
 
-      const {rerender} = render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      const {rerender} = render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // Should load events once
       expect(eventsStatsMock).toHaveBeenCalledTimes(1);
@@ -782,14 +675,11 @@ describe('Results', function () {
       // Update location simulating a browser back button action
       rerender(
         <Results
-          organization={organization}
           location={{
             ...router.location,
             query: {...generateFields(), yAxis: 'count_unique(user)'},
           }}
           router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
         />
       );
 
@@ -826,20 +716,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      const {rerender} = render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      const {rerender} = render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // Should load events once
       expect(eventsStatsMock).toHaveBeenCalledTimes(1);
@@ -860,14 +741,11 @@ describe('Results', function () {
       // Update location simulating a browser back button action
       rerender(
         <Results
-          organization={organization}
           location={{
             ...router.location,
             query: {...generateFields(), display: 'previous', yAxis: 'count()'},
           }}
           router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
         />
       );
 
@@ -904,20 +782,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      const {rerender} = render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      const {rerender} = render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       // Should load events once
       expect(eventsStatsMock).toHaveBeenCalledTimes(1);
@@ -938,7 +807,6 @@ describe('Results', function () {
       // Update location simulating a browser back button action
       rerender(
         <Results
-          organization={organization}
           location={{
             ...router.location,
             query: {
@@ -948,8 +816,6 @@ describe('Results', function () {
             },
           }}
           router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
         />
       );
 
@@ -986,20 +852,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await userEvent.click(await screen.findByRole('button', {name: 'Show Tags'}));
 
@@ -1051,20 +908,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'Pinned Project'})]);
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       const projectPageFilter = await screen.findByTestId('page-filter-project-selector');
 
@@ -1098,20 +946,11 @@ describe('Results', function () {
 
       ProjectsStore.loadInitialData([ProjectFixture()]);
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(screen.getByText('this is a tip')).toBeInTheDocument();
@@ -1134,20 +973,11 @@ describe('Results', function () {
 
       renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       expect(
         await screen.findByText(
@@ -1172,20 +1002,11 @@ describe('Results', function () {
 
       renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       expect(
         await screen.findByText(/These are unparameterized transactions/)
@@ -1214,20 +1035,11 @@ describe('Results', function () {
       ProjectsStore.loadInitialData([ProjectFixture()]);
       renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() =>
         expect(screen.getByRole('button', {name: /set as default/i})).toBeEnabled()
@@ -1284,20 +1096,11 @@ describe('Results', function () {
       ProjectsStore.loadInitialData([ProjectFixture()]);
       renderMockRequests();
 
-      const {rerender} = render(
-        <Results
-          loading={false}
-          setSavedQuery={jest.fn()}
-          organization={organization}
-          location={router.location}
-          router={router}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      const {rerender} = render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() =>
         expect(screen.getByRole('button', {name: /set as default/i})).toBeEnabled()
@@ -1316,13 +1119,7 @@ describe('Results', function () {
       });
 
       rerender(
-        <Results
-          loading={false}
-          setSavedQuery={jest.fn()}
-          organization={organization}
-          location={rerenderData.router.location}
-          router={rerenderData.router}
-        />
+        <Results location={rerenderData.router.location} router={rerenderData.router} />
       );
       screen.getByText('Previous Period');
       expect(await screen.findByText('Set as Default')).toBeInTheDocument();
@@ -1356,20 +1153,11 @@ describe('Results', function () {
       ProjectsStore.loadInitialData([ProjectFixture()]);
       renderMockRequests();
 
-      const {rerender} = render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      const {rerender} = render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await screen.findAllByText(getTransactionViews(organization)[0]!.name);
       await userEvent.click(screen.getByText('Set as Default'));
@@ -1385,13 +1173,7 @@ describe('Results', function () {
       });
 
       rerender(
-        <Results
-          organization={organization}
-          location={rerenderData.router.location}
-          router={rerenderData.router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />
+        <Results location={rerenderData.router.location} router={rerenderData.router} />
       );
       screen.getByText('Previous Period');
       expect(await screen.findByText('Set as Default')).toBeInTheDocument();
@@ -1412,20 +1194,11 @@ describe('Results', function () {
       ProjectsStore.loadInitialData([ProjectFixture()]);
       const {measurementsMetaMock} = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(measurementsMetaMock).toHaveBeenCalled();
@@ -1450,20 +1223,11 @@ describe('Results', function () {
       });
       const {measurementsMetaMock} = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(measurementsMetaMock).toHaveBeenCalled();
@@ -1498,20 +1262,11 @@ describe('Results', function () {
       ProjectsStore.loadInitialData([ProjectFixture()]);
       const {measurementsMetaMock} = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(measurementsMetaMock).toHaveBeenCalled();
@@ -1540,20 +1295,11 @@ describe('Results', function () {
       });
       const {measurementsMetaMock} = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(measurementsMetaMock).toHaveBeenCalled();
@@ -1582,20 +1328,11 @@ describe('Results', function () {
 
       const mockRequests = renderMockRequests();
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(mockRequests.measurementsMetaMock).toHaveBeenCalled();
@@ -1661,20 +1398,11 @@ describe('Results', function () {
         },
       });
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(mockRequests.measurementsMetaMock).toHaveBeenCalled();
@@ -1754,20 +1482,11 @@ describe('Results', function () {
         },
       });
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await waitFor(() => {
         expect(mockRequests.measurementsMetaMock).toHaveBeenCalled();
@@ -1878,20 +1597,11 @@ describe('Results', function () {
         },
       });
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await userEvent.click(
         screen.getByPlaceholderText('Search for events, users, tags, and more')
@@ -1999,20 +1709,11 @@ describe('Results', function () {
         },
       });
 
-      render(
-        <Results
-          organization={organization}
-          location={router.location}
-          router={router}
-          loading={false}
-          setSavedQuery={jest.fn()}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
+      render(<Results location={router.location} router={router} />, {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      });
 
       await userEvent.click(
         screen.getByPlaceholderText('Search for events, users, tags, and more')

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -920,7 +920,7 @@ const TipContainer = styled(MarkedText)`
   }
 `;
 
-function SavedQueryAPI(props: Props) {
+function SavedQueryAPI(props: Omit<Props, 'savedQuery' | 'loading' | 'setSavedQuery'>) {
   const queryClient = useQueryClient();
   const {organization, location} = props;
 
@@ -956,7 +956,7 @@ function SavedQueryAPI(props: Props) {
   return (
     <Results
       {...props}
-      savedQuery={data}
+      savedQuery={getSavedQueryWithDataset(data)}
       loading={isFetching}
       setSavedQuery={setSavedQuery}
     />
@@ -964,7 +964,10 @@ function SavedQueryAPI(props: Props) {
 }
 
 export default function ResultsContainer(
-  props: Omit<Props, 'api' | 'organization' | 'selection'>
+  props: Omit<
+    Props,
+    'api' | 'organization' | 'selection' | 'savedQuery' | 'loading' | 'setSavedQuery'
+  >
 ) {
   const api = useApi();
   const organization = useOrganization();

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -930,12 +930,13 @@ function SavedQueryAPI(props: Omit<Props, 'savedQuery' | 'loading' | 'setSavedQu
     ],
     [organization, location.query.id]
   );
-  const {data, isError, isPending, isFetching, refetch} = useApiQuery<
-    SavedQuery | undefined
-  >(queryKey, {
-    enabled: Boolean(location.query.id),
-    staleTime: 0,
-  });
+  const {data, isError, isFetching, refetch} = useApiQuery<SavedQuery | undefined>(
+    queryKey,
+    {
+      enabled: Boolean(location.query.id),
+      staleTime: 0,
+    }
+  );
 
   const setSavedQuery = useCallback(
     (newQuery?: SavedQuery) => {
@@ -945,7 +946,7 @@ function SavedQueryAPI(props: Omit<Props, 'savedQuery' | 'loading' | 'setSavedQu
     [queryClient, queryKey]
   );
 
-  if (isPending) {
+  if (isFetching) {
     return <LoadingIndicator />;
   }
 
@@ -956,7 +957,9 @@ function SavedQueryAPI(props: Omit<Props, 'savedQuery' | 'loading' | 'setSavedQu
   return (
     <Results
       {...props}
-      savedQuery={getSavedQueryWithDataset(data)}
+      savedQuery={
+        hasDatasetSelector(organization) ? getSavedQueryWithDataset(data) : data
+      }
       loading={isFetching}
       setSavedQuery={setSavedQuery}
     />
@@ -964,10 +967,7 @@ function SavedQueryAPI(props: Omit<Props, 'savedQuery' | 'loading' | 'setSavedQu
 }
 
 export default function ResultsContainer(
-  props: Omit<
-    Props,
-    'api' | 'organization' | 'selection' | 'savedQuery' | 'loading' | 'setSavedQuery'
-  >
+  props: Omit<Props, 'api' | 'organization' | 'selection' | 'loading' | 'setSavedQuery'>
 ) {
   const api = useApi();
   const organization = useOrganization();


### PR DESCRIPTION
To test this:
- load up `/explore/discover/queries/` and then open a saved query. I've been using https://sentry.dev.getsentry.net:7999/explore/discover/results/?id=32482&project=11276&statsPeriod=7d, but you can just make your own too.
- edit something simple, like the query, click 'enter' to fetch the latest data to match your changes
- Notice that there is a button across the top of the screen "Save changes"
- Click to save changes
- Notice that the query is now saved, and the page successfully updated with the new query. Not jank along the way.
