### PR TITLE
feat(symbolication): get gcp token instead of credentials

### DIFF
--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -149,7 +149,7 @@ class SourceSerializer(serializers.Serializer):
     )
     private_key = serializers.CharField(
         required=False,
-        help_text="The GCS private key. Required for GCS sources, invalid for all others.",
+        help_text="The GCS private key. Required for GCS sources if not using impersonated tokens. Invalid for all others.",
     )
 
     def validate(self, data):
@@ -160,8 +160,8 @@ class SourceSerializer(serializers.Serializer):
             required = ["type", "name", "bucket", "region", "access_key", "secret_key", "layout"]
             allowed = required + ["prefix"]
         else:
-            required = ["type", "name", "bucket", "client_email", "private_key", "layout"]
-            allowed = required + ["prefix"]
+            required = ["type", "name", "bucket", "client_email", "layout"]
+            allowed = required + ["prefix", "private_key"]
 
         missing = [field for field in required if field not in data]
         invalid = [field for field in data if field not in allowed]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -422,6 +422,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:user-feedback-event-link-ingestion-changes", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable view hierarchies options
     manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables GCP token fetching instead of providing credentials
+    manager.add("organizations:gcp-bearer-token-authentication", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=False)
     # Enable admin features on the new explore page
     manager.add("organizations:visibility-explore-admin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable equations feature on the new explore page

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -423,7 +423,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable view hierarchies options
     manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables GCP token fetching instead of providing credentials
-    manager.add("organizations:gcp-bearer-token-authentication", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=False)
+    manager.add("organizations:gcp-bearer-token-authentication", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=False)
     # Enable admin features on the new explore page
     manager.add("organizations:visibility-explore-admin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable equations feature on the new explore page

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -259,7 +259,7 @@ LAST_UPLOAD_TTL = 24 * 3600
 TOKEN_TTL_SECONDS = 3600
 # Set the TTL a little shorter than the actual token expiration to acomodate a bit of delay
 # while obtaining the token and storing it
-token_cache: TTLCache[str, str | None] = TTLCache(maxsize=128, ttl=TOKEN_TTL_SECONDS - 100)
+token_cache: TTLCache[Any, Any] = TTLCache(maxsize=128, ttl=TOKEN_TTL_SECONDS - 100)
 
 
 def _get_cluster() -> RedisCluster:
@@ -588,7 +588,7 @@ def get_sources_for_project(project):
 
         if features.has("organizations:gcp-bearer-token-authentication", organization):
             if source.get("type") == "gcs":
-                client_email: str = source.get("client_email")
+                client_email = source.get("client_email")
                 token = get_gcp_token(client_email)
                 # if target_credentials.token is None it means that the
                 # token could not be fetched successfully
@@ -612,7 +612,7 @@ def get_sources_for_project(project):
     return sources
 
 
-def get_gcp_token(client_email: str) -> str | None:
+def get_gcp_token(client_email):
     """
     Returns a cached GCP token or fetches it if not is cached.
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -259,7 +259,7 @@ LAST_UPLOAD_TTL = 24 * 3600
 TOKEN_TTL_SECONDS = 3600
 # Set the TTL a little shorter than the actual token expiration to acomodate a bit of delay
 # while obtaining the token and storing it
-token_cache = TTLCache(ttl=TOKEN_TTL_SECONDS - 100)
+token_cache = TTLCache(maxsize=128, ttl=TOKEN_TTL_SECONDS - 100)
 
 
 def _get_cluster() -> RedisCluster:

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -613,7 +613,7 @@ def get_sources_for_project(project):
 
 def get_gcp_token(client_email: str) -> str | None:
     """
-    Returns a cached GCP token or fetches it if nothing is cached
+    Returns a cached GCP token or fetches it if not is cached.
 
     :param client_email: GCP client email
     """

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -639,6 +639,8 @@ def get_gcp_token(client_email):
         if target_credentials.token is None:
             return None
 
+        token_cache[client_email] = target_credentials.token
+
         return target_credentials.token
 
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -611,7 +611,7 @@ def get_sources_for_project(project):
     return sources
 
 
-def get_gcp_token(client_email: str) -> str | None:
+def get_gcp_token(client_email):
     """
     Returns a cached GCP token or fetches it if not is cached.
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -614,7 +614,7 @@ def get_sources_for_project(project):
 
 def get_gcp_token(client_email):
     """
-    Returns a cached GCP token or fetches it if not is cached.
+    Returns a cached GCP token or fetches it if not cached.
 
     :param client_email: GCP client email
     """

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -259,7 +259,7 @@ LAST_UPLOAD_TTL = 24 * 3600
 TOKEN_TTL_SECONDS = 3600
 # Set the TTL a little shorter than the actual token expiration to acomodate a bit of delay
 # while obtaining the token and storing it
-token_cache = TTLCache(maxsize=128, ttl=TOKEN_TTL_SECONDS - 100)
+token_cache: TTLCache[str, str | None] = TTLCache(maxsize=128, ttl=TOKEN_TTL_SECONDS - 100)
 
 
 def _get_cluster() -> RedisCluster:
@@ -588,7 +588,8 @@ def get_sources_for_project(project):
 
         if features.has("organizations:gcp-bearer-token-authentication", organization):
             if source.get("type") == "gcs":
-                token = get_gcp_token(source.get("client_email"))
+                client_email: str = source.get("client_email")
+                token = get_gcp_token(client_email)
                 # if target_credentials.token is None it means that the
                 # token could not be fetched successfully
                 if token is not None:
@@ -611,7 +612,7 @@ def get_sources_for_project(project):
     return sources
 
 
-def get_gcp_token(client_email):
+def get_gcp_token(client_email: str) -> str | None:
     """
     Returns a cached GCP token or fetches it if not is cached.
 


### PR DESCRIPTION
This PR adds the GCP token fetching for symbolication to pass it down to symbolicator instead of using credentials.