### PR TITLE
feat(aci): Move alert_id to evidence data for metric issue poc

### DIFF
--- a/src/sentry/incidents/utils/metric_issue_poc.py
+++ b/src/sentry/incidents/utils/metric_issue_poc.py
@@ -125,7 +125,7 @@ def _build_occurrence_from_incident(
         culprit="",
         priority=priority,
         # TODO(snigdha): Add more data here as needed
-        evidence_data={"metric_value": metric_value, "alert_rule_id": incident.alert_rule.id},
+        evidence_data={"metric_value": metric_value, "alert_id": incident.alert_rule.id},
         evidence_display=[],
         assignee=incident.alert_rule.owner if incident.alert_rule else None,
     )
@@ -151,7 +151,6 @@ def create_or_update_metric_issue(
         "timestamp": incident.date_started.isoformat(),
         "platform": project.platform or "",
         "received": incident.date_started.isoformat(),
-        "contexts": {"metric_alert": {"alert_rule_id": incident.alert_rule.id}},
     }
 
     occurrence = _build_occurrence_from_incident(project, incident, event_data, metric_value)


### PR DESCRIPTION
Reconciling differences between the poc and `MetricIssue` group types to simplify the transition to Metric Issues. 