### PR TITLE
chore(ACI): Add log for non-fe requests that pass latestIncident

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -132,7 +132,9 @@ class AlertRuleIndexMixin(Endpoint):
         if not features.has("organizations:performance-view", organization):
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
 
-        if "latestIncident" in request.GET.get("expand") and not is_frontend_request(request):
+        if "latestIncident" in request.GET.getlist("expand", []) and not is_frontend_request(
+            request
+        ):
             logger.info(
                 "organization_alert_rule_index.passed_latest_incident",
                 extra={"organization": organization.id},

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -1,3 +1,4 @@
+import logging
 from copy import deepcopy
 from datetime import UTC, datetime
 
@@ -48,6 +49,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
+from sentry.middleware import is_frontend_request
 from sentry.models.organization import Organization
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
@@ -70,6 +72,8 @@ from sentry.snuba.dataset import Dataset
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeStatus
 from sentry.uptime.types import ProjectUptimeSubscriptionMode
 from sentry.utils.cursors import Cursor, StringCursor
+
+logger = logging.getLogger(__name__)
 
 
 def create_metric_alert(
@@ -127,6 +131,12 @@ class AlertRuleIndexMixin(Endpoint):
 
         if not features.has("organizations:performance-view", organization):
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
+
+        if "latestIncident" in request.GET.get("expand") and not is_frontend_request(request):
+            logger.info(
+                "organization_alert_rule_index.passed_latest_incident",
+                extra={"organization": organization.id},
+            )
 
         response = self.paginate(
             request,


### PR DESCRIPTION
In order to track whether non-Sentry users ever pass `latestIncident` to the `OrganizationAlertRuleIndexEndpoint` we're adding logs when it happens. 