### PR TITLE
feat(admin): Remove translations from gsAdmin, lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -921,6 +921,10 @@ export default typescript.config([
               message:
                 "Use 'useTheme' hook of withTheme HOC instead of importing theme directly. For tests, use ThemeFixture.",
             },
+            {
+              group: ['sentry/locale'],
+              message: 'Do not import locale into gsAdmin. No translations required.',
+            },
           ],
           paths: restrictedImportPaths,
         },

--- a/static/gsAdmin/components/addBillingMetricUsage.tsx
+++ b/static/gsAdmin/components/addBillingMetricUsage.tsx
@@ -8,7 +8,6 @@ import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -155,7 +154,7 @@ function AddBillingMetricUsageModal({
       <Body>
         <div>Create and add mock billing metric usage for testing purposes.</div>
         <br />
-        <Form onSubmit={onSubmit} submitLabel={t('Create')} onCancel={closeModal}>
+        <Form onSubmit={onSubmit} submitLabel={'Create'} onCancel={closeModal}>
           <SelectField
             inline={false}
             stacked

--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -8,7 +8,6 @@ import InputField from 'sentry/components/forms/fields/inputField';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -101,7 +100,7 @@ function AddGiftBudgetModal({
         ) : (
           <div />
         )}
-        <Form onSubmit={onSubmit} submitLabel={t('Confirm')} onCancel={closeModal}>
+        <Form onSubmit={onSubmit} submitLabel={'Confirm'} onCancel={closeModal}>
           {reservedBudgetOptions.map(budget => (
             <BudgetCard
               key={budget.id}

--- a/static/gsAdmin/components/addOrRemoveOrgModal.tsx
+++ b/static/gsAdmin/components/addOrRemoveOrgModal.tsx
@@ -5,7 +5,6 @@ import {Alert} from 'sentry/components/core/alert';
 import TextField from 'sentry/components/forms/fields/inputField';
 import SentryOrganizationRoleSelectorField from 'sentry/components/forms/fields/sentryOrganizationRoleSelectorField';
 import Form from 'sentry/components/forms/form';
-import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
 
 interface AddOrRemoveOrgModalProps extends ModalRenderProps {
@@ -38,7 +37,7 @@ function AddToOrgModal({Header, Body, userId, closeModal}: AddOrRemoveOrgModalPr
   return (
     <Fragment>
       <Header closeButton>
-        <h4>{t('Add Member to an Organization')}</h4>
+        <h4>Add Member to an Organization</h4>
       </Header>
       <Body>
         <Form onSubmit={onSubmit} submitLabel="Submit" cancelLabel="Cancel">
@@ -92,7 +91,7 @@ function RemoveFromOrgModal({
   return (
     <Fragment>
       <Header closeButton>
-        <h4>{t('Remove Member from an Organization')}</h4>
+        <h4>Remove Member from an Organization</h4>
       </Header>
       <Body>
         <Form onSubmit={onSubmit} submitLabel="Submit" cancelLabel="Cancel">

--- a/static/gsAdmin/components/changeARRAction.tsx
+++ b/static/gsAdmin/components/changeARRAction.tsx
@@ -5,7 +5,6 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import NumberField from 'sentry/components/forms/fields/numberField';
-import {tct} from 'sentry/locale';
 
 type Props = {
   // TODO(ts): Type customer when available
@@ -63,9 +62,12 @@ class ChangeARRModal extends Component<ModalProps, ModalState> {
             label="ARR"
             stacked
             inline={false}
-            help={tct('Their new annual contract value will be [newAvc]', {
-              newAvc: <strong>${this.state.newAcv.toLocaleString()}</strong>,
-            })}
+            help={
+              <Fragment>
+                Their new annual contract value will be{' '}
+                <strong>${this.state.newAcv.toLocaleString()}</strong>
+              </Fragment>
+            }
             defaultValue={this.props.customer.acv / 100}
             onChange={this.onChange}
           />

--- a/static/gsAdmin/components/customers/customerMembers.tsx
+++ b/static/gsAdmin/components/customers/customerMembers.tsx
@@ -6,7 +6,6 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {LinkButton} from 'sentry/components/core/button';
 import Link from 'sentry/components/links/link';
 import {IconMail} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 import ResultGrid from 'admin/components/resultGrid';
@@ -25,7 +24,7 @@ const getRow = (row: any) => [
         href={`mailto:${row.email}`}
         icon={<IconMail size="xs" />}
         title="Send email"
-        aria-label={t('Send email')}
+        aria-label={'Send email'}
       />
       {row.user ? (
         <Link to={`/_admin/users/${row.user.id}/`}>{row.email}</Link>

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -8,7 +8,6 @@ import type {ResponseMeta} from 'sentry/api';
 import {Button} from 'sentry/components/core/button';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -675,7 +674,7 @@ function CustomerOverview({customer, onAction, organization}: Props) {
                           )
                         }
                       >
-                        {tct('Allow Trial', {categoryName})}
+                        Allow Trial
                       </Button>
                       <Button
                         size="xs"
@@ -686,7 +685,7 @@ function CustomerOverview({customer, onAction, organization}: Props) {
                           )
                         }
                       >
-                        {tct('Start Trial', {categoryName})}
+                        Start Trial
                       </Button>
                       <Button
                         size="xs"
@@ -697,7 +696,7 @@ function CustomerOverview({customer, onAction, organization}: Props) {
                           )
                         }
                       >
-                        {tct('Stop Trial', {categoryName})}
+                        Stop Trial
                       </Button>
                     </TrialActions>
                   </DetailLabel>

--- a/static/gsAdmin/components/customers/customerProjects.tsx
+++ b/static/gsAdmin/components/customers/customerProjects.tsx
@@ -5,7 +5,6 @@ import {PlatformIcon} from 'platformicons';
 import {LinkButton} from 'sentry/components/core/button';
 import Link from 'sentry/components/links/link';
 import {IconProject} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 import ResultGrid from 'admin/components/resultGrid';
@@ -46,7 +45,7 @@ function CustomerProjects({orgId}: Props) {
               href={`/${orgId}/${row.slug}/`}
               icon={<IconProject size="xs" />}
               title="View in Sentry"
-              aria-label={t('View in Sentry')}
+              aria-label={'View in Sentry'}
             />
             <Link to={`/_admin/customers/${orgId}/projects/${row.slug}/`}>
               {row.slug}

--- a/static/gsAdmin/components/deleteBillingMetricHistory.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.tsx
@@ -6,7 +6,6 @@ import {openModal} from 'sentry/actionCreators/modal';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -101,7 +100,7 @@ function DeleteBillingMetricHistoryModal({
       <Body>
         <div>Delete billing metric history for a specific data category.</div>
         <br />
-        <Form onSubmit={onSubmit} submitLabel={t('Delete')} onCancel={closeModal}>
+        <Form onSubmit={onSubmit} submitLabel={'Delete'} onCancel={closeModal}>
           <SelectField
             inline={false}
             stacked

--- a/static/gsAdmin/components/docIntegrationModal.tsx
+++ b/static/gsAdmin/components/docIntegrationModal.tsx
@@ -13,7 +13,6 @@ import Form from 'sentry/components/forms/form';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconAdd, IconClose} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DocIntegration, IntegrationFeature} from 'sentry/types/integrations';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -111,7 +110,7 @@ function DocIntegrationModal(props: Props) {
               return existingResources;
             });
           }}
-          aria-label={t('Close')}
+          aria-label={'Close'}
         />
       </ResourceContainer>
     ));
@@ -179,7 +178,7 @@ function DocIntegrationModal(props: Props) {
     onSuccess: (response: Record<string, any>) => void,
     onError: (error: any) => void
   ) => {
-    addLoadingMessage(t('Saving changes\u2026'));
+    addLoadingMessage('Saving changes\u2026');
     api.request(
       docIntegration ? `/doc-integrations/${docIntegration.slug}/` : '/doc-integrations/',
       {

--- a/static/gsAdmin/components/forkCustomer.tsx
+++ b/static/gsAdmin/components/forkCustomer.tsx
@@ -2,7 +2,6 @@ import {Component, Fragment} from 'react';
 
 import {Client} from 'sentry/api';
 import SelectField from 'sentry/components/forms/fields/selectField';
-import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {
@@ -69,10 +68,10 @@ class ForkCustomerAction extends Component<Props> {
       <Fragment>
         <SelectField
           name="regionUrl"
-          label={t('Duplicate into Region')}
-          help={t(
+          label={'Duplicate into Region'}
+          help={
             "Choose which region to duplicate this organization's low volume metadata into. This will kick off a SAAS->SAAS relocation job, but the source organization will not be affected."
-          )}
+          }
           choices={regionChoices}
           inline={false}
           stacked

--- a/static/gsAdmin/components/refundVercelRequestModal.tsx
+++ b/static/gsAdmin/components/refundVercelRequestModal.tsx
@@ -5,7 +5,6 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
-import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
@@ -60,11 +59,11 @@ function RefundVercelRequestModal({
       <Body>
         <div>Send request to Vercel to initiate a refund for a given invoice.</div>
         <br />
-        <Form onSubmit={onSubmit} submitLabel={t('Send Request')} onCancel={closeModal}>
+        <Form onSubmit={onSubmit} submitLabel={'Send Request'} onCancel={closeModal}>
           <TextField
             label="Invoice GUID"
             name="invoice_guid"
-            placeholder={t('invoice guid')}
+            placeholder={'invoice guid'}
             onChange={(value: string) => {
               setGuid(value);
             }}
@@ -73,7 +72,7 @@ function RefundVercelRequestModal({
           <TextField
             label="Reason"
             name="reason"
-            placeholder={t('reason for refund')}
+            placeholder={'reason for refund'}
             onChange={(value: string) => {
               setReason(value);
             }}

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -13,7 +13,6 @@ import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {IconList, IconSearch} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
@@ -449,7 +448,7 @@ class ResultGrid extends Component<ResultGridProps, State> {
         <SortSearchForm onSubmit={this.onSearch}>
           {this.props.isRegional && (
             <CompactSelect
-              triggerProps={{prefix: t('Region')}}
+              triggerProps={{prefix: 'Region'}}
               value={this.state.region ? this.state.region.url : undefined}
               options={ConfigStore.get('regions').map((r: any) => ({
                 label: r.name,
@@ -494,7 +493,7 @@ class ResultGrid extends Component<ResultGridProps, State> {
                 icon={<IconSearch />}
                 priority="primary"
                 size="sm"
-                aria-label={t('Search')}
+                aria-label={'Search'}
               />
             </SearchBar>
           )}

--- a/static/gsAdmin/components/sentryAppUpdateModal.tsx
+++ b/static/gsAdmin/components/sentryAppUpdateModal.tsx
@@ -7,7 +7,6 @@ import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {tct} from 'sentry/locale';
 import type {IntegrationFeature} from 'sentry/types/integrations';
 import {useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
@@ -128,13 +127,7 @@ function SentryAppUpdateModal(props: Props) {
             {...fieldProps}
             name="popularity"
             label="New popularity"
-            help={tct(
-              'Higher values will be more prominent on the integration directory. Only values between [POPULARITY_MIN] and [POPULARITY_MAX] are permitted.',
-              {
-                POPULARITY_MIN,
-                POPULARITY_MAX,
-              }
-            )}
+            help={`Higher values will be more prominent on the integration directory. Only values between ${POPULARITY_MIN} and ${POPULARITY_MAX} are permitted.`}
             onChange={onPopularityChange}
             defaultValue={sentryAppData.popularity}
           />

--- a/static/gsAdmin/components/toggleSpendAllocationModal.tsx
+++ b/static/gsAdmin/components/toggleSpendAllocationModal.tsx
@@ -4,7 +4,6 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import type {Client} from 'sentry/api';
 import Form from 'sentry/components/forms/form';
-import {t, tct} from 'sentry/locale';
 import withApi from 'sentry/utils/withApi';
 
 type Props = {
@@ -49,21 +48,16 @@ function SpendAllocationModal({
       <Body>
         <Form
           onSubmit={onSubmit}
-          submitLabel={isCurrentlyEnabled ? t('Disable') : t('Enable')}
+          submitLabel={isCurrentlyEnabled ? 'Disable' : 'Enable'}
           onCancel={closeModal}
         >
-          {t('Access to spend allocations is currently ')}
-          <strong>
-            {tct('[action]', {
-              action: isCurrentlyEnabled ? t('enabled') : t('disabled'),
-            })}
-          </strong>
-          {t(' for this organization.')}
-
-          {tct('Would you like to [newAction] access to spend allocations?', {
-            root: <p />,
-            newAction: isCurrentlyEnabled ? t('disable') : t('enable'),
-          })}
+          Access to spend allocations is currently{' '}
+          <strong>{isCurrentlyEnabled ? 'enabled' : 'disabled'}</strong> for this
+          organization.
+          <p>
+            Would you like to {isCurrentlyEnabled ? 'disable' : 'enable'} access to spend
+            allocations?
+          </p>
         </Form>
       </Body>
     </Fragment>

--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -1,6 +1,5 @@
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
-import {t} from 'sentry/locale';
 
 import {AddToOrgModal, RemoveFromOrgModal} from 'admin/components/addOrRemoveOrgModal';
 import CustomerGrid from 'admin/components/customerGrid';
@@ -38,10 +37,10 @@ function UserCustomers({userId}: Props) {
               marginRight: 8,
             }}
           >
-            {t('Add to Org')}
+            Add to Org
           </Button>
           <Button priority="default" size="sm" onClick={openRemoveFromOrgModal}>
-            {t('Remove from Org')}
+            Remove from Org
           </Button>
         </div>
       }

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -6,7 +6,6 @@ import {Button} from 'sentry/components/core/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {IconNot} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import type {UserIdentityConfig} from 'sentry/types/auth';
 import {UserIdentityCategory, UserIdentityStatus} from 'sentry/types/auth';
 import type {InternalAppApiToken, User} from 'sentry/types/user';
@@ -111,7 +110,7 @@ function UserOverview({
                     size="xs"
                     title="Disconnect Identity"
                     onClick={() => onIdentityDisconnect(identity)}
-                    aria-label={t('Disconnect Identity')}
+                    aria-label={'Disconnect Identity'}
                     disabled={
                       identity.status !== UserIdentityStatus.CAN_DISCONNECT &&
                       identity.category !== UserIdentityCategory.ORG_IDENTITY
@@ -151,7 +150,7 @@ function UserOverview({
                     size="xs"
                     title="Remove Authenticator"
                     onClick={() => onAuthenticatorRemove(auth)}
-                    aria-label={t('Remove Authenticator')}
+                    aria-label={'Remove Authenticator'}
                   />
                 </ButtonWrapper>
                 <small style={{color: '#999999'}}>
@@ -175,9 +174,9 @@ function UserOverview({
                 key={token.id}
                 token={token}
                 onRemove={revokeToken}
-                onRemoveConfirmMessage={t(
+                onRemoveConfirmMessage={
                   "Are you sure you want to revoke this user's token? Doing so may break user's applications, and should usually only be done if the token has been leaked."
-                )}
+                }
               />
             ))}
           </ApiTokenList>

--- a/static/gsAdmin/components/users/userPermissionsModal.tsx
+++ b/static/gsAdmin/components/users/userPermissionsModal.tsx
@@ -6,7 +6,6 @@ import BooleanField from 'sentry/components/forms/fields/booleanField';
 import Form from 'sentry/components/forms/form';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t} from 'sentry/locale';
 import type {User} from 'sentry/types/user';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -50,7 +49,7 @@ function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}: Props)
       <Body>
         <Form
           onSubmit={(data, onSuccess, onError) => {
-            addLoadingMessage(t('Saving changes\u2026'));
+            addLoadingMessage('Saving changes\u2026');
 
             // XXX(dcramer): why did i optimize the api for individual idempotent perm changes..
 

--- a/static/gsAdmin/views/billingPlans.tsx
+++ b/static/gsAdmin/views/billingPlans.tsx
@@ -6,7 +6,6 @@ import {Badge} from 'sentry/components/core/badge';
 import {Button} from 'sentry/components/core/button';
 import Panel from 'sentry/components/panels/panel';
 import {IconDownload} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DataCategory} from 'sentry/types/core';
 import useApi from 'sentry/utils/useApi';
@@ -309,9 +308,7 @@ function PlanDetailsSection({
         <h3 id={planTypeId} style={{margin: 0}}>
           {planTierIdFormatted} {planNameFormatted} Plan
         </h3>
-        <Badge type={notLive ? 'warning' : 'new'}>
-          {notLive ? t('NOT LIVE') : t('LIVE')}
-        </Badge>
+        <Badge type={notLive ? 'warning' : 'new'}>{notLive ? 'NOT LIVE' : 'LIVE'}</Badge>
       </div>
 
       {/* Pricing Table */}
@@ -381,7 +378,7 @@ function PriceTiersTable({
 
   const disabled = data_categories_disabled.includes(dataCategory);
 
-  const badgeText = notLive ? t('NOT LIVE') : disabled ? t('DISABLED') : t('LIVE');
+  const badgeText = notLive ? 'NOT LIVE' : disabled ? 'DISABLED' : 'LIVE';
   const badgeType = notLive || disabled ? 'warning' : 'new';
 
   return (

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -10,7 +10,6 @@ import {
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -268,7 +267,7 @@ export default function CustomerDetails() {
   }) => {
     if (error) {
       const msg = JSON.stringify(error.responseText);
-      addErrorMessage(t('Failed to toggle spend allocations due to [msg]', {msg}));
+      addErrorMessage(`Failed to toggle spend allocations due to ${msg}`);
     } else {
       const clone = cloneDeep(subscription);
       if (clone) {
@@ -276,9 +275,7 @@ export default function CustomerDetails() {
         setApiQueryData(queryClient, SUBSCRIPTION_QUERY_KEY, clone);
       }
       addSuccessMessage(
-        tct('Spend Allocations has been [action] for organization.', {
-          action: spendAllocationEnabled ? t('enabled') : t('disabled'),
-        })
+        `Spend Allocations has been ${spendAllocationEnabled ? 'enabled' : 'disabled'} for organization.`
       );
     }
   };

--- a/static/gsAdmin/views/debuggingTools.tsx
+++ b/static/gsAdmin/views/debuggingTools.tsx
@@ -8,7 +8,6 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {Input} from 'sentry/components/core/input';
 import {PanelTable} from 'sentry/components/panels/panelTable';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import useApi from 'sentry/utils/useApi';
@@ -33,7 +32,7 @@ function IssueOwnerDebbuging() {
     event.preventDefault();
     if (!projectSlug || !stacktracePath) {
       addErrorMessage(
-        t('Requires the organization slug, the project slug and the stacktrace path.')
+        'Requires the organization slug, the project slug and the stacktrace path.'
       );
       return;
     }

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -5,7 +5,6 @@ import {Button} from 'sentry/components/core/button';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import Truncate from 'sentry/components/truncate';
-import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
@@ -111,7 +110,7 @@ function HomePage(props: Props) {
       </div>
       <RegionPanel>
         <CompactSelect
-          triggerProps={{prefix: t('Region')}}
+          triggerProps={{prefix: 'Region'}}
           value={regionUrl}
           options={regions.map((r: any) => ({
             label: r.name,

--- a/static/gsAdmin/views/notFound.tsx
+++ b/static/gsAdmin/views/notFound.tsx
@@ -1,16 +1,15 @@
 import styled from '@emotion/styled';
 
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 function NotFound() {
   return (
     <SplashWrapper>
       <Header>
-        <HeaderTitle>{t('Not Found')}</HeaderTitle>
+        <HeaderTitle>Not Found</HeaderTitle>
       </Header>
       <div>
-        <strong>{t('Page not found.')}</strong>
+        <strong>Page not found.</strong>
       </div>
     </SplashWrapper>
   );

--- a/static/gsAdmin/views/relocationCreate.tsx
+++ b/static/gsAdmin/views/relocationCreate.tsx
@@ -7,7 +7,6 @@ import {Button} from 'sentry/components/core/button';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Input} from 'sentry/components/core/input';
 import Well from 'sentry/components/well';
-import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {browserHistory} from 'sentry/utils/browserHistory';
@@ -17,9 +16,8 @@ import PageHeader from 'admin/components/pageHeader';
 
 const FILE_MAX_SIZE = 200e6; // 200 MB limit for file upload
 
-const PROMO_CODE_ERROR_MSG = t(
-  'That promotional code has already been claimed, does not have enough remaining uses, is no longer valid, or never existed.'
-);
+const PROMO_CODE_ERROR_MSG =
+  'That promotional code has already been claimed, does not have enough remaining uses, is no longer valid, or never existed.';
 
 function RelocationForm() {
   // Use our own api client to initialize, since we need to be careful with the headers when using multipart/form-data


### PR DESCRIPTION
Adds a lint rule that prevents locale from being imported and used in the gsAdmin folder where we don't translate things
