### PR TITLE
fix(grouping): Only show client fingerprint tooltip when appropriate

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -51,13 +51,15 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
       t('Client fingerprint values'),
       <TextWithQuestionTooltip key="type">
         {variant.client_values}
-        <QuestionTooltip
-          size="xs"
-          position="top"
-          title={t(
-            'The client sent a fingerprint that was overridden by a server-side fingerprinting rule.'
-          )}
-        />
+        {'matched_rule' in variant && ( // Only display override tooltip if overriding actually happened
+          <QuestionTooltip
+            size="xs"
+            position="top"
+            title={t(
+              'The client sent a fingerprint that was overridden by a server-side fingerprinting rule.'
+            )}
+          />
+        )}
       </TextWithQuestionTooltip>,
     ]);
   }


### PR DESCRIPTION
In our grouping info section, on the issue details page, we show a tooltip next to the client fingerprint which says it was overridden by server-side fingerprinting, regardless of whether or not it actually was. This changes the logic so that the tooltip only shows when we also have information about a server-side rule which was matched.

Fixes https://github.com/getsentry/sentry/issues/90842.