### PR TITLE
feat(insights): migrate app start bar chart to use discover hooks

### DIFF
--- a/static/app/views/insights/mobile/appStarts/components/appStartup.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/appStartup.tsx
@@ -30,12 +30,16 @@ import {getFreeTextFromQuery} from 'sentry/views/insights/mobile/screenload/comp
 import {useTableQuery} from 'sentry/views/insights/mobile/screenload/components/tables/screensTable';
 import {YAxis, YAXIS_COLUMNS} from 'sentry/views/insights/mobile/screenload/constants';
 import {transformReleaseEvents} from 'sentry/views/insights/mobile/screenload/utils';
+import type {MetricsProperty} from 'sentry/views/insights/types';
 import {ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
 import {prepareQueryForLandingPage} from 'sentry/views/performance/data';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 
 const Y_AXES = [YAxis.COLD_START, YAxis.WARM_START];
-const Y_AXIS_COLS = [YAXIS_COLUMNS[YAxis.COLD_START], YAXIS_COLUMNS[YAxis.WARM_START]];
+const Y_AXIS_COLS: MetricsProperty[] = [
+  'avg(measurements.app_start_cold)',
+  'avg(measurements.app_start_warm)',
+] as const;
 
 type Props = {
   additionalFilters?: string[];

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -33,7 +33,6 @@ import {
   YAXIS_COLUMNS,
 } from 'sentry/views/insights/mobile/screenload/constants';
 import {transformDeviceClassEvents} from 'sentry/views/insights/mobile/screenload/utils';
-import type {MetricsProperty} from 'sentry/views/insights/types';
 
 export enum YAxis {
   WARM_START = 0,
@@ -47,17 +46,22 @@ export enum YAxis {
 }
 
 type Props = {
-  yAxes: YAxis[];
   additionalFilters?: string[];
   chartHeight?: number;
 };
 
-export function ScreenCharts({yAxes, additionalFilters}: Props) {
+const yAxes = [YAxis.TTID, YAxis.TTFD, YAxis.COUNT];
+
+export function ScreenCharts({additionalFilters}: Props) {
   const theme = useTheme();
   const useEap = useInsightsEap();
   const pageFilter = usePageFilters();
   const {isProjectCrossPlatform, selectedPlatform: platform} = useCrossPlatformProject();
-  const yAxisCols = yAxes.map(val => YAXIS_COLUMNS[val]) as MetricsProperty[];
+  const yAxisCols = [
+    'avg(measurements.time_to_initial_display)',
+    'avg(measurements.time_to_full_display)',
+    'count()',
+  ] as const;
 
   const {
     primaryRelease,

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -14,25 +14,26 @@ import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/ch
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
 import MiniChartPanel from 'sentry/views/insights/common/components/miniChartPanel';
+import {useMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {formatVersionAndCenterTruncate} from 'sentry/views/insights/common/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/insights/common/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {useEventsStatsQuery} from 'sentry/views/insights/common/utils/useEventsStatsQuery';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {ScreensBarChart} from 'sentry/views/insights/mobile/screenload/components/charts/screenBarChart';
-import {useTableQuery} from 'sentry/views/insights/mobile/screenload/components/tables/screensTable';
 import {
   CHART_TITLES,
   OUTPUT_TYPE,
   YAXIS_COLUMNS,
 } from 'sentry/views/insights/mobile/screenload/constants';
 import {transformDeviceClassEvents} from 'sentry/views/insights/mobile/screenload/utils';
+import type {MetricsProperty} from 'sentry/views/insights/types';
 
 export enum YAxis {
   WARM_START = 0,
@@ -53,10 +54,10 @@ type Props = {
 
 export function ScreenCharts({yAxes, additionalFilters}: Props) {
   const theme = useTheme();
+  const useEap = useInsightsEap();
   const pageFilter = usePageFilters();
-  const location = useLocation();
   const {isProjectCrossPlatform, selectedPlatform: platform} = useCrossPlatformProject();
-  const yAxisCols = yAxes.map(val => YAXIS_COLUMNS[val]);
+  const yAxisCols = yAxes.map(val => YAXIS_COLUMNS[val]) as MetricsProperty[];
 
   const {
     primaryRelease,
@@ -75,6 +76,10 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
       query.addFilterValue('os.name', platform);
     }
 
+    if (useEap) {
+      query.addFilterValue('is_transaction', 'true');
+    }
+
     return appendReleaseFilters(query, primaryRelease, secondaryRelease);
   }, [
     additionalFilters,
@@ -82,6 +87,7 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
     platform,
     primaryRelease,
     secondaryRelease,
+    useEap,
   ]);
 
   const {
@@ -151,22 +157,15 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
     });
   }
 
-  const {data: deviceClassEvents, isPending: isDeviceClassEventsLoading} = useTableQuery({
-    eventView: EventView.fromNewQueryWithLocation(
-      {
-        name: '',
-        fields: ['device.class', 'release', ...yAxisCols],
-        orderby: yAxisCols[0],
-        yAxis: yAxisCols,
-        query: queryString,
-        dataset: DiscoverDatasets.METRICS,
-        version: 2,
-      },
-      location
-    ),
-    enabled: !isReleasesLoading,
-    referrer: 'api.starfish.mobile-device-breakdown',
-  });
+  const {data: deviceClassEvents, isPending: isDeviceClassEventsLoading} = useMetrics(
+    {
+      enabled: !isReleasesLoading,
+      search: queryString,
+      orderby: yAxisCols[0],
+      fields: ['device.class', 'release', ...yAxisCols],
+    },
+    'api.starfish.mobile-device-breakdown'
+  );
 
   if (isReleasesLoading) {
     return <LoadingContainer />;

--- a/static/app/views/insights/mobile/screenload/constants.ts
+++ b/static/app/views/insights/mobile/screenload/constants.ts
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import type {MetricsProperty, SpanMetricsProperty} from 'sentry/views/insights/types';
 
 export enum MobileCursors {
   SPANS_TABLE = 'spansCursor',
@@ -27,7 +28,9 @@ export enum YAxis {
   FRAMES_DELAY = 10,
 }
 
-export const YAXIS_COLUMNS: Readonly<Record<YAxis, string>> = {
+export const YAXIS_COLUMNS: Readonly<
+  Record<YAxis, MetricsProperty | SpanMetricsProperty>
+> = {
   [YAxis.WARM_START]: 'avg(measurements.app_start_warm)',
   [YAxis.COLD_START]: 'avg(measurements.app_start_cold)',
   [YAxis.TTID]: 'avg(measurements.time_to_initial_display)',

--- a/static/app/views/insights/mobile/screenload/utils.tsx
+++ b/static/app/views/insights/mobile/screenload/utils.tsx
@@ -4,9 +4,9 @@ import Color from 'color';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
-import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type {YAxis} from 'sentry/views/insights/mobile/screenload/constants';
 import {YAXIS_COLUMNS} from 'sentry/views/insights/mobile/screenload/constants';
+import type {MetricsResponse} from 'sentry/views/insights/types';
 
 export function isCrossPlatform(project: Project) {
   return project.platform && ['react-native', 'flutter'].includes(project.platform);
@@ -81,7 +81,7 @@ export function transformDeviceClassEvents({
 }: {
   theme: Theme;
   yAxes: YAxis[];
-  data?: TableData;
+  data?: Array<Partial<MetricsResponse> & Pick<MetricsResponse, 'device.class'>>;
   primaryRelease?: string;
   secondaryRelease?: string;
 }): Record<string, Record<string, Series>> {
@@ -114,8 +114,8 @@ export function transformDeviceClassEvents({
   );
 
   if (defined(data)) {
-    data.data?.forEach(row => {
-      const deviceClass = row['device.class']!;
+    data?.forEach(row => {
+      const deviceClass = row['device.class'];
       const index = deviceClassIndex[deviceClass];
 
       const release = row.release;
@@ -127,7 +127,7 @@ export function transformDeviceClassEvents({
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           transformedData[YAXIS_COLUMNS[val]][release].data[index] = {
             name: deviceClass,
-            value: row[YAXIS_COLUMNS[val]],
+            value: row[YAXIS_COLUMNS[val] as keyof MetricsResponse],
             itemStyle: {
               color: isPrimary ? colors[0] : colors[1],
             },

--- a/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
+++ b/static/app/views/insights/mobile/screenload/views/screenLoadSpansPage.tsx
@@ -21,14 +21,12 @@ import {
 } from 'sentry/views/insights/common/components/releaseSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import type {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {SpanSamplesPanel} from 'sentry/views/insights/mobile/common/components/spanSamplesPanel';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
-import {
-  ScreenCharts,
-  YAxis,
-} from 'sentry/views/insights/mobile/screenload/components/charts/screenCharts';
+import {ScreenCharts} from 'sentry/views/insights/mobile/screenload/components/charts/screenCharts';
 import {ScreenLoadEventSamples} from 'sentry/views/insights/mobile/screenload/components/eventSamples';
 import {MobileMetricsRibbon} from 'sentry/views/insights/mobile/screenload/components/metricsRibbon';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
@@ -82,6 +80,7 @@ function ScreenLoadSpans() {
 export function ScreenLoadSpansContent() {
   const router = useRouter();
   const location = useLocation<Query>();
+  const useEap = useInsightsEap();
 
   const {spanGroup, transaction: transactionName} = location.query;
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
@@ -113,7 +112,7 @@ export function ScreenLoadSpansContent() {
         <MobileMetricsRibbon
           dataset={DiscoverDatasets.METRICS}
           filters={[
-            'event.type:transaction',
+            useEap ? 'is_transaction:true' : 'event.type:transaction',
             'transaction.op:ui.load',
             `transaction:${transactionName}`,
           ]}
@@ -163,7 +162,6 @@ export function ScreenLoadSpansContent() {
 
       <ErrorBoundary mini>
         <ScreenCharts
-          yAxes={[YAxis.TTID, YAxis.TTFD, YAxis.COUNT]}
           additionalFilters={[`transaction:${transactionName}`]}
           chartHeight={120}
         />

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -536,6 +536,7 @@ export enum MetricsFields {
   TIME_TO_INITIAL_DISPLAY = 'measurements.time_to_initial_display',
   TIME_TO_FULL_DISPLAY = 'measurements.time_to_full_display',
   RELEASE = 'release',
+  DEVICE_CLASS = 'device.class',
 }
 
 type MetricsNumberFields =
@@ -571,7 +572,8 @@ type MetricsStringFields =
   | MetricsFields.USER_DISPLAY
   | MetricsFields.PROFILE_ID
   | MetricsFields.RELEASE
-  | MetricsFields.TIMESTAMP;
+  | MetricsFields.TIMESTAMP
+  | MetricsFields.DEVICE_CLASS;
 
 export type MetricsResponse = {
   [Property in MetricsNumberFields as `${Aggregate}(${Property})`]: number;


### PR DESCRIPTION
Use discover hooks in app start bar chart (which toggles eap), and some additional cleanup 
![image](https://github.com/user-attachments/assets/51ae4bc0-0d11-4533-8262-28fa59a28baf)
