### PR TITLE
fix(ui): disable form fields that are in "saving" state

### DIFF
--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -16,6 +16,7 @@ import type {FieldGroupProps} from 'sentry/components/forms/fieldGroup/types';
 import FormContext from 'sentry/components/forms/formContext';
 import type FormModel from 'sentry/components/forms/model';
 import {MockModel} from 'sentry/components/forms/model';
+import FormState from 'sentry/components/forms/state';
 import type {FieldValue} from 'sentry/components/forms/types';
 import PanelAlert from 'sentry/components/panels/panelAlert';
 import {t} from 'sentry/locale';
@@ -351,6 +352,7 @@ function FormField(props: FormFieldProps) {
               {() => {
                 const error = model.getError(name);
                 const value = model.getValue(name);
+                const isSaving = model.getFieldState(name, FormState.SAVING);
 
                 return (
                   <Fragment>
@@ -360,6 +362,7 @@ function FormField(props: FormFieldProps) {
                       model,
                       name,
                       id,
+                      disabled: fieldProps.disabled || isSaving,
                       onKeyDown: handleKeyDown,
                       onChange: handleChange,
                       onBlur: handleBlur,


### PR DESCRIPTION
this fix side-steps the issue where selecting "the same value" again will not trigger another request, which makes the ui out-of-sync with the backend. It's especially visible with toggle buttons, but can happen for any form field.

here’s how this will look for auto-saving toggle buttons:

https://github.com/user-attachments/assets/aab7fce5-e693-4931-8749-904e96497193

and for auto-saving select fields:

https://github.com/user-attachments/assets/5813e3ce-3245-4091-b2a5-6688cedd7ddd

@evanpurkhiser please let me know if this has any impact aside from the auto-saving fields I tested.
