### PR TITLE
feat(insights): migrate screen rendering table to eap

### DIFF
--- a/static/app/views/insights/mobile/common/components/tables/screensTable.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/screensTable.tsx
@@ -13,8 +13,9 @@ import SortLink from 'sentry/components/gridEditable/sortLink';
 import Pagination from 'sentry/components/pagination';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
+import type {MetaType} from 'sentry/utils/discover/eventView';
 import {isFieldSortable} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
@@ -22,6 +23,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {PercentChangeCell} from 'sentry/views/insights/common/components/tableCells/percentChangeCell';
 import type {ModuleName} from 'sentry/views/insights/types';
+
+export type TableData = {
+  data: Array<Record<string, string | number>>;
+  meta?: MetaType;
+};
 
 type Props = {
   columnNameMap: Record<string, string>;

--- a/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
+++ b/static/app/views/insights/mobile/ui/components/tables/spanOperationTable.tsx
@@ -18,13 +18,13 @@ import {
   SECONDARY_RELEASE_ALIAS,
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
+import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/insights/common/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {APP_START_SPANS} from 'sentry/views/insights/mobile/appStarts/components/spanOpSelector';
 import type {SpanOperationTableProps} from 'sentry/views/insights/mobile/common/components/tables/samplesTables';
 import {ScreensTable} from 'sentry/views/insights/mobile/common/components/tables/screensTable';
-import {useTableQuery} from 'sentry/views/insights/mobile/screenload/components/tables/screensTable';
 import {MobileCursors} from 'sentry/views/insights/mobile/screenload/constants';
 import {SUMMARY_PAGE_BASE_URL} from 'sentry/views/insights/mobile/screenRendering/settings';
 import {Referrer} from 'sentry/views/insights/mobile/ui/referrers';
@@ -104,12 +104,27 @@ export function SpanOperationTable({
 
   const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
 
-  const {data, isPending, pageLinks} = useTableQuery({
-    eventView,
-    enabled: true,
-    referrer: Referrer.SPAN_OPERATION_TABLE,
-    cursor,
-  });
+  const {data, meta, isPending, pageLinks} = useSpanMetrics(
+    {
+      cursor,
+      search: queryStringPrimary,
+      orderby,
+      fields: [
+        PROJECT_ID,
+        SPAN_OP,
+        SPAN_GROUP,
+        SPAN_DESCRIPTION,
+        `division_if(mobile.slow_frames,mobile.total_frames,release,${primaryRelease})`,
+        `division_if(mobile.slow_frames,mobile.total_frames,release,${secondaryRelease})`,
+        `division_if(mobile.frozen_frames,mobile.total_frames,release,${primaryRelease})`,
+        `division_if(mobile.frozen_frames,mobile.total_frames,release,${secondaryRelease})`,
+        `avg_if(mobile.frames_delay,release,${primaryRelease})`,
+        `avg_if(mobile.frames_delay,release,${secondaryRelease})`,
+        `avg_compare(mobile.frames_delay,release,${primaryRelease},${secondaryRelease})`,
+      ],
+    },
+    Referrer.SPAN_OPERATION_TABLE
+  );
 
   const columnNameMap = {
     [SPAN_OP]: t('Operation'),
@@ -202,7 +217,7 @@ export function SpanOperationTable({
     <ScreensTable
       columnNameMap={columnNameMap}
       columnTooltipMap={columnTooltipMap}
-      data={data}
+      data={{data, meta}}
       eventView={eventView}
       isLoading={isPending}
       pageLinks={pageLinks}

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -190,6 +190,7 @@ type CounterConditionalAggregate =
 
 type ConditionalAggregate =
   | `avg_if`
+  | `division_if`
   | `count_op`
   | `failure_rate_if`
   | 'trace_status_rate'
@@ -288,7 +289,8 @@ export type EAPSpanResponse = {
     [Property in ConditionalAggregate as
       | `${Property}(${string})`
       | `${Property}(${string},${string})`
-      | `${Property}(${string},${string},${string})`]: number;
+      | `${Property}(${string},${string},${string})`
+      | `${Property}(${string},${string},${string},${string})`]: number;
   } & {
     [SpanMetricsField.USER_GEO_SUBREGION]: SubregionCode;
   } & {


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/90908

One key difference, we had to keep eventview around here as it's required for the table.