### PR TITLE
:sparkles: feat(workflow engine): pass `workflow_id` to Actions when they are triggered

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -127,13 +127,8 @@ def evaluate_workflows_action_filters(
 ) -> set[DataConditionGroup]:
     filtered_action_groups: set[DataConditionGroup] = set()
 
-    # Gets the list of the workflow ids, and then get the workflow_data_condition_groups for those workflows
-    workflow_ids_to_envs = {workflow.id: workflow.environment for workflow in workflows}
-
     action_conditions = (
-        DataConditionGroup.objects.filter(
-            workflowdataconditiongroup__workflow_id__in=list(workflow_ids_to_envs.keys())
-        )
+        DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow__in=list(workflows))
         .prefetch_related("workflowdataconditiongroup_set")
         .distinct()
     )

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -306,7 +306,6 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
 def build_action_workflow_lookup(
     action_data_condition_groups: set[DataConditionGroup],
 ) -> dict[int, int]:
-    action_workflow_lookup: dict[int, int] = {}
     # fetch all actions via the DataConditionGroupAction model
     data_condition_group_actions = DataConditionGroupAction.objects.filter(
         condition_group__in=action_data_condition_groups

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -312,6 +312,4 @@ def build_action_workflow_lookup(
         condition_group__in=action_data_condition_groups
     ).values_list("action_id", "condition_group__workflowdataconditiongroup__workflow_id")
 
-    for action_id, workflow_id in data_condition_group_actions:
-        action_workflow_lookup[action_id] = workflow_id
-    return action_workflow_lookup
+    return dict(data_condition_group_actions)

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -772,11 +772,15 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
         assert mock_trigger.call_count == 2
         assert mock_trigger.call_args_list[0][0] == (
-            WorkflowEventData(event=self.event1.for_group(self.group1)),
+            WorkflowEventData(
+                event=self.event1.for_group(self.group1), workflow_id=self.workflow1.id
+            ),
             self.detector,
         )
         assert mock_trigger.call_args_list[1][0] == (
-            WorkflowEventData(event=self.event2.for_group(self.group2)),
+            WorkflowEventData(
+                event=self.event2.for_group(self.group2), workflow_id=self.workflow2.id
+            ),
             self.detector,
         )
 


### PR DESCRIPTION
Take 3

This PR adds the corresponding `workflow_id` to the `WorkflowEventData` dataclass.

This allows us to use that `workflow_id` in our notifications