### PR TITLE
fix(grouping): Set grouping config for projects without it

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -54,7 +54,7 @@ from sentry.grouping.api import (
     get_grouping_config_dict_for_project,
 )
 from sentry.grouping.grouptype import ErrorGroupType
-from sentry.grouping.ingest.config import is_in_transition, update_grouping_config_if_needed
+from sentry.grouping.ingest.config import is_in_transition, update_or_set_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
     find_grouphash_with_group,
     get_or_create_grouphashes,
@@ -1247,7 +1247,7 @@ def assign_event_to_group(
     # hashes, we're free to perform a config update if needed. Future events will use the new
     # config, but will also be grandfathered into the current config for a week, so as not to
     # erroneously create new groups.
-    update_grouping_config_if_needed(project, "ingest")
+    update_or_set_grouping_config_if_needed(project, "ingest")
 
     # The only way there won't be group info is we matched to a performance, cron, replay, or
     # other-non-error-type group because of a hash collision - exceedingly unlikely, and not

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -27,7 +27,7 @@ CONFIGS_TO_DEPRECATE = set(CONFIGURATIONS.keys()) - {
 }
 
 
-def update_grouping_config_if_needed(project: Project, source: str) -> None:
+def update_or_set_grouping_config_if_needed(project: Project, source: str) -> None:
     current_config = project.get_option("sentry:grouping_config")
 
     if current_config == BETA_GROUPING_CONFIG:

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -11,6 +11,7 @@ from django.core.cache import cache
 from sentry import audit_log, options
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.locks import locks
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import BETA_GROUPING_CONFIG, DEFAULT_GROUPING_CONFIG
 from sentry.utils import metrics
@@ -29,8 +30,21 @@ CONFIGS_TO_DEPRECATE = set(CONFIGURATIONS.keys()) - {
 def update_grouping_config_if_needed(project: Project, source: str) -> None:
     current_config = project.get_option("sentry:grouping_config")
 
-    if current_config == DEFAULT_GROUPING_CONFIG or current_config == BETA_GROUPING_CONFIG:
+    if current_config == BETA_GROUPING_CONFIG:
         return
+
+    if current_config == DEFAULT_GROUPING_CONFIG:
+        # If the project's current config comes back as the default one, it might be because that's
+        # actually what's set in the database for that project, or it might be relying on the
+        # default value of that project option. In the latter case, we can use this upgrade check as
+        # a chance to set it. (We want projects to have their own record of the config they're
+        # using, so that when we introduce a new one, we know to transition them.)
+        project_option_exists = ProjectOption.objects.filter(
+            key="sentry:grouping_config", project_id=project.id
+        ).exists()
+
+        if project_option_exists:
+            return
 
     # We want to try to write the audit log entry and project option change just once, so we use a
     # cache key to avoid raciness. It's not perfect, but it reduces the risk significantly.
@@ -47,8 +61,8 @@ def update_grouping_config_if_needed(project: Project, source: str) -> None:
 
         changes: dict[str, str | int] = {"sentry:grouping_config": DEFAULT_GROUPING_CONFIG}
 
-        # If the current config is still valid, put the project into a migration period
-        if current_config in CONFIGURATIONS.keys():
+        # If the current config is out of date but still valid, start a transition period
+        if current_config != DEFAULT_GROUPING_CONFIG and current_config in CONFIGURATIONS.keys():
             # This is when we will stop calculating the old hash in cases where we don't find the
             # new hash (which we do in an effort to preserve group continuity).
             transition_expiry = int(time.time()) + settings.SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
@@ -69,11 +83,25 @@ def update_grouping_config_if_needed(project: Project, source: str) -> None:
             event=audit_log.get_event_id("PROJECT_EDIT"),
             data={**changes, **project.get_audit_log_data()},
         )
-        metrics.incr(
-            "grouping.config_updated",
-            sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
-            tags={"current_config": current_config, "source": source},
-        )
+
+        if current_config == DEFAULT_GROUPING_CONFIG:
+            metrics.incr(
+                "grouping.default_config_set",
+                sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
+                tags={
+                    "source": source,
+                    "reason": "new_project" if not project.first_event else "backfill",
+                },
+            )
+        else:
+            metrics.incr(
+                "grouping.outdated_config_updated",
+                sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
+                tags={
+                    "source": source,
+                    "current_config": current_config,
+                },
+            )
 
 
 def is_in_transition(project: Project) -> bool:

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from time import time
 from typing import Any
 from unittest import mock
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -11,8 +11,10 @@ from sentry import audit_log
 from sentry.conf.server import SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
+from sentry.grouping.ingest.config import update_or_set_grouping_config_if_needed
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.group import Group
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.testutils.cases import TestCase
@@ -167,6 +169,60 @@ class EventManagerGroupingTest(TestCase):
             int(audit_log_entry.datetime.timestamp()) + SENTRY_GROUPING_UPDATE_MIGRATION_PHASE
         )
         assert actual_expiry == expected_expiry or actual_expiry == expected_expiry - 1
