### PR TITLE
fix(nextjs-insights): Broken date picker

### DIFF
--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -46,8 +46,7 @@ export function PlatformLandingPageLayout({
 }) {
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
-  const {defaultPeriod, maxPickableDays, relativeOptions} =
-    limitMaxPickableDays(organization);
+  const datePageFilterProps = limitMaxPickableDays(organization);
 
   const showOnboarding = onboardingProject !== undefined;
 
@@ -86,14 +85,7 @@ export function PlatformLandingPageLayout({
                 <PageFilterBar condensed>
                   <ProjectPageFilter resetParamsOnChange={['starred']} />
                   <EnvironmentPageFilter />
-                  <DatePageFilter
-                    maxPickableDays={maxPickableDays}
-                    defaultPeriod={defaultPeriod}
-                    relativeOptions={({arbitraryOptions}) => ({
-                      ...arbitraryOptions,
-                      ...relativeOptions,
-                    })}
-                  />
+                  <DatePageFilter {...datePageFilterProps} />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar


### PR DESCRIPTION
The interface of the underlying util `limitMaxPickableDays` which is used to calculate the queryable timeframes had a [breaking change](https://github.com/getsentry/sentry/pull/90965).

This one usage of it was forgotten as the change did not cause any type errors.