### PR TITLE
feat(nextjs-insights): add web vitals pill to pages table

### DIFF
--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -23,6 +23,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
+import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -33,7 +34,8 @@ type SortableField =
   | 'count()'
   | 'failure_rate()'
   | 'sum(span.duration)'
-  | 'avg(span.duration)';
+  | 'avg(span.duration)'
+  | 'performance_score(measurements.score.total)';
 
 interface TableData {
   avgDuration: number;
@@ -43,6 +45,7 @@ interface TableData {
   projectID: number;
   spanOp: string;
   totalTime: number;
+  'performance_score(measurements.score.total)'?: number;
 }
 
 const errorRateColorThreshold = {
@@ -63,6 +66,11 @@ const getOrderBy = (field: string, order: 'asc' | 'desc') => {
 
 const defaultColumnOrder: Array<GridColumnOrder<SortableField>> = [
   {key: 'transaction', name: t('Page'), width: COL_WIDTH_UNDEFINED},
+  {
+    key: 'performance_score(measurements.score.total)',
+    name: t('Perf Score'),
+    width: COL_WIDTH_UNDEFINED,
+  },
   {key: 'count()', name: t('Page Views'), width: 122},
   {key: 'failure_rate()', name: t('Error Rate'), width: 122},
   {key: 'sum(span.duration)', name: t('Total'), width: 110},
@@ -145,6 +153,7 @@ export function PagesTable({
         'count()',
         'sum(span.duration)',
         'avg(span.duration)',
+        'performance_score(measurements.score.total)',
         'project.id',
       ],
       limit: 10,
@@ -171,6 +180,8 @@ export function PagesTable({
       avgDuration: span['avg(span.duration)'],
       spanOp: span['span.op'],
       projectID: span['project.id'],
+      'performance_score(measurements.score.total)':
+        span['performance_score(measurements.score.total)'],
     }));
   }, [spansRequest.data]);
 
@@ -183,6 +194,18 @@ export function PagesTable({
 
   const renderBodyCell = useCallback(
     (column: GridColumnHeader<SortableField>, dataRow: TableData) => {
+      if (column.key === 'performance_score(measurements.score.total)') {
+        const score = dataRow['performance_score(measurements.score.total)'];
+        if (typeof score !== 'number') {
+          return <AlignRight>{' — '}</AlignRight>;
+        }
+        return (
+          <AlignCenter>
+            <PerformanceBadge score={Math.round(score * 100)} />
+          </AlignCenter>
+        );
+      }
+
       return (
         <BodyCell
           column={column}
@@ -341,4 +364,12 @@ const ColoredValue = styled('span')<{
 `;
 const CellExpander = styled('div')`
   width: 100vw;
+`;
+
+const AlignRight = styled('div')`
+  text-align: right;
+`;
+
+const AlignCenter = styled('div')`
+  text-align: center;
 `;


### PR DESCRIPTION
- Add the web vitals "pill" to the pageloads table
- On the navigations view, display a dash instead

|Before|After|
|------|------|
|![Screenshot 2025-05-06 at 09 21 57](https://github.com/user-attachments/assets/5c37da08-3be5-4e6f-b0f4-6854b79713f5)|![Screenshot 2025-05-06 at 09 20 27](https://github.com/user-attachments/assets/bbc1ad4a-0cdb-4401-8420-78968676f270)|
|![Screenshot 2025-05-06 at 09 21 52](https://github.com/user-attachments/assets/cebcbc9e-bcf2-4162-b337-d437ca42c03b)|![Screenshot 2025-05-06 at 09 20 35](https://github.com/user-attachments/assets/166459a7-3697-4a87-8713-6a7c8f8d515a)|

