### PR TITLE
fix(insights): Ensure all overview pages have the same date page filter

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -5,10 +5,6 @@ import Feature from 'sentry/components/acl/feature';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -24,7 +20,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -51,6 +46,7 @@ import {
   MOBILE_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {LaravelOverviewPage} from 'sentry/views/insights/pages/platform/laravel';
 import {CachesWidget} from 'sentry/views/insights/pages/platform/laravel/cachesWidget';
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
@@ -236,11 +232,7 @@ function EAPBackendOverviewPage() {
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
+                <OverviewDatePageFilter />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}
@@ -299,18 +291,8 @@ function EAPBackendOverviewPage() {
 }
 
 function BackendOverviewPageWithProviders() {
-  const organization = useOrganization();
-  const isLaravelPageAvailable = useIsLaravelInsightsAvailable();
-  const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
-
-  const {maxPickableDays} = limitMaxPickableDays(organization);
-
   return (
-    <DomainOverviewPageProviders
-      maxPickableDays={
-        isLaravelPageAvailable || isNextJsPageEnabled ? maxPickableDays : undefined
-      }
-    >
+    <DomainOverviewPageProviders>
       <BackendOverviewPage />
     </DomainOverviewPageProviders>
   );

--- a/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
@@ -6,10 +6,6 @@ import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import {tct} from 'sentry/locale';
@@ -45,6 +41,7 @@ import {
   MOBILE_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {
   generateBackendPerformanceEventView,
@@ -239,11 +236,7 @@ export function OldBackendOverviewPage() {
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
+                <OverviewDatePageFilter />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}

--- a/static/app/views/insights/pages/domainOverviewPageProviders.tsx
+++ b/static/app/views/insights/pages/domainOverviewPageProviders.tsx
@@ -6,19 +6,13 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 
-export function DomainOverviewPageProviders({
-  children,
-  maxPickableDays,
-}: {
-  children: React.ReactNode;
-  maxPickableDays?: number;
-}) {
+export function DomainOverviewPageProviders({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
   const location = useLocation();
 
   return (
     <NoProjectMessage organization={organization}>
-      <PageFiltersContainer maxPickableDays={maxPickableDays}>
+      <PageFiltersContainer>
         <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
           <MEPSettingProvider location={location}>{children}</MEPSettingProvider>
         </SentryDocumentTitle>

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -4,10 +4,6 @@ import Feature from 'sentry/components/acl/feature';
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -25,7 +21,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -46,6 +41,7 @@ import {
   FRONTEND_LANDING_TITLE,
   FRONTEND_PLATFORMS,
 } from 'sentry/views/insights/pages/frontend/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
 import {useIsNextJsInsightsEnabled} from 'sentry/views/insights/pages/platform/nextjs/features';
 import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
@@ -218,11 +214,7 @@ function EAPOverviewPage() {
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
+                <OverviewDatePageFilter />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}
@@ -266,14 +258,11 @@ function EAPOverviewPage() {
 }
 
 function FrontendOverviewPageWithProviders() {
-  const organization = useOrganization();
   const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
   const useEap = useInsightsEap();
 
-  const {maxPickableDays} = limitMaxPickableDays(organization);
-
   return (
-    <DomainOverviewPageProviders maxPickableDays={maxPickableDays}>
+    <DomainOverviewPageProviders>
       {isNextJsPageEnabled ? (
         <NextJsOverviewPage performanceType="frontend" />
       ) : useEap ? (

--- a/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
@@ -6,10 +6,6 @@ import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import {tct} from 'sentry/locale';
@@ -39,6 +35,7 @@ import {
   FRONTEND_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/frontend/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import {
@@ -215,11 +212,7 @@ export function OldFrontendOverviewPage() {
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
+                <OverviewDatePageFilter />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -3,10 +3,6 @@ import styled from '@emotion/styled';
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -43,6 +39,7 @@ import {
   MOBILE_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 import {
@@ -222,11 +219,7 @@ function EAPMobileOverviewPage() {
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
+                <OverviewDatePageFilter />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}

--- a/static/app/views/insights/pages/mobile/oldMobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/oldMobileOverviewPage.tsx
@@ -4,10 +4,6 @@ import styled from '@emotion/styled';
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import * as TeamKeyTransactionManager from 'sentry/components/performance/teamKeyTransactionsManager';
 import type {Project} from 'sentry/types/project';
@@ -35,6 +31,7 @@ import {
   MOBILE_PLATFORMS,
   OVERVIEW_PAGE_ALLOWED_OPS,
 } from 'sentry/views/insights/pages/mobile/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import {
   generateGenericPerformanceEventView,
@@ -219,11 +216,7 @@ export function OldMobileOverviewPage() {
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter />
-                </PageFilterBar>
+                <OverviewDatePageFilter />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     organization={organization}

--- a/static/app/views/insights/pages/overviewFilterBar.tsx
+++ b/static/app/views/insights/pages/overviewFilterBar.tsx
@@ -1,0 +1,25 @@
+import {
+  DatePageFilter,
+  type DatePageFilterProps,
+} from 'sentry/components/organizations/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+
+interface OverviewDatePageFilterProps {
+  resetProjectParamsOnChange?: string[];
+}
+
+export function OverviewDatePageFilter({
+  resetProjectParamsOnChange,
+}: OverviewDatePageFilterProps) {
+  const dateFilterProps: DatePageFilterProps = {};
+
+  return (
+    <PageFilterBar condensed>
+      <ProjectPageFilter resetParamsOnChange={resetProjectParamsOnChange} />
+      <EnvironmentPageFilter />
+      <DatePageFilter {...dateFilterProps} />
+    </PageFilterBar>
+  );
+}

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -4,14 +4,9 @@ import styled from '@emotion/styled';
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoAccess} from 'sentry/components/noAccess';
-import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
-import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
-import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
@@ -19,6 +14,7 @@ import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHead
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_TITLE} from 'sentry/views/insights/pages/frontend/settings';
+import {OverviewDatePageFilter} from 'sentry/views/insights/pages/overviewFilterBar';
 import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
@@ -46,8 +42,6 @@ export function PlatformLandingPageLayout({
 }) {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
-  const {defaultPeriod, maxPickableDays, relativeOptions} =
-    limitMaxPickableDays(organization);
 
   const showOnboarding = onboardingProject !== undefined;
 
@@ -83,18 +77,7 @@ export function PlatformLandingPageLayout({
           <ModuleLayout.Layout>
             <ModuleLayout.Full>
               <ToolRibbon>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter resetParamsOnChange={['starred']} />
-                  <EnvironmentPageFilter />
-                  <DatePageFilter
-                    maxPickableDays={maxPickableDays}
-                    defaultPeriod={defaultPeriod}
-                    relativeOptions={({arbitraryOptions}) => ({
-                      ...arbitraryOptions,
-                      ...relativeOptions,
-                    })}
-                  />
-                </PageFilterBar>
+                <OverviewDatePageFilter resetProjectParamsOnChange={['starred']} />
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar
                     // Force the search bar to re-render when the derivedQuery changes


### PR DESCRIPTION
The various overview pages have different restrictions. Specifically the nextjs and laravel specific pages are using the limits imposed on explore. Here we make sure they are all using the same defaults.