### PR TITLE
:sparkles: feat: add `workflow_id` to `WorkflowEventData`

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -20,7 +20,6 @@ from sentry.workflow_engine.models import (
     ActionGroupStatus,
     DataCondition,
     DataConditionGroup,
-    Workflow,
     WorkflowDataConditionGroup,
     WorkflowFireHistory,
 )
@@ -88,7 +87,7 @@ def update_workflow_fire_histories(
 
 # TODO(cathy): only reinforce workflow frequency for certain issue types
 def filter_recently_fired_workflow_actions(
-    filtered_action_groups: dict[DataConditionGroup, Workflow], event_data: WorkflowEventData
+    filtered_action_groups: dict[DataConditionGroup, int], event_data: WorkflowEventData
 ) -> set[tuple[Action, int]]:
     # get the actions for any of the triggered data condition groups
     actions = (
@@ -128,8 +127,8 @@ def filter_recently_fired_workflow_actions(
     for action in filtered_actions:
         dcg_action = action.dataconditiongroupaction_set.first()
         if dcg_action:
-            workflow = filtered_action_groups[dcg_action.condition_group]
-            result_list.add((action, workflow.id))
+            workflow_id = filtered_action_groups[dcg_action.condition_group]
+            result_list.add((action, workflow_id))
         else:
             logger.error(
                 "Action %s has no associated DataConditionGroupAction",

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -89,7 +89,7 @@ def update_workflow_fire_histories(
 # TODO(cathy): only reinforce workflow frequency for certain issue types
 def filter_recently_fired_workflow_actions(
     filtered_action_groups: dict[DataConditionGroup, Workflow], event_data: WorkflowEventData
-) -> list[tuple[Action, Workflow]]:
+) -> set[tuple[Action, int]]:
     # get the actions for any of the triggered data condition groups
     actions = (
         Action.objects.filter(
@@ -124,12 +124,12 @@ def filter_recently_fired_workflow_actions(
     actions_without_statuses_ids = {action.id for action in actions_without_statuses}
     filtered_actions = actions.filter(id__in=actions_to_include | actions_without_statuses_ids)
 
-    result_list: list[tuple[Action, Workflow]] = []
+    result_list: set[tuple[Action, int]] = set()
     for action in filtered_actions:
         dcg_action = action.dataconditiongroupaction_set.first()
         if dcg_action:
             workflow = filtered_action_groups[dcg_action.condition_group]
-            result_list.append((action, workflow))
+            result_list.add((action, workflow.id))
         else:
             logger.error(
                 "Action %s has no associated DataConditionGroupAction",

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -427,8 +427,8 @@ def fire_actions_for_groups(
             condition_group__in=action_filters
         ).select_related("workflow", "condition_group")
 
-        action_filters_map: dict[DataConditionGroup, Workflow] = {
-            wdcg.condition_group: wdcg.workflow for wdcg in wdcgs
+        action_filters_map: dict[DataConditionGroup, int] = {
+            wdcg.condition_group: wdcg.workflow.id for wdcg in wdcgs
         }
 
         action_filter_results = filter_recently_fired_workflow_actions(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -126,8 +126,8 @@ def evaluate_workflows_action_filters(
     event_data: WorkflowEventData,
 ) -> set[tuple[Action, int]]:
 
-    # This is a mapping of the DataConditionGroup to the Workflow
-    filtered_action_groups: dict[DataConditionGroup, Workflow] = {}
+    # This is a mapping of the DataConditionGroup to the workflow_id
+    filtered_action_groups: dict[DataConditionGroup, int] = {}
 
     # Gets the list of the workflow ids, and then get the workflow_data_condition_groups for those workflows
     workflow_ids_to_envs = {workflow.id: workflow.environment for workflow in workflows}
@@ -176,7 +176,7 @@ def evaluate_workflows_action_filters(
         else:
             if evaluation:
                 filtered_action_groups[workflow_data_condition_group.condition_group] = (
-                    workflow_data_condition_group.workflow
+                    workflow_data_condition_group.workflow.id
                 )
 
     return filter_recently_fired_workflow_actions(filtered_action_groups, event_data)

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -39,7 +39,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_2 = ActionGroupStatus.objects.create(action=action, group=self.group)
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            {self.action_group: self.workflow}, self.event_data
+            {self.action_group: self.workflow.id}, self.event_data
         )
         assert triggered_actions == {(self.action, self.workflow.id)}
 
@@ -62,9 +62,9 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
 
         triggered_actions = filter_recently_fired_workflow_actions(
             {
-                self.action_group: self.workflow,
-                action_group_2: workflow,
-                action_group_3: workflow,
+                self.action_group: self.workflow.id,
+                action_group_2: workflow.id,
+                action_group_3: workflow.id,
             },
             self.event_data,
         )

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
+from sentry.workflow_engine.models import Action, WorkflowFireHistory
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import (
     filter_recently_fired_workflow_actions,
@@ -39,9 +39,9 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_2 = ActionGroupStatus.objects.create(action=action, group=self.group)
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.event_data
+            {self.action_group: self.workflow}, self.event_data
         )
-        assert set(triggered_actions) == {self.action}
+        assert triggered_actions == {(self.action, self.workflow.id)}
 
         for status in [status_1, status_2]:
             status.refresh_from_db()
@@ -53,17 +53,25 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
 
         workflow = self.create_workflow(organization=self.organization, config={"frequency": 1440})
         self.create_detector_workflow(detector=self.detector, workflow=workflow)
-        _, action_2 = self.create_workflow_action(workflow=workflow)
+        action_group_2, action_2 = self.create_workflow_action(workflow=workflow)
         status_2 = ActionGroupStatus.objects.create(action=action_2, group=self.group)
 
-        _, action_3 = self.create_workflow_action(workflow=workflow)
+        action_group_3, action_3 = self.create_workflow_action(workflow=workflow)
         status_3 = ActionGroupStatus.objects.create(action=action_3, group=self.group)
         status_3.update(date_updated=timezone.now() - timedelta(days=2))
 
         triggered_actions = filter_recently_fired_workflow_actions(
-            set(DataConditionGroup.objects.all()), self.event_data
+            {
+                self.action_group: self.workflow,
+                action_group_2: workflow,
+                action_group_3: workflow,
+            },
+            self.event_data,
         )
-        assert set(triggered_actions) == {self.action, action_3}
+        assert triggered_actions == {
+            (self.action, self.workflow.id),
+            (action_3, workflow.id),
+        }
 
         for status in [status_1, status_2, status_3]:
             status.refresh_from_db()

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -154,7 +154,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        mock_filter.assert_called_with({workflow_filters: workflow}, self.event_data)
+        mock_filter.assert_called_with({workflow_filters: workflow.id}, self.event_data)
 
     def test_same_environment_only(self):
         env = self.create_environment(project=self.project)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -102,7 +102,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             "workflow_engine.process_workflows.triggered_actions (batch)",
             extra={
                 "workflow_ids": [self.error_workflow.id],
-                "action_ids": [self.action.id],
+                "actions_with_workflows": [(self.action.id, self.error_workflow.id)],
                 "detector_type": self.error_detector.type,
             },
         )
@@ -154,7 +154,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         process_workflows(self.event_data)
 
-        mock_filter.assert_called_with({workflow_filters}, self.event_data)
+        mock_filter.assert_called_with({workflow_filters: workflow}, self.event_data)
 
     def test_same_environment_only(self):
         env = self.create_environment(project=self.project)
@@ -532,7 +532,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
     def test_basic__no_filter(self):
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
-        assert set(triggered_actions) == {self.action}
+        assert triggered_actions == {(self.action, self.workflow.id)}
 
     def test_basic__with_filter__passes(self):
         self.create_data_condition(
@@ -543,7 +543,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
 
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
-        assert set(triggered_actions) == {self.action}
+        assert triggered_actions == {(self.action, self.workflow.id)}
 
     def test_basic__with_filter__filtered(self):
         # Add a filter to the action's group
@@ -634,7 +634,7 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
         triggered_actions = evaluate_workflows_action_filters(
             {self.workflow, workflow}, self.event_data
         )
-        assert set(triggered_actions) == {self.action}
+        assert triggered_actions == {(self.action, self.workflow.id)}
 
         assert (
             WorkflowFireHistory.objects.filter(


### PR DESCRIPTION
This PR adds the corresponding `workflow_id` to the `WorkflowEventData` dataclass.

This allows us to use that `workflow_id` in our notifications

The main change is rather than returning a set of `Action`, we return a set of `tuple[Action, int]`, where the int is the `workflow_id`