### PR TITLE
fix(issue-views): Stats period not triggering unsaved changes

### DIFF
--- a/static/app/views/issueList/issueViews/createIssueViewFromUrl.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewFromUrl.tsx
@@ -25,7 +25,7 @@ export function createIssueViewFromUrl({query}: {query: Query}): IssueViewParams
     timeFilters: {
       start: decodeScalar(normalizedTimeFilters.start) ?? null,
       end: decodeScalar(normalizedTimeFilters.end) ?? null,
-      period: decodeScalar(normalizedTimeFilters.period) ?? null,
+      period: decodeScalar(normalizedTimeFilters.statsPeriod) ?? null,
       utc: decodeBoolean(normalizedTimeFilters.utc) ?? null,
     },
   };


### PR DESCRIPTION
Fixes a minor issue where changing the stats period would not trigger unsaved changes sometimes. 