### PR TITLE
feat(nextjs-insights): Rage and dead click widget

### DIFF
--- a/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
+++ b/static/app/utils/replays/hooks/useDeadRageSelectors.tsx
@@ -12,13 +12,13 @@ export default function useDeadRageSelectors(params: DeadRageSelectorQueryParams
   const location = useLocation();
   const {query} = location;
 
-  const {isPending, isError, data, getResponseHeader} =
+  const {isPending, isError, error, data, getResponseHeader} =
     useApiQuery<DeadRageSelectorListResponse>(
       [
         `/organizations/${organization.slug}/replay-selectors/`,
         {
           query: {
-            query: '!count_dead_clicks:0',
+            query: params.query ?? '!count_dead_clicks:0',
             cursor: params.cursor,
             environment: query.environment,
             project: query.project,
@@ -34,6 +34,7 @@ export default function useDeadRageSelectors(params: DeadRageSelectorQueryParams
   return {
     isLoading: isPending,
     isError,
+    error,
     data: hydratedSelectorData(
       data ? data.data : [],
       params.isWidgetData ? params.sort?.replace(/^-/, '') : null

--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -68,7 +68,7 @@ export function DeadRageClicksWidget({
 
   return (
     <Widget
-      Title={<Widget.WidgetTitle title={t('Dead Rage Clicks')} />}
+      Title={<Widget.WidgetTitle title={t('Rage & Dead Clicks')} />}
       Visualization={visualization}
       noVisualizationPadding
       Actions={

--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -1,0 +1,183 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+import {LinkButton} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import TextOverflow from 'sentry/components/textOverflow';
+import {IconCursorArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelectors';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import type {Release} from 'sentry/views/dashboards/widgets/common/types';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {SlowSSRWidget} from 'sentry/views/insights/pages/platform/nextjs/slowSsrWidget';
+import {
+  SelectorLink,
+  transformSelectorQuery,
+} from 'sentry/views/replays/deadRageClick/selectorTable';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
+import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
+
+export function DeadRageClicksWidget({
+  query,
+  releases,
+}: {
+  query?: string;
+  releases?: Release[];
+}) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const fullQuery = `!count_dead_clicks:0 ${query}`.trim();
+
+  const {isLoading, error, data} = useDeadRageSelectors({
+    per_page: 5,
+    sort: '-count_dead_clicks',
+    cursor: undefined,
+    query: fullQuery,
+    isWidgetData: true,
+  });
+
+  const isEmpty = !isLoading && data.length === 0;
+
+  if (isEmpty) {
+    return <SlowSSRWidget query={query} releases={releases} />;
+  }
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isLoading={isLoading}
+      error={error}
+      isEmpty={isEmpty}
+      VisualizationType={DeadRageClickWidgetVisualization}
+      visualizationProps={{
+        items: data,
+      }}
+    />
+  );
+
+  const allSelectorsPath = makeReplaysPathname({
+    path: '/selectors/',
+    organization,
+  });
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={t('Dead Rage Clicks')} />}
+      Visualization={visualization}
+      noVisualizationPadding
+      Actions={
+        <LinkButton
+          size="xs"
+          to={{
+            pathname: allSelectorsPath,
+            query: {
+              ...location.query,
+              sort: '-count_dead_clicks',
+              query: undefined,
+              cursor: undefined,
+            },
+          }}
+        >
+          {t('View all')}
+        </LinkButton>
+      }
+    />
+  );
+}
+
+function DeadRageClickWidgetVisualization({items}: {items: DeadRageSelectorItem[]}) {
+  return (
+    <ClicksGrid>
+      {items.map((item, index) => (
+        <Fragment key={index}>
+          <ClicksGridCell>
+            <SelectorLink
+              value={item.dom_element.selector}
+              selectorQuery={`dead.selector:"${transformSelectorQuery(item.dom_element.fullSelector)}"`}
+              projectId={item.project_id.toString()}
+            />
+          </ClicksGridCell>
+          <ClicksGridCell>
+            <ClickCount>
+              <IconCursorArrow size="xs" color="yellow400" />
+              {item.count_dead_clicks || 0}
+            </ClickCount>
+          </ClicksGridCell>
+          <ClicksGridCell>
+            <ClickCount>
+              <IconCursorArrow size="xs" color="red400" />
+              {item.count_rage_clicks || 0}
+            </ClickCount>
+          </ClicksGridCell>
+          <ClicksGridCell>
+            <ProjectInfo id={item.project_id} />
+          </ClicksGridCell>
+        </Fragment>
+      ))}
+    </ClicksGrid>
+  );
+}
+
+DeadRageClickWidgetVisualization.LoadingPlaceholder =
+  TimeSeriesWidgetVisualization.LoadingPlaceholder;
+
+export function ProjectInfo({id}: {id: number}) {
+  const {projects} = useProjects();
+  const project = projects.find(p => p.id === id.toString());
+  const platform = project?.platform;
+  const slug = project?.slug;
+  return (
+    <ProjectInfoWrapper>
+      <Tooltip title={slug}>
+        <PlatformIcon
+          style={{display: 'block'}}
+          size={16}
+          platform={platform ?? 'default'}
+        />
+      </Tooltip>
+    </ProjectInfoWrapper>
+  );
+}
+
+const COLUMN_COUNT = 4;
+
+const ClicksGrid = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr repeat(${COLUMN_COUNT - 1}, min-content);
+  grid-auto-rows: min-content;
+  margin-top: ${space(1)};
+  overflow-y: auto;
+`;
+
+const ClicksGridCell = styled('div')`
+  padding: ${space(1.5)} ${space(1)};
+  min-width: 0;
+  overflow: hidden;
+  border-top: 1px solid ${p => p.theme.border};
+  &:nth-child(${COLUMN_COUNT}n + 1) {
+    padding-left: ${space(2)};
+  }
+  &:nth-child(${COLUMN_COUNT}n) {
+    padding-right: ${space(2)};
+  }
+`;
+
+const ClickCount = styled(TextOverflow)`
+  color: ${p => p.theme.gray400};
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: ${space(0.75)};
+  align-items: center;
+`;
+
+const ProjectInfoWrapper = styled('div')`
+  display: block;
+  width: 16px;
+  height: 16px;
+`;

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -12,7 +12,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {SlowSSRWidget} from 'sentry/views/insights/pages/platform/nextjs/slowSsrWidget';
+import {DeadRageClicksWidget} from 'sentry/views/insights/pages/platform/nextjs/deadRageClickWidget';
 import {WebVitalsWidget} from 'sentry/views/insights/pages/platform/nextjs/webVitalsWidget';
 import {DurationWidget} from 'sentry/views/insights/pages/platform/shared/durationWidget';
 import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWidget';
@@ -110,7 +110,7 @@ export function NextJsOverviewPage({
           <WebVitalsWidget query={query} />
         </WebVitalsContainer>
         <QueriesContainer>
-          <SlowSSRWidget query={query} releases={releases} />
+          <DeadRageClicksWidget query={query} releases={releases} />
         </QueriesContainer>
         <CachesContainer>
           <PlaceholderWidget />

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -186,7 +186,7 @@ export function SelectorLink({
   return (
     <StyledTextOverflow>
       <WiderHovercard position="right" body={hovercardContent}>
-        <Link
+        <StyledLink
           to={{
             pathname,
             query: {
@@ -198,7 +198,7 @@ export function SelectorLink({
           }}
         >
           <TextOverflow>{value}</TextOverflow>
-        </Link>
+        </StyledLink>
       </WiderHovercard>
     </StyledTextOverflow>
   );
@@ -222,6 +222,10 @@ const ClickCount = styled(TextOverflow)`
   gap: ${space(0.75)};
   align-items: center;
   justify-content: start;
+`;
+
+const StyledLink = styled(Link)`
+  min-width: 0;
 `;
 
 const StyledTextOverflow = styled(TextOverflow)`

--- a/static/app/views/replays/list/listContent.spec.tsx
+++ b/static/app/views/replays/list/listContent.spec.tsx
@@ -21,6 +21,7 @@ const mockUseDeadRageSelectors = jest.mocked(useDeadRageSelectors);
 mockUseDeadRageSelectors.mockReturnValue({
   isLoading: false,
   isError: false,
+  error: null,
   data: [],
   pageLinks: undefined,
 });

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -210,6 +210,7 @@ export interface DeadRageSelectorQueryParams {
   cursor?: string | string[] | undefined | null;
   per_page?: number;
   prefix?: string;
+  query?: string;
   sort?:
     | 'count_dead_clicks'
     | '-count_dead_clicks'


### PR DESCRIPTION
Add the dead click widget to the nextjs insights page.
If there is no data it falls back to rendering the `SlowSSRWidget`.

<img width="367" alt="Screenshot 2025-05-06 at 08 06 37" src="https://github.com/user-attachments/assets/250b1b1b-3fa6-4eb3-b383-628910e829f7" />

