### PR TITLE
fix(perf-issues): Ignore non `http.client` spans in Consecutive HTTP detector

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/consecutive_http_detector.py
@@ -157,6 +157,9 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         if not span_id or not op or not hash or not description:
             return False
 
+        if not op.startswith("http.client"):
+            return False
+
         if (
             not description.strip().upper().startswith(("GET", "POST", "DELETE", "PUT", "PATCH"))
         ):  # Just using all methods to see if anything interesting pops up

--- a/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
+++ b/tests/sentry/utils/performance_issues/test_consecutive_http_detector.py
@@ -382,3 +382,14 @@ class ConsecutiveHTTPSpansDetectorTest(TestCase):
         detector = ConsecutiveHTTPSpanDetector(settings, event)
 
         assert not detector.is_creation_allowed_for_project(project)
+
+    def test_ignores_non_http_operations(self):
+        span_duration = 2000
+        spans = [
+            create_span("db", span_duration, "DELETE /api/endpoint2", "hash2"),
+            create_span("db", span_duration, "DELETE /api/endpoint1", "hash1"),
+            create_span("db", span_duration, "DELETE /api/endpoint3", "hash3"),
+        ]
+        spans = [modify_span_start(span, span_duration * spans.index(span)) for span in spans]
+        problems = self.find_problems(create_event(spans))
+        assert len(problems) == 0


### PR DESCRIPTION
I believe this check was intended given the function name & tests,  but probably missed by accident.