### PR TITLE
fix(ui2): remove custom styles from banner

### DIFF
--- a/static/app/components/core/alert/index.chonk.tsx
+++ b/static/app/components/core/alert/index.chonk.tsx
@@ -125,6 +125,7 @@ function generateAlertBackground(
 export const TrailingItems = chonkStyled('div')<ChonkAlertProps>`
   display: grid;
   grid-auto-flow: column;
+  grid-auto-columns: max-content;
   grid-template-rows: 100%;
   gap: ${p => p.theme.space.md};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback} from 'react';
-import styled from '@emotion/styled';
 
 import {useDismissable} from 'sentry/components/banner';
 import {Alert} from 'sentry/components/core/alert';
@@ -7,7 +6,6 @@ import {Button} from 'sentry/components/core/button';
 import {feedbackClient} from 'sentry/components/featureFeedback/feedbackModal';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
-import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
@@ -80,39 +78,21 @@ export default function AnomalyDetectionFeedbackBanner({
     return null;
   }
   return (
-    <StyledAlert
+    <Alert
       type="info"
       trailingItems={
         <Fragment>
-          <StyledButton borderless onClick={() => handleClick(true)}>
+          <Button size="zero" onClick={() => handleClick(true)}>
             {t('Yes')}
-          </StyledButton>
-          <StyledButton borderless onClick={() => handleClick(false)}>
+          </Button>
+          <Button size="zero" onClick={() => handleClick(false)}>
             {t('No')}
-          </StyledButton>
+          </Button>
         </Fragment>
       }
       showIcon
     >
       {t('Was the anomaly correctly identified?')}
-    </StyledAlert>
+    </Alert>
   );
 }
-
-const StyledButton = styled(Button)`
-  background-color: transparent;
-  color: ${p => p.theme.alert.info.color};
-  border: 1px solid ${p => p.theme.alert.info.border};
-
-  &:hover,
-  &:focus,
-  &:active {
-    color: ${p => p.theme.alert.info.color};
-    border-color: ${p => p.theme.alert.info.borderHover};
-  }
-`;
-
-const StyledAlert = styled(Alert)`
-  padding-top: ${space(3)};
-  padding-bottom: ${space(3)};
-`;

--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
@@ -82,10 +82,10 @@ export default function AnomalyDetectionFeedbackBanner({
       type="info"
       trailingItems={
         <Fragment>
-          <Button size="zero" onClick={() => handleClick(true)}>
+          <Button size="xs" onClick={() => handleClick(true)}>
             {t('Yes')}
           </Button>
-          <Button size="zero" onClick={() => handleClick(false)}>
+          <Button size="xs" onClick={() => handleClick(false)}>
             {t('No')}
           </Button>
         </Fragment>


### PR DESCRIPTION
Removes custom styling from Anomaly Detection feedback banner

## Before this PR

<img width="763" alt="'was this screenshot correctly identified?' banner with large yes or no buttons" src="https://github.com/user-attachments/assets/e2882fa8-50ac-46b7-9043-f14e00d13a7a" />

<img width="763" alt="chonky 'was this screenshot correctly identified?' banner with misaligned yes or no buttons" src="https://github.com/user-attachments/assets/48cfeafb-4c48-4125-8236-7aaec3d62116" />

## After this PR

<img width="805" alt="'was this screenshot correctly identified?' banner with standard yes or no buttons" src="https://github.com/user-attachments/assets/b8dbf9b8-82a1-4a78-9a42-c632f59b20ba" />

<img width="811" alt="chonky 'was this screenshot correctly identified?' banner with standard yes or no buttons" src="https://github.com/user-attachments/assets/2eff4ff0-ec60-4d97-9de8-31f39711a57a" />
