### PR TITLE
fix(issues): Reduce interval for 3 to 6 hour graphs

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -31,6 +31,7 @@ export const ONE_WEEK = 10080;
 export const FORTY_EIGHT_HOURS = 2880;
 export const TWENTY_FOUR_HOURS = 1440;
 export const SIX_HOURS = 360;
+export const THREE_HOURS = 180;
 export const ONE_HOUR = 60;
 export const FIVE_MINUTES = 5;
 
@@ -190,6 +191,7 @@ const issuesFidelityLadder = new GranularityLadder([
   [FORTY_EIGHT_HOURS, '1h'],
   [TWENTY_FOUR_HOURS, '20m'],
   [SIX_HOURS, '5m'],
+  [THREE_HOURS, '2m'],
   [ONE_HOUR, '1m'],
   [0, '1m'],
 ]);


### PR DESCRIPTION
Graphs that were 4 hours had 240 intervals at 1 minute making them really thin. Now they'll have just 120.

before
![image](https://github.com/user-attachments/assets/82ae211f-3fc8-43e1-82ad-d8c29076bc95)

after
![image](https://github.com/user-attachments/assets/72521738-aacf-4d67-842c-b03a5745c525)
