### PR TITLE
ref(feedback/llm): update vertex provider to use gemini generateContent API

### DIFF
--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -63,7 +63,7 @@ class VertexProvider(LlmModelBase):
             )
             raise VertexRequestFailed(f"Response {response.status_code}: {response.text}")
 
-        return response.json()["predictions"][0]["content"]
+        return response.json()["candidates"][0]["content"]["parts"][0]["text"]
 
     def _get_access_token(self) -> str:
         # https://stackoverflow.com/questions/53472429/how-to-get-a-gcp-bearer-token-programmatically-with-python

--- a/src/sentry/llm/providers/vertex.py
+++ b/src/sentry/llm/providers/vertex.py
@@ -33,8 +33,13 @@ class VertexProvider(LlmModelBase):
         content = f"{prompt} {message}" if prompt else message
 
         payload = {
-            "instances": [{"content": content}],
-            "parameters": {
+            "contents": {
+                "role": "user",
+                "parts": [
+                    {"text": content},
+                ],
+            },
+            "generationConfig": {
                 "candidateCount": self.candidate_count,
                 "maxOutputTokens": max_output_tokens,
                 "temperature": temperature,
@@ -47,7 +52,7 @@ class VertexProvider(LlmModelBase):
             "Content-Type": "application/json",
         }
         vertex_url = self.provider_config["options"]["url"]
-        vertex_url += usecase_config["options"]["model"] + ":predict"
+        vertex_url += usecase_config["options"]["model"] + ":generateContent"
 
         response = requests.post(vertex_url, headers=headers, json=payload)
 

--- a/tests/sentry/llm/test_vertex.py
+++ b/tests/sentry/llm/test_vertex.py
@@ -22,7 +22,26 @@ def test_complete_prompt(set_sentry_option):
             return_value=type(
                 "obj",
                 (object,),
-                {"status_code": 200, "json": lambda x: {"predictions": [{"content": ""}]}},
+                {
+                    "status_code": 200,
+                    "json": lambda x: {
+                        "candidates": [
+                            {
+                                "content": {
+                                    "role": "model",
+                                    "parts": [
+                                        {
+                                            "text": "hellogemini",
+                                            "finishReason": "STOP",
+                                            "avgLogprobs": -4.491923997799556e-06,
+                                        }
+                                    ],
+                                    "modelVersion": "vertex-1.0",
+                                }
+                            }
+                        ]
+                    },
+                },
             )(),
         ),
     ):
@@ -33,4 +52,4 @@ def test_complete_prompt(set_sentry_option):
             temperature=0.0,
             max_output_tokens=1024,
         )
-    assert res == ""
+    assert res == "hellogemini"


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/90986

Updates the vertex provider code to work with Gemini's [`generateContent` API](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference?_gl=1*bbne9m*_ga*MTI2MDIzODEwNy4xNzMzOTQ1MzE5*_ga_WH2QY8WWF5*czE3NDY1NTI1NTkkbzI3JGcxJHQxNzQ2NTUyODU2JGo2MCRsMCRoMA..). Previously we were using `:predict` which is not compatible with newer models. Tested locally with the `llm.py` runner and [2.0 flash lite model](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/gemini-2.0-flash-lite-001).

Once merged with https://github.com/getsentry/getsentry/pull/17384, this PR will fix UF spam detection, which broke after google removed the `text-bison` model we were using.