### PR TITLE
feat(issue-taxonomy): Update taxonomy pages to new categorizations

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2217,8 +2217,8 @@ function buildRoutes() {
         component={make(() => import('sentry/views/issueList/pages/errorsOutages'))}
       />
       <Route
-        path={`${IssueTaxonomy.REGRESSIONS}/`}
-        component={make(() => import('sentry/views/issueList/pages/regressions'))}
+        path={`${IssueTaxonomy.BREACHED_METRICS}/`}
+        component={make(() => import('sentry/views/issueList/pages/breachedMetrics'))}
       />
       <Route
         path={`${IssueTaxonomy.WARNINGS}/`}

--- a/static/app/views/issueList/pages/breachedMetrics.tsx
+++ b/static/app/views/issueList/pages/breachedMetrics.tsx
@@ -9,7 +9,7 @@ import {ISSUE_TAXONOMY_CONFIG, IssueTaxonomy} from 'sentry/views/issueList/taxon
 
 type Props = RouteComponentProps;
 
-const CONFIG = ISSUE_TAXONOMY_CONFIG[IssueTaxonomy.REGRESSIONS];
+const CONFIG = ISSUE_TAXONOMY_CONFIG[IssueTaxonomy.BREACHED_METRICS];
 const QUERY = `is:unresolved issue.category:[${CONFIG.categories.join(',')}]`;
 
 export default function RegressionsPage(props: Props) {

--- a/static/app/views/issueList/taxonomies.tsx
+++ b/static/app/views/issueList/taxonomies.tsx
@@ -3,7 +3,7 @@ import {IssueCategory} from 'sentry/types/group';
 
 export enum IssueTaxonomy {
   ERRORS_AND_OUTAGES = 'errors-outages',
-  REGRESSIONS = 'regressions',
+  BREACHED_METRICS = 'breached-metrics',
   WARNINGS = 'warnings',
 }
 
@@ -20,16 +20,17 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
     label: t('Errors & Outages'),
     key: 'errors-outages',
   },
-  [IssueTaxonomy.REGRESSIONS]: {
-    categories: [IssueCategory.PERFORMANCE_REGRESSION],
-    label: t('Regressions'),
-    key: 'regressions',
+  [IssueTaxonomy.BREACHED_METRICS]: {
+    categories: [IssueCategory.METRIC],
+    label: t('Breached Metrics'),
+    key: 'breached-metrics',
   },
   [IssueTaxonomy.WARNINGS]: {
     categories: [
-      IssueCategory.RESPONSIVENESS,
-      IssueCategory.USER_EXPERIENCE,
-      IssueCategory.PERFORMANCE_BEST_PRACTICE,
+      IssueCategory.DB_QUERY,
+      IssueCategory.HTTP_CLIENT,
+      IssueCategory.FRONTEND,
+      IssueCategory.MOBILE,
     ],
     label: t('Warnings'),
     key: 'warnings',


### PR DESCRIPTION
- Update regressions -> breached metrics
- Use new categories for each taxonomy

Searches with the new categories will fail until the backend deploy goes out