### PR TITLE
feat(primary-nav): Wrap components with error boundary

### DIFF
--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -152,14 +152,22 @@ export function PrimaryNavigationItems() {
       <SidebarFooter>
         <ChonkOptInBanner collapsed="never" />
         <PrimaryNavigationHelp />
-        <PrimaryNavigationWhatsNew />
-        <Hook
-          name="sidebar:try-business"
-          organization={organization}
-          orientation="left"
-        />
-        <Hook name="sidebar:billing-status" organization={organization} />
-        <PrimaryNavigationServiceIncidents />
+        <ErrorBoundary customComponent={null}>
+          <PrimaryNavigationWhatsNew />
+        </ErrorBoundary>
+        <ErrorBoundary customComponent={null}>
+          <Hook
+            name="sidebar:try-business"
+            organization={organization}
+            orientation="left"
+          />
+        </ErrorBoundary>
+        <ErrorBoundary customComponent={null}>
+          <Hook name="sidebar:billing-status" organization={organization} />
+        </ErrorBoundary>
+        <ErrorBoundary customComponent={null}>
+          <PrimaryNavigationServiceIncidents />
+        </ErrorBoundary>
         <ErrorBoundary customComponent={null}>
           <PrimaryNavigationOnboarding />
         </ErrorBoundary>


### PR DESCRIPTION
Wrap sidebar components that fetch data / contain a bunch of logic with ErrorBoundary.

### Background
We recently had an incident in during which a wrong return type from our API crashed the onboarding quickstart nav item, taking the whole app down with it. To prevent such outages, we wrap similar nav items (which fetch data or contain more complicated logic) with ErrorBoundary. That way only the affected item will not render and the rest of the app stays functional.

- closes [TET-364: \[INC-1121\] Add error boundaries to sidebar components](https://linear.app/getsentry/issue/TET-364/inc-1121-add-error-boundaries-to-sidebar-components)