### PR TITLE
feat(seer billing): define category info

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -434,6 +434,27 @@ export const DATA_CATEGORY_INFO = {
     uid: 24,
     isBilledCategory: false,
   },
+  // TODO(Seer): Confirm naming
+  [DataCategoryExact.SEER_AUTOFIX]: {
+    name: DataCategoryExact.SEER_AUTOFIX,
+    apiName: 'seer_autofix',
+    plural: DataCategory.SEER_AUTOFIX,
+    displayName: 'issue fix run',
+    titleName: t('Issue Fix Run'),
+    productName: t('Seer'),
+    uid: 27,
+    isBilledCategory: false, // TODO(Seer): change to True for launch
+  },
+  [DataCategoryExact.SEER_SCANNER]: {
+    name: DataCategoryExact.SEER_SCANNER,
+    apiName: 'seer_scanner',
+    plural: DataCategory.SEER_SCANNER,
+    displayName: 'issue triage run',
+    titleName: t('Issue Triage Run'),
+    productName: t('Seer'),
+    uid: 28,
+    isBilledCategory: false, // TODO(Seer): change to True for launch
+  },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;
 
 // Special Search characters

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -90,6 +90,8 @@ export enum DataCategory {
   UPTIME = 'uptime',
   LOG_ITEM = 'logItems',
   LOG_BYTE = 'logBytes',
+  SEER_AUTOFIX = 'seerAutofix',
+  SEER_SCANNER = 'seerScanner',
 }
 
 /**
@@ -113,9 +115,10 @@ export enum DataCategoryExact {
   SPAN = 'span',
   SPAN_INDEXED = 'spanIndexed',
   UPTIME = 'uptime',
-
   LOG_ITEM = 'logItem',
   LOG_BYTE = 'logByte',
+  SEER_AUTOFIX = 'seerAutofix',
+  SEER_SCANNER = 'seerScanner',
 }
 
 export interface DataCategoryInfo {

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -165,4 +165,20 @@ export const BILLED_DATA_CATEGORY_INFO = {
     freeEventsMultiple: 1, // in hours
     feature: null,
   },
+  [DataCategoryExact.SEER_AUTOFIX]: {
+    ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_AUTOFIX],
+    canAllocate: false,
+    canProductTrial: true,
+    maxAdminGift: 0,
+    freeEventsMultiple: 0,
+    feature: 'track-seer-outcomes',
+  },
+  [DataCategoryExact.SEER_SCANNER]: {
+    ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_SCANNER],
+    canAllocate: false,
+    canProductTrial: true,
+    maxAdminGift: 0,
+    freeEventsMultiple: 0,
+    feature: 'track-seer-outcomes',
+  },
 } as const satisfies Record<DataCategoryExact, BilledDataCategoryInfo>;


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-617/add-the-new-category-to-data-category-info-in-the-frontend and https://linear.app/getsentry/issue/BIL-651/set-billed-data-categorydatacategoryexactnew-categorycanproducttrial