### PR TITLE
feat(explore): Add contains to filter search options

### DIFF
--- a/fixtures/search-syntax/aggregate_rel_time_filter.json
+++ b/fixtures/search-syntax/aggregate_rel_time_filter.json
@@ -67,7 +67,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "-2w", "quoted": false}
+        "value": {"type": "valueText", "value": "-2w", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/basic_fallthrough.json
+++ b/fixtures/search-syntax/basic_fallthrough.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "<hello", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "<hello",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "<512.1.0", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "<512.1.0",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +49,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "2018-01-01", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "2018-01-01",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +69,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "+7d", "quoted": false}
+        "value": {"type": "valueText", "value": "+7d", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -69,7 +84,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">2018-01-01", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">2018-01-01",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -84,7 +104,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hello", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "hello",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -99,7 +124,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/custom_explicit_tag.json
+++ b/fixtures/search-syntax/custom_explicit_tag.json
@@ -13,7 +13,12 @@
           "key": {"type": "keySimple", "value": "fruit", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "apple", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -22,7 +27,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -35,7 +45,7 @@
           "key": {"type": "keySimple", "value": "project_id", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/custom_tag.json
+++ b/fixtures/search-syntax/custom_tag.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "fruit", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "apple", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -18,7 +23,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -33,7 +43,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "p95", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">5s", "quoted": false}
+        "value": {"type": "valueText", "value": ">5s", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -48,7 +58,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "p95", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">5k", "quoted": false}
+        "value": {"type": "valueText", "value": ">5k", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/disallow_wildcard_filter.json
+++ b/fixtures/search-syntax/disallow_wildcard_filter.json
@@ -57,7 +57,8 @@
               "value": {
                 "quoted": false,
                 "type": "valueText",
-                "value": "*"
+                "value": "*",
+                "contains": false
               }
             }
           ],
@@ -94,7 +95,8 @@
         "value": {
           "type": "valueText",
           "value": "*",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         },
         "invalid": {
           "type": "wildcard-not-allowed",

--- a/fixtures/search-syntax/duration_on_non_duration_field.json
+++ b/fixtures/search-syntax/duration_on_non_duration_field.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "500s", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "500s",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/empty_filter_value.json
+++ b/fixtures/search-syntax/empty_filter_value.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "", "quoted": true}
+        "value": {"type": "valueText", "value": "", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -28,7 +28,7 @@
         },
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "", "quoted": false}
+        "value": {"type": "valueText", "value": "", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/empty_spaces_stripped_correctly.json
+++ b/fixtures/search-syntax/empty_spaces_stripped_correctly.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "event.type", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "transaction", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "transaction",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": "   "},
       {
@@ -21,7 +26,8 @@
         "value": {
           "type": "valueText",
           "value": "/organizations/:orgId/discover/results/",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {"type": "spaces", "value": ""}

--- a/fixtures/search-syntax/escaped_quote_value.json
+++ b/fixtures/search-syntax/escaped_quote_value.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\\\"", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "\\\"",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "te\\\"st", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "te\\\"st",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -40,7 +50,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "te", "quoted": true}
+        "value": {"type": "valueText", "value": "te", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": ""},
       {"type": "freeText", "value": "st", "quoted": false, "invalid": null},

--- a/fixtures/search-syntax/escaped_quotes.json
+++ b/fixtures/search-syntax/escaped_quotes.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\\\"thing\\\"", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\\\"thing\\\"",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\\\"\\\"release", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\\\"\\\"release",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/explicit_number_tag.json
+++ b/fixtures/search-syntax/explicit_number_tag.json
@@ -13,7 +13,7 @@
           "key": {"type": "keySimple", "value": "foo", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "456", "quoted": false}
+        "value": {"type": "valueText", "value": "456", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {
@@ -22,7 +22,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -35,7 +40,7 @@
           "key": {"type": "keySimple", "value": "project_id", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/explicit_number_tags_in_filter.json
+++ b/fixtures/search-syntax/explicit_number_tags_in_filter.json
@@ -18,11 +18,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "123", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "123",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "456", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "456",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -31,4 +41,3 @@
     ]
   }
 ]
-

--- a/fixtures/search-syntax/explicit_string_tag.json
+++ b/fixtures/search-syntax/explicit_string_tag.json
@@ -13,7 +13,12 @@
           "key": {"type": "keySimple", "value": "fruit", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "apple", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -22,7 +27,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -35,7 +45,7 @@
           "key": {"type": "keySimple", "value": "project_id", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/explicit_string_tags_in_filter.json
+++ b/fixtures/search-syntax/explicit_string_tags_in_filter.json
@@ -18,11 +18,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "apple",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -49,11 +59,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple wow", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "apple wow",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -62,4 +82,3 @@
     ]
   }
 ]
-

--- a/fixtures/search-syntax/explicit_tags_in_filter.json
+++ b/fixtures/search-syntax/explicit_tags_in_filter.json
@@ -18,11 +18,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "apple",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -49,11 +59,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple wow", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "apple wow",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }

--- a/fixtures/search-syntax/free_text_search_anywhere.json
+++ b/fixtures/search-syntax/free_text_search_anywhere.json
@@ -11,7 +11,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "where ", "quoted": false, "invalid": null},
@@ -22,7 +27,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "when", "quoted": false, "invalid": null},
@@ -65,7 +75,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "there", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "bye", "quoted": false}
+        "value": {"type": "valueText", "value": "bye", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/has_tag.json
+++ b/fixtures/search-syntax/has_tag.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "release", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "release",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +31,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hi:there", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "hi:there",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -42,7 +52,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hi there", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "hi there",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_boolean_filter.json
+++ b/fixtures/search-syntax/invalid_boolean_filter.json
@@ -14,7 +14,7 @@
         },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "lol", "quoted": false}
+        "value": {"type": "valueText", "value": "lol", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -34,7 +34,7 @@
         },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +54,12 @@
         },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">true", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">true",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_date_formats.json
