### PR TITLE
chore(shared-views): add prompt for all views banner

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -14,6 +14,7 @@ DEFAULT_PROMPTS = {
     "issue_priority": {"required_fields": ["organization_id"]},
     "issue_replay_inline_onboarding": {"required_fields": ["organization_id", "project_id"]},
     "issue_views_add_view_banner": {"required_fields": ["organization_id"]},
+    "issue_views_all_views_banner": {"required_fields": ["organization_id"]},
     "metric_alert_ignore_archived_issues": {"required_fields": ["organization_id", "project_id"]},
     "profiling_onboarding": {"required_fields": ["organization_id"]},
     "quick_trace_missing": {"required_fields": ["organization_id", "project_id"]},


### PR DESCRIPTION
Adds BE prompt that will be used to track dismissal of the new all views banner 