### PR TITLE
fix: restore the sso-saml2 disabled-feature

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -253,6 +253,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:relay': FeatureDisabledHook;
   'feature-disabled:replay-sidebar-item': FeatureDisabledHook;
   'feature-disabled:sso-basic': FeatureDisabledHook;
+  'feature-disabled:sso-saml2': FeatureDisabledHook;
 };
 
 /**

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -257,6 +257,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'feature-disabled:relay': p => <DisabledRelay {...p} />,
   'feature-disabled:rate-limits': p => <DisabledRateLimits {...p} />,
   'feature-disabled:sso-basic': p => <DisabledAuthProvider {...p} />,
+  'feature-disabled:sso-saml2': p => <DisabledAuthProvider {...p} />,
   'feature-disabled:custom-inbound-filters': p => <DisabledCustomInboundFilters {...p} />,
   'feature-disabled:discover2-sidebar-item': p =>
     typeof p.children === 'function' ? p.children(p) : p.children,


### PR DESCRIPTION
we dynamically require this here: https://github.com/getsentry/sentry/blob/46fb30a52c8d737d579772a9574282505b282754/static/app/views/settings/organizationAuth/providerItem.tsx#L67-L69