### PR TITLE
feat(uptime): Send both detector and subscription based fingerprints to the issue platform

### DIFF
--- a/src/sentry/uptime/issue_platform.py
+++ b/src/sentry/uptime/issue_platform.py
@@ -16,7 +16,7 @@ from sentry.workflow_engine.models.detector import Detector
 
 def create_issue_platform_occurrence(result: CheckResult, detector: Detector):
     project_subscription = get_project_subscription(detector)
-    occurrence = build_occurrence_from_result(result, project_subscription)
+    occurrence = build_occurrence_from_result(result, detector, project_subscription)
     event_data = build_event_data_for_occurrence(result, project_subscription, occurrence)
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE,
@@ -25,14 +25,19 @@ def create_issue_platform_occurrence(result: CheckResult, detector: Detector):
     )
 
 
+def build_detector_fingerprint_component(detector: Detector) -> str:
+    return f"uptime-detector:{detector.id}"
+
+
 def build_fingerprint_for_project_subscription(
+    detector: Detector,
     project_subscription: ProjectUptimeSubscription,
 ) -> list[str]:
-    return [str(project_subscription.id)]
+    return [build_detector_fingerprint_component(detector), str(project_subscription.id)]
 
 
 def build_occurrence_from_result(
-    result: CheckResult, project_subscription: ProjectUptimeSubscription
+    result: CheckResult, detector: Detector, project_subscription: ProjectUptimeSubscription
 ) -> IssueOccurrence:
     status_reason = result["status_reason"]
     assert status_reason
@@ -71,7 +76,7 @@ def build_occurrence_from_result(
         resource_id=None,
         project_id=project_subscription.project_id,
         event_id=uuid.uuid4().hex,
-        fingerprint=build_fingerprint_for_project_subscription(project_subscription),
+        fingerprint=build_fingerprint_for_project_subscription(detector, project_subscription),
         type=UptimeDomainCheckFailure,
         issue_title=f"Downtime detected for {project_subscription.uptime_subscription.url}",
         subtitle="Your monitored domain is down",
@@ -117,7 +122,7 @@ def resolve_uptime_issue(detector: Detector):
     """
     project_subscription = get_project_subscription(detector)
     status_change = StatusChangeMessage(
-        fingerprint=build_fingerprint_for_project_subscription(project_subscription),
+        fingerprint=build_fingerprint_for_project_subscription(detector, project_subscription),
         project_id=project_subscription.project_id,
         new_status=GroupStatus.RESOLVED,
         new_substatus=None,

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -25,7 +25,7 @@ class BuildDetectorFingerprintComponentTest(UptimeTestCase):
     def test_build_detector_fingerprint_component(self):
         project_subscription = self.create_project_uptime_subscription()
         detector = get_detector(project_subscription.uptime_subscription)
-        assert detector is not None
+        assert detector
 
         fingerprint_component = build_detector_fingerprint_component(detector)
         assert fingerprint_component == f"uptime-detector:{detector.id}"
@@ -35,7 +35,7 @@ class BuildFingerprintForProjectSubscriptionTest(UptimeTestCase):
     def test_build_fingerprint_for_project_subscription(self):
         project_subscription = self.create_project_uptime_subscription()
         detector = get_detector(project_subscription.uptime_subscription)
-        assert detector is not None
+        assert detector
 
         fingerprint = build_fingerprint_for_project_subscription(detector, project_subscription)
         expected_fingerprint = [
@@ -77,7 +77,7 @@ class BuildOccurrenceFromResultTest(UptimeTestCase):
         result = self.create_uptime_result()
         project_subscription = self.create_project_uptime_subscription()
         detector = get_detector(project_subscription.uptime_subscription)
-        assert detector is not None
+        assert detector
 
         assert build_occurrence_from_result(
             result, detector, project_subscription
@@ -113,7 +113,7 @@ class BuildEventDataForOccurrenceTest(UptimeTestCase):
         result = self.create_uptime_result()
         project_subscription = self.create_project_uptime_subscription()
         detector = get_detector(project_subscription.uptime_subscription)
-        assert detector is not None
+        assert detector
 
         event_id = uuid.uuid4()
         occurrence = IssueOccurrence(


### PR DESCRIPTION
We're switching over to use `Detectors`. To handle the transition, we need to send both new and old fingerprints to associate to the same issue. We'll do a backfill after this, and then can remove the old fingerprint.
