### PR TITLE
chore(seer rpc): Return empty list if snuba rpc fails

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeNamesRequest,
     TraceItemAttributeValuesRequest,
+    TraceItemAttributeValuesResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
@@ -292,7 +293,7 @@ def get_attribute_values(
             values_response = snuba_rpc.attribute_values_rpc(req)
         except Exception:
             logger.warning("Error with fetching attribute %s", field)
-            values_response = []
+            values_response = TraceItemAttributeValuesResponse(values=[])
 
         values[field["key"]] = [value for value in values_response.values]
 

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -231,7 +231,6 @@ def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: st
                     "string" if attr_type == AttributeKey.Type.TYPE_STRING else "number",
                     SupportedTraceItemType.SPANS,
                 )["key"],
-                # "name": attr.name,
                 "type": attr_type,
             }
             for attr in fields_resp.attributes
@@ -289,7 +288,12 @@ def get_attribute_values(
             limit=limit,
         )
 
-        values_response = snuba_rpc.attribute_values_rpc(req)
+        try:
+            values_response = snuba_rpc.attribute_values_rpc(req)
+        except Exception:
+            logger.warning("Error with fetching attribute %s", field)
+            values_response = []
+
         values[field["key"]] = [value for value in values_response.values]
 
     return {"values": values}


### PR DESCRIPTION
- Add exception handling in case snuba rpc fails due to missing definition for fetching attribute value
- defaults to an empty list for values if failure