### PR TITLE
feat(trace): Add event id

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -59,6 +59,7 @@ class SerializedSpan(SerializedEvent):
     profiler_id: str
     sdk_name: str
     is_transaction: bool
+    transaction_id: str
 
 
 @region_silo_endpoint
@@ -129,6 +130,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
                 errors=[self.serialize_rpc_issue(error) for error in event["errors"]],
                 occurrences=[self.serialize_rpc_issue(error) for error in event["occurrences"]],
                 event_id=event["id"],
+                transaction_id=event["transaction.event_id"],
                 project_id=event["project.id"],
                 project_slug=event["project.slug"],
                 profile_id=event["profile.id"],

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -143,6 +143,11 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="transaction.event_id",
+            internal_name="sentry.event_id",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="profile.id",
             internal_name="sentry.profile_id",
             search_type="string",

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -362,6 +362,7 @@ def run_trace_query(
         "span.op",
         "is_transaction",
         "transaction.span_id",
+        "transaction.event_id",
         "transaction",
         "precise.start_ts",
         "precise.finish_ts",

--- a/tests/sentry/api/endpoints/test_organization_trace_summary.py
+++ b/tests/sentry/api/endpoints/test_organization_trace_summary.py
@@ -39,6 +39,7 @@ class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
                 profiler_id="",
                 sdk_name="test_sdk",
                 is_transaction=True,
+                transaction_id="1" * 32,
             ),
             SerializedSpan(
                 description="db.query",
@@ -60,6 +61,7 @@ class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
                 profiler_id="",
                 sdk_name="test_sdk",
                 is_transaction=False,
+                transaction_id="1" * 32,
             ),
         ]
 

--- a/tests/sentry/seer/test_trace_summary.py
+++ b/tests/sentry/seer/test_trace_summary.py
@@ -42,6 +42,7 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
                 profiler_id="",
                 sdk_name="test_sdk",
                 is_transaction=True,
+                transaction_id="1" * 32,
             ),
             SerializedSpan(
                 description="db.query",
@@ -63,6 +64,7 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
                 profiler_id="",
                 sdk_name="test_sdk",
                 is_transaction=False,
+                transaction_id="1" * 32,
             ),
         ]
 

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -21,6 +21,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert result["start_timestamp"] == event_data.data["start_timestamp"], message
         assert result["project_slug"] == event_data.project.slug, message
         assert result["sdk_name"] == event_data.data["sdk"]["name"], message
+        assert result["transaction_id"] == event_data.event_id, message
 
     def get_transaction_children(self, event):
         """Assumes that the test setup only gives each event 1 txn child"""

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -230,7 +230,6 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
             },
             {"name": "project_id", "type": "int", "value": str(self.project.id)},
             {"name": "span.duration", "type": "int", "value": "1000"},
-            {"name": "event_id", "type": "str", "value": span_1["event_id"]},
             {"name": "parent_span", "type": "str", "value": span_1["parent_span_id"]},
             {"name": "profile.id", "type": "str", "value": span_1["profile_id"]},
             {"name": "raw_description", "type": "str", "value": "foo"},
@@ -238,6 +237,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
             {"name": "sdk.version", "type": "str", "value": "1.0"},
             {"name": "span.status", "type": "str", "value": "success"},
             {"name": "trace", "type": "str", "value": self.trace_uuid},
+            {"name": "transaction.event_id", "type": "str", "value": span_1["event_id"]},
             {"name": "transaction.span_id", "type": "str", "value": span_1["segment_id"]},
         ]
         assert trace_details_response.data["itemId"] == item_id


### PR DESCRIPTION
- This adds the transaction event_id to the trace response so we can grab things like attachments, or nodestore (temporarily)