### PR TITLE
fix(dashboards-eap): Patch count aggregate to only allow `spans`

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -185,6 +185,16 @@ function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryField
     return true;
   }
 
+  if (
+    fieldValue?.kind === 'function' &&
+    fieldValue?.function[0] === AggregationKey.COUNT
+  ) {
+    return (
+      option.value.meta.name === 'span.duration' ||
+      fieldValue.function[1] === option.value.meta.name
+    );
+  }
+
   const expectedDataType =
     fieldValue?.kind === 'function' &&
     fieldValue?.function[0] === AggregationKey.COUNT_UNIQUE

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import trimStart from 'lodash/trimStart';
 import uniqBy from 'lodash/uniqBy';
@@ -48,6 +48,10 @@ interface Props {
   hasGroupBy?: boolean;
 }
 
+// Lock the sort by parameter option when the value is `count(span.duration)`
+// because we do not want to expose the concept of counting by other fields
+const LOCKED_SPAN_COUNT_SORT = 'count(span.duration)';
+
 export function SortBySelectors({
   values,
   widgetType,
@@ -77,6 +81,23 @@ export function SortBySelectors({
     }
     setShowCustomEquation(isSortingByEquation);
   }, [values.sortBy, values.sortDirection]);
+
+  const queryFieldOptions = useMemo(() => {
+    const options = datasetConfig.getTimeseriesSortOptions!(
+      organization,
+      widgetQuery,
+      tags
+    );
+    if (widgetType === WidgetType.SPANS && options['measurement:span.duration']) {
+      // Re-map the span duration measurement label so we can simply render
+      // `spans` in the parameter UI
+      options['measurement:span.duration'] = {
+        ...options['measurement:span.duration'],
+        label: t('spans'),
+      };
+    }
+    return options;
+  }, [datasetConfig, organization, tags, widgetQuery, widgetType]);
 
   return (
     <Wrapper>
@@ -137,17 +158,16 @@ export function SortBySelectors({
                   ? explodeField({field: CUSTOM_EQUATION_VALUE})
                   : explodeField({field: values.sortBy})
             }
-            fieldOptions={datasetConfig.getTimeseriesSortOptions!(
-              organization,
-              widgetQuery,
-              tags
-            )}
+            fieldOptions={queryFieldOptions}
             filterPrimaryOptions={
               datasetConfig.filterSeriesSortOptions
                 ? datasetConfig.filterSeriesSortOptions(columnSet)
                 : undefined
             }
             filterAggregateParameters={datasetConfig.filterAggregateParams}
+            disableParameterSelector={
+              widgetType === WidgetType.SPANS && values.sortBy === LOCKED_SPAN_COUNT_SORT
+            }
             onChange={value => {
               if (value.alias && isEquationAlias(value.alias)) {
                 onChange({

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -65,6 +65,7 @@ type Props = {
   fieldValue: QueryFieldValue;
   onChange: (fieldValue: QueryFieldValue) => void;
   className?: string;
+  disableParameterSelector?: boolean;
   disabled?: boolean;
   error?: string;
   /**
@@ -439,6 +440,7 @@ class _QueryField extends Component<Props> {
       fieldValue,
       useMenuPortal,
       theme,
+      disableParameterSelector,
     } = this.props;
 
     const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
@@ -483,7 +485,7 @@ class _QueryField extends Component<Props> {
             required={descriptor.required}
             onChange={this.handleFieldParameterChange}
             inFieldLabel={inFieldLabels ? t('Parameter: ') : undefined}
-            disabled={disabled}
+            disabled={disabled || disableParameterSelector}
             menuPortalTarget={portalProps.menuPortalTarget}
             styles={{
               ...portalProps.styles,


### PR DESCRIPTION
The widget should only allow `count(spans)`. If the user already has something set, we allow them to change it but the only other option is `spans` and once it's selected, the field is locked.