### PR TITLE
fix(typing): Fixes typing for sentry.rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ module = [
     "sentry.notifications.notifications.activity.base",
     "sentry.plugins.config",
     "sentry.release_health.metrics_sessions_v2",
-    "sentry.rules.history.preview",
     "sentry.search.events.builder.errors",
     "sentry.search.events.builder.metrics",
     "sentry.search.events.datasets.filter_aliases",

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -190,7 +190,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         return current_value > value
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Mapping[datetime, int | float]
+        self, activity: ConditionActivity, buckets: dict[datetime, int]
     ) -> bool:
         interval, value = self._get_options()
         if not (interval and value is not None):
@@ -1010,7 +1010,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         return batch_percents
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Mapping[datetime, int | float]
+        self, activity: ConditionActivity, buckets: dict[datetime, int]
     ) -> bool:
         raise NotImplementedError
 
@@ -1018,9 +1018,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         return EventFrequencyPercentForm(self.data)
 
 
-def bucket_count(
-    start: datetime, end: datetime, buckets: Mapping[datetime, int | float]
-) -> int | float:
+def bucket_count(start: datetime, end: datetime, buckets: dict[datetime, int]) -> int:
     rounded_end = round_to_five_minute(end)
     rounded_start = round_to_five_minute(start)
     count = buckets.get(rounded_end, 0) - buckets.get(rounded_start, 0)

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -190,7 +190,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         return current_value > value
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: dict[datetime, int | float]
+        self, activity: ConditionActivity, buckets: Mapping[datetime, int | float]
     ) -> bool:
         interval, value = self._get_options()
         if not (interval and value is not None):
@@ -1010,7 +1010,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         return batch_percents
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: dict[datetime, int | float]
+        self, activity: ConditionActivity, buckets: Mapping[datetime, int | float]
     ) -> bool:
         raise NotImplementedError
 
@@ -1019,7 +1019,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
 
 
 def bucket_count(
-    start: datetime, end: datetime, buckets: dict[datetime, int | float]
+    start: datetime, end: datetime, buckets: Mapping[datetime, int | float]
 ) -> int | float:
     rounded_end = round_to_five_minute(end)
     rounded_start = round_to_five_minute(start)

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -256,11 +256,7 @@ def get_top_groups(
     Since frequency conditions require snuba query(s), we need to limit the number groups we process.
     """
     if has_issue_state_condition:
-        datasets = {
-            dataset_map.get(group)
-            for group in condition_activity.keys()
-            if dataset_map.get(group) is not None
-        }
+        datasets = {dataset_map[group] for group in condition_activity.keys()}
     else:
         # condition_activity will be empty because there are no issue state conditions.
         # So, we look to find top groups over all datasets

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -256,7 +256,11 @@ def get_top_groups(
     Since frequency conditions require snuba query(s), we need to limit the number groups we process.
     """
     if has_issue_state_condition:
-        datasets = {dataset_map.get(group) for group in condition_activity.keys()}
+        datasets = {
+            dataset_map.get(group)
+            for group in condition_activity.keys()
+            if dataset_map.get(group) is not None
+        }
     else:
         # condition_activity will be empty because there are no issue state conditions.
         # So, we look to find top groups over all datasets

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -72,7 +72,7 @@ If there are no issue state changes (causes no group ids), then do not filter by
 
 
 def get_update_kwargs_for_groups(
-    dataset: Dataset,
+    dataset: Dataset | None,
     group_ids: Sequence[int],
     kwargs: dict[str, Any],
     has_issue_state_condition: bool = True,


### PR DESCRIPTION
Fixes ECO-489

Removes last `sentry.rules` skip for typing skips.

This change does the following:
- Changes the typing for buckets from `dict[datetime, int | float]` to `dict[datetime, int]`, since callers only seem to pass integers along.
- Adds assertions for condition typing in cases where subclass methods are being invoked, but the condition input typing itself is of the parent `RuleBase` class
