### PR TITLE
fix(issues): Fix breadcrumb scrolling, tag scrolling

### DIFF
--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -72,7 +72,6 @@ export const EventDrawerBody = styled(DrawerBody)`
   display: flex;
   gap: ${space(2)};
   flex-direction: column;
-  height: fit-content; /* makes drawer resize work better with flex */
   direction: rtl;
   * {
     direction: ltr;

--- a/static/app/views/issueDetails/groupDistributionsDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributionsDrawer.tsx
@@ -30,26 +30,24 @@ export function GroupDistributionsDrawer({group, includeFeatureFlagsTab}: Props)
   return (
     <AnalyticsArea name="distributions_drawer">
       <EventDrawerContainer>
-        <EventDrawerContainer>
-          <EventDrawerHeader>
-            <GroupDistributionCrumbs project={project} group={group} tab={tab} />
-          </EventDrawerHeader>
-          {tab === DrawerTab.TAGS ? (
-            <TagsDistributionDrawer
-              organization={organization}
-              group={group}
-              project={project}
-              setTab={setTab}
-              includeFeatureFlagsTab={includeFeatureFlagsTab}
-            />
-          ) : (
-            <FlagsDistributionDrawer
-              organization={organization}
-              group={group}
-              setTab={setTab}
-            />
-          )}
-        </EventDrawerContainer>
+        <EventDrawerHeader>
+          <GroupDistributionCrumbs project={project} group={group} tab={tab} />
+        </EventDrawerHeader>
+        {tab === DrawerTab.TAGS ? (
+          <TagsDistributionDrawer
+            organization={organization}
+            group={group}
+            project={project}
+            setTab={setTab}
+            includeFeatureFlagsTab={includeFeatureFlagsTab}
+          />
+        ) : (
+          <FlagsDistributionDrawer
+            organization={organization}
+            group={group}
+            setTab={setTab}
+          />
+        )}
       </EventDrawerContainer>
     </AnalyticsArea>
   );


### PR DESCRIPTION
fit-content Adds another scroll bar that breaks breadcrumbs on some screen sizes. [example issue](https://sentry.sentry.io/issues/5349166693/events/38c4a75044fd404b9d0e7f5ffaad9c77/?project=1)

Scrolling on tags and flags drawer was scrolling the wrong div. Header and breadcrumbs should be sticky.

part of #90784