### PR TITLE
fix(issues): Add more languages to map

### DIFF
--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -47,6 +47,7 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   jbuilder: 'ruby',
   ru: 'ruby',
   rake: 'ruby',
+  rabl: 'ruby',
 
   // JS
   cjs: 'javascript',
@@ -56,11 +57,24 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   vue: 'javascript',
   svelte: 'javascript',
   'js?': 'javascript',
+  'ts?': 'typescript',
+  'tsx?': 'typescript',
+  mts: 'typescript',
 
   // Clojure
   clj: 'clojure',
   cljc: 'clojure',
   cljs: 'clojure',
+
+  // Php
+  php5: 'php',
+  phtml: 'php',
+
+  // Various
+  // Flutter ARB file .arb is a JSON file
+  arb: 'json',
+  ps1: 'powershell',
+  jinja: 'jinja2',
 };
 
 export const getPrismLanguage = (lang: string) => {

--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -58,7 +58,7 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   svelte: 'javascript',
   'js?': 'javascript',
   'ts?': 'typescript',
-  'tsx?': 'typescript',
+  'tsx?': 'tsx',
   mts: 'typescript',
 
   // Clojure


### PR DESCRIPTION
Adds syntax highlighting for more file extensions. These file extensions are missing from the built-in prism language map.

there is a redash query here https://redash.getsentry.net/queries/7534