### PR TITLE
fix(dashboards): Updates edit permissions check

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -275,6 +275,9 @@ function Controls({
                       showChevron: true,
                       icon: <IconAdd isCircled size="sm" />,
                       priority: 'primary',
+                      title:
+                        !hasEditAccess &&
+                        t('You do not have permission to edit this dashboard'),
                     }}
                     position="bottom-end"
                   />

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -196,7 +196,7 @@ export function checkUserHasEditAccess(
   dashboardCreator?: User
 ): boolean {
   if (
-    hasEveryAccess(['org:write'], {organization}) || // Managers and Owners
+    hasEveryAccess(['org:admin'], {organization}) || // Owners
     !dashboardPermissions ||
     dashboardPermissions.isEditableByEveryone ||
     dashboardCreator?.id === currentUser.id


### PR DESCRIPTION
Managers no longer have edit access, only owners so update the check to org:admin, which only the owner has. This updates the button so it now disables for managers and adds the tooltip text.

You can see this config in this config [here](https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L2055).