### PR TITLE
fix(integrations): ignore `teamId` in `/external-teams/` requests

### DIFF
--- a/src/sentry/integrations/api/endpoints/external_team_details.py
+++ b/src/sentry/integrations/api/endpoints/external_team_details.py
@@ -72,6 +72,9 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         """
         self.assert_has_feature(request, team.organization)
 
+        if "teamId" in request.data:
+            del request.data["teamId"]
+
         serializer = ExternalTeamSerializer(
             instance=external_team,
             data={**request.data, "team_id": team.id},

--- a/src/sentry/integrations/api/endpoints/external_team_index.py
+++ b/src/sentry/integrations/api/endpoints/external_team_index.py
@@ -49,6 +49,9 @@ class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         """
         self.assert_has_feature(request, team.organization)
 
+        if "teamId" in request.data:
+            del request.data["teamId"]
+
         serializer = ExternalTeamSerializer(
             data={**request.data, "team_id": team.id}, context={"organization": team.organization}
         )

--- a/tests/sentry/integrations/api/endpoints/test_external_team.py
+++ b/tests/sentry/integrations/api/endpoints/test_external_team.py
@@ -34,6 +34,25 @@ class ExternalTeamTest(APITestCase):
             "integrationId": str(self.integration.id),
         }
 
+    def test_ignore_camelcase_teamid(self):
+        other_team = self.create_team(organization=self.organization)
+        data = {
+            "externalName": "@getsentry/ecosystem",
+            "provider": "github",
+            "integrationId": self.integration.id,
+            "teamId": other_team.id,
+        }
+        with self.feature({"organizations:integrations-codeowners": True}):
+            response = self.get_success_response(
+                self.organization.slug, self.team.slug, status_code=201, **data
+            )
+        assert response.data == {
+            **data,
+            "id": str(response.data["id"]),
+            "teamId": str(self.team.id),
+            "integrationId": str(self.integration.id),
+        }
+
     def test_without_feature_flag(self):
         data = {
             "externalName": "@getsentry/ecosystem",

--- a/tests/sentry/integrations/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_external_team_details.py
@@ -30,6 +30,18 @@ class ExternalTeamDetailsTest(APITestCase):
         assert response.data["id"] == str(self.external_team.id)
         assert response.data["externalName"] == "@getsentry/growth"
 
+    def test_ignore_camelcase_teamid(self):
+        other_team = self.create_team(organization=self.organization)
+        data = {
+            "externalName": "@getsentry/growth",
+            "teamId": other_team.id,
+        }
+        with self.feature({"organizations:integrations-codeowners": True}):
+            self.get_success_response(
+                self.organization.slug, self.team.slug, self.external_team.id, **data
+            )
+        assert not ExternalActor.objects.filter(team_id=other_team.id).exists()
+
     def test_invalid_provider_update(self):
         data = {"provider": "git"}
         with self.feature({"organizations:integrations-codeowners": True}):


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/VULN-84

Since the check is already done at the TeamEndpoint's permission class (TeamPermission).