### PR TITLE
chore(onboarding): test the public api of the onboarding snippets in python

### DIFF
--- a/static/app/utils/gettingStartedDocs/python.spec.tsx
+++ b/static/app/utils/gettingStartedDocs/python.spec.tsx
@@ -8,26 +8,74 @@ jest.mock('sentry/utils/gettingStartedDocs/python', () => {
   };
 });
 
-import {getPythonInstallSnippet} from 'sentry/utils/gettingStartedDocs/python';
+import {getPythonInstallConfig} from 'sentry/utils/gettingStartedDocs/python';
 
-describe('getPythonInstallSnippet', () => {
+describe('getPythonInstallConfig', () => {
   it('generates install commands with default parameters', () => {
-    const result = getPythonInstallSnippet({
+    const result = getPythonInstallConfig({
       packageName: 'sentry-sdk',
+      description: 'Install the Sentry SDK',
     });
 
-    expect(result.pip).toBe(`pip install "sentry-sdk"`);
-    expect(result.uv).toBe(`uv add "sentry-sdk"`);
-    expect(result.poetry).toBe(`poetry add "sentry-sdk"`);
+    expect(result).toEqual([
+      {
+        description: 'Install the Sentry SDK',
+        language: 'bash',
+        code: [
+          {
+            label: 'pip',
+            value: 'pip',
+            language: 'bash',
+            code: `pip install "sentry-sdk"`,
+          },
+          {
+            label: 'uv',
+            value: 'uv',
+            language: 'bash',
+            code: `uv add "sentry-sdk"`,
+          },
+          {
+            label: 'poetry',
+            value: 'poetry',
+            language: 'bash',
+            code: `poetry add "sentry-sdk"`,
+          },
+        ],
+      },
+    ]);
   });
 
   it('generates pip install command with minimum version and extras', () => {
-    const result = getPythonInstallSnippet({
+    const result = getPythonInstallConfig({
       packageName: 'sentry-sdk[with-extras]',
+      description: 'Install the Sentry SDK',
       minimumVersion: '2.3.4',
     });
-    expect(result.pip).toBe(`pip install --upgrade "sentry-sdk[with-extras]>=2.3.4"`);
-    expect(result.uv).toBe(`uv add --upgrade "sentry-sdk[with-extras]>=2.3.4"`);
-    expect(result.poetry).toBe(`poetry add "sentry-sdk[with-extras]>=2.3.4"`);
+    expect(result).toEqual([
+      {
+        description: 'Install the Sentry SDK',
+        language: 'bash',
+        code: [
+          {
+            label: 'pip',
+            value: 'pip',
+            language: 'bash',
+            code: `pip install --upgrade "sentry-sdk[with-extras]>=2.3.4"`,
+          },
+          {
+            label: 'uv',
+            value: 'uv',
+            language: 'bash',
+            code: `uv add --upgrade "sentry-sdk[with-extras]>=2.3.4"`,
+          },
+          {
+            label: 'poetry',
+            value: 'poetry',
+            language: 'bash',
+            code: `poetry add "sentry-sdk[with-extras]>=2.3.4"`,
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/static/app/utils/gettingStartedDocs/python.tsx
+++ b/static/app/utils/gettingStartedDocs/python.tsx
@@ -10,7 +10,7 @@ import type {
 import {AlternativeConfiguration} from 'sentry/gettingStartedDocs/python/python';
 import {t, tct} from 'sentry/locale';
 
-export function getPythonInstallSnippet({
+function getPythonInstallSnippet({
   packageName,
   minimumVersion,
 }: {
@@ -72,14 +72,6 @@ export function getPythonInstallConfig({
   ];
 }
 
-export function getPythonProfilingMinVersionMessage() {
-  return tct(
-    'You need a minimum version [code:2.24.1] of the [code:sentry-python] SDK for the profiling feature.',
-    {
-      code: <code />,
-    }
-  );
-}
 export function getPythonAiocontextvarsConfig({
   description,
 }: {


### PR DESCRIPTION
- Remove the unused min profiling version export
- Test getPythonInstallConfig instead of getPythonInstallSnippet
- Remove export of getPythonInstallSnippet
