### PR TITLE
feat(feedback/LLM): update vertex provider to use gemini models

### DIFF
--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -2,11 +2,12 @@ import logging
 
 import google.auth
 import google.auth.transport.requests
-import requests
+from google import genai
+from google.genai.types import GenerateContentConfig, HttpOptions
 
 from sentry.llm.exceptions import VertexRequestFailed
 from sentry.llm.providers.base import LlmModelBase
-from sentry.llm.types import UseCaseConfig
+from sentry.llm.types import ProviderConfig, UseCaseConfig
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,15 @@ class VertexProvider(LlmModelBase):
     candidate_count = 1  # we only want one candidate returned at the moment
     top_p = 1  # TODO: make this configurable?
 
+    def __init__(self, provider_config: ProviderConfig) -> None:
+        super().__init__(provider_config)
+        self.client = genai.Client(
+            vertexai=True,
+            project=provider_config["options"]["project"],
+            location=provider_config["options"]["location"],
+            http_options=HttpOptions(api_version="v1"),
+        )
+
     def _complete_prompt(
         self,
         *,
@@ -30,35 +40,29 @@ class VertexProvider(LlmModelBase):
         max_output_tokens: int,
     ) -> str | None:
 
+        model = usecase_config["options"]["model"]
         content = f"{prompt} {message}" if prompt else message
+        generate_config = GenerateContentConfig(
+            candidate_count=self.candidate_count,
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            top_p=self.top_p,
+        )
 
-        payload = {
-            "instances": [{"content": content}],
-            "parameters": {
-                "candidateCount": self.candidate_count,
-                "maxOutputTokens": max_output_tokens,
-                "temperature": temperature,
-                "topP": self.top_p,
-            },
-        }
-
-        headers = {
-            "Authorization": f"Bearer {self._get_access_token()}",
-            "Content-Type": "application/json",
-        }
-        vertex_url = self.provider_config["options"]["url"]
-        vertex_url += usecase_config["options"]["model"] + ":predict"
-
-        response = requests.post(vertex_url, headers=headers, json=payload)
+        response = self.client.models.generate_content(
+            model=model,
+            contents=content,
+            config=generate_config,
+        )
 
         if response.status_code != 200:
             logger.error(
-                "Request failed with status code and response text.",
-                extra={"status_code": response.status_code, "response_text": response.text},
+                "Vertex request failed.",
+                extra={"status_code": response.status_code},
             )
-            raise VertexRequestFailed(f"Response {response.status_code}: {response.text}")
+            raise VertexRequestFailed(f"Response {response.status_code}")
 
-        return response.json()["predictions"][0]["content"]
+        return response.text
 
     def _get_access_token(self) -> str:
         # https://stackoverflow.com/questions/53472429/how-to-get-a-gcp-bearer-token-programmatically-with-python

--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -60,8 +60,8 @@ class VertexProvider(LlmModelBase):
     def _create_genai_client(self):
         return genai.Client(
             vertexai=True,
-            project=self.provider_config["options"]["project"],
-            location=self.provider_config["options"]["location"],
+            project=self.provider_config["options"]["gcp_project"],
+            location=self.provider_config["options"]["gcp_location"],
             http_options=HttpOptions(api_version="v1"),
         )
 

--- a/tests/sentry/llm/test_vertex.py
+++ b/tests/sentry/llm/test_vertex.py
@@ -46,7 +46,7 @@ def test_complete_prompt(mock_options):
     )
 
     with patch(
-        "sentry.llm.providers.vertex.genai.Client",
+        "sentry.llm.providers.vertex.VertexProvider._create_genai_client",
         return_value=MockGenaiClient(mock_generate_content),
     ):
         res = complete_prompt(
@@ -73,7 +73,7 @@ def test_complete_prompt_error(mock_options):
     )
 
     with patch(
-        "sentry.llm.providers.vertex.genai.Client",
+        "sentry.llm.providers.vertex.VertexProvider._create_genai_client",
         return_value=MockGenaiClient(mock_generate_content),
     ):
         with pytest.raises(VertexRequestFailed):

--- a/tests/sentry/llm/test_vertex.py
+++ b/tests/sentry/llm/test_vertex.py
@@ -14,7 +14,7 @@ def mock_options(set_sentry_option):
             {
                 "vertex": {
                     "models": ["vertex-1.0"],
-                    "options": {"project": "my-gcp-project", "location": "us-central1"},
+                    "options": {"gcp_project": "my-gcp-project", "gcp_location": "us-central1"},
                 }
             },
         ),

--- a/tests/sentry/llm/test_vertex.py
+++ b/tests/sentry/llm/test_vertex.py
@@ -1,29 +1,53 @@
-from unittest.mock import patch
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
 
 from sentry.llm.usecases import LLMUseCase, complete_prompt
 
 
-def test_complete_prompt(set_sentry_option):
+@contextmanager
+def mock_options(set_sentry_option):
     with (
         set_sentry_option(
             "llm.provider.options",
-            {"vertex": {"models": ["vertex-1.0"], "options": {"url": "fake_url"}}},
+            {
+                "vertex": {
+                    "models": ["vertex-1.0"],
+                    "options": {"project": "my-gcp-project", "location": "us-central1"},
+                }
+            },
         ),
         set_sentry_option(
             "llm.usecases.options",
             {"example": {"provider": "vertex", "options": {"model": "vertex-1.0"}}},
         ),
+    ):
+        yield
+
+
+class MockGenaiClient:
+    def __init__(self, mock_generate_content):
+        self.models = type(
+            "obj",
+            (object,),
+            {"generate_content": mock_generate_content},
+        )()
+
+
+def test_complete_prompt(set_sentry_option):
+
+    mock_generate_content = Mock(
+        return_value=type(
+            "obj",
+            (object,),
+            {"status_code": 200, "text": "hello world"},
+        )()
+    )
+
+    with (
+        mock_options(set_sentry_option),
         patch(
-            "sentry.llm.providers.vertex.VertexProvider._get_access_token",
-            return_value="fake_token",
-        ),
-        patch(
-            "requests.post",
-            return_value=type(
-                "obj",
-                (object,),
-                {"status_code": 200, "json": lambda x: {"predictions": [{"content": ""}]}},
-            )(),
+            "sentry.llm.providers.vertex.genai.Client",
+            return_value=MockGenaiClient(mock_generate_content),
         ),
     ):
         res = complete_prompt(
@@ -33,4 +57,7 @@ def test_complete_prompt(set_sentry_option):
             temperature=0.0,
             max_output_tokens=1024,
         )
-    assert res == ""
+
+    assert res == "hello world"
+    assert mock_generate_content.call_count == 1
+    assert mock_generate_content.call_args[1]["model"] == "vertex-1.0"


### PR DESCRIPTION
For gemini models, it's recommended to use the genai SDK instead of posting to a URL like we were for `text-bison`. We need this before we can request the new model, [2.0 flash lite](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-2.0-flash-lite-001). 

Spam detection has been disabled in all regions except S4S, so we don't need to worry about errors if this is deployed before options, or vice versa

- [x] Depends on pypi: https://github.com/getsentry/pypi/pull/1419
- [ ] Bump in sentry: https://github.com/getsentry/sentry/pull/91028
- [ ] Depends on options: https://github.com/getsentry/getsentry/pull/17378

Ref https://github.com/getsentry/sentry/issues/90986