### PR TITLE
feat(insights): create eap transaction search for insight overview pages

### DIFF
--- a/static/app/views/insights/pages/backend/settings.ts
+++ b/static/app/views/insights/pages/backend/settings.ts
@@ -1,4 +1,6 @@
+import {backend} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
+import type {PlatformKey} from 'sentry/types/project';
 import type {ValidSort} from 'sentry/views/insights/pages/backend/backendTable';
 import {type EAPSpanProperty, ModuleName} from 'sentry/views/insights/types';
 
@@ -21,3 +23,5 @@ export const DEFAULT_SORT: ValidSort = {
   field: 'time_spent_percentage(span.duration)' satisfies EAPSpanProperty,
   kind: 'desc',
 };
+
+export const BACKEND_PLATFORMS: PlatformKey[] = [...backend];

--- a/static/app/views/insights/pages/insightsSpanTagProvider.tsx
+++ b/static/app/views/insights/pages/insightsSpanTagProvider.tsx
@@ -1,0 +1,10 @@
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+
+export function InsightsSpanTagProvider({children}: {children: React.ReactNode}) {
+  return (
+    <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP_RPC} enabled>
+      {children}
+    </SpanTagsProvider>
+  );
+}

--- a/static/app/views/insights/pages/transactionNameSearchBar.tsx
+++ b/static/app/views/insights/pages/transactionNameSearchBar.tsx
@@ -15,6 +15,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOnClickOutside from 'sentry/utils/useOnClickOutside';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {useTraceItemAttributeValues} from 'sentry/views/explore/hooks/useTraceItemAttributeValues';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
@@ -45,6 +46,9 @@ export function TransactionNameSearchBar(props: SearchBarProps) {
   const [loading, setLoading] = useState(false);
   const [searchString, setSearchString] = useState(searchQuery);
   const containerRef = useRef<HTMLDivElement>(null);
+  const {
+    selection: {projects: selectedProjectIds},
+  } = usePageFilters();
   useOnClickOutside(containerRef, useCallback(closeDropdown, []));
 
   const getTraceItemAttributeValues = useTraceItemAttributeValues({
@@ -201,7 +205,9 @@ export function TransactionNameSearchBar(props: SearchBarProps) {
       view,
       organization,
       transaction,
-      projectID: projectIds,
+      projectID: projectIds.length
+        ? projectIds
+        : selectedProjectIds.map(id => id.toString()),
       query: {},
     });
 

--- a/static/app/views/insights/pages/transactionNameSearchBar.tsx
+++ b/static/app/views/insights/pages/transactionNameSearchBar.tsx
@@ -1,0 +1,272 @@
+import {useCallback, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
+
+import SearchDropdown from 'sentry/components/deprecatedSmartSearchBar/searchDropdown';
+import type {SearchGroup} from 'sentry/components/deprecatedSmartSearchBar/types';
+import {ItemType} from 'sentry/components/deprecatedSmartSearchBar/types';
+import {getSearchGroupWithItemMarkedActive} from 'sentry/components/deprecatedSmartSearchBar/utils';
+import BaseSearchBar from 'sentry/components/searchBar';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
+import {useTraceItemAttributeValues} from 'sentry/views/explore/hooks/useTraceItemAttributeValues';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {SpanFields} from 'sentry/views/insights/types';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+
+export type SearchBarProps = {
+  onSearch: (query: string) => void;
+  organization: Organization;
+  /** The project ids to search for */
+  projectIds: Array<Project['id']>;
+  /** The query in the search bar */
+  query: string;
+  className?: string;
+};
+
+export function TransactionNameSearchBar(props: SearchBarProps) {
+  const {organization, onSearch, query: searchQuery, projectIds, className} = props;
+
+  const navigate = useNavigate();
+  const {view} = useDomainViewFilters();
+  const [searchResults, setSearchResults] = useState<SearchGroup[]>([]);
+  const transactionCount = searchResults[0]?.children?.length || 0;
+  const [highlightedItemIndex, setHighlightedItemIndex] = useState(-1);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const openDropdown = () => setIsDropdownOpen(true);
+  const closeDropdown = () => setIsDropdownOpen(false);
+  const [loading, setLoading] = useState(false);
+  const [searchString, setSearchString] = useState(searchQuery);
+  const containerRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside(containerRef, useCallback(closeDropdown, []));
+
+  const getTraceItemAttributeValues = useTraceItemAttributeValues({
+    traceItemType: TraceItemDataset.SPANS,
+    attributeKey: 'transaction',
+    enabled: true,
+    type: 'string',
+    projectIds: projectIds.map(id => parseInt(id, 10)),
+  });
+
+  const handleSearchChange = (query: any) => {
+    setSearchString(query);
+
+    if (query.length === 0) {
+      onSearch('');
+    }
+
+    if (query.length < 3) {
+      setSearchResults([]);
+      closeDropdown();
+      return;
+    }
+
+    openDropdown();
+    getSuggestedTransactions(query);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    const {key} = event;
+
+    if (loading) {
+      return;
+    }
+
+    if (key === 'Escape' && isDropdownOpen) {
+      closeDropdown();
+      return;
+    }
+
+    if (
+      (key === 'ArrowUp' || key === 'ArrowDown') &&
+      isDropdownOpen &&
+      transactionCount > 0
+    ) {
+      const currentHighlightedItem = searchResults[0]!.children[highlightedItemIndex];
+      const nextHighlightedItemIndex =
+        (highlightedItemIndex + transactionCount + (key === 'ArrowUp' ? -1 : 1)) %
+        transactionCount;
+      setHighlightedItemIndex(nextHighlightedItemIndex);
+      const nextHighlightedItem = searchResults[0]!.children[nextHighlightedItemIndex];
+
+      let newSearchResults = searchResults;
+      if (currentHighlightedItem) {
+        newSearchResults = getSearchGroupWithItemMarkedActive(
+          searchResults,
+          currentHighlightedItem,
+          false
+        );
+      }
+
+      if (nextHighlightedItem) {
+        newSearchResults = getSearchGroupWithItemMarkedActive(
+          newSearchResults,
+          nextHighlightedItem,
+          true
+        );
+      }
+
+      setSearchResults(newSearchResults);
+      return;
+    }
+
+    if (key === 'Enter') {
+      event.preventDefault();
+      const currentItem = searchResults[0]?.children[highlightedItemIndex];
+
+      if (currentItem?.value) {
+        handleChooseItem(currentItem.value);
+      } else {
+        handleSearch(searchString, true);
+      }
+    }
+  };
+
+  const getSuggestedTransactions = debounce(
+    async query => {
+      try {
+        setLoading(true);
+
+        const results = await getTraceItemAttributeValues(
+          {
+            key: SpanFields.TRANSACTION,
+            name: SpanFields.TRANSACTION,
+          },
+          query
+        );
+
+        const parsedResults = results.reduce(
+          (searchGroup: SearchGroup, item) => {
+            searchGroup.children.push({
+              value: item,
+              title: item,
+              type: ItemType.LINK,
+              desc: '',
+            });
+            return searchGroup;
+          },
+          {
+            title: 'All Transactions',
+            children: [],
+            icon: null,
+            type: 'header',
+          }
+        );
+
+        setHighlightedItemIndex(-1);
+
+        setSearchResults([parsedResults]);
+      } catch (_) {
+        throw new Error('Unable to fetch event field values');
+      } finally {
+        setLoading(false);
+      }
+    },
+    DEFAULT_DEBOUNCE_DURATION,
+    {leading: true}
+  );
+
+  const handleChooseItem = (transactionName: string) => {
+    handleSearch(transactionName, false);
+  };
+
+  const handleClickItemIcon = (value: string) => {
+    const item = decodeValueToItem(value);
+    navigateToItemTransactionSummary(item);
+  };
+
+  const handleSearch = (query: string, asRawText: boolean) => {
+    setSearchResults([]);
+    setSearchString(query);
+    query = new MutableSearch(query).formatString();
+
+    const fullQuery = asRawText ? query : `transaction:"${query}"`;
+    onSearch(query ? fullQuery : '');
+    closeDropdown();
+  };
+
+  const navigateToItemTransactionSummary = (item: DataItem) => {
+    const {transaction} = item;
+
+    setSearchResults([]);
+
+    const next = transactionSummaryRouteWithQuery({
+      view,
+      organization,
+      transaction,
+      projectID: projectIds,
+      query: {},
+    });
+
+    navigate(next);
+  };
+  const logDocsOpenedEvent = () => {
+    trackAnalytics('search.docs_opened', {
+      organization,
+      search_type: 'performance',
+      search_source: 'performance_landing',
+      query: props.query,
+    });
+  };
+
+  return (
+    <Container
+      className={className || ''}
+      data-test-id="transaction-search-bar"
+      ref={containerRef}
+    >
+      <BaseSearchBar
+        placeholder={t('Search Transactions')}
+        onChange={handleSearchChange}
+        onKeyDown={handleKeyDown}
+        query={searchString}
+      />
+      {isDropdownOpen && (
+        <SearchDropdown
+          maxMenuHeight={300}
+          searchSubstring={searchString}
+          loading={loading}
+          items={searchResults}
+          onClick={handleChooseItem}
+          onIconClick={handleClickItemIcon}
+          onDocsOpen={() => logDocsOpenedEvent()}
+        />
+      )}
+    </Container>
+  );
+}
+
+const decodeValueToItem = (value: string): DataItem => {
+  const lastIndex = value.lastIndexOf(':');
+
+  return {
+    transaction: value.slice(0, lastIndex),
+  };
+};
+
+interface DataItem {
+  transaction: string;
+}
+
+export const wrapQueryInWildcards = (query: string) => {
+  if (!query.startsWith('*')) {
+    query = '*' + query;
+  }
+
+  if (!query.endsWith('*')) {
+    query = query + '*';
+  }
+
+  return query;
+};
+
+const Container = styled('div')`
+  position: relative;
+`;

--- a/static/app/views/insights/pages/utils.ts
+++ b/static/app/views/insights/pages/utils.ts
@@ -1,4 +1,8 @@
 import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {BACKEND_PLATFORMS} from 'sentry/views/insights/pages/backend/settings';
+import {FRONTEND_PLATFORMS} from 'sentry/views/insights/pages/frontend/settings';
+import {MOBILE_PLATFORMS} from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_MODULES} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {
@@ -31,4 +35,25 @@ export const getModuleView = (module: ModuleName): DomainView => {
     return 'ai';
   }
   return 'backend';
+};
+
+export const categorizeProjects = (projects: Project[]) => {
+  const otherProjects: Project[] = [];
+  const backendProjects: Project[] = [];
+  const frontendProjects: Project[] = [];
+  const mobileProjects: Project[] = [];
+
+  projects.forEach(project => {
+    if (project?.platform && FRONTEND_PLATFORMS.includes(project.platform)) {
+      frontendProjects.push(project);
+    } else if (project?.platform && MOBILE_PLATFORMS.includes(project.platform)) {
+      mobileProjects.push(project);
+    } else if (project?.platform && BACKEND_PLATFORMS.includes(project.platform)) {
+      backendProjects.push(project);
+    } else {
+      otherProjects.push(project);
+    }
+  });
+
+  return {otherProjects, frontendProjects, mobileProjects, backendProjects};
 };

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -68,6 +68,7 @@ export enum SpanMetricsField {
 
 // TODO: This will be the final field type for eap spans
 export enum SpanFields {
+  TRANSACTION = 'transaction',
   IS_TRANSACTION = 'is_transaction',
   CACHE_HIT = 'cache.hit',
   IS_STARRED_TRANSACTION = 'is_starred_transaction',


### PR DESCRIPTION
Create search bar for insight overview pages, it's mostly a copy of the old performance landing search except it queries the trace-items endpoint for auto complete.

There are also several misc changes associated with this in this PR