### PR TITLE
fix(dashboards): Intervals error on release health widgets

### DIFF
--- a/static/app/utils/duration/statsPeriodToDays.tsx
+++ b/static/app/utils/duration/statsPeriodToDays.tsx
@@ -11,6 +11,9 @@ export function statsPeriodToDays(
   if (statsPeriod?.endsWith('h')) {
     return parseInt(statsPeriod.slice(0, -1), 10) / 24;
   }
+  if (statsPeriod?.endsWith('m')) {
+    return parseInt(statsPeriod.slice(0, -1), 10) / 1440;
+  }
   if (start && end) {
     return (new Date(end).getTime() - new Date(start).getTime()) / (24 * 60 * 60 * 1000);
   }

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -5,7 +5,7 @@ import {doReleaseHealthRequest} from 'sentry/actionCreators/metrics';
 import {doSessionsRequest} from 'sentry/actionCreators/sessions';
 import type {Client} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {PageFilters, SelectValue} from 'sentry/types/core';
+import type {DateString, PageFilters, SelectValue} from 'sentry/types/core';
 import type {Organization, SessionApiResponse} from 'sentry/types/organization';
 import type {SessionsMeta} from 'sentry/types/sessions';
 import {SessionField} from 'sentry/types/sessions';
@@ -369,7 +369,7 @@ function getReleasesRequest(
   // filter condition. We also maintain an ordered array of release versions
   // to order the results returned from the metrics endpoint.
   //
-  // Also note that we request a limit of 100 on the metrics endpoint, this
+  // Also note that we request a limit on the metrics endpoint, this
   // is because in a query, the limit should be applied after the results are
   // sorted based on the release version. The larger number of rows we
   // request, the more accurate our results are going to be.
@@ -381,7 +381,7 @@ function getReleasesRequest(
   //      selected period if there are more than 50 releases in the selected
   //      period.
   //
-  //   2. if a recent release is not returned due to the 100 row limit
+  //   2. if a recent release is not returned due to the row limit
   //      imposed on the metrics query the user won't see it on the
   //      table/chart/
   //
@@ -435,7 +435,12 @@ function getReleasesRequest(
     end,
     environment: environments,
     groupBy: columns.map(fieldsToDerivedMetrics),
-    limit: columns.length === 0 ? 1 : isCustomReleaseSorting ? 100 : limit,
+    limit:
+      columns.length === 0
+        ? 1
+        : isCustomReleaseSorting
+          ? getCustomReleaseSortLimit(period, start, end)
+          : limit,
     orderBy: unsupportedOrderby
       ? ''
       : isDescending
@@ -450,4 +455,22 @@ function getReleasesRequest(
     includeSeries,
     includeTotals,
   });
+}
+
+/**
+ * This is used to decide the "limit" parameter for the release health request.
+ * This limit is actually passed to the "per_page" parameter of the request.
+ * For stats period less than 14 days we limit to 50 releases, otherwise we limit to 25;
+ * this will prevent the "requested intervals is too granular for per_page..." error.
+ */
+function getCustomReleaseSortLimit(
+  period: string | null,
+  start?: DateString,
+  end?: DateString
+) {
+  const periodInDays = statsPeriodToDays(period, start, end);
+  if (periodInDays < 14) {
+    return 50;
+  }
+  return 25;
 }

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -457,6 +457,11 @@ function getReleasesRequest(
   });
 }
 
+/**
+ * This is the maximum number of data points that can be returned by the metrics API.
+ * Should be kept in sync with MAX_POINTS constant in backend
+ * @file src/sentry/snuba/metrics/utils.py
+ */
 const MAX_POINTS = 10000;
 
 /**

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -180,7 +180,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
           includeSeries: 1,
           includeTotals: 1,
           interval: '1h',
-          per_page: 100,
+          per_page: 25,
           project: [1],
           query: ' release:be1ddfb18126dd2cbde26bfe75488503280e716e',
           statsPeriod: '14d',

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -180,7 +180,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
           includeSeries: 1,
           includeTotals: 1,
           interval: '1h',
-          per_page: 25,
+          per_page: 28,
           project: [1],
           query: ' release:be1ddfb18126dd2cbde26bfe75488503280e716e',
           statsPeriod: '14d',


### PR DESCRIPTION
We were seeing this error on all Release Health widgets. The options to fix this were to change the timeseries interval (which would get significantly less accurate data), change the statsPeriod or change the `per_page` request prop. The best way to go about this is do adjust the per_page prop. I've found that this prop needs to be changed depending on the statsPeriod so i've put in the correct values so we get a response from our request.

![image](https://github.com/user-attachments/assets/b3f477b7-4720-4c76-b31b-56408033dd47)

