### PR TITLE
chore(trace-items): Remove snake cake params on trace items endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -61,13 +61,6 @@ class OrganizationTraceItemAttributesEndpointBase(OrganizationEventsV2EndpointBa
         return any(org_features.get(feature) for feature in self.feature_flags)
 
 
-class OrganizationTraceItemAttributesEndpointSnakeCaseSerializer(serializers.Serializer):
-    item_type = serializers.ChoiceField([e.value for e in SupportedTraceItemType], required=True)
-    attribute_type = serializers.ChoiceField(["string", "number"], required=True)
-    substring_match = serializers.CharField(required=False)
-    query = serializers.CharField(required=False)
-
-
 class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
     itemType = serializers.ChoiceField(
         [e.value for e in SupportedTraceItemType], required=True, source="item_type"
@@ -129,19 +122,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         if not self.has_feature(organization, request):
             return Response(status=404)
 
-        serializer: (
-            OrganizationTraceItemAttributesEndpointSerializer
-            | OrganizationTraceItemAttributesEndpointSnakeCaseSerializer
-        )
-        serializer = OrganizationTraceItemAttributesEndpointSnakeCaseSerializer(data=request.GET)
+        serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
         if not serializer.is_valid():
-            serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
-            if not serializer.is_valid():
-                return Response(serializer.errors, status=400)
-            else:
-                sentry_sdk.set_tag("param.casing", "camel")
-        else:
-            sentry_sdk.set_tag("param.casing", "snake")
+            return Response(serializer.errors, status=400)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -220,19 +203,9 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
         if not self.has_feature(organization, request):
             return Response(status=404)
 
-        serializer: (
-            OrganizationTraceItemAttributesEndpointSerializer
-            | OrganizationTraceItemAttributesEndpointSnakeCaseSerializer
-        )
-        serializer = OrganizationTraceItemAttributesEndpointSnakeCaseSerializer(data=request.GET)
+        serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
         if not serializer.is_valid():
-            serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
-            if not serializer.is_valid():
-                return Response(serializer.errors, status=400)
-            else:
-                sentry_sdk.set_tag("param.casing", "camel")
-        else:
-            sentry_sdk.set_tag("param.casing", "snake")
+            return Response(serializer.errors, status=400)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -10,15 +10,6 @@ from sentry.testutils.cases import APITestCase, BaseSpansTestCase, OurLogTestCas
 from sentry.testutils.helpers.datetime import before_now
 
 
-# temporary helper to rewrite snake case to camel tests in the tests
-# eventually, we should just use camel case
-def snake_to_camel_query(query):
-    query["itemType"] = query.pop("item_type")
-    query["attributeType"] = query.pop("attribute_type")
-    if "substring_match" in query:
-        query["substringMatch"] = query.pop("substring_match")
-
-
 class OrganizationTraceItemAttributesEndpointTestBase(APITestCase, SnubaTestCase):
     feature_flags: dict[str, bool]
     item_type: SupportedTraceItemType
@@ -32,10 +23,10 @@ class OrganizationTraceItemAttributesEndpointTestBase(APITestCase, SnubaTestCase
     def do_request(self, query=None, features=None, **kwargs):
         if query is None:
             query = {}
-        if "item_type" not in query:
-            query["item_type"] = self.item_type.value
-        if "attribute_type" not in query:
-            query["attribute_type"] = "string"
+        if "itemType" not in query:
+            query["itemType"] = self.item_type.value
+        if "attributeType" not in query:
+            query["attributeType"] = "string"
 
         if features is None:
             features = self.feature_flags
@@ -56,17 +47,16 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert response.status_code == 404, response.content
 
     def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
+        response = self.do_request(query={"itemType": "invalid"})
         assert response.status_code == 400, response.content
-        # This error message doesn't quite make sense because we're trying
-        # to transition from snake case to camel case
         assert response.data == {
-            "itemType": [ErrorDetail(string="This field is required.", code="required")],
-            "attributeType": [ErrorDetail(string="This field is required.", code="required")],
+            "itemType": [
+                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
+            ],
         }
 
     def test_no_projects(self):
-        response = self.do_request(query={"item_type": SupportedTraceItemType.LOGS.value})
+        response = self.do_request()
         assert response.status_code == 200, response.content
         assert response.data == []
 
@@ -95,7 +85,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         self.store_ourlogs(logs)
 
         # Test with empty prefix (should return all attributes)
-        response = self.do_request(query={"substring_match": ""})
+        response = self.do_request(query={"substringMatch": ""})
         assert response.status_code == 200, response.content
 
         keys = {item["key"] for item in response.data}
@@ -108,7 +98,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert "severity" in keys
 
         # With a prefix only match the attributes that start with "tes"
-        response = self.do_request(query={"substring_match": "tes"})
+        response = self.do_request(query={"substringMatch": "tes"})
         assert response.status_code == 200, response.content
         keys = {item["key"] for item in response.data}
         assert len(keys) == 3
@@ -179,36 +169,6 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
         assert keys == {"severity", "message", "project", "sentry.item_type2"}
 
 
-class OrganizationTraceItemAttributesEndpointLogsCamelCaseTest(
-    OrganizationTraceItemAttributesEndpointLogsTest
-):
-    def do_request(self, query=None, features=None, **kwargs):
-        if query is None:
-            query = {}
-        if "item_type" not in query:
-            query["item_type"] = self.item_type.value
-        if "attribute_type" not in query:
-            query["attribute_type"] = "string"
-
-        snake_to_camel_query(query)
-
-        if features is None:
-            features = self.feature_flags
-
-        with self.feature(features):
-            url = reverse(self.viewname, kwargs={"organization_id_or_slug": self.organization.slug})
-            return self.client.get(url, query, format="json", **kwargs)
-
-    def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "itemType": [
-                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
-            ],
-        }
-
-
 class OrganizationTraceItemAttributesEndpointSpansTest(
     OrganizationTraceItemAttributesEndpointTestBase, BaseSpansTestCase
 ):
@@ -220,17 +180,16 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert response.status_code == 404, response.content
 
     def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
+        response = self.do_request(query={"itemType": "invalid"})
         assert response.status_code == 400, response.content
-        # This error message doesn't quite make sense because we're trying
-        # to transition from snake case to camel case
         assert response.data == {
-            "itemType": [ErrorDetail(string="This field is required.", code="required")],
-            "attributeType": [ErrorDetail(string="This field is required.", code="required")],
+            "itemType": [
+                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
+            ],
         }
 
     def test_no_projects(self):
-        response = self.do_request(query={"item_type": SupportedTraceItemType.LOGS.value})
+        response = self.do_request()
         assert response.status_code == 200, response.content
         assert response.data == []
 
@@ -253,7 +212,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
         response = self.do_request(
             {
-                "attribute_type": "string",
+                "attributeType": "string",
             }
         )
         assert response.status_code == 200, response.data
@@ -294,7 +253,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
         response = self.do_request(
             {
-                "attribute_type": "number",
+                "attributeType": "number",
             }
         )
         assert response.status_code == 200, response.data
@@ -320,36 +279,6 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         ]
 
 
-class OrganizationTraceItemAttributesEndpointSpansCamelCaseTest(
-    OrganizationTraceItemAttributesEndpointSpansTest
-):
-    def do_request(self, query=None, features=None, **kwargs):
-        if query is None:
-            query = {}
-        if "item_type" not in query:
-            query["item_type"] = self.item_type.value
-        if "attribute_type" not in query:
-            query["attribute_type"] = "string"
-
-        snake_to_camel_query(query)
-
-        if features is None:
-            features = self.feature_flags
-
-        with self.feature(features):
-            url = reverse(self.viewname, kwargs={"organization_id_or_slug": self.organization.slug})
-            return self.client.get(url, query, format="json", **kwargs)
-
-    def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "itemType": [
-                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
-            ],
-        }
-
-
 class OrganizationTraceItemAttributeValuesEndpointBaseTest(APITestCase, SnubaTestCase):
     feature_flags: dict[str, bool]
     item_type: SupportedTraceItemType
