### PR TITLE
feat(ACI): Create open period serializer for old incident endpoint

### DIFF
--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -4,7 +4,7 @@ from typing import TypedDict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register
-from sentry.incidents.models.incident import IncidentActivity
+from sentry.incidents.models.incident import IncidentActivity, IncidentActivityType
 from sentry.interfaces.user import EventUserApiContext
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -14,7 +14,7 @@ class IncidentActivitySerializerResponse(TypedDict):
     id: str
     incidentIdentifier: str
     user: EventUserApiContext
-    type: int
+    type: IncidentActivityType.value
     value: str
     previousValue: str
     comment: str

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -4,7 +4,7 @@ from typing import TypedDict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register
-from sentry.incidents.models.incident import IncidentActivity, IncidentActivityType
+from sentry.incidents.models.incident import IncidentActivity
 from sentry.interfaces.user import EventUserApiContext
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -14,7 +14,7 @@ class IncidentActivitySerializerResponse(TypedDict):
     id: str
     incidentIdentifier: str
     user: EventUserApiContext
-    type: IncidentActivityType.value
+    type: int
     value: str
     previousValue: str
     comment: str

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -250,7 +250,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
         date_closed = obj.date_ended.replace(second=0, microsecond=0) if obj.date_ended else None
         return {
             "id": str(incident_group_open_period.incident_id),
-            "identifier": str(obj.id),
+            "identifier": "-1",
             # TODO this ^ isn't the same thing, it's Incident.identifier which we need to add to IncidentGroupOpenPeriod
             "organizationId": str(obj.project.organization.id),
             "projects": attrs["projects"],
@@ -293,7 +293,7 @@ class WorkflowEngineDetailedIncidentSerializer(WorkflowEngineIncidentSerializer)
 
         try:
             query_subscription = QuerySubscription.objects.get(
-                id=data_source_detector.detector.data_source.source_id
+                id=data_source_detector.detector.data_sources.all()[0].source_id
             )
         except QuerySubscription.DoesNotExist:
             return ""

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -136,7 +136,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
 
         # look up Activity rows for other status changes (warning / critical)
         status_change_activities = Activity.objects.filter(
-            group=open_period.group, type=ActivityType.ActivityType.SET_PRIORITY
+            group=open_period.group, type=ActivityType.SET_PRIORITY.value
         )
 
         activity_status_to_incident_status = {

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -105,14 +105,14 @@ class WorkflowEngineIncidentSerializer(Serializer):
     def get_open_period_activities(
         self, open_period: GroupOpenPeriod
     ) -> list[IncidentActivitySerializerResponse]:
-        # an incident will be 1:1 with open periods, but there can be multiple open periods per metric issue
-        # this won't actually work until we start writing to the table for metric issues (or are we planning a backfill? I can't remember)
+        # XXX: an incident will be 1:1 with open periods, but there can be multiple open periods per metric issue
+        # XXX: this won't actually work until we start writing to the table for metric issues (or are we planning a backfill?)
 
         open_period_activities = []
-        incident_activity_id = "-1"  # temp until I figure out how to store this
+        incident_activity_id = "-1"  # temp until we add lookup table
         incident_identifier = "-1"  # temp until we add a column
 
-        # if we are here we have IncidentActivityType.CREATED and IncidentActivityType.DETECTED so fill those out
+        # if we are here we have both IncidentActivityType.CREATED and IncidentActivityType.DETECTED
         created = {
             "id": incident_activity_id,
             "incidentIdentifier": incident_identifier,
@@ -128,7 +128,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
         open_period_activities.append(created)
         open_period_activities.append(detected)
 
-        # look up Activity rows for other status changes (warning / critical)
+        # look up Activity rows for other status changes (warning, critical, and resolved)
         activity_status_to_incident_status = {
             "high": IncidentStatus.CRITICAL,
             "medium": IncidentStatus.WARNING,
@@ -251,7 +251,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
         return {
             "id": str(incident_group_open_period.incident_id),
             "identifier": str(obj.id),
-            # TODO this ^ isn't the same thing, it's Incident.identifier which we might want to add to IncidentGroupOpenPeriod
+            # TODO this ^ isn't the same thing, it's Incident.identifier which we need to add to IncidentGroupOpenPeriod
             "organizationId": str(obj.project.organization.id),
             "projects": attrs["projects"],
             "alertRule": attrs["alert_rule"],

--- a/src/sentry/incidents/models/incident.py
+++ b/src/sentry/incidents/models/incident.py
@@ -144,8 +144,8 @@ class IncidentStatus(Enum):
 
 
 class IncidentStatusMethod(Enum):
-    MANUAL = 1
-    RULE_UPDATED = 2
+    MANUAL = 1  # not in use
+    RULE_UPDATED = 2  # always corresponds with IncidentStatus.CLOSED
     RULE_TRIGGERED = 3
 
 

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -12,7 +12,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_metric_data_conditions,
     migrate_resolve_threshold_data_condition,
 )
-from sentry.workflow_engine.models import ActionGroupStatus
+from sentry.workflow_engine.models import ActionGroupStatus, IncidentGroupOpenPeriod
 
 
 @freeze_time("2024-12-11 03:21:34")
@@ -128,6 +128,9 @@ class TestWorklowEngineSerializer(TestCase):
         self.group.priority = PriorityLevel.HIGH
         self.group.save()
         ActionGroupStatus.objects.create(action=self.critical_action, group=self.group)
-        GroupOpenPeriod.objects.create(
+        self.group_open_period = GroupOpenPeriod.objects.create(
             group=self.group, project=self.detector.project, date_started=self.incident.date_started
+        )
+        self.incident_group_open_period = IncidentGroupOpenPeriod.objects.create(
+            group_open_period=self.group_open_period, incident_id=self.incident.id
         )

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -2,7 +2,12 @@ from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineIncidentSerializer,
 )
-from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod, IncidentType
+from sentry.incidents.models.incident import (
+    IncidentActivityType,
+    IncidentStatus,
+    IncidentStatusMethod,
+    IncidentType,
+)
 from tests.sentry.incidents.serializers.test_workflow_engine_base import TestWorklowEngineSerializer
 
 
@@ -38,3 +43,32 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
             self.group_open_period, self.user, WorkflowEngineIncidentSerializer()
         )
         assert serialized_incident == self.incident_expected
+
+    def test_activity(self) -> None:
+        open_period_activities = []
+        created = {
+            "id": "-1",  # temp and wrong
+            "incidentIdentifier": "-1",  # temp and wrong
+            "type": IncidentActivityType.CREATED,
+            "value": None,
+            "previousValue": None,
+            "user": None,
+            "comment": None,
+            "dateCreated": self.group_open_period.date_started,
+        }
+        detected = created.copy()
+        detected["type"] = IncidentActivityType.DETECTED
+        open_period_activities.append(created)
+        open_period_activities.append(detected)
+        self.incident_expected["activities"] = open_period_activities
+
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        assert serialized_incident == self.incident_expected
+
+        # TODO add status changes
+
+        # TODOadd resolution activity

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -23,14 +23,14 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
         super().setUp()
         self.add_warning_trigger()
         self.add_incident_data()
-        self.expected_activities = None
+        self.incident_identifier = "-1"  # temp and wrong
         self.incident_expected = {
             "id": str(self.incident_group_open_period.incident_id),
-            "identifier": str(self.group_open_period.id),  # temp and wrong
+            "identifier": self.incident_identifier,
             "organizationId": str(self.group_open_period.project.organization_id),
             "projects": [self.project.slug],
             "alertRule": self.expected,
-            "activities": self.expected_activities,
+            "activities": None,
             "status": IncidentStatus.CRITICAL.value,
             "statusMethod": IncidentStatusMethod.RULE_TRIGGERED.value,
             "type": IncidentType.ALERT_TRIGGERED.value,
@@ -53,12 +53,11 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
 
     def test_activity(self) -> None:
         incident_activity_id = "-1"  # temp and wrong
-        incident_identifier = "-1"  # temp and wrong
 
         open_period_activities = []
         created = {
             "id": incident_activity_id,
-            "incidentIdentifier": incident_identifier,
+            "incidentIdentifier": self.incident_identifier,
             "type": IncidentActivityType.CREATED,
             "value": None,
             "previousValue": None,
@@ -73,7 +72,7 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
 
         updated_warning = {
             "id": incident_activity_id,
-            "incidentIdentifier": incident_identifier,
+            "incidentIdentifier": self.incident_identifier,
             "type": IncidentActivityType.STATUS_CHANGE,
             "value": IncidentStatus.WARNING,
             "previousValue": None,
@@ -105,7 +104,7 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
         )
         updated_critical = {
             "id": incident_activity_id,
-            "incidentIdentifier": incident_identifier,
+            "incidentIdentifier": self.incident_identifier,
             "type": IncidentActivityType.STATUS_CHANGE,
             "value": IncidentStatus.CRITICAL,
             "previousValue": IncidentStatus.WARNING,
@@ -142,7 +141,7 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
 
         resolved = {
             "id": incident_activity_id,
-            "incidentIdentifier": incident_identifier,
+            "incidentIdentifier": self.incident_identifier,
             "type": IncidentActivityType.STATUS_CHANGE,
             "value": IncidentStatus.CLOSED,
             "previousValue": IncidentStatus.CRITICAL,

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -145,7 +145,7 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
             "incidentIdentifier": incident_identifier,
             "type": IncidentActivityType.STATUS_CHANGE,
             "value": IncidentStatus.CLOSED,
-            "previousValue": None,  # TODO we should have this info
+            "previousValue": IncidentStatus.CRITICAL,
             "user": self.group_open_period.user_id,
             "comment": None,
             "dateCreated": self.group_open_period.date_started,

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -1,13 +1,20 @@
+from datetime import timedelta
+
 from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineIncidentSerializer,
 )
+from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models.incident import (
     IncidentActivityType,
     IncidentStatus,
     IncidentStatusMethod,
     IncidentType,
 )
+from sentry.issues.priority import PriorityChangeReason
+from sentry.models.activity import Activity
+from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 from tests.sentry.incidents.serializers.test_workflow_engine_base import TestWorklowEngineSerializer
 
 
@@ -16,7 +23,7 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
         super().setUp()
         self.add_warning_trigger()
         self.add_incident_data()
-        self.expected_activities = None  # TODO add activities
+        self.expected_activities = None
         self.incident_expected = {
             "id": str(self.incident_group_open_period.incident_id),
             "identifier": str(self.group_open_period.id),  # temp and wrong
@@ -45,10 +52,13 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
         assert serialized_incident == self.incident_expected
 
     def test_activity(self) -> None:
+        incident_activity_id = "-1"  # temp and wrong
+        incident_identifier = "-1"  # temp and wrong
+
         open_period_activities = []
         created = {
-            "id": "-1",  # temp and wrong
-            "incidentIdentifier": "-1",  # temp and wrong
+            "id": incident_activity_id,
+            "incidentIdentifier": incident_identifier,
             "type": IncidentActivityType.CREATED,
             "value": None,
             "previousValue": None,
@@ -60,6 +70,18 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
         detected["type"] = IncidentActivityType.DETECTED
         open_period_activities.append(created)
         open_period_activities.append(detected)
+
+        updated_warning = {
+            "id": incident_activity_id,
+            "incidentIdentifier": incident_identifier,
+            "type": IncidentActivityType.STATUS_CHANGE,
+            "value": IncidentStatus.WARNING,
+            "previousValue": None,
+            "user": None,
+            "comment": None,
+            "dateCreated": self.group_open_period.date_started,
+        }
+        open_period_activities.append(updated_warning)
         self.incident_expected["activities"] = open_period_activities
 
         serialized_incident = serialize(
@@ -69,6 +91,76 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
         )
         assert serialized_incident == self.incident_expected
 
-        # TODO add status changes
+        # escalate to critical status
+        update_incident_status(self.incident, IncidentStatus.CRITICAL)
+        Activity.objects.create(
+            project=self.group_open_period.group.project,
+            group=self.group_open_period.group,
+            type=ActivityType.SET_PRIORITY.value,
+            data={
+                "priority": PriorityLevel.HIGH.to_str(),
+                "reason": PriorityChangeReason.ONGOING,
+            },
+            datetime=self.now + timedelta(minutes=5),
+        )
+        updated_critical = {
+            "id": incident_activity_id,
+            "incidentIdentifier": incident_identifier,
+            "type": IncidentActivityType.STATUS_CHANGE,
+            "value": IncidentStatus.CRITICAL,
+            "previousValue": IncidentStatus.WARNING,
+            "user": None,
+            "comment": None,
+            "dateCreated": self.group_open_period.date_started,
+        }
+        open_period_activities.append(updated_critical)
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        assert serialized_incident == self.incident_expected
 
-        # TODOadd resolution activity
+        # resolve incident
+        update_incident_status(
+            self.incident,
+            IncidentStatus.CLOSED,
+            IncidentStatusMethod.RULE_UPDATED,
+            self.group_open_period.date_ended,
+        )
+        resolution_activity = Activity.objects.create(
+            project=self.group_open_period.group.project,
+            group=self.group_open_period.group,
+            user_id=self.group_open_period.user_id,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            datetime=self.now + timedelta(minutes=10),
+        )
+        self.group_open_period.date_ended = self.now + timedelta(days=1)
+        self.group_open_period.resolution_activity = resolution_activity
+        self.group_open_period.save()
+
+        resolved = {
+            "id": incident_activity_id,
+            "incidentIdentifier": incident_identifier,
+            "type": IncidentActivityType.STATUS_CHANGE,
+            "value": IncidentStatus.CLOSED,
+            "previousValue": None,  # TODO we should have this info
+            "user": self.group_open_period.user_id,
+            "comment": None,
+            "dateCreated": self.group_open_period.date_started,
+        }
+        open_period_activities.append(resolved)
+        self.incident_expected["statusMethod"] = IncidentStatusMethod.RULE_UPDATED.value
+        self.incident_expected["status"] = IncidentStatus.CLOSED.value
+        self.incident_expected["dateClosed"] = (
+            self.group_open_period.date_ended.replace(second=0, microsecond=0)
+            if self.group_open_period.date_ended
+            else None
+        )
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        assert serialized_incident == self.incident_expected

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
+    WorkflowEngineDetailedIncidentSerializer,
     WorkflowEngineIncidentSerializer,
 )
 from sentry.incidents.logic import update_incident_status
@@ -162,4 +163,11 @@ class TestDetectorSerializer(TestWorklowEngineSerializer):
             self.user,
             WorkflowEngineIncidentSerializer(expand=["activities"]),
         )
+        assert serialized_incident == self.incident_expected
+
+    def test_detailed(self) -> None:
+        serialized_incident = serialize(
+            self.group_open_period, self.user, WorkflowEngineDetailedIncidentSerializer()
+        )
+        self.incident_expected["discoverQuery"] = "(event.type:error) AND (level:error)"
         assert serialized_incident == self.incident_expected

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -1,94 +1,40 @@
-from django.utils import timezone
-
 from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineIncidentSerializer,
 )
-from sentry.incidents.models.incident import (
-    IncidentStatus,
-    IncidentStatusMethod,
-    IncidentTrigger,
-    IncidentType,
-    TriggerStatus,
-)
-from sentry.models.groupopenperiod import GroupOpenPeriod
-from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.datetime import freeze_time
-from sentry.types.group import PriorityLevel
-from sentry.workflow_engine.migration_helpers.alert_rule import (
-    migrate_alert_rule,
-    migrate_metric_action,
-    migrate_metric_data_conditions,
-    migrate_resolve_threshold_data_condition,
-)
-from sentry.workflow_engine.models import ActionGroupStatus, IncidentGroupOpenPeriod
+from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod, IncidentType
+from tests.sentry.incidents.serializers.test_workflow_engine_base import TestWorklowEngineSerializer
 
 
-@freeze_time("2024-12-11 03:21:34")
-class TestDetectorSerializer(TestCase):
+class TestDetectorSerializer(TestWorklowEngineSerializer):
     def setUp(self) -> None:
-        self.alert_rule = self.create_alert_rule()
-        self.critical_trigger = self.create_alert_rule_trigger(
-            alert_rule=self.alert_rule, label="critical"
-        )
-        self.critical_trigger_action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=self.critical_trigger
-        )
-        self.warning_trigger = self.create_alert_rule_trigger(
-            alert_rule=self.alert_rule, label="warning"
-        )
-        self.warning_trigger_action = self.create_alert_rule_trigger_action(
-            alert_rule_trigger=self.warning_trigger
-        )
-        _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        self.critical_detector_trigger, _ = migrate_metric_data_conditions(self.critical_trigger)
-        self.warning_detector_trigger, _ = migrate_metric_data_conditions(self.warning_trigger)
-
-        self.critical_action, _, _ = migrate_metric_action(self.critical_trigger_action)
-        self.warning_action, _, _ = migrate_metric_action(self.warning_trigger_action)
-        self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(
-            self.alert_rule
-        )
-
-        now = timezone.now()
-        self.incident = self.create_incident(alert_rule=self.alert_rule, date_started=now)
-        IncidentTrigger.objects.create(
-            incident=self.incident,
-            alert_rule_trigger=self.critical_trigger,
-            status=TriggerStatus.ACTIVE.value,
-        )
-        # TODO make the incident go from warning / critical etc. and make Activity rows for that
-        self.group.priority = PriorityLevel.HIGH
-        self.group.save()
-        ActionGroupStatus.objects.create(action=self.critical_action, group=self.group)
-        self.group_open_period = GroupOpenPeriod.objects.create(
-            group=self.group, project=self.detector.project, date_started=self.incident.date_started
-        )
-        self.incident_group_open_period = IncidentGroupOpenPeriod.objects.create(
-            group_open_period=self.group_open_period, incident_id=self.incident.id
-        )
-        alert_rule_data = (
-            {}
-        )  # fill this out, might want to refactor tests to have a shared base class so I can grab this easily
-        self.expected = {
+        super().setUp()
+        self.add_warning_trigger()
+        self.add_incident_data()
+        self.expected_activities = None  # TODO add activities
+        self.incident_expected = {
             "id": str(self.incident_group_open_period.incident_id),
-            "identifier": str(self.group_open_period.id),  # this is temporary and incorrect
-            "organizationId": str(self.organization.id),
+            "identifier": str(self.group_open_period.id),  # temp and wrong
+            "organizationId": str(self.group_open_period.project.organization_id),
             "projects": [self.project.slug],
-            "alertRule": alert_rule_data,
-            "activities": None,  # TODO fill this out
+            "alertRule": self.expected,
+            "activities": self.expected_activities,
             "status": IncidentStatus.CRITICAL.value,
             "statusMethod": IncidentStatusMethod.RULE_TRIGGERED.value,
             "type": IncidentType.ALERT_TRIGGERED.value,
-            "title": self.group_open_period.group.title,
+            "title": self.group.title,
             "dateStarted": self.group_open_period.date_started,
             "dateDetected": self.group_open_period.date_started,
             "dateCreated": self.group_open_period.date_added,
-            "dateClosed": self.group_open_period.date_ended,
+            "dateClosed": (
+                self.group_open_period.date_ended.replace(second=0, microsecond=0)
+                if self.group_open_period.date_ended
+                else None
+            ),
         }
 
     def test_simple(self) -> None:
         serialized_incident = serialize(
             self.group_open_period, self.user, WorkflowEngineIncidentSerializer()
         )
-        assert serialized_incident == self.expected
+        assert serialized_incident == self.incident_expected

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -1,0 +1,94 @@
+from django.utils import timezone
+
+from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
+    WorkflowEngineIncidentSerializer,
+)
+from sentry.incidents.models.incident import (
+    IncidentStatus,
+    IncidentStatusMethod,
+    IncidentTrigger,
+    IncidentType,
+    TriggerStatus,
+)
+from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    migrate_alert_rule,
+    migrate_metric_action,
+    migrate_metric_data_conditions,
+    migrate_resolve_threshold_data_condition,
+)
+from sentry.workflow_engine.models import ActionGroupStatus, IncidentGroupOpenPeriod
+
+
+@freeze_time("2024-12-11 03:21:34")
+class TestDetectorSerializer(TestCase):
+    def setUp(self) -> None:
+        self.alert_rule = self.create_alert_rule()
+        self.critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.alert_rule, label="critical"
+        )
+        self.critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.critical_trigger
+        )
+        self.warning_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.alert_rule, label="warning"
+        )
+        self.warning_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.warning_trigger
+        )
+        _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
+        self.critical_detector_trigger, _ = migrate_metric_data_conditions(self.critical_trigger)
+        self.warning_detector_trigger, _ = migrate_metric_data_conditions(self.warning_trigger)
+
+        self.critical_action, _, _ = migrate_metric_action(self.critical_trigger_action)
+        self.warning_action, _, _ = migrate_metric_action(self.warning_trigger_action)
+        self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(
+            self.alert_rule
+        )
+
+        now = timezone.now()
+        self.incident = self.create_incident(alert_rule=self.alert_rule, date_started=now)
+        IncidentTrigger.objects.create(
+            incident=self.incident,
+            alert_rule_trigger=self.critical_trigger,
+            status=TriggerStatus.ACTIVE.value,
+        )
+        # TODO make the incident go from warning / critical etc. and make Activity rows for that
+        self.group.priority = PriorityLevel.HIGH
+        self.group.save()
+        ActionGroupStatus.objects.create(action=self.critical_action, group=self.group)
+        self.group_open_period = GroupOpenPeriod.objects.create(
+            group=self.group, project=self.detector.project, date_started=self.incident.date_started
+        )
+        self.incident_group_open_period = IncidentGroupOpenPeriod.objects.create(
+            group_open_period=self.group_open_period, incident_id=self.incident.id
+        )
+        alert_rule_data = (
+            {}
+        )  # fill this out, might want to refactor tests to have a shared base class so I can grab this easily
+        self.expected = {
+            "id": str(self.incident_group_open_period.incident_id),
+            "identifier": str(self.group_open_period.id),  # this is temporary and incorrect
+            "organizationId": str(self.organization.id),
+            "projects": [self.project.slug],
+            "alertRule": alert_rule_data,
+            "activities": None,  # TODO fill this out
+            "status": IncidentStatus.CRITICAL.value,
+            "statusMethod": IncidentStatusMethod.RULE_TRIGGERED.value,
+            "type": IncidentType.ALERT_TRIGGERED.value,
+            "title": self.group_open_period.group.title,
+            "dateStarted": self.group_open_period.date_started,
+            "dateDetected": self.group_open_period.date_started,
+            "dateCreated": self.group_open_period.date_added,
+            "dateClosed": self.group_open_period.date_ended,
+        }
+
+    def test_simple(self) -> None:
+        serialized_incident = serialize(
+            self.group_open_period, self.user, WorkflowEngineIncidentSerializer()
+        )
+        assert serialized_incident == self.expected


### PR DESCRIPTION
Update the `WorkflowEngineIncidentSerializer` to return real data instead of dummy data for the incident endpoint and when the detector serializer requires it.

For now I'm hardcoding the incident identifier and the incident activity id until we add a column on the `IncidentGroupOpenPeriod` lookup table for the incident identifier and add a lookup table between `Activity` and `IncidentActivity`.