### PR TITLE
fix(integrations): allow Manager to delete User Mappings

### DIFF
--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 
 from sentry import features
+from sentry.api.bases import OrganizationPermission
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.integrations.api.parsers.external_actor import (
     is_valid_provider,
@@ -172,6 +173,14 @@ class ExternalTeamSerializer(ExternalActorSerializerBase):
     class Meta:
         model = ExternalActor
         fields = ["team_id", "external_id", "external_name", "provider", "integration_id"]
+
+
+class ExternalUserPermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["org:write", "org:admin"],
+        "PUT": ["org:write", "org:admin"],
+        "DELETE": ["org:write", "org:admin"],
+    }
 
 
 class ExternalActorEndpointMixin:

--- a/src/sentry/integrations/api/endpoints/external_user_details.py
+++ b/src/sentry/integrations/api/endpoints/external_user_details.py
@@ -18,6 +18,7 @@ from sentry.apidocs.examples.integration_examples import IntegrationExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams
 from sentry.integrations.api.bases.external_actor import (
     ExternalActorEndpointMixin,
+    ExternalUserPermission,
     ExternalUserSerializer,
 )
 from sentry.integrations.api.serializers.models.external_actor import ExternalActorSerializer
@@ -30,11 +31,12 @@ logger = logging.getLogger(__name__)
 @region_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
+    owner = ApiOwner.ENTERPRISE
+    permission_classes = (ExternalUserPermission,)
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
 
     def convert_args(
         self,

--- a/src/sentry/integrations/api/endpoints/external_user_details.py
+++ b/src/sentry/integrations/api/endpoints/external_user_details.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 @region_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.ECOSYSTEM
     permission_classes = (ExternalUserPermission,)
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,

--- a/src/sentry/integrations/api/endpoints/external_user_index.py
+++ b/src/sentry/integrations/api/endpoints/external_user_index.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @region_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
-    owner = ApiOwner.ENTERPRISE
+    owner = ApiOwner.ECOSYSTEM
     permission_classes = (ExternalUserPermission,)
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,

--- a/src/sentry/integrations/api/endpoints/external_user_index.py
+++ b/src/sentry/integrations/api/endpoints/external_user_index.py
@@ -15,6 +15,7 @@ from sentry.apidocs.examples.integration_examples import IntegrationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.integrations.api.bases.external_actor import (
     ExternalActorEndpointMixin,
+    ExternalUserPermission,
     ExternalUserSerializer,
 )
 from sentry.integrations.api.serializers.models.external_actor import ExternalActorSerializer
@@ -26,10 +27,11 @@ logger = logging.getLogger(__name__)
 @region_silo_endpoint
 @extend_schema(tags=["Integrations"])
 class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
+    owner = ApiOwner.ENTERPRISE
+    permission_classes = (ExternalUserPermission,)
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
     }
-    owner = ApiOwner.ENTERPRISE
 
     @extend_schema(
         operation_id="Create an External User",

--- a/tests/sentry/integrations/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_external_user_details.py
@@ -17,6 +17,13 @@ class ExternalUserDetailsTest(APITestCase):
         self.get_success_response(self.organization.slug, self.external_user.id, method="delete")
         assert not ExternalActor.objects.filter(id=str(self.external_user.id)).exists()
 
+    def test_manager_can_delete(self):
+        manager_user = self.create_user()
+        self.create_member(organization=self.organization, user=manager_user, role="manager")
+        self.login_as(user=manager_user)
+        self.get_success_response(self.organization.slug, self.external_user.id, method="delete")
+        assert not ExternalActor.objects.filter(id=str(self.external_user.id)).exists()
+
     def test_basic_update(self):
         with self.feature({"organizations:integrations-codeowners": True}):
             data = {"externalName": "@new_username"}


### PR DESCRIPTION
Currently, Managers are not allowed to delete User Mappings in Integrations. This behavior is happening because `ExternalUserDetailsEndpoint` has the `OrganizationPermission` permission class:
https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/api/endpoints/external_user_details.py#L32
https://github.com/getsentry/sentry/blob/master/src/sentry/api/bases/organization.py#L51-L52

This permission class allows PUT for Manager and Owner, but DELETE only for Owner. The idea behind this is that only Owner can delete an organization. We have a wrong choice of permission class for this particular case.

This PR fixes that allowing Manager to delete User Mappings in Integrations.