### PR TITLE
chore(autofix): Update ack error message

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_update.py
+++ b/src/sentry/api/endpoints/group_autofix_update.py
@@ -46,7 +46,9 @@ class GroupAutofixUpdateEndpoint(GroupAiEndpoint):
         if not get_seer_org_acknowledgement(org_id=group.organization.id):
             return Response(
                 status=403,
-                data={"error": "AI Autofix has not been acknowledged by the organization."},
+                data={
+                    "error": "Seer has not been enabled for this organization. Please open an issue at sentry.io/issues and set up Seer."
+                },
             )
 
         path = "/v1/automation/autofix/update"

--- a/src/sentry/seer/autofix.py
+++ b/src/sentry/seer/autofix.py
@@ -742,7 +742,10 @@ def trigger_autofix(
         return _respond_with_error("AI Autofix is not enabled for this project.", 403)
 
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
-        return _respond_with_error("AI Autofix has not been acknowledged by the organization.", 403)
+        return _respond_with_error(
+            "Seer has not been enabled for this organization. Please open an issue at sentry.io/issues and set up Seer.",
+            403,
+        )
 
     if event_id is None:
         event: Event | GroupEvent | None = group.get_recommended_event_for_environments()

--- a/tests/sentry/api/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/api/endpoints/test_group_autofix_update.py
@@ -107,7 +107,10 @@ class TestGroupAutofixUpdate(APITestCase):
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.data["error"] == "AI Autofix has not been acknowledged by the organization."
+        assert (
+            response.data["error"]
+            == "Seer has not been enabled for this organization. Please open an issue at sentry.io/issues and set up Seer."
+        )
 
     @patch(
         "sentry.api.endpoints.group_autofix_update.get_seer_org_acknowledgement", return_value=True

--- a/tests/sentry/seer/test_autofix.py
+++ b/tests/sentry/seer/test_autofix.py
@@ -1300,7 +1300,8 @@ class TestTriggerAutofixWithoutOrgAcknowledgement(APITestCase, SnubaTestCase):
 
         assert response.status_code == 403
         assert (
-            "AI Autofix has not been acknowledged by the organization." in response.data["detail"]
+            "Seer has not been enabled for this organization. Please open an issue at sentry.io/issues and set up Seer."
+            in response.data["detail"]
         )
         # Verify _get_serialized_event was not called since we have no event
         mock_get_serialized_event.assert_not_called()


### PR DESCRIPTION
Makes error message more human readable when Seer has not been acknowledged by the org.