### PR TITLE
chore(billing): Clean up gsBanner tests

### DIFF
--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -37,65 +37,69 @@ jest.mock('sentry/stores/guideStore', () => ({
   state: {},
 }));
 
+function setUpTests() {
+  ModalStore.reset();
+  jest.clearAllMocks();
+  delete window.pendo;
+
+  MockApiClient.clearMockResponses();
+  MockApiClient.addMockResponse({
+    method: 'POST',
+    url: '/_experiment/log_exposure/',
+    body: {},
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/projects/`,
+    body: [],
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/teams/`,
+    body: [],
+  });
+  MockApiClient.addMockResponse({
+    url: `/subscriptions/org-slug/`,
+    body: {},
+  });
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/`,
+    body: {},
+  });
+
+  [
+    'another-slug-1',
+    'another-slug-2',
+    'another-slug-3',
+    'another-slug-4',
+    'org-slug',
+    'promotion-platform',
+    'forced-trial',
+    'soft-cap',
+    'grace-period',
+    'trial-ending',
+    'partner-plan-ending',
+    'suspended',
+    'exceeded',
+    'past-due',
+    'past-due-2',
+    'past-due-3',
+    'past-due-4',
+  ].forEach(slug => {
+    SubscriptionStore.set(slug, {});
+    MockApiClient.addMockResponse({
+      url: `/organizations/${slug}/promotions/trigger-check/`,
+      method: 'POST',
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/${slug}/prompts-activity/`,
+      body: {},
+    });
+  });
+}
+
 describe('GSBanner', function () {
   beforeEach(() => {
-    ModalStore.reset();
-    jest.clearAllMocks();
-    delete window.pendo;
-
-    MockApiClient.clearMockResponses();
-    MockApiClient.addMockResponse({
-      method: 'POST',
-      url: '/_experiment/log_exposure/',
-      body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/projects/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/teams/`,
-      body: [],
-    });
-    MockApiClient.addMockResponse({
-      url: `/subscriptions/org-slug/`,
-      body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/`,
-      body: {},
-    });
-
-    [
-      'another-slug-1',
-      'another-slug-2',
-      'another-slug-3',
-      'another-slug-4',
-      'org-slug',
-      'promotion-platform',
-      'forced-trial',
-      'soft-cap',
-      'grace-period',
-      'trial-ending',
-      'partner-plan-ending',
-      'suspended',
-      'exceeded',
-      'past-due',
-      'past-due-2',
-      'past-due-3',
-      'past-due-4',
-    ].forEach(slug => {
-      SubscriptionStore.set(slug, {});
-      MockApiClient.addMockResponse({
-        url: `/organizations/${slug}/promotions/trigger-check/`,
-        method: 'POST',
-      });
-      MockApiClient.addMockResponse({
-        method: 'GET',
-        url: `/organizations/${slug}/prompts-activity/`,
-        body: {},
-      });
-    });
+    setUpTests();
   });
 
   it('renders empty', async function () {
@@ -112,729 +116,7 @@ describe('GSBanner', function () {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('shows overage notification banner and request more events btn for members', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am2_team',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: false}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByTestId('overage-banner-transaction-attachment')
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('performance unit')).toBeInTheDocument();
-    expect(screen.queryByText('transaction')).not.toBeInTheDocument();
-
-    expect(screen.getByTestId('btn-request_add_events')).toBeInTheDocument();
-  });
-
-  it('shows overage notification banner for multiple categories', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_t',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: true}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByTestId('overage-banner-error-transaction-attachment-monitorSeat')
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('transaction')).toBeInTheDocument();
-    expect(screen.getByText('cron monitor')).toBeInTheDocument();
-    expect(screen.queryByText('performance unit')).not.toBeInTheDocument();
-  });
-
-  it('does not show overage notification banner if is not self served', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_t',
-      categories: {attachments: MetricHistoryFixture({usageExceeded: true})},
-      canSelfServe: false,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    const {container} = render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('does not show overage notification banner if active product trial', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am2_team',
-      categories: {replays: MetricHistoryFixture({usageExceeded: true})},
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.REPLAYS,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(20, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    const {container} = render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('shows overage notification banner even if other category is on active trial', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am2_team',
-      categories: {
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.REPLAYS,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(20, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(await screen.findByTestId('overage-banner-attachment')).toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-replay')).not.toBeInTheDocument();
-  });
-
-  it('shows start trial btn for billing admins if can trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_f',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: false}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      canTrial: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByTestId('overage-banner-transaction-attachment')
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('btn-start_trial')).toBeInTheDocument();
-  });
-
-  it('shows upgrade plan btn for free plans for admins', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_f',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: true}),
-        transactions: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      canTrial: false,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByTestId('overage-banner-error-attachment')
-    ).toBeInTheDocument();
-
-    expect(screen.getByRole('button', {name: /upgrade plan/i})).toBeInTheDocument();
-  });
-
-  it('shows add quota btn for paid plans for admins', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: true}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      canTrial: false,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByTestId(
-        'overage-banner-error-transaction-replay-attachment-monitorSeat'
-      )
-    ).toBeInTheDocument();
-
-    expect(screen.getByRole('button', {name: /setup on-demand/i})).toBeInTheDocument();
-  });
-
-  it('shows add quota button for paid plans without active product trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: false}),
-        spans: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({usageExceeded: false}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
-        profileDuration: MetricHistoryFixture({usageExceeded: false}),
-        profileDurationUI: MetricHistoryFixture({usageExceeded: false}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.SPANS,
-          reasonCode: 1001,
-          isStarted: false,
-          lengthDays: undefined,
-          startDate: undefined,
-          endDate: undefined,
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
-    ).toBeInTheDocument();
-  });
-
-  it('does not show add quota button for paid plans with active product trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: false}),
-        spans: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({usageExceeded: false}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
-        profileDuration: MetricHistoryFixture({usageExceeded: false}),
-        profileDurationUI: MetricHistoryFixture({usageExceeded: false}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.SPANS,
-          reasonCode: 1001,
-          isStarted: true,
-          lengthDays: 20,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(10, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup pay-as-you-go/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('user can dismiss notification', async function () {
-    const organization = OrganizationFixture();
-
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_t',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: true}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
-        spans: MetricHistoryFixture({usageExceeded: true}),
-        profileDuration: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    const snoozeEndpoint = MockApiClient.addMockResponse({
-      method: 'PUT',
-      url: `/organizations/${organization.slug}/prompts-activity/`,
-      body: {},
-    });
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByTestId(
-        'overage-banner-error-transaction-replay-attachment-monitorSeat-span-profileDuration'
-      )
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('btn-overage-notification-snooze')).toBeInTheDocument();
-
-    await userEvent.click(screen.getByTestId('btn-overage-notification-snooze'));
-
-    for (const feature of [
-      'errors_overage_alert',
-      'transactions_overage_alert',
-      'replays_overage_alert',
-      'attachments_overage_alert',
-      'spans_overage_alert',
-      'profile_duration_overage_alert',
-    ]) {
-      expect(snoozeEndpoint).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/prompts-activity/`,
-        expect.objectContaining({
-          data: {
-            feature,
-            organization_id: organization.id,
-            status: 'snoozed',
-          },
-        })
-      );
-    }
-
-    expect(screen.queryByTestId(/overage-banner/)).not.toBeInTheDocument();
-  });
-
-  it('do not show banner when dismissed', async function () {
-    const organization = OrganizationFixture();
-    const snoozeTime = new Date('2020-02-02');
-    snoozeTime.setHours(23, 59, 59);
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: `/organizations/${organization.slug}/prompts-activity/`,
-      body: {
-        features: {
-          transactions_overage_alert: {
-            snoozed_ts: snoozeTime.getTime() / 1000,
-          },
-          replays_overage_alert: {
-            snoozed_ts: snoozeTime.getTime() / 1000,
-          },
-        },
-      },
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_t',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: false}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({usageExceeded: false}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
-      },
-      canSelfServe: true,
-      onDemandPeriodEnd: '2020-02-02',
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    const {container} = render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('shows add quota btn for paid plans for admins for warnings', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: true}),
-        transactions: MetricHistoryFixture({sentUsageWarning: false}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({sentUsageWarning: false}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByRole('button', {name: /setup on-demand/i})
-    ).toBeInTheDocument();
-  });
-
-  it('shows add quota button for paid plans warnings with no active product trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: false}),
-        spans: MetricHistoryFixture({sentUsageWarning: false}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({sentUsageWarning: false}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
-        profileDuration: MetricHistoryFixture({sentUsageWarning: false}),
-        profileDurationUI: MetricHistoryFixture({sentUsageWarning: false}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.REPLAYS,
-          reasonCode: 1001,
-          isStarted: false,
-          lengthDays: undefined,
-          startDate: undefined,
-          endDate: undefined,
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
-    ).toBeInTheDocument();
-  });
-
-  it('does not show add quota btn for paid plans warnings with active product trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: false}),
-        spans: MetricHistoryFixture({sentUsageWarning: false}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({sentUsageWarning: false}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.REPLAYS,
-          reasonCode: 1001,
-          isStarted: true,
-          lengthDays: 20,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(10, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup pay-as-you-go/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show warning if on-demand is set', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {errors: MetricHistoryFixture({sentUsageWarning: true})},
-      canSelfServe: true,
-      onDemandMaxSpend: 10,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup on-demand/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show warning if active product trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {monitorSeats: MetricHistoryFixture({sentUsageWarning: true})},
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.MONITOR_SEATS,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(20, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    const {container} = render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('shows warning even if other category is on active trial', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: true}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: true}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.MONITOR_SEATS,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(20, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(await screen.findByTestId('overage-banner-error')).toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-monitorSeat')).not.toBeInTheDocument();
-  });
-
-  it('does not show alert if hasOverageNotificationsDisabled is set', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-2',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: true}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      hasOverageNotificationsDisabled: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup on-demand/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show notification if hasOverageNotificationsDisabled is set', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-3',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({usageExceeded: true}),
-        transactions: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-        attachments: MetricHistoryFixture({usageExceeded: true}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      hasOverageNotificationsDisabled: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup on-demand/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show warning if hasOverageNotificationsDisabled is set', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-4',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({
-          category: DataCategory.ERRORS,
-          sentUsageWarning: true,
-        }),
-        transactions: MetricHistoryFixture({
-          category: DataCategory.TRANSACTIONS,
-          sentUsageWarning: true,
-        }),
-        replays: MetricHistoryFixture({
-          category: DataCategory.REPLAYS,
-          sentUsageWarning: true,
-        }),
-        attachments: MetricHistoryFixture({
-          category: DataCategory.ATTACHMENTS,
-          sentUsageWarning: true,
-        }),
-        monitorSeats: MetricHistoryFixture({
-          category: DataCategory.MONITOR_SEATS,
-          sentUsageWarning: true,
-        }),
-      },
-      canSelfServe: true,
-      hasOverageNotificationsDisabled: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(screen.queryByTestId('overage-banner-error')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-transaction')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-replay')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-attachment')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-monitorSeat')).not.toBeInTheDocument();
-  });
-
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
   it('renders suspension modal', async function () {
     const organization = OrganizationFixture({slug: 'suspended'});
     SubscriptionStore.set(
@@ -884,32 +166,6 @@ describe('GSBanner', function () {
     renderGlobalModal({deprecatedRouterMocks: true});
 
     expect(await screen.findByTestId('modal-grace-period')).toBeInTheDocument();
-  });
-
-  it('does not render overage banner without grace period and usage exceeded', async function () {
-    const organization = OrganizationFixture({
-      slug: 'soft-cap',
-      access: ['org:billing'],
-    });
-    SubscriptionStore.set(
-      organization.slug,
-      SubscriptionFixture({
-        organization,
-        isGracePeriod: false,
-        usageExceeded: false,
-      })
-    );
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(screen.queryByTestId('grace-period-banner')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('usage-exceeded-banner')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('modal-usage-exceeded')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('modal-grace-period')).not.toBeInTheDocument();
   });
 
   it('opens the trialEndingModal within 3 days of ending', async function () {
@@ -1484,7 +740,7 @@ describe('GSBanner', function () {
     await waitFor(() => expect(openPartnerPlanEndingModal).not.toHaveBeenCalled());
   });
 
-  it('show disabled member header', async function () {
+  it('shows disabled member header', async function () {
     const organization = OrganizationFixture({
       access: ['org:billing'],
     });
@@ -1604,7 +860,7 @@ describe('GSBanner', function () {
     delete window.pendo;
   });
 
-  it('delay pendo guides if other guides are active', async function () {
+  it('delays pendo guides if other guides are active', async function () {
     guideMock.state.currentGuide = true;
     const organization = OrganizationFixture();
     SubscriptionStore.set(
@@ -1672,7 +928,7 @@ describe('GSBanner', function () {
     });
   });
 
-  it('forced trial automatically starts', async function () {
+  it('automatically starts forced trial', async function () {
     const organization = OrganizationFixture({
       access: ['org:billing'],
     });
@@ -1709,7 +965,7 @@ describe('GSBanner', function () {
     expect(openForcedTrialModal).toHaveBeenCalled();
   });
 
-  it('forced trial automatically starts for restricted integration', async function () {
+  it('automatically starts forced trial for restricted integration', async function () {
     const organization = OrganizationFixture({
       access: ['org:billing'],
     });
@@ -1747,7 +1003,7 @@ describe('GSBanner', function () {
     expect(openForcedTrialModal).toHaveBeenCalled();
   });
 
-  it('open the forced trial modal', async function () {
+  it('opens the forced trial modal', async function () {
     const now = moment();
     const organization = OrganizationFixture({
       slug: 'forced-trial',
@@ -1850,6 +1106,7 @@ describe('GSBanner', function () {
       );
     });
   });
+
   it("doesn't activate non auto-opt-in promos", async function () {
     const now = moment();
     const organization = OrganizationFixture({
@@ -1992,7 +1249,693 @@ describe('GSBanner', function () {
     expect(screen.queryByTestId('modal-continue-button')).not.toBeInTheDocument();
   });
 
-  it('shows specific banner text just for cron overages', async function () {
+  it('does not show past due modal for enterprise orgs', async function () {
+    const organization = OrganizationFixture({
+      slug: 'past-due-3',
+      access: ['org:billing'],
+    });
+    const subscription = InvoicedSubscriptionFixture({
+      organization,
+      plan: 'am2_business_ent',
+      isPastDue: true,
+      canSelfServe: false,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+    renderGlobalModal({deprecatedRouterMocks: true});
+
+    await act(tick);
+    expect(screen.queryByTestId('banner-alert-past-due')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /update payment information/i})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /update billing details/i})
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('GSBanner Overage Alerts', function () {
+  beforeEach(() => {
+    setUpTests();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows overage notification banner and request more events btn for members', async function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am2_team',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: false}),
+        transactions: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: false}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
+      },
+      canSelfServe: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByTestId('overage-banner-transaction-attachment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('performance unit')).toBeInTheDocument();
+    expect(screen.queryByText('transaction')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('btn-request_add_events')).toBeInTheDocument();
+  });
+
+  it('does not show overage notification banner if is not self serve', async function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_t',
+      categories: {attachments: MetricHistoryFixture({usageExceeded: true})},
+      canSelfServe: false,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not show overage notification banner if active product trial', async function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am2_team',
+      categories: {replays: MetricHistoryFixture({usageExceeded: true})},
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.REPLAYS,
+          isStarted: true,
+          reasonCode: 1001,
+          startDate: moment().utc().subtract(10, 'days').format(),
+          endDate: moment().utc().add(20, 'days').format(),
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows overage notification banner even if other category is on active trial', async function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am2_team',
+      categories: {
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: true}),
+      },
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.REPLAYS,
+          isStarted: true,
+          reasonCode: 1001,
+          startDate: moment().utc().subtract(10, 'days').format(),
+          endDate: moment().utc().add(20, 'days').format(),
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(await screen.findByTestId('overage-banner-attachment')).toBeInTheDocument();
+    expect(screen.queryByTestId('overage-banner-replay')).not.toBeInTheDocument();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows start trial btn for billing admins if can trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_f',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: false}),
+        transactions: MetricHistoryFixture({usageExceeded: true}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+      },
+      canSelfServe: true,
+      canTrial: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByTestId('overage-banner-transaction-attachment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('btn-start_trial')).toBeInTheDocument();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows upgrade plan btn for free plans for admins', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_f',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: true}),
+        transactions: MetricHistoryFixture({usageExceeded: false}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+      },
+      canSelfServe: true,
+      canTrial: false,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByTestId('overage-banner-error-attachment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: /upgrade plan/i})).toBeInTheDocument();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows add quota btn for paid plans for admins', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: true}),
+        transactions: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: true}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
+      },
+      canSelfServe: true,
+      canTrial: false,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByTestId(
+        'overage-banner-error-transaction-replay-attachment-monitorSeat'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: /setup on-demand/i})).toBeInTheDocument();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows add quota button for paid plans without active product trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: false}),
+        spans: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: false}),
+        attachments: MetricHistoryFixture({usageExceeded: false}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
+        profileDuration: MetricHistoryFixture({usageExceeded: false}),
+        profileDurationUI: MetricHistoryFixture({usageExceeded: false}),
+      },
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.SPANS,
+          reasonCode: 1001,
+          isStarted: false,
+          lengthDays: undefined,
+          startDate: undefined,
+          endDate: undefined,
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
+    ).toBeInTheDocument();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('does not show add quota button for paid plans with active product trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: false}),
+        spans: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: false}),
+        attachments: MetricHistoryFixture({usageExceeded: false}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
+        profileDuration: MetricHistoryFixture({usageExceeded: false}),
+        profileDurationUI: MetricHistoryFixture({usageExceeded: false}),
+      },
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.SPANS,
+          reasonCode: 1001,
+          isStarted: true,
+          lengthDays: 20,
+          startDate: moment().utc().subtract(10, 'days').format(),
+          endDate: moment().utc().add(10, 'days').format(),
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+    await act(tick);
+    expect(
+      screen.queryByRole('button', {name: /setup pay-as-you-go/i})
+    ).not.toBeInTheDocument();
+  });
+
+  it('closes the banner when dismissed', async function () {
+    const organization = OrganizationFixture();
+
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_t',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: true}),
+        transactions: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: true}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
+        spans: MetricHistoryFixture({usageExceeded: true}),
+        profileDuration: MetricHistoryFixture({usageExceeded: true}),
+      },
+      canSelfServe: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const snoozeEndpoint = MockApiClient.addMockResponse({
+      method: 'PUT',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
+      body: {},
+    });
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByTestId(
+        'overage-banner-error-transaction-replay-attachment-monitorSeat-span-profileDuration'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('btn-overage-notification-snooze')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('btn-overage-notification-snooze'));
+
+    for (const feature of [
+      'errors_overage_alert',
+      'transactions_overage_alert',
+      'replays_overage_alert',
+      'attachments_overage_alert',
+      'spans_overage_alert',
+      'profile_duration_overage_alert',
+    ]) {
+      expect(snoozeEndpoint).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/prompts-activity/`,
+        expect.objectContaining({
+          data: {
+            feature,
+            organization_id: organization.id,
+            status: 'snoozed',
+          },
+        })
+      );
+    }
+
+    expect(screen.queryByTestId(/overage-banner/)).not.toBeInTheDocument();
+  });
+
+  it('does not show banner when dismissed', async function () {
+    const organization = OrganizationFixture();
+    const snoozeTime = new Date('2020-02-02');
+    snoozeTime.setHours(23, 59, 59);
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
+      body: {
+        features: {
+          transactions_overage_alert: {
+            snoozed_ts: snoozeTime.getTime() / 1000,
+          },
+          replays_overage_alert: {
+            snoozed_ts: snoozeTime.getTime() / 1000,
+          },
+        },
+      },
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_t',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: false}),
+        transactions: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: true}),
+        attachments: MetricHistoryFixture({usageExceeded: false}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
+      },
+      canSelfServe: true,
+      onDemandPeriodEnd: '2020-02-02',
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows add quota btn for paid plans for admins for warnings', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-1',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {
+        errors: MetricHistoryFixture({sentUsageWarning: true}),
+        transactions: MetricHistoryFixture({sentUsageWarning: false}),
+        replays: MetricHistoryFixture({usageExceeded: false}),
+        attachments: MetricHistoryFixture({sentUsageWarning: false}),
+        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
+      },
+      canSelfServe: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: /setup on-demand/i})
+    ).toBeInTheDocument();
+  });
+
+  // TODO(isabella): move this to addEventsCTA.spec.tsx
+  it('shows add quota button for paid plans warnings with no active product trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-1',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      categories: {
+        errors: MetricHistoryFixture({sentUsageWarning: false}),
+        spans: MetricHistoryFixture({sentUsageWarning: false}),
+        replays: MetricHistoryFixture({usageExceeded: true}),
+        attachments: MetricHistoryFixture({sentUsageWarning: false}),
+        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
+        profileDuration: MetricHistoryFixture({sentUsageWarning: false}),
+        profileDurationUI: MetricHistoryFixture({sentUsageWarning: false}),
+      },
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.REPLAYS,
+          reasonCode: 1001,
+          isStarted: false,
+          lengthDays: undefined,
+          startDate: undefined,
+          endDate: undefined,
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
+    ).toBeInTheDocument();
+  });
+
+  it('does not show warning if on-demand is set', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-1',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {errors: MetricHistoryFixture({sentUsageWarning: true})},
+      canSelfServe: true,
+      onDemandMaxSpend: 10,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(
+      screen.queryByRole('button', {name: /setup on-demand/i})
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show warning if active product trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-1',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {monitorSeats: MetricHistoryFixture({sentUsageWarning: true})},
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.MONITOR_SEATS,
+          isStarted: true,
+          reasonCode: 1001,
+          startDate: moment().utc().subtract(10, 'days').format(),
+          endDate: moment().utc().add(20, 'days').format(),
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows warning even if other category is on active trial', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-1',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {
+        errors: MetricHistoryFixture({sentUsageWarning: true}),
+        monitorSeats: MetricHistoryFixture({sentUsageWarning: true}),
+      },
+      canSelfServe: true,
+      productTrials: [
+        {
+          category: DataCategory.MONITOR_SEATS,
+          isStarted: true,
+          reasonCode: 1001,
+          startDate: moment().utc().subtract(10, 'days').format(),
+          endDate: moment().utc().add(20, 'days').format(),
+        },
+      ],
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(await screen.findByTestId('overage-banner-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('overage-banner-monitorSeat')).not.toBeInTheDocument();
+  });
+
+  it('does not show alert if hasOverageNotificationsDisabled is set', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-2',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: true}),
+        transactions: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: true}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
+      },
+      canSelfServe: true,
+      hasOverageNotificationsDisabled: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not show warning if hasOverageNotificationsDisabled is set', async function () {
+    const organization = OrganizationFixture({
+      access: ['org:billing'],
+      slug: 'another-slug-4',
+    });
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_team',
+      categories: {
+        errors: MetricHistoryFixture({
+          category: DataCategory.ERRORS,
+          sentUsageWarning: true,
+        }),
+        transactions: MetricHistoryFixture({
+          category: DataCategory.TRANSACTIONS,
+          sentUsageWarning: true,
+        }),
+        replays: MetricHistoryFixture({
+          category: DataCategory.REPLAYS,
+          sentUsageWarning: true,
+        }),
+        attachments: MetricHistoryFixture({
+          category: DataCategory.ATTACHMENTS,
+          sentUsageWarning: true,
+        }),
+        monitorSeats: MetricHistoryFixture({
+          category: DataCategory.MONITOR_SEATS,
+          sentUsageWarning: true,
+        }),
+      },
+      canSelfServe: true,
+      hasOverageNotificationsDisabled: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const {container} = render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render overage banner without grace period and usage exceeded', async function () {
+    const organization = OrganizationFixture({
+      slug: 'soft-cap',
+      access: ['org:billing'],
+    });
+    SubscriptionStore.set(
+      organization.slug,
+      SubscriptionFixture({
+        organization,
+        isGracePeriod: false,
+        usageExceeded: false,
+      })
+    );
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    await act(tick);
+    expect(screen.queryByTestId('grace-period-banner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('usage-exceeded-banner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('modal-usage-exceeded')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('modal-grace-period')).not.toBeInTheDocument();
+  });
+
+  it('shows specific banner text just for single seat-based overage', async function () {
     const organization = OrganizationFixture({access: ['org:billing']});
     const subscription = SubscriptionFixture({
       organization,
@@ -2025,7 +1968,7 @@ describe('GSBanner', function () {
     ).toBeInTheDocument();
   });
 
-  it('shows specific banner text just for uptime overages', async function () {
+  it('shows specific banner text just for multiple seat-based overage', async function () {
     const organization = OrganizationFixture({access: ['org:billing']});
     const subscription = SubscriptionFixture({
       organization,
@@ -2035,7 +1978,7 @@ describe('GSBanner', function () {
         transactions: MetricHistoryFixture({usageExceeded: false}),
         replays: MetricHistoryFixture({usageExceeded: false}),
         attachments: MetricHistoryFixture({usageExceeded: false}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: true}),
         profileDuration: MetricHistoryFixture({usageExceeded: false}),
         uptime: MetricHistoryFixture({usageExceeded: true}),
       },
@@ -2050,7 +1993,7 @@ describe('GSBanner', function () {
 
     expect(
       await screen.findByText(
-        "We can't enable additional Uptime Monitors because you don't have a sufficient on-demand budget."
+        "We can't enable additional Cron Monitors and Uptime Monitors because you don't have a sufficient on-demand budget."
       )
     ).toBeInTheDocument();
 
@@ -2059,47 +2002,13 @@ describe('GSBanner', function () {
     ).toBeInTheDocument();
   });
 
-  it('does not show past due modal for enterprise orgs', async function () {
-    const organization = OrganizationFixture({
-      slug: 'past-due-3',
-      access: ['org:billing'],
-    });
-    const subscription = InvoicedSubscriptionFixture({
-      organization,
-      plan: 'am2_business_ent',
-      isPastDue: true,
-      canSelfServe: false,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-    renderGlobalModal({deprecatedRouterMocks: true});
-
-    await act(tick);
-    expect(screen.queryByTestId('banner-alert-past-due')).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: /update payment information/i})
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: /update billing details/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows overage notification banner for the spans category', async function () {
+  it('shows overage alert banner for single category', async function () {
     const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({
       organization,
-      plan: 'am1_t',
+      plan: 'am3_t',
       categories: {
-        errors: MetricHistoryFixture({usageExceeded: false}),
-        transactions: MetricHistoryFixture({usageExceeded: false}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({usageExceeded: false}),
-        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
-        spans: MetricHistoryFixture({usageExceeded: true}),
+        errors: MetricHistoryFixture({usageExceeded: true}),
       },
       canSelfServe: true,
     });
@@ -2110,16 +2019,14 @@ describe('GSBanner', function () {
       deprecatedRouterMocks: true,
     });
 
-    expect(await screen.findByTestId('overage-banner-span')).toBeInTheDocument();
-
-    expect(screen.getByText('span')).toBeInTheDocument();
+    expect(await screen.findByTestId('overage-banner-error')).toBeInTheDocument();
   });
 
-  it('shows overage notification banner for multiple categories including spans', async function () {
+  it('shows overage alert banner for multiple categories', async function () {
     const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({
       organization,
-      plan: 'am1_t',
+      plan: 'am3_t',
       categories: {
         errors: MetricHistoryFixture({usageExceeded: true}),
         transactions: MetricHistoryFixture({usageExceeded: true}),
@@ -2143,109 +2050,76 @@ describe('GSBanner', function () {
         'overage-banner-error-transaction-attachment-monitorSeat-span-uptime'
       )
     ).toBeInTheDocument();
-
-    expect(screen.getByText('span')).toBeInTheDocument();
   });
 
-  it('does not show overage notification banner for spans if overage notifications are disabled', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-2',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        spans: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      hasOverageNotificationsDisabled: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup on-demand/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows overage warning banner for spans', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: false}),
-        spans: MetricHistoryFixture({sentUsageWarning: true}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({sentUsageWarning: false}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByRole('button', {name: /setup on-demand/i})
-    ).toBeInTheDocument();
-  });
-
-  it('does not show overage warning banner for spans if on-demand is set', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am1_team',
-      categories: {spans: MetricHistoryFixture({sentUsageWarning: true})},
-      canSelfServe: true,
-      onDemandMaxSpend: 10,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(
-      screen.queryByRole('button', {name: /setup on-demand/i})
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show overage notification banner for spans if active product trial', async function () {
+  it('shows overage warning banner for single category', async function () {
     const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({
       organization,
-      plan: 'am3_team',
-      categories: {spans: MetricHistoryFixture({usageExceeded: true})},
+      plan: 'am3_t',
+      categories: {
+        errors: MetricHistoryFixture({sentUsageWarning: true}),
+      },
       canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.SPANS,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(20, 'days').format(),
-        },
-      ],
     });
     SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(await screen.findByTestId('overage-banner-error')).toBeInTheDocument();
+  });
+
+  it('shows overage warning banner for multiple categories', async function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t',
+      categories: {
+        errors: MetricHistoryFixture({sentUsageWarning: true}),
+        transactions: MetricHistoryFixture({sentUsageWarning: true}),
+        spans: MetricHistoryFixture({sentUsageWarning: true}),
+        replays: MetricHistoryFixture({sentUsageWarning: false}),
+        attachments: MetricHistoryFixture({sentUsageWarning: true}),
+        monitorSeats: MetricHistoryFixture({sentUsageWarning: true}),
+        uptime: MetricHistoryFixture({sentUsageWarning: true}),
+      },
+      canSelfServe: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
+
+    expect(
+      await screen.findByTestId(
+        'overage-banner-error-transaction-attachment-monitorSeat-span-uptime'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('does not show banner for non-billed categories', async function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t',
+      categories: {
+        // this would never happen in practice, but we're asserting that we properly filter out non-billed categories
+        logBytes: MetricHistoryFixture({usageExceeded: true}),
+        logItems: MetricHistoryFixture({usageExceeded: true}),
+        profileChunks: MetricHistoryFixture({usageExceeded: true}),
+      },
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<GSBanner organization={organization} />, {
+      organization,
+      deprecatedRouterMocks: true,
+    });
 
     const {container} = render(<GSBanner organization={organization} />, {
       organization,
@@ -2254,98 +2128,5 @@ describe('GSBanner', function () {
 
     await act(tick);
     expect(container).toBeEmptyDOMElement();
-  });
-
-  it('shows overage notification banner for spans even if other category is on active trial', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        spans: MetricHistoryFixture({usageExceeded: true}),
-        replays: MetricHistoryFixture({usageExceeded: true}),
-      },
-      canSelfServe: true,
-      productTrials: [
-        {
-          category: DataCategory.REPLAYS,
-          isStarted: true,
-          reasonCode: 1001,
-          startDate: moment().utc().subtract(10, 'days').format(),
-          endDate: moment().utc().add(20, 'days').format(),
-        },
-      ],
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(await screen.findByTestId('overage-banner-span')).toBeInTheDocument();
-    expect(screen.queryByTestId('overage-banner-replay')).not.toBeInTheDocument();
-  });
-
-  it('shows overage warning banner for profileDuration', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: false}),
-        spans: MetricHistoryFixture({sentUsageWarning: false}),
-        profileDuration: MetricHistoryFixture({sentUsageWarning: true}), // Warning sent
-        profileDurationUI: MetricHistoryFixture({sentUsageWarning: false}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({sentUsageWarning: false}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
-    ).toBeInTheDocument();
-  });
-
-  it('shows overage warning banner for profileDurationUI', async function () {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-      slug: 'another-slug-1',
-    });
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-      categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: false}),
-        spans: MetricHistoryFixture({sentUsageWarning: false}),
-        profileDuration: MetricHistoryFixture({sentUsageWarning: false}),
-        profileDurationUI: MetricHistoryFixture({sentUsageWarning: true}),
-        replays: MetricHistoryFixture({usageExceeded: false}),
-        attachments: MetricHistoryFixture({sentUsageWarning: false}),
-        monitorSeats: MetricHistoryFixture({sentUsageWarning: false}),
-      },
-      canSelfServe: true,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    expect(
-      await screen.findByRole('button', {name: /setup pay-as-you-go/i})
-    ).toBeInTheDocument();
   });
 });

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -2101,32 +2101,4 @@ describe('GSBanner Overage Alerts', function () {
       )
     ).toBeInTheDocument();
   });
-
-  it('does not show banner for non-billed categories', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_t',
-      categories: {
-        // this would never happen in practice, but we're asserting that we properly filter out non-billed categories
-        logBytes: MetricHistoryFixture({usageExceeded: true}),
-        logItems: MetricHistoryFixture({usageExceeded: true}),
-        profileChunks: MetricHistoryFixture({usageExceeded: true}),
-      },
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    const {container} = render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-
-    await act(tick);
-    expect(container).toBeEmptyDOMElement();
-  });
 });


### PR DESCRIPTION
Split out from https://github.com/getsentry/sentry/pull/90979

This test file is messy, so this was an attempt to clean that up by:
- Splitting into two suites, one specifically for the overage banner
- Adding TODOs for tests to move
- Clearing out duplicate / redundant tests
- Adding tests for cases that hadn't yet been covered
- Fixing naming
- Improving empty assertions (instead of querying that certain text doesn't show up, just assert the render container is empty)