### PR TITLE
:bug: fix(aci): use correct rule label in NOA

### DIFF
--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -134,7 +134,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.environment_id is not None
         assert self.workflow.environment is not None
         assert rule.environment_id == self.workflow.environment.id
-        assert rule.label == self.detector.name
+        assert rule.label == rule.label
         assert rule.data == {
             "actions": [
                 {
@@ -189,7 +189,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.id == self.action.id
         assert rule.project == self.detector.project
         assert rule.environment_id is None
-        assert rule.label == self.detector.name
+        assert rule.label == rule.label
         assert rule.data == {
             "actions": [
                 {


### PR DESCRIPTION
when firing notifications, i realized the rule label was incorrect in notification when we are firing notifications.

this uses the correct label if we aren't in the new UI.

![image](https://github.com/user-attachments/assets/344cb3c9-e95e-4bb2-91ea-843da5b3e02c)
