### PR TITLE
feat(replays) - Added millisecond precision to error timestamp on replay-events-meta

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -36,6 +36,7 @@ from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS
 from sentry.search.events.fields import get_function_alias
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba import discover
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.utils import DATASET_LABELS, DATASET_OPTIONS, get_dataset
 from sentry.users.services.user.serial import serialize_generic_user
@@ -108,7 +109,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         return [team for team in teams]
 
     def get_dataset(self, request: Request) -> Any:
-        dataset_label = request.GET.get("dataset", "discover")
+        dataset_label = request.GET.get("dataset", Dataset.Discover.value)
         result = get_dataset(dataset_label)
         if result is None:
             raise ParseError(detail=f"dataset must be one of: {', '.join(DATASET_OPTIONS.keys())}")

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -854,3 +854,12 @@ class Columns(Enum):
         discover_name="contexts[ota_updates.update_id]",
         alias="ota_updates.update_id",
     )
+
+    TIMESTAMP_MS = Column(
+        group_name="events.timestamp_ms",
+        event_name="timestamp_ms",
+        transaction_name=None,
+        discover_name="timestamp_ms",
+        issue_platform_name=None,
+        alias="timestamp_ms",
+    )

--- a/tests/sentry/replays/test_organization_replay_events_meta.py
+++ b/tests/sentry/replays/test_organization_replay_events_meta.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 from django.urls import reverse
@@ -28,16 +28,33 @@ class OrganizationEventsMetaTest(APITestCase, SnubaTestCase, OccurrenceTestMixin
         event_id_a = "a" * 32
         event_id_b = "b" * 32
 
+        min_ago_ms = self.min_ago + timedelta(milliseconds=123)
         event_a = self.store_event(
-            data={"event_id": event_id_a, "timestamp": self.min_ago.isoformat()},
+            data={
+                "event_id": event_id_a,
+                "timestamp": min_ago_ms.isoformat(),
+            },
             project_id=self.project_1.id,
         )
         event_b = self.store_event(
-            data={"event_id": event_id_b, "timestamp": self.min_ago.isoformat()},
+            data={
+                "event_id": event_id_b,
+                "timestamp": min_ago_ms.isoformat(),
+            },
             project_id=self.project_2.id,
         )
-        self.store_event(data={"timestamp": self.min_ago.isoformat()}, project_id=self.project_1.id)
-        self.store_event(data={"timestamp": self.min_ago.isoformat()}, project_id=self.project_1.id)
+        self.store_event(
+            data={
+                "timestamp": min_ago_ms.isoformat(),
+            },
+            project_id=self.project_1.id,
+        )
+        self.store_event(
+            data={
+                "timestamp": min_ago_ms.isoformat(),
+            },
+            project_id=self.project_1.id,
+        )
 
         query = {"query": f"id:[{event_id_a}, {event_id_b}]"}
         with self.feature(self.features):
@@ -51,7 +68,7 @@ class OrganizationEventsMetaTest(APITestCase, SnubaTestCase, OccurrenceTestMixin
                 "issue.id": event_a.group.id,
                 "issue": event_a.group.qualified_short_id,
                 "project.name": self.project_1.slug,
-                "timestamp": self.min_ago.isoformat(),
+                "timestamp": min_ago_ms.isoformat(),
                 "title": "<unlabeled event>",
             },
             {
@@ -61,7 +78,7 @@ class OrganizationEventsMetaTest(APITestCase, SnubaTestCase, OccurrenceTestMixin
                 "issue.id": event_b.group.id,
                 "issue": event_b.group.qualified_short_id,
                 "project.name": self.project_2.slug,
-                "timestamp": self.min_ago.isoformat(),
+                "timestamp": min_ago_ms.isoformat(),
                 "title": "<unlabeled event>",
             },
         ]


### PR DESCRIPTION
previously errors returned by replay-events-meta API had a timestamp with a one second resolution. we now use the new `timestamp_ms` field to populate the returned timestamp with a more precise timestamp.