@@ -364,10 +293,10 @@ class OrganizationTraceItemAttributeValuesEndpointBaseTest(APITestCase, SnubaTes
         if query is None:
             query = {}
 
-        if "item_type" not in query:
-            query["item_type"] = self.item_type.value
-        if "attribute_type" not in query:
-            query["attribute_type"] = "string"
+        if "itemType" not in query:
+            query["itemType"] = self.item_type.value
+        if "attributeType" not in query:
+            query["attributeType"] = "string"
 
         if features is None:
             features = self.feature_flags
@@ -391,13 +320,12 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
         assert response.status_code == 404, response.content
 
     def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
+        response = self.do_request(query={"itemType": "invalid"})
         assert response.status_code == 400, response.content
-        # This error message doesn't quite make sense because we're trying
-        # to transition from snake case to camel case
         assert response.data == {
-            "itemType": [ErrorDetail(string="This field is required.", code="required")],
-            "attributeType": [ErrorDetail(string="This field is required.", code="required")],
+            "itemType": [
+                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
+            ],
         }
 
     def test_no_projects(self):
@@ -438,40 +366,6 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
         assert all(item["key"] == "test1" for item in response.data)
 
 
-class OrganizationTraceItemAttributeValuesEndpointLogsCamelCaseTest(
-    OrganizationTraceItemAttributeValuesEndpointLogsTest
-):
-    def do_request(self, query=None, features=None, key=None, **kwargs):
-        if query is None:
-            query = {}
-
-        if "item_type" not in query:
-            query["item_type"] = self.item_type.value
-        if "attribute_type" not in query:
-            query["attribute_type"] = "string"
-
-        snake_to_camel_query(query)
-
-        if features is None:
-            features = self.feature_flags
-
-        with self.feature(features):
-            url = reverse(
-                self.viewname,
-                kwargs={"organization_id_or_slug": self.organization.slug, "key": key},
-            )
-            return self.client.get(url, query, format="json", **kwargs)
-
-    def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "itemType": [
-                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
-            ],
-        }
-
-
 class OrganizationTraceItemAttributeValuesEndpointSpansTest(
     OrganizationTraceItemAttributeValuesEndpointBaseTest, BaseSpansTestCase
 ):
