### PR TITLE
fix(aci): remove order by id from RuleActivity query in issue alert migration

### DIFF
--- a/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
@@ -2234,7 +2234,7 @@ def migrate_remaining_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchema
             )
             sentry_sdk.capture_exception(e)
 
-    backfill_key = "backfill_workflow_engine_remaining_issue_alerts_take_2"
+    backfill_key = "backfill_workflow_engine_remaining_issue_alerts_take_3"
     redis_client = redis.redis_clusters.get(settings.SENTRY_MONITORS_REDIS_CLUSTER)
     progress_id = int(redis_client.get(backfill_key) or 0)
 

--- a/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
@@ -2204,7 +2204,9 @@ def migrate_remaining_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchema
 
                 data = rule.data
                 user_id = None
-                created_activity = RuleActivity.objects.filter(rule=rule, type=1).first()  # created
+                created_activity = list(RuleActivity.objects.filter(rule=rule, type=1))[
+                    0
+                ]  # created
                 if created_activity:
                     user_id = getattr(created_activity, "user_id")
 

--- a/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
+++ b/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py
@@ -2204,11 +2204,9 @@ def migrate_remaining_issue_alerts(apps: Apps, schema_editor: BaseDatabaseSchema
 
                 data = rule.data
                 user_id = None
-                created_activity = list(RuleActivity.objects.filter(rule=rule, type=1))[
-                    0
-                ]  # created
+                created_activity = list(RuleActivity.objects.filter(rule=rule, type=1))  # created
                 if created_activity:
-                    user_id = getattr(created_activity, "user_id")
+                    user_id = getattr(created_activity[0], "user_id")
 
                 conditions, filters = split_conditions_and_filters(data["conditions"])
                 action_match = data.get("action_match") or "all"


### PR DESCRIPTION
We have 1 issue alert that keeps timing out in the issue alert migration when attempting to fetch the `RuleActivity` for when it was created and by whom.

This query takes forever
```
SELECT "sentry_ruleactivity"."id", "sentry_ruleactivity"."type", "sentry_ruleactivity"."date_added", "sentry_ruleactivity"."rule_id", "sentry_ruleactivity"."user_id" FROM "sentry_ruleactivity" WHERE ("sentry_ruleactivity"."rule_id" = %s AND "sentry_ruleactivity"."type" = %s) ORDER BY "sentry_ruleactivity"."id" ASC LIMIT 1
```

This is the line
https://github.com/getsentry/sentry/blob/10d4aae8a300a4b1933cdd8037670ab72bea17fa/src/sentry/workflow_engine/migrations/0051_migrate_remaining_issue_alerts.py#L2207

If we remove the `.first()` and replace with `list()[0]` it should pull everything into Python, then grab the first item without ORDER BY. There is 1 `RuleActivity` with type=1 (created) in the db.

Fixes SENTRY-3TE1