### PR TITLE
Some CSP noise seems to come directly from "chrome-extension"

### DIFF
--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -15,6 +15,7 @@ DEFAULT_DISALLOWED_SOURCES = (
     "ms-browser-extension",
     "chrome://*",
     "chrome-extension://*",
+    "chrome-extension",
     "chromeinvokeimmediate://*",
     "chromenull://*",
     "data:text/html,chromewebdata",

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -27,6 +27,7 @@ config:
       - ms-browser-extension
       - chrome://*
       - chrome-extension://*
+      - chrome-extension
       - chromeinvokeimmediate://*
       - chromenull://*
       - data:text/html,chromewebdata


### PR DESCRIPTION
E.g. this websocket noise generated by [this](https://chromewebstore.google.com/detail/mmodal-fluency-direct-web/phgddhgfnjjaobkeekohieahfingldac?pli=1) Chrome extension used by healthcare professionals.

![image](https://github.com/user-attachments/assets/be4f05ad-54f0-464c-841f-27ff144b3ece)

![image](https://github.com/user-attachments/assets/1837ee97-c57f-4f88-8ebd-497e8f6a4aeb)


Doesn't appear to get caught by the `chrome-extension://*` rule, presumably because it's not a normal URI with a protocol. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
