### PR TITLE
fix(profiling): Convert task to use JSON encodable values

### DIFF
--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -1,3 +1,4 @@
+from base64 import b64encode
 from collections.abc import Iterable, Mapping
 
 from arroyo.backends.kafka.consumer import KafkaPayload
@@ -15,7 +16,7 @@ def process_message(message: Message[KafkaPayload]) -> None:
     sampled = is_sampled(message.payload.headers)
 
     if sampled or options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
-        process_profile_task.delay(payload=message.payload.value, sampled=sampled)
+        process_profile_task.delay(payload=b64encode(message.payload.value), sampled=sampled)
 
 
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/profiles/consumers/process/factory.py
+++ b/src/sentry/profiles/consumers/process/factory.py
@@ -16,7 +16,9 @@ def process_message(message: Message[KafkaPayload]) -> None:
     sampled = is_sampled(message.payload.headers)
 
     if sampled or options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
-        process_profile_task.delay(payload=b64encode(message.payload.value), sampled=sampled)
+        process_profile_task.delay(
+            payload=b64encode(message.payload.value).decode("utf-8"), sampled=sampled
+        )
 
 
 class ProcessProfileStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -108,7 +108,7 @@ def process_profile_task(
         return
 
     if payload:
-        message_dict = msgpack.unpackb(b64decode(payload), use_list=False)
+        message_dict = msgpack.unpackb(b64decode(payload.encode("utf-8")), use_list=False)
         profile = json.loads(message_dict["payload"], use_rapid_json=True)
 
         assert profile is not None

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from base64 import b64decode
+from base64 import b64decode, b64encode
 from copy import deepcopy
 from datetime import datetime, timezone
 from operator import itemgetter
@@ -81,6 +81,14 @@ profile_chunks_producer = SingletonProducer(
 )
 
 
+def decode_payload(encoded: str) -> dict[str, Any]:
+    return msgpack.unpackb(b64decode(encoded.encode("utf-8")), use_list=False)
+
+
+def encode_payload(message: dict[str, Any]) -> str:
+    return b64encode(msgpack.packb(message)).decode("utf-8")
+
+
 @instrumented_task(
     name="sentry.profiles.task.process_profile",
     retry_backoff=True,
@@ -108,7 +116,7 @@ def process_profile_task(
         return
 
     if payload:
-        message_dict = msgpack.unpackb(b64decode(payload.encode("utf-8")), use_list=False)
+        message_dict = decode_payload(payload)
         profile = json.loads(message_dict["payload"], use_rapid_json=True)
 
         assert profile is not None

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from base64 import b64decode
 from copy import deepcopy
 from datetime import datetime, timezone
 from operator import itemgetter
@@ -99,7 +100,7 @@ profile_chunks_producer = SingletonProducer(
 )
 def process_profile_task(
     profile: Profile | None = None,
-    payload: Any = None,
+    payload: str | None = None,
     sampled: bool = True,
     **kwargs: Any,
 ) -> None:
@@ -107,7 +108,7 @@ def process_profile_task(
         return
 
     if payload:
-        message_dict = msgpack.unpackb(payload, use_list=False)
+        message_dict = msgpack.unpackb(b64decode(payload), use_list=False)
         profile = json.loads(message_dict["payload"], use_rapid_json=True)
 
         assert profile is not None

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from base64 import b64encode
 from datetime import datetime
 from typing import Any
 from unittest.mock import Mock, patch
@@ -52,7 +53,7 @@ class TestProcessProfileConsumerStrategy(TestCase):
         processing_strategy.join(1)
         processing_strategy.terminate()
 
-        process_profile_task.assert_called_with(payload=payload, sampled=True)
+        process_profile_task.assert_called_with(payload=b64encode(payload), sampled=True)
 
 
 def test_adjust_instruction_addr_sample_format():

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -53,7 +53,9 @@ class TestProcessProfileConsumerStrategy(TestCase):
         processing_strategy.join(1)
         processing_strategy.terminate()
 
-        process_profile_task.assert_called_with(payload=b64encode(payload), sampled=True)
+        process_profile_task.assert_called_with(
+            payload=b64encode(payload).decode("utf-8"), sampled=True
+        )
 
 
 def test_adjust_instruction_addr_sample_format():

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import zipfile
-from base64 import b64encode
 from io import BytesIO
 from os.path import join
 from typing import Any
 from unittest.mock import patch
 
-import msgpack
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -27,6 +25,7 @@ from sentry.profiles.task import (
     _process_symbolicator_results_for_sample,
     _set_frames_platform,
     _symbolicate_profile,
+    encode_payload,
     process_profile_task,
 )
 from sentry.profiles.utils import Profile
@@ -1018,7 +1017,7 @@ def test_track_latest_sdk_with_payload(
         "received": "2024-01-02T03:04:05",
         "payload": json.dumps(profile),
     }
-    payload = b64encode(msgpack.packb(kafka_payload))
+    payload = encode_payload(kafka_payload)
 
     with Feature("organizations:profiling-sdks"):
         process_profile_task(payload=payload)


### PR DESCRIPTION
Depending on the JSON encoder used, byte strings are not always JSON encodable. Since the taskworker
expects all arguments to the functions to be JSON encodable, b64encode the byte string before
passing it to the task code, and b64decode it in the task processing.