### PR TITLE
feat(query-builder): Turn on automatic searching across app when feature flag is on

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -279,6 +279,7 @@ export default function FeedbackSearch() {
 
   return (
     <SearchQueryBuilder
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       initialQuery={decodeScalar(locationQuery.query, '')}
       fieldDefinitionGetter={getFeedbackFieldDefinition}
       filterKeys={filterKeys}

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -151,6 +151,7 @@ function useSpanSearchQueryBuilderProps({
     disallowUnsupportedFilters: true,
     recentSearches: SavedSearchType.SPAN,
     showUnsubmittedIndicator: true,
+    searchOnChange: organization.features.includes('ui-search-on-change'),
   };
 }
 

--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -140,6 +140,7 @@ export function TransactionSearchQueryBuilder({
       recentSearches={SavedSearchType.EVENT}
       filterKeyMenuWidth={filterKeyMenuWidth}
       trailingItems={trailingItems}
+      searchOnChange={organization.features.includes('ui-search-on-change')}
     />
   );
 }

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -214,7 +214,7 @@ function SearchQueryBuilderUI({
       <PanelProvider>
         <SearchIndicator
           initialQuery={initialQuery}
-          showUnsubmittedIndicator={showUnsubmittedIndicator}
+          showUnsubmittedIndicator={showUnsubmittedIndicator && !searchOnChange}
         />
         {!parsedQuery || queryInterface === QueryInterfaceType.TEXT ? (
           <PlainTextQueryInput label={label} />

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -641,6 +641,9 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                     ) : (
                       <SearchContainer>
                         <SearchQueryBuilder
+                          searchOnChange={organization.features.includes(
+                            'ui-search-on-change'
+                          )}
                           initialQuery={initialData?.query ?? ''}
                           getTagValues={this.getEventFieldValues}
                           placeholder={this.searchPlaceholder}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -73,6 +73,7 @@ export function ReleaseSearchBar({
 
   return (
     <SearchQueryBuilder
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       initialQuery={widgetQuery.conditions}
       filterKeySections={filterKeySections}
       filterKeys={supportedTags}

--- a/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
+++ b/static/app/views/discover/results/resultsSearchQueryBuilder.tsx
@@ -350,6 +350,7 @@ function ResultsSearchQueryBuilder(props: Props) {
 
   return (
     <SearchQueryBuilder
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       placeholder={placeholderText}
       filterKeys={getTagList}
       initialQuery={props.query ?? ''}

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import {SavedSearchType, type TagCollection} from 'sentry/types/group';
 import type {AggregationKey} from 'sentry/utils/fields';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useTraceItemAttributeValues} from 'sentry/views/explore/hooks/useTraceItemAttributeValues';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -61,6 +62,7 @@ export function useSearchQueryBuilderProps({
   projects,
   supportedAggregates = [],
 }: TraceItemSearchQueryBuilderProps) {
+  const organization = useOrganization();
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
   const functionTags = useFunctionTags(itemType, supportedAggregates);
   const filterKeySections = useFilterKeySections(itemType, stringAttributes);
@@ -75,6 +77,7 @@ export function useSearchQueryBuilderProps({
   });
 
   return {
+    searchOnChange: organization.features.includes('ui-search-on-change'),
     placeholder: placeholderText,
     filterKeys: filterTags,
     initialQuery,

--- a/static/app/views/insights/sessions/components/releaseTableSearch.tsx
+++ b/static/app/views/insights/sessions/components/releaseTableSearch.tsx
@@ -66,6 +66,7 @@ export default function ReleaseTableSearch() {
 
   return (
     <StyledSearchQueryBuilder
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       onSearch={handleSearch}
       initialQuery={getQuery() || ''}
       filterKeys={filterKeys}

--- a/static/app/views/issueDetails/streamline/eventSearch.tsx
+++ b/static/app/views/issueDetails/streamline/eventSearch.tsx
@@ -205,6 +205,7 @@ export function EventSearch({
 
   return (
     <SearchQueryBuilder
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       initialQuery={query}
       onSearch={handleSearch}
       filterKeys={filterKeys}

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -175,6 +175,7 @@ function IssueListSearchBar({
       disallowLogicalOperators
       showUnsubmittedIndicator
       searchSource={searchSource}
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       {...props}
     />
   );

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -6,6 +6,7 @@ import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   LogsPageDataProvider,
   useLogsPageData,
@@ -60,12 +61,14 @@ export function TraceViewLogsSection() {
 }
 
 function LogsSectionContent({tableData}: {tableData: UseExploreLogsTableResult}) {
+  const organization = useOrganization();
   const setLogsQuery = useSetLogsQuery();
   const logsSearch = useLogsSearch();
 
   return (
     <Fragment>
       <SearchQueryBuilder
+        searchOnChange={organization.features.includes('ui-search-on-change')}
         placeholder={t('Search logs for this event')}
         filterKeys={{}}
         getTagValues={() => new Promise<string[]>(() => [])}

--- a/static/app/views/projectDetail/projectFilters.tsx
+++ b/static/app/views/projectDetail/projectFilters.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Tag} from 'sentry/types/group';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {TagValueLoader} from 'sentry/views/issueList/types';
 
 type Props = {
@@ -27,6 +28,7 @@ const SUPPORTED_TAGS = {
 };
 
 function ProjectFilters({query, relativeDateOptions, tagValueLoader, onSearch}: Props) {
+  const organization = useOrganization();
   const getTagValues = useCallback(
     async (tag: Tag, currentQuery: string): Promise<string[]> => {
       const values = await tagValueLoader(tag.key, currentQuery);
@@ -42,6 +44,7 @@ function ProjectFilters({query, relativeDateOptions, tagValueLoader, onSearch}: 
         <DatePageFilter relativeOptions={relativeDateOptions} />
       </PageFilterBar>
       <SearchQueryBuilder
+        searchOnChange={organization.features.includes('ui-search-on-change')}
         searchSource="project_filters"
         initialQuery={query ?? ''}
         placeholder={t('Search by release version, build, package, or stage')}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -580,6 +580,7 @@ class ReleasesList extends DeprecatedAsyncComponent<Props, State> {
               {this.shouldShowQuickstart ? null : (
                 <SortAndFilterWrapper>
                   <StyledSearchQueryBuilder
+                    searchOnChange={organization.features.includes('ui-search-on-change')}
                     onSearch={this.handleSearch}
                     initialQuery={this.getQuery() || ''}
                     filterKeys={this.filterKeys}

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -198,6 +198,7 @@ function ReplaySearchBar(props: Props) {
   return (
     <SearchQueryBuilder
       {...props}
+      searchOnChange={organization.features.includes('ui-search-on-change')}
       onChange={undefined} // not implemented and different type from SmartSearchBar
       disallowLogicalOperators={undefined} // ^
       className={props.className}


### PR DESCRIPTION
With the feature flag `ui-search-on-change`, this enables all search bars to automatically search when the query is changed - different from how most operate currently (waiting for the user to press enter).