### PR TITLE
feat(workflow): Support sorting in the Detectors index api

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -430,7 +430,7 @@ Available fields are:
 - `name`
 - `id`
 - `type`
-- `connected_workflows`
+- `connectedWorkflows`
 
 Prefix with `-` to sort in descending order.
         """,

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -419,6 +419,23 @@ class DetectorParams:
         description="The ID of the detector you'd like to query.",
     )
 
+    SORT = OpenApiParameter(
+        name="sortBy",
+        location="query",
+        required=False,
+        type=str,
+        description="""The property to sort results by. If not specified, the results are sorted by id.
+
+Available fields are:
+- `name`
+- `id`
+- `type`
+- `connected_workflows`
+
+Prefix with `-` to sort in descending order.
+        """,
+    )
+
 
 class WorkflowParams:
     WORKFLOW_ID = OpenApiParameter(

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -90,8 +90,7 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         sort_by = request.GET.get("sortBy", "id")
         sort_field = sort_by[1:] if sort_by.startswith("-") else sort_by
         if sort_field not in SORT_ATTRS:
-            sort_field = "id"
-            sort_by = "id"
+            raise ValidationError({"sortBy": ["Invalid sort field"]})
         if sort_field == "connectedWorkflows":
             queryset = queryset.annotate(connectedWorkflows=Count("detectorworkflow"))
 

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -46,7 +46,7 @@ def get_detector_validator(
     )
 
 
-SORT_ATTRS = {"name", "id", "type", "connected_workflows"}
+SORT_ATTRS = {"name", "id", "type", "connectedWorkflows"}
 
 
 @region_silo_endpoint
@@ -92,8 +92,8 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         if sort_field not in SORT_ATTRS:
             sort_field = "id"
             sort_by = "id"
-        if sort_field == "connected_workflows":
-            queryset = queryset.annotate(connected_workflows=Count("detectorworkflow"))
+        if sort_field == "connectedWorkflows":
+            queryset = queryset.annotate(connectedWorkflows=Count("detectorworkflow"))
 
         queryset = queryset.order_by(sort_by)
 

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -275,6 +275,10 @@ class DetectorSerializer(Serializer):
             for group, serialized in zip(condition_groups, serialize(condition_groups, user=user))
         }
 
+        workflows_map = defaultdict[int, list[str]](list)
+        for dw in DetectorWorkflow.objects.filter(detector__in=item_list):
+            workflows_map[dw.detector_id].append(str(dw.workflow_id))
+
         filtered_item_list = [item for item in item_list if item.type == ErrorGroupType.slug]
         project_ids = [item.project_id for item in filtered_item_list]
 
@@ -295,6 +299,7 @@ class DetectorSerializer(Serializer):
             attrs[item]["condition_group"] = condition_group_map.get(
                 str(item.workflow_condition_group_id)
             )
+            attrs[item]["connected_workflows"] = workflows_map.get(item.id, [])
             if item.id in configs:
                 attrs[item]["config"] = configs[item.id]
             else:
@@ -308,6 +313,7 @@ class DetectorSerializer(Serializer):
             "projectId": str(obj.project_id),
             "name": obj.name,
             "type": obj.type,
+            "connectedWorkflows": attrs.get("connected_workflows"),
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
             "dataSources": attrs.get("data_sources"),

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -299,7 +299,7 @@ class DetectorSerializer(Serializer):
             attrs[item]["condition_group"] = condition_group_map.get(
                 str(item.workflow_condition_group_id)
             )
-            attrs[item]["connected_workflows"] = workflows_map.get(item.id, [])
+            attrs[item]["connected_workflows"] = workflows_map[item.id]
             if item.id in configs:
                 attrs[item]["config"] = configs[item.id]
             else:

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -81,14 +81,14 @@ class ProjectDetectorIndexGetTest(ProjectDetectorIndexBaseTest):
         self.create_detector_workflow(detector=detector, workflow=workflow)
         self.create_detector_workflow(detector=detector, workflow=workflow_2)
         response1 = self.get_success_response(
-            self.organization.slug, self.project.slug, qs_params={"sortBy": "-connected_workflows"}
+            self.organization.slug, self.project.slug, qs_params={"sortBy": "-connectedWorkflows"}
         )
         assert [d["name"] for d in response1.data] == [
             detector.name,
             detector_2.name,
         ]
         response2 = self.get_success_response(
-            self.organization.slug, self.project.slug, qs_params={"sortBy": "connected_workflows"}
+            self.organization.slug, self.project.slug, qs_params={"sortBy": "connectedWorkflows"}
         )
         assert [d["name"] for d in response2.data] == [
             detector_2.name,

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -50,6 +50,14 @@ class ProjectDetectorIndexGetTest(ProjectDetectorIndexBaseTest):
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert len(response.data) == 0
 
+    def test_invalid_sort_by(self):
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"sortBy": "general_malaise"},
+        )
+        assert "sortBy" in response.data
+
     def test_sort_by_name(self):
         detector = self.create_detector(
             project_id=self.project.id, name="A Test Detector", type=MetricIssue.slug

--- a/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_project_detector_index.py
@@ -50,6 +50,51 @@ class ProjectDetectorIndexGetTest(ProjectDetectorIndexBaseTest):
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert len(response.data) == 0
 
+    def test_sort_by_name(self):
+        detector = self.create_detector(
+            project_id=self.project.id, name="A Test Detector", type=MetricIssue.slug
+        )
+        detector_2 = self.create_detector(
+            project_id=self.project.id, name="B Test Detector 2", type=MetricIssue.slug
+        )
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, qs_params={"sortBy": "-name"}
+        )
+        assert [d["name"] for d in response.data] == [
+            detector_2.name,
+            detector.name,
+        ]
+
+    def test_sort_by_connected_workflows(self):
+        workflow = self.create_workflow(
+            organization_id=self.organization.id,
+        )
+        workflow_2 = self.create_workflow(
+            organization_id=self.organization.id,
+        )
+        detector = self.create_detector(
+            project_id=self.project.id, name="Test Detector", type=MetricIssue.slug
+        )
+        detector_2 = self.create_detector(
+            project_id=self.project.id, name="Test Detector 2", type=MetricIssue.slug
+        )
+        self.create_detector_workflow(detector=detector, workflow=workflow)
+        self.create_detector_workflow(detector=detector, workflow=workflow_2)
+        response1 = self.get_success_response(
+            self.organization.slug, self.project.slug, qs_params={"sortBy": "-connected_workflows"}
+        )
+        assert [d["name"] for d in response1.data] == [
+            detector.name,
+            detector_2.name,
+        ]
+        response2 = self.get_success_response(
+            self.organization.slug, self.project.slug, qs_params={"sortBy": "connected_workflows"}
+        )
+        assert [d["name"] for d in response2.data] == [
+            detector_2.name,
+            detector.name,
+        ]
+
 
 @region_silo_test
 class ProjectDetectorIndexPostTest(ProjectDetectorIndexBaseTest):

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -31,6 +31,7 @@ class TestDetectorSerializer(TestCase):
             "dateUpdated": detector.date_updated,
             "dataSources": None,
             "conditionGroup": None,
+            "connectedWorkflows": [],
             "config": default_detector_config_data[MetricIssue.slug],
         }
 
@@ -79,6 +80,10 @@ class TestDetectorSerializer(TestCase):
             source_id=str(subscription.id),
         )
         data_source.detectors.set([detector])
+        workflow = self.create_workflow(
+            organization=self.organization,
+        )
+        self.create_detector_workflow(detector=detector, workflow=workflow)
 
         result = serialize(detector)
         assert result == {
@@ -131,6 +136,7 @@ class TestDetectorSerializer(TestCase):
                     }
                 ],
             },
+            "connectedWorkflows": [str(workflow.id)],
             "config": default_detector_config_data[MetricIssue.slug],
         }
 


### PR DESCRIPTION
Add a 'sortBy' parameter to ProjectDetectorIndexEndpoint that can be used to sort by a few basic attributes, along with `connectedWorkflows`. Given that connected workflows are in scope for sorting, also add  `connectedWorkflows` to the serializer result with a `list[str]` of workflow IDs.

Part of ACI-44