### PR TITLE
feat(releases): Disable fullscreen charts in Releases Drawer

### DIFF
--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -154,30 +154,32 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
             {props.description && (
               <Widget.WidgetDescription description={props.description} />
             )}
-            <Button
-              size="xs"
-              aria-label={t('Open Full-Screen View')}
-              borderless
-              icon={<IconExpand />}
-              onClick={() => {
-                openInsightChartModal({
-                  title: props.title,
-                  children: (
-                    <ModalChartContainer>
-                      <TimeSeriesWidgetVisualization
-                        id={props.id}
-                        {...visualizationProps}
-                        {...enableReleaseBubblesProps}
-                        onZoom={() => {}}
-                        legendSelection={props.legendSelection}
-                        onLegendSelectionChange={props.onLegendSelectionChange}
-                        releases={releases ?? []}
-                      />
-                    </ModalChartContainer>
-                  ),
-                });
-              }}
-            />
+            {props.loaderSource !== 'releases-drawer' && (
+              <Button
+                size="xs"
+                aria-label={t('Open Full-Screen View')}
+                borderless
+                icon={<IconExpand />}
+                onClick={() => {
+                  openInsightChartModal({
+                    title: props.title,
+                    children: (
+                      <ModalChartContainer>
+                        <TimeSeriesWidgetVisualization
+                          id={props.id}
+                          {...visualizationProps}
+                          {...enableReleaseBubblesProps}
+                          onZoom={() => {}}
+                          legendSelection={props.legendSelection}
+                          onLegendSelectionChange={props.onLegendSelectionChange}
+                          releases={releases ?? []}
+                        />
+                      </ModalChartContainer>
+                    ),
+                  });
+                }}
+              />
+            )}
           </Widget.WidgetToolbar>
         }
       />

--- a/static/app/views/insights/common/components/widgets/types.tsx
+++ b/static/app/views/insights/common/components/widgets/types.tsx
@@ -19,6 +19,11 @@ export interface LoadableChartWidgetProps {
   id?: string;
 
   /**
+   * The source where this widget was loaded via `<ChartWidgetLoader>` component
+   */
+  loaderSource?: 'releases-drawer';
+
+  /**
    * PageFilters-like object that will override the main PageFilters e.g. in
    * Releases Drawer, we have a smaller timeframe to show a smaller amount of
    * releases.

--- a/static/app/views/releases/drawer/releasesDrawerList.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerList.tsx
@@ -134,6 +134,7 @@ export function ReleasesDrawerList({chart, pageFilters}: ReleasesDrawerListProps
               height={chartHeight}
               pageFilters={pageFilters}
               showReleaseAs="line"
+              loaderSource="releases-drawer"
             />
           </div>
         ) : null}


### PR DESCRIPTION
This removes the button that opens the chart in full-screen for charts rendered inside of the Releases Drawer. Full screen mode should be unnecessary since the chart inside of the drawer provides a zoomed in view of the Releases data already. It is also odd UX to have a modal on top of a drawer.

Instead of having an explicit prop to disable the fullscreen, I've chosen to pass the loader source so that we can push the rendering logic down to the widget itself as it's possible not all widgets will have a fullscreen mode.