+++ b/fixtures/search-syntax/invalid_date_formats.json
@@ -14,7 +14,12 @@
         },
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hello", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "hello",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -34,7 +39,7 @@
         },
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +59,12 @@
         },
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "2018-01-01T00:01ZZ", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "2018-01-01T00:01ZZ",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_duration_filter.json
+++ b/fixtures/search-syntax/invalid_duration_filter.json
@@ -14,7 +14,12 @@
         },
         "key": {"quoted": false, "type": "keySimple", "value": "transaction.duration"},
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": ">..500s"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": ">..500s",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_numeric_fields.json
+++ b/fixtures/search-syntax/invalid_numeric_fields.json
@@ -14,7 +14,7 @@
         },
         "key": {"type": "keySimple", "value": "project.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "one", "quoted": false}
+        "value": {"type": "valueText", "value": "one", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -34,7 +34,7 @@
         },
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "two", "quoted": false}
+        "value": {"type": "valueText", "value": "two", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +54,12 @@
         },
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">hotdog", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">hotdog",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -74,7 +79,12 @@
         },
         "key": {"type": "keySimple", "value": "measurements.lcp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">hotdog", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">hotdog",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -94,7 +104,12 @@
         },
         "key": {"type": "keySimple", "value": "spans.db", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">hotdog", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">hotdog",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_numeric_shorthand.json
+++ b/fixtures/search-syntax/invalid_numeric_shorthand.json
@@ -14,7 +14,7 @@
         },
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">3s", "quoted": false}
+        "value": {"type": "valueText", "value": ">3s", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/multiple_quotes.json
+++ b/fixtures/search-syntax/multiple_quotes.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "", "quoted": true}
+        "value": {"type": "valueText", "value": "", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {
@@ -18,7 +18,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "Chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "Chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -33,7 +38,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\\\"", "quoted": true}
+        "value": {"type": "valueText", "value": "\\\"", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {
@@ -42,7 +47,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "Chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "Chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/negated_duration_on_non_duration_field.json
+++ b/fixtures/search-syntax/negated_duration_on_non_duration_field.json
@@ -9,7 +9,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "500s", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "500s",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/negated_on_boolean_values_and_non_boolean_field.json
+++ b/fixtures/search-syntax/negated_on_boolean_values_and_non_boolean_field.json
@@ -9,7 +9,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "true", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "true",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1", "quoted": false}
+        "value": {"type": "valueText", "value": "1", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/newline_within_quote.json
+++ b/fixtures/search-syntax/newline_within_quote.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\nrelease", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\nrelease",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/not_has_tag.json
+++ b/fixtures/search-syntax/not_has_tag.json
@@ -10,7 +10,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "release", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "release",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +31,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hi:there", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "hi:there",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_filter.json
+++ b/fixtures/search-syntax/numeric_filter.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random_field", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">500", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">500",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +31,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "random_field", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">500", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">500",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -41,7 +51,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "random_field", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "500", "quoted": false}
+        "value": {"type": "valueText", "value": "500", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_in_filter.json
+++ b/fixtures/search-syntax/numeric_in_filter.json
@@ -293,15 +293,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "500", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "500",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "501", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "501",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "502", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "502",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }

--- a/fixtures/search-syntax/other_dates.json
+++ b/fixtures/search-syntax/other_dates.json
@@ -54,7 +54,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">2015-05-18", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">2015-05-18",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/quoted_free_text_search_anywhere.json
+++ b/fixtures/search-syntax/quoted_free_text_search_anywhere.json
@@ -11,7 +11,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "general kenobi", "quoted": true, "invalid": null},

--- a/fixtures/search-syntax/quoted_key.json
+++ b/fixtures/search-syntax/quoted_key.json
@@ -9,7 +9,12 @@
         "key": {"quoted": true, "type": "keySimple", "value": "hi:there"},
         "operator": "",
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": "value"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "value",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "key": {"quoted": true, "type": "keySimple", "value": "hi:there"},
         "operator": "",
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": "value"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "value",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/quoted_val.json
+++ b/fixtures/search-syntax/quoted_val.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a release", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a release",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a release", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a release",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -44,7 +54,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -67,11 +82,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "b release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "b release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -94,15 +119,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ",    ",
-              "value": {"type": "valueText", "value": "b release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "b release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "c release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "c release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -125,11 +165,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "b release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "b release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -152,7 +202,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -169,7 +224,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "123", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "123",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }

--- a/fixtures/search-syntax/quotes_filtered_on_raw.json
+++ b/fixtures/search-syntax/quotes_filtered_on_raw.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "thinger", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "unknown", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "unknown",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "what is this?", "quoted": true, "invalid": null},

--- a/fixtures/search-syntax/rel_time_filter.json
+++ b/fixtures/search-syntax/rel_time_filter.json
@@ -85,7 +85,8 @@
         "value": {
           "type": "valueText",
           "value": "-2w",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {

--- a/fixtures/search-syntax/semver.json
+++ b/fixtures/search-syntax/semver.json
@@ -9,7 +9,12 @@
         "negated": false,
         "operator": ">",
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "key": {"quoted": false, "type": "keySimple", "value": "release.version"},
         "negated": false,
         "operator": ">",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3-hi"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3-hi",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +49,12 @@
         "key": {"quoted": false, "type": "keySimple", "value": "release.version"},
         "negated": false,
         "operator": ">=",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3-hi"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3-hi",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +69,12 @@
         "key": {"quoted": false, "type": "keySimple", "value": "release.version"},
         "negated": false,
         "operator": "",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3-hi"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3-hi",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/simple.json
+++ b/fixtures/search-syntax/simple.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -19,7 +24,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "hello", "quoted": false, "invalid": null},
@@ -38,7 +48,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -47,7 +62,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/simple_in.json
+++ b/fixtures/search-syntax/simple_in.json
@@ -14,7 +14,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -31,7 +36,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "hello", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "hello",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -54,15 +64,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "test2@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test2@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "test3@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test3@test.com",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -79,7 +104,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "hello", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "hello",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -102,15 +132,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "test@test2.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test2.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",     ",
-              "value": {"type": "valueText", "value": "test@test3.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test3.com",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -127,7 +172,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "hello", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "hello",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -145,7 +195,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "h[e]llo]", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "h[e]llo]",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -160,7 +215,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h[e]llo", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "[h[e]llo",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -175,7 +235,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h]", "quoted": true}
+        "value": {"type": "valueText", "value": "[h]", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -190,7 +250,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h]*", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "[h]*",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -205,7 +270,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h", "quoted": false}
+        "value": {"type": "valueText", "value": "[h", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "e]", "quoted": false, "invalid": null},
@@ -222,7 +287,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[]", "quoted": false}
+        "value": {"type": "valueText", "value": "[]", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -242,15 +307,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "hi", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "hi",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "1", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "1",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -273,15 +353,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "hi", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "hi",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "1.0", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "1.0",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -304,7 +399,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "[h]", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "[h]",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -327,11 +427,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "a",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "[h]", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "[h]",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -352,7 +462,8 @@
         "value": {
           "type": "valueText",
           "value": "[test@test.com]user.email:hello@hello.com",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {"type": "spaces", "value": ""}
@@ -377,7 +488,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",

--- a/fixtures/search-syntax/sooo_many_quotes.json
+++ b/fixtures/search-syntax/sooo_many_quotes.json
@@ -12,7 +12,8 @@
         "value": {
           "type": "valueText",
           "value": "\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"",
-          "quoted": true
+          "quoted": true,
+          "contains": false
         }
       },
       {"type": "spaces", "value": ""}

--- a/fixtures/search-syntax/specific_time_filter.json
+++ b/fixtures/search-syntax/specific_time_filter.json
@@ -119,7 +119,8 @@
         "value": {
           "type": "valueText",
           "value": "2018-01-01T05:06:07",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {

--- a/fixtures/search-syntax/supported_tags.json
+++ b/fixtures/search-syntax/supported_tags.json
@@ -19,7 +19,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -32,7 +37,12 @@
         },
         "key": {"type": "keySimple", "value": "os", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "*windows*", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "windows",
+          "quoted": false,
+          "contains": true
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -57,7 +67,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {

--- a/fixtures/search-syntax/tab_outside_quote.json
+++ b/fixtures/search-syntax/tab_outside_quote.json
@@ -10,7 +10,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a", "quoted": false}
+        "value": {"type": "valueText", "value": "a", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""},
       {"quoted": false, "type": "freeText", "value": "\trelease", "invalid": null},

--- a/fixtures/search-syntax/tab_within_quote.json
+++ b/fixtures/search-syntax/tab_within_quote.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\trelease", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\trelease",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/trailing_quote_value.json
+++ b/fixtures/search-syntax/trailing_quote_value.json
@@ -13,7 +13,12 @@
         },
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\"test", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "\"test",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -32,7 +37,12 @@
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "test\"", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "test\"",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -51,7 +61,12 @@
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\"test", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "\"test",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -60,7 +75,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "transaction", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "abadcafe", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "abadcafe",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -79,7 +99,12 @@
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "te\"st", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "te\"st",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -88,7 +113,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "transaction", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "abadcafe", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "abadcafe",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -514,6 +514,13 @@ function multiSelectTokenValue(
       return updateFilterMultipleValues(state, action.token, newValues);
     }
     default: {
+      if (
+        tokenValue.type === Token.VALUE_TEXT &&
+        tokenValue.contains &&
+        tokenValue.value === action.value
+      ) {
+        return updateFilterMultipleValues(state, action.token, ['']);
+      }
       if (tokenValue.text === action.value) {
         return updateFilterMultipleValues(state, action.token, ['']);
       }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -174,20 +174,24 @@ function modifyFilterOperatorQuery(
   // if the operator is contains, update the token (output value) to be wrapped in stars
   if (newOperator === TermOperatorNew.CONTAINS) {
     newToken.operator = TermOperator.DEFAULT;
-    if (
-      newToken.value.type === Token.VALUE_TEXT &&
-      !newToken.value.value.startsWith('*') &&
-      !newToken.value.value.endsWith('*')
-    ) {
-      newToken.value.value = `*${newToken.value.value}*`;
+    if (newToken.value.type === Token.VALUE_TEXT) {
+      if (!newToken.value.value.startsWith('*')) {
+        newToken.value.value = `*${newToken.value.value}`;
+      }
+
+      if (!newToken.value.value.endsWith('*')) {
+        newToken.value.value = `${newToken.value.value}*`;
+      }
     } else if (newToken.value.type === Token.VALUE_TEXT_LIST) {
       newToken.value.items.forEach(item => {
-        if (
-          item.value?.text &&
-          !item.value.text.startsWith('*') &&
-          !item.value.text.endsWith('*')
-        ) {
-          item.value.text = `*${item.value.text}*`;
+        if (item.value?.text) {
+          if (!item.value.text.startsWith('*')) {
+            item.value.text = `*${item.value.text}`;
+          }
+
+          if (!item.value.text.endsWith('*')) {
+            item.value.text = `${item.value.text}*`;
+          }
         }
       });
     }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -511,7 +511,12 @@ function multiSelectTokenValue(
   switch (tokenValue.type) {
     case Token.VALUE_TEXT_LIST:
     case Token.VALUE_NUMBER_LIST: {
-      const values = tokenValue.items.map(item => item.value?.text ?? '');
+      const values = tokenValue.items.map(item => {
+        if (item?.value?.type === Token.VALUE_TEXT && item.value.contains) {
+          return item.value?.value ?? '';
+        }
+        return item.value?.text ?? '';
+      });
       const containsValue = values.includes(action.value);
       const newValues = containsValue
         ? values.filter(value => value !== action.value)

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -458,6 +458,12 @@ function modifyFilterValue(
     return modifyFilterValueDate(query, token, newValue);
   }
 
+  if (token.value.type === Token.VALUE_TEXT) {
+    if (token.value.value.startsWith('*') && token.value.value.endsWith('*')) {
+      newValue = `*${newValue}*`;
+    }
+  }
+
   return replaceQueryToken(query, token.value, newValue);
 }
 
@@ -473,10 +479,19 @@ function updateFilterMultipleValues(
     return {...state, query: replaceQueryToken(state.query, token.value, '""')};
   }
 
-  const newValue =
-    uniqNonEmptyValues.length > 1
-      ? `[${uniqNonEmptyValues.join(',')}]`
-      : uniqNonEmptyValues[0]!;
+  let newValue = uniqNonEmptyValues[0]!;
+
+  if (uniqNonEmptyValues.length > 1) {
+    if (uniqNonEmptyValues.some(value => value.startsWith('*') && value.endsWith('*'))) {
+      const containsValues = uniqNonEmptyValues.map(value => {
+        return value.startsWith('*') && value.endsWith('*') ? value : `*${value}*`;
+      });
+
+      newValue = `[${containsValues.join(',')}]`;
+    } else {
+      newValue = `[${uniqNonEmptyValues.join(',')}]`;
+    }
+  }
 
   return {...state, query: replaceQueryToken(state.query, token.value, newValue)};
 }

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2107,6 +2107,34 @@ describe('SearchQueryBuilder', function () {
           await screen.findByRole('row', {name: 'release.version:>1.0'})
         ).toBeInTheDocument();
       });
+
+      it('wraps text values in stars when contains is selected', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="browser.name:foo" />);
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        );
+        await userEvent.click(screen.getByRole('option', {name: 'contains'}));
+
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:*foo*'})
+        ).toBeInTheDocument();
+      });
+
+      it('unwraps text values when contains is deselected', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:*foo*" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        );
+        await userEvent.click(screen.getByRole('option', {name: 'is'}));
+
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:foo'})
+        ).toBeInTheDocument();
+      });
     });
 
     describe('numeric', function () {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2108,6 +2108,40 @@ describe('SearchQueryBuilder', function () {
         ).toBeInTheDocument();
       });
 
+      it('includes contains operator', async function () {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="browser.name:foo" />);
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        );
+        expect(await screen.findByRole('option', {name: 'contains'})).toBeInTheDocument();
+      });
+
+      it('does not include contains operator when allowWildcard is false', async function () {
+        const filterKeys = {
+          [FieldKey.ISSUE_PRIORITY]: {
+            key: FieldKey.ISSUE_PRIORITY,
+            name: '',
+            allowAllOperators: false,
+            allowWildcard: false,
+          },
+        };
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            filterKeys={filterKeys}
+            filterKeySections={[]}
+            initialQuery="issue.priority:foo"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: issue.priority'})
+        );
+        expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
+        expect(screen.queryByRole('option', {name: 'contains'})).not.toBeInTheDocument();
+      });
+
       it('wraps text values in stars when contains is selected', async function () {
         render(<SearchQueryBuilder {...defaultProps} initialQuery="browser.name:foo" />);
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -53,15 +53,18 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
       const items = token.value.items;
 
       if (items.length === 1 && items[0]!.value) {
+        const isContains =
+          items[0]!.value.type === Token.VALUE_TEXT ? items[0]!.value.contains : false;
+
         return (
           <FilterValueSingleTruncatedValue>
-            {formatFilterValue(items[0]!.value, false)}
+            {formatFilterValue(items[0]!.value, isContains)}
           </FilterValueSingleTruncatedValue>
         );
       }
 
       const maxItems = size === 'small' ? 1 : 3;
-      const allContains = items.every(item => {
+      const allItemsContains = items.every(item => {
         if (item.value?.type === Token.VALUE_TEXT) {
           return item.value?.contains;
         }
@@ -74,7 +77,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
             <Fragment key={index}>
               <FilterMultiValueTruncated>
                 {/* @ts-expect-error TS(2345): Argument of type '{ type: Token.VALUE_NUMBER; valu... Remove this comment to see the full error message */}
-                {formatFilterValue(item.value, allContains)}
+                {formatFilterValue(item.value, allItemsContains)}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
                 <FilterValueOr> or </FilterValueOr>
@@ -92,12 +95,15 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
         <DateTime date={token.value.value} dateOnly={!token.value.time} utc={isUtc} />
       );
     }
-    default:
+    default: {
+      const isContains =
+        token.value.type === Token.VALUE_TEXT ? token.value.contains : false;
       return (
         <FilterValueSingleTruncatedValue>
-          {formatFilterValue(token.value, false)}
+          {formatFilterValue(token.value, isContains)}
         </FilterValueSingleTruncatedValue>
       );
+    }
   }
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -55,12 +55,18 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
       if (items.length === 1 && items[0]!.value) {
         return (
           <FilterValueSingleTruncatedValue>
-            {formatFilterValue(items[0]!.value)}
+            {formatFilterValue(items[0]!.value, false)}
           </FilterValueSingleTruncatedValue>
         );
       }
 
       const maxItems = size === 'small' ? 1 : 3;
+      const allContains = items.every(item => {
+        if (item.value?.type === Token.VALUE_TEXT) {
+          return item.value?.contains;
+        }
+        return false;
+      });
 
       return (
         <FilterValueList>
@@ -68,7 +74,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
             <Fragment key={index}>
               <FilterMultiValueTruncated>
                 {/* @ts-expect-error TS(2345): Argument of type '{ type: Token.VALUE_NUMBER; valu... Remove this comment to see the full error message */}
-                {formatFilterValue(item.value)}
+                {formatFilterValue(item.value, allContains)}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
                 <FilterValueOr> or </FilterValueOr>
@@ -89,7 +95,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
     default:
       return (
         <FilterValueSingleTruncatedValue>
-          {formatFilterValue(token.value)}
+          {formatFilterValue(token.value, false)}
         </FilterValueSingleTruncatedValue>
       );
   }

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -206,9 +206,9 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
     if (token.value.type === Token.VALUE_TEXT) {
       isContains = token.value.value.startsWith('*') && token.value.value.endsWith('*');
     } else if (token.value.type === Token.VALUE_TEXT_LIST) {
-      isContains = token.value.items.every(item => {
-        return item.value?.value.startsWith('*') && item.value?.value.endsWith('*');
-      });
+      isContains = token.value.items.every(
+        item => item.value?.value.startsWith('*') && item.value?.value.endsWith('*')
+      );
     }
 
     return {
@@ -264,6 +264,10 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
   let isContains = false;
   if (token.value.type === Token.VALUE_TEXT) {
     isContains = token.value.value.startsWith('*') && token.value.value.endsWith('*');
+  } else if (token.value.type === Token.VALUE_TEXT_LIST) {
+    isContains = token.value.items.every(
+      entry => entry.value?.value.startsWith('*') && entry.value?.value.endsWith('*')
+    );
   }
 
   return (

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -10,6 +10,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {getValidOpsForFilter} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {TermOperatorNew} from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
   recentSearchTypeToLabel,
@@ -17,8 +18,7 @@ import {
 import {
   FilterType,
   type ParseResultToken,
-  TermOperator,
-  type Token,
+  Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
 import {getKeyName} from 'sentry/components/searchSyntax/utils';
@@ -37,51 +37,52 @@ interface FilterOperatorProps {
 const MENU_OFFSET: [number, number] = [0, 12];
 
 const OP_LABELS = {
-  [TermOperator.DEFAULT]: 'is',
-  [TermOperator.GREATER_THAN]: '>',
-  [TermOperator.GREATER_THAN_EQUAL]: '>=',
-  [TermOperator.LESS_THAN]: '<',
-  [TermOperator.LESS_THAN_EQUAL]: '<=',
-  [TermOperator.NOT_EQUAL]: 'is not',
+  [TermOperatorNew.DEFAULT]: 'is',
+  [TermOperatorNew.GREATER_THAN]: '>',
+  [TermOperatorNew.GREATER_THAN_EQUAL]: '>=',
+  [TermOperatorNew.LESS_THAN]: '<',
+  [TermOperatorNew.LESS_THAN_EQUAL]: '<=',
+  [TermOperatorNew.NOT_EQUAL]: 'is not',
+  [TermOperatorNew.CONTAINS]: 'contains',
 };
 
 const DATE_OP_LABELS = {
-  [TermOperator.GREATER_THAN]: 'is after',
-  [TermOperator.GREATER_THAN_EQUAL]: 'is on or after',
-  [TermOperator.LESS_THAN]: 'is before',
-  [TermOperator.LESS_THAN_EQUAL]: 'is on or before',
-  [TermOperator.EQUAL]: 'is',
-  [TermOperator.DEFAULT]: 'is',
+  [TermOperatorNew.GREATER_THAN]: 'is after',
+  [TermOperatorNew.GREATER_THAN_EQUAL]: 'is on or after',
+  [TermOperatorNew.LESS_THAN]: 'is before',
+  [TermOperatorNew.LESS_THAN_EQUAL]: 'is on or before',
+  [TermOperatorNew.EQUAL]: 'is',
+  [TermOperatorNew.DEFAULT]: 'is',
 };
 
-const DATE_OPTIONS: TermOperator[] = [
-  TermOperator.GREATER_THAN,
-  TermOperator.GREATER_THAN_EQUAL,
-  TermOperator.LESS_THAN,
-  TermOperator.LESS_THAN_EQUAL,
-  TermOperator.EQUAL,
+const DATE_OPTIONS: TermOperatorNew[] = [
+  TermOperatorNew.GREATER_THAN,
+  TermOperatorNew.GREATER_THAN_EQUAL,
+  TermOperatorNew.LESS_THAN,
+  TermOperatorNew.LESS_THAN_EQUAL,
+  TermOperatorNew.EQUAL,
 ];
 
 function getOperatorFromDateToken(token: TokenResult<Token.FILTER>) {
   switch (token.filter) {
     case FilterType.DATE:
     case FilterType.SPECIFIC_DATE:
-      return token.operator;
+      return token.operator as unknown as TermOperatorNew;
     case FilterType.RELATIVE_DATE:
       return token.value.sign === '+'
-        ? TermOperator.LESS_THAN
-        : TermOperator.GREATER_THAN;
+        ? TermOperatorNew.LESS_THAN
+        : TermOperatorNew.GREATER_THAN;
     default:
-      return TermOperator.DEFAULT;
+      return TermOperatorNew.DEFAULT;
   }
 }
 
-function getTermOperatorFromToken(token: TokenResult<Token.FILTER>) {
+function getTermOperatorFromToken(token: TokenResult<Token.FILTER>): TermOperatorNew {
   if (token.negated) {
-    return TermOperator.NOT_EQUAL;
+    return TermOperatorNew.NOT_EQUAL;
   }
 
-  return token.operator;
+  return token.operator as unknown as TermOperatorNew;
 }
 
 function FilterKeyOperatorLabel({
@@ -107,8 +108,8 @@ function FilterKeyOperatorLabel({
 
 export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
   label: ReactNode;
-  operator: TermOperator;
-  options: Array<SelectOption<TermOperator>>;
+  operator: TermOperatorNew;
+  options: Array<SelectOption<TermOperatorNew>>;
 } {
   if (isDateToken(token)) {
     const operator = getOperatorFromDateToken(token);
@@ -118,7 +119,7 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
     return {
       operator,
       label: <OpLabel>{opLabel}</OpLabel>,
-      options: DATE_OPTIONS.map((op): SelectOption<TermOperator> => {
+      options: DATE_OPTIONS.map((op): SelectOption<TermOperatorNew> => {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         const optionOpLabel = DATE_OP_LABELS[op] ?? op;
 
@@ -139,18 +140,18 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
       label: (
         <FilterKeyOperatorLabel
           keyLabel={token.key.text}
-          opLabel={operator === TermOperator.NOT_EQUAL ? 'not' : undefined}
+          opLabel={operator === TermOperatorNew.NOT_EQUAL ? 'not' : undefined}
           includeKeyLabel
         />
       ),
       options: [
         {
-          value: TermOperator.DEFAULT,
+          value: TermOperatorNew.DEFAULT,
           label: <FilterKeyOperatorLabel keyLabel={token.key.text} includeKeyLabel />,
           textValue: 'is',
         },
         {
-          value: TermOperator.NOT_EQUAL,
+          value: TermOperatorNew.NOT_EQUAL,
           label: (
             <FilterKeyOperatorLabel
               keyLabel={token.key.text}
@@ -169,18 +170,18 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
       operator,
       label: (
         <FilterKeyOperatorLabel
-          keyLabel={operator === TermOperator.NOT_EQUAL ? 'does not have' : 'has'}
+          keyLabel={operator === TermOperatorNew.NOT_EQUAL ? 'does not have' : 'has'}
           includeKeyLabel
         />
       ),
       options: [
         {
-          value: TermOperator.DEFAULT,
+          value: TermOperatorNew.DEFAULT,
           label: <FilterKeyOperatorLabel keyLabel="has" includeKeyLabel />,
           textValue: 'has',
         },
         {
-          value: TermOperator.NOT_EQUAL,
+          value: TermOperatorNew.NOT_EQUAL,
           label: <FilterKeyOperatorLabel keyLabel="does not have" includeKeyLabel />,
           textValue: 'does not have',
         },
@@ -188,16 +189,57 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
     };
   }
 
+  // make new enum that contains all the operators and the new ones
+  // change all the places that accept the old enum to use the new one
+  // add contains to the special case for text (here)
+  // change the reducer (modifyFilterOperator in useQueryBuilderState) to use the new enum
+  // if the value is contains do things (i.e. wrap in the stars)
+  // if the value is wrapped in stars parse it out and switch to the `contains` operator from `is` operator
+
   const keyLabel = token.key.text;
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const opLabel = OP_LABELS[operator] ?? operator;
+
+  // special case for text, and add in contains option
+  if (token.filter === FilterType.TEXT || token.filter === FilterType.TEXT_IN) {
+    let isContains = false;
+    if (token.value.type === Token.VALUE_TEXT) {
+      isContains = token.value.value.startsWith('*') && token.value.value.endsWith('*');
+    } else if (token.value.type === Token.VALUE_TEXT_LIST) {
+      isContains = token.value.items.every(item => {
+        return item.value?.value.startsWith('*') && item.value?.value.endsWith('*');
+      });
+    }
+
+    return {
+      operator,
+      label: isContains ? <OpLabel>contains</OpLabel> : <OpLabel>{opLabel}</OpLabel>,
+      options: [
+        {
+          value: TermOperatorNew.DEFAULT,
+          label: <FilterKeyOperatorLabel keyLabel="is" includeKeyLabel />,
+          textValue: 'is',
+        },
+        {
+          value: TermOperatorNew.NOT_EQUAL,
+          label: <FilterKeyOperatorLabel keyLabel="is not" includeKeyLabel />,
+          textValue: 'is not',
+        },
+        {
+          value: TermOperatorNew.CONTAINS,
+          label: <FilterKeyOperatorLabel keyLabel="contains" includeKeyLabel />,
+          textValue: 'contains',
+        },
+      ],
+    };
+  }
 
   return {
     operator,
     label: <OpLabel>{opLabel}</OpLabel>,
     options: getValidOpsForFilter(token)
-      .filter(op => op !== TermOperator.EQUAL)
-      .map((op): SelectOption<TermOperator> => {
+      .filter(op => op !== TermOperatorNew.EQUAL)
+      .map((op): SelectOption<TermOperatorNew> => {
         const optionOpLabel = OP_LABELS[op] ?? op;
 
         return {
@@ -219,6 +261,11 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
 
   const onlyOperator = token.filter === FilterType.IS || token.filter === FilterType.HAS;
 
+  let isContains = false;
+  if (token.value.type === Token.VALUE_TEXT) {
+    isContains = token.value.value.startsWith('*') && token.value.value.endsWith('*');
+  }
+
   return (
     <CompactSelect
       disabled={disabled}
@@ -230,12 +277,12 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
           {...mergeProps(triggerProps, filterButtonProps)}
         >
           <InteractionStateLayer />
-          {label}
+          {isContains ? <OpLabel>contains</OpLabel> : label}
         </OpButton>
       )}
       size="sm"
       options={options}
-      value={operator}
+      value={isContains ? TermOperatorNew.CONTAINS : operator}
       onOpenChange={onOpenChange}
       onChange={option => {
         trackAnalytics('search.operator_autocompleted', {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -204,11 +204,9 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
   if (token.filter === FilterType.TEXT || token.filter === FilterType.TEXT_IN) {
     let isContains = false;
     if (token.value.type === Token.VALUE_TEXT) {
-      isContains = token.value.value.startsWith('*') && token.value.value.endsWith('*');
+      isContains = token.value.contains;
     } else if (token.value.type === Token.VALUE_TEXT_LIST) {
-      isContains = token.value.items.every(
-        item => item.value?.value.startsWith('*') && item.value?.value.endsWith('*')
-      );
+      isContains = token.value.items.every(item => item.value?.contains);
     }
 
     return {
@@ -263,11 +261,9 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
 
   let isContains = false;
   if (token.value.type === Token.VALUE_TEXT) {
-    isContains = token.value.value.startsWith('*') && token.value.value.endsWith('*');
+    isContains = token.value.contains;
   } else if (token.value.type === Token.VALUE_TEXT_LIST) {
-    isContains = token.value.items.every(
-      entry => entry.value?.value.startsWith('*') && entry.value?.value.endsWith('*')
-    );
+    isContains = token.value.items.every(entry => entry.value?.contains);
   }
 
   return (

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -189,48 +189,9 @@ export function getOperatorInfo(token: TokenResult<Token.FILTER>): {
     };
   }
 
-  // make new enum that contains all the operators and the new ones
-  // change all the places that accept the old enum to use the new one
-  // add contains to the special case for text (here)
-  // change the reducer (modifyFilterOperator in useQueryBuilderState) to use the new enum
-  // if the value is contains do things (i.e. wrap in the stars)
-  // if the value is wrapped in stars parse it out and switch to the `contains` operator from `is` operator
-
   const keyLabel = token.key.text;
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   const opLabel = OP_LABELS[operator] ?? operator;
-
-  // special case for text, and add in contains option
-  if (token.filter === FilterType.TEXT || token.filter === FilterType.TEXT_IN) {
-    let isContains = false;
-    if (token.value.type === Token.VALUE_TEXT) {
-      isContains = token.value.contains;
-    } else if (token.value.type === Token.VALUE_TEXT_LIST) {
-      isContains = token.value.items.every(item => item.value?.contains);
-    }
-
-    return {
-      operator,
-      label: isContains ? <OpLabel>contains</OpLabel> : <OpLabel>{opLabel}</OpLabel>,
-      options: [
-        {
-          value: TermOperatorNew.DEFAULT,
-          label: <FilterKeyOperatorLabel keyLabel="is" includeKeyLabel />,
-          textValue: 'is',
-        },
-        {
-          value: TermOperatorNew.NOT_EQUAL,
-          label: <FilterKeyOperatorLabel keyLabel="is not" includeKeyLabel />,
-          textValue: 'is not',
-        },
-        {
-          value: TermOperatorNew.CONTAINS,
-          label: <FilterKeyOperatorLabel keyLabel="contains" includeKeyLabel />,
-          textValue: 'contains',
-        },
-      ],
-    };
-  }
 
   return {
     operator,

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/grammar.pegjs
@@ -36,13 +36,7 @@ contains_value
         // Handle '**' as an empty contains value
         return tc.tokenValueText('', false, true);
       }
-      if (Array.isArray(value) && value.length === 1 && value[0]?.type) {
-        // quoted_value returns a tokenValueText, so mark as contains
-        const v = value[0];
-        v.contains = true;
-        return v;
-      }
-      return tc.tokenValueText(value.map(v => typeof v === "string" ? v : v.text).join(''), false, true);
+      return tc.tokenValueText(value.join(''), false, true);
     }
 
 contains_inner_value
@@ -55,9 +49,7 @@ quoted_value
 
 quoted_contains_value
   = '"' "*" value:('\\"' / '\\*' / [^"*\\])* "*" '"' {
-      const result = tc.tokenValueText(value.join(''), true, true);
-      result.text = '"' + value.join('') + '"';
-      return result;
+      return tc.tokenValueText(value.join(''), true, true);
   }
 
 in_value_termination

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/grammar.pegjs
@@ -14,8 +14,9 @@ item = s1:spaces c:comma s2:spaces value:(!comma text_in_value)? {
 }
 
 text_in_value
-  = contains_value
+  = quoted_contains_value
   / quoted_value
+  / contains_value
   / in_value
   / empty_value
 
@@ -30,7 +31,7 @@ in_value
   }
 
 contains_value
-  = "*" value:(quoted_value / contains_inner_value)* "*" {
+  = "*" value:(contains_inner_value)* "*" {
       if (!value.length) {
         // Handle '**' as an empty contains value
         return tc.tokenValueText('', false, true);
@@ -50,6 +51,13 @@ contains_inner_value
 quoted_value
   = '"' value:('\\"' / '\\*' / [^"\\])* '"' {
       return tc.tokenValueText(value.join(''), true, false);
+  }
+
+quoted_contains_value
+  = '"' "*" value:('\\"' / '\\*' / [^"*\\])* "*" '"' {
+      const result = tc.tokenValueText(value.join(''), true, true);
+      result.text = '"' + value.join('') + '"';
+      return result;
   }
 
 in_value_termination

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/grammar.pegjs
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/grammar.pegjs
@@ -14,21 +14,42 @@ item = s1:spaces c:comma s2:spaces value:(!comma text_in_value)? {
 }
 
 text_in_value
-  = quoted_value / in_value / empty_value
+  = contains_value
+  / quoted_value
+  / in_value
+  / empty_value
 
 empty_value
   = spaces {
-    return tc.tokenValueText(text(), false);
+    return tc.tokenValueText(text(), false, false);
   }
 
 in_value
   = (in_value_char)+ {
-    return tc.tokenValueText(text(), false);
+    return tc.tokenValueText(text(), false, false);
   }
 
+contains_value
+  = "*" value:(quoted_value / contains_inner_value)* "*" {
+      if (!value.length) {
+        // Handle '**' as an empty contains value
+        return tc.tokenValueText('', false, true);
+      }
+      if (Array.isArray(value) && value.length === 1 && value[0]?.type) {
+        // quoted_value returns a tokenValueText, so mark as contains
+        const v = value[0];
+        v.contains = true;
+        return v;
+      }
+      return tc.tokenValueText(value.map(v => typeof v === "string" ? v : v.text).join(''), false, true);
+    }
+
+contains_inner_value
+  = [^*""]
+
 quoted_value
-  = '"' value:('\\"' / [^"])* '"' {
-    return tc.tokenValueText(value.join(''), true);
+  = '"' value:('\\"' / '\\*' / [^"\\])* '"' {
+      return tc.tokenValueText(value.join(''), true, false);
   }
 
 in_value_termination

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
@@ -94,4 +94,107 @@ describe('parseMultiSelectValue', function () {
     expect(result?.items[1]!.value?.value).toBe('b c');
     expect(result?.items[2]!.value?.value).toBe('d');
   });
+
+  describe('contains', function () {
+    describe('when the value is wrapped in asterisks', function () {
+      it('sets contains to true', function () {
+        const result = parseMultiSelectFilterValue('*a*');
+
+        expect(result).not.toBeNull();
+
+        expect(result!.items[0]!.value?.contains).toBe(true);
+      });
+    });
+
+    describe('when the value is not wrapped in asterisks', function () {
+      it('sets contains to false', function () {
+        const result = parseMultiSelectFilterValue('a');
+
+        expect(result).not.toBeNull();
+      });
+    });
+
+    it('single value', function () {
+      const result = parseMultiSelectFilterValue('*a*');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(1);
+      expect(result!.items[0]!.value?.value).toBe('a');
+    });
+
+    it('multiple value', function () {
+      const result = parseMultiSelectFilterValue('*a*,*b*,*c*');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(3);
+      expect(result?.items[0]!.value?.value).toBe('a');
+      expect(result?.items[1]!.value?.value).toBe('b');
+      expect(result?.items[2]!.value?.value).toBe('c');
+    });
+
+    it('quoted value', function () {
+      const result = parseMultiSelectFilterValue('*a*,*"b"*,*c*');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(3);
+      expect(result?.items[0]!.value?.value).toBe('a');
+
+      expect(result?.items[1]!.value?.value).toBe('b');
+      expect(result?.items[1]!.value?.text).toBe('"b"');
+      expect(result?.items[1]!.value?.quoted).toBe(true);
+
+      expect(result!.items[2]!.value?.value).toBe('c');
+    });
+
+    it('just quotes', function () {
+      const result = parseMultiSelectFilterValue('*""*');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(1);
+      const item = result!.items[0];
+
+      expect(item!.value?.value).toBe('');
+      expect(item!.value?.text).toBe('""');
+      expect(item!.value?.quoted).toBe(true);
+    });
+
+    it('multiple empty value', function () {
+      const result = parseMultiSelectFilterValue('*a*,**,*b*');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(3);
+
+      expect(result?.items[0]!.value?.value).toBe('a');
+      expect(result?.items[1]!.value?.value).toBe('');
+      expect(result?.items[2]!.value?.value).toBe('b');
+    });
+
+    it('trailing comma', function () {
+      const result = parseMultiSelectFilterValue('*a*,');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(2);
+
+      expect(result?.items[0]!.value?.value).toBe('a');
+      expect(result?.items[1]!.value?.value).toBe('');
+    });
+
+    it('spaces', function () {
+      const result = parseMultiSelectFilterValue('*a*,*b c*,*d*');
+
+      expect(result).not.toBeNull();
+
+      expect(result!.items).toHaveLength(3);
+
+      expect(result?.items[0]!.value?.value).toBe('a');
+      expect(result?.items[1]!.value?.value).toBe('b c');
+      expect(result?.items[2]!.value?.value).toBe('d');
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
@@ -123,14 +123,15 @@ describe('parseMultiSelectValue', function () {
       expect(multipleEntries?.items[1]!.value?.value).toBe('b');
       expect(multipleEntries?.items[2]!.value?.value).toBe('c');
 
-      const multiQuoteValue = parseMultiSelectFilterValue('*a*,*"b"*,*c*');
+      const multiQuoteValue = parseMultiSelectFilterValue('*a*,"*b*",*c*');
       expect(multiQuoteValue?.items[0]!.value?.value).toBe('a');
       expect(multiQuoteValue?.items[1]!.value?.value).toBe('b');
       expect(multiQuoteValue?.items[1]!.value?.text).toBe('"b"');
       expect(multiQuoteValue?.items[1]!.value?.quoted).toBe(true);
+      expect(multiQuoteValue?.items[1]!.value?.contains).toBe(true);
       expect(multiQuoteValue!.items[2]!.value?.value).toBe('c');
 
-      const justQuotes = parseMultiSelectFilterValue('*""*');
+      const justQuotes = parseMultiSelectFilterValue('"**"');
       expect(justQuotes?.items[0]!.value?.value).toBe('');
       expect(justQuotes?.items[0]!.value?.text).toBe('""');
       expect(justQuotes?.items[0]!.value?.quoted).toBe(true);

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
@@ -101,7 +101,6 @@ describe('parseMultiSelectValue', function () {
         const result = parseMultiSelectFilterValue('*a*');
 
         expect(result).not.toBeNull();
-
         expect(result!.items[0]!.value?.contains).toBe(true);
       });
     });
@@ -111,90 +110,44 @@ describe('parseMultiSelectValue', function () {
         const result = parseMultiSelectFilterValue('a');
 
         expect(result).not.toBeNull();
+        expect(result!.items[0]!.value?.contains).toBe(false);
       });
     });
 
-    it('single value', function () {
-      const result = parseMultiSelectFilterValue('*a*');
+    it('strips asterisks from the value', function () {
+      const singleEntry = parseMultiSelectFilterValue('*a*');
+      expect(singleEntry!.items[0]!.value?.value).toBe('a');
 
-      expect(result).not.toBeNull();
+      const multipleEntries = parseMultiSelectFilterValue('*a*,*b*,*c*');
+      expect(multipleEntries?.items[0]!.value?.value).toBe('a');
+      expect(multipleEntries?.items[1]!.value?.value).toBe('b');
+      expect(multipleEntries?.items[2]!.value?.value).toBe('c');
 
-      expect(result!.items).toHaveLength(1);
-      expect(result!.items[0]!.value?.value).toBe('a');
-    });
+      const multiQuoteValue = parseMultiSelectFilterValue('*a*,*"b"*,*c*');
+      expect(multiQuoteValue?.items[0]!.value?.value).toBe('a');
+      expect(multiQuoteValue?.items[1]!.value?.value).toBe('b');
+      expect(multiQuoteValue?.items[1]!.value?.text).toBe('"b"');
+      expect(multiQuoteValue?.items[1]!.value?.quoted).toBe(true);
+      expect(multiQuoteValue!.items[2]!.value?.value).toBe('c');
 
-    it('multiple value', function () {
-      const result = parseMultiSelectFilterValue('*a*,*b*,*c*');
+      const justQuotes = parseMultiSelectFilterValue('*""*');
+      expect(justQuotes?.items[0]!.value?.value).toBe('');
+      expect(justQuotes?.items[0]!.value?.text).toBe('""');
+      expect(justQuotes?.items[0]!.value?.quoted).toBe(true);
 
-      expect(result).not.toBeNull();
+      const multiValuesWithEmpty = parseMultiSelectFilterValue('*a*,**,*b*');
+      expect(multiValuesWithEmpty?.items[0]!.value?.value).toBe('a');
+      expect(multiValuesWithEmpty?.items[1]!.value?.value).toBe('');
+      expect(multiValuesWithEmpty?.items[2]!.value?.value).toBe('b');
 
-      expect(result!.items).toHaveLength(3);
-      expect(result?.items[0]!.value?.value).toBe('a');
-      expect(result?.items[1]!.value?.value).toBe('b');
-      expect(result?.items[2]!.value?.value).toBe('c');
-    });
+      const trailingComma = parseMultiSelectFilterValue('*a*,**');
+      expect(trailingComma?.items[0]!.value?.value).toBe('a');
+      expect(trailingComma?.items[1]!.value?.value).toBe('');
 
-    it('quoted value', function () {
-      const result = parseMultiSelectFilterValue('*a*,*"b"*,*c*');
-
-      expect(result).not.toBeNull();
-
-      expect(result!.items).toHaveLength(3);
-      expect(result?.items[0]!.value?.value).toBe('a');
-
-      expect(result?.items[1]!.value?.value).toBe('b');
-      expect(result?.items[1]!.value?.text).toBe('"b"');
-      expect(result?.items[1]!.value?.quoted).toBe(true);
-
-      expect(result!.items[2]!.value?.value).toBe('c');
-    });
-
-    it('just quotes', function () {
-      const result = parseMultiSelectFilterValue('*""*');
-
-      expect(result).not.toBeNull();
-
-      expect(result!.items).toHaveLength(1);
-      const item = result!.items[0];
-
-      expect(item!.value?.value).toBe('');
-      expect(item!.value?.text).toBe('""');
-      expect(item!.value?.quoted).toBe(true);
-    });
-
-    it('multiple empty value', function () {
-      const result = parseMultiSelectFilterValue('*a*,**,*b*');
-
-      expect(result).not.toBeNull();
-
-      expect(result!.items).toHaveLength(3);
-
-      expect(result?.items[0]!.value?.value).toBe('a');
-      expect(result?.items[1]!.value?.value).toBe('');
-      expect(result?.items[2]!.value?.value).toBe('b');
-    });
-
-    it('trailing comma', function () {
-      const result = parseMultiSelectFilterValue('*a*,');
-
-      expect(result).not.toBeNull();
-
-      expect(result!.items).toHaveLength(2);
-
-      expect(result?.items[0]!.value?.value).toBe('a');
-      expect(result?.items[1]!.value?.value).toBe('');
-    });
-
-    it('spaces', function () {
-      const result = parseMultiSelectFilterValue('*a*,*b c*,*d*');
-
-      expect(result).not.toBeNull();
-
-      expect(result!.items).toHaveLength(3);
-
-      expect(result?.items[0]!.value?.value).toBe('a');
-      expect(result?.items[1]!.value?.value).toBe('b c');
-      expect(result?.items[2]!.value?.value).toBe('d');
+      const spaces = parseMultiSelectFilterValue('*a*,*b c*,*d*');
+      expect(spaces?.items[0]!.value?.value).toBe('a');
+      expect(spaces?.items[1]!.value?.value).toBe('b c');
+      expect(spaces?.items[2]!.value?.value).toBe('d');
     });
   });
 });

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -46,8 +46,8 @@ export function getValidOpsForFilter(
       allOperators as unknown as TermOperatorNew[]
     );
 
-    if (isTextFilter) {
-      validOps.add(TermOperatorNew.CONTAINS);
+    if (isTextFilter && fieldDefinition?.allowWildcard === false) {
+      validOps.delete(TermOperatorNew.CONTAINS);
     }
 
     return [...validOps];
@@ -72,7 +72,7 @@ export function getValidOpsForFilter(
   );
 
   // Special case for text, add contains operator
-  if (isTextFilter) {
+  if (isTextFilter && fieldDefinition?.allowWildcard !== false) {
     validOps.add(TermOperatorNew.CONTAINS);
   }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -84,7 +84,7 @@ export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): st
         return token.text;
       }
 
-      if (token.text.startsWith('*') && token.text.endsWith('*')) {
+      if (token.contains) {
         const newToken = token.text.slice(1, -1);
         return token.quoted ? unescapeTagValue(newToken) : newToken;
       }

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -4,7 +4,6 @@ import {
   FilterType,
   filterTypeConfig,
   interchangeableFilterOperators,
-  type TermOperator,
   Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
@@ -36,11 +35,11 @@ export function isAggregateFilterToken(
 
 export function getValidOpsForFilter(
   filterToken: TokenResult<Token.FILTER>
-): readonly TermOperator[] {
+): readonly TermOperatorNew[] {
   const fieldDefinition = getFieldDefinition(filterToken.key.text);
 
   if (fieldDefinition?.allowComparisonOperators) {
-    return allOperators;
+    return allOperators as unknown as TermOperatorNew[];
   }
 
   // If the token is invalid we want to use the possible expected types as our filter type
@@ -56,7 +55,7 @@ export function getValidOpsForFilter(
   const allValidTypes = [...new Set([...validTypes, ...interchangeableTypes.flat()])];
 
   // Find all valid operations
-  const validOps = new Set<TermOperator>(
+  const validOps = new Set<TermOperatorNew>(
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     allValidTypes.flatMap(type => filterTypeConfig[type].validOps)
   );

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -83,6 +83,11 @@ export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): st
         return token.text;
       }
 
+      if (token.text.startsWith('*') && token.text.endsWith('*')) {
+        const newToken = token.text.slice(1, -1);
+        return token.quoted ? unescapeTagValue(newToken) : newToken;
+      }
+
       return token.quoted ? unescapeTagValue(token.value) : token.text;
     }
     case Token.VALUE_RELATIVE_DATE:

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -92,19 +92,23 @@ export function unescapeTagValue(value: string): string {
   return value.replace(/\\"/g, '"');
 }
 
-export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): string {
+export function formatFilterValue(
+  token: TokenResult<Token.FILTER>['value'],
+  allContains: boolean
+): string {
   switch (token.type) {
     case Token.VALUE_TEXT: {
       if (!token.value) {
         return token.text;
       }
 
-      if (token.contains) {
-        const newToken = token.text.slice(1, -1);
-        return token.quoted ? unescapeTagValue(newToken) : newToken;
+      if (allContains) {
+        return token.quoted ? unescapeTagValue(token.value) : token.text.slice(1, -1);
       }
 
-      return token.quoted ? unescapeTagValue(token.value) : token.text;
+      return token.quoted
+        ? unescapeTagValue(token.contains ? `*${token.value}*` : token.value)
+        : token.text;
     }
     case Token.VALUE_RELATIVE_DATE:
       return t('%s', `${token.value}${token.unit} ago`);

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -1,3 +1,4 @@
+import {type TermOperatorNew} from 'sentry/components/searchQueryBuilder/types';
 import {
   type AggregateFilter,
   allOperators,

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -861,7 +861,14 @@ export function SearchQueryBuilderValueCombobox({
         onExit={onCommit}
         inputValue={inputValue}
         filterValue={filterValue}
-        placeholder={canSelectMultipleValues ? '' : formatFilterValue(token.value)}
+        placeholder={
+          canSelectMultipleValues
+            ? ''
+            : formatFilterValue(
+                token.value,
+                token?.value?.type === Token.VALUE_TEXT ? token.value.contains : false
+              )
+        }
         token={token}
         inputLabel={t('Edit filter value')}
         onInputChange={e => setInputValue(e.target.value)}

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -25,3 +25,15 @@ export type CallbackSearchState = {
   parsedQuery: ParseResult | null;
   queryIsValid: boolean;
 };
+
+// TODO: @nsdeschenes - Rename to something more descriptive/better
+export enum TermOperatorNew {
+  DEFAULT = '',
+  GREATER_THAN_EQUAL = '>=',
+  LESS_THAN_EQUAL = '<=',
+  GREATER_THAN = '>',
+  LESS_THAN = '<',
+  EQUAL = '=',
+  NOT_EQUAL = '!=',
+  CONTAINS = 'contains',
+}

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -303,21 +303,15 @@ quoted_value
 
 quoted_contains_value
   = '"' "*" value:('\\"' / '\\*' / [^"*\\])* "*" '"' {
-    const result = tc.tokenValueText(value.join(''), true, true);
-    result.text = '"' + value.join('') + '"';
-    return result;
-  }
+      return tc.tokenValueText(value.join(''), true, true);
+    }
 
 contains_value
   = "*" value:(contains_inner_value)* "*" {
       if (!value.length) {
         return tc.tokenValueText('', false, true);
       }
-      if (Array.isArray(value) && value.length === 1 && value[0]?.type) {
-        const v = value[0];
-        return tc.tokenValueText(v.value, v.quoted, true);
-      }
-      return tc.tokenValueText(value.map(v => typeof v === "string" ? v : v.text).join(''), false, true);
+      return tc.tokenValueText(value.join(''), false, true);
     }
 
 contains_inner_value
@@ -329,7 +323,7 @@ in_value
     }
 
 text_in_value
-  = quoted_contains_value  / quoted_value / contains_value / in_value
+  = quoted_contains_value / quoted_value / contains_value / in_value
 
 search_value
   = quoted_contains_value / quoted_value / contains_value / value

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -301,8 +301,15 @@ quoted_value
       return tc.tokenValueText(value.join(''), true, false);
     }
 
+quoted_contains_value
+  = '"' "*" value:('\\"' / '\\*' / [^"*\\])* "*" '"' {
+    const result = tc.tokenValueText(value.join(''), true, true);
+    result.text = '"' + value.join('') + '"';
+    return result;
+  }
+
 contains_value
-  = "*" value:(quoted_value / contains_inner_value)* "*" {
+  = "*" value:(contains_inner_value)* "*" {
       if (!value.length) {
         return tc.tokenValueText('', false, true);
       }
@@ -322,10 +329,10 @@ in_value
     }
 
 text_in_value
-  = contains_value / quoted_value / in_value
+  = quoted_contains_value  / quoted_value / contains_value / in_value
 
 search_value
-  = contains_value / quoted_value / value
+  = quoted_contains_value / quoted_value / contains_value / value
 
 numeric_value
   = value:("-"? numeric) unit:(number_unit)? &(end_value / comma / closed_bracket) {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -696,12 +696,13 @@ export class TokenConverter {
     items: [{separator: '', value: item1}, ...items.map(listJoiner)],
   });
 
-  tokenValueText = (value: string, quoted: boolean) => {
+  tokenValueText = (value: string, quoted: boolean, contains: boolean) => {
     return {
       ...this.defaultTokenFields,
       type: Token.VALUE_TEXT as const,
       value,
       quoted,
+      contains,
     };
   };
 

--- a/static/app/components/searchSyntax/renderer.spec.tsx
+++ b/static/app/components/searchSyntax/renderer.spec.tsx
@@ -32,6 +32,7 @@ const query: ParseResult = [
         end: {offset: 27, line: 1, column: 28},
         source: {},
       },
+      contains: false,
     },
     invalid: null,
     warning: null,

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -327,6 +327,7 @@ export function stringifyToken(token: TokenResult<Token>): string {
     case Token.LOGIC_BOOLEAN:
       return token.value;
     case Token.VALUE_TEXT_LIST: {
+      // so we use text here because it's the original text from the token, this seems to handle cases where the text is quoted
       const textListItems = token.items
         .map(item => item.value?.text ?? '')
         .filter(text => text.length > 0);
@@ -359,7 +360,8 @@ export function stringifyToken(token: TokenResult<Token>): string {
     case Token.KEY_EXPLICIT_STRING_FLAG:
       return `flags[${token.key.value},string]`;
     case Token.VALUE_TEXT:
-      return token.quoted ? `"${token.value}"` : token.value;
+      // so i changed this to return the text to mimic the behavior of VALUE_TEXT_LIST where we return the text
+      return token.text;
     case Token.VALUE_RELATIVE_DATE:
       return `${token.sign}${token.value}${token.unit}`;
     case Token.VALUE_BOOLEAN:


### PR DESCRIPTION
This PR adds in a new `contains` "operator" when searching text in the query builder. This is done by adding `*<text content>*` under the hood. This also supports multiple text values by wrapping each on in `*`'s