+
+    @patch(
+        "sentry.event_manager.update_or_set_grouping_config_if_needed",
+        wraps=update_or_set_grouping_config_if_needed,
+    )
+    def test_sets_default_grouping_config_project_option_if_missing(
+        self, update_config_spy: MagicMock
+    ):
+        # To start, the project defaults to the current config but doesn't have its own config
+        # option set in the DB
+        assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+        assert (
+            ProjectOption.objects.filter(
+                project_id=self.project.id, key="sentry:grouping_config"
+            ).first()
+            is None
+        )
+
+        save_new_event({"message": "Dogs are great!"}, self.project)
+
+        update_config_spy.assert_called_with(self.project, "ingest")
+
+        # After the function has been called, the config still defaults to the current one (and no
+        # transition has started), but the project now has its own config record in the DB
+        assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+        assert self.project.get_option("sentry:secondary_grouping_config") is None
+        assert self.project.get_option("sentry:secondary_grouping_expiry") == 0
+        assert ProjectOption.objects.filter(
+            project_id=self.project.id, key="sentry:grouping_config"
+        ).exists()
+
+    @patch(
+        "sentry.event_manager.update_or_set_grouping_config_if_needed",
+        wraps=update_or_set_grouping_config_if_needed,
+    )
+    def test_no_ops_if_grouping_config_project_option_exists_and_is_current(
+        self, update_config_spy: MagicMock
+    ):
+        self.project.update_option("sentry:grouping_config", DEFAULT_GROUPING_CONFIG)
+
+        assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+        assert ProjectOption.objects.filter(
+            project_id=self.project.id, key="sentry:grouping_config"
+        ).exists()
+
+        save_new_event({"message": "Dogs are great!"}, self.project)
+
+        update_config_spy.assert_called_with(self.project, "ingest")
+
+        # After the function has been called, the config still defaults to the current one and no
+        # transition has started
+        assert self.project.get_option("sentry:grouping_config") == DEFAULT_GROUPING_CONFIG
+        assert self.project.get_option("sentry:secondary_grouping_config") is None
+        assert self.project.get_option("sentry:secondary_grouping_expiry") == 0
 
 
 class PlaceholderTitleTest(TestCase):


### PR DESCRIPTION
When we introduce new grouping configs, we run a transition period for each project, wherein we calculate both new and old hashes for incoming events so as not to create new groups when we shouldn't. And the system works well... when it runs.

Though we intend to transition all projects when the config changes, in practice we actually only transition a small fraction of them. The way we decide if a project needs transitioning is we compare its grouping config to the current one, and if it's out of date, we start the transition. But only about 0.5% of projects actually have a grouping config set; those that don't just return whatever the current universal default is when we ask them what config they're on. In other words, 99.5% of our projects will never report themselves as being out of date, and will therefore never enter transition. Whoops.

To fix this, we need every project to have its own option value set in the database. We could accomplish this with a giant backfill migration, and create the ~2.5 million missing records at once, but a) that'd probably be pretty slow, b) it'd end up including a whole bunch of zombie projects that will never see another event along with the projects that actually need the upgrade, and c) that wouldn't help us with any project created after the backfill.

To get around those problems while still solving the larger issue, this PR changes our config upgrade function to be a config upgrade and set function. Now, if we detect that a project is using the current config, rather than just bailing immediately, we'll check if the project has its own database record stating that, or whether it's just relying on the global default. In the former case we'll still bail, but in the latter case, we'll now create the missing database record.

This solves the slowness of a backfill by spreading it out over time, solves the zombie project problem by only adding config values to projects actively sending us events, and solves the new project problem by guaranteeing that new projects get a config value set as soon as they send their first event. At the same time, it won't kick these projects into transition because they're already using the default config.

Over time, this should mean that more and more projects have their own config, making more and more of them able to be transitioned whenever we next release a new config. (Any projects we can't transition at that point - because they didn't get updated before the new config was launched - will continue to miss out on that transition, but will then be able to be transitioned the next time.)