### PR TITLE
chore(aci): default issue alert dual write flag to True

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -447,7 +447,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enforce stacked navigation feature (with ability to opt out)
     manager.add("organizations:enforce-stacked-navigation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable dual writing for issue alert issues (see: alerts create issues)
-    manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:workflow-engine-issue-alert-dual-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable workflow processing for metric issues
     manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow engine for issue alerts

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -55,6 +55,11 @@ class ProjectRuleCreator:
                         "workflow_engine.issue_alert.migrated",
                         extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
                     )
+                else:
+                    logger.error(
+                        "workflow_engine.issue_alert.missing_flag",
+                        extra={"rule_id": self.rule.id},
+                    )
         except UnableToAcquireLock:
             raise UnableToAcquireLockApiError
 

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -2,32 +2,31 @@ import logging
 
 import sentry_sdk
 from django.db import IntegrityError
-from django.db.models.signals import post_save
 
 from sentry import features
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.project import Project
+from sentry.signals import project_created
 from sentry.utils.rollback_metrics import incr_rollback_metrics
 from sentry.workflow_engine.models import Detector
 
 logger = logging.getLogger(__name__)
 
 
-def create_project_detectors(instance, created, **kwargs):
-    if created:
-        try:
-            if features.has(
-                "organizations:workflow-engine-issue-alert-dual-write", instance.organization
-            ):
-                Detector.objects.create(
-                    name="Error Detector", type=ErrorGroupType.slug, project=instance, config={}
-                )
-                logger.info("project.detector-created", extra={"project_id": instance.id})
-        except IntegrityError as e:
-            incr_rollback_metrics(Detector)
-            sentry_sdk.capture_exception(e)
+def create_project_detectors(project: Project, **kwargs):
+    try:
+        if features.has(
+            "organizations:workflow-engine-issue-alert-dual-write", project.organization
+        ):
+            Detector.objects.create(
+                name="Error Detector", type=ErrorGroupType.slug, project=project, config={}
+            )
+            logger.info("project.detector-created", extra={"project_id": project.id})
+    except IntegrityError as e:
+        incr_rollback_metrics(Detector)
+        sentry_sdk.capture_exception(e)
 
 
-post_save.connect(
-    create_project_detectors, sender=Project, dispatch_uid="create_project_detectors", weak=False
+project_created.connect(
+    create_project_detectors, dispatch_uid="create_project_detectors", weak=False
 )

--- a/src/sentry/receivers/rules.py
+++ b/src/sentry/receivers/rules.py
@@ -52,6 +52,11 @@ def create_default_rules(project: Project, default_rules=True, RuleModel=Rule, *
                 "workflow_engine.default_issue_alert.migrated",
                 extra={"rule_id": rule.id, "workflow_id": workflow.id},
             )
+        else:
+            logger.error(
+                "workflow_engine.issue_alert.missing_flag",
+                extra={"rule_id": rule.id},
+            )
 
     try:
         user: RpcUser = project.organization.get_default_owner()

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -429,13 +429,10 @@ class ProjectTest(APITestCase, TestCase):
         assert alert_rule.team_id is None
         assert alert_rule.user_id is None
 
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
     def test_project_detector(self):
-        project = self.create_project()
-        assert not Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
-
-        with self.feature({"organizations:workflow-engine-issue-alert-dual-write": True}):
-            project = self.create_project()
-            assert Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
+        project = self.create_project(fire_project_created=True)
+        assert Detector.objects.filter(project=project, type=ErrorGroupType.slug).exists()
 
 
 class ProjectOptionsTests(TestCase):


### PR DESCRIPTION
I'm seeing weird issues with default rules somehow not being migrated (in May!) even though the flag is `True` in flagpole.

We can default the flag to `True` in sentry and throw logs if it's somehow not the case.