### PR TITLE
ref(uptime): Power result consumer via detectors

### DIFF
--- a/src/sentry/uptime/issue_platform.py
+++ b/src/sentry/uptime/issue_platform.py
@@ -10,12 +10,12 @@ from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscription, get_project_subscription
+from sentry.workflow_engine.models.detector import Detector
 
 
-def create_issue_platform_occurrence(
-    result: CheckResult, project_subscription: ProjectUptimeSubscription
-):
+def create_issue_platform_occurrence(result: CheckResult, detector: Detector):
+    project_subscription = get_project_subscription(detector)
     occurrence = build_occurrence_from_result(result, project_subscription)
     event_data = build_event_data_for_occurrence(result, project_subscription, occurrence)
     produce_occurrence_to_kafka(
@@ -111,10 +111,11 @@ def build_event_data_for_occurrence(
     }
 
 
-def resolve_uptime_issue(project_subscription: ProjectUptimeSubscription):
+def resolve_uptime_issue(detector: Detector):
     """
     Sends an update to the issue platform to resolve the uptime issue for this monitor.
     """
+    project_subscription = get_project_subscription(detector)
     status_change = StatusChangeMessage(
         fingerprint=build_fingerprint_for_project_subscription(project_subscription),
         project_id=project_subscription.project_id,

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -351,7 +351,7 @@ def disable_uptime_detector(detector: Detector):
 
     if uptime_subscription.uptime_status == UptimeStatus.FAILED:
         # Resolve the issue so that we don't see it in the ui anymore
-        resolve_uptime_issue(uptime_monitor)
+        resolve_uptime_issue(detector)
 
     # We set the status back to ok here so that if we re-enable we'll start
     # from a good state

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -44,6 +44,7 @@ from sentry.uptime.models import (
     UptimeStatus,
     UptimeSubscription,
     UptimeSubscriptionRegion,
+    get_detector,
 )
 from sentry.uptime.types import ProjectUptimeSubscriptionMode
 from sentry.utils import json
@@ -68,6 +69,9 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             uptime_subscription=self.subscription,
             owner=self.user,
         )
+        detector = get_detector(self.subscription)
+        assert detector
+        self.detector = detector
 
     def send_result(
         self, result: CheckResult, consumer: ProcessingStrategy[KafkaPayload] | None = None
@@ -159,7 +163,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert self.project_subscription.uptime_subscription.uptime_status == UptimeStatus.FAILED
 
     def test_does_nothing_when_missing_project_subscription(self):
-        self.project_subscription.delete()
+        self.detector.delete()
 
         result = self.create_uptime_result(
             self.subscription.subscription_id,
@@ -488,7 +492,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
     def test_skip_already_processed(self):
         result = self.create_uptime_result(self.subscription.subscription_id)
         _get_cluster().set(
-            build_last_update_key(self.project_subscription),
+            build_last_update_key(self.detector),
             int(result["scheduled_check_time_ms"]),
         )
         with (
@@ -591,13 +595,20 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         self.project_subscription.update(
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
         )
+        self.detector.update(
+            config={
+                **self.detector.config,
+                "mode": ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+            }
+        )
+
         result = self.create_uptime_result(
             self.subscription.subscription_id,
             status=CHECKSTATUS_FAILURE,
             scheduled_check_time=datetime.now() - timedelta(minutes=5),
         )
         redis = _get_cluster()
-        key = build_onboarding_failure_key(self.project_subscription)
+        key = build_onboarding_failure_key(self.detector)
         assert redis.get(key) is None
         with (
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
@@ -697,13 +708,21 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
             date_added=datetime.now(timezone.utc) - timedelta(minutes=5),
         )
+        self.detector.update(
+            config={
+                **self.detector.config,
+                "mode": ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+            },
+            date_added=datetime.now(timezone.utc)
+            - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
+        )
         result = self.create_uptime_result(
             self.subscription.subscription_id,
             status=CHECKSTATUS_SUCCESS,
             scheduled_check_time=datetime.now() - timedelta(minutes=5),
         )
         redis = _get_cluster()
-        key = build_onboarding_failure_key(self.project_subscription)
+        key = build_onboarding_failure_key(self.detector)
         assert redis.get(key) is None
         with (
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as metrics,
@@ -737,6 +756,15 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             date_added=datetime.now(timezone.utc)
             - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
         )
+        self.detector.update(
+            config={
+                **self.detector.config,
+                "mode": ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+            },
+            date_added=datetime.now(timezone.utc)
+            - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
+        )
+
         uptime_subscription = self.project_subscription.uptime_subscription
         result = self.create_uptime_result(
             self.subscription.subscription_id,
@@ -744,7 +772,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             scheduled_check_time=datetime.now() - timedelta(minutes=2),
         )
         redis = _get_cluster()
-        key = build_onboarding_failure_key(self.project_subscription)
+        key = build_onboarding_failure_key(self.detector)
         assert redis.get(key) is None
         with (
             mock.patch("sentry.uptime.consumers.results_consumer.metrics") as consumer_metrics,

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -746,7 +746,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
                 self.create_uptime_result(
                     subscription_id=proj_sub.uptime_subscription.subscription_id
                 ),
-                proj_sub,
+                detector,
             )
             hashed_fingerprint = md5(str(proj_sub.id).encode("utf-8")).hexdigest()
             assert Group.objects.filter(


### PR DESCRIPTION
Instead of reading from ProjectUptimeSubscription we now only read from Detector (par creating issues, where we still need to read from ProjectUptimeSubscription since we use the project_subscription.id for the finterprint)