### PR TITLE
fix(insights): capitalize instead of uppercase button in issues widget

### DIFF
--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -308,13 +308,13 @@ const SuperHeaderLabel = styled(IssueStreamHeaderLabel)`
   font-size: 1rem;
   line-height: 1.2;
   padding-left: ${space(1)};
-  text-transform: capitalize;
   font-weight: ${p => p.theme.fontWeightBold};
 `;
 
 const SuperHeader = styled(PanelHeader)`
   background-color: ${p => p.theme.headerBackground};
   padding: ${space(1)};
+  text-transform: capitalize;
 `;
 
 const HeaderContainer = styled('div')`


### PR DESCRIPTION
- Move `capitalize` from SuperHeaderLabel to SuperHeader - otherwise the button inherits `uppercase` from PanelHeader

Before: 
![Screenshot 2025-05-05 at 10 36 32](https://github.com/user-attachments/assets/258adb86-00d2-4dfe-9271-82c13b007a38)

After:
![Screenshot 2025-05-05 at 10 36 36](https://github.com/user-attachments/assets/a33165b2-c05e-44b4-a6d9-533e4c5c916b)