### PR TITLE
fix(widget-builder): count_unique sort by should default to span.op 

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -59,19 +59,49 @@ const DEFAULT_FIELD: QueryFieldValue = {
 };
 
 const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce((acc, aggregate) => {
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  acc[aggregate] = {
-    isSortable: true,
-    outputType: null,
-    parameters: [
-      {
-        kind: 'column',
-        columnTypes: ['number', 'string'], // Need to keep the string type for unknown values before tags are resolved
-        defaultValue: 'span.duration',
-        required: true,
-      },
-    ],
-  };
+  if (aggregate === AggregationKey.COUNT) {
+    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+    acc[AggregationKey.COUNT] = {
+      isSortable: true,
+      outputType: null,
+      parameters: [
+        {
+          kind: 'column',
+          columnTypes: ['number'],
+          defaultValue: 'span.duration',
+          required: true,
+        },
+      ],
+    };
+  } else if (aggregate === AggregationKey.COUNT_UNIQUE) {
+    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+    acc[AggregationKey.COUNT_UNIQUE] = {
+      isSortable: true,
+      outputType: null,
+      parameters: [
+        {
+          kind: 'column',
+          columnTypes: ['string'],
+          defaultValue: 'span.op',
+          required: true,
+        },
+      ],
+    };
+  } else {
+    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+    acc[aggregate] = {
+      isSortable: true,
+      outputType: null,
+      parameters: [
+        {
+          kind: 'column',
+          columnTypes: ['number', 'string'], // Need to keep the string type for unknown values before tags are resolved
+          defaultValue: 'span.duration',
+          required: true,
+        },
+      ],
+    };
+  }
   return acc;
 }, {});
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -16,6 +16,7 @@ import {
   getEquation,
   isEquation,
   isEquationAlias,
+  parseFunction,
 } from 'sentry/utils/discover/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
@@ -89,9 +90,10 @@ export function SortBySelectors({
     let options: Record<string, SelectValue<FieldValue>> = {};
     if (displayType !== DisplayType.TABLE) {
       options = datasetConfig.getTimeseriesSortOptions!(organization, widgetQuery, tags);
+      const parsedFunction = parseFunction(values.sortBy);
       if (
         widgetType === WidgetType.SPANS &&
-        values.sortBy.startsWith('count(') &&
+        parsedFunction?.name === 'count' &&
         options['measurement:span.duration']
       ) {
         // Re-map the span duration measurement label so we can simply render

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/sortByStep/sortBySelectors.tsx
@@ -21,6 +21,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {getColumnOptions} from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import {
   type SortDirection,
   sortDirections,
@@ -28,6 +29,7 @@ import {
 import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
 import {QueryField} from 'sentry/views/discover/table/queryField';
 import type {FieldValue} from 'sentry/views/discover/table/types';
+import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 import {CUSTOM_EQUATION_VALUE} from '.';
 
@@ -87,7 +89,11 @@ export function SortBySelectors({
     let options: Record<string, SelectValue<FieldValue>> = {};
     if (displayType !== DisplayType.TABLE) {
       options = datasetConfig.getTimeseriesSortOptions!(organization, widgetQuery, tags);
-      if (widgetType === WidgetType.SPANS && options['measurement:span.duration']) {
+      if (
+        widgetType === WidgetType.SPANS &&
+        values.sortBy.startsWith('count(') &&
+        options['measurement:span.duration']
+      ) {
         // Re-map the span duration measurement label so we can simply render
         // `spans` in the parameter UI
         options['measurement:span.duration'] = {
@@ -97,7 +103,15 @@ export function SortBySelectors({
       }
     }
     return options;
-  }, [datasetConfig, organization, tags, widgetQuery, widgetType, displayType]);
+  }, [
+    datasetConfig,
+    organization,
+    tags,
+    widgetQuery,
+    widgetType,
+    displayType,
+    values.sortBy,
+  ]);
 
   return (
     <Wrapper>
@@ -177,12 +191,42 @@ export function SortBySelectors({
                 return;
               }
 
-              const parsedValue = generateFieldAsString(value);
+              let parsedValue = generateFieldAsString(value);
               const isSortingByCustomEquation = isEquation(parsedValue);
               setShowCustomEquation(isSortingByCustomEquation);
               if (isSortingByCustomEquation) {
                 onChange(customEquation);
                 return;
+              }
+              if (
+                widgetType === WidgetType.SPANS &&
+                value.kind === FieldValueKind.FUNCTION
+              ) {
+                // A spans function is selected, check if the argument is compatible with the function
+                const functionName = value.function[0];
+                const newValidOptions = getColumnOptions(
+                  widgetType,
+                  value,
+                  timeseriesSortOptions,
+                  datasetConfig.filterAggregateParams ?? (() => true),
+                  true
+                );
+                const newOptionSet = new Set(newValidOptions.map(option => option.value));
+                const newFunctionOption =
+                  timeseriesSortOptions[`function:${functionName}`];
+                if (
+                  value.function[1] &&
+                  !newOptionSet.has(value.function[1]) &&
+                  newFunctionOption?.value?.kind === FieldValueKind.FUNCTION
+                ) {
+                  // Select the default value if it exists, otherwise get the first option from
+                  // the new valid options
+                  const defaultValue: string =
+                    newFunctionOption.value?.meta?.parameters?.[0]?.defaultValue ??
+                    newValidOptions[0]?.value ??
+                    '';
+                  parsedValue = `${functionName}(${defaultValue})`;
+                }
               }
               onChange({
                 sortBy: parsedValue,

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -3,36 +3,43 @@ import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
+import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import WidgetBuilderSortBySelector from 'sentry/views/dashboards/widgetBuilder/components/sortBySelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {ELLIPSIS} from 'sentry/views/insights/common/utils/centerTruncate';
 
 jest.mock('sentry/utils/useNavigate', () => ({
   useNavigate: jest.fn(),
 }));
 
-const {organization, router} = initializeOrg({
-  organization: {features: ['global-views', 'open-membership', 'dashboards-eap']},
-  projects: [],
-  router: {
-    location: {
-      pathname: '/organizations/org-slug/dashboard/1/',
-      query: {
-        displayType: 'line',
-        fields: ['transaction.duration', 'count()', 'id'],
-        yAxis: ['count()', 'count_unique(transaction.duration)'],
-      },
-    },
-    params: {},
-  },
-});
-
 const mockUseNavigate = jest.mocked(useNavigate);
 
 describe('WidgetBuilderSortBySelector', function () {
+  let organization: Organization;
+  let router: InjectedRouter<Record<string, string | undefined>, any>;
   beforeEach(function () {
+    const setupOrg = initializeOrg({
+      organization: {features: ['global-views', 'open-membership', 'dashboards-eap']},
+      projects: [],
+      router: {
+        location: {
+          pathname: '/organizations/org-slug/dashboard/1/',
+          query: {
+            displayType: 'line',
+            fields: ['transaction.duration', 'count()', 'id'],
+            yAxis: ['count()', 'count_unique(transaction.duration)'],
+          },
+        },
+        params: {},
+      },
+    });
+    organization = setupOrg.organization;
+    router = setupOrg.router;
+
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
@@ -199,6 +206,66 @@ describe('WidgetBuilderSortBySelector', function () {
     expect(mockNavigate).toHaveBeenLastCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({limit: 3}),
+      }),
+      {replace: true}
+    );
+  });
+
+  it('switches the default value for count_unique functions', async function () {
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/`,
+      body: [{key: 'span.duration', name: 'span.duration'}],
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.attributeType === 'number';
+        },
+      ],
+    });
+
+    const setupOrg = initializeOrg({
+      organization: {features: ['global-views', 'open-membership', 'dashboards-eap']},
+      projects: [],
+      router: {
+        location: {
+          pathname: '/organizations/org-slug/dashboard/1/',
+          query: {
+            displayType: 'line',
+            fields: ['transaction.duration', 'count()', 'id'],
+            yAxis: ['count()', 'count_unique(span.op)'],
+            sort: ['-count(span.duration)'],
+            dataset: 'spans',
+          },
+        },
+        params: {},
+      },
+    });
+    organization = setupOrg.organization;
+    router = setupOrg.router;
+
+    render(
+      <WidgetBuilderProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <WidgetBuilderSortBySelector />
+        </SpanTagsProvider>
+      </WidgetBuilderProvider>,
+      {
+        router,
+        organization,
+        deprecatedRouterMocks: true,
+      }
+    );
+
+    expect(await screen.findByText(`count(${ELLIPSIS})`)).toBeInTheDocument();
+    expect(screen.getByText('spans')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText(`count(${ELLIPSIS})`));
+    await userEvent.click(screen.getByText(`count_unique(${ELLIPSIS})`));
+
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({sort: ['-count_unique(span.op)']}),
       }),
       {replace: true}
     );

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -129,16 +129,14 @@ export function getColumnOptions(
   columnFilterMethod: (
     option: SelectValue<FieldValue>,
     field?: QueryFieldValue
-  ) => boolean
+  ) => boolean,
+  filterOutIncompatibleResults?: boolean
 ) {
   const fieldValues = Object.values(fieldOptions);
   if (selectedField.kind !== FieldValueKind.FUNCTION || dataset === WidgetType.SPANS) {
-    return formatColumnOptions(
-      dataset,
-      fieldValues,
-      columnFilterMethod,
-      selectedField
-    ).sort(_sortFn);
+    return formatColumnOptions(dataset, fieldValues, columnFilterMethod, selectedField)
+      .filter(option => (filterOutIncompatibleResults ? !option.disabled : true))
+      .sort(_sortFn);
   }
 
   const fieldData = fieldValues.find(


### PR DESCRIPTION
The sort by for the widget builder wasn't handling `count_unique` properly. It should default to `span.op` and only show string tags. Likewise, the other aggregates in widget builder should swap to their own default if the currently selection option isn't allowed (i.e. not the same type)