### PR TITLE
fix(quota-exceeded-banner): Prevent infinite useEffect loop when quota banner is opened automatically

### DIFF
--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect} from 'react';
+import {Fragment, useCallback, useEffect, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion, type MotionProps} from 'framer-motion';
@@ -220,6 +220,7 @@ function PrimaryNavigationQuotaExceeded({organization}: {organization: Organizat
     return Object.values(isPromptDismissed).every(Boolean);
   }, [isPromptDismissed]);
 
+  const hasAutoOpenedAlertRef = useRef(false);
   useEffect(() => {
     // auto open the alert if it hasn't been explicitly dismissed, and
     // either it has been more than a day since the last shown date,
@@ -237,11 +238,13 @@ function PrimaryNavigationQuotaExceeded({organization}: {organization: Organizat
       .utc()
       .isAfter(moment(lastShownDate).utc());
     if (
+      !hasAutoOpenedAlertRef.current &&
       !hasSnoozedAllPrompts() &&
       (daysSinceLastShown >= 1 ||
         currentCategories !== lastShownCategories ||
         lastShownBeforeCurrentPeriod)
     ) {
+      hasAutoOpenedAlertRef.current = true;
       overlayState.open();
       localStorage.setItem(
         `billing-status-last-shown-categories-${organization.id}`,


### PR DESCRIPTION
Fixes JAVASCRIPT-2Y6A

It appears that the useEffect caused state updates which retriggered the useEffect, causing an infinite loop which crashed the page. Adding a ref to ensure that it only triggers once (which is the intended behavior).