### PR TITLE
fix(ourlogs): Hide internal attributes from the details

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -29,7 +29,9 @@ const AlwaysHiddenLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.ID,
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.ITEM_TYPE,
-  OurLogKnownFieldKey.PROJECT,
+  'project',
+  'project.id',
+  'project_id', // these are all aliases that might show up
 ];
 
 /**
@@ -38,6 +40,12 @@ const AlwaysHiddenLogFields: OurLogFieldKey[] = [
 export const HiddenLogDetailFields: OurLogFieldKey[] = [
   ...AlwaysHiddenLogFields,
   OurLogKnownFieldKey.MESSAGE,
+
+  // deprecated/otel fields that clutter the UI
+  'sentry.timestamp_nanos',
+  'tags[sentry.timestamp_precise,number]',
+  'tags[sentry.trace_flags,number]',
+  'span_id',
 ];
 
 export const HiddenColumnEditorLogFields: OurLogFieldKey[] = [...AlwaysHiddenLogFields];

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -29,9 +29,8 @@ const AlwaysHiddenLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.ID,
   OurLogKnownFieldKey.ORGANIZATION_ID,
   OurLogKnownFieldKey.ITEM_TYPE,
-  'project',
   'project.id',
-  'project_id', // these are all aliases that might show up
+  'project_id', // these are both aliases that might show up
 ];
 
 /**

--- a/static/app/views/explore/logs/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/logsTableRow.spec.tsx
@@ -152,7 +152,7 @@ describe('logsTableRow', () => {
     expect(hasNoWrapRecursive(logTableRow)).toBe(false);
 
     // Check that the attribute values are rendered
-    expect(screen.getByText(projects[0]!.id)).toBeInTheDocument();
+    expect(screen.queryByText(projects[0]!.id)).not.toBeInTheDocument();
     expect(screen.getByText('456')).toBeInTheDocument();
     expect(screen.getByText('7b91699f')).toBeInTheDocument();
 

--- a/static/app/views/explore/logs/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/logsTableRow.spec.tsx
@@ -157,8 +157,6 @@ describe('logsTableRow', () => {
     expect(screen.getByText('7b91699f')).toBeInTheDocument();
 
     // Check that the attributes keys are rendered
-    expect(screen.getByTestId('tree-key-project.id')).toBeInTheDocument();
-    expect(screen.getByTestId('tree-key-project.id')).toHaveTextContent('id');
     expect(screen.getByTestId('tree-key-severity_number')).toBeInTheDocument();
     expect(screen.getByTestId('tree-key-severity_number')).toHaveTextContent(
       'severity_number'

--- a/tests/acceptance/test_explore_logs.py
+++ b/tests/acceptance/test_explore_logs.py
@@ -81,6 +81,7 @@ class ExploreLogsTest(AcceptanceTestCase, SnubaTestCase, OurLogTestCase):
             assert "1234567890" in columns[0].text
             assert "long_attribute" in columns[0].text
             assert "a" * 1000 in columns[0].text
-            assert "nested value1" in columns[1].text
-            assert "nested value2" in columns[1].text
-            assert "nested value3" in columns[1].text
+            assert "nested value1" in columns[0].text
+            assert "nested value2" in columns[0].text
+            assert "nested value3" in columns[0].text
+            assert "value1" in columns[1].text


### PR DESCRIPTION
Some attributes like 'project' can be sent as one of multiple aliases, and there are a few other internal attributes that we'd like to hide.