### PR TITLE
feat(ui): Do not reset Organization store on 429 request errors

### DIFF
--- a/static/app/bootstrap/bootstrapRequestOptions.tsx
+++ b/static/app/bootstrap/bootstrapRequestOptions.tsx
@@ -1,0 +1,155 @@
+import {type ApiResult, Client} from 'sentry/api';
+import type {Organization, Team} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {queryOptions, skipToken} from 'sentry/utils/queryClient';
+
+// 30 second stale time
+// Stale time decides if the query should be refetched
+const BOOTSTRAP_QUERY_STALE_TIME = 30 * 1000;
+
+// 10 minute gc time
+// Warning: We will always have an observer on the organization object
+// so it will never be garbage collected from the query cache
+const BOOTSTRAP_QUERY_GC_TIME = 10 * 60 * 1000;
+
+export function getBootstrapOrganizationQueryOptions(orgSlug: string | null) {
+  return queryOptions({
+    queryKey: ['bootstrap-organization', orgSlug],
+    queryFn: orgSlug
+      ? async (): Promise<Organization> => {
+          // Get the preloaded data promise
+          try {
+            const preloadResponse = await getPreloadedData('organization', orgSlug);
+            // If the preload request was for a different org or the promise was rejected
+            if (Array.isArray(preloadResponse) && preloadResponse[0] !== null) {
+              return preloadResponse[0];
+            }
+          } catch {
+            // Silently try again with non-preloaded data
+          }
+
+          const uncancelableApi = new Client();
+          const [org] = await uncancelableApi.requestPromise(
+            `/organizations/${orgSlug}/`,
+            {
+              includeAllArgs: true,
+              query: {detailed: 0, include_feature_flags: 1},
+            }
+          );
+          return org;
+        }
+      : skipToken,
+    staleTime: BOOTSTRAP_QUERY_STALE_TIME,
+    gcTime: BOOTSTRAP_QUERY_GC_TIME,
+    retry: false,
+  });
+}
+
+/**
+ * The TeamsStore expects a cursor, hasMore, and teams
+ * Since some of this information exists in headers, parse it into something we can serialize
+ */
+function createTeamsObject(response: ApiResult): {
+  cursor: string | null;
+  hasMore: boolean;
+  teams: Team[];
+} {
+  const teams = response[0];
+  const paginationObject = parseLinkHeader(response[2]!.getResponseHeader('Link'));
+  const hasMore = paginationObject?.next?.results ?? false;
+  const cursor = paginationObject.next?.cursor ?? null;
+  return {teams, hasMore, cursor};
+}
+
+export function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
+  return queryOptions({
+    queryKey: ['bootstrap-teams', orgSlug],
+    queryFn: orgSlug
+      ? async (): Promise<{
+          cursor: string | null;
+          hasMore: boolean;
+          teams: Team[];
+        }> => {
+          // Get the preloaded data promise
+          try {
+            const preloadResponse = await getPreloadedData('teams', orgSlug);
+            // If the preload request was successful, find the matching team
+            if (preloadResponse !== null && preloadResponse[0] !== null) {
+              return createTeamsObject(preloadResponse);
+            }
+          } catch {
+            // Silently try again with non-preloaded data
+          }
+
+          const uncancelableApi = new Client();
+          const teamsApiResponse = await uncancelableApi.requestPromise(
+            `/organizations/${orgSlug}/teams/`,
+            {
+              includeAllArgs: true,
+            }
+          );
+          return createTeamsObject(teamsApiResponse);
+        }
+      : skipToken,
+    staleTime: BOOTSTRAP_QUERY_STALE_TIME,
+    gcTime: BOOTSTRAP_QUERY_GC_TIME,
+    retry: false,
+  });
+}
+
+export function getBootstrapProjectsQueryOptions(orgSlug: string | null) {
+  return queryOptions({
+    queryKey: ['bootstrap-projects', orgSlug],
+    queryFn: orgSlug
+      ? async (): Promise<Project[]> => {
+          // Get the preloaded data promise
+          try {
+            const preloadResponse = await getPreloadedData('projects', orgSlug);
+            // If the preload request was successful
+            if (preloadResponse !== null && preloadResponse[0] !== null) {
+              return preloadResponse[0];
+            }
+          } catch {
+            // Silently try again with non-preloaded data
+          }
+
+          const uncancelableApi = new Client();
+          const [projects] = await uncancelableApi.requestPromise(
+            `/organizations/${orgSlug}/projects/`,
+            {
+              includeAllArgs: true,
+              query: {
+                all_projects: 1,
+                collapse: ['latestDeploys', 'unusedFeatures'],
+              },
+            }
+          );
+          return projects;
+        }
+      : skipToken,
+    staleTime: BOOTSTRAP_QUERY_STALE_TIME,
+    gcTime: BOOTSTRAP_QUERY_GC_TIME,
+    retry: false,
+  });
+}
+
+/**
+ * Small helper to access the preload requests in window.__sentry_preload
+ * See preload-data.html for more details, this request is started before the app is loaded
+ * saving time on the initial page load.
+ */
+function getPreloadedData(
+  name: 'organization' | 'projects' | 'teams',
+  slug: string
+): Promise<ApiResult | null> {
+  const data = window.__sentry_preload;
+  if (!data?.[name] || data.orgSlug?.toLowerCase() !== slug.toLowerCase()) {
+    throw new Error('Prefetch query not found or slug mismatch');
+  }
+
+  const promise = data[name];
+  // Prevent reusing the promise later
+  delete data[name];
+  return promise;
+}

