### PR TITLE
fix(ui): Fix some `useOrganization` crashes due to `<GlobalDrawer>`

### DIFF
--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -10,7 +10,6 @@ import {openCommandPalette} from 'sentry/actionCreators/modal';
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {initApiClientErrorHandling} from 'sentry/api';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import {GlobalDrawer} from 'sentry/components/globalDrawer';
 import GlobalModal from 'sentry/components/globalModal';
 import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
 import Hook from 'sentry/components/hook';
@@ -258,15 +257,13 @@ function App({children, params}: Props) {
           {renderOrganizationContextProvider(
             <AsyncSDKIntegrationContextProvider>
               <GlobalFeedbackForm>
-                <GlobalDrawer>
-                  <MainContainer tabIndex={-1} ref={mainContainerRef}>
-                    <DemoToursProvider>
-                      <GlobalModal onClose={handleModalClose} />
-                      <Indicators className="indicators-container" />
-                      <ErrorBoundary>{renderBody()}</ErrorBoundary>
-                    </DemoToursProvider>
-                  </MainContainer>
-                </GlobalDrawer>
+                <MainContainer tabIndex={-1} ref={mainContainerRef}>
+                  <DemoToursProvider>
+                    <GlobalModal onClose={handleModalClose} />
+                    <Indicators className="indicators-container" />
+                    <ErrorBoundary>{renderBody()}</ErrorBoundary>
+                  </DemoToursProvider>
+                </MainContainer>
               </GlobalFeedbackForm>
             </AsyncSDKIntegrationContextProvider>
           )}

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -5,6 +5,7 @@ import DemoHeader from 'sentry/components/demo/demoHeader';
 import {useFeatureFlagOnboardingDrawer} from 'sentry/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar';
 import {useFeedbackOnboardingDrawer} from 'sentry/components/feedback/feedbackOnboarding/sidebar';
 import Footer from 'sentry/components/footer';
+import {GlobalDrawer} from 'sentry/components/globalDrawer';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {usePerformanceOnboardingDrawer} from 'sentry/components/performanceOnboarding/sidebar';
 import {useProfilingOnboardingDrawer} from 'sentry/components/profiling/profilingOnboardingSidebar';
@@ -59,7 +60,9 @@ function OrganizationLayout({children}: Props) {
   return (
     <SentryDocumentTitle noSuffix title={organization?.name ?? 'Sentry'}>
       <OrganizationContainer>
-        <App organization={organization}>{children}</App>
+        <GlobalDrawer>
+          <App organization={organization}>{children}</App>
+        </GlobalDrawer>
       </OrganizationContainer>
       <ScrollRestoration />
     </SentryDocumentTitle>


### PR DESCRIPTION
This fixes a class of issues relating to `useOrganization` and `<GlobalDrawer>`. If the drawer is opened and for whatever reason, the organization context gets set to undefined/null (e.g. moving to settings where org is not guaranteed, or possibly when user hits a 401/3 and org gets unset (unconfirmed)) - then any components that are rendered inside of `<GlobalDrawer>` that use `useOrganization` will throw because org is undefined. This causes a hard crash for users.

This PR moves `<GlobalDrawer>` inside of the `<OrganizationLayout>` where organization is ensured to exist. Now when the org context changes, `<GlobalDrawer>` gets unmounted so the `useOrganization` hook no longer reacts to the undefined org.

Note: this also means that we can no longer use `<GlobalDrawer>` outside of org scope, which should be fine as we have very few areas that do not require an org.

Fixes JAVASCRIPT-2WMG
Fixes JAVASCRIPT-2V98
Fixes JAVASCRIPT-2ZT9
