### PR TITLE
feat(explore): padding and margin part 2

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -392,5 +392,4 @@ const ChartLabel = styled('div')`
 
 const ChartTitle = styled('div')`
   display: flex;
-  margin-left: ${space(2)};
 `;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -455,7 +455,7 @@ function checkIsAllowedSelection(
 const BodySearch = styled(Layout.Body)`
   flex-grow: 0;
   border-bottom: 1px solid ${p => p.theme.border};
-  padding-bottom: ${space(1)};
+  padding-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     padding-bottom: ${space(2)};
@@ -487,8 +487,8 @@ const ControlSection = styled('aside')<{expanded: boolean}>`
     ${p =>
       p.expanded
         ? css`
-            width: 338px; /* 300px for the toolbar + padding */
-            padding: ${space(2)} ${space(1)} ${space(1)} ${space(4)};
+            width: 343px; /* 300px for the toolbar + padding */
+            padding: ${space(2)} ${space(1.5)} ${space(1)} ${space(4)};
             border-right: 1px solid ${p.theme.border};
           `
         : css`
@@ -511,7 +511,7 @@ const ContentSection = styled('section')<{expanded: boolean}>`
     ${p =>
       p.expanded
         ? css`
-            padding: ${space(1)} ${space(4)} ${space(3)} ${space(1)};
+            padding: ${space(1)} ${space(4)} ${space(3)} ${space(1.5)};
           `
         : css`
             padding: ${space(1)} ${space(4)} ${space(3)} ${space(4)};
@@ -551,7 +551,7 @@ const ChevronButton = styled(Button)<{expanded: boolean}>`
   ${p =>
     p.expanded
       ? css`
-          margin-left: -9px;
+          margin-left: -13px;
         `
       : css`
           margin-left: -31px;

--- a/static/app/views/explore/toolbar/styles.tsx
+++ b/static/app/views/explore/toolbar/styles.tsx
@@ -44,7 +44,7 @@ export const ToolbarRow = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  gap: ${space(0.5)};
+  gap: ${space(1)};
 
   :not(:last-child) {
     margin-bottom: ${space(0.5)};


### PR DESCRIPTION
- Loosen padding in between chart and controls
- Remove left margin from chart title

**Before:**
![Screenshot 2025-05-06 at 11 13 26 AM](https://github.com/user-attachments/assets/ba190b51-18e1-4676-a1df-f92151ae94ef)

**After:**
![Screenshot 2025-05-06 at 11 13 18 AM](https://github.com/user-attachments/assets/b8c0208f-6457-4b5e-a8fb-7f824dc91dfc)