### PR TITLE
feat(releases): Add `source` attribute to `releases.drawer_opened` analytics event

### DIFF
--- a/static/app/components/replays/releaseDropdownFilter.tsx
+++ b/static/app/components/replays/releaseDropdownFilter.tsx
@@ -48,6 +48,7 @@ export default function ReleaseDropdownFilter({version}: {version: string}) {
                     location,
                     release: version,
                     projectId: location?.query.project,
+                    source: 'replay-tags',
                   })
                 : makeReleasesPathname({
                     organization,

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -83,6 +83,7 @@ function Version({
               location,
               release: version,
               projectId: releaseDetailProjectId,
+              source: 'release-version-link',
             })
           : {
               pathname: makeReleasesPathname({

--- a/static/app/utils/analytics/releasesAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/releasesAnalyticsEvents.tsx
@@ -3,7 +3,7 @@ import type {ReleaseComparisonChartType} from 'sentry/types/release';
 export type ReleasesEventParameters = {
   'releases.bubbles_legend': {selected: boolean};
   'releases.change_chart_type': {chartType: ReleaseComparisonChartType};
-  'releases.drawer_opened': {organization: string; release?: boolean};
+  'releases.drawer_opened': {organization: string; source: string; release?: boolean};
   'releases.drawer_view_full_details': {project_id: string};
   'releases.quickstart_copied': {project_id: string};
   'releases.quickstart_create_integration.success': {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -162,7 +162,13 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           props.releases,
           function onReleaseClick(release: Release) {
             if (organization.features.includes('release-bubbles-ui')) {
-              navigate(makeReleaseDrawerPathname({location, release: release.version}));
+              navigate(
+                makeReleaseDrawerPathname({
+                  location,
+                  release: release.version,
+                  source: 'time-series-widget',
+                })
+              );
               return;
             }
             navigate(

--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -267,7 +267,13 @@ export function EventGraph({
 
   const handleReleaseLineClick = useCallback(
     (release: ReleaseMetaBasic) => {
-      navigate(makeReleaseDrawerPathname({location, release: release.version}));
+      navigate(
+        makeReleaseDrawerPathname({
+          location,
+          release: release.version,
+          source: 'issue-details',
+        })
+      );
     },
     [location, navigate]
   );

--- a/static/app/views/releases/drawer/releasesDrawer.tsx
+++ b/static/app/views/releases/drawer/releasesDrawer.tsx
@@ -23,10 +23,19 @@ import {RELEASES_DRAWER_FIELD_MAP} from './utils';
  * releases list or details.
  */
 export function ReleasesDrawer() {
-  const {rd, rdChart, rdEnd, rdEnv, rdStart, rdProject, rdRelease, rdReleaseProjectId} =
-    useLocationQuery({
-      fields: RELEASES_DRAWER_FIELD_MAP,
-    });
+  const {
+    rd,
+    rdChart,
+    rdEnd,
+    rdEnv,
+    rdSource,
+    rdStart,
+    rdProject,
+    rdRelease,
+    rdReleaseProjectId,
+  } = useLocationQuery({
+    fields: RELEASES_DRAWER_FIELD_MAP,
+  });
   const start = getDateFromTimestamp(rdStart);
   const end = getDateFromTimestamp(rdEnd);
   const defaultPageFilters = usePageFilters();
@@ -54,9 +63,10 @@ export function ReleasesDrawer() {
       trackAnalytics('releases.drawer_opened', {
         release: Boolean(rdRelease),
         organization: organization.id,
+        source: rdChart ?? rdSource ?? 'unknown',
       });
     }
-  }, [organization, rd, rdProject, rdRelease]);
+  }, [organization, rd, rdProject, rdRelease, rdSource, rdChart]);
 
   useEffect(() => {
     if (rd === 'show' && !rdRelease && !rdStart && !rdEnd) {

--- a/static/app/views/releases/drawer/utils.tsx
+++ b/static/app/views/releases/drawer/utils.tsx
@@ -17,6 +17,7 @@ export enum ReleasesDrawerFields {
   RELEASE = 'rdRelease',
   RELEASE_PROJECT_ID = 'rdReleaseProjectId',
   START = 'rdStart',
+  SOURCE = 'rdSource',
 }
 
 /**
@@ -34,6 +35,7 @@ export const RELEASES_DRAWER_FIELD_MAP = {
   [ReleasesDrawerFields.RELEASE]: decodeScalar,
   [ReleasesDrawerFields.RELEASE_PROJECT_ID]: decodeScalar,
   [ReleasesDrawerFields.START]: decodeScalar,
+  [ReleasesDrawerFields.SOURCE]: decodeScalar,
 };
 
 const RELEASES_DRAWER_FIELD_KEYS = Object.keys(RELEASES_DRAWER_FIELD_MAP);

--- a/static/app/views/releases/utils/pathnames.tsx
+++ b/static/app/views/releases/utils/pathnames.tsx
@@ -29,9 +29,11 @@ export function makeReleaseDrawerPathname({
   location,
   release,
   projectId,
+  source,
 }: {
   location: Location;
   release: string;
+  source: string;
   projectId?: string | string[] | null;
 }) {
   return {
@@ -40,6 +42,7 @@ export function makeReleaseDrawerPathname({
       [ReleasesDrawerFields.DRAWER]: 'show',
       [ReleasesDrawerFields.RELEASE]: release,
       [ReleasesDrawerFields.RELEASE_PROJECT_ID]: projectId,
+      [ReleasesDrawerFields.SOURCE]: source,
     },
   };
 }


### PR DESCRIPTION
Adds a `source` attribute to above analytics event. Source is either chartId or `releases-version-link`, `time-series-widget`, or `issue-details`. The latter 3 are release details vs releases list for the former.
