### PR TITLE
fix(typing): Fixes typing for Create Ticket utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ module = [
     "sentry.notifications.notifications.activity.base",
     "sentry.plugins.config",
     "sentry.release_health.metrics_sessions_v2",
-    "sentry.rules.actions.integrations.create_ticket.utils",
     "sentry.rules.history.preview",
     "sentry.search.events.builder.errors",
     "sentry.search.events.builder.metrics",

--- a/src/sentry/integrations/models/external_issue.py
+++ b/src/sentry/integrations/models/external_issue.py
@@ -11,7 +11,7 @@ from sentry.constants import ObjectStatus
 from sentry.db.models import FlexibleForeignKey, JSONField, Model, region_silo_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 
 if TYPE_CHECKING:
     from sentry.integrations.services.integration import RpcIntegration
@@ -38,7 +38,7 @@ class ExternalIssueManager(BaseManager["ExternalIssue"]):
         return self.filter(**kwargs)
 
     def get_linked_issues(
-        self, event: Event, integration: RpcIntegration
+        self, event: GroupEvent, integration: RpcIntegration
     ) -> QuerySet[ExternalIssue]:
         from sentry.models.grouplink import GroupLink
 
@@ -52,7 +52,7 @@ class ExternalIssueManager(BaseManager["ExternalIssue"]):
             integration_id=integration.id,
         )
 
-    def has_linked_issue(self, event: Event, integration: RpcIntegration) -> bool:
+    def has_linked_issue(self, event: GroupEvent, integration: RpcIntegration) -> bool:
         return self.get_linked_issues(event, integration).exists()
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -75,7 +75,7 @@ from sentry.auth.superuser import COOKIE_SECURE as SU_COOKIE_SECURE
 from sentry.auth.superuser import SUPERUSER_ORG_ID, Superuser
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.event_manager import EventManager
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.issues.grouptype import (
     NoiseConfig,
@@ -789,6 +789,9 @@ class RuleTestCase(TestCase):
 
     def get_event(self):
         return self.event
+
+    def get_group_event(self):
+        return GroupEvent.from_event(self.event, self.event.group)
 
     def get_rule(self, **kwargs):
         kwargs.setdefault("project", self.project)

--- a/tests/sentry/integrations/github/test_ticket_action.py
+++ b/tests/sentry/integrations/github/test_ticket_action.py
@@ -5,7 +5,7 @@ import responses
 from django.urls import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.github import client
 from sentry.integrations.github.actions.create_ticket import GitHubCreateTicketAction
 from sentry.integrations.github.integration import GitHubIntegration
@@ -65,7 +65,7 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
         return results[0].callback(event, futures=[rule_future])
 
-    def get_key(self, event: Event):
+    def get_key(self, event: GroupEvent):
         return ExternalIssue.objects.get_linked_issues(event, self.integration).values_list(
             "key", flat=True
         )[0]
@@ -132,7 +132,7 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
         # Get the rule from DB
         rule_object = Rule.objects.get(id=response.data["id"])
-        event = self.get_event()
+        event = self.get_group_event()
 
         # Trigger its `after`
         self.trigger(event, rule_object)

--- a/tests/sentry/integrations/github_enterprise/test_ticket_action.py
+++ b/tests/sentry/integrations/github_enterprise/test_ticket_action.py
@@ -5,7 +5,7 @@ import responses
 from django.urls import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.github_enterprise import client
 from sentry.integrations.github_enterprise.actions.create_ticket import (
     GitHubEnterpriseCreateTicketAction,
@@ -80,7 +80,7 @@ class GitHubEnterpriseEnterpriseTicketRulesTestCase(RuleTestCase, BaseAPITestCas
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
         return results[0].callback(event, futures=[rule_future])
 
-    def get_key(self, event: Event):
+    def get_key(self, event: GroupEvent):
         return ExternalIssue.objects.get_linked_issues(event, self.integration).values_list(
             "key", flat=True
         )[0]
@@ -147,7 +147,7 @@ class GitHubEnterpriseEnterpriseTicketRulesTestCase(RuleTestCase, BaseAPITestCas
 
         # Get the rule from DB
         rule_object = Rule.objects.get(id=response.data["id"])
-        event = self.get_event()
+        event = self.get_group_event()
 
         # Trigger its `after`
         self.trigger(event, rule_object)

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
 
 from fixtures.integrations.jira.mock import MockJira
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.jira import JiraCreateTicketAction, JiraIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.types import EventLifecycleOutcome
@@ -56,7 +56,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
         return results[0].callback(event, futures=[rule_future])
 
-    def get_key(self, event: Event):
+    def get_key(self, event: GroupEvent):
         return ExternalIssue.objects.get_linked_issues(event, self.integration).values_list(
             "key", flat=True
         )[0]
@@ -103,7 +103,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
             # Get the rule from DB
             rule_object = Rule.objects.get(id=response.data["id"])
-            event = self.get_event()
+            event = self.get_group_event()
 
             # Trigger its `after`
             self.trigger(event, rule_object)

--- a/tests/sentry/integrations/jira_server/test_ticket_action.py
+++ b/tests/sentry/integrations/jira_server/test_ticket_action.py
@@ -2,7 +2,7 @@ import responses
 from django.urls import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.jira_server import JiraServerCreateTicketAction, JiraServerIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.models.rule import Rule
@@ -46,7 +46,7 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         self.installation = self.integration.get_installation(self.organization.id)
         self.login_as(user=self.user)
 
-    def trigger(self, event, rule_object):
+    def trigger(self, event: GroupEvent, rule_object: Rule):
         action = rule_object.data.get("actions", ())[0]
         action_inst = self.get_rule(data=action, rule=rule_object)
         results = list(action_inst.after(event=event))
@@ -55,7 +55,7 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
         return results[0].callback(event, futures=[rule_future])
 
-    def get_key(self, event: Event):
+    def get_key(self, event: GroupEvent):
         return ExternalIssue.objects.get_linked_issues(event, self.integration).values_list(
             "key", flat=True
         )[0]
@@ -185,7 +185,7 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
         # Get the rule from DB
         rule_object = Rule.objects.get(id=response.data["id"])
-        event = self.get_event()
+        event = self.get_group_event()
 
         # Trigger its `after`
         self.trigger(event, rule_object)


### PR DESCRIPTION
Fixes a couple of issues in the `create_ticket/utils` file:
- Updates all linking helpers to take a `GroupEvent` instead of an event.
- Adds a check to ensure an integration is of the correct lineage for ticket creation
