### PR TITLE
fix(nextjs-insights): return an empty array when path is empty or empty string

### DIFF
--- a/src/sentry/api/endpoints/organization_insights_tree.py
+++ b/src/sentry/api/endpoints/organization_insights_tree.py
@@ -51,7 +51,7 @@ class OrganizationInsightsTreeEndpoint(OrganizationEventsEndpoint):
                 path = match.group(2)
                 path_components = path.strip("/").split("/")
                 if not path_components or (len(path_components) == 1 and path_components[0] == ""):
-                    path_components = ["/"]  # Handle root path case
+                    path_components = []  # Handle root path case
 
             else:
                 component_type = None

--- a/tests/sentry/api/endpoints/test_organization_insights_tree.py
+++ b/tests/sentry/api/endpoints/test_organization_insights_tree.py
@@ -106,7 +106,7 @@ class OrganizationInsightsTreeEndpointTest(
         root_route_idx = span_descriptions.index("Page Server Component (/)")
         element = response.data["data"][root_route_idx]
         assert element["function.nextjs.component_type"] == "Page Server Component"
-        assert element["function.nextjs.path"] == ["/"]
+        assert element["function.nextjs.path"] == []
 
         unparameterized_route_idx = span_descriptions.index(
             "Page.generateMetadata (/app/dashboard/)"


### PR DESCRIPTION
- Implements this suggestion: https://github.com/getsentry/sentry/pull/91120#issuecomment-2858432150