### PR TITLE
feat(trace-eap-waterfall): Adding measurement score ratio, instead of just score

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -381,7 +381,7 @@ def run_trace_query(
         "ttfb",
     }:
         trace_attributes.append(f"measurements.{key}")
-        trace_attributes.append(f"measurements.score.{key}")
+        trace_attributes.append(f"measurements.score.ratio.{key}")
     resolver = get_resolver(params=params, config=SearchResolverConfig())
     columns, _ = resolver.resolve_attributes(trace_attributes)
     meta = resolver.resolve_meta(referrer=referrer)


### PR DESCRIPTION
Frontend is already expecting this: [link](https://github.com/getsentry/sentry/blob/abdk/trace-eap-measurements/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx#L132)