### PR TITLE
feat(issues): Allow sorting feature flags by distribution

### DIFF
--- a/static/app/components/events/featureFlags/utils.tsx
+++ b/static/app/components/events/featureFlags/utils.tsx
@@ -7,23 +7,28 @@ export enum OrderBy {
   A_TO_Z = 'a-z',
   Z_TO_A = 'z-a',
   HIGH_TO_LOW = 'high to low',
+  LOW_TO_HIGH = 'low to high',
 }
 
 export enum SortBy {
   EVAL_ORDER = 'eval',
   ALPHABETICAL = 'alphabetical',
   SUSPICION = 'suspicion',
+  DISTRIBUTION = 'distribution',
 }
 
-export const getSelectionType = (selection: string) => {
+export const getSelectionType = (selection: string): SortBy => {
   switch (selection) {
+    case OrderBy.HIGH_TO_LOW:
+    case OrderBy.LOW_TO_HIGH:
+      return SortBy.DISTRIBUTION;
     case OrderBy.A_TO_Z:
     case OrderBy.Z_TO_A:
-      return 'alphabetical';
+      return SortBy.ALPHABETICAL;
     case OrderBy.OLDEST:
     case OrderBy.NEWEST:
     default:
-      return 'eval';
+      return SortBy.EVAL_ORDER;
   }
 };
 
@@ -45,6 +50,8 @@ const getSortByLabel = (sort: string) => {
   switch (sort) {
     case SortBy.ALPHABETICAL:
       return t('Alphabetical');
+    case SortBy.DISTRIBUTION:
+      return t('Distribution');
     case SortBy.SUSPICION:
       return t('Suspiciousness');
     case SortBy.EVAL_ORDER:
@@ -53,17 +60,17 @@ const getSortByLabel = (sort: string) => {
   }
 };
 
-export const getDefaultOrderBy = (sortBy: SortBy) => {
-  if (sortBy === SortBy.EVAL_ORDER) {
-    return OrderBy.NEWEST;
+export const getDefaultOrderBy = (sortBy: SortBy): OrderBy => {
+  switch (sortBy) {
+    case SortBy.DISTRIBUTION:
+    case SortBy.SUSPICION:
+      return OrderBy.HIGH_TO_LOW;
+    case SortBy.EVAL_ORDER:
+      return OrderBy.NEWEST;
+    case SortBy.ALPHABETICAL:
+    default:
+      return OrderBy.A_TO_Z;
   }
-  if (sortBy === SortBy.ALPHABETICAL) {
-    return OrderBy.A_TO_Z;
-  }
-  if (sortBy === SortBy.SUSPICION) {
-    return OrderBy.HIGH_TO_LOW;
-  }
-  return OrderBy.A_TO_Z;
 };
 
 export const SORT_BY_OPTIONS = [

--- a/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
@@ -67,6 +67,10 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
           label: t('Suspiciousness'),
           value: SortBy.SUSPICION,
         },
+        {
+          label: t('Distribution'),
+          value: SortBy.DISTRIBUTION,
+        },
       ]
     : [
         {
@@ -87,6 +91,10 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
         {
           label: t('High to Low'),
           value: OrderBy.HIGH_TO_LOW,
+        },
+        {
+          label: t('Low to High'),
+          value: OrderBy.LOW_TO_HIGH,
         },
       ]
     : [

--- a/static/app/views/issueDetails/groupFeatureFlags/hooks/useGroupFlagDrawerData.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/hooks/useGroupFlagDrawerData.tsx
@@ -76,8 +76,8 @@ export default function useGroupFlagDrawerData({
     }));
   }, [groupFlags, suspectScores]);
 
-  // Flatten all the tag values together into a big string.
-  // A perf improvement: here we iterate over all tags&values once, (N*M) then
+  // Flatten all the tag values together into a big string. This is meant as a
+  // perf improvement: here we iterate over all tags&values once, (N*M) then
   // later only iterate through each tag (N) as the search term changes.
   const tagValues = useMemo(
     () =>
@@ -111,6 +111,14 @@ export default function useGroupFlagDrawerData({
       return filteredFlags.toSorted(
         (a, b) => (b.suspect.score ?? 0) - (a.suspect.score ?? 0)
       );
+    }
+    if (sortBy === SortBy.DISTRIBUTION) {
+      const sorted = filteredFlags.toSorted((a, b) => {
+        const aTopPct = (a.topValues[0]?.count ?? 0) / a.totalValues;
+        const bTopPct = (b.topValues[0]?.count ?? 0) / b.totalValues;
+        return bTopPct - aTopPct;
+      });
+      return orderBy === OrderBy.HIGH_TO_LOW ? sorted : sorted.reverse();
     }
     return filteredFlags;
   }, [filteredFlags, orderBy, sortBy]);


### PR DESCRIPTION
Sorting by distribution should be useful to quickly sort through things that are on 100% of the time, and things that have a lot of cardinality and different values. 

| High to Low | Low to High |
| --- | --- |
| <img width="662" alt="sort flag dist high-to-low" src="https://github.com/user-attachments/assets/5905bef5-92e2-4d15-a839-23673ebec9eb" /> | <img width="685" alt="sort flag dists low-to-high" src="https://github.com/user-attachments/assets/2fe52720-e1c5-4fab-99bb-cd4d6833d0b0" />

Fixes https://github.com/getsentry/team-replay/issues/578