### PR TITLE
fix(ui): apply overflow:hidden to text inside buttons

### DIFF
--- a/static/app/components/core/button/index.chonk.tsx
+++ b/static/app/components/core/button/index.chonk.tsx
@@ -108,6 +108,7 @@ export function getChonkButtonStyles(
       justifyContent: 'inherit',
       flex: '1',
       gap: 'inherit',
+      overflow: 'hidden',
 
       whiteSpace: 'nowrap',
       transform: 'translateY(-2px)',


### PR DESCRIPTION
Not sure if this is the way to go, please see the linked issue: https://linear.app/getsentry/issue/DE-80/fix-dropdown-overflow-handling-issues#comment-29853d83