### PR TITLE
feat(trace-eap-waterfall): Updating trace waterfall preferences

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfaces/performance/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -24,7 +25,7 @@ import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceA
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
 import {
-  loadTraceViewPreferences,
+  getInitialTracePreferences,
   type TracePreferencesState,
 } from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
@@ -57,10 +58,16 @@ const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
 interface EventTraceViewInnerProps {
   event: Event;
   organization: Organization;
+  preferences: TracePreferencesState;
   traceId: string;
 }
 
-function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
+function EventTraceViewInner({
+  event,
+  organization,
+  traceId,
+  preferences,
+}: EventTraceViewInnerProps) {
   const timestamp = new Date(event.dateReceived).getTime() / 1e3;
 
   const trace = useTrace({
@@ -91,6 +98,7 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
   return (
     <IssuesTraceContainer>
       <IssuesTraceWaterfall
+        preferences={preferences}
         tree={tree}
         trace={trace}
         traceSlug={traceId}
@@ -141,8 +149,10 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
   // Span Evidence section contains the trace view already
   const preferences = useMemo(
     () =>
-      loadTraceViewPreferences('issue-details-trace-view-preferences') ||
-      DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES,
+      getInitialTracePreferences(
+        TRACE_WATERFALL_PREFERENCES_KEY,
+        DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES
+      ),
     []
   );
 
@@ -191,12 +201,13 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
       {hasTracePreviewFeature && (
         <TraceStateProvider
           initialPreferences={preferences}
-          preferencesStorageKey="issue-details-view-preferences"
+          preferencesStorageKey={TRACE_WATERFALL_PREFERENCES_KEY}
         >
           <EventTraceViewInner
             event={event}
             organization={organization}
             traceId={traceId}
+            preferences={preferences}
           />
         </TraceStateProvider>
       )}

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -58,16 +58,10 @@ const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
 interface EventTraceViewInnerProps {
   event: Event;
   organization: Organization;
-  preferences: TracePreferencesState;
   traceId: string;
 }
 
-function EventTraceViewInner({
-  event,
-  organization,
-  traceId,
-  preferences,
-}: EventTraceViewInnerProps) {
+function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
   const timestamp = new Date(event.dateReceived).getTime() / 1e3;
 
   const trace = useTrace({
@@ -98,7 +92,6 @@ function EventTraceViewInner({
   return (
     <IssuesTraceContainer>
       <IssuesTraceWaterfall
-        preferences={preferences}
         tree={tree}
         trace={trace}
         traceSlug={traceId}
@@ -207,7 +200,6 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
             event={event}
             organization={organization}
             traceId={traceId}
-            preferences={preferences}
           />
         </TraceStateProvider>
       )}

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
@@ -66,7 +66,7 @@ export function SpanEvidenceTraceView(props: SpanEvidenceTraceViewProps) {
       initialPreferences={preferences}
       preferencesStorageKey="issue-details-trace-view-preferences"
     >
-      <SpanEvidenceTraceViewImpl {...props} preferences={preferences} />
+      <SpanEvidenceTraceViewImpl {...props} />
     </TraceStateProvider>
   );
 }
@@ -75,8 +75,7 @@ function SpanEvidenceTraceViewImpl({
   event,
   organization,
   traceId,
-  preferences,
-}: SpanEvidenceTraceViewProps & {preferences: TracePreferencesState}) {
+}: SpanEvidenceTraceViewProps) {
   const timestamp = new Date(event.dateReceived).getTime() / 1e3;
 
   const trace = useTrace({
@@ -107,7 +106,6 @@ function SpanEvidenceTraceViewImpl({
       <Suspense fallback={null}>
         <LazyIssuesTraceWaterfall
           tree={tree}
-          preferences={preferences}
           trace={trace}
           traceSlug={traceId}
           rootEventResults={rootEventResults}

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -9,6 +9,9 @@ import type {EntrySpans, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {getIssueTypeFromOccurrenceType, IssueType} from 'sentry/types/group';
 
+export const TRACE_WATERFALL_PREFERENCES_KEY =
+  'issue-details-trace-waterfall-preferences';
+
 export function getSpanInfoFromTransactionEvent(
   event: Pick<
     EventTransaction,

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -22,7 +22,6 @@ import {useTraceTree} from './traceApi/useTraceTree';
 import {
   DEFAULT_TRACE_VIEW_PREFERENCES,
   getInitialTracePreferences,
-  TracePreferencesState,
 } from './traceState/tracePreferences';
 import {TraceStateProvider} from './traceState/traceStateProvider';
 import {TraceMetaDataHeader} from './traceHeader';
@@ -63,19 +62,13 @@ export function TraceView() {
         initialPreferences={preferences}
         preferencesStorageKey={TRACE_VIEW_PREFERENCES_KEY}
       >
-        <TraceViewImpl traceSlug={traceSlug} preferences={preferences} />
+        <TraceViewImpl traceSlug={traceSlug} />
       </TraceStateProvider>
     </TraceViewLogsDataProvider>
   );
 }
 
-function TraceViewImpl({
-  traceSlug,
-  preferences,
-}: {
-  preferences: TracePreferencesState;
-  traceSlug: string;
-}) {
+function TraceViewImpl({traceSlug}: {traceSlug: string}) {
   const organization = useOrganization();
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);
@@ -117,7 +110,6 @@ function TraceViewImpl({
             />
             <TraceInnerLayout>
               <TraceWaterfall
-                preferences={preferences}
                 tree={tree}
                 trace={trace}
                 meta={meta}

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -21,7 +21,8 @@ import {useTraceRootEvent} from './traceApi/useTraceRootEvent';
 import {useTraceTree} from './traceApi/useTraceTree';
 import {
   DEFAULT_TRACE_VIEW_PREFERENCES,
-  loadTraceViewPreferences,
+  getInitialTracePreferences,
+  TracePreferencesState,
 } from './traceState/tracePreferences';
 import {TraceStateProvider} from './traceState/traceStateProvider';
 import {TraceMetaDataHeader} from './traceHeader';
@@ -41,14 +42,18 @@ function decodeTraceSlug(maybeSlug: string | undefined): string {
   return maybeSlug.trim();
 }
 
+export const TRACE_VIEW_PREFERENCES_KEY = 'trace-waterfall-preferences';
+
 export function TraceView() {
   const params = useParams<{traceSlug?: string}>();
   const traceSlug = useMemo(() => decodeTraceSlug(params.traceSlug), [params.traceSlug]);
 
   const preferences = useMemo(
     () =>
-      loadTraceViewPreferences('trace-view-preferences') ||
-      DEFAULT_TRACE_VIEW_PREFERENCES,
+      getInitialTracePreferences(
+        TRACE_VIEW_PREFERENCES_KEY,
+        DEFAULT_TRACE_VIEW_PREFERENCES
+      ),
     []
   );
 
@@ -56,15 +61,21 @@ export function TraceView() {
     <TraceViewLogsDataProvider traceSlug={traceSlug}>
       <TraceStateProvider
         initialPreferences={preferences}
-        preferencesStorageKey="trace-view-preferences"
+        preferencesStorageKey={TRACE_VIEW_PREFERENCES_KEY}
       >
-        <TraceViewImpl traceSlug={traceSlug} />
+        <TraceViewImpl traceSlug={traceSlug} preferences={preferences} />
       </TraceStateProvider>
     </TraceViewLogsDataProvider>
   );
 }
 
-function TraceViewImpl({traceSlug}: {traceSlug: string}) {
+function TraceViewImpl({
+  traceSlug,
+  preferences,
+}: {
+  preferences: TracePreferencesState;
+  traceSlug: string;
+}) {
   const organization = useOrganization();
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);
@@ -106,6 +117,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
             />
             <TraceInnerLayout>
               <TraceWaterfall
+                preferences={preferences}
                 tree={tree}
                 trace={trace}
                 meta={meta}

--- a/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/issuesTraceWaterfall.tsx
@@ -341,6 +341,7 @@ export function IssuesTraceWaterfall(props: IssuesTraceWaterfallProps) {
         organization={organization}
       />
       <IssuesTraceGrid
+        minHeight={traceState.preferences.drawer.sizes['trace grid height']}
         layout={traceState.preferences.layout}
         rowCount={
           props.tree.type === 'trace' && onLoadScrollStatus === 'success'

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -21,7 +21,7 @@ import {
   makeTraceError,
   makeTransaction,
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
-import type {TracePreferencesState} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import type {StoredTracePreferences} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 
 // TODO Abdullah Khan: Remove this, it's a hack as mocking ProjectsStore is not working,
@@ -68,24 +68,14 @@ function mockQueryString(queryString: string) {
   });
 }
 
-function mockTracePreferences(preferences: Partial<TracePreferencesState>) {
-  const merged: TracePreferencesState = {
-    ...DEFAULT_TRACE_VIEW_PREFERENCES,
+function mockTracePreferences(preferences: Partial<StoredTracePreferences>) {
+  const storedPreferences: StoredTracePreferences = {
+    drawer_layout: DEFAULT_TRACE_VIEW_PREFERENCES.layout,
+    missing_instrumentation: DEFAULT_TRACE_VIEW_PREFERENCES.missing_instrumentation,
+    autogroup: DEFAULT_TRACE_VIEW_PREFERENCES.autogroup,
     ...preferences,
-    autogroup: {
-      ...DEFAULT_TRACE_VIEW_PREFERENCES.autogroup,
-      ...preferences.autogroup,
-    },
-    drawer: {
-      ...DEFAULT_TRACE_VIEW_PREFERENCES.drawer,
-      ...preferences.drawer,
-    },
-    list: {
-      ...DEFAULT_TRACE_VIEW_PREFERENCES.list,
-      ...preferences.list,
-    },
   };
-  localStorage.setItem('trace-view-preferences', JSON.stringify(merged));
+  localStorage.setItem('trace-waterfall-preferences', JSON.stringify(storedPreferences));
 }
 
 function mockTraceResponse(resp?: Partial<ResponseType>) {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -2166,7 +2166,7 @@ function nodeToId(n: TraceTreeNode<TraceTree.NodeValue>): TraceTree.NodePath {
     const spanId = isEAPSpanNode(n) ? n.value.event_id : n.value.span_id;
     return `span-${spanId}`;
   }
-  if (isTraceNode(n)) {
+  if (isTraceNode(n) || isEAPTraceNode(n)) {
     return `trace-root`;
   }
 

--- a/static/app/views/performance/newTraceDetails/traceState/tracePreferences.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/tracePreferences.tsx
@@ -36,7 +36,7 @@ export type TracePreferencesState = {
   missing_instrumentation: boolean;
 };
 
-type StoredTracePreferences = {
+export type StoredTracePreferences = {
   autogroup: TracePreferencesState['autogroup'];
   drawer_layout: TraceLayoutPreferences;
   missing_instrumentation: boolean;
@@ -88,8 +88,8 @@ export function storeTraceViewPreferences(
 
 function isPreferenceState(parsed: any): parsed is StoredTracePreferences {
   return (
-    'drawerLayout' in parsed &&
-    'missingInstrumentation' in parsed &&
+    'drawer_layout' in parsed &&
+    'missing_instrumentation' in parsed &&
     'autogroup' in parsed
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -37,7 +37,6 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import {TracePreferencesState} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {useDividerResizeSync} from 'sentry/views/performance/newTraceDetails/useDividerResizeSync';
 import {useTraceSpaceListeners} from 'sentry/views/performance/newTraceDetails/useTraceSpaceListeners';
 import type {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
@@ -95,7 +94,6 @@ const TRACE_TAB: TraceReducerState['tabs']['tabs'][0] = {
 export interface TraceWaterfallProps {
   meta: TraceMetaQueryResults;
   organization: Organization;
-  preferences: TracePreferencesState;
   replay: ReplayRecord | null;
   rootEventResults: TraceRootEventQueryResults;
   source: string;
@@ -710,7 +708,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   ]);
 
   const [height, setHeight] = useState(
-    clampHeight(props.preferences.drawer.sizes['trace grid height'])
+    clampHeight(traceState.preferences.drawer.sizes['trace grid height'])
   );
 
   const handleMouseDown = useCallback(

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -173,18 +173,12 @@ export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
       initialPreferences={preferences}
       preferencesStorageKey={REPLAY_TRACE_WATERFALL_PREFERENCES_KEY}
     >
-      <NewTraceViewImpl replay={replay} preferences={preferences} />
+      <NewTraceViewImpl replay={replay} />
     </TraceStateProvider>
   );
 }
 
-function NewTraceViewImpl({
-  replay,
-  preferences,
-}: {
-  preferences: TracePreferencesState;
-  replay: undefined | ReplayRecord;
-}) {
+function NewTraceViewImpl({replay}: {replay: undefined | ReplayRecord}) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {eventView, indexComplete, indexError, replayTraces} = useReplayTraces({
@@ -255,7 +249,6 @@ function NewTraceViewImpl({
   return (
     <TraceViewWaterfallWrapper>
       <TraceWaterfall
-        preferences={preferences}
         traceSlug={firstTrace.traceSlug}
         trace={trace}
         tree={tree}

--- a/static/app/views/replays/detail/trace/trace.tsx
+++ b/static/app/views/replays/detail/trace/trace.tsx
@@ -18,7 +18,7 @@ import {useTraceRootEvent} from 'sentry/views/performance/newTraceDetails/traceA
 import {useTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceTree';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TracePreferencesState} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
-import {loadTraceViewPreferences} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
+import {getInitialTracePreferences} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import {TraceWaterfall} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
 import {useTraceWaterfallModels} from 'sentry/views/performance/newTraceDetails/useTraceWaterfallModels';
@@ -156,25 +156,35 @@ function Trace({replay}: {replay: undefined | ReplayRecord}) {
   );
 }
 
+const REPLAY_TRACE_WATERFALL_PREFERENCES_KEY = 'replay-trace-waterfall-preferences';
+
 export function NewTraceView({replay}: {replay: undefined | ReplayRecord}) {
   const preferences = useMemo(
     () =>
-      loadTraceViewPreferences('replay-trace-view-preferences') ||
-      DEFAULT_REPLAY_TRACE_VIEW_PREFERENCES,
+      getInitialTracePreferences(
+        REPLAY_TRACE_WATERFALL_PREFERENCES_KEY,
+        DEFAULT_REPLAY_TRACE_VIEW_PREFERENCES
+      ),
     []
   );
 
   return (
     <TraceStateProvider
       initialPreferences={preferences}
-      preferencesStorageKey="replay-trace-view-preferences"
+      preferencesStorageKey={REPLAY_TRACE_WATERFALL_PREFERENCES_KEY}
     >
-      <NewTraceViewImpl replay={replay} />
+      <NewTraceViewImpl replay={replay} preferences={preferences} />
     </TraceStateProvider>
   );
 }
 
-function NewTraceViewImpl({replay}: {replay: undefined | ReplayRecord}) {
+function NewTraceViewImpl({
+  replay,
+  preferences,
+}: {
+  preferences: TracePreferencesState;
+  replay: undefined | ReplayRecord;
+}) {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {eventView, indexComplete, indexError, replayTraces} = useReplayTraces({
@@ -245,6 +255,7 @@ function NewTraceViewImpl({replay}: {replay: undefined | ReplayRecord}) {
   return (
     <TraceViewWaterfallWrapper>
       <TraceWaterfall
+        preferences={preferences}
         traceSlug={firstTrace.traceSlug}
         trace={trace}
         tree={tree}


### PR DESCRIPTION
The only 3 things that we want persistence for in the trace view is:

1. The drawer layout: left | right | bottom
2. autogrouping: enabled | disabled
3. missing instrumentation: enabled | disabled

Added new storage keys 
