### PR TITLE
feat(aci): Check issue evidence data to get alert id

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -225,7 +225,8 @@ export function EventDetailsContent({
           project={project}
         />
       )}
-      {event.contexts?.metric_alert?.alert_rule_id && (
+      {(event.contexts?.metric_alert?.alert_rule_id ||
+        event?.occurrence?.evidenceData?.alertId) && (
         <MetricIssuesSection
           organization={organization}
           group={group}

--- a/static/app/views/issueDetails/metricIssues/utils.tsx
+++ b/static/app/views/issueDetails/metricIssues/utils.tsx
@@ -45,7 +45,10 @@ export function useMetricIssueAlertId({groupId}: {groupId: string}): string | un
   );
 
   // Fall back to the fetched event in case the provider doesn't have the detector details
-  return hasMetricDetector ? detectorId : event?.contexts?.metric_alert?.alert_rule_id;
+  const fallback =
+    event?.occurrence?.evidenceData?.alertId ||
+    event?.contexts?.metric_alert?.alert_rule_id;
+  return hasMetricDetector ? detectorId : fallback;
 }
 
 interface UseMetricTimePeriodParams {

--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -34,7 +34,9 @@ export function getDetectorDetails({
    * for Alert Rule IDs. Hopefully we can consolidate this when we move to the detector system.
    * Ideally, this function wouldn't even check the event, but rather the group/issue.
    */
-  const metricAlertRuleId = event?.contexts?.metric_alert?.alert_rule_id;
+  const metricAlertRuleId =
+    event?.occurrence?.evidenceData?.alertId ||
+    event?.contexts?.metric_alert?.alert_rule_id;
   if (metricAlertRuleId) {
     return {
       detectorType: 'metric_alert',


### PR DESCRIPTION
FE counterpart to #90859

Reconciling differences between the poc and MetricIssue group types to simplify the transition to Metric Issues.

The checks to `event.contexts?.metric_alert?.alert_rule_id` can be removed when we remove the POC group type.