### PR TITLE
fix(migrations): Fix monitor migrations move dependencies

### DIFF
--- a/src/sentry/monitors/migrations/0001_initial.py
+++ b/src/sentry/monitors/migrations/0001_initial.py
@@ -31,7 +31,9 @@ class Migration(CheckedMigration):
 
     initial = True
 
-    dependencies = []
+    dependencies = [
+        ("sentry", "0864_move_monitors"),
+    ]
 
     operations = [
         migrations.SeparateDatabaseAndState(


### PR DESCRIPTION
This will make the migrations deterministic so they are run only after the monitors are moved from the sentry app.