### PR TITLE
feat(insights): update eap triple chart rows to open in explore

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -280,7 +280,7 @@ function WidgetInteractiveTitle({
           title: eventView.name,
           query: eventView.getQueryWithAdditionalConditions(),
           sort: eventView.sorts[0] ? encodeSort(eventView.sorts[0]) : undefined,
-          field: eventView.fields.map(field => field.field),
+          groupBy: eventView.fields.map(field => field.field),
         })
       );
     } else if (option.value === 'open_in_discover') {

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -15,6 +15,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
+import {encodeSort} from 'sentry/utils/discover/eventView';
 import type {Field} from 'sentry/utils/discover/fields';
 import {DisplayModes, SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -23,6 +24,10 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import withOrganization from 'sentry/utils/withOrganization';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {GenericPerformanceWidgetDataType} from 'sentry/views/performance/landing/widgets/types';
 import {
   _setChartSetting,
@@ -238,6 +243,7 @@ function WidgetInteractiveTitle({
   const navigate = useNavigate();
   const organization = useOrganization();
   const menuOptions: Array<SelectOption<string>> = [];
+  const useEap = useInsightsEap();
 
   const settingsMap = WIDGET_DEFINITIONS({organization, theme});
   for (const setting of allowedCharts) {
@@ -252,11 +258,32 @@ function WidgetInteractiveTitle({
   const chartDefinition = WIDGET_DEFINITIONS({organization, theme})[chartSetting];
 
   if (chartDefinition.allowsOpenInDiscover) {
-    menuOptions.push({label: t('Open in Discover'), value: 'open_in_discover'});
+    if (useEap) {
+      menuOptions.push({label: t('Open in Explore'), value: 'open_in_explore'});
+    } else {
+      menuOptions.push({label: t('Open in Discover'), value: 'open_in_discover'});
+    }
   }
 
   const handleChange = (option: {value: string | number}) => {
-    if (option.value === 'open_in_discover') {
+    if (option.value === 'open_in_explore') {
+      const yAxis =
+        typeof eventView.yAxis === 'string' ? [eventView.yAxis] : (eventView.yAxis ?? []);
+      navigate(
+        getExploreUrl({
+          organization,
+          visualize: yAxis?.map(y => ({
+            chartType: ChartType.LINE,
+            yAxes: [y],
+          })),
+          mode: Mode.AGGREGATE,
+          title: eventView.name,
+          query: eventView.getQueryWithAdditionalConditions(),
+          sort: eventView.sorts[0] ? encodeSort(eventView.sorts[0]) : undefined,
+          field: eventView.fields.map(field => field.field),
+        })
+      );
+    } else if (option.value === 'open_in_discover') {
       navigate(getEventViewDiscoverPath(organization, eventView));
     } else {
       setChartSetting(option.value as PerformanceWidgetSetting);


### PR DESCRIPTION
When eap is enabled, we update the triple chart rows to open in explore instead of discover.

![image](https://github.com/user-attachments/assets/b47f18a4-357c-4d0e-a7a2-87e1c2c0ef64)

Note: some of these fields are not exposed in the frontend of explore, that will updated separately