### PR TITLE
feat(workflow_engine): Implement priority thresholds

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -43,11 +43,6 @@ class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscripti
         )
         return occurrence, {}
 
-    @property
-    def counter_names(self) -> list[str]:
-        # Placeholder for now, this should be a list of counters that we want to update as we go above warning / critical
-        return []
-
     def get_dedupe_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
         return int(data_packet.packet.get("timestamp", datetime.now(UTC)).timestamp())
 

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -95,11 +95,10 @@ class DetectorStateData:
     # processed and all workflows have been done, this value will be used by the stateful detector to prevent
     # reprocessing
     dedupe_value: int
-    # Stateful detectors allow various counts to be tracked. We need to update these after we process workflows, so
-    # include the updates in the state.
-    # This dictionary is in the format {counter_name: counter_value, ...}
-    # If a counter value is `None` it means to unset the value
-    counter_updates: dict[str, int | None]
+    # Stateful detectors can track thresholds for DetectorPriorityLevel
+    # transitions. This dictionary maps the count of consecutive evauations for
+    # each DetectorPriorityLevel.
+    threshold_counts: dict[DetectorPriorityLevel, int]
 
 
 class DetectorHandler(abc.ABC, Generic[PacketT]):


### PR DESCRIPTION
This replaces the incomplete "counters" mechanism that is part of the `StatefulGroupingDetectorHandler`, with a less generic and more specialized priority threshold mechanism.

This mechanism allows evaluations to not result in a `DetectorEvaluationResult` if the evaluation has not yet met a configured threshold for the number of consecutive evaluations at a specified priority level. This is configured by overriding the `priority_transition_thresholds` @property method and returning a mapping of `DetectorPriorityLevel`'s to the number of consecutive evaluations returning that level required before the detector is activated.

A example configuration may look like:

```py
@override
@property
def priority_transition_thresholds(self):
  return {
    DetectorPriorityLevel.OK: 5,
    DetectorPriorityLevel:HIGH: 10,
  }
```

This configuration would mean there must be 10 consecutive evaluations resulting in a `DetectorPriorityLevel.HIGH` before the detector will produce a `DetectorEvaluationResult`.

Likewise for transitioning to `DetectorPriorityLevel.OK`, there must be 5 consecutive `OK` evaluations.

> [!IMPORTANT]
> This does not account for cases where we may want to "group" priority level thresholds. For example, if we had a configuration of `LOW: 10` and `HIGH: 10`, and we process 5 evaluations resulting in `LOW` and then 5 more evaluations resulting in `HIGH`, we may want to have carried over the counter from he `LOW` evaluations into the `HIGH` evaluations, meaning the combination of those 10 evluations would trigger a `HIGH` result.