### PR TITLE
fix(chonk): make last bar visible in charts

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -67,7 +67,7 @@ export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable 
           color: params => {
             const datum = markedSeries.values[params.dataIndex]!;
 
-            return datum.delayed ? colorObject.lighten(0.5).string() : color;
+            return datum.delayed ? colorObject.alpha(0.5).string() : color;
           },
           opacity: 1.0,
         },


### PR DESCRIPTION
- Use alpha to change opacity instead of lighten for the last element of the barchart to indicate data that is still changing

|Mode|Before|After|
|------|------|------|
|Dark Mode - Original|<img width="200" alt="image" src="https://github.com/user-attachments/assets/e2f6c2d7-865b-4bc7-a04d-ecbc7d8ac8c6" />|<img width="221" alt="image" src="https://github.com/user-attachments/assets/a272fb35-7ab3-4215-862f-5a52532c2dc4" />|
|Light Mode - Original|<img width="215" alt="image" src="https://github.com/user-attachments/assets/022e443b-908a-4140-afb5-9c8c9d9c83e8" />|<img width="210" alt="image" src="https://github.com/user-attachments/assets/db98af67-83e0-48b5-938f-d868dd1b364c" />|
|Dark Mode - Chonk|<img width="206" alt="Screenshot 2025-05-06 at 13 43 54" src="https://github.com/user-attachments/assets/7f251374-686f-4083-8436-bc9ff729f55b" />|<img width="202" alt="image" src="https://github.com/user-attachments/assets/d5a8e2c7-54c3-470b-bda7-a59df880707b" />|
|Light Mode - Chonk|<img width="201" alt="Screenshot 2025-05-06 at 13 43 48" src="https://github.com/user-attachments/assets/e6bfab38-2786-496b-8e79-3cc9069cadde" />|<img width="206" alt="image" src="https://github.com/user-attachments/assets/673afb2b-1560-44b3-8ee7-a655a9eafae7" />|