### PR TITLE
fix(taskworker) Remove bytes from relocation celery task

### DIFF
--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -3,6 +3,7 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
+import base64
 import logging
 from datetime import UTC, datetime
 from io import BytesIO
@@ -65,7 +66,7 @@ class DBBackedRelocationExportService(RegionRelocationExportService):
                 requesting_region_name,
                 replying_region_name,
                 org_slug,
-                encrypt_with_public_key,
+                base64.b64encode(encrypt_with_public_key).decode("utf8"),
                 int(round(datetime.now(tz=UTC).timestamp())),
             ]
         )

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -358,7 +358,7 @@ def fulfill_cross_region_export_request(
     call is received with the encrypted export in tow, it will trigger the next step in the
     `SAAS_TO_SAAS` relocation's pipeline, namely `uploading_complete`.
     """
-    encrypt_with_public_key = base64.b64decode(encrypt_with_public_key)
+    encrypt_with_public_key_bytes = base64.b64decode(encrypt_with_public_key.encode("utf8"))
 
     logger_data = {
         "uuid": uuid_str,
@@ -366,7 +366,7 @@ def fulfill_cross_region_export_request(
         "requesting_region_name": requesting_region_name,
         "replying_region_name": replying_region_name,
         "org_slug": org_slug,
-        "encrypted_public_key_size": len(encrypt_with_public_key),
+        "encrypted_public_key_size": len(encrypt_with_public_key_bytes),
         "scheduled_at": scheduled_at,
     }
     logger.info(
@@ -398,7 +398,7 @@ def fulfill_cross_region_export_request(
 
     export_in_organization_scope(
         fp,
-        encryptor=LocalFileEncryptor(BytesIO(encrypt_with_public_key)),
+        encryptor=LocalFileEncryptor(BytesIO(encrypt_with_public_key_bytes)),
         org_filter={org_slug},
         printer=LoggingPrinter(uuid_str),
         checkpointer=StorageBackedCheckpointExporter(

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import logging
 import re
 from collections import defaultdict
@@ -344,7 +345,7 @@ def fulfill_cross_region_export_request(
     requesting_region_name: str,
     replying_region_name: str,
     org_slug: str,
-    encrypt_with_public_key: bytes,
+    encrypt_with_public_key: str,
     # Unix timestamp, in seconds.
     scheduled_at: int,
 ) -> None:
@@ -357,6 +358,7 @@ def fulfill_cross_region_export_request(
     call is received with the encrypted export in tow, it will trigger the next step in the
     `SAAS_TO_SAAS` relocation's pipeline, namely `uploading_complete`.
     """
+    encrypt_with_public_key = base64.b64decode(encrypt_with_public_key)
 
     logger_data = {
         "uuid": uuid_str,


### PR DESCRIPTION
bytes can't always be json encoded