### PR TITLE
fix(ui): Dropdown button chevron colour

### DIFF
--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -51,7 +51,7 @@ function DropdownButton({
       {showChevron && (
         <ChevronWrap>
           <IconChevron
-            color="subText"
+            color={props.priority === 'default' ? 'subText' : undefined}
             direction={isOpen ? 'up' : 'down'}
             size={size === 'zero' || size === 'xs' ? 'xs' : 'sm'}
           />

--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -51,7 +51,9 @@ function DropdownButton({
       {showChevron && (
         <ChevronWrap>
           <IconChevron
-            color={props.priority === 'default' ? 'subText' : undefined}
+            color={
+              !props.priority || props.priority === 'default' ? 'subText' : undefined
+            }
             direction={isOpen ? 'up' : 'down'}
             size={size === 'zero' || size === 'xs' ? 'xs' : 'sm'}
           />


### PR DESCRIPTION
The chevron for the dropdown button was set to a static colour which means it worked for the `default` priority buttons but not for the rest. I've added a condition to the `color` prop to allow the correct colours on the rest of the button priorities. This should fix the colour mismatch on the dashboard details page 😌 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cb34e56d-3465-4ec7-be62-cfca4f1177cb) | ![image](https://github.com/user-attachments/assets/c5e4c3e2-744e-4d59-83d9-322ffed83340) | 
