### PR TITLE
feat(ourlogs): Make logs drawer on issues resizable

### DIFF
--- a/static/app/views/explore/logs/logsIssuesSection.tsx
+++ b/static/app/views/explore/logs/logsIssuesSection.tsx
@@ -63,6 +63,7 @@ export function LogsIssuesSection({
       ),
       {
         ariaLabel: 'logs drawer',
+        drawerKey: 'logs-issue-drawer',
       }
     );
   }, [group, event, project, openDrawer, organization, limitToTraceId]);


### PR DESCRIPTION
We made the logs drawer before the resizable trait was added, this adds drawer key which should enable resizing on the logs drawer for issues.

Fixes LOGS-97

