### PR TITLE
fix(ui): Avoid inspecting children in button bars

### DIFF
--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -77,8 +77,8 @@ export default storyBook('ButtonBar', (story, APIReference) => {
         </ButtonBar>
 
         <p>
-          If a <JSXNode name="ButtonBar" /> has only one button, it will render the button
-          directly without the button bar wrapper.
+          <JSXNode name="ButtonBar" />s can have a single button in which case it looks
+          like a button.
         </p>
         <ButtonBar>
           <Button>One Lonely Button</Button>

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -1,4 +1,3 @@
-import {Children, cloneElement, Fragment, isValidElement} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,18 +12,6 @@ interface ButtonBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'cla
 }
 
 export function ButtonBar({children, merged = false, gap = 0, ...props}: ButtonBarProps) {
-  if (Children.count(children) <= 1) {
-    // There is no need to render a button bar if there is only one button.
-    if (isValidElement(children)) {
-      if (children.type !== Fragment) {
-        return cloneElement(children, props);
-      }
-      return children;
-    }
-
-    return children;
-  }
-
   return (
     <StyledButtonBar merged={merged} gap={gap} {...props}>
       {children}

--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -1,4 +1,3 @@
-import {Children, cloneElement, Fragment, isValidElement} from 'react';
 import type {DO_NOT_USE_ChonkTheme, Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -14,17 +13,6 @@ interface PageFilterBarProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const PageFilterBar = styled(({children, condensed, ...props}: PageFilterBarProps) => {
-  if (Children.count(children) <= 1) {
-    if (isValidElement(children)) {
-      if (children.type !== Fragment) {
-        return cloneElement(children, props);
-      }
-      return children;
-    }
-
-    return children;
-  }
-
   return (
     <StyledPageFilterBar condensed={condensed} {...props}>
       {children}
@@ -181,7 +169,7 @@ except in mobile */
     z-index: 3;
   }
 
-  & > div:first-child > button {
+  & > div:first-child:not(:last-child) > button {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
@@ -195,7 +183,7 @@ except in mobile */
     }
   }
 
-  & > div:last-child > button {
+  & > div:last-child:not(:first-child) > button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }


### PR DESCRIPTION
We have at least two button bar components which can contain zero
or more buttons: ButtonBar and PageFilterBar.

Recently there was bug where PageFilterBar rendered single buttons like
middle buttons (without rounded edges). To fix this #89772 introduced
some logic which inspected children and avoided doing any of the button
bar styling when there was exactly one child. Unfortunately this is quite
fragile in the presence of fragments. In cases like:

```
  <ButtonBar>
    <Fragment>
      <ButtonA />
      <ButtonB />
    </Fragment>
  </ButtonBar>
```

ButtonBar has only one child according to `Children.count` which does
not traverse into fragments. This broke:
https://github.com/getsentry/sentry/blob/86d33c1fe2ca1537ee3ed505c9b2dd684e5fab5b/static/app/components/noProjectMessage.tsx#L82
for example.

This logic was added to both ButtonBar and PageFilterBar but ButtonBar
actually did not have the original bug due to how the specific CSS
worked:

```css
&:first-child:not(:last-child) {
  border-top-right-radius: 0;
}
```

vs.

```css
& > div:first-child > button {
  border-top-right-radius: 0;
}
```

This applies the CSS logic from ButtonBar to PageFilterBar and removes
the counting children logic - keeping the original bug fixed and also
handling the fragment case.

Fixes: DE-60

