### PR TITLE
feat(query-builder): Improve `onChange` callback to wait for token completion

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -29,6 +29,7 @@ interface SearchQueryBuilderContextData {
   focusOverride: FocusOverride | null;
   getFieldDefinition: (key: string, kind?: FieldKind) => FieldDefinition | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
+  handleOnChange: (query: string) => void;
   handleSearch: (query: string) => void;
   parsedQuery: ParseResult | null;
   query: string;
@@ -70,6 +71,7 @@ export function SearchQueryBuilderProvider({
   filterKeyMenuWidth = 360,
   filterKeySections,
   getTagValues,
+  onChange,
   onSearch,
   placeholder,
   recentSearches,
@@ -114,6 +116,14 @@ export function SearchQueryBuilderProvider({
     recentSearches,
     searchSource,
     onSearch,
+    trigger: 'onsearch',
+  });
+  const handleOnChange = useHandleSearch({
+    parsedQuery,
+    recentSearches,
+    searchSource,
+    onSearch: onChange,
+    trigger: 'onchange',
   });
   const {width: searchBarWidth} = useDimensions({elementRef: wrapperRef});
   const size =
@@ -135,6 +145,7 @@ export function SearchQueryBuilderProvider({
       wrapperRef,
       actionBarRef,
       handleSearch,
+      handleOnChange,
       placeholder,
       recentSearches,
       searchSource,
@@ -154,6 +165,7 @@ export function SearchQueryBuilderProvider({
     fieldDefinitionGetter,
     dispatch,
     handleSearch,
+    handleOnChange,
     placeholder,
     recentSearches,
     searchSource,

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -19,6 +19,7 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 
 interface SearchQueryBuilderContextData {
   actionBarRef: React.RefObject<HTMLDivElement | null>;
+  committedQuery: string;
   disabled: boolean;
   disallowFreeText: boolean;
   disallowWildcard: boolean;

--- a/static/app/components/searchQueryBuilder/hooks/useHandleSearch.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useHandleSearch.tsx
@@ -21,6 +21,7 @@ type UseHandleSearchProps = {
   parsedQuery: ParseResult | null;
   recentSearches: SavedSearchType | undefined;
   searchSource: string;
+  trigger: 'onchange' | 'onsearch';
   onSearch?: (query: string, state: CallbackSearchState) => void;
 };
 
@@ -55,12 +56,14 @@ function trackIndividualSearchFilters({
   searchSource,
   query,
   organization,
+  trigger,
 }: {
   organization: Organization;
   parsedQuery: ParseResult | null;
   query: string;
   searchSource: string;
   searchType: string;
+  trigger: 'onchange' | 'onsearch';
 }) {
   try {
     parsedQuery?.forEach(token => {
@@ -82,6 +85,7 @@ function trackIndividualSearchFilters({
         search_type: searchType,
         search_source: searchSource,
         new_experience: true,
+        trigger,
       });
     });
   } catch (e) {
@@ -94,6 +98,7 @@ export function useHandleSearch({
   recentSearches,
   searchSource,
   onSearch,
+  trigger,
 }: UseHandleSearchProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -111,6 +116,7 @@ export function useHandleSearch({
           search_type: searchType,
           search_source: searchSource,
           new_experience: true,
+          trigger,
         });
         return;
       }
@@ -120,7 +126,7 @@ export function useHandleSearch({
         query,
         search_type: searchType,
         search_source: searchSource,
-        new_experience: true,
+        trigger,
       });
 
       trackIndividualSearchFilters({
@@ -129,10 +135,11 @@ export function useHandleSearch({
         searchSource,
         query,
         organization,
+        trigger,
       });
 
       saveAsRecentSearch({api, organization, query, recentSearches});
     },
-    [api, onSearch, organization, parsedQuery, recentSearches, searchSource]
+    [api, onSearch, organization, parsedQuery, recentSearches, searchSource, trigger]
   );
 }

--- a/static/app/components/searchQueryBuilder/hooks/useOnChange.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useOnChange.tsx
@@ -1,0 +1,15 @@
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
+import usePrevious from 'sentry/utils/usePrevious';
+
+export function useOnChange() {
+  const {committedQuery, handleOnChange} = useSearchQueryBuilder();
+
+  const previousCommittedQuery = usePrevious(committedQuery);
+
+  useEffectAfterFirstRender(() => {
+    if (committedQuery !== previousCommittedQuery) {
+      handleOnChange(committedQuery);
+    }
+  }, [committedQuery, previousCommittedQuery, handleOnChange]);
+}

--- a/static/app/components/searchQueryBuilder/hooks/useOnChange.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useOnChange.tsx
@@ -1,15 +1,34 @@
+import type {SearchQueryBuilderProps} from 'sentry/components/searchQueryBuilder';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {queryIsValid} from 'sentry/components/searchQueryBuilder/utils';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 import usePrevious from 'sentry/utils/usePrevious';
 
-export function useOnChange() {
-  const {committedQuery, handleOnChange} = useSearchQueryBuilder();
+export function useOnChange({
+  onChange,
+  searchOnChange,
+}: Pick<SearchQueryBuilderProps, 'onChange' | 'searchOnChange'>) {
+  const {committedQuery, handleSearch, parseQuery} = useSearchQueryBuilder();
 
   const previousCommittedQuery = usePrevious(committedQuery);
 
   useEffectAfterFirstRender(() => {
     if (committedQuery !== previousCommittedQuery) {
-      handleOnChange(committedQuery);
+      if (onChange) {
+        const parsedQuery = parseQuery(committedQuery);
+        onChange(committedQuery, {parsedQuery, queryIsValid: queryIsValid(parsedQuery)});
+      }
+
+      if (searchOnChange) {
+        handleSearch(committedQuery);
+      }
     }
-  }, [committedQuery, previousCommittedQuery, handleOnChange]);
+  }, [
+    committedQuery,
+    previousCommittedQuery,
+    onChange,
+    handleSearch,
+    searchOnChange,
+    parseQuery,
+  ]);
 }

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -182,6 +182,25 @@ describe('SearchQueryBuilder', function () {
       });
       expect(mockOnBlur).toHaveBeenCalledWith('ab', expectedQueryState);
     });
+
+    it('waits to call onChange until token value has been selected', async function () {
+      const mockOnChange = jest.fn();
+      render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
+
+      // Value has yet to be selected, so onChange should not have been called
+      expect(mockOnChange).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole('option', {name: 'Firefox'}));
+
+      // Value has been selected, so onChange should have been called
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'browser.name:firefox',
+        expect.anything()
+      );
+    });
   });
 
   describe('actions', function () {
@@ -605,9 +624,11 @@ describe('SearchQueryBuilder', function () {
 
   describe('mouse interactions', function () {
     it('can remove a token by clicking the delete button', async function () {
+      const mockOnChange = jest.fn();
       render(
         <SearchQueryBuilder
           {...defaultProps}
+          onChange={mockOnChange}
           initialQuery="browser.name:firefox custom_tag_name:123"
         />
       );
@@ -634,6 +655,9 @@ describe('SearchQueryBuilder', function () {
 
       // Custom tag token should still be present
       expect(screen.getByRole('row', {name: 'custom_tag_name:123'})).toBeInTheDocument();
+
+      // onChange should have been called with the updated query
+      expect(mockOnChange).toHaveBeenCalledWith('custom_tag_name:123', expect.anything());
     });
 
     it('can modify the operator by clicking into it', async function () {
@@ -792,7 +816,14 @@ describe('SearchQueryBuilder', function () {
 
   describe('new search tokens', function () {
     it('can add an unsupported filter key and value', async function () {
-      render(<SearchQueryBuilder {...defaultProps} />);
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          onChange={mockOnChange}
+          initialQuery="browser.name:firefox"
+        />
+      );
       await userEvent.click(getLastInput());
 
       // Typing "foo", then " a:b" should add the "foo" text followed by a new token "a:b"
@@ -802,10 +833,17 @@ describe('SearchQueryBuilder', function () {
       );
       expect(screen.getByRole('row', {name: 'foo'})).toBeInTheDocument();
       expect(screen.getByRole('row', {name: 'a:b'})).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(mockOnChange).toHaveBeenCalledWith('foo a:b', expect.anything());
+      });
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
     });
 
     it('adds default value for filter when typing <filter>:', async function () {
-      render(<SearchQueryBuilder {...defaultProps} />);
+      const mockOnChange = jest.fn();
+      render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />);
       await userEvent.click(getLastInput());
 
       // Typing `is:` and escaping should result in `is:unresolved`
@@ -814,6 +852,9 @@ describe('SearchQueryBuilder', function () {
         'is:{escape}'
       );
       expect(await screen.findByRole('row', {name: 'is:unresolved'})).toBeInTheDocument();
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith('is:unresolved', expect.anything());
     });
 
     it('does not automatically create a filter if the user intends to wrap in quotes', async function () {
@@ -840,18 +881,28 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('can add a new token by clicking a key suggestion', async function () {
-      render(<SearchQueryBuilder {...defaultProps} />);
+      const mockOnChange = jest.fn();
+      render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />);
 
       await userEvent.click(screen.getByRole('combobox', {name: 'Add a search term'}));
       await userEvent.click(screen.getByRole('option', {name: 'browser.name'}));
 
       // New token should be added with the correct key and default value
       expect(screen.getByLabelText('browser.name:""')).toBeInTheDocument();
+      // onChange should not be called until exiting edit mode
+      expect(mockOnChange).not.toHaveBeenCalled();
 
       await userEvent.click(await screen.findByLabelText('Firefox'));
 
       // New token should have a value
       expect(screen.getByLabelText('browser.name:Firefox')).toBeInTheDocument();
+
+      // Now we call onChange
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'browser.name:Firefox',
+        expect.anything()
+      );
     });
 
     it('can add free text by typing', async function () {
@@ -1736,8 +1787,13 @@ describe('SearchQueryBuilder', function () {
       });
 
       it('keeps focus inside value when multi-selecting with checkboxes', async function () {
+        const mockOnChange = jest.fn();
         render(
-          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:firefox"
+            onChange={mockOnChange}
+          />
         );
 
         await userEvent.click(
@@ -1754,6 +1810,7 @@ describe('SearchQueryBuilder', function () {
         // - Commit an empty string as the filter value
         // - Input value should be cleared
         // - Keep focus inside the input
+        // - Not call onChange
         await userEvent.click(
           await screen.findByRole('checkbox', {name: 'Toggle firefox'})
         );
@@ -1766,11 +1823,13 @@ describe('SearchQueryBuilder', function () {
           );
         });
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+        expect(mockOnChange).not.toHaveBeenCalled();
 
         // Toggling on the "Chrome" option should:
         // - Commit the value "Chrome" to the filter
         // - Input value should be "Chrome,"
         // - Keep focus inside the input
+        // - Still not call onChange
         await userEvent.click(
           await screen.findByRole('checkbox', {name: 'Toggle Chrome'})
         );
@@ -1783,11 +1842,26 @@ describe('SearchQueryBuilder', function () {
           );
         });
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+        expect(mockOnChange).not.toHaveBeenCalled();
+
+        // Clicking outside of the input should call onChange
+        await userEvent.click(document.body);
+        await waitFor(() => {
+          expect(mockOnChange).toHaveBeenCalledWith(
+            'browser.name:Chrome',
+            expect.anything()
+          );
+        });
       });
 
       it('keeps focus inside value when multi-selecting with ctrl+enter', async function () {
+        const mockOnChange = jest.fn();
         render(
-          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:firefox"
+            onChange={mockOnChange}
+          />
         );
 
         await userEvent.click(
@@ -1807,11 +1881,27 @@ describe('SearchQueryBuilder', function () {
           );
         });
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+
+        // onChange should not be called until exiting edit mode
+        expect(mockOnChange).not.toHaveBeenCalled();
+
+        await userEvent.keyboard('{Escape}');
+        await waitFor(() => {
+          expect(mockOnChange).toHaveBeenCalledWith(
+            'browser.name:[firefox,Chrome]',
+            expect.anything()
+          );
+        });
       });
 
       it('keeps focus inside value when multi-selecting with ctrl+click', async function () {
+        const mockOnChange = jest.fn();
         render(
-          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:firefox"
+            onChange={mockOnChange}
+          />
         );
 
         const user = userEvent.setup();
@@ -1832,6 +1922,17 @@ describe('SearchQueryBuilder', function () {
           );
         });
         expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveFocus();
+
+        // onChange should not be called until exiting edit mode
+        expect(mockOnChange).not.toHaveBeenCalled();
+
+        await userEvent.keyboard('{Escape}');
+        await waitFor(() => {
+          expect(mockOnChange).toHaveBeenCalledWith(
+            'browser.name:[firefox,Chrome]',
+            expect.anything()
+          );
+        });
       });
 
       it('collapses many selected options', async function () {

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -9,6 +9,7 @@ import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilder,
 } from 'sentry/components/searchQueryBuilder/context';
+import {useOnChange} from 'sentry/components/searchQueryBuilder/hooks/useOnChange';
 import {PlainTextQueryInput} from 'sentry/components/searchQueryBuilder/plainTextQueryInput';
 import {TokenizedQueryGrid} from 'sentry/components/searchQueryBuilder/tokenizedQueryGrid';
 import {
@@ -187,6 +188,7 @@ function SearchQueryBuilderUI({
   const {parsedQuery, query, dispatch, wrapperRef, actionBarRef, size} =
     useSearchQueryBuilder();
 
+  useOnChange();
   useLayoutEffect(() => {
     dispatch({type: 'UPDATE_QUERY', query: initialQuery});
   }, [dispatch, initialQuery]);

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -108,6 +108,10 @@ export interface SearchQueryBuilderProps {
    */
   recentSearches?: SavedSearchType;
   /**
+   * When true, will trigger the `onSearch` callback when the query changes.
+   */
+  searchOnChange?: boolean;
+  /**
    * When true, will display a visual indicator when there are unsaved changes.
    * This search is considered unsubmitted when query !== initialQuery.
    */
@@ -184,11 +188,13 @@ function SearchQueryBuilderUI({
   queryInterface = QueryInterfaceType.TOKENIZED,
   showUnsubmittedIndicator,
   trailingItems,
+  onChange,
+  searchOnChange,
 }: SearchQueryBuilderProps) {
   const {parsedQuery, query, dispatch, wrapperRef, actionBarRef, size} =
     useSearchQueryBuilder();
 
-  useOnChange();
+  useOnChange({onChange, searchOnChange});
   useLayoutEffect(() => {
     dispatch({type: 'UPDATE_QUERY', query: initialQuery});
   }, [dispatch, initialQuery]);

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -25,8 +25,6 @@ import {space} from 'sentry/styles/space';
 import type {SavedSearchType, Tag, TagCollection} from 'sentry/types/group';
 import PanelProvider from 'sentry/utils/panelProvider';
 import {useDimensions} from 'sentry/utils/useDimensions';
-import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
-import usePrevious from 'sentry/utils/usePrevious';
 
 export interface SearchQueryBuilderProps {
   /**
@@ -181,7 +179,6 @@ function SearchQueryBuilderUI({
   disabled = false,
   label,
   initialQuery,
-  onChange,
   onBlur,
   queryInterface = QueryInterfaceType.TOKENIZED,
   showUnsubmittedIndicator,
@@ -193,13 +190,6 @@ function SearchQueryBuilderUI({
   useLayoutEffect(() => {
     dispatch({type: 'UPDATE_QUERY', query: initialQuery});
   }, [dispatch, initialQuery]);
-
-  const previousQuery = usePrevious(query);
-  useEffectAfterFirstRender(() => {
-    if (previousQuery !== query) {
-      onChange?.(query, {parsedQuery, queryIsValid: queryIsValid(parsedQuery)});
-    }
-  }, [onChange, query, previousQuery, parsedQuery]);
 
   const {width: actionBarWidth} = useDimensions({elementRef: actionBarRef});
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -135,6 +135,7 @@ function FilterValue({token, state, item, filterRef, onActiveChange}: FilterValu
           onCommit={() => {
             setIsEditing(false);
             onActiveChange(false);
+            dispatch({type: 'COMMIT_QUERY'});
             if (state.collection.getKeyAfter(item.key)) {
               state.selectionManager.setFocusedKey(
                 state.collection.getKeyAfter(item.key)

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -71,10 +71,15 @@ export type SearchEventParameters = {
   };
   'search.saved_search_open_create_modal': OpenEvent;
   'search.saved_search_sidebar_toggle_clicked': {open: boolean};
-  'search.search_with_invalid': SearchEventBase;
-  'search.searched': SearchEventBase;
+  'search.search_with_invalid': SearchEventBase & {
+    trigger: 'onchange' | 'onsearch';
+  };
+  'search.searched': SearchEventBase & {
+    trigger: 'onchange' | 'onsearch';
+  };
   'search.searched_filter': SearchEventBase & {
     key: string;
+    trigger: 'onchange' | 'onsearch';
     values: string[];
   };
   'search.shortcut_used': SearchEventBase & {

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -71,15 +71,10 @@ export type SearchEventParameters = {
   };
   'search.saved_search_open_create_modal': OpenEvent;
   'search.saved_search_sidebar_toggle_clicked': {open: boolean};
-  'search.search_with_invalid': SearchEventBase & {
-    trigger: 'onchange' | 'onsearch';
-  };
-  'search.searched': SearchEventBase & {
-    trigger: 'onchange' | 'onsearch';
-  };
+  'search.search_with_invalid': SearchEventBase;
+  'search.searched': SearchEventBase;
   'search.searched_filter': SearchEventBase & {
     key: string;
-    trigger: 'onchange' | 'onsearch';
     values: string[];
   };
   'search.shortcut_used': SearchEventBase & {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -149,7 +149,7 @@ describe('SpansSearchBar', () => {
     const searchInput = await screen.findByRole('combobox', {
       name: 'Add a search term',
     });
-    await userEvent.type(searchInput, 'span.op:function');
+    await userEvent.type(searchInput, 'span.op:function{enter}');
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalled();


### PR DESCRIPTION
There is interest in changing default search behavior to search on change rather than requiring the user to hit enter. The problem with the existing `onChange` handler is that it fires every time the query changes, which is often in the middle of the user editing a filter value.

This PR introduces state to track the committed value (`committedQuery`) separately from `query` so that we can fire `onChange` only when necessary. It also adds a `searchOnChange` prop which can be used to start implementing the automatic search behavior.

https://github.com/user-attachments/assets/9468c807-0b8e-480a-9515-969731b76043

