### PR TITLE
feat(alerts-comparison): Translate a few more columns

### DIFF
--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -414,6 +414,8 @@ def compare_timeseries_for_alert_rule(alert_rule: AlertRule):
     aligned_timeseries = align_timeseries(snql_result=snql_result, rpc_result=rpc_result)
     is_close, mismatches, all_zeros = assert_timeseries_close(aligned_timeseries, alert_rule)
 
+    sentry_sdk.set_tag("aggregate", snuba_query.aggregate)
+
     if all_zeros:
         with sentry_sdk.isolation_scope() as scope:
             scope.set_tag("mismatch_type", MismatchType.INSUFFICIENT_DATA.value)

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -26,15 +26,16 @@ def column_switcheroo(term):
     if parsed_mri:
         term = parsed_mri.name
 
-    swapped_term = term
-    if term == "transaction.duration":
-        swapped_term = "span.duration"
+    column_swap_map = {
+        "transaction.duration": "span.duration",
+        "http.method": "transaction.method",
+        "title": "transaction",
+        "url": "request.url",
+        "http.url": "request.url",
+        "transaction.status": "trace.status",
+    }
 
-    if term == "http.method":
-        swapped_term = "transaction.method"
-
-    if term == "title":
-        swapped_term = "transaction"
+    swapped_term = column_swap_map.get(term, term)
 
     return swapped_term, swapped_term != term
 


### PR DESCRIPTION
In the last run I noticed we were missing mappings for `url`, `http.url` and `transaction.status`