### PR TITLE
chore(aci): fire metrics for when rules and workflows fire

### DIFF
--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -221,6 +221,7 @@ class RuleProcessor:
         self.is_new_group_environment = is_new_group_environment
         self.has_reappeared = has_reappeared
         self.has_escalated = has_escalated
+        self.triggered_rules = 0
 
         self.grouped_futures: MutableMapping[
             str, tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], list[RuleFuture]]
@@ -387,6 +388,8 @@ class RuleProcessor:
 
         if not updated:
             return
+
+        self.triggered_rules += 1
 
         if randrange(10) == 0:
             analytics.record(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1029,6 +1029,15 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
+        if features.has(
+            "organizations:workflow-engine-process-workflows", group_event.project.organization
+        ):
+            metrics.incr(
+                "post_process.process_rules.fired_rules",
+                amount=rp.triggered_rules,
+                tags={"event_type": rp.event.group.type},
+            )
+
         # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
         for callback, futures in callback_and_futures:
             has_alert = True

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -422,7 +422,7 @@ def fire_actions_for_groups(
         # create WorkflowFireHistory (updated in evaluate_workflows_action_filters)
         create_workflow_fire_histories(workflows, event_data)
         filtered_actions = filtered_actions.union(
-            evaluate_workflows_action_filters(workflows, event_data)
+            evaluate_workflows_action_filters(workflows, event_data, is_delayed_processing=True)
         )
 
         # temporary fetching of organization, so not passing in as parameter

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -414,7 +414,9 @@ def fire_actions_for_groups(
                 action_filters.add(dcg)
 
         # process action filters
-        filtered_actions = filter_recently_fired_workflow_actions(action_filters, event_data)
+        filtered_actions = filter_recently_fired_workflow_actions(
+            action_filters, event_data, is_delayed_processing=True
+        )
 
         # process workflow_triggers
         workflows = set(Workflow.objects.filter(when_condition_group_id__in=workflow_triggers))
@@ -422,7 +424,7 @@ def fire_actions_for_groups(
         # create WorkflowFireHistory (updated in evaluate_workflows_action_filters)
         create_workflow_fire_histories(workflows, event_data)
         filtered_actions = filtered_actions.union(
-            evaluate_workflows_action_filters(workflows, event_data, is_delayed_processing=True)
+            evaluate_workflows_action_filters(workflows, event_data)
         )
 
         # temporary fetching of organization, so not passing in as parameter


### PR DESCRIPTION
We currently fire metrics for actions in both systems. It would be good to compare when rules and workflows meet trigger + filter conditions, as we would have fewer metrics to sift through (there can be N actions per rule/workflow).