### PR TITLE
fix(insights): frontend overview eap span condition incorrect

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -111,7 +111,7 @@ function EAPOverviewPage() {
   const existingQuery = new MutableSearch(eventView.query);
   // TODO - this query is getting complicated, once were on EAP, we should consider moving this to the backend
   existingQuery.addOp('(');
-  existingQuery.addFilterValues('span.op', EAP_OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addDisjunctionFilterValues('span.op', EAP_OVERVIEW_PAGE_ALLOWED_OPS);
   // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
   if (selectedFrontendProjects.length > 0) {
     existingQuery.addOp('OR');


### PR DESCRIPTION
We should be using `addDisjunctionFilterValues` (i.e an OR filter) instead of `addfFilterValues` for allowed span ops in frontend page.

this broke in https://github.com/getsentry/sentry/pull/90736/files