### PR TITLE
feat(workflow_engine): Allow stateful detector values beside int

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -29,7 +29,7 @@ class MetricIssueEvidenceData(EvidenceData):
     alert_id: int
 
 
-class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate]):
+class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate, int]):
     def build_occurrence_and_event_data(
         self, group_key: DetectorGroupKey, new_status: PriorityLevel
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -14,12 +14,14 @@ from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detect
 from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
-T = TypeVar("T")
+
+PacketT = TypeVar("PacketT")
+EvidenceValueT = TypeVar("EvidenceValueT")
 
 
 @dataclass
-class EvidenceData(Generic[T]):
-    value: T
+class EvidenceData(Generic[EvidenceValueT]):
+    value: EvidenceValueT
     detector_id: int
     data_condition_ids: list[int]
 
@@ -95,7 +97,7 @@ class DetectorStateData:
     counter_updates: dict[str, int | None]
 
 
-class DetectorHandler(abc.ABC, Generic[T]):
+class DetectorHandler(abc.ABC, Generic[PacketT]):
     def __init__(self, detector: Detector):
         self.detector = detector
         if detector.workflow_condition_group_id is not None:
@@ -115,7 +117,7 @@ class DetectorHandler(abc.ABC, Generic[T]):
 
     @abc.abstractmethod
     def evaluate(
-        self, data_packet: DataPacket[T]
+        self, data_packet: DataPacket[PacketT]
     ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
         pass
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -47,13 +47,13 @@ def status_change_comparator(self: StatusChangeMessage, other: StatusChangeMessa
     )
 
 
-class MockDetectorStateHandler(StatefulGroupingDetectorHandler[dict]):
+class MockDetectorStateHandler(StatefulGroupingDetectorHandler[dict, int | None]):
     counter_names = ["test1", "test2"]
 
     def get_dedupe_value(self, data_packet: DataPacket[dict]) -> int:
         return data_packet.packet.get("dedupe", 0)
 
-    def get_group_key_values(self, data_packet: DataPacket[dict]) -> dict[str | None, int]:
+    def get_group_key_values(self, data_packet: DataPacket[dict]) -> dict[str | None, int | None]:
         return data_packet.packet.get("group_vals", {})
 
     def build_occurrence_and_event_data(


### PR DESCRIPTION
Adds a Generic TypeVar to the `StatefulGroupingDetectorHandler` to allow the
`get_group_key_values` to return a value other than an `int`.