### PR TITLE
feat(group_deletion): Remove countdown from Group deletions

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -53,11 +53,6 @@ def delete_group_list(
         if g.issue_category == GroupCategory.ERROR:
             error_ids.append(g.id)
 
-    countdown = 3600
-    # With ClickHouse light deletes we want to get rid of the long delay
-    if not error_ids:
-        countdown = 0
-
     Group.objects.filter(id__in=group_ids).exclude(
         status__in=[GroupStatus.PENDING_DELETION, GroupStatus.DELETION_IN_PROGRESS]
     ).update(status=GroupStatus.PENDING_DELETION, substatus=None)
@@ -86,8 +81,7 @@ def delete_group_list(
             "object_ids": group_ids,
             "transaction_id": str(transaction_id),
             "eventstream_state": eventstream_state,
-        },
-        countdown=countdown,
+        }
     )
 
 

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -330,8 +330,6 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         ) as mock_apply_async:
             response = self.client.delete(url, format="json")
             mock_apply_async.assert_called_once()
-            kwargs = mock_apply_async.call_args[1]
-            assert kwargs["countdown"] == 3600
             assert response.status_code == 202
             # Since the task has not executed yet the group is pending deletion
             assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
@@ -362,9 +360,6 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             # Since the task has not executed yet the group is pending deletion
             assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
             mock_apply_async.assert_called_once()
-            kwargs = mock_apply_async.call_args[1]
-            # We don't wait to schedule the deletion of non-error issues
-            assert kwargs["countdown"] == 0
 
         # Undo some of what the previous endpoint call did
         group.update(status=GroupStatus.RESOLVED)


### PR DESCRIPTION
Originally added in [this commit](https://github.com/getsentry/sentry/commit/951e993b56cc6ab768ea0883d73d9faefd065d08).