### PR TITLE
fix(jira-server): Truncastes Jira Server titles that are too long

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1003,7 +1003,8 @@ class JiraServerIntegration(IssueSyncIntegration):
                 cleaned_data[field_name] = data[field_name]
                 continue
             elif field_name == "summary":
-                cleaned_data["summary"] = data["title"]
+                title = data.get("title")
+                cleaned_data["summary"] = title[:255] if title else None
                 continue
             elif field_name == "labels" and "labels" in data:
                 labels = [label.strip() for label in data["labels"].split(",") if label.strip()]


### PR DESCRIPTION
Fixes #55524 for Jira Server

Automatically truncates the issue title to 255 characters or less.
