### PR TITLE
feat(trace-eap-waterfall): Triggering capture exception only when query is enabled

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -77,7 +77,8 @@ export function useTraceItemDetails(props: UseTraceItemDetailsProps) {
   const project = useProjectFromId({project_id: props.projectId});
   const enabled = (props.enabled ?? true) && !!project;
 
-  if (!project) {
+  // Only capture exception if the project is not found and the query is enabled.
+  if ((props.enabled ?? true) && !project) {
     captureException(
       new Error(`Project "${props.projectId}" not found in useTraceItemDetails`)
     );


### PR DESCRIPTION
Fixes JAVASCRIPT-2ZX1