### PR TITLE
feat(dashboards): Change widget builder title to breadcrumbs

### DIFF
--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -2381,7 +2381,7 @@ describe('Dashboards > Detail', function () {
         await userEvent.click(
           await screen.findByRole('menuitemradio', {name: 'Create Custom Widget'})
         );
-        expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+        expect(await screen.findByText('Custom Widget Builder')).toBeInTheDocument();
       });
 
       it('opens the widget builder library slideout when clicking add widget from widget library', async function () {
@@ -2405,7 +2405,7 @@ describe('Dashboards > Detail', function () {
         await userEvent.click(
           await screen.findByRole('menuitemradio', {name: 'From Widget Library'})
         );
-        expect(await screen.findByText('Add from Widget Library')).toBeInTheDocument();
+        expect(await screen.findByText('Widget Library')).toBeInTheDocument();
       });
 
       it('opens the widget builder slideout when clicking add widget in edit mode', async function () {
@@ -2429,7 +2429,7 @@ describe('Dashboards > Detail', function () {
         await userEvent.click(
           await screen.findByRole('menuitemradio', {name: 'Create Custom Widget'})
         );
-        expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+        expect(await screen.findByText('Custom Widget Builder')).toBeInTheDocument();
       });
 
       it('opens the widget builder library slideout when clicking add widget from widget library in edit mode', async function () {
@@ -2453,7 +2453,7 @@ describe('Dashboards > Detail', function () {
         await userEvent.click(
           await screen.findByRole('menuitemradio', {name: 'From Widget Library'})
         );
-        expect(await screen.findByText('Add from Widget Library')).toBeInTheDocument();
+        expect(await screen.findByText('Widget Library')).toBeInTheDocument();
       });
 
       it('allows for editing a widget in edit mode', async function () {
@@ -2538,13 +2538,13 @@ describe('Dashboards > Detail', function () {
           await screen.findByRole('menuitemradio', {name: 'Create Custom Widget'})
         );
 
-        expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+        expect(await screen.findByText('Custom Widget Builder')).toBeInTheDocument();
 
         await userEvent.click(screen.getByText('Add Widget'));
 
         // The widget builder is closed after the widget is updated
         await waitFor(() => {
-          expect(screen.queryByText('Create Custom Widget')).not.toBeInTheDocument();
+          expect(screen.queryByText('Custom Widget Builder')).not.toBeInTheDocument();
         });
 
         // The widget is added in the dashboard
@@ -2642,7 +2642,7 @@ describe('Dashboards > Detail', function () {
           await screen.findByRole('menuitemradio', {name: 'Create Custom Widget'})
         );
 
-        expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+        expect(await screen.findByText('Custom Widget Builder')).toBeInTheDocument();
 
         await userEvent.click(
           await within(screen.getByTestId('widget-slideout')).findByText('Add Widget')
@@ -2650,7 +2650,7 @@ describe('Dashboards > Detail', function () {
 
         // The widget builder is closed after the widget is updated
         await waitFor(() => {
-          expect(screen.queryByText('Create Custom Widget')).not.toBeInTheDocument();
+          expect(screen.queryByText('Custom Widget Builder')).not.toBeInTheDocument();
         });
 
         // The update action is called with the new widget

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -117,7 +117,7 @@ describe('NewWidgetBuiler', function () {
       }
     );
 
-    expect(await screen.findByText('Create Custom Widget')).toBeInTheDocument();
+    expect(await screen.findByText('Custom Widget Builder')).toBeInTheDocument();
 
     expect(await screen.findByLabelText('Close Widget Builder')).toBeInTheDocument();
 
@@ -270,7 +270,7 @@ describe('NewWidgetBuiler', function () {
       }
     );
 
-    expect(await screen.findByText('Add from Widget Library')).toBeInTheDocument();
+    expect(await screen.findByText('Widget Library')).toBeInTheDocument();
 
     expect(await screen.findByText('Select a widget to preview')).toBeInTheDocument();
   });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -284,7 +284,7 @@ describe('WidgetBuilderSlideout', () => {
       expect(addErrorMessage).toHaveBeenCalledWith('Unable to save widget');
     });
 
-    expect(screen.getByText('Create Custom Widget')).toBeInTheDocument();
+    expect(screen.getByText('Custom Widget Builder')).toBeInTheDocument();
   });
 
   it('clears the alias when dataset changes', async () => {
@@ -469,5 +469,78 @@ describe('WidgetBuilderSlideout', () => {
     await userEvent.click(await screen.findByText('Add Widget'));
 
     expect(onSave).toHaveBeenCalledWith({index: undefined, widget: expect.any(Object)});
+  });
+
+  it('should render the widget template title if templates selected', () => {
+    const onSave = jest.fn();
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={onSave}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+      }
+    );
+
+    expect(screen.getByText('Widget Library')).toBeInTheDocument();
+  });
+
+  it('should render appropriate breadcrumbs if library widget is customized', async () => {
+    const onSave = jest.fn();
+    const {rerender} = render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={onSave}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+      }
+    );
+
+    screen.getByText('Widget Library');
+
+    await userEvent.click(screen.getByText('Duration Distribution'));
+    await userEvent.click(screen.getByText('Customize'));
+
+    rerender(
+      <WidgetBuilderProvider>
+        <WidgetBuilderSlideout
+          dashboard={DashboardFixture([])}
+          dashboardFilters={{release: undefined}}
+          isWidgetInvalid
+          onClose={jest.fn()}
+          onQueryConditionChange={jest.fn()}
+          onSave={onSave}
+          setIsPreviewDraggable={jest.fn()}
+          isOpen
+          openWidgetTemplates={false}
+          setOpenWidgetTemplates={jest.fn()}
+        />
+      </WidgetBuilderProvider>
+    );
+
+    expect(await screen.findByText('Widget Library')).toBeInTheDocument();
+    expect(await screen.findByText('Custom Widget Builder')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -2,17 +2,22 @@ import {Fragment, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
 import SlideOverPanel from 'sentry/components/slideOverPanel';
+import {URL_PARAM} from 'sentry/constants/pageFilters';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useValidateWidgetQuery} from 'sentry/views/dashboards/hooks/useValidateWidget';
 import {
@@ -74,11 +79,13 @@ function WidgetBuilderSlideout({
   const organization = useOrganization();
   const {state} = useWidgetBuilderContext();
   const [initialState] = useState(state);
+  const [customizeFromLibrary, setCustomizeFromLibrary] = useState(false);
   const [error, setError] = useState<Record<string, any>>({});
   const theme = useTheme();
   const isEditing = useIsEditingWidget();
   const source = useDashboardWidgetSource();
-
+  const navigate = useNavigate();
+  const location = useLocation();
   const validatedWidgetResponse = useValidateWidgetQuery(
     convertBuilderStateToWidget(state)
   );
@@ -99,10 +106,10 @@ function WidgetBuilderSlideout({
   }, [openWidgetTemplates, organization]);
 
   const title = openWidgetTemplates
-    ? t('Add from Widget Library')
+    ? t('Widget Library')
     : isEditing
       ? t('Edit Widget')
-      : t('Create Custom Widget');
+      : t('Custom Widget Builder');
   const isChartWidget =
     state.displayType !== DisplayType.BIG_NUMBER &&
     state.displayType !== DisplayType.TABLE;
@@ -136,6 +143,42 @@ function WidgetBuilderSlideout({
     return () => observer.disconnect();
   }, [setIsPreviewDraggable, openWidgetTemplates]);
 
+  const widgetLibraryElement = (
+    <SlideoutBreadcrumb
+      onClick={() => {
+        setCustomizeFromLibrary(false);
+        setOpenWidgetTemplates(true);
+        // clears the widget to start fresh on the library page
+        navigate({
+          pathname: location.pathname,
+          query: {
+            ...pick(location.query, [...Object.values(URL_PARAM)]),
+          },
+        });
+      }}
+    >
+      {t('Widget Library')}
+    </SlideoutBreadcrumb>
+  );
+
+  const breadcrumbs = customizeFromLibrary
+    ? [
+        {
+          label: widgetLibraryElement,
+          to: '',
+        },
+        {
+          label: title,
+          to: '',
+        },
+      ]
+    : [
+        {
+          label: title,
+          to: '',
+        },
+      ];
+
   return (
     <SlideOverPanel
       collapsed={!isOpen}
@@ -144,7 +187,7 @@ function WidgetBuilderSlideout({
       transitionProps={animationTransitionSettings}
     >
       <SlideoutHeaderWrapper>
-        <SlideoutTitle>{title}</SlideoutTitle>
+        <Breadcrumbs crumbs={breadcrumbs} />
         <CloseButton
           priority="link"
           size="zero"
@@ -183,6 +226,7 @@ function WidgetBuilderSlideout({
               onSave={onSave}
               setOpenWidgetTemplates={setOpenWidgetTemplates}
               setIsPreviewDraggable={setIsPreviewDraggable}
+              setCustomizeFromLibrary={setCustomizeFromLibrary}
             />
           </Fragment>
         ) : (
@@ -262,16 +306,16 @@ const CloseButton = styled(Button)`
   z-index: 100;
 `;
 
-const SlideoutTitle = styled('h5')`
-  margin: 0;
-`;
-
 const SlideoutHeaderWrapper = styled('div')`
-  padding: ${space(3)} ${space(4)};
+  padding: ${space(1)} ${space(4)};
   display: flex;
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const SlideoutBreadcrumb = styled('div')`
+  cursor: pointer;
 `;
 
 const SlideoutBodyWrapper = styled('div')`

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -59,6 +59,7 @@ describe('WidgetTemplatesList', () => {
           onSave={onSave}
           setOpenWidgetTemplates={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
+          setCustomizeFromLibrary={jest.fn()}
         />
       </WidgetBuilderProvider>,
       {
@@ -77,6 +78,7 @@ describe('WidgetTemplatesList', () => {
           onSave={onSave}
           setOpenWidgetTemplates={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
+          setCustomizeFromLibrary={jest.fn()}
         />
       </WidgetBuilderProvider>,
       {
@@ -101,6 +103,7 @@ describe('WidgetTemplatesList', () => {
           onSave={onSave}
           setOpenWidgetTemplates={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
+          setCustomizeFromLibrary={jest.fn()}
         />
       </WidgetBuilderProvider>,
       {
@@ -133,6 +136,7 @@ describe('WidgetTemplatesList', () => {
           onSave={onSave}
           setOpenWidgetTemplates={jest.fn()}
           setIsPreviewDraggable={jest.fn()}
+          setCustomizeFromLibrary={jest.fn()}
         />
       </WidgetBuilderProvider>,
       {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -20,6 +20,7 @@ import {getWidgetIcon} from 'sentry/views/dashboards/widgetLibrary/widgetCard';
 
 interface WidgetTemplatesListProps {
   onSave: ({index, widget}: {index: number; widget: Widget}) => void;
+  setCustomizeFromLibrary: (customizeFromLibrary: boolean) => void;
   setIsPreviewDraggable: (isPreviewDraggable: boolean) => void;
   setOpenWidgetTemplates: (openWidgetTemplates: boolean) => void;
 }
@@ -28,6 +29,7 @@ function WidgetTemplatesList({
   onSave,
   setOpenWidgetTemplates,
   setIsPreviewDraggable,
+  setCustomizeFromLibrary,
 }: WidgetTemplatesListProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -97,6 +99,7 @@ function WidgetTemplatesList({
                       onClick={e => {
                         e.stopPropagation();
                         setOpenWidgetTemplates(false);
+                        setCustomizeFromLibrary(true);
                         // reset preview when customizing templates
                         setIsPreviewDraggable(false);
                         trackAnalytics(


### PR DESCRIPTION
Instead of having the big title for the widget builder, we've opted for the breadcrumbs title. This way when users go from the widget library to the custom builder, they have a way to go back to the library without closing the builder and restarting the flow.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1f638e52-39b0-41fc-ac1a-563bc557960b) ![image](https://github.com/user-attachments/assets/e98a2eb1-4f15-49e4-9b3b-91a5356a442f) | ![image](https://github.com/user-attachments/assets/25bcb989-60c2-414a-a01f-9ecf785ce088) ![image](https://github.com/user-attachments/assets/497681b3-fd8a-4d84-873b-f6a51c5c35e9) | 