@@ -483,13 +377,12 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
         assert response.status_code == 404, response.content
 
     def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
+        response = self.do_request(query={"itemType": "invalid"})
         assert response.status_code == 400, response.content
-        # This error message doesn't quite make sense because we're trying
-        # to transition from snake case to camel case
         assert response.data == {
-            "itemType": [ErrorDetail(string="This field is required.", code="required")],
-            "attributeType": [ErrorDetail(string="This field is required.", code="required")],
+            "itemType": [
+                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
+            ],
         }
 
     def test_no_projects(self):
@@ -611,7 +504,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
 
         key = "transaction"
 
-        response = self.do_request(query={"substring_match": "b"}, key=key)
+        response = self.do_request(query={"substringMatch": "b"}, key=key)
         assert response.status_code == 200, response.data
         assert response.data == [
             {
@@ -651,7 +544,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
 
         key = "transaction"
 
-        response = self.do_request(query={"substring_match": r"\*b"}, key=key)
+        response = self.do_request(query={"substringMatch": r"\*b"}, key=key)
         assert response.status_code == 200, response.data
         assert response.data == [
             {
@@ -741,7 +634,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
 
         key = "tag"
 
-        response = self.do_request(query={"substring_match": "b"}, key=key)
+        response = self.do_request(query={"substringMatch": "b"}, key=key)
         assert response.status_code == 200, response.data
         assert response.data == [
             {
@@ -782,7 +675,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
 
         key = "tag"
 
-        response = self.do_request(query={"substring_match": r"\*b"}, key=key)
+        response = self.do_request(query={"substringMatch": r"\*b"}, key=key)
         assert response.status_code == 200, response.data
         assert response.data == [
             {
@@ -885,7 +778,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
                 },
             ]
 
-            response = self.do_request(query={"substring_match": "ba"}, features=features, key=key)
+            response = self.do_request(query={"substringMatch": "ba"}, features=features, key=key)
             assert response.status_code == 200, response.data
             assert sorted(response.data, key=lambda v: v["value"]) == [
                 {
@@ -937,7 +830,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
             },
         ]
 
-        response = self.do_request(query={"substring_match": "99"}, features=features, key=key)
+        response = self.do_request(query={"substringMatch": "99"}, features=features, key=key)
         assert response.status_code == 200, response.data
         assert sorted(response.data, key=lambda v: v["value"]) == [
             {
@@ -1003,7 +896,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
             },
         ]
 
-        response = self.do_request(query={"substring_match": "in"}, key="span.status")
+        response = self.do_request(query={"substringMatch": "in"}, key="span.status")
         assert response.status_code == 200, response.data
         assert response.data == [
             {
@@ -1120,37 +1013,3 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
 
         response = self.do_request(key="tag")
         assert response.status_code == 400, response.data
-
-
-class OrganizationTraceItemAttributeValuesEndpointSpansCamelCaseTest(
-    OrganizationTraceItemAttributeValuesEndpointSpansTest
-):
-    def do_request(self, query=None, features=None, key=None, **kwargs):
-        if query is None:
-            query = {}
-
-        if "item_type" not in query:
-            query["item_type"] = self.item_type.value
-        if "attribute_type" not in query:
-            query["attribute_type"] = "string"
-
-        snake_to_camel_query(query)
-
-        if features is None:
-            features = self.feature_flags
-
-        with self.feature(features):
-            url = reverse(
-                self.viewname,
-                kwargs={"organization_id_or_slug": self.organization.slug, "key": key},
-            )
-            return self.client.get(url, query, format="json", **kwargs)
-
-    def test_invalid_item_type(self):
-        response = self.do_request(query={"item_type": "invalid"})
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "itemType": [
-                ErrorDetail(string='"invalid" is not a valid choice.', code="invalid_choice")
-            ],
-        }


### PR DESCRIPTION
The frontend cutover was done some time ago so it's safe to remove it now.