### PR TITLE
feat(nav): Make configure section sticky to the bottom of the nav

### DIFF
--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -88,16 +88,18 @@ SecondaryNav.Body = function SecondaryNavBody({children}: {children: ReactNode})
 SecondaryNav.Section = function SecondaryNavSection({
   title,
   children,
+  className,
   trailingItems,
 }: {
   children: ReactNode;
+  className?: string;
   title?: ReactNode;
   trailingItems?: ReactNode;
 }) {
   const {layout} = useNavContext();
 
   return (
-    <Section>
+    <Section className={className} data-nav-section>
       <SectionSeparator />
       {title && (
         <SectionTitle layout={layout}>
@@ -178,7 +180,6 @@ const Header = styled('div')`
 `;
 
 const Body = styled('div')<{layout: NavLayout}>`
-  padding: ${space(1)};
   overflow-y: auto;
 
   ${p =>
@@ -189,8 +190,19 @@ const Body = styled('div')<{layout: NavLayout}>`
 `;
 
 const Section = styled('div')`
-  & + & {
-    hr {
+  padding: 0 ${space(1)};
+
+  &:first-child {
+    padding-top: ${space(1)};
+  }
+
+  &:last-child {
+    padding-bottom: ${space(1)};
+  }
+
+  /* Hide separators if there is not a previous section */
+  [data-nav-section] + & {
+    > hr {
       display: block;
     }
   }

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useRef} from 'react';
+import styled from '@emotion/styled';
 
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
@@ -75,7 +76,7 @@ export function IssuesSecondaryNav() {
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
   const hasWorkflowEngine = useWorkflowEngineFeatureGate();
   return (
-    <SecondaryNav.Section title={t('Configure')}>
+    <StickyBottomSection title={t('Configure')}>
       {hasWorkflowEngine ? (
         <Fragment>
           <SecondaryNav.Item
@@ -102,6 +103,12 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
           {t('Alerts')}
         </SecondaryNav.Item>
       )}
-    </SecondaryNav.Section>
+    </StickyBottomSection>
   );
 }
+
+const StickyBottomSection = styled(SecondaryNav.Section)`
+  position: sticky;
+  bottom: 0;
+  background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface200)};
+`;


### PR DESCRIPTION
If you have a lot of starred issue views, it could push the configure section out of view. This ensure that it stays sticky at the bottom in that case.

![CleanShot 2025-05-05 at 15 42 09](https://github.com/user-attachments/assets/5d2e18be-b38d-4ad6-ba92-237b2fc1fb1b)
