### PR TITLE
feat(nav): Move 'All *' nav items up above starred section

### DIFF
--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -32,7 +32,7 @@ export function DashboardsSecondaryNav() {
       <SecondaryNav.Body>
         <SecondaryNav.Section>
           <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="dashboards_all">
-            {t('All')}
+            {t('All Dashboards')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <SecondaryNav.Section title={t('Starred Dashboards')}>

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -76,13 +76,15 @@ export function ExploreSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <Feature features={['performance-trace-explorer', 'performance-view']}>
+          <SecondaryNav.Section>
+            <SecondaryNav.Item to={`${baseUrl}/saved-queries/`}>
+              {t('All Queries')}
+            </SecondaryNav.Item>
+          </SecondaryNav.Section>
           <SecondaryNav.Section title={t('Starred Queries')}>
             {starredQueries && starredQueries.length > 0 && (
               <ExploreSavedQueryNavItems queries={starredQueries} />
             )}
-            <SecondaryNav.Item to={`${baseUrl}/saved-queries/`}>
-              {t('All Queries')}
-            </SecondaryNav.Item>
           </SecondaryNav.Section>
         </Feature>
       </SecondaryNav.Body>

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -101,6 +101,15 @@ export function InsightsSecondaryNav() {
             {AI_SIDEBAR_LABEL}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
+        <SecondaryNav.Section>
+          <SecondaryNav.Item
+            to={`${baseUrl}/projects/`}
+            end
+            analyticsItemName="insights_projects_all"
+          >
+            {t('All Projects')}
+          </SecondaryNav.Item>
+        </SecondaryNav.Section>
         <SecondaryNav.Section
           title={displayStarredProjects ? t('Starred Projects') : t('Projects')}
           trailingItems={
@@ -140,13 +149,6 @@ export function InsightsSecondaryNav() {
               {project.slug}
             </SecondaryNav.Item>
           ))}
-          <SecondaryNav.Item
-            to={`${baseUrl}/projects/`}
-            end
-            analyticsItemName="insights_projects_all"
-          >
-            {t('All Projects')}
-          </SecondaryNav.Item>
         </SecondaryNav.Section>
       </SecondaryNav.Body>
     </SecondaryNav>

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -17,7 +17,6 @@ import {IssueViewNavItemContent} from 'sentry/views/nav/secondary/sections/issue
 import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 
 interface IssueViewNavItemsProps {
-  baseUrl: string;
   sectionRef: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -31,7 +30,7 @@ export interface NavIssueView extends IssueViewParams {
   stars: number;
 }
 
-export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps) {
+export function IssueViewNavItems({sectionRef}: IssueViewNavItemsProps) {
   const organization = useOrganization();
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
 
@@ -89,11 +88,6 @@ export function IssueViewNavItems({sectionRef, baseUrl}: IssueViewNavItemsProps)
           />
         ))}
       </Reorder.Group>
-      {organization.features.includes('enforce-stacked-navigation') && (
-        <SecondaryNav.Item to={`${baseUrl}/views/`} end>
-          {t('All Views')}
-        </SecondaryNav.Item>
-      )}
     </SecondaryNav.Section>
   );
 }

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -64,8 +64,15 @@ export function IssuesSecondaryNav() {
             </SecondaryNav.Section>
           </Fragment>
         )}
+        {organization.features.includes('enforce-stacked-navigation') && (
+          <SecondaryNav.Section>
+            <SecondaryNav.Item to={`${baseUrl}/views/`} end>
+              {t('All Views')}
+            </SecondaryNav.Item>
+          </SecondaryNav.Section>
+        )}
         {organization.features.includes('issue-stream-custom-views') && (
-          <IssueViewNavItems sectionRef={sectionRef} baseUrl={baseUrl} />
+          <IssueViewNavItems sectionRef={sectionRef} />
         )}
         <ConfigureSection baseUrl={baseUrl} />
       </SecondaryNav.Body>


### PR DESCRIPTION
For better visibility of the "All *" nav item.

![CleanShot 2025-05-06 at 16 23 38](https://github.com/user-attachments/assets/85af3528-a35d-4e3f-9d3e-b74a0de464b4)![CleanShot 2025-05-06 at 16 23 52](https://github.com/user-attachments/assets/88c635f6-522d-45e8-8fdb-f595b10fe173)![CleanShot 2025-05-06 at 16 23 45](https://github.com/user-attachments/assets/cb050abc-db69-4bb6-b94d-b17f9ff8928b)
