### PR TITLE
ref(feedback): make new flagpole flag for spam LLM requests

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -412,8 +412,10 @@ def register_temporary_features(manager: FeatureManager):
     # Enable processing uptime results via the detector handler
     manager.add("organizations:uptime-detector-handler", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable User Feedback spam auto filtering feature ingest
+    # Enable User Feedback spam auto filtering feature ingest. TODO: Deprecate - replaced by user-feedback-spam-ingest.
     manager.add("organizations:user-feedback-spam-filter-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enable User Feedback spam requests to LLM
+    manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Block User Feedback spam auto filtering feature ingest
     manager.add("organizations:user-feedback-spam-ingest-blocklist", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable User Feedback spam auto filtering feature actions

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -64,7 +64,10 @@ def trim_response(text):
 
 def spam_detection_enabled(project: Project) -> bool:
     return (
-        features.has("organizations:user-feedback-spam-filter-ingest", project.organization)
+        (
+            features.has("organizations:user-feedback-spam-filter-ingest", project.organization)
+            or features.has("organizations:user-feedback-spam-ingest", project.organization)
+        )
         and project.get_option("sentry:feedback_ai_spam_detection")
         and not features.has(
             "organizations:user-feedback-spam-ingest-blocklist", project.organization


### PR DESCRIPTION
Ports the `spam-filter-ingest` flag from the old options-backed INTERNAL feature manager to flagpole. The old manager doesn't work with `.la-orgs` or `.ea-rollout`. LA and EA rollout options are registered but don't work as expected, only GA works. There's little documentation I could find on INTERNAL - to make this killswitch easier to use going forward, let's use flagpole. 

Once this is deployed we can clean up the old flag - this PR uses an OR of both. Spam is currently disabled so this won't affect the service.