### PR TITLE
chore(rules): Add more information to logs to help debugging

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -470,6 +470,7 @@ def fire_rules(
                 extra={
                     "group_to_groupevent": serialized_groups,
                     "project_id": project_id,
+                    "rule_id": rule.id,
                 },
             )
         for group, groupevent in group_to_groupevent.items():
@@ -534,6 +535,8 @@ def fire_rules(
                     extra={
                         "total": len(callback_and_futures),
                         "not_sent": not_sent,
+                        "project_id": project_id,
+                        "rule_id": rule.id,
                     },
                 )
 

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -508,7 +508,7 @@ def fire_rules(
             if features.has(
                 "organizations:workflow-engine-process-workflows-logs",
                 project.organization,
-            ):
+            ) or features.has("projects:num-events-issue-debugging", project):
                 logger.info(
                     "post_process.delayed_processing.triggered_rule",
                     extra={


### PR DESCRIPTION
After adding logs in https://github.com/getsentry/sentry/pull/90790 we were able to determine that the rules we're investigating were properly getting the information we expect in group to group event, but are still unable to determine where it's falling off and failing to fire as it's not creating a `RuleFireHistory` entry.  Add more params to the logs further down to help continue debugging.