### PR TITLE
feat(insights): update mobile span op selector to use discover hooks

### DIFF
--- a/static/app/views/insights/mobile/appStarts/components/charts/countChart.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/charts/countChart.tsx
@@ -103,7 +103,7 @@ export function CountChart({chartHeight}: Props) {
       pageFilter.selection
     ),
     enabled: !isReleasesLoading,
-    referrer: 'api.starfish.mobile-startup-series',
+    referrer: 'api.starfish.mobile-startup-series-1',
     initialData: {},
   });
 

--- a/static/app/views/insights/mobile/appStarts/components/charts/countChart.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/charts/countChart.tsx
@@ -103,7 +103,7 @@ export function CountChart({chartHeight}: Props) {
       pageFilter.selection
     ),
     enabled: !isReleasesLoading,
-    referrer: 'api.starfish.mobile-startup-series-1',
+    referrer: 'api.starfish.mobile-startup-series',
     initialData: {},
   });
 

--- a/static/app/views/insights/mobile/appStarts/components/spanOpSelector.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/spanOpSelector.tsx
@@ -1,20 +1,16 @@
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {t} from 'sentry/locale';
-import type {NewQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
+import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {COLD_START_TYPE} from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {TTID_CONTRIBUTING_SPAN_OPS} from 'sentry/views/insights/mobile/screenload/components/spanOpSelector';
-import {useTableQuery} from 'sentry/views/insights/mobile/screenload/components/tables/screensTable';
 import {MobileCursors} from 'sentry/views/insights/mobile/screenload/constants';
 import {SpanMetricsField} from 'sentry/views/insights/types';
 
@@ -38,7 +34,6 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
-  const {selection} = usePageFilters();
   const {isProjectCrossPlatform, selectedPlatform} = useCrossPlatformProject();
 
   const value = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
@@ -71,30 +66,22 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
     secondaryRelease
   );
 
-  const newQuery: NewQuery = {
-    name: '',
-    fields: [SpanMetricsField.SPAN_OP, 'count()'],
-    query: queryStringPrimary,
-    dataset: DiscoverDatasets.SPANS_METRICS,
-    version: 2,
-    projects: selection.projects,
-  };
-
-  const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
-  const {data} = useTableQuery({
-    eventView,
-    enabled: true,
-    limit: 25,
-    referrer: 'api.starfish.get-span-operations',
-  });
+  const {data} = useSpanMetrics(
+    {
+      limit: 25,
+      search: queryStringPrimary,
+      fields: [SpanMetricsField.SPAN_OP, 'count()'],
+    },
+    'api.starfish.get-span-operations'
+  );
 
   const options = [
     {value: '', label: t('All')},
-    ...(data?.data ?? [])
+    ...data
       .filter(datum => Boolean(datum[SpanMetricsField.SPAN_OP]))
       .map(datum => {
         return {
-          value: datum[SpanMetricsField.SPAN_OP]!,
+          value: datum[SpanMetricsField.SPAN_OP],
           label: datum[SpanMetricsField.SPAN_OP],
         };
       }),

--- a/static/app/views/insights/mobile/common/components/tables/samplesTables.spec.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/samplesTables.spec.tsx
@@ -18,6 +18,22 @@ describe('SamplesTables', () => {
       method: 'GET',
       match: [
         MockApiClient.matchQuery({
+          referrer: 'api.starfish.get-span-operations',
+        }),
+      ],
+      body: {
+        data: [{'span.op': 'app.start.cold', 'count()': 1996}],
+        meta: {
+          fields: {'span.op': 'string', 'count()': 'integer'},
+        },
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events/`,
+      method: 'GET',
+      match: [
+        MockApiClient.matchQuery({
           referrer: 'api.insights.user-geo-subregion-selector',
         }),
       ],


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/90908