### PR TITLE
fix(gs-hooks): Memoize <Hook /> to prevent infinite rerenders

### DIFF
--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -1,4 +1,4 @@
-import {Component, type ComponentType} from 'react';
+import {Component, type ComponentType, memo} from 'react';
 
 import HookStore from 'sentry/stores/hookStore';
 import type {HookName, Hooks} from 'sentry/types/hooks';
@@ -86,4 +86,6 @@ function Hook<H extends ComponentHookName>({name, ...props}: Props<H>) {
   return <HookComponent />;
 }
 
-export default Hook;
+export default memo(Hook) as <H extends ComponentHookName>(
+  props: Props<H>
+) => React.ReactNode;


### PR DESCRIPTION
Fixes JAVASCRIPT-2Y6A

The `<Hook />` component defines a class component within it, which was causing components rendered by it to continually remount when its parent rerenders, which in turn caused infinite rerenders in some cases.

This component can probably be rewritten in a better way, but in the interest of introducing minimal change, wrapping it in a `React.memo` prevents the subcomponents from remounting.