### PR TITLE
feat(flags): add action menu to event flag section

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -12,6 +12,7 @@ import {
 } from 'sentry/components/events/featureFlags/eventFeatureFlagDrawer';
 import FeatureFlagSettingsButton from 'sentry/components/events/featureFlags/featureFlagSettingsButton';
 import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
+import FlagActionDropdown from 'sentry/components/events/featureFlags/flagActionDropdown';
 import {
   FlagControlOptions,
   ORDER_BY_OPTIONS,
@@ -159,17 +160,19 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
         item: {
           key: f.flag,
           subject: f.flag,
-          value: suspectFlagNames.has(f.flag) ? (
+          value: (
             <ValueWrapper>
               {f.result.toString()}
-              <SuspectLabel>{t('Suspect')}</SuspectLabel>
+              {suspectFlagNames.has(f.flag) && (
+                <SuspectLabel>{t('Suspect')}</SuspectLabel>
+              )}
+              <FlagActionDropdown
+                flag={f.flag}
+                result={f.result}
+                generateAction={generateAction}
+              />
             </ValueWrapper>
-          ) : (
-            f.result.toString()
           ),
-          action: {
-            link: generateAction({key: `flags["${f.flag}"]`, value: f.result.toString()}),
-          },
         },
         isSuspectFlag: suspectFlagNames.has(f.flag),
       };
@@ -344,4 +347,14 @@ const SuspectLabel = styled('div')`
 const ValueWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
+
+  .invisible {
+    visibility: hidden;
+  }
+  &:hover,
+  &:active {
+    .invisible .flag-button {
+      visibility: visible;
+    }
+  }
 `;

--- a/static/app/components/events/featureFlags/flagActionDropdown.tsx
+++ b/static/app/components/events/featureFlags/flagActionDropdown.tsx
@@ -1,0 +1,92 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import type {LocationDescriptor} from 'history';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconEllipsis} from 'sentry/icons/iconEllipsis';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import {useLocation} from 'sentry/utils/useLocation';
+import {DrawerTab} from 'sentry/views/issueDetails/groupDistributions/types';
+import {Tab} from 'sentry/views/issueDetails/types';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
+
+export default function FlagActionDropdown({
+  flag,
+  result,
+  generateAction,
+}: {
+  flag: string;
+  generateAction: ({
+    key,
+    value,
+  }: {
+    key: string;
+    value: string;
+  }) => LocationDescriptor | undefined;
+  result: string;
+}) {
+  const {onClick: handleCopy} = useCopyToClipboard({
+    text: flag,
+  });
+  const location = useLocation();
+  const {baseUrl} = useGroupDetailsRoute();
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <StyledDropdownMenu
+      position="bottom-end"
+      className={isVisible ? '' : 'invisible'}
+      onOpenChange={isOpen => setIsVisible(isOpen)}
+      size="xs"
+      triggerProps={{
+        'aria-label': t('Flag Details'),
+        icon: <IconEllipsis />,
+        showChevron: false,
+        size: 'xs',
+        className: 'flag-button',
+      }}
+      items={[
+        {
+          key: 'open-flag-details',
+          label: t('See flag details'),
+          to: {
+            pathname: `${baseUrl}${Tab.DISTRIBUTIONS}/${flag}`,
+            query: {...location.query, tab: DrawerTab.FEATURE_FLAGS},
+          },
+        },
+        {
+          key: 'view-issues',
+          label: t('Search issues for this flag value'),
+          to: generateAction({
+            key: `flags["${flag}"]`,
+            value: result.toString(),
+          }),
+        },
+        {
+          key: 'copy-value',
+          label: t('Copy flag value to clipboard'),
+          onAction: handleCopy,
+        },
+      ]}
+    />
+  );
+}
+
+const StyledDropdownMenu = styled(DropdownMenu)`
+  font-family: ${p => p.theme.text.family};
+
+  /* Override monospace styling that might be applied */
+  [data-test-id='menu-list-item-label'] {
+    font-family: ${p => p.theme.text.family};
+  }
+
+  .flag-button {
+    height: 20px;
+    min-height: 20px;
+    padding: 0 ${space(0.75)};
+    border-radius: ${space(0.5)};
+    z-index: 0;
+  }
+`;

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -41,7 +41,7 @@ export interface KeyValueDataContentProps {
   expandLeft?: boolean;
   /**
    * Used for the feature flag section.
-   * If true, then the row will be highlighted in red.
+   * If true, then the row will be highlighted in yellow.
    */
   isSuspectFlag?: boolean;
   /**


### PR DESCRIPTION
adds an action menu next to the flag name in the event feature flag section on issue details:

<img width="511" alt="SCR-20250506-mxjz" src="https://github.com/user-attachments/assets/d6b4eacf-93c9-4ff1-9b02-e0e53de883c9" />


https://github.com/user-attachments/assets/a2ed5057-1185-4650-be69-e4c4fa706a35


options are
- open flag details drawer
- search for issues with that flag key & value (original behavior was that clicking the value would do this search -- removed this link behavior in favor of the action menu)
- copy flag to clipboard

closes https://github.com/getsentry/sentry/issues/90021