### PR TITLE
fix(eap-spans): add count_if, fix meta field for `avg_compare`

### DIFF
--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -157,6 +157,24 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
         arguments=[ValueArgumentDefinition(argument_types={"string"})],
         aggregate_resolver=resolve_count_op,
     ),
+    "count_ic": ConditionalAggregateDefinition(
+        internal_function=Function.FUNCTION_COUNT,
+        default_search_type="duration",
+        arguments=[
+            AttributeArgumentDefinition(
+                attribute_types={
+                    "duration",
+                    "number",
+                    "percentage",
+                    *constants.SIZE_TYPE,
+                    *constants.DURATION_TYPE,
+                },
+            ),
+            AttributeArgumentDefinition(attribute_types={"string"}),
+            ValueArgumentDefinition(argument_types={"string"}),
+        ],
+        aggregate_resolver=resolve_key_eq_value_filter,
+    ),
     "avg_if": ConditionalAggregateDefinition(
         internal_function=Function.FUNCTION_AVG,
         default_search_type="duration",

--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -157,7 +157,7 @@ SPAN_CONDITIONAL_AGGREGATE_DEFINITIONS = {
         arguments=[ValueArgumentDefinition(argument_types={"string"})],
         aggregate_resolver=resolve_count_op,
     ),
-    "count_ic": ConditionalAggregateDefinition(
+    "count_if": ConditionalAggregateDefinition(
         internal_function=Function.FUNCTION_COUNT,
         default_search_type="duration",
         arguments=[

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -669,6 +669,7 @@ SPAN_FORMULA_DEFINITIONS = {
     ),
     "avg_compare": FormulaDefinition(
         default_search_type="percentage",
+        infer_search_type_from_arguments=False,
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3006,6 +3006,12 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert len(data) == 1
         assert data[0]["avg_compare(span.self_time, release, foo, bar)"] == -0.9
         assert meta["dataset"] == self.dataset
+        assert meta["fields"] == {
+            "avg_compare(span.self_time, release, foo, bar)": "percentage",
+        }
+        assert meta["units"] == {
+            "avg_compare(span.self_time, release, foo, bar)": None,
+        }
 
     def test_avg_if_invalid_param(self):
         self.store_spans(


### PR DESCRIPTION
1. `avg_compare` should always return `percentage` as the meta and not infer from parameters
2. Add `count_if` function (needed for mobile modules on eap)