### PR TITLE
fix(ui): Wrong `repos` URL for "Connect a Repository" hovercard

### DIFF
--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -72,7 +72,7 @@ function VersionHoverCard({
               'Connect a repository to see commit info, files changed, and authors involved in future releases.'
             )}
           </p>
-          <LinkButton to={`/organizations/${orgSlug}/repos/`} priority="primary">
+          <LinkButton to={`/settings/${orgSlug}/repos/`} priority="primary">
             {t('Connect a repository')}
           </LinkButton>
         </ConnectRepo>


### PR DESCRIPTION
The old url would attempt to open the `repos` org slug, instead we need to link to the "Repos" page in org settings.

Fixes JAVASCRIPT-2ZT9