### PR TITLE
fix(aci): fixes to migrate remaining issue alerts

### DIFF
--- a/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
@@ -9,16 +9,19 @@ from typing import Any, ClassVar, NotRequired, TypedDict
 
 import sentry_sdk
 from django.apps.registry import Apps
+from django.conf import settings
 from django.db import migrations, router, transaction
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from jsonschema import ValidationError, validate
 
 from sentry.new_migrations.migrations import CheckedMigration
+from sentry.utils import redis
+from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBarApprox
 
 logger = logging.getLogger(__name__)
 
-CHUNK_SIZE = 1000
+CHUNK_SIZE = 5000
 
 # COPY PASTES FOR RULE REGISTRY
 
@@ -2231,12 +2234,29 @@ def migrate_remaining_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchema
             )
             sentry_sdk.capture_exception(e)
 
-    for rule in RangeQuerySetWrapperWithProgressBarApprox(Rule.objects.all()):
-        if AlertRuleWorkflow.objects.filter(rule_id=rule.id).exists():
-            continue
+    backfill_key = "backfill_workflow_engine_remaining_issue_alerts"
+    redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
+    progress_id = int(redis_client.get(backfill_key) or 0)
 
-        migrate_issue_alert(rule)
-        logger.info("Migrated issue alert", extra={"rule_id": rule.id})
+    for rules in chunked(
+        RangeQuerySetWrapperWithProgressBarApprox(
+            Rule.objects.filter(id__gt=progress_id), step=CHUNK_SIZE
+        ),
+        CHUNK_SIZE,
+    ):
+        rule_ids = [rule.id for rule in rules]
+        migrated_rules = AlertRuleWorkflow.objects.filter(rule_id__in=rule_ids).values_list(
+            "rule_id", flat=True
+        )
+
+        for rule in rules:
+            if rule.id in migrated_rules:
+                continue
+
+            migrate_issue_alert(rule)
+            logger.info("Migrated issue alert", extra={"rule_id": rule.id})
+
+        redis_client.set(backfill_key, rules[-1].id, ex=60 * 60 * 24 * 7)
 
 
 class Migration(CheckedMigration):


### PR DESCRIPTION
1. There are cases where we have an `AlertRuleDetector` lookup row but not an `AlertRuleWorkflow` lookup row for a `Rule`. Handle these correctly so that workflows are created -- added a test for it (skipped in CI).
2. Iterate through all the Rules in big chunks (5000) because the original query to get them was timing out (even with the indices on the AlertRuleWorkflow table).