### PR TITLE
fix(ui): chonk colors of what's new badge and center numbers

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -545,13 +545,19 @@ const TruncatedLabel = styled(TextOverflow)<{hasNewNav?: boolean}>`
     `}
 `;
 
-const getCollapsedBadgeStyle = ({collapsed, theme}: any) => {
+const getCollapsedBadgeStyle = ({
+  collapsed,
+  theme,
+}: {
+  collapsed: boolean | undefined;
+  theme: Theme;
+}) => {
   if (!collapsed) {
     return '';
   }
 
   return css`
-    background: ${theme.red300};
+    background: ${isChonkTheme(theme) ? theme.colors.chonk.red400 : theme.red300};
     text-indent: -99999em;
     position: absolute;
     right: 0;
@@ -560,12 +566,11 @@ const getCollapsedBadgeStyle = ({collapsed, theme}: any) => {
     height: 11px;
     border-radius: 11px;
     line-height: 11px;
-    box-shadow: ${theme.isChonk ? 'none' : '0 3px 3px #2f2936'};
+    box-shadow: ${isChonkTheme(theme) ? 'none' : '0 3px 3px #2f2936'};
   `;
 };
 
-// @ts-expect-error TS(7031): Binding element '_' implicitly has an 'any' type.
-const SidebarItemBadge = styled(({collapsed: _, ...props}) => <span {...props} />)`
+const SidebarItemBadge = styled('span')<{collapsed: boolean | undefined}>`
   color: ${p => p.theme.white};
   background: ${p =>
     isChonkTheme(p.theme) ? p.theme.colors.chonk.red400 : p.theme.red300};
@@ -576,7 +581,7 @@ const SidebarItemBadge = styled(({collapsed: _, ...props}) => <span {...props} /
   height: 22px;
   border-radius: 22px;
   line-height: 22px;
-
+  font-variant-numeric: tabular-nums;
   ${getCollapsedBadgeStyle};
 `;
 


### PR DESCRIPTION
- centered numbers: especially the number `1` looks uncentered within the badge, using `font-variant-numeric: tabular-nums;` to make numbers monospaced fixes it:

| before | after |
|--------|--------|
| ![Screenshot 2025-05-06 at 12 08 01](https://github.com/user-attachments/assets/2544201f-1d6c-44d1-88fb-1bee06b37ca9) | ![Screenshot 2025-05-06 at 12 49 47](https://github.com/user-attachments/assets/7b421892-f1eb-432f-95a3-af6095e6cbec) |

- chonk colors for collapsed badges:

| before | after |
|--------|--------|
| ![Screenshot 2025-05-06 at 12 51 58](https://github.com/user-attachments/assets/f82788ba-a48b-4e89-aa06-459e04611ea1) | ![Screenshot 2025-05-06 at 12 56 21](https://github.com/user-attachments/assets/108754b4-97b1-421f-bdc8-38875a0abdbb) |

