### PR TITLE
fix(ui): chart contrast in chonk

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -429,7 +429,7 @@ export function EventGraph({
     data: flagSeries.type === 'line' ? ['Feature Flags', 'Releases'] : ['Releases'],
     selected: legendSelected,
     zlevel: 10,
-    inactiveColor: theme.gray200,
+    inactiveColor: theme.isChonk ? theme.tokens.content.muted : theme.gray200,
   });
 
   const onLegendSelectChanged = useMemo(

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -30,7 +30,7 @@ function useEventMarklineSeries({
     ? MarkLine({
         animation: false,
         lineStyle: {
-          color: theme.pink200,
+          color: theme.isChonk ? theme.tokens.graphics.promotion : theme.pink200,
           type: 'solid',
         },
         label: {


### PR DESCRIPTION
fixes both the inactive series as well as the event markLine

closes DE-44

| before | after |
|--------|--------|
| ![Screenshot 2025-05-06 at 13 29 53](https://github.com/user-attachments/assets/c20161aa-e892-4156-9dff-17b3b1a0f480) | ![Screenshot 2025-05-06 at 13 32 55](https://github.com/user-attachments/assets/efed6826-b2e4-40d6-b9b8-0954c6694f3f) | 