### PR TITLE
ref(grouping): Refactor and fix bugs in `get_hint_for_frame`

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -166,7 +166,6 @@ def get_hint_for_frame(
     """
     Determine a hint to use for the frame, handling special-casing and precedence.
     """
-    frame_type = "in-app" if frame_component.in_app else "system"
     client_in_app = get_path(frame, "data", "client_in_app")
     rust_in_app = frame["in_app"]
     rust_hint = rust_frame.hint
@@ -174,16 +173,6 @@ def get_hint_for_frame(
         None if rust_hint is None else "in-app" if rust_hint.startswith("marked") else "contributes"
     )
     incoming_hint = frame_component.hint
-    incoming_hint_type = (
-        None
-        if incoming_hint is None
-        else "contributes" if incoming_hint.startswith("ignored") else "in-app"
-    )
-    use_rust_hint = True
-
-    # Ignore the incoming hint if it's not the kind we want
-    if desired_hint_type and incoming_hint_type != desired_hint_type:
-        incoming_hint = None
 
     # TODO: We can switch this to `desired_hint_type == "in-app"` once we're only using split
     # enhancements. For now, we need to also include the case where `desired_hint_type` is None. (At
@@ -199,27 +188,18 @@ def get_hint_for_frame(
         )
         incoming_hint = client_in_app_hint or default_in_app_hint or incoming_hint
 
-    # Prevent clobbering an existing hint with no hint
-    if rust_hint is None:
-        use_rust_hint = False
-
-    # System frames can't contribute to the app variant, no matter what +/-group rules say, so we
-    # ignore the rust hint if it's about contributing since it's irrelevant
-    elif variant_name == "app" and frame_type == "system" and rust_hint_type == "contributes":
-        use_rust_hint = False
-
-    # Similarly, we don't need hints about marking frames in or out of app in the system stacktrace
-    # because such changes don't actually have an effect there
-    elif variant_name == "system" and rust_hint_type == "in-app":
-        use_rust_hint = False
+    can_use_rust_hint = _can_use_hint(variant_name, frame_component, rust_hint, desired_hint_type)
+    can_use_incoming_hint = _can_use_hint(
+        variant_name, frame_component, incoming_hint, desired_hint_type
+    )
 
     # We don't want the rust enhancer taking credit for changing things if we know the value didn't
     # actually change. (This only happens with in-app hints, not contributes hints, because of the
     # weird (a.k.a. wrong) second condition in the rust enhancer's version of `in_app_changed`.)
-    elif variant_name == "app" and rust_hint_type == "in-app" and rust_in_app == client_in_app:
-        use_rust_hint = False
+    if variant_name == "app" and rust_hint_type == "in-app" and rust_in_app == client_in_app:
+        can_use_rust_hint = False
 
-    return rust_hint if use_rust_hint else incoming_hint
+    return rust_hint if can_use_rust_hint else incoming_hint if can_use_incoming_hint else None
 
 
 def _split_rules(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -192,7 +192,9 @@ def get_hint_for_frame(
         default_in_app_hint = "non app frame" if not frame_component.in_app else None
         client_in_app_hint = (
             f"marked {"in-app" if client_in_app else "out of app"} by the client"
-            if client_in_app is not None
+            # Only create the hint if it's going to match the eventual outcome. Otherwise, we might
+            # fall back to the client hint even though the client in-app value got overridden.
+            if client_in_app is not None and client_in_app == rust_in_app
             else None
         )
         incoming_hint = client_in_app_hint or default_in_app_hint or incoming_hint

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -130,6 +130,7 @@ def _can_use_hint(
     variant_name: str,
     frame_component: FrameGroupingComponent,
     hint: str | None,
+    desired_hint_type: Literal["in-app", "contributes"] | None = None,
 ) -> bool:
     # Prevent clobbering an existing hint with no hint
     if hint is None:
@@ -137,6 +138,10 @@ def _can_use_hint(
 
     frame_type = "in-app" if frame_component.in_app else "system"
     hint_type = "contributes" if "ignored" in hint else "in-app"
+
+    # Don't use the hint if we've specifically asked for something different
+    if desired_hint_type and hint_type != desired_hint_type:
+        return False
 
     # System frames can't contribute to the app variant, no matter what +/-group rules say, so we
     # ignore the hint if it's about contributing since it's irrelevant

--- a/tests/sentry/grouping/enhancements/test_hints.py
+++ b/tests/sentry/grouping/enhancements/test_hints.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+
+from sentry.grouping.component import FrameGroupingComponent
+from sentry.grouping.enhancer import get_hint_for_frame
+
+
+@dataclass
+class DummyRustFrame:
+    hint: str | None
+    contributes: bool | None = None
+
+
+in_app_hint = "marked in-app by (...)"
+client_in_app_hint = "marked in-app by the client"
+out_of_app_hint = "marked out of app by (...)"
+client_out_of_app_hint = "marked out of app by the client"
+ignored_hint = "ignored by (...)"
+ignored_because_hint = "ignored because ..."
+unignored_hint = "un-ignored by (...)"
+default_system_frame_hint = "non app frame"
+
+
+@pytest.mark.parametrize(
+    [
+        "variant_name",
+        "in_app",
+        "client_in_app",
+        "rust_hint",
+        "incoming_hint",
+        "desired_hint_type",
+        "expected_result",
+    ],
+    # This represents every combo of:
+    #
+    #    variant_name: app or system
+    #    in_app: True or False
+    #    client_in_app: None, True, or False
+    #    rust_hint: in_app_hint, out_of_app_hint, ignored_hint, unignored_hint, or None
+    #    incoming_hint: None or ignored_because_hint (the only kind of hint that gets set ahead of time)
+    #    desired_hint_type: None, in-app, or contributes
+    #
+    # Some of the combos will never happen in real life, and those that won't are marked. They're still
+    # in the list because it's much easier to ensure every case is covered that way.
+    #
+    # No formatting so that we can keep all the cases as single lines
+    # fmt: off
+    [
+        ("app", True, None, in_app_hint, None, None, in_app_hint),
+        ("app", True, None, in_app_hint, None, "in-app", in_app_hint),
+        ("app", True, None, in_app_hint, None, "contributes", None),
+        ("app", True, None, in_app_hint, ignored_because_hint, None, in_app_hint),
+        ("app", True, None, in_app_hint, ignored_because_hint, "in-app", in_app_hint),
+        ("app", True, None, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("app", True, None, out_of_app_hint, None, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, None, out_of_app_hint, None, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, None, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, None, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, None, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, None, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, None, ignored_hint, None, None, ignored_hint),
+        ("app", True, None, ignored_hint, None, "in-app", None),
+        ("app", True, None, ignored_hint, None, "contributes", ignored_hint),
+        ("app", True, None, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("app", True, None, ignored_hint, ignored_because_hint, "in-app", None),
+        ("app", True, None, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("app", True, None, unignored_hint, None, None, unignored_hint),
+        ("app", True, None, unignored_hint, None, "in-app", None),
+        ("app", True, None, unignored_hint, None, "contributes", unignored_hint),
+        ("app", True, None, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("app", True, None, unignored_hint, ignored_because_hint, "in-app", None),
+        ("app", True, None, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("app", True, None, None, None, None, None),
+        ("app", True, None, None, None, "in-app", None),
+        ("app", True, None, None, None, "contributes", None),
+        ("app", True, None, None, ignored_because_hint, None, ignored_because_hint),
+        ("app", True, None, None, ignored_because_hint, "in-app", None),
+        ("app", True, None, None, ignored_because_hint, "contributes", ignored_because_hint),
+        ("app", True, True, in_app_hint, None, None, client_in_app_hint),
+        ("app", True, True, in_app_hint, None, "in-app", client_in_app_hint),
+        ("app", True, True, in_app_hint, None, "contributes", None),
+        ("app", True, True, in_app_hint, ignored_because_hint, None, client_in_app_hint),
+        ("app", True, True, in_app_hint, ignored_because_hint, "in-app", client_in_app_hint),
+        ("app", True, True, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("app", True, True, out_of_app_hint, None, None, client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, True, out_of_app_hint, None, "in-app", client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, True, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, True, out_of_app_hint, ignored_because_hint, None, client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, True, out_of_app_hint, ignored_because_hint, "in-app", client_in_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, True, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, True, ignored_hint, None, None, ignored_hint),
+        ("app", True, True, ignored_hint, None, "in-app", client_in_app_hint),
+        ("app", True, True, ignored_hint, None, "contributes", ignored_hint),
+        ("app", True, True, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("app", True, True, ignored_hint, ignored_because_hint, "in-app", client_in_app_hint),
+        ("app", True, True, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("app", True, True, unignored_hint, None, None, unignored_hint),
+        ("app", True, True, unignored_hint, None, "in-app", client_in_app_hint),
+        ("app", True, True, unignored_hint, None, "contributes", unignored_hint),
+        ("app", True, True, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("app", True, True, unignored_hint, ignored_because_hint, "in-app", client_in_app_hint),
+        ("app", True, True, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("app", True, True, None, None, None, client_in_app_hint),
+        ("app", True, True, None, None, "in-app", client_in_app_hint),
+        ("app", True, True, None, None, "contributes", None),
+        ("app", True, True, None, ignored_because_hint, None, client_in_app_hint),
+        ("app", True, True, None, ignored_because_hint, "in-app", client_in_app_hint),
+        ("app", True, True, None, ignored_because_hint, "contributes", ignored_because_hint),
+        ("app", True, False, in_app_hint, None, None, in_app_hint),
+        ("app", True, False, in_app_hint, None, "in-app", in_app_hint),
+        ("app", True, False, in_app_hint, None, "contributes", None),
+        ("app", True, False, in_app_hint, ignored_because_hint, None, in_app_hint),
+        ("app", True, False, in_app_hint, ignored_because_hint, "in-app", in_app_hint),
+        ("app", True, False, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("app", True, False, out_of_app_hint, None, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, False, out_of_app_hint, None, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, False, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, False, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, False, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, False, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("app", True, False, ignored_hint, None, None, ignored_hint),
+        ("app", True, False, ignored_hint, None, "in-app", None),
+        ("app", True, False, ignored_hint, None, "contributes", ignored_hint),
+        ("app", True, False, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("app", True, False, ignored_hint, ignored_because_hint, "in-app", None),
+        ("app", True, False, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("app", True, False, unignored_hint, None, None, unignored_hint),
+        ("app", True, False, unignored_hint, None, "in-app", None),
+        ("app", True, False, unignored_hint, None, "contributes", unignored_hint),
+        ("app", True, False, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("app", True, False, unignored_hint, ignored_because_hint, "in-app", None),
+        ("app", True, False, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("app", True, False, None, None, None, None),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", True, False, None, None, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", True, False, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", True, False, None, ignored_because_hint, None, ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", True, False, None, ignored_because_hint, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", True, False, None, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, None, in_app_hint, None, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, None, in_app_hint, None, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, None, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, None, in_app_hint, ignored_because_hint, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, None, in_app_hint, ignored_because_hint, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, None, in_app_hint, ignored_because_hint, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, None, out_of_app_hint, None, None, out_of_app_hint),
+        ("app", False, None, out_of_app_hint, None, "in-app", out_of_app_hint),
+        ("app", False, None, out_of_app_hint, None, "contributes", None),
+        ("app", False, None, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),
+        ("app", False, None, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),
+        ("app", False, None, out_of_app_hint, ignored_because_hint, "contributes", None),
+        ("app", False, None, ignored_hint, None, None, default_system_frame_hint),
+        ("app", False, None, ignored_hint, None, "in-app", default_system_frame_hint),
+        ("app", False, None, ignored_hint, None, "contributes", None),
+        ("app", False, None, ignored_hint, ignored_because_hint, None, default_system_frame_hint),
+        ("app", False, None, ignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
+        ("app", False, None, ignored_hint, ignored_because_hint, "contributes", None),
+        ("app", False, None, unignored_hint, None, None, default_system_frame_hint),
+        ("app", False, None, unignored_hint, None, "in-app", default_system_frame_hint),
+        ("app", False, None, unignored_hint, None, "contributes", None),
+        ("app", False, None, unignored_hint, ignored_because_hint, None, default_system_frame_hint),
+        ("app", False, None, unignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
+        ("app", False, None, unignored_hint, ignored_because_hint, "contributes", None),
+        ("app", False, None, None, None, None, default_system_frame_hint),
+        ("app", False, None, None, None, "in-app", default_system_frame_hint),
+        ("app", False, None, None, None, "contributes", None),
+        ("app", False, None, None, ignored_because_hint, None, default_system_frame_hint),
+        ("app", False, None, None, ignored_because_hint, "in-app", default_system_frame_hint),
+        ("app", False, None, None, ignored_because_hint, "contributes", None),
+        ("app", False, True, in_app_hint, None, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, True, in_app_hint, None, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, True, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, True, in_app_hint, ignored_because_hint, None, in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, True, in_app_hint, ignored_because_hint, "in-app", in_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, True, in_app_hint, ignored_because_hint, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, True, out_of_app_hint, None, None, out_of_app_hint),
+        ("app", False, True, out_of_app_hint, None, "in-app", out_of_app_hint),
+        ("app", False, True, out_of_app_hint, None, "contributes", None),
+        ("app", False, True, out_of_app_hint, ignored_because_hint, None, out_of_app_hint),
+        ("app", False, True, out_of_app_hint, ignored_because_hint, "in-app", out_of_app_hint),
+        ("app", False, True, out_of_app_hint, ignored_because_hint, "contributes", None),
+        ("app", False, True, ignored_hint, None, None, default_system_frame_hint),
+        ("app", False, True, ignored_hint, None, "in-app", default_system_frame_hint),
+        ("app", False, True, ignored_hint, None, "contributes", None),
+        ("app", False, True, ignored_hint, ignored_because_hint, None, default_system_frame_hint),
+        ("app", False, True, ignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
+        ("app", False, True, ignored_hint, ignored_because_hint, "contributes", None),
+        ("app", False, True, unignored_hint, None, None, default_system_frame_hint),
+        ("app", False, True, unignored_hint, None, "in-app", default_system_frame_hint),
+        ("app", False, True, unignored_hint, None, "contributes", None),
+        ("app", False, True, unignored_hint, ignored_because_hint, None, default_system_frame_hint),
+        ("app", False, True, unignored_hint, ignored_because_hint, "in-app", default_system_frame_hint),
+        ("app", False, True, unignored_hint, ignored_because_hint, "contributes", None),
+        ("app", False, True, None, None, None, default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, True, None, None, "in-app", default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, True, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, True, None, ignored_because_hint, None, default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, True, None, ignored_because_hint, "in-app", default_system_frame_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, True, None, ignored_because_hint, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("app", False, False, in_app_hint, None, None, client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, False, in_app_hint, None, "in-app", client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, False, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, False, in_app_hint, ignored_because_hint, None, client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, False, in_app_hint, ignored_because_hint, "in-app", client_out_of_app_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, False, in_app_hint, ignored_because_hint, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("app", False, False, out_of_app_hint, None, None, client_out_of_app_hint),
+        ("app", False, False, out_of_app_hint, None, "in-app", client_out_of_app_hint),
+        ("app", False, False, out_of_app_hint, None, "contributes", None),
+        ("app", False, False, out_of_app_hint, ignored_because_hint, None, client_out_of_app_hint),
+        ("app", False, False, out_of_app_hint, ignored_because_hint, "in-app", client_out_of_app_hint),
+        ("app", False, False, out_of_app_hint, ignored_because_hint, "contributes", None),
+        ("app", False, False, ignored_hint, None, None, client_out_of_app_hint),
+        ("app", False, False, ignored_hint, None, "in-app", client_out_of_app_hint),
+        ("app", False, False, ignored_hint, None, "contributes", None),
+        ("app", False, False, ignored_hint, ignored_because_hint, None, client_out_of_app_hint),
+        ("app", False, False, ignored_hint, ignored_because_hint, "in-app", client_out_of_app_hint),
+        ("app", False, False, ignored_hint, ignored_because_hint, "contributes", None),
+        ("app", False, False, unignored_hint, None, None, client_out_of_app_hint),
+        ("app", False, False, unignored_hint, None, "in-app", client_out_of_app_hint),
+        ("app", False, False, unignored_hint, None, "contributes", None),
+        ("app", False, False, unignored_hint, ignored_because_hint, None, client_out_of_app_hint),
+        ("app", False, False, unignored_hint, ignored_because_hint, "in-app", client_out_of_app_hint),
+        ("app", False, False, unignored_hint, ignored_because_hint, "contributes", None),
+        ("app", False, False, None, None, None, client_out_of_app_hint),
+        ("app", False, False, None, None, "in-app", client_out_of_app_hint),
+        ("app", False, False, None, None, "contributes", None),
+        ("app", False, False, None, ignored_because_hint, None, client_out_of_app_hint),
+        ("app", False, False, None, ignored_because_hint, "in-app", client_out_of_app_hint),
+        ("app", False, False, None, ignored_because_hint, "contributes", None),
+        ("system", True, None, in_app_hint, None, None, None),
+        ("system", True, None, in_app_hint, None, "in-app", None),
+        ("system", True, None, in_app_hint, None, "contributes", None),
+        ("system", True, None, in_app_hint, ignored_because_hint, None, ignored_because_hint),
+        ("system", True, None, in_app_hint, ignored_because_hint, "in-app", None),
+        ("system", True, None, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", True, None, out_of_app_hint, None, None, None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, None, out_of_app_hint, None, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, None, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, None, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, None, out_of_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, None, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, None, ignored_hint, None, None, ignored_hint),
+        ("system", True, None, ignored_hint, None, "in-app", None),
+        ("system", True, None, ignored_hint, None, "contributes", ignored_hint),
+        ("system", True, None, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("system", True, None, ignored_hint, ignored_because_hint, "in-app", None),
+        ("system", True, None, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("system", True, None, unignored_hint, None, None, unignored_hint),
+        ("system", True, None, unignored_hint, None, "in-app", None),
+        ("system", True, None, unignored_hint, None, "contributes", unignored_hint),
+        ("system", True, None, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("system", True, None, unignored_hint, ignored_because_hint, "in-app", None),
+        ("system", True, None, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("system", True, None, None, None, None, None),
+        ("system", True, None, None, None, "in-app", None),
+        ("system", True, None, None, None, "contributes", None),
+        ("system", True, None, None, ignored_because_hint, None, ignored_because_hint),
+        ("system", True, None, None, ignored_because_hint, "in-app", None),
+        ("system", True, None, None, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", True, True, in_app_hint, None, None, None),
+        ("system", True, True, in_app_hint, None, "in-app", None),
+        ("system", True, True, in_app_hint, None, "contributes", None),
+        ("system", True, True, in_app_hint, ignored_because_hint, None, ignored_because_hint),
+        ("system", True, True, in_app_hint, ignored_because_hint, "in-app", None),
+        ("system", True, True, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", True, True, out_of_app_hint, None, None, None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, True, out_of_app_hint, None, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, True, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, True, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, True, out_of_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, True, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, True, ignored_hint, None, None, ignored_hint),
+        ("system", True, True, ignored_hint, None, "in-app", None),
+        ("system", True, True, ignored_hint, None, "contributes", ignored_hint),
+        ("system", True, True, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("system", True, True, ignored_hint, ignored_because_hint, "in-app", None),
+        ("system", True, True, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("system", True, True, unignored_hint, None, None, unignored_hint),
+        ("system", True, True, unignored_hint, None, "in-app", None),
+        ("system", True, True, unignored_hint, None, "contributes", unignored_hint),
+        ("system", True, True, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("system", True, True, unignored_hint, ignored_because_hint, "in-app", None),
+        ("system", True, True, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("system", True, True, None, None, None, None),
+        ("system", True, True, None, None, "in-app", None),
+        ("system", True, True, None, None, "contributes", None),
+        ("system", True, True, None, ignored_because_hint, None, ignored_because_hint),
+        ("system", True, True, None, ignored_because_hint, "in-app", None),
+        ("system", True, True, None, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", True, False, in_app_hint, None, None, None),
+        ("system", True, False, in_app_hint, None, "in-app", None),
+        ("system", True, False, in_app_hint, None, "contributes", None),
+        ("system", True, False, in_app_hint, ignored_because_hint, None, ignored_because_hint),
+        ("system", True, False, in_app_hint, ignored_because_hint, "in-app", None),
+        ("system", True, False, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", True, False, out_of_app_hint, None, None, None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, False, out_of_app_hint, None, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, False, out_of_app_hint, None, "contributes", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, False, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, False, out_of_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, False, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return out of app hint if it marks frame in-app
+        ("system", True, False, ignored_hint, None, None, ignored_hint),
+        ("system", True, False, ignored_hint, None, "in-app", None),
+        ("system", True, False, ignored_hint, None, "contributes", ignored_hint),
+        ("system", True, False, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("system", True, False, ignored_hint, ignored_because_hint, "in-app", None),
+        ("system", True, False, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("system", True, False, unignored_hint, None, None, unignored_hint),
+        ("system", True, False, unignored_hint, None, "in-app", None),
+        ("system", True, False, unignored_hint, None, "contributes", unignored_hint),
+        ("system", True, False, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("system", True, False, unignored_hint, ignored_because_hint, "in-app", None),
+        ("system", True, False, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("system", True, False, None, None, None, None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", True, False, None, None, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", True, False, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", True, False, None, ignored_because_hint, None, ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", True, False, None, ignored_because_hint, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", True, False, None, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, None, in_app_hint, None, None, None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, None, in_app_hint, None, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, None, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, None, in_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, None, in_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, None, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, None, out_of_app_hint, None, None, None),
+        ("system", False, None, out_of_app_hint, None, "in-app", None),
+        ("system", False, None, out_of_app_hint, None, "contributes", None),
+        ("system", False, None, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),
+        ("system", False, None, out_of_app_hint, ignored_because_hint, "in-app", None),
+        ("system", False, None, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", False, None, ignored_hint, None, None, ignored_hint),
+        ("system", False, None, ignored_hint, None, "in-app", None),
+        ("system", False, None, ignored_hint, None, "contributes", ignored_hint),
+        ("system", False, None, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("system", False, None, ignored_hint, ignored_because_hint, "in-app", None),
+        ("system", False, None, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("system", False, None, unignored_hint, None, None, unignored_hint),
+        ("system", False, None, unignored_hint, None, "in-app", None),
+        ("system", False, None, unignored_hint, None, "contributes", unignored_hint),
+        ("system", False, None, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("system", False, None, unignored_hint, ignored_because_hint, "in-app", None),
+        ("system", False, None, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("system", False, None, None, None, None, None),
+        ("system", False, None, None, None, "in-app", None),
+        ("system", False, None, None, None, "contributes", None),
+        ("system", False, None, None, ignored_because_hint, None, ignored_because_hint),
+        ("system", False, None, None, ignored_because_hint, "in-app", None),
+        ("system", False, None, None, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", False, True, in_app_hint, None, None, None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, True, in_app_hint, None, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, True, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, True, in_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, True, in_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, True, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, True, out_of_app_hint, None, None, None),
+        ("system", False, True, out_of_app_hint, None, "in-app", None),
+        ("system", False, True, out_of_app_hint, None, "contributes", None),
+        ("system", False, True, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),
+        ("system", False, True, out_of_app_hint, ignored_because_hint, "in-app", None),
+        ("system", False, True, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", False, True, ignored_hint, None, None, ignored_hint),
+        ("system", False, True, ignored_hint, None, "in-app", None),
+        ("system", False, True, ignored_hint, None, "contributes", ignored_hint),
+        ("system", False, True, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("system", False, True, ignored_hint, ignored_because_hint, "in-app", None),
+        ("system", False, True, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("system", False, True, unignored_hint, None, None, unignored_hint),
+        ("system", False, True, unignored_hint, None, "in-app", None),
+        ("system", False, True, unignored_hint, None, "contributes", unignored_hint),
+        ("system", False, True, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("system", False, True, unignored_hint, ignored_because_hint, "in-app", None),
+        ("system", False, True, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("system", False, True, None, None, None, None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, True, None, None, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, True, None, None, "contributes", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, True, None, ignored_because_hint, None, ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, True, None, ignored_because_hint, "in-app", None),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, True, None, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - can't have no rust hint if client in-app is changed
+        ("system", False, False, in_app_hint, None, None, None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, False, in_app_hint, None, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, False, in_app_hint, None, "contributes", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, False, in_app_hint, ignored_because_hint, None, ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, False, in_app_hint, ignored_because_hint, "in-app", None),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, False, in_app_hint, ignored_because_hint, "contributes", ignored_because_hint),  # impossible - rust can't return in-app hint if it marks frame out of app
+        ("system", False, False, out_of_app_hint, None, None, None),
+        ("system", False, False, out_of_app_hint, None, "in-app", None),
+        ("system", False, False, out_of_app_hint, None, "contributes", None),
+        ("system", False, False, out_of_app_hint, ignored_because_hint, None, ignored_because_hint),
+        ("system", False, False, out_of_app_hint, ignored_because_hint, "in-app", None),
+        ("system", False, False, out_of_app_hint, ignored_because_hint, "contributes", ignored_because_hint),
+        ("system", False, False, ignored_hint, None, None, ignored_hint),
+        ("system", False, False, ignored_hint, None, "in-app", None),
+        ("system", False, False, ignored_hint, None, "contributes", ignored_hint),
+        ("system", False, False, ignored_hint, ignored_because_hint, None, ignored_hint),
+        ("system", False, False, ignored_hint, ignored_because_hint, "in-app", None),
+        ("system", False, False, ignored_hint, ignored_because_hint, "contributes", ignored_hint),
+        ("system", False, False, unignored_hint, None, None, unignored_hint),
+        ("system", False, False, unignored_hint, None, "in-app", None),
+        ("system", False, False, unignored_hint, None, "contributes", unignored_hint),
+        ("system", False, False, unignored_hint, ignored_because_hint, None, unignored_hint),
+        ("system", False, False, unignored_hint, ignored_because_hint, "in-app", None),
+        ("system", False, False, unignored_hint, ignored_because_hint, "contributes", unignored_hint),
+        ("system", False, False, None, None, None, None),
+        ("system", False, False, None, None, "in-app", None),
+        ("system", False, False, None, None, "contributes", None),
+        ("system", False, False, None, ignored_because_hint, None, ignored_because_hint),
+        ("system", False, False, None, ignored_because_hint, "in-app", None),
+        ("system", False, False, None, ignored_because_hint, "contributes", ignored_because_hint),
+    ]
+    # fmt: on,
+)
+def test_get_hint_for_frame(
+    variant_name: str,
+    in_app: bool,
+    client_in_app: bool | None,
+    rust_hint: str | None,
+    incoming_hint: str | None,
+    desired_hint_type: Literal["in-app", "contributes"] | None,
+    expected_result: str | None,
+) -> None:
+
+    frame = {"in_app": in_app, "data": {"client_in_app": client_in_app}}
+    frame_component = FrameGroupingComponent(in_app=in_app, hint=incoming_hint, values=[])
+    rust_frame = DummyRustFrame(hint=rust_hint)
+
+    assert (
+        get_hint_for_frame(variant_name, frame, frame_component, rust_frame, desired_hint_type)  # type: ignore[arg-type]
+        == expected_result
+    )


### PR DESCRIPTION
This refactors the recently-added `get_hint_for_frame` helper to fix a few bugs and prepare it for use with split enhancements. It also adds comprehensive tests for it.

- Pull logic for when to ignore hint into separate helper, `_can_use_hint`, so that it can also be applied to the incoming hint.

- Prevent falling back to `marked in-app by the client` if the frame was later marked out of app by stacktrace rules (and vice-versa).

- Allow `get_hint_for_frame` to take an optional `desired_hint_type` parameter, to prevent it from returning the wrong kind of hint if that's all it has.