### PR TITLE
fix(projects): Enforce unique accounts for transferring projects

### DIFF
--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -72,24 +72,34 @@ class ProjectTransferEndpoint(ProjectEndpoint):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_403_FORBIDDEN)
 
-        try:
-            owner = OrganizationMember.objects.get_members_by_email_and_role(
-                email=email, role=roles.get_top_dog().id
-            )[0]
-        except IndexError:
+        owners = OrganizationMember.objects.get_members_by_email_and_role(
+            email=email,
+            role=roles.get_top_dog().id,
+        ).exclude(organization_id=project.organization_id)
+
+        unique_user_ids: set[int] = {owner.user_id for owner in owners}
+
+        if len(unique_user_ids) == 0:
             return Response(
                 {"detail": "Could not find an organization owner with that email"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        organization = project.organization
+        if len(unique_user_ids) > 1:
+            return Response(
+                {
+                    "detail": "That email belongs to multiple accounts. Contact the person and ensure the email is associated with only one account."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         transaction_id = uuid4().hex
         url_data = sign(
             salt=SALT,
             actor_id=request.user.id,
-            from_organization_id=organization.id,
+            from_organization_id=project.organization_id,
             project_id=project.id,
-            user_id=owner.user_id,
+            user_id=unique_user_ids.pop(),
             transaction_id=transaction_id,
         )
 

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -187,9 +187,9 @@ class ProjectTransferTest(APITestCase):
         )
         assert transfer_link_match is not None
         transfer_link = transfer_link_match.group()
-        url: ParseResult = urlparse(url=transfer_link)
-        parsed_url = parse_qs(url.query)
-        signed_data = str(parsed_url["data"][0])
+        parsed_url: ParseResult = urlparse(url=transfer_link)
+        parsed_qs = parse_qs(parsed_url.query)
+        signed_data = str(parsed_qs["data"][0])
         parsed_data = unsign(signed_data, salt=SALT)
 
         assert parsed_data["actor_id"] == owner_a.id

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -1,10 +1,16 @@
+import re
+from typing import cast
+from urllib.parse import ParseResult, parse_qs, urlparse
+
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
+from sentry.api.endpoints.project_transfer import SALT
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils.signing import unsign
 
 
 class ProjectTransferTest(APITestCase):
@@ -99,3 +105,95 @@ class ProjectTransferTest(APITestCase):
             response.content
             == b'"You are attempting to use this endpoint too frequently. Limit is 3 requests in 3600 seconds"'
         )
+
+    def test_transfer_project_to_current_organization(self):
+        owner_a = self.create_user("a@example.com")
+        self.create_useremail(owner_a, "shared@example.com")
+        org_a = self.create_organization(name="Org A", slug="org-a", owner=owner_a)
+
+        project = self.create_project(organization=org_a)
+        self.login_as(user=owner_a)
+
+        url = reverse(
+            "sentry-api-0-project-transfer",
+            kwargs={"organization_id_or_slug": org_a.slug, "project_id_or_slug": project.slug},
+        )
+
+        with self.tasks():
+            response = self.client.post(url, {"email": "shared@example.com"})
+
+        assert len(mail.outbox) == 0
+        assert response.status_code == 404
+        assert response.data == {"detail": "Could not find an organization owner with that email"}
+
+    def test_transfer_project_to_multiple_accounts(self):
+        owner_a = self.create_user("a@example.com")
+        org_a = self.create_organization(name="Org A", slug="org-a", owner=owner_a)
+
+        owner_b = self.create_user("b@example.com")
+        self.create_useremail(owner_b, "shared@example.com")
+        self.create_organization(name="Org B", slug="org-b", owner=owner_b)
+
+        owner_c = self.create_user("c@example.com")
+        self.create_useremail(owner_c, "shared@example.com")
+        self.create_organization(name="Org C", slug="org-c", owner=owner_c)
+
+        project = self.create_project(organization=org_a)
+        self.login_as(user=owner_a)
+
+        url = reverse(
+            "sentry-api-0-project-transfer",
+            kwargs={
+                "organization_id_or_slug": org_a.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+
+        with self.tasks():
+            response = self.client.post(url, {"email": "shared@example.com"})
+
+        assert len(mail.outbox) == 0
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": "That email belongs to multiple accounts. Contact the person and ensure the email is associated with only one account."
+        }
+
+    def test_transfer_project_to_multiple_accounts_ignores_project_org(self):
+        owner_a = self.create_user("a@example.com")
+        self.create_useremail(owner_a, "shared@example.com")
+        org_a = self.create_organization(name="Org A", slug="org-a", owner=owner_a)
+
+        owner_b = self.create_user("b@example.com")
+        self.create_useremail(owner_b, "shared@example.com")
+        self.create_organization(name="Org B", slug="org-b", owner=owner_b)
+
+        project = self.create_project(organization=org_a)
+        self.login_as(user=owner_a)
+
+        url = reverse(
+            "sentry-api-0-project-transfer",
+            kwargs={"organization_id_or_slug": org_a.slug, "project_id_or_slug": project.slug},
+        )
+
+        with self.tasks():
+            response = self.client.post(url, {"email": "shared@example.com"})
+
+        assert response.status_code == 204
+        assert len(mail.outbox) == 1
+
+        mail_body = mail.outbox[0].body
+        transfer_link_match = re.search(
+            r"(http://testserver/accept-transfer/\?[^\s]+)", cast(str, mail_body)
+        )
+        assert transfer_link_match is not None
+        transfer_link = transfer_link_match.group()
+        url: ParseResult = urlparse(url=transfer_link)
+        parsed_url = parse_qs(url.query)
+        signed_data = str(parsed_url["data"][0])
+        parsed_data = unsign(signed_data, salt=SALT)
+
+        assert parsed_data["actor_id"] == owner_a.id
+        assert parsed_data["user_id"] == owner_b.id
+        assert parsed_data["project_id"] == project.id
+        assert parsed_data["from_organization_id"] == org_a.id
+        assert parsed_data["transaction_id"] is not None


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/82643. We could add a field for them to enter a User ID or something, but the UX would probably be unused and confusing in most cases. Instead, just have better error handling.

