### PR TITLE
fix(attributes-tree): Make actions appear in nested values too

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -182,6 +182,7 @@ function getAttributesTreeRows<RendererExtra extends RenderFunctionBaggage>({
         uniqueKey: `${uniqueKey}-${i}`,
         renderers,
         rendererExtra,
+        getCustomActions,
       });
       return rows.concat(branchRows);
     },


### PR DESCRIPTION
There was a regression where nested attributes would not get context actions. Fix it and add a test.

Fixes LOGS-90