### PR TITLE
chore(devservices): Bump devservices to 1.1.4

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -37,7 +37,7 @@ cryptography==44.0.1
 cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
-devservices==1.1.1
+devservices==1.1.3
 distlib==0.3.8
 distro==1.8.0
 django==5.1.7

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -37,7 +37,7 @@ cryptography==44.0.1
 cssselect==1.0.3
 cssutils==2.9.0
 datadog==0.49.1
-devservices==1.1.3
+devservices==1.1.4
 distlib==0.3.8
 distro==1.8.0
 django==5.1.7

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -191,7 +191,7 @@ sentry-kafka-schemas==1.2.0
 sentry-ophio==1.1.3
 sentry-protos==0.1.74
 sentry-redis-tools==0.5.0
-sentry-relay==0.9.8
+sentry-relay==0.9.9
 sentry-sdk==2.27.0
 sentry-usage-accountant==0.0.10
 simplejson==3.17.6
@@ -205,6 +205,7 @@ sqlparse==0.5.0
 statsd==3.3.0
 stripe==4.2.0
 structlog==22.1.0
+supervisor==4.2.5
 symbolic==12.14.1
 tiktoken==0.8.0
 time-machine==2.16.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 sentry-devenv>=1.18
-devservices>=1.1.3
+devservices>=1.1.4
 
 covdefaults>=2.3.0
 sentry-covdefaults-disable-branch-coverage>=1.0.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 sentry-devenv>=1.18
-devservices>=1.1.1
+devservices>=1.1.3
 
 covdefaults>=2.3.0
 sentry-covdefaults-disable-branch-coverage>=1.0.2


### PR DESCRIPTION
Picks up fixes to the toggle command and the new serve command.

https://github.com/getsentry/devservices/releases/tag/1.1.3