### PR TITLE
ref(aci): allow rule deletion task to delete workflows from API

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -8,7 +8,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log, features
+from sentry import analytics, audit_log
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
@@ -38,9 +38,6 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
-from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
-    delete_migrated_issue_alert,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -356,24 +353,12 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
-        rule_id = rule.id
-
         with transaction.atomic(router.db_for_write(Rule)):
             rule.update(status=ObjectStatus.PENDING_DELETION)
             RuleActivity.objects.create(
                 rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
             )
             scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
-
-            if features.has(
-                "organizations:workflow-engine-issue-alert-dual-write", project.organization
-            ):
-                workflow_id = delete_migrated_issue_alert(rule)
-                if workflow_id:
-                    logger.info(
-                        "workflow_engine.issue_alert.deleted",
-                        extra={"rule_id": rule_id, "workflow_id": workflow_id},
-                    )
 
         self.create_audit_entry(
             request=request,


### PR DESCRIPTION
Scheduling a Rule for deletion will delete the associated workflow. So in the API we don't need to explicitly delete the workflow.