### PR TITLE
:bug: fix(aci): fix test notifications for slack in aci

### DIFF
--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -319,6 +319,47 @@ class TestInit(RuleTestCase):
         assert send_notification_success.args[0] == EventLifecycleOutcome.SUCCESS
 
     @with_feature("organizations:workflow-engine-trigger-actions")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
+    @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
+    def test_after_noa_test_action(self, mock_api_call, mock_post, mock_record):
+        mock_api_call.return_value = {
+            "body": orjson.dumps({"ok": True}).decode(),
+            "headers": {},
+            "status": 200,
+        }
+
+        action_data = self.action_data.copy()
+        action_data["legacy_rule_id"] = "123"
+        rule = self.create_project_rule(project=self.project, action_data=[action_data])
+        # Represents a test action
+        rule.id = -1
+        rule.environment_id = None
+
+        rule_cls_instance = self.get_rule(data=action_data)
+
+        results = list(rule_cls_instance.after(event=self.event))
+        assert len(results) == 1
+
+        results[0].callback(self.event, futures=[RuleFuture(rule=rule, kwargs={})])
+        blocks = mock_post.call_args.kwargs["blocks"]
+        blocks = orjson.loads(blocks)
+
+        assert (
+            blocks[0]["text"]["text"]
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={action_data['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+        )
+
+        # Test action should not create a notification message
+        assert NotificationMessage.objects.all().count() == 0
+
+        assert len(mock_record.mock_calls) == 2
+        thread_ts_start, thread_ts_success = mock_record.mock_calls
+
+        assert thread_ts_start.args[0] == EventLifecycleOutcome.STARTED
+        assert thread_ts_success.args[0] == EventLifecycleOutcome.SUCCESS
+
+    @with_feature("organizations:workflow-engine-trigger-actions")
     @with_feature("organizations:workflow-engine-ui-links")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")


### PR DESCRIPTION
when `action_id = -1`, it means its a test notification. if it is, don't query for an action, just fire it!