### PR TITLE
fix(aci): Minor fixes for the open period backfill

### DIFF
--- a/src/sentry/migrations/0878_backfill_open_periods.py
+++ b/src/sentry/migrations/0878_backfill_open_periods.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CHUNK_SIZE = 10000
+CHUNK_SIZE = 100
 
 
 # copied constants and enums
@@ -51,8 +51,6 @@ class GroupStatus:
 
 
 # end copy
-
-BATCH_SIZE = 100
 
 
 def get_open_periods_for_group(

--- a/src/sentry/migrations/0878_backfill_open_periods.py
+++ b/src/sentry/migrations/0878_backfill_open_periods.py
@@ -182,7 +182,7 @@ def _backfill_group_open_periods(
 def backfill_group_open_periods(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
     Group = apps.get_model("sentry", "Group")
 
-    backfill_key = "backfill_group_open_periods_from_activity"
+    backfill_key = "backfill_group_open_periods_from_activity_1"
     redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
 
     progress_id = int(redis_client.get(backfill_key) or 0)

--- a/src/sentry/migrations/0878_backfill_open_periods.py
+++ b/src/sentry/migrations/0878_backfill_open_periods.py
@@ -62,7 +62,7 @@ def get_open_periods_for_group(
     activities: list[Any],
     GroupOpenPeriod: Any,
 ) -> list[Any]:
-    # Filter to REGRESSION and RESOLVED activties to find the bounds of each open period.
+    # Filter to REGRESSION and SET_RESOLVED_XX activties to find the bounds of each open period.
     # The only UNRESOLVED activity we would care about is the first UNRESOLVED activity for the group creation,
     # but we don't create an entry for that.
     open_periods = []
@@ -96,6 +96,13 @@ def get_open_periods_for_group(
                     extra={"group_id": group_id, "starting_activity": activity.id},
                 )
             if start is not None and end is not None:
+                if start > end:
+                    logger.error(
+                        "Open period has invalid start and end dates",
+                        extra={"group_id": group_id},
+                    )
+                    return []
+
                 open_periods.append(
                     GroupOpenPeriod(
                         group_id=group_id,


### PR DESCRIPTION
4 fixes in this pr: 
* Reducing the chunk size to 100 - some of these groups a large number of activities, we're better off processing it in smaller batches
* Skip groups that fail the date_started < date_ended invariant - this will fail when we try to write it anyway. We'll need to look at the failures and do a second pass later to fix them.
* Wrap bulk_create in try/except to continue processing 
* Bump the redis key so we can restart from 0