### PR TITLE
fix(taskworker): Make the profiling task compatible with taskworker

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from base64 import b64decode, b64encode
 from copy import deepcopy
 from datetime import datetime, timezone
 from operator import itemgetter
@@ -80,6 +81,14 @@ profile_chunks_producer = SingletonProducer(
 )
 
 
+def decode_payload(encoded: str) -> dict[str, Any]:
+    return msgpack.unpackb(b64decode(encoded.encode("utf-8")), use_list=False)
+
+
+def encode_payload(message: dict[str, Any]) -> str:
+    return b64encode(msgpack.packb(message)).decode("utf-8")
+
+
 @instrumented_task(
     name="sentry.profiles.task.process_profile",
     retry_backoff=True,
@@ -99,7 +108,7 @@ profile_chunks_producer = SingletonProducer(
 )
 def process_profile_task(
     profile: Profile | None = None,
-    payload: Any = None,
+    payload: str | bytes | None = None,
     sampled: bool = True,
     **kwargs: Any,
 ) -> None:
@@ -107,7 +116,11 @@ def process_profile_task(
         return
 
     if payload:
-        message_dict = msgpack.unpackb(payload, use_list=False)
+        if isinstance(payload, str):  # It's been b64encoded for taskworker
+            message_dict = decode_payload(payload)
+        else:
+            message_dict = msgpack.unpackb(payload, use_list=False)
+
         profile = json.loads(message_dict["payload"], use_rapid_json=True)
 
         assert profile is not None

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -10,7 +10,7 @@ from arroyo.types import BrokerValue, Message, Partition, Topic
 from django.utils import timezone
 
 from sentry.profiles.consumers.process.factory import ProcessProfileStrategyFactory
-from sentry.profiles.task import _prepare_frames_from_profile, encode_payload
+from sentry.profiles.task import _prepare_frames_from_profile
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
 
@@ -33,40 +33,6 @@ class TestProcessProfileConsumerStrategy(TestCase):
             "payload": json.dumps({"platform": "android", "profile": ""}),
         }
         payload = msgpack.packb(message_dict)
-
-        processing_strategy.submit(
-            Message(
-                BrokerValue(
-                    KafkaPayload(
-                        b"key",
-                        payload,
-                        [],
-                    ),
-                    Partition(Topic("profiles"), 1),
-                    1,
-                    datetime.now(),
-                )
-            )
-        )
-        processing_strategy.poll()
-        processing_strategy.join(1)
-        processing_strategy.terminate()
-
-        process_profile_task.assert_called_with(payload=payload, sampled=True)
-
-    @patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
-    def test_encoded_profile_to_celery(self, process_profile_task):
-        processing_strategy = self.processing_factory().create_with_partitions(
-            commit=Mock(), partitions=None
-        )
-        message_dict = {
-            "organization_id": 1,
-            "project_id": 1,
-            "key_id": 1,
-            "received": int(timezone.now().timestamp()),
-            "payload": json.dumps({"platform": "android", "profile": ""}),
-        }
-        payload = encode_payload(message_dict)
 
         processing_strategy.submit(
             Message(

--- a/tests/sentry/profiles/consumers/test_process.py
+++ b/tests/sentry/profiles/consumers/test_process.py
@@ -10,7 +10,7 @@ from arroyo.types import BrokerValue, Message, Partition, Topic
 from django.utils import timezone
 
 from sentry.profiles.consumers.process.factory import ProcessProfileStrategyFactory
-from sentry.profiles.task import _prepare_frames_from_profile
+from sentry.profiles.task import _prepare_frames_from_profile, encode_payload
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
 
@@ -33,6 +33,40 @@ class TestProcessProfileConsumerStrategy(TestCase):
             "payload": json.dumps({"platform": "android", "profile": ""}),
         }
         payload = msgpack.packb(message_dict)
+
+        processing_strategy.submit(
+            Message(
+                BrokerValue(
+                    KafkaPayload(
+                        b"key",
+                        payload,
+                        [],
+                    ),
+                    Partition(Topic("profiles"), 1),
+                    1,
+                    datetime.now(),
+                )
+            )
+        )
+        processing_strategy.poll()
+        processing_strategy.join(1)
+        processing_strategy.terminate()
+
+        process_profile_task.assert_called_with(payload=payload, sampled=True)
+
+    @patch("sentry.profiles.consumers.process.factory.process_profile_task.delay")
+    def test_encoded_profile_to_celery(self, process_profile_task):
+        processing_strategy = self.processing_factory().create_with_partitions(
+            commit=Mock(), partitions=None
+        )
+        message_dict = {
+            "organization_id": 1,
+            "project_id": 1,
+            "key_id": 1,
+            "received": int(timezone.now().timestamp()),
+            "payload": json.dumps({"platform": "android", "profile": ""}),
+        }
+        payload = encode_payload(message_dict)
 
         processing_strategy.submit(
             Message(

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -1065,6 +1065,7 @@ def test_track_latest_sdk_with_payload(
         "received": "2024-01-02T03:04:05",
         "payload": json.dumps(profile),
     }
+    payload: str | bytes
     if should_encode:
         payload = encode_payload(kafka_payload)
     else:


### PR DESCRIPTION
The taskworker can't send through Python bytes in task args, since they are not strictly JSON
encodable. Change the task processor to be compatible with the strings that the taskworker will send
through, while remaining backwards compatible with the way celery encodes args.