### PR TITLE
update user context to mark 'data' keys

### DIFF
--- a/static/app/components/events/contexts/knownContext/user.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/user.spec.tsx
@@ -54,13 +54,13 @@ describe('UserContext', function () {
       },
       {
         key: 'extra_data',
-        subject: 'extra_data',
+        subject: 'data.extra_data',
         value: 'something',
         meta: undefined,
       },
       {
         key: 'unknown_key',
-        subject: 'unknown_key',
+        subject: 'data.unknown_key',
         value: 123,
         meta: undefined,
       },

--- a/static/app/components/events/contexts/knownContext/user.tsx
+++ b/static/app/components/events/contexts/knownContext/user.tsx
@@ -114,7 +114,7 @@ export function getUserContextData({
           default:
             return {
               key: ctxKey,
-              subject: ctxKey,
+              subject: `data.${ctxKey}`,
               value: data[ctxKey],
               meta: meta?.[ctxKey]?.[''],
             };


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-native/issues/1225

For User Context, SDKs are [expected](https://develop.sentry.dev/sdk/data-model/event-payloads/user/) to send the default fields in lowercase (e.g. `username`, `email`, `ip_address`, ...) which get rendered nicely (`Username`, `Email`, `IP Address`, ...) in the Sentry UI. But, when they send us a key like`Email` this will look the same in the UI (but will not be treated the same). Hence I propose this fix which marks keys from the user context's `data` section as `data.X`.

(this is just a suggestion; maybe there is a cleaner way to mark these items as "data" that has less visual clutter, so I'm open to feedback 😄 )

```json
"user": {
    "id": "42",
    "email": "john.doe@email.com",
    "ip_address": "127.0.0.1",
    "username": "John Doe",
    "sentry_user": "id:42",
    "data": {
        "Email": "jane.doe@email.com",
        "Username": "Jane Doe"
    }
}
```
currently rendered as 

![image](https://github.com/user-attachments/assets/caef6671-e604-44fd-ad53-a1796f0f3a4b)

newly rendered as 
![image](https://github.com/user-attachments/assets/48226087-b77f-4bcb-969c-331942198759)
