### PR TITLE
fix(releases): Fix opening drawer on new load of issue details

### DIFF
--- a/static/app/views/releases/drawer/releasesDrawerList.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerList.tsx
@@ -85,7 +85,7 @@ const unhighlightMarkLines = createMarkLineUpdater({});
 export function ReleasesDrawerList({chart, pageFilters}: ReleasesDrawerListProps) {
   const {releases} = useReleaseStats(pageFilters);
   const chartRef = useRef<ReactEchartsRef | null>(null);
-  const chartHeight = chart === EVENT_GRAPH_WIDGET_ID ? 'auto' : '220px';
+  const chartHeight = chart === EVENT_GRAPH_WIDGET_ID ? '160px' : '220px';
 
   const handleMouseOverRelease = useCallback((release: string) => {
     if (!chartRef.current) {


### PR DESCRIPTION
This happens only on a new load w/ releases drawer on issue details. The group data is still loading.

Also specifies a height for placeholder for EventGraph.

Fixes JAVASCRIPT-2ZZ2