--- a/static/app/bootstrap/bootstrapRequests.tsx
+++ b/static/app/bootstrap/bootstrapRequests.tsx
@@ -2,31 +2,25 @@ import {useLayoutEffect} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {setActiveOrganization} from 'sentry/actionCreators/organizations';
-import {type ApiResult, Client} from 'sentry/api';
+import {
+  getBoostrapTeamsQueryOptions,
+  getBootstrapOrganizationQueryOptions,
+  getBootstrapProjectsQueryOptions,
+} from 'sentry/bootstrap/bootstrapRequestOptions';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import type {Organization, Team} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
 import {
   addOrganizationFeaturesHandler,
   buildSentryFeaturesHandler,
 } from 'sentry/utils/featureFlags';
-import parseLinkHeader from 'sentry/utils/parseLinkHeader';
-import {queryOptions, skipToken, useQuery} from 'sentry/utils/queryClient';
-
-// 30 second stale time
-// Stale time decides if the query should be refetched
-const BOOTSTRAP_QUERY_STALE_TIME = 30 * 1000;
-
-// 10 minute gc time
-// Warning: We will always have an observer on the organization object
-// so it will never be garbage collected from the query cache
-const BOOTSTRAP_QUERY_GC_TIME = 10 * 60 * 1000;
+import {useQuery} from 'sentry/utils/queryClient';
+import RequestError from 'sentry/utils/requestError/requestError';
 
 export function useBootstrapOrganizationQuery(orgSlug: string | null) {
-  const organizationQuery = useQuery(getBootstrapOrganizationQueryOptions(orgSlug));
+  const options = getBootstrapOrganizationQueryOptions(orgSlug);
+  const organizationQuery = useQuery(options);
 
   useLayoutEffect(() => {
     if (organizationQuery.data) {
@@ -52,9 +46,23 @@ export function useBootstrapOrganizationQuery(orgSlug: string | null) {
       });
     }
     if (organizationQuery.error) {
-      OrganizationStore.onFetchOrgError(organizationQuery.error as any);
+      if (
+        organizationQuery.error instanceof RequestError &&
+        // By default, `react-query` will refetch stale queries on window focus.
+        // This can lead to many queries that hit Sentry's API rate limit. In the case
+        // of the organization details endpoint, an error means that the OrganizationStore
+        // will not have an organization, which leads to `useOrganization` throwning because
+        // organization is undefined. This ultimately leads to a "crash" for the user
+        // (e.g. blank page w/ an error message).
+        !(
+          organizationQuery.error.status === 429 &&
+          orgSlug === OrganizationStore.state.organization?.slug
+        )
+      ) {
+        OrganizationStore.onFetchOrgError(organizationQuery.error as any);
+      }
     }
-  }, [organizationQuery.data, organizationQuery.error]);
+  }, [organizationQuery.data, organizationQuery.error, orgSlug]);
 
   return organizationQuery;
 }
