### PR TITLE
fix(ourlogs): Tags would be red if they were sentry. tags in searchbar

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -10,6 +10,7 @@ import {
   isSpanOperationBreakdownField,
   measurementType,
 } from 'sentry/utils/discover/fields';
+import {isKnownAttribute} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 
 import grammar from './grammar.pegjs';
 import {getKeyName} from './utils';
@@ -877,7 +878,8 @@ export class TokenConverter {
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&
-      !this.config.supportedTags[getKeyName(key)]
+      !this.config.supportedTags[getKeyName(key)] &&
+      !isKnownAttribute({key: key.text, name: getKeyName(key)})
     ) {
       return {
         type: InvalidReason.INVALID_KEY,

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -85,7 +85,7 @@ export function useTraceItemAttributeKeys({
   };
 }
 
-function isKnownAttribute(attribute: Tag) {
+export function isKnownAttribute(attribute: Tag) {
   // For now, skip all the sentry. prefixed attributes as they
   // should be covered by the static attributes that will be
   // merged with these results.


### PR DESCRIPTION
The 'collect tags' rules and 'validate tags' rules had different sets of logic, this unifies them.