### PR TITLE
ref(replay): only show ellipsis button on release tag row hover

### DIFF
--- a/static/app/components/replays/releaseDropdownFilter.tsx
+++ b/static/app/components/replays/releaseDropdownFilter.tsx
@@ -70,6 +70,7 @@ export default function ReleaseDropdownFilter({version}: {version: string}) {
           aria-label={t('Actions')}
           icon={<IconEllipsis size="xs" />}
           size="zero"
+          className="invisible-button"
         />
       )}
     />

--- a/static/app/components/replays/releaseDropdownFilter.tsx
+++ b/static/app/components/replays/releaseDropdownFilter.tsx
@@ -8,11 +8,14 @@ import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
+import {
+  makeReleaseDrawerPathname,
+  makeReleasesPathname,
+} from 'sentry/views/releases/utils/pathnames';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
-export default function ReleaseDropdownFilter({val}: {val: string}) {
+export default function ReleaseDropdownFilter({version}: {version: string}) {
   const location = useLocation<ReplayListLocationQuery>();
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -31,7 +34,7 @@ export default function ReleaseDropdownFilter({val}: {val: string}) {
               }),
               query: {
                 ...location.query,
-                query: `release:"${val}"`,
+                query: `release:"${version}"`,
               },
             }),
         },
@@ -40,10 +43,16 @@ export default function ReleaseDropdownFilter({val}: {val: string}) {
           label: t('Go to release details'),
           onAction: () =>
             navigate(
-              makeReleasesPathname({
-                organization,
-                path: `/${encodeURIComponent(val)}/`,
-              })
+              organization.features.includes('release-bubbles-ui')
+                ? makeReleaseDrawerPathname({
+                    location,
+                    release: version,
+                    projectId: location?.query.project,
+                  })
+                : makeReleasesPathname({
+                    organization,
+                    path: `/${encodeURIComponent(version)}/`,
+                  })
             ),
         },
       ]}

--- a/static/app/components/replays/replayTagsTableRow.tsx
+++ b/static/app/components/replays/replayTagsTableRow.tsx
@@ -147,4 +147,14 @@ const StyledVersionContainer = styled('div')`
   display: flex;
   justify-content: flex-end;
   gap: ${space(0.75)};
+
+  .invisible-button {
+    visibility: hidden;
+  }
+
+  &:hover {
+    .invisible-button {
+      visibility: visible;
+    }
+  }
 `;

--- a/static/app/components/replays/replayTagsTableRow.tsx
+++ b/static/app/components/replays/replayTagsTableRow.tsx
@@ -58,7 +58,7 @@ function ReplayTagsTableRow({name, values, generateUrl}: Props) {
         <Fragment key={`${name}-${index}-${value}`}>
           {index > 0 && ', '}
           <StyledVersionContainer>
-            <ReleaseDropdownFilter val={String(value)} />
+            <ReleaseDropdownFilter version={String(value)} />
             <QuickContextHoverWrapper
               dataRow={{release: String(value)}}
               contextType={ContextType.RELEASE}


### PR DESCRIPTION
only show the ellipsis button on the releases tag row if it's hovered over (more consistent with styles across the product)


https://github.com/user-attachments/assets/1683586d-7a3f-4e34-908a-550e2b00dfcb

