### PR TITLE
feat(docs): Update stories to show the comitter date of the story file

### DIFF
--- a/static/app/components/timeline/index.stories.tsx
+++ b/static/app/components/timeline/index.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
-export default storyBook('Timeline (Updated 06/17/24)', story => {
+export default storyBook('Timeline', story => {
   story('Usage', () => (
     <CodeSnippet language="js">
       import Timeline from 'sentry/components/timeline';

--- a/static/app/views/stories/storyExports.tsx
+++ b/static/app/views/stories/storyExports.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import {ErrorBoundary} from '@sentry/react';
 
 import {space} from 'sentry/styles/space';
 import {StorySourceLinks} from 'sentry/views/stories/storySourceLinks';
@@ -12,7 +13,9 @@ export function StoryExports(props: {story: StoryDescriptor}) {
   return (
     <Fragment>
       <StorySourceLinksContainer>
-        <StorySourceLinks story={props.story} />
+        <ErrorBoundary>
+          <StorySourceLinks story={props.story} />
+        </ErrorBoundary>
       </StorySourceLinksContainer>
       {/* Render default export first */}
       {DefaultExport ? (

--- a/static/app/views/stories/storySourceLinks.tsx
+++ b/static/app/views/stories/storySourceLinks.tsx
@@ -1,14 +1,39 @@
 import {Fragment} from 'react';
 
 import {LinkButton} from 'sentry/components/core/button';
+import {DateTime} from 'sentry/components/dateTime';
 import {IconGithub} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useQuery} from 'sentry/utils/queryClient';
 
 import type {StoryDescriptor} from './useStoriesLoader';
 
+type GithubCommitResponse = Array<{commit: {committer: {date: string}}}>;
+
 export function StorySourceLinks(props: {story: StoryDescriptor}) {
+  const {data} = useQuery<GithubCommitResponse, Error, GithubCommitResponse, [string]>({
+    queryKey: [
+      `https://api.github.com/repos/getsentry/sentry/commits?&page=1per_page=1&path=static/${props.story.filename}`,
+    ],
+    queryFn: async ({queryKey}) => {
+      const [url] = queryKey;
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      return response.json();
+    },
+  });
+  const committerDate = data?.[0]?.commit.committer.date;
+
   return (
     <Fragment>
+      {committerDate ? (
+        <Fragment>
+          Story Last Edited:
+          <DateTime date={committerDate} />
+        </Fragment>
+      ) : null}
       <LinkButton
         href={`https://github.com/getsentry/sentry/blob/master/static/${props.story.filename}`}
         external


### PR DESCRIPTION
The date will only be fetched and rendered if you're logged into github. I expect that being logged in is the typical case for people working on the codebase. If you're not logged in then nothing should render.

![SCR-20250505-khzd](https://github.com/user-attachments/assets/7ad67163-ea27-4848-b450-96dd189e9c1f)
