### PR TITLE
ref(feedback/llm): add google-genai and bump openai==1.77.0 and pydantic==2.11.4

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ python-rapidjson>=1.4
 psutil>=5.9.2
 psycopg2-binary>=2.9.10
 PyJWT>=2.4.0
-pydantic>=2.0.0,<3
+pydantic==2.11.4
 python-dateutil>=2.9.0
 pymemcache
 python-u2flib-server>=5.0.0
@@ -82,7 +82,7 @@ symbolic==12.14.1
 tiktoken>=0.8.0
 tldextract>=5.1.2
 toronado>=0.1.0
-typing-extensions>=4.12.2
+typing-extensions>=4.9.0
 ua-parser>=0.10.0
 unidiff>=0.7.4
 urllib3[brotli]>=2.2.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ python-rapidjson>=1.4
 psutil>=5.9.2
 psycopg2-binary>=2.9.10
 PyJWT>=2.4.0
-pydantic>=1.10.20,<2
+pydantic>=2.0.0,<3
 python-dateutil>=2.9.0
 pymemcache
 python-u2flib-server>=5.0.0
@@ -82,7 +82,7 @@ symbolic==12.14.1
 tiktoken>=0.8.0
 tldextract>=5.1.2
 toronado>=0.1.0
-typing-extensions>=4.9.0
+typing-extensions>=4.12.2
 ua-parser>=0.10.0
 unidiff>=0.7.4
 urllib3[brotli]>=2.2.2
@@ -102,7 +102,8 @@ grpcio>=1.67
 # not directly used, but provides a speedup for redis
 hiredis>=2.3.2
 
-openai==1.3.5
+openai>=1.77.0
+google-genai>=1.13.0
 
 # remove once there are no unmarked transitive dependencies on setuptools
 setuptools

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -7,7 +7,8 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 amqp==5.3.1
-anyio==3.7.1
+annotated-types==0.7.0
+anyio==4.9.0
 asgiref==3.8.1
 attrs==24.2.0
 avalara==20.9.0
@@ -66,6 +67,7 @@ google-cloud-pubsub==2.23.0
 google-cloud-spanner==3.49.0
 google-cloud-storage==2.18.0
 google-crc32c==1.6.0
+google-genai==1.13.0
 google-resumable-media==2.7.0
 googleapis-common-protos==1.63.2
 grpc-google-iam-v1==0.13.1
@@ -78,7 +80,7 @@ hiredis==2.3.2
 honcho==2.0.0
 hpack==4.1.0
 httpcore==1.0.2
-httpx==0.25.2
+httpx==0.28.1
 hyperframe==6.1.0
 identify==2.6.1
 idna==3.7
@@ -87,6 +89,7 @@ iniconfig==1.1.1
 iso3166==2.1.1
 isodate==0.6.1
 isort==5.10.1
+jiter==0.9.0
 jmespath==0.10.0
 jsonschema==4.20.0
 jsonschema-path==0.3.2
@@ -109,7 +112,7 @@ mypy==1.15.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1
 oauthlib==3.1.0
-openai==1.3.5
+openai==1.77.0
 openapi-core==0.18.2
 openapi-pydantic==0.4.0
 openapi-schema-validator==0.6.2
@@ -140,7 +143,8 @@ pyasn1-modules==0.2.4
 pycodestyle==2.13.0
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.20
+pydantic==2.11.4
+pydantic-core==2.33.2
 pyflakes==3.3.2
 pyjwt==2.4.0
 pymemcache==4.0.0
@@ -233,7 +237,8 @@ types-requests-oauthlib==2.0.0.20250119
 types-setuptools==69.0.0.0
 types-simplejson==3.17.7.2
 types-unidiff==0.7.0.20240505
-typing-extensions==4.12.0
+typing-extensions==4.13.2
+typing-inspection==0.4.0
 tzdata==2023.3
 ua-parser==0.10.0
 unidiff==0.7.4
@@ -242,6 +247,7 @@ urllib3==2.2.2
 vine==5.1.0
 virtualenv==20.26.6
 wcwidth==0.2.10
+websockets==15.0.1
 werkzeug==3.0.6
 wheel==0.38.4
 wrapt==1.17.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -7,7 +7,8 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 amqp==5.3.1
-anyio==3.7.1
+annotated-types==0.7.0
+anyio==4.9.0
 asgiref==3.8.1
 attrs==24.2.0
 avalara==20.9.0
@@ -53,6 +54,7 @@ google-cloud-pubsub==2.23.0
 google-cloud-spanner==3.49.0
 google-cloud-storage==2.18.0
 google-crc32c==1.6.0
+google-genai==1.13.0
 google-resumable-media==2.7.0
 googleapis-common-protos==1.63.2
 grpc-google-iam-v1==0.13.1
@@ -64,12 +66,13 @@ h2==4.2.0
 hiredis==2.3.2
 hpack==4.1.0
 httpcore==1.0.2
-httpx==0.25.2
+httpx==0.28.1
 hyperframe==6.1.0
 idna==3.7
 inflection==0.5.1
 iso3166==2.1.1
 isodate==0.6.1
+jiter==0.9.0
 jmespath==0.10.0
 jsonschema==4.20.0
 jsonschema-specifications==2023.7.1
@@ -81,7 +84,7 @@ mistune==2.0.4
 mmh3==4.0.0
 msgpack==1.1.0
 oauthlib==3.1.0
-openai==1.3.5
+openai==1.77.0
 orjson==3.10.10
 packaging==24.1
 parsimonious==0.10.0
@@ -98,7 +101,8 @@ pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pycountry==17.5.14
 pycparser==2.21
-pydantic==1.10.20
+pydantic==2.11.4
+pydantic-core==2.33.2
 pyjwt==2.4.0
 pymemcache==4.0.0
 python-dateutil==2.9.0
@@ -147,7 +151,8 @@ tiktoken==0.8.0
 tldextract==5.1.2
 toronado==0.1.0
 tqdm==4.66.4
-typing-extensions==4.12.0
+typing-extensions==4.13.2
+typing-inspection==0.4.0
 tzdata==2023.3
 ua-parser==0.10.0
 unidiff==0.7.4
@@ -155,6 +160,7 @@ uritemplate==4.1.1
 urllib3==2.2.2
 vine==5.1.0
 wcwidth==0.2.10
+websockets==15.0.1
 xmlsec==1.3.14
 zstandard==0.18.0
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/90986
The `google-genai` SDK is to be used in https://github.com/getsentry/sentry/pull/90982, which upgrades UF spam filters to use a gemini model. To resolve dependency conflicts, we need to bump 
- `openai` - to match [genai's `anyio` requirement](https://github.com/googleapis/python-genai/blob/1efc057b1daebbebab8c5601d6917341fba9c7c4/pyproject.toml#L29)
- `pydantic` - for [genai requirements](https://github.com/googleapis/python-genai/blob/1efc057b1daebbebab8c5601d6917341fba9c7c4/pyproject.toml#L32). The [versions of pydantic](https://github.com/getsentry/pypi/blob/main/packages.ini#L1333) in getsentry/pypi require strict versions of pydantic-core, which leads to a conflict unless we pin a specific version 