### PR TITLE
ref: make open PR comment workflow generic

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -28,14 +28,23 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
 from sentry.integrations.github.tasks.link_all_repos import link_all_repos
+from sentry.integrations.github.tasks.utils import GithubAPIErrorType
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.commit_context import (
+    OPEN_PR_MAX_FILES_CHANGED,
+    OPEN_PR_MAX_LINES_CHANGED,
+    OPEN_PR_METRICS_BASE,
     CommitContextIntegration,
+    OpenPRCommentWorkflow,
     PRCommentWorkflow,
+    PullRequestFile,
+    PullRequestIssue,
+    _open_pr_comment_log,
 )
+from sentry.integrations.source_code_management.language_parsers import PATCH_PARSERS
 from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
@@ -53,7 +62,8 @@ from sentry.pipeline import Pipeline, PipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.snuba.referrer import Referrer
-from sentry.types.referrer_ids import GITHUB_PR_BOT_REFERRER
+from sentry.templatetags.sentry_helpers import small_count
+from sentry.types.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER, GITHUB_PR_BOT_REFERRER
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 from sentry.web.frontend.base import determine_active_organization
@@ -340,6 +350,9 @@ class GitHubIntegration(
     def get_pr_comment_workflow(self) -> PRCommentWorkflow:
         return GitHubPRCommentWorkflow(integration=self)
 
+    def get_open_pr_comment_workflow(self) -> OpenPRCommentWorkflow:
+        return GitHubOpenPRCommentWorkflow(integration=self)
+
 
 MERGED_PR_COMMENT_BODY_TEMPLATE = """\
 ## Suspect Issues
@@ -405,6 +418,220 @@ class GitHubPRCommentWorkflow(PRCommentWorkflow):
             ]
 
         return comment_data
+
+
+OPEN_PR_COMMENT_BODY_TEMPLATE = """\
+## 🔍 Existing Issues For Review
+Your pull request is modifying functions with the following pre-existing issues:
+
+{issue_tables}
+---
+
+<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+
+OPEN_PR_ISSUE_TABLE_TEMPLATE = """\
+📄 File: **{filename}**
+
+| Function | Unhandled Issue |
+| :------- | :----- |
+{issue_rows}"""
+
+OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """\
+<details>
+<summary><b>📄 File: {filename} (Click to Expand)</b></summary>
+
+| Function | Unhandled Issue |
+| :------- | :----- |
+{issue_rows}
+</details>"""
+
+OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
+
+
+class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
+    organization_option_key = "sentry:github_open_pr_bot"
+    referrer = Referrer.GITHUB_PR_COMMENT_BOT
+    referrer_id = GITHUB_OPEN_PR_BOT_REFERRER
+
+    def safe_for_comment(self, repo: Repository, pr: PullRequest) -> list[PullRequestFile]:
+        client = self.integration.get_client()
+        logger.info(
+            _open_pr_comment_log(
+                integration_name=self.integration.integration_name, suffix="check_safe_for_comment"
+            )
+        )
+        try:
+            pr_files = client.get_pullrequest_files(repo=repo.name, pull_number=pr.key)
+        except ApiError as e:
+            logger.info(
+                _open_pr_comment_log(
+                    integration_name=self.integration.integration_name, suffix="api_error"
+                )
+            )
+            if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(
+                        integration=self.integration.integration_name, key="api_error"
+                    ),
+                    tags={"type": GithubAPIErrorType.RATE_LIMITED.value, "code": e.code},
+                )
+            elif e.code == 404:
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(
+                        integration=self.integration.integration_name, key="api_error"
+                    ),
+                    tags={"type": GithubAPIErrorType.MISSING_PULL_REQUEST.value, "code": e.code},
+                )
+            else:
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(
+                        integration=self.integration.integration_name, key="api_error"
+                    ),
+                    tags={"type": GithubAPIErrorType.UNKNOWN.value, "code": e.code},
+                )
+                logger.exception(
+                    _open_pr_comment_log(
+                        integration_name=self.integration.integration_name,
+                        suffix="unknown_api_error",
+                    ),
+                    extra={"error": str(e)},
+                )
+            return []
+
+        changed_file_count = 0
+        changed_lines_count = 0
+        filtered_pr_files = []
+
+        patch_parsers = PATCH_PARSERS
+        # NOTE: if we are testing beta patch parsers, add check here
+
+        for file in pr_files:
+            filename = file["filename"]
+            # we only count the file if it's modified and if the file extension is in the list of supported file extensions
+            # we cannot look at deleted or newly added files because we cannot extract functions from the diffs
+            if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
+                continue
+
+            changed_file_count += 1
+            changed_lines_count += file["changes"]
+            filtered_pr_files.append(file)
+
+            if changed_file_count > OPEN_PR_MAX_FILES_CHANGED:
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(
+                        integration=self.integration.integration_name, key="rejected_comment"
+                    ),
+                    tags={"reason": "too_many_files"},
+                )
+                return []
+            if changed_lines_count > OPEN_PR_MAX_LINES_CHANGED:
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(
+                        integration=self.integration.integration_name, key="rejected_comment"
+                    ),
+                    tags={"reason": "too_many_lines"},
+                )
+                return []
+
+        return filtered_pr_files
+
+    def get_pr_files(self, pr_files: list[dict[str, Any]]) -> list[PullRequestFile]:
+        # new files will not have sentry issues associated with them
+        # only fetch Python files
+        pullrequest_files = [
+            PullRequestFile(filename=file["filename"], patch=file["patch"])
+            for file in pr_files
+            if "patch" in file
+        ]
+
+        logger.info(
+            _open_pr_comment_log(
+                integration_name=self.integration.integration_name,
+                suffix="pr_filenames",
+            ),
+            extra={"count": len(pullrequest_files)},
+        )
+
+        return pullrequest_files
+
+    def get_pr_files_safe_for_comment(
+        self, repo: Repository, pr: PullRequest
+    ) -> list[PullRequestFile]:
+        pr_files = self.safe_for_comment(repo=repo, pr=pr)
+
+        if len(pr_files) == 0:
+            logger.info(
+                _open_pr_comment_log(
+                    integration_name=self.integration.integration_name,
+                    suffix="not_safe_for_comment",
+                ),
+                extra={"file_count": len(pr_files)},
+            )
+            metrics.incr(
+                OPEN_PR_METRICS_BASE.format(
+                    integration=self.integration.integration_name, key="error"
+                ),
+                tags={"type": "unsafe_for_comment"},
+            )
+            return []
+
+        return self.get_pr_files(pr_files)
+
+    def get_comment_data(self, comment_body: str) -> dict[str, Any]:
+        return {
+            "body": comment_body,
+        }
+
+    @staticmethod
+    def format_comment_url(url: str, referrer: str) -> str:
+        return url + "?referrer=" + referrer
+
+    @staticmethod
+    def format_open_pr_comment(issue_tables: list[str]) -> str:
+        return OPEN_PR_COMMENT_BODY_TEMPLATE.format(issue_tables="\n".join(issue_tables))
+
+    @staticmethod
+    def format_open_pr_comment_subtitle(title_length, subtitle):
+        # the title length + " " + subtitle should be <= 52
+        subtitle_length = OPEN_PR_ISSUE_DESCRIPTION_LENGTH - title_length - 1
+        return (
+            subtitle[: subtitle_length - 3] + "..." if len(subtitle) > subtitle_length else subtitle
+        )
+
+    def format_issue_table(
+        self,
+        diff_filename: str,
+        issues: list[PullRequestIssue],
+        patch_parsers: dict[str, Any],
+        toggle: bool,
+    ) -> str:
+        language_parser = patch_parsers.get(diff_filename.split(".")[-1], None)
+
+        if not language_parser:
+            return ""
+
+        issue_row_template = language_parser.issue_row_template
+
+        issue_rows = "\n".join(
+            [
+                issue_row_template.format(
+                    title=issue.title,
+                    subtitle=self.format_open_pr_comment_subtitle(len(issue.title), issue.subtitle),
+                    url=self.format_comment_url(issue.url, GITHUB_OPEN_PR_BOT_REFERRER),
+                    event_count=small_count(issue.event_count),
+                    function_name=issue.function_name,
+                    affected_users=small_count(issue.affected_users),
+                )
+                for issue in issues
+            ]
+        )
+
+        if toggle:
+            return OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE.format(
+                filename=diff_filename, issue_rows=issue_rows
+            )
+
+        return OPEN_PR_ISSUE_TABLE_TEMPLATE.format(filename=diff_filename, issue_rows=issue_rows)
 
 
 class GitHubIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/github/tasks/open_pr_comment.py
+++ b/src/sentry/integrations/github/tasks/open_pr_comment.py
@@ -2,410 +2,27 @@ from __future__ import annotations
 
 import itertools
 import logging
-from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from django.db.models import Value
-from django.db.models.functions import StrIndex
-from snuba_sdk import (
-    BooleanCondition,
-    BooleanOp,
-    Column,
-    Condition,
-    Direction,
-    Entity,
-    Function,
-    Op,
-    OrderBy,
-    Query,
-)
-from snuba_sdk import Request as SnubaRequest
-
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
-from sentry.integrations.github.client import GitHubApiClient
-from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
-from sentry.integrations.github.tasks.utils import (
-    GithubAPIErrorType,
-    PullRequestFile,
-    PullRequestIssue,
-)
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
-from sentry.integrations.source_code_management.constants import STACKFRAME_COUNT
+from sentry.integrations.source_code_management.commit_context import (
+    OPEN_PR_METRICS_BASE,
+    CommitContextIntegration,
+    _open_pr_comment_log,
+)
 from sentry.integrations.source_code_management.language_parsers import PATCH_PARSERS
-from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.models.pullrequest import CommentType, PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import integrations_tasks
-from sentry.templatetags.sentry_helpers import small_count
-from sentry.types.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER
 from sentry.utils import metrics
-from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
-
-OPEN_PR_METRICS_BASE = "{integration}.open_pr_comment.{key}"
-
-# Caps the number of files that can be modified in a PR to leave a comment
-OPEN_PR_MAX_FILES_CHANGED = 7
-# Caps the number of lines that can be modified in a PR to leave a comment
-OPEN_PR_MAX_LINES_CHANGED = 500
-
-OPEN_PR_COMMENT_BODY_TEMPLATE = """\
-## 🔍 Existing Issues For Review
-Your pull request is modifying functions with the following pre-existing issues:
-
-{issue_tables}
----
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
-
-OPEN_PR_ISSUE_TABLE_TEMPLATE = """\
-📄 File: **{filename}**
-
-| Function | Unhandled Issue |
-| :------- | :----- |
-{issue_rows}"""
-
-OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """\
-<details>
-<summary><b>📄 File: {filename} (Click to Expand)</b></summary>
-
-| Function | Unhandled Issue |
-| :------- | :----- |
-{issue_rows}
-</details>"""
-
-OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
-
-MAX_RECENT_ISSUES = 5000
-
-
-def format_comment_url(url: str, referrer: str) -> str:
-    return url + "?referrer=" + referrer
-
-
-def format_open_pr_comment(issue_tables: list[str]) -> str:
-    return OPEN_PR_COMMENT_BODY_TEMPLATE.format(issue_tables="\n".join(issue_tables))
-
-
-def format_open_pr_comment_subtitle(title_length, subtitle):
-    # the title length + " " + subtitle should be <= 52
-    subtitle_length = OPEN_PR_ISSUE_DESCRIPTION_LENGTH - title_length - 1
-    return subtitle[: subtitle_length - 3] + "..." if len(subtitle) > subtitle_length else subtitle
-
-
-# for a single file, create a table
-def format_issue_table(
-    diff_filename: str, issues: list[PullRequestIssue], patch_parsers: dict[str, Any], toggle: bool
-) -> str:
-    language_parser = patch_parsers.get(diff_filename.split(".")[-1], None)
-
-    if not language_parser:
-        return ""
-
-    issue_row_template = language_parser.issue_row_template
-
-    issue_rows = "\n".join(
-        [
-            issue_row_template.format(
-                title=issue.title,
-                subtitle=format_open_pr_comment_subtitle(len(issue.title), issue.subtitle),
-                url=format_comment_url(issue.url, GITHUB_OPEN_PR_BOT_REFERRER),
-                event_count=small_count(issue.event_count),
-                function_name=issue.function_name,
-                affected_users=small_count(issue.affected_users),
-            )
-            for issue in issues
-        ]
-    )
-
-    if toggle:
-        return OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE.format(
-            filename=diff_filename, issue_rows=issue_rows
-        )
-
-    return OPEN_PR_ISSUE_TABLE_TEMPLATE.format(filename=diff_filename, issue_rows=issue_rows)
-
-
-# for a single file, get the contents
-def get_issue_table_contents(issue_list: list[dict[str, Any]]) -> list[PullRequestIssue]:
-    group_id_to_info = {}
-    for issue in issue_list:
-        group_id = issue["group_id"]
-        group_id_to_info[group_id] = dict(filter(lambda k: k[0] != "group_id", issue.items()))
-
-    issues = Group.objects.filter(id__in=list(group_id_to_info.keys())).all()
-
-    pull_request_issues = [
-        PullRequestIssue(
-            title=issue.title,
-            subtitle=issue.culprit,
-            url=issue.get_absolute_url(),
-            affected_users=issue.count_users_seen(
-                referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_OPEN_PR_COMMENT.value
-            ),
-            event_count=group_id_to_info[issue.id]["event_count"],
-            function_name=group_id_to_info[issue.id]["function_name"],
-        )
-        for issue in issues
-    ]
-    pull_request_issues.sort(key=lambda k: k.event_count or 0, reverse=True)
-
-    return pull_request_issues
-
-
-# TODO(cathy): Change the client typing to allow for multiple SCM Integrations
-def safe_for_comment(
-    gh_client: GitHubApiClient, repository: Repository, pull_request: PullRequest
-) -> list[dict[str, str]]:
-    logger.info("github.open_pr_comment.check_safe_for_comment")
-    try:
-        pr_files = gh_client.get_pullrequest_files(
-            repo=repository.name, pull_number=pull_request.key
-        )
-    except ApiError as e:
-        logger.info("github.open_pr_comment.api_error")
-        if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
-            metrics.incr(
-                OPEN_PR_METRICS_BASE.format(integration="github", key="api_error"),
-                tags={"type": GithubAPIErrorType.RATE_LIMITED.value, "code": e.code},
-            )
-        elif e.code == 404:
-            metrics.incr(
-                OPEN_PR_METRICS_BASE.format(integration="github", key="api_error"),
-                tags={"type": GithubAPIErrorType.MISSING_PULL_REQUEST.value, "code": e.code},
-            )
-        else:
-            metrics.incr(
-                OPEN_PR_METRICS_BASE.format(integration="github", key="api_error"),
-                tags={"type": GithubAPIErrorType.UNKNOWN.value, "code": e.code},
-            )
-            logger.exception("github.open_pr_comment.unknown_api_error", extra={"error": str(e)})
-        return []
-
-    changed_file_count = 0
-    changed_lines_count = 0
-    filtered_pr_files = []
-
-    patch_parsers = PATCH_PARSERS
-    # NOTE: if we are testing beta patch parsers, add check here
-
-    for file in pr_files:
-        filename = file["filename"]
-        # we only count the file if it's modified and if the file extension is in the list of supported file extensions
-        # we cannot look at deleted or newly added files because we cannot extract functions from the diffs
-        if file["status"] != "modified" or filename.split(".")[-1] not in patch_parsers:
-            continue
-
-        changed_file_count += 1
-        changed_lines_count += file["changes"]
-        filtered_pr_files.append(file)
-
-        if changed_file_count > OPEN_PR_MAX_FILES_CHANGED:
-            metrics.incr(
-                OPEN_PR_METRICS_BASE.format(integration="github", key="rejected_comment"),
-                tags={"reason": "too_many_files"},
-            )
-            return []
-        if changed_lines_count > OPEN_PR_MAX_LINES_CHANGED:
-            metrics.incr(
-                OPEN_PR_METRICS_BASE.format(integration="github", key="rejected_comment"),
-                tags={"reason": "too_many_lines"},
-            )
-            return []
-
-    return filtered_pr_files
-
-
-def get_pr_files(pr_files: list[dict[str, str]]) -> list[PullRequestFile]:
-    # new files will not have sentry issues associated with them
-    # only fetch Python files
-    pullrequest_files = [
-        PullRequestFile(filename=file["filename"], patch=file["patch"])
-        for file in pr_files
-        if "patch" in file
-    ]
-
-    logger.info("github.open_pr_comment.pr_filenames", extra={"count": len(pullrequest_files)})
-
-    return pullrequest_files
-
-
-def get_projects_and_filenames_from_source_file(
-    org_id: int,
-    repo_id: int,
-    pr_filename: str,
-) -> tuple[set[Project], set[str]]:
-    # fetch the code mappings in which the source_root is a substring at the start of pr_filename
-    code_mappings = (
-        RepositoryProjectPathConfig.objects.filter(
-            organization_id=org_id,
-            repository_id=repo_id,
-        )
-        .annotate(substring_match=StrIndex(Value(pr_filename), "source_root"))
-        .filter(substring_match=1)
-    )
-
-    project_list: set[Project] = set()
-    sentry_filenames = set()
-
-    if len(code_mappings):
-        for code_mapping in code_mappings:
-            project_list.add(code_mapping.project)
-            sentry_filenames.add(
-                pr_filename.replace(code_mapping.source_root, code_mapping.stack_root, 1)
-            )
-    return project_list, sentry_filenames
-
-
-def get_top_5_issues_by_count_for_file(
-    projects: list[Project], sentry_filenames: list[str], function_names: list[str]
-) -> list[dict[str, Any]]:
-    """
-    Given a list of projects, Github filenames reverse-codemapped into filenames in Sentry,
-    and function names representing the list of functions changed in a PR file, return a
-    sublist of the top 5 recent unhandled issues ordered by event count.
-    """
-    if not len(projects):
-        return []
-
-    patch_parsers = PATCH_PARSERS
-    # NOTE: if we are testing beta patch parsers, add check here
-
-    # fetches the appropriate parser for formatting the snuba query given the file extension
-    # the extension is never replaced in reverse codemapping
-    language_parser = patch_parsers.get(sentry_filenames[0].split(".")[-1], None)
-
-    if not language_parser:
-        return []
-
-    group_ids = list(
-        Group.objects.filter(
-            first_seen__gte=datetime.now(UTC) - timedelta(days=90),
-            last_seen__gte=datetime.now(UTC) - timedelta(days=14),
-            status=GroupStatus.UNRESOLVED,
-            project__in=projects,
-        )
-        .order_by("-times_seen")
-        .values_list("id", flat=True)
-    )[:MAX_RECENT_ISSUES]
-    project_ids = [p.id for p in projects]
-
-    multi_if = language_parser.generate_multi_if(function_names)
-
-    # fetch the count of events for each group_id
-    subquery = (
-        Query(Entity("events"))
-        .set_select(
-            [
-                Column("title"),
-                Column("culprit"),
-                Column("group_id"),
-                Function("count", [], "event_count"),
-                Function(
-                    "multiIf",
-                    multi_if,
-                    "function_name",
-                ),
-            ]
-        )
-        .set_groupby(
-            [
-                Column("title"),
-                Column("culprit"),
-                Column("group_id"),
-                Column("exception_frames.function"),
-            ]
-        )
-        .set_where(
-            [
-                Condition(Column("project_id"), Op.IN, project_ids),
-                Condition(Column("group_id"), Op.IN, group_ids),
-                Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
-                Condition(Column("timestamp"), Op.LT, datetime.now()),
-                # NOTE: ideally this would follow suspect commit logic
-                BooleanCondition(
-                    BooleanOp.OR,
-                    [
-                        BooleanCondition(
-                            BooleanOp.AND,
-                            [
-                                Condition(
-                                    Function(
-                                        "arrayElement",
-                                        (Column("exception_frames.filename"), i),
-                                    ),
-                                    Op.IN,
-                                    sentry_filenames,
-                                ),
-                                language_parser.generate_function_name_conditions(
-                                    function_names, i
-                                ),
-                            ],
-                        )
-                        for i in range(-STACKFRAME_COUNT, 0)  # first n frames
-                    ],
-                ),
-                Condition(Function("notHandled", []), Op.EQ, 1),
-            ]
-        )
-        .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
-    )
-
-    # filter on the subquery to squash group_ids with the same title and culprit
-    # return the group_id with the greatest count of events
-    query = (
-        Query(subquery)
-        .set_select(
-            [
-                Column("function_name"),
-                Function(
-                    "arrayElement",
-                    (Function("groupArray", [Column("group_id")]), 1),
-                    "group_id",
-                ),
-                Function(
-                    "arrayElement",
-                    (Function("groupArray", [Column("event_count")]), 1),
-                    "event_count",
-                ),
-            ]
-        )
-        .set_groupby(
-            [
-                Column("title"),
-                Column("culprit"),
-                Column("function_name"),
-            ]
-        )
-        .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
-        .set_limit(5)
-    )
-
-    request = SnubaRequest(
-        dataset=Dataset.Events.value,
-        app_id="default",
-        tenant_ids={"organization_id": projects[0].organization_id},
-        query=query,
-    )
-
-    try:
-        return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
-    except Exception:
-        logger.exception(
-            "github.open_pr_comment.snuba_query_error", extra={"query": request.to_dict()["query"]}
-        )
-        return []
 
 
 @instrumented_task(
@@ -416,16 +33,19 @@ def get_top_5_issues_by_count_for_file(
     ),
 )
 def open_pr_comment_workflow(pr_id: int) -> None:
-    logger.info("github.open_pr_comment.start_workflow")
+    # TODO(jianyuan): Move this to source code management tasks
+    integration_name = "github"
+
+    logger.info(_open_pr_comment_log(integration_name=integration_name, suffix="start_workflow"))
 
     # CHECKS
     # check PR exists to get PR key
     try:
         pull_request = PullRequest.objects.get(id=pr_id)
     except PullRequest.DoesNotExist:
-        logger.info("github.open_pr_comment.pr_missing")
+        logger.info(_open_pr_comment_log(integration_name=integration_name, suffix="pr_missing"))
         metrics.incr(
-            OPEN_PR_METRICS_BASE.format(integration="github", key="error"),
+            OPEN_PR_METRICS_BASE.format(integration=integration_name, key="error"),
             tags={"type": "missing_pr"},
         )
         return
@@ -433,11 +53,14 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     # check org option
     org_id = pull_request.organization_id
     try:
-        Organization.objects.get_from_cache(id=org_id)
+        organization = Organization.objects.get_from_cache(id=org_id)
+        assert isinstance(organization, Organization)
     except Organization.DoesNotExist:
-        logger.exception("github.open_pr_comment.org_missing")
+        logger.exception(
+            _open_pr_comment_log(integration_name=integration_name, suffix="org_missing")
+        )
         metrics.incr(
-            OPEN_PR_METRICS_BASE.format(integration="github", key="error"),
+            OPEN_PR_METRICS_BASE.format(integration=integration_name, key="error"),
             tags={"type": "missing_org"},
         )
         return
@@ -446,9 +69,12 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     try:
         repo = Repository.objects.get(id=pull_request.repository_id)
     except Repository.DoesNotExist:
-        logger.info("github.open_pr_comment.repo_missing", extra={"organization_id": org_id})
+        logger.info(
+            _open_pr_comment_log(integration_name=integration_name, suffix="repo_missing"),
+            extra={"organization_id": organization.id},
+        )
         metrics.incr(
-            OPEN_PR_METRICS_BASE.format(integration="github", key="error"),
+            OPEN_PR_METRICS_BASE.format(integration=integration_name, key="error"),
             tags={"type": "missing_repo"},
         )
         return
@@ -458,34 +84,27 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         integration_id=repo.integration_id, status=ObjectStatus.ACTIVE
     )
     if not integration:
-        logger.info("github.open_pr_comment.integration_missing", extra={"organization_id": org_id})
+        logger.info(
+            _open_pr_comment_log(integration_name=integration_name, suffix="integration_missing"),
+            extra={"organization_id": organization.id},
+        )
         metrics.incr(
-            OPEN_PR_METRICS_BASE.format(integration="github", key="error"),
+            OPEN_PR_METRICS_BASE.format(integration=integration_name, key="error"),
             tags={"type": "missing_integration"},
         )
         return
 
-    installation = integration.get_installation(organization_id=org_id)
+    installation = integration.get_installation(organization_id=organization.id)
     assert isinstance(installation, CommitContextIntegration)
 
-    client = installation.get_client()
+    open_pr_comment_workflow = installation.get_open_pr_comment_workflow()
 
     # CREATING THE COMMENT
 
     # fetch the files in the PR and determine if it is safe to comment
-    pr_files = safe_for_comment(gh_client=client, repository=repo, pull_request=pull_request)
-
-    if len(pr_files) == 0:
-        logger.info(
-            "github.open_pr_comment.not_safe_for_comment", extra={"file_count": len(pr_files)}
-        )
-        metrics.incr(
-            OPEN_PR_METRICS_BASE.format(integration="github", key="error"),
-            tags={"type": "unsafe_for_comment"},
-        )
-        return
-
-    pullrequest_files = get_pr_files(pr_files)
+    pullrequest_files = open_pr_comment_workflow.get_pr_files_safe_for_comment(
+        repo=repo, pr=pull_request
+    )
 
     issue_table_contents = {}
     top_issues_per_file = []
@@ -496,15 +115,17 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     file_extensions = set()
     # fetch issues related to the files
     for file in pullrequest_files:
-        projects, sentry_filenames = get_projects_and_filenames_from_source_file(
-            org_id, repo.id, file.filename
+        projects, sentry_filenames = (
+            open_pr_comment_workflow.get_projects_and_filenames_from_source_file(
+                organization=organization, repo=repo, pr_filename=file.filename
+            )
         )
         if not len(projects) or not len(sentry_filenames):
             continue
 
         file_extension = file.filename.split(".")[-1]
         logger.info(
-            "github.open_pr_comment.file_extension",
+            _open_pr_comment_log(integration_name=integration_name, suffix="file_extension"),
             extra={
                 "organization_id": org_id,
                 "repository_id": repo.id,
@@ -515,10 +136,11 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         language_parser = patch_parsers.get(file.filename.split(".")[-1], None)
         if not language_parser:
             logger.info(
-                "github.open_pr_comment.missing_parser", extra={"extension": file_extension}
+                _open_pr_comment_log(integration_name=integration_name, suffix="missing_parser"),
+                extra={"extension": file_extension},
             )
             metrics.incr(
-                OPEN_PR_METRICS_BASE.format(integration="github", key="missing_parser"),
+                OPEN_PR_METRICS_BASE.format(integration=integration_name, key="missing_parser"),
                 tags={"extension": file_extension},
             )
             continue
@@ -527,7 +149,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
 
         if file_extension in ["js", "jsx"]:
             logger.info(
-                "github.open_pr_comment.javascript",
+                _open_pr_comment_log(integration_name=integration_name, suffix="javascript"),
                 extra={
                     "organization_id": org_id,
                     "repository_id": repo.id,
@@ -538,7 +160,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
 
         if file_extension == ["php"]:
             logger.info(
-                "github.open_pr_comment.php",
+                _open_pr_comment_log(integration_name=integration_name, suffix="php"),
                 extra={
                     "organization_id": org_id,
                     "repository_id": repo.id,
@@ -549,7 +171,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
 
         if file_extension == ["rb"]:
             logger.info(
-                "github.open_pr_comment.ruby",
+                _open_pr_comment_log(integration_name=integration_name, suffix="ruby"),
                 extra={
                     "organization_id": org_id,
                     "repository_id": repo.id,
@@ -561,8 +183,10 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         if not len(function_names):
             continue
 
-        top_issues = get_top_5_issues_by_count_for_file(
-            list(projects), list(sentry_filenames), list(function_names)
+        top_issues = open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=list(projects),
+            sentry_filenames=list(sentry_filenames),
+            function_names=list(function_names),
         )
         if not len(top_issues):
             continue
@@ -570,12 +194,14 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         top_issues_per_file.append(top_issues)
         file_extensions.add(file_extension)
 
-        issue_table_contents[file.filename] = get_issue_table_contents(top_issues)
+        issue_table_contents[file.filename] = open_pr_comment_workflow.get_issue_table_contents(
+            top_issues
+        )
 
     if not len(issue_table_contents):
-        logger.info("github.open_pr_comment.no_issues")
+        logger.info(_open_pr_comment_log(integration_name=integration_name, suffix="no_issues"))
         # don't leave a comment if no issues for files in PR
-        metrics.incr(OPEN_PR_METRICS_BASE.format(integration="github", key="no_issues"))
+        metrics.incr(OPEN_PR_METRICS_BASE.format(integration=integration_name, key="no_issues"))
         return
 
     # format issues per file into comment
@@ -589,19 +215,25 @@ def open_pr_comment_workflow(pr_id: int) -> None:
             continue
 
         if first_table:
-            issue_table = format_issue_table(
-                pr_filename, issue_table_content, patch_parsers, toggle=False
+            issue_table = open_pr_comment_workflow.format_issue_table(
+                diff_filename=pr_filename,
+                issues=issue_table_content,
+                patch_parsers=patch_parsers,
+                toggle=False,
             )
             first_table = False
         else:
             # toggle all tables but the first one
-            issue_table = format_issue_table(
-                pr_filename, issue_table_content, patch_parsers, toggle=True
+            issue_table = open_pr_comment_workflow.format_issue_table(
+                diff_filename=pr_filename,
+                issues=issue_table_content,
+                patch_parsers=patch_parsers,
+                toggle=True,
             )
 
         issue_tables.append(issue_table)
 
-    comment_body = format_open_pr_comment(issue_tables)
+    comment_body = open_pr_comment_workflow.format_open_pr_comment(issue_tables)
 
     # list all issues in the comment
     issue_list: list[dict[str, Any]] = list(itertools.chain.from_iterable(top_issues_per_file))
@@ -615,11 +247,13 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     ]
     language = languages[0] if len(languages) else "not found"
 
+    comment_data = open_pr_comment_workflow.get_comment_data(comment_body=comment_body)
+
     try:
         installation.create_or_update_comment(
             repo=repo,
             pr=pull_request,
-            comment_data={"body": comment_body},
+            comment_data=comment_data,
             issue_list=issue_id_list,
             comment_type=CommentType.OPEN_PR,
             metrics_base=OPEN_PR_METRICS_BASE,
@@ -632,7 +266,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
             return
 
         metrics.incr(
-            OPEN_PR_METRICS_BASE.format(integration="github", key="error"),
+            OPEN_PR_METRICS_BASE.format(integration=integration_name, key="error"),
             tags={"type": "api_error"},
         )
         raise

--- a/src/sentry/integrations/github/tasks/open_pr_comment.py
+++ b/src/sentry/integrations/github/tasks/open_pr_comment.py
@@ -97,7 +97,14 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     installation = integration.get_installation(organization_id=organization.id)
     assert isinstance(installation, CommitContextIntegration)
 
-    open_pr_comment_workflow = installation.get_open_pr_comment_workflow()
+    # TODO(jianyuan): Remove this once we have implemented the new open_pr_comment_workflow for GH Enterprise
+    try:
+        open_pr_comment_workflow = installation.get_open_pr_comment_workflow()
+    except NotImplementedError:
+        logger.info(
+            _open_pr_comment_log(integration_name=integration_name, suffix="not_implemented")
+        )
+        return
 
     # CREATING THE COMMENT
 

--- a/src/sentry/integrations/github/tasks/utils.py
+++ b/src/sentry/integrations/github/tasks/utils.py
@@ -1,24 +1,4 @@
-import logging
-from dataclasses import dataclass
 from enum import Enum
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass
-class PullRequestIssue:
-    title: str
-    subtitle: str | None
-    url: str
-    affected_users: int | None = None
-    event_count: int | None = None
-    function_name: str | None = None
-
-
-@dataclass
-class PullRequestFile:
-    filename: str
-    patch: str
 
 
 class GithubAPIErrorType(Enum):

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -557,7 +557,8 @@ class PullRequestEventWebhook(GitHubWebhook):
                 },
             )
 
-            if action == "opened" and created:
+            # TODO(jianyuan): Remove self.provider == "github" once we have implemented the new open_pr_comment_workflow for GH Enterprise
+            if action == "opened" and created and self.provider == "github":
                 if not OrganizationOption.objects.get_value(
                     organization=organization,
                     key="sentry:github_open_pr_bot",

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -4,19 +4,34 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 import sentry_sdk
 from django.db import connection
+from django.db.models import Value
+from django.db.models.functions import StrIndex
 from django.utils import timezone as django_timezone
-from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query
+from snuba_sdk import (
+    BooleanCondition,
+    BooleanOp,
+    Column,
+    Condition,
+    Direction,
+    Entity,
+    Function,
+    Op,
+    OrderBy,
+    Query,
+)
 from snuba_sdk import Request as SnubaRequest
 
 from sentry import analytics
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.source_code_management.constants import STACKFRAME_COUNT
+from sentry.integrations.source_code_management.language_parsers import PATCH_PARSERS
 from sentry.integrations.source_code_management.metrics import (
     CommitContextHaltReason,
     CommitContextIntegrationInteractionEvent,
@@ -25,7 +40,7 @@ from sentry.integrations.source_code_management.metrics import (
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.locks import locks
 from sentry.models.commit import Commit
-from sentry.models.group import Group
+from sentry.models.group import Group, GroupStatus
 from sentry.models.groupowner import GroupOwner
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
@@ -65,11 +80,22 @@ def _pr_comment_log(integration_name: str, suffix: str) -> str:
     return f"{integration_name}.pr_comment.{suffix}"
 
 
+def _open_pr_comment_log(integration_name: str, suffix: str) -> str:
+    return f"{integration_name}.open_pr_comment.{suffix}"
+
+
 PR_COMMENT_TASK_TTL = timedelta(minutes=5).total_seconds()
 PR_COMMENT_WINDOW = 14  # days
 
 MERGED_PR_METRICS_BASE = "{integration}.pr_comment.{key}"
+OPEN_PR_METRICS_BASE = "{integration}.open_pr_comment.{key}"
 MAX_SUSPECT_COMMITS = 1000
+
+OPEN_PR_MAX_RECENT_ISSUES = 5000
+# Caps the number of files that can be modified in a PR to leave a comment
+OPEN_PR_MAX_FILES_CHANGED = 7
+# Caps the number of lines that can be modified in a PR to leave a comment
+OPEN_PR_MAX_LINES_CHANGED = 500
 
 
 @dataclass
@@ -93,6 +119,22 @@ class CommitInfo:
 @dataclass
 class FileBlameInfo(SourceLineInfo):
     commit: CommitInfo
+
+
+@dataclass
+class PullRequestIssue:
+    title: str
+    subtitle: str | None
+    url: str
+    affected_users: int | None = None
+    event_count: int | None = None
+    function_name: str | None = None
+
+
+@dataclass
+class PullRequestFile:
+    filename: str
+    patch: str
 
 
 class CommitContextIntegration(ABC):
@@ -397,6 +439,9 @@ class CommitContextIntegration(ABC):
     def get_pr_comment_workflow(self) -> PRCommentWorkflow:
         raise NotImplementedError
 
+    def get_open_pr_comment_workflow(self) -> OpenPRCommentWorkflow:
+        raise NotImplementedError
+
 
 class CommitContextClient(ABC):
     base_url: str
@@ -519,3 +564,252 @@ class PRCommentWorkflow(ABC):
             ),
         )
         return raw_snql_query(request, referrer=self.referrer.value)["data"]
+
+
+class OpenPRCommentWorkflow(ABC):
+    def __init__(self, integration: CommitContextIntegration):
+        self.integration = integration
+
+    @property
+    @abstractmethod
+    def organization_option_key(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def referrer(self) -> Referrer:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def referrer_id(self) -> str:
+        raise NotImplementedError
+
+    def queue_task(self, pr: PullRequest) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_pr_files_safe_for_comment(
+        self, repo: Repository, pr: PullRequest
+    ) -> list[PullRequestFile]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_comment_data(self, comment_body: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def get_projects_and_filenames_from_source_file(
+        self,
+        organization: Organization,
+        repo: Repository,
+        pr_filename: str,
+    ) -> tuple[set[Project], set[str]]:
+        # fetch the code mappings in which the source_root is a substring at the start of pr_filename
+        code_mappings = (
+            RepositoryProjectPathConfig.objects.filter(
+                organization_id=organization.id,
+                repository_id=repo.id,
+            )
+            .annotate(substring_match=StrIndex(Value(pr_filename), "source_root"))
+            .filter(substring_match=1)
+        )
+
+        project_list: set[Project] = set()
+        sentry_filenames = set()
+
+        if len(code_mappings):
+            for code_mapping in code_mappings:
+                project_list.add(code_mapping.project)
+                sentry_filenames.add(
+                    pr_filename.replace(code_mapping.source_root, code_mapping.stack_root, 1)
+                )
+        return project_list, sentry_filenames
+
+    def get_top_5_issues_by_count_for_file(
+        self, projects: list[Project], sentry_filenames: list[str], function_names: list[str]
+    ) -> list[dict[str, Any]]:
+        """
+        Given a list of projects, Github filenames reverse-codemapped into filenames in Sentry,
+        and function names representing the list of functions changed in a PR file, return a
+        sublist of the top 5 recent unhandled issues ordered by event count.
+        """
+        if not len(projects):
+            return []
+
+        patch_parsers = PATCH_PARSERS
+        # NOTE: if we are testing beta patch parsers, add check here
+
+        # fetches the appropriate parser for formatting the snuba query given the file extension
+        # the extension is never replaced in reverse codemapping
+        language_parser = patch_parsers.get(sentry_filenames[0].split(".")[-1], None)
+
+        if not language_parser:
+            return []
+
+        group_ids = list(
+            Group.objects.filter(
+                first_seen__gte=datetime.now(UTC) - timedelta(days=90),
+                last_seen__gte=datetime.now(UTC) - timedelta(days=14),
+                status=GroupStatus.UNRESOLVED,
+                project__in=projects,
+            )
+            .order_by("-times_seen")
+            .values_list("id", flat=True)
+        )[:OPEN_PR_MAX_RECENT_ISSUES]
+        project_ids = [p.id for p in projects]
+
+        multi_if = language_parser.generate_multi_if(function_names)
+
+        # fetch the count of events for each group_id
+        subquery = (
+            Query(Entity("events"))
+            .set_select(
+                [
+                    Column("title"),
+                    Column("culprit"),
+                    Column("group_id"),
+                    Function("count", [], "event_count"),
+                    Function(
+                        "multiIf",
+                        multi_if,
+                        "function_name",
+                    ),
+                ]
+            )
+            .set_groupby(
+                [
+                    Column("title"),
+                    Column("culprit"),
+                    Column("group_id"),
+                    Column("exception_frames.function"),
+                ]
+            )
+            .set_where(
+                [
+                    Condition(Column("project_id"), Op.IN, project_ids),
+                    Condition(Column("group_id"), Op.IN, group_ids),
+                    Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
+                    Condition(Column("timestamp"), Op.LT, datetime.now()),
+                    # NOTE: ideally this would follow suspect commit logic
+                    BooleanCondition(
+                        BooleanOp.OR,
+                        [
+                            BooleanCondition(
+                                BooleanOp.AND,
+                                [
+                                    Condition(
+                                        Function(
+                                            "arrayElement",
+                                            (Column("exception_frames.filename"), i),
+                                        ),
+                                        Op.IN,
+                                        sentry_filenames,
+                                    ),
+                                    language_parser.generate_function_name_conditions(
+                                        function_names, i
+                                    ),
+                                ],
+                            )
+                            for i in range(-STACKFRAME_COUNT, 0)  # first n frames
+                        ],
+                    ),
+                    Condition(Function("notHandled", []), Op.EQ, 1),
+                ]
+            )
+            .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
+        )
+
+        # filter on the subquery to squash group_ids with the same title and culprit
+        # return the group_id with the greatest count of events
+        query = (
+            Query(subquery)
+            .set_select(
+                [
+                    Column("function_name"),
+                    Function(
+                        "arrayElement",
+                        (Function("groupArray", [Column("group_id")]), 1),
+                        "group_id",
+                    ),
+                    Function(
+                        "arrayElement",
+                        (Function("groupArray", [Column("event_count")]), 1),
+                        "event_count",
+                    ),
+                ]
+            )
+            .set_groupby(
+                [
+                    Column("title"),
+                    Column("culprit"),
+                    Column("function_name"),
+                ]
+            )
+            .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
+            .set_limit(5)
+        )
+
+        request = SnubaRequest(
+            dataset=Dataset.Events.value,
+            app_id="default",
+            tenant_ids={"organization_id": projects[0].organization_id},
+            query=query,
+        )
+
+        try:
+            return raw_snql_query(request, referrer=self.referrer.value)["data"]
+        except Exception:
+            logger.exception(
+                "github.open_pr_comment.snuba_query_error",
+                extra={"query": request.to_dict()["query"]},
+            )
+            return []
+
+    @abstractmethod
+    def format_open_pr_comment(self, issue_tables: list[str]) -> str:
+        """
+        Given a list of issue tables, return a string that can be used to format an open PR comment.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def format_issue_table(
+        self,
+        diff_filename: str,
+        issues: list[PullRequestIssue],
+        patch_parsers: dict[str, Any],
+        toggle: bool,
+    ) -> str:
+        """
+        Given a list of issues, return a string that can be used to format an issue table.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_issue_table_contents(issue_list: list[dict[str, Any]]) -> list[PullRequestIssue]:
+        """
+        Given a list of issue group ids, return a list of PullRequestIssue objects sorted by event count.
+        """
+        group_id_to_info = {}
+        for issue in issue_list:
+            group_id = issue["group_id"]
+            group_id_to_info[group_id] = dict(filter(lambda k: k[0] != "group_id", issue.items()))
+
+        issues = Group.objects.filter(id__in=list(group_id_to_info.keys())).all()
+
+        pull_request_issues = [
+            PullRequestIssue(
+                title=issue.title,
+                subtitle=issue.culprit,
+                url=issue.get_absolute_url(),
+                affected_users=issue.count_users_seen(
+                    referrer=Referrer.TAGSTORE_GET_GROUPS_USER_COUNTS_OPEN_PR_COMMENT.value
+                ),
+                event_count=group_id_to_info[issue.id]["event_count"],
+                function_name=group_id_to_info[issue.id]["function_name"],
+            )
+            for issue in issues
+        ]
+        pull_request_issues.sort(key=lambda k: k.event_count or 0, reverse=True)
+
+        return pull_request_issues

--- a/src/sentry/seer/fetch_issues/fetch_issues.py
+++ b/src/sentry/seer/fetch_issues/fetch_issues.py
@@ -11,13 +11,13 @@ from snuba_sdk import Request as SnubaRequest
 from sentry import eventstore
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.api.serializers.models.event import EventSerializerResponse
-from sentry.integrations.github.tasks.open_pr_comment import (
-    MAX_RECENT_ISSUES,
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.source_code_management.commit_context import (
     OPEN_PR_MAX_FILES_CHANGED,
     OPEN_PR_MAX_LINES_CHANGED,
+    OPEN_PR_MAX_RECENT_ISSUES,
+    PullRequestFile,
 )
-from sentry.integrations.github.tasks.utils import PullRequestFile
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.repository import Repository
@@ -103,7 +103,7 @@ def _get_issues_for_file(
         )
         .order_by("-times_seen")
         .values_list("id", flat=True)
-    )[:MAX_RECENT_ISSUES]
+    )[:OPEN_PR_MAX_RECENT_ISSUES]
     project_ids = [project.id for project in projects]
 
     # Fetch the latest event for each group, along with some other event data we'll need for

--- a/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_open_pr_comment.py
@@ -6,18 +6,13 @@ import responses
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.github.tasks.open_pr_comment import (
-    format_issue_table,
-    format_open_pr_comment,
-    get_issue_table_contents,
-    get_pr_files,
-    get_projects_and_filenames_from_source_file,
-    get_top_5_issues_by_count_for_file,
-    open_pr_comment_workflow,
-    safe_for_comment,
-)
-from sentry.integrations.github.tasks.utils import PullRequestFile, PullRequestIssue
+from sentry.integrations.github.integration import GitHubIntegration, GitHubIntegrationProvider
+from sentry.integrations.github.tasks.open_pr_comment import open_pr_comment_workflow
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.source_code_management.commit_context import (
+    PullRequestFile,
+    PullRequestIssue,
+)
 from sentry.integrations.source_code_management.constants import STACKFRAME_COUNT
 from sentry.integrations.source_code_management.language_parsers import PATCH_PARSERS
 from sentry.models.group import Group, GroupStatus
@@ -25,6 +20,7 @@ from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComme
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.integrations.github.tasks.test_pr_comment import GithubCommentTestCase
@@ -87,9 +83,17 @@ class TestSafeForComment(GithubCommentTestCase):
     def setUp(self):
         super().setUp()
         self.pr = self.create_pr_issues()
-        self.mock_metrics = patch(
-            "sentry.integrations.github.tasks.open_pr_comment.metrics"
-        ).start()
+
+        mock_metrics_patcher = patch(
+            "sentry.integrations.source_code_management.commit_context.metrics"
+        )
+        self.mock_metrics = mock_metrics_patcher.start()
+        self.addCleanup(mock_metrics_patcher.stop)
+
+        mock_integration_metrics_patcher = patch("sentry.integrations.github.integration.metrics")
+        self.mock_integration_metrics = mock_integration_metrics_patcher.start()
+        self.addCleanup(mock_integration_metrics_patcher.stop)
+
         self.gh_path = self.base_url + "/repos/getsentry/sentry/pulls/{pull_number}/files"
         installation = self.integration.get_installation(organization_id=self.organization.id)
         self.gh_client = installation.get_client()
@@ -112,7 +116,7 @@ class TestSafeForComment(GithubCommentTestCase):
             json=data,
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == [
             {"filename": "foo.py", "changes": 100, "status": "modified"},
             {"filename": "bar.js", "changes": 100, "status": "modified"},
@@ -139,9 +143,9 @@ class TestSafeForComment(GithubCommentTestCase):
             ],
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == []  # not safe
-        self.mock_metrics.incr.assert_called_with(
+        self.mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.rejected_comment", tags={"reason": "too_many_files"}
         )
 
@@ -157,9 +161,9 @@ class TestSafeForComment(GithubCommentTestCase):
             ],
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == []  # not safe
-        self.mock_metrics.incr.assert_called_with(
+        self.mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
         )
 
@@ -182,9 +186,9 @@ class TestSafeForComment(GithubCommentTestCase):
             ],
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == []  # not safe
-        self.mock_metrics.incr.assert_any_call(
+        self.mock_integration_metrics.incr.assert_any_call(
             "github.open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
         )
 
@@ -200,9 +204,9 @@ class TestSafeForComment(GithubCommentTestCase):
             },
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == []  # not safe
-        self.mock_metrics.incr.assert_called_with(
+        self.mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.api_error", tags={"type": "gh_rate_limited", "code": 429}
         )
 
@@ -212,9 +216,9 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET, self.gh_path.format(pull_number=self.pr.key), status=404, json={}
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == []  # not safe
-        self.mock_metrics.incr.assert_called_with(
+        self.mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.api_error",
             tags={"type": "missing_gh_pull_request", "code": 404},
         )
@@ -225,9 +229,9 @@ class TestSafeForComment(GithubCommentTestCase):
             responses.GET, self.gh_path.format(pull_number=self.pr.key), status=400, json={}
         )
 
-        pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        pr_files = self.open_pr_comment_workflow.safe_for_comment(repo=self.gh_repo, pr=self.pr)
         assert pr_files == []  # not safe
-        self.mock_metrics.incr.assert_called_with(
+        self.mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.api_error", tags={"type": "unknown_api_error", "code": 400}
         )
 
@@ -236,9 +240,13 @@ class TestGetFilenames(GithubCommentTestCase):
     def setUp(self):
         super().setUp()
         self.pr = self.create_pr_issues()
-        self.mock_metrics = patch(
+
+        mock_metrics_patcher = patch(
             "sentry.integrations.source_code_management.commit_context.metrics"
-        ).start()
+        )
+        self.mock_metrics = mock_metrics_patcher.start()
+        self.addCleanup(mock_metrics_patcher.stop)
+
         self.gh_path = self.base_url + "/repos/getsentry/sentry/pulls/{pull_number}/files"
         installation = self.integration.get_installation(organization_id=self.organization.id)
         self.gh_client = installation.get_client()
@@ -250,7 +258,7 @@ class TestGetFilenames(GithubCommentTestCase):
             {"filename": "baz.py", "status": "modified"},
         ]
 
-        pr_files = get_pr_files(data)
+        pr_files = self.open_pr_comment_workflow.get_pr_files(data)
         assert len(pr_files) == 1
 
         pr_file = pr_files[0]
@@ -308,8 +316,10 @@ class TestGetFilenames(GithubCommentTestCase):
             "sentry/tasks/integrations/github/open_pr_comment.py",
         ]
 
-        project_list, sentry_filenames = get_projects_and_filenames_from_source_file(
-            self.organization.id, self.gh_repo.id, filename
+        project_list, sentry_filenames = (
+            self.open_pr_comment_workflow.get_projects_and_filenames_from_source_file(
+                organization=self.organization, repo=self.gh_repo, pr_filename=filename
+            )
         )
         assert project_list == set(projects)
         assert sentry_filenames == set(correct_filenames)
@@ -355,15 +365,27 @@ class TestGetFilenames(GithubCommentTestCase):
             "sentry/tasks/integrations/github/open_pr_comment.py",
         ]
 
-        project_list, sentry_filenames = get_projects_and_filenames_from_source_file(
-            self.organization.id, self.gh_repo.id, filename
+        project_list, sentry_filenames = (
+            self.open_pr_comment_workflow.get_projects_and_filenames_from_source_file(
+                organization=self.organization, repo=self.gh_repo, pr_filename=filename
+            )
         )
         assert project_list == set(projects)
         assert sentry_filenames == set(correct_filenames)
 
 
-class TestGetCommentIssues(CreateEventTestCase):
+class TestGetCommentIssues(IntegrationTestCase, CreateEventTestCase):
+    provider = GitHubIntegrationProvider
+    base_url = "https://api.github.com"
+
     def setUp(self):
+        super().setUp()
+
+        self.installation = get_installation_of_type(
+            GitHubIntegration, integration=self.integration, org_id=self.organization.id
+        )
+        self.open_pr_comment_workflow = self.installation.get_open_pr_comment_workflow()
+
         self.group_id = [self._create_event(user_id=str(i)) for i in range(6)][0].group.id
         self.another_org = self.create_organization()
         self.another_org_project = self.create_project(organization=self.another_org)
@@ -372,8 +394,8 @@ class TestGetCommentIssues(CreateEventTestCase):
         group_id = [
             self._create_event(function_names=["blue", "planet"], user_id=str(i)) for i in range(7)
         ][0].group.id
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.py"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world", "planet"]
         )
 
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
@@ -399,8 +421,8 @@ class TestGetCommentIssues(CreateEventTestCase):
             )
             for i in range(6)
         ][0].group.id
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.js"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.js"], function_names=["world", "planet"]
         )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
@@ -425,8 +447,10 @@ class TestGetCommentIssues(CreateEventTestCase):
             )
             for i in range(6)
         ][0].group.id
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.php"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project],
+            sentry_filenames=["baz.php"],
+            function_names=["world", "planet"],
         )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
@@ -451,8 +475,8 @@ class TestGetCommentIssues(CreateEventTestCase):
             )
             for i in range(6)
         ][0].group.id
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.rb"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.rb"], function_names=["world", "planet"]
         )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
@@ -466,13 +490,17 @@ class TestGetCommentIssues(CreateEventTestCase):
         group.substatus = None
         group.save()
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         assert len(top_5_issues) == 0
 
     def test_filters_handled_issue(self):
         group_id = self._create_event(filenames=["bar.py", "baz.py"], handled=True).group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert group_id != self.group_id
         assert top_5_issue_ids == [self.group_id]
@@ -481,7 +509,9 @@ class TestGetCommentIssues(CreateEventTestCase):
         # we fetch all group_ids that belong to the projects passed into the function
         self._create_event(project_id=self.another_org_project.id)
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert top_5_issue_ids == [self.group_id]
 
@@ -490,7 +520,9 @@ class TestGetCommentIssues(CreateEventTestCase):
             filenames=["foo.py", "bar.py"],
         ).group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert group_id != self.group_id
         assert top_5_issue_ids == [self.group_id]
@@ -500,7 +532,9 @@ class TestGetCommentIssues(CreateEventTestCase):
             function_names=["world", "hello"],
         ).group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert group_id != self.group_id
         assert top_5_issue_ids == [self.group_id]
@@ -510,7 +544,9 @@ class TestGetCommentIssues(CreateEventTestCase):
             function_names=["world", "hello"], filenames=["baz.py", "bar.py"], culprit="hi"
         ).group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
         assert group_id != self.group_id
@@ -522,7 +558,9 @@ class TestGetCommentIssues(CreateEventTestCase):
         filenames = ["baz.py"] + ["foo.py" for _ in range(STACKFRAME_COUNT)]
         group_id = self._create_event(function_names=function_names, filenames=filenames).group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert group_id != self.group_id
         assert top_5_issue_ids == [self.group_id]
@@ -532,7 +570,9 @@ class TestGetCommentIssues(CreateEventTestCase):
             timestamp=before_now(days=15).isoformat(), filenames=["bar.py", "baz.py"]
         ).group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world"]
+        )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert group_id != self.group_id
         assert top_5_issue_ids == [self.group_id]
@@ -559,8 +599,8 @@ class TestGetCommentIssues(CreateEventTestCase):
             for i in range(5)
         ][0].group_id
 
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.py"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world", "planet"]
         )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
@@ -613,8 +653,8 @@ class TestGetCommentIssues(CreateEventTestCase):
         # unrelated issue with same stack trace in different project
         self._create_event(project_id=self.another_org_project.id)
 
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.py"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world", "planet"]
         )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
@@ -665,14 +705,16 @@ class TestGetCommentIssues(CreateEventTestCase):
             for i in range(2)
         ][0].group.id
 
-        top_5_issues = get_top_5_issues_by_count_for_file(
-            [self.project], ["baz.py"], ["world", "planet"]
+        top_5_issues = self.open_pr_comment_workflow.get_top_5_issues_by_count_for_file(
+            projects=[self.project], sentry_filenames=["baz.py"], function_names=["world", "planet"]
         )
         affected_users = [6, 5, 4, 3, 2]
         event_count = [issue["event_count"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
 
-        comment_table_contents = get_issue_table_contents(top_5_issues)
+        comment_table_contents = self.open_pr_comment_workflow.get_issue_table_contents(
+            top_5_issues
+        )
         group_ids = [self.group_id, group_id_1, group_id_2, group_id_3, group_id_4]
 
         for i in range(5):
@@ -690,9 +732,16 @@ class TestGetCommentIssues(CreateEventTestCase):
             )
 
 
-class TestFormatComment(TestCase):
+class TestFormatComment(IntegrationTestCase):
+    provider = GitHubIntegrationProvider
+    base_url = "https://api.github.com"
+
     def setUp(self):
         super().setUp()
+        self.installation = get_installation_of_type(
+            GitHubIntegration, integration=self.integration, org_id=self.organization.id
+        )
+        self.open_pr_comment_workflow = self.installation.get_open_pr_comment_workflow()
 
     def test_comment_format_python(self):
         file1 = "tests/sentry/tasks/integrations/github/test_open_pr_comment.py"
@@ -722,31 +771,37 @@ class TestFormatComment(TestCase):
             for i in range(2)
         ]
 
-        issue_table = format_issue_table(file1, file1_issues, PATCH_PARSERS, toggle=False)
-        toggle_issue_table = format_issue_table(file2, file2_issues, PATCH_PARSERS, toggle=True)
-        comment = format_open_pr_comment([issue_table, toggle_issue_table])
+        issue_table = self.open_pr_comment_workflow.format_issue_table(
+            diff_filename=file1, issues=file1_issues, patch_parsers=PATCH_PARSERS, toggle=False
+        )
+        toggle_issue_table = self.open_pr_comment_workflow.format_issue_table(
+            diff_filename=file2, issues=file2_issues, patch_parsers=PATCH_PARSERS, toggle=True
+        )
+        comment = self.open_pr_comment_workflow.format_open_pr_comment(
+            [issue_table, toggle_issue_table]
+        )
 
         assert (
             comment
-            == """## 🔍 Existing Issues For Review
+            == f"""## 🔍 Existing Issues For Review
 Your pull request is modifying functions with the following pre-existing issues:
 
 📄 File: **tests/sentry/tasks/integrations/github/test_open_pr_comment.py**
 
 | Function | Unhandled Issue |
 | :------- | :----- |
-| **`function_0`** | [**file1 0**](http://testserver/organizations/baz/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** |
-| **`function_1`** | [**file1 1**](http://testserver/organizations/baz/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** |
-| **`function_2`** | [**file1 2**](http://testserver/organizations/baz/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** |
-| **`function_3`** | [**file1 3**](http://testserver/organizations/baz/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** |
-| **`function_4`** | [**file1 4**](http://testserver/organizations/baz/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** |
+| **`function_0`** | [**file1 0**](http://testserver/organizations/{self.organization.slug}/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** |
+| **`function_1`** | [**file1 1**](http://testserver/organizations/{self.organization.slug}/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** |
+| **`function_2`** | [**file1 2**](http://testserver/organizations/{self.organization.slug}/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** |
+| **`function_3`** | [**file1 3**](http://testserver/organizations/{self.organization.slug}/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** |
+| **`function_4`** | [**file1 4**](http://testserver/organizations/{self.organization.slug}/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** |
 <details>
 <summary><b>📄 File: tests/sentry/tasks/integrations/github/test_pr_comment.py (Click to Expand)</b></summary>
 
 | Function | Unhandled Issue |
 | :------- | :----- |
-| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/baz/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** |
-| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/baz/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** |
+| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/{self.organization.slug}/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** |
+| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/{self.organization.slug}/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** |
 </details>
 ---
 
@@ -781,31 +836,37 @@ Your pull request is modifying functions with the following pre-existing issues:
             for i in range(2)
         ]
 
-        issue_table = format_issue_table(file1, file1_issues, PATCH_PARSERS, toggle=False)
-        toggle_issue_table = format_issue_table(file2, file2_issues, PATCH_PARSERS, toggle=True)
-        comment = format_open_pr_comment([issue_table, toggle_issue_table])
+        issue_table = self.open_pr_comment_workflow.format_issue_table(
+            diff_filename=file1, issues=file1_issues, patch_parsers=PATCH_PARSERS, toggle=False
+        )
+        toggle_issue_table = self.open_pr_comment_workflow.format_issue_table(
+            diff_filename=file2, issues=file2_issues, patch_parsers=PATCH_PARSERS, toggle=True
+        )
+        comment = self.open_pr_comment_workflow.format_open_pr_comment(
+            [issue_table, toggle_issue_table]
+        )
 
         assert (
             comment
-            == """## 🔍 Existing Issues For Review
+            == f"""## 🔍 Existing Issues For Review
 Your pull request is modifying functions with the following pre-existing issues:
 
 📄 File: **tests/sentry/tasks/integrations/github/test_open_pr_comment.js**
 
 | Function | Unhandled Issue |
 | :------- | :----- |
-| **`function_0`** | [**file1 0**](http://testserver/organizations/baz/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** `Affected Users:` **5k** |
-| **`function_1`** | [**file1 1**](http://testserver/organizations/baz/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** `Affected Users:` **4k** |
-| **`function_2`** | [**file1 2**](http://testserver/organizations/baz/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** `Affected Users:` **3k** |
-| **`function_3`** | [**file1 3**](http://testserver/organizations/baz/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** `Affected Users:` **2k** |
-| **`function_4`** | [**file1 4**](http://testserver/organizations/baz/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** `Affected Users:` **1k** |
+| **`function_0`** | [**file1 0**](http://testserver/organizations/{self.organization.slug}/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** `Affected Users:` **5k** |
+| **`function_1`** | [**file1 1**](http://testserver/organizations/{self.organization.slug}/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** `Affected Users:` **4k** |
+| **`function_2`** | [**file1 2**](http://testserver/organizations/{self.organization.slug}/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** `Affected Users:` **3k** |
+| **`function_3`** | [**file1 3**](http://testserver/organizations/{self.organization.slug}/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** `Affected Users:` **2k** |
+| **`function_4`** | [**file1 4**](http://testserver/organizations/{self.organization.slug}/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** `Affected Users:` **1k** |
 <details>
 <summary><b>📄 File: tests/sentry/tasks/integrations/github/test_pr_comment.js (Click to Expand)</b></summary>
 
 | Function | Unhandled Issue |
 | :------- | :----- |
-| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/baz/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** `Affected Users:` **20k** |
-| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/baz/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** `Affected Users:` **10k** |
+| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/{self.organization.slug}/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** `Affected Users:` **20k** |
+| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/{self.organization.slug}/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** `Affected Users:` **10k** |
 </details>
 ---
 
@@ -815,20 +876,24 @@ Your pull request is modifying functions with the following pre-existing issues:
     def test_comment_format_missing_language(self):
         file1 = "tests/sentry/tasks/integrations/github/test_open_pr_comment.docx"
 
-        issue_table = format_issue_table(file1, [], PATCH_PARSERS, toggle=False)
+        issue_table = self.open_pr_comment_workflow.format_issue_table(
+            diff_filename=file1, issues=[], patch_parsers=PATCH_PARSERS, toggle=False
+        )
 
         assert issue_table == ""
 
 
-@patch("sentry.integrations.github.tasks.open_pr_comment.get_pr_files")
+@patch("sentry.integrations.github.integration.GitHubOpenPRCommentWorkflow.get_pr_files")
 @patch(
-    "sentry.integrations.github.tasks.open_pr_comment.get_projects_and_filenames_from_source_file"
+    "sentry.integrations.github.integration.GitHubOpenPRCommentWorkflow.get_projects_and_filenames_from_source_file"
 )
 @patch(
     "sentry.integrations.source_code_management.language_parsers.PythonParser.extract_functions_from_patch"
 )
-@patch("sentry.integrations.github.tasks.open_pr_comment.get_top_5_issues_by_count_for_file")
-@patch("sentry.integrations.github.tasks.open_pr_comment.safe_for_comment")
+@patch(
+    "sentry.integrations.github.integration.GitHubOpenPRCommentWorkflow.get_top_5_issues_by_count_for_file"
+)
+@patch("sentry.integrations.github.integration.GitHubOpenPRCommentWorkflow.safe_for_comment")
 @patch("sentry.integrations.source_code_management.commit_context.metrics")
 class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
     base_url = "https://api.github.com"
@@ -978,9 +1043,11 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
     @patch("sentry.analytics.record")
     @patch("sentry.integrations.github.tasks.open_pr_comment.metrics")
+    @patch("sentry.integrations.github.integration.metrics")
     @responses.activate
     def test_comment_workflow_early_return(
         self,
+        mock_integration_metrics,
         mock_metrics,
         mock_analytics,
         _,
@@ -996,7 +1063,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         pull_request_comment_query = PullRequestComment.objects.all()
         assert len(pull_request_comment_query) == 0
-        mock_metrics.incr.assert_called_with(
+        mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.error", tags={"type": "unsafe_for_comment"}
         )
 
@@ -1199,10 +1266,10 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github.open_pr_comment.error", tags={"type": "missing_integration"}
         )
 
-    @patch("sentry.integrations.github.tasks.open_pr_comment.metrics")
+    @patch("sentry.integrations.github.integration.metrics")
     def test_comment_workflow_not_safe_for_comment(
         self,
-        mock_metrics,
+        mock_integration_metrics,
         _,
         mock_safe_for_comment,
         mock_issues,
@@ -1214,6 +1281,6 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         open_pr_comment_workflow(self.pr.id)
 
         assert not mock_pr_filenames.called
-        mock_metrics.incr.assert_called_with(
+        mock_integration_metrics.incr.assert_called_with(
             "github.open_pr_comment.error", tags={"type": "unsafe_for_comment"}
         )

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import UTC, datetime, timedelta
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -7,7 +8,11 @@ import responses
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.github.integration import GitHubIntegration, GitHubIntegrationProvider
+from sentry.integrations.github.integration import (
+    GitHubIntegration,
+    GitHubIntegrationProvider,
+    GitHubOpenPRCommentWorkflow,
+)
 from sentry.integrations.github.tasks.pr_comment import (
     github_comment_reactions,
     github_comment_workflow,
@@ -48,6 +53,9 @@ class GithubCommentTestCase(IntegrationTestCase):
             GitHubIntegration, integration=self.integration, org_id=self.organization.id
         )
         self.pr_comment_workflow = self.installation.get_pr_comment_workflow()
+        self.open_pr_comment_workflow = cast(
+            GitHubOpenPRCommentWorkflow, self.installation.get_open_pr_comment_workflow()
+        )
         self.another_integration = self.create_integration(
             organization=self.organization, external_id="1", provider="gitlab"
         )

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -651,9 +651,10 @@ class PullRequestEventWebhook(APITestCase):
 
         assert_failure_metric(mock_record, error)
 
+    @patch("sentry.integrations.github.webhook.open_pr_comment_workflow.delay")
     @patch("sentry.integrations.github.webhook.metrics")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_opened(self, mock_record, mock_metrics):
+    def test_opened(self, mock_record, mock_metrics, mock_delay):
         project = self.project  # force creation
         group = self.create_group(project=project, short_id=7)
 
@@ -688,6 +689,10 @@ class PullRequestEventWebhook(APITestCase):
         mock_metrics.incr.assert_called_with("github.open_pr_comment.queue_task")
 
         assert_success_metric(mock_record)
+
+        mock_delay.assert_called_with(
+            pr_id=pr.id,
+        )
 
     @patch("sentry.integrations.github.webhook.metrics")
     def test_opened_missing_option(self, mock_metrics):


### PR DESCRIPTION
Make the Open PR Comment Workflow generic.

Migrate the GitHub integration to use it, but do not allow the GitHub Enterprise integration to use it yet.