@@ -85,145 +93,4 @@ export function useBootstrapProjectsQuery(orgSlug: string | null) {
   }, [projectsQuery.data]);
 
   return projectsQuery;
-}
-
-export function getBootstrapOrganizationQueryOptions(orgSlug: string | null) {
-  return queryOptions({
-    queryKey: ['bootstrap-organization', orgSlug],
-    queryFn: orgSlug
-      ? async (): Promise<Organization> => {
-          // Get the preloaded data promise
-          try {
-            const preloadResponse = await getPreloadedData('organization', orgSlug);
-            // If the preload request was for a different org or the promise was rejected
-            if (Array.isArray(preloadResponse) && preloadResponse[0] !== null) {
-              return preloadResponse[0];
-            }
-          } catch {
-            // Silently try again with non-preloaded data
-          }
-
-          const uncancelableApi = new Client();
-          const [org] = await uncancelableApi.requestPromise(
-            `/organizations/${orgSlug}/`,
-            {
-              includeAllArgs: true,
-              query: {detailed: 0, include_feature_flags: 1},
-            }
-          );
-          return org;
-        }
-      : skipToken,
-    staleTime: BOOTSTRAP_QUERY_STALE_TIME,
-    gcTime: BOOTSTRAP_QUERY_GC_TIME,
-    retry: false,
-  });
-}
-
-/**
- * The TeamsStore expects a cursor, hasMore, and teams
- * Since some of this information exists in headers, parse it into something we can serialize
- */
-function createTeamsObject(response: ApiResult): {
-  cursor: string | null;
-  hasMore: boolean;
-  teams: Team[];
-} {
-  const teams = response[0];
-  const paginationObject = parseLinkHeader(response[2]!.getResponseHeader('Link'));
-  const hasMore = paginationObject?.next?.results ?? false;
-  const cursor = paginationObject.next?.cursor ?? null;
-  return {teams, hasMore, cursor};
-}
-
-export function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
-  return queryOptions({
-    queryKey: ['bootstrap-teams', orgSlug],
-    queryFn: orgSlug
-      ? async (): Promise<{
-          cursor: string | null;
-          hasMore: boolean;
-          teams: Team[];
-        }> => {
-          // Get the preloaded data promise
-          try {
-            const preloadResponse = await getPreloadedData('teams', orgSlug);
-            // If the preload request was successful, find the matching team
-            if (preloadResponse !== null && preloadResponse[0] !== null) {
-              return createTeamsObject(preloadResponse);
-            }
-          } catch {
-            // Silently try again with non-preloaded data
-          }
-
-          const uncancelableApi = new Client();
-          const teamsApiResponse = await uncancelableApi.requestPromise(
-            `/organizations/${orgSlug}/teams/`,
-            {
-              includeAllArgs: true,
-            }
-          );
-          return createTeamsObject(teamsApiResponse);
-        }
-      : skipToken,
-    staleTime: BOOTSTRAP_QUERY_STALE_TIME,
-    gcTime: BOOTSTRAP_QUERY_GC_TIME,
-    retry: false,
-  });
-}
-
-export function getBootstrapProjectsQueryOptions(orgSlug: string | null) {
-  return queryOptions({
-    queryKey: ['bootstrap-projects', orgSlug],
-    queryFn: orgSlug
-      ? async (): Promise<Project[]> => {
-          // Get the preloaded data promise
-          try {
-            const preloadResponse = await getPreloadedData('projects', orgSlug);
-            // If the preload request was successful
-            if (preloadResponse !== null && preloadResponse[0] !== null) {
-              return preloadResponse[0];
-            }
-          } catch {
-            // Silently try again with non-preloaded data
-          }
-
-          const uncancelableApi = new Client();
-          const [projects] = await uncancelableApi.requestPromise(
-            `/organizations/${orgSlug}/projects/`,
-            {
-              includeAllArgs: true,
-              query: {
-                all_projects: 1,
-                collapse: ['latestDeploys', 'unusedFeatures'],
-              },
-            }
-          );
-          return projects;
-        }
-      : skipToken,
-    staleTime: BOOTSTRAP_QUERY_STALE_TIME,
-    gcTime: BOOTSTRAP_QUERY_GC_TIME,
-    retry: false,
-  });
-}
-
-/**
- * Small helper to access the preload requests in window.__sentry_preload
- * See preload-data.html for more details, this request is started before the app is loaded
- * saving time on the initial page load.
- */
-function getPreloadedData(
-  name: 'organization' | 'projects' | 'teams',
-  slug: string
-): Promise<ApiResult | null> {
-  const data = window.__sentry_preload;
-  if (!data?.[name] || data.orgSlug?.toLowerCase() !== slug.toLowerCase()) {
-    throw new Error('Prefetch query not found or slug mismatch');
-  }
-
-  const promise = data[name];
-  // Prevent reusing the promise later
-  delete data[name];
-  return promise;
 }

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -8,7 +8,7 @@ import {
   getBoostrapTeamsQueryOptions,
   getBootstrapOrganizationQueryOptions,
   getBootstrapProjectsQueryOptions,
-} from 'sentry/bootstrap/bootstrapRequests';
+} from 'sentry/bootstrap/bootstrapRequestOptions';
 import {Alert} from 'sentry/components/core/alert';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import SecretField from 'sentry/components/forms/fields/secretField';

--- a/static/app/views/organizationLayout/index.spec.tsx
+++ b/static/app/views/organizationLayout/index.spec.tsx
@@ -1,12 +1,17 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import * as bootstrapRequestOptions from 'sentry/bootstrap/bootstrapRequestOptions';
 import AlertStore from 'sentry/stores/alertStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import OrganizationLayout from 'sentry/views/organizationLayout';
+import {queryOptions} from 'sentry/utils/queryClient';
+import App from 'sentry/views/app';
+
+import OrganizationLayout from './index';
 
 jest.mock(
   'sentry/components/sidebar',
@@ -137,5 +142,96 @@ describe('OrganizationLayout', function () {
     expect(
       await screen.findByText(/Celery workers have not checked in/)
     ).toBeInTheDocument();
+  });
+
+  describe('organizaztion details request errors', () => {
+    const organization = OrganizationFixture();
+    function SimpleChild() {
+      return <div>hello world</div>;
+    }
+
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/',
+        body: [organization],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        body: organization,
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/teams/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/assistant/',
+        body: [],
+      });
+    });
+
+    it('handles 429 errors', async () => {
+      const orgQueryOptions =
+        bootstrapRequestOptions.getBootstrapOrganizationQueryOptions(organization.slug);
+
+      const {router, routerProps} = initializeOrg({
+        organization,
+        router: {
+          params: {orgId: organization.slug},
+        },
+      });
+
+      const {rerender} = render(
+        <App {...routerProps}>
+          <OrganizationLayout>
+            <SimpleChild />
+          </OrganizationLayout>
+        </App>,
+        {router, deprecatedRouterMocks: true}
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Loading data for your organization')
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('hello world')).toBeInTheDocument();
+
+      // mock console.error to prevent it from failing jest tests since we're expecting the request error
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      jest
+        .spyOn(bootstrapRequestOptions, 'getBootstrapOrganizationQueryOptions')
+        .mockImplementation(() => {
+          return queryOptions({
+            ...orgQueryOptions,
+            // change queryKey to force a new query
+            queryKey: ['bootstrap-organization-429', organization.slug],
+          });
+        });
+
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        body: null,
+        statusCode: 429,
+      });
+
+      // Simulate a second API call (e.g., user focuses page after being idle, react-query queries re-fire due to expiration
+      rerender(
+        <App {...routerProps}>
+          <OrganizationLayout>
+            <SimpleChild />
+          </OrganizationLayout>
+        </App>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('hello world')).toBeInTheDocument();
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
By default, `react-query` will refetch stale queries on window focus.
This can lead to many queries that can reach Sentrys API rate limit.

In the case of the organization details endpoint, an error means that the
OrganizationStore will not have an organization, which leads to
`useOrganization` throwning because organization is undefined. This ultimately
leads to a "crash" for the user (e.g. blank page w/ an error message).

This PR does not call the OrganizationStore error handler in the case of a 429
(granted the organization has not changed).

Note: I had to split up the query option creators from the hooks so that we
could mock them for the test
