### PR TITLE
feat(nav): Add ability to collapse sections in secondary nav

### DIFF
--- a/static/app/components/search/sources/routeSource.spec.tsx
+++ b/static/app/components/search/sources/routeSource.spec.tsx
@@ -37,6 +37,7 @@ describe('RouteSource', function () {
     const mock = jest.fn().mockReturnValue(null);
     HookStore.add('settings:organization-navigation-config', () => {
       return {
+        id: 'settings-usage-billing',
         name: 'Usage & Billing',
         items: [
           {

--- a/static/app/views/admin/adminLayout.tsx
+++ b/static/app/views/admin/adminLayout.tsx
@@ -16,6 +16,7 @@ export function AdminNavigation() {
       stickyTop="0"
       navigationObjects={[
         {
+          id: 'admin-system-status',
           name: 'System Status',
           items: [
             {path: '/manage/', index: true, title: 'Overview'},
@@ -30,6 +31,7 @@ export function AdminNavigation() {
           ],
         },
         {
+          id: 'admin-manage',
           name: 'Manage',
           items: [
             {path: '/manage/organizations/', title: 'Organizations'},

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -134,13 +134,6 @@ describe('Nav', function () {
   });
 
   describe('secondary navigation', function () {
-    it('renders secondary navigation', async function () {
-      renderNav();
-      expect(
-        await screen.findByRole('navigation', {name: 'Secondary Navigation'})
-      ).toBeInTheDocument();
-    });
-
     it('includes expected secondary nav items', function () {
       renderNav();
       const container = screen.getByRole('navigation', {name: 'Secondary Navigation'});
@@ -154,6 +147,21 @@ describe('Nav', function () {
       const link = screen.getByRole('link', {name: 'Feed'});
       expect(link).toHaveAttribute('aria-current', 'page');
       expect(link).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('can collapse sections with titles', async function () {
+      renderNav();
+      const container = screen.getByRole('navigation', {name: 'Secondary Navigation'});
+
+      expect(within(container).getByRole('link', {name: 'Alerts'})).toBeInTheDocument();
+
+      // Click "Configure" button to collapse the section
+      await userEvent.click(within(container).getByRole('button', {name: 'Configure'}));
+
+      // Section should be collapsed and no longer show "Alerts" link
+      expect(
+        within(container).queryByRole('link', {name: 'Alerts'})
+      ).not.toBeInTheDocument();
     });
 
     describe('sections', function () {

--- a/static/app/views/nav/secondary/secondary.stories.tsx
+++ b/static/app/views/nav/secondary/secondary.stories.tsx
@@ -18,7 +18,7 @@ export default storyBook('SecondaryNav', story => {
           <SecondarySidebar />
           <SecondaryNav>
             <SecondaryNav.Body>
-              <SecondaryNav.Section>
+              <SecondaryNav.Section id="stories-product-areas">
                 <SecondaryNav.Item
                   to="/product-area-1"
                   isActive={activeItem === 'product-area-1'}
@@ -50,7 +50,7 @@ export default storyBook('SecondaryNav', story => {
                   Product Area 3
                 </SecondaryNav.Item>
               </SecondaryNav.Section>
-              <SecondaryNav.Section title="Starred">
+              <SecondaryNav.Section id="stories-starred" title="Starred">
                 <SecondaryNav.Item
                   to="/starred-item"
                   isActive={activeItem === 'starred-item'}

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -120,20 +120,24 @@ SecondaryNav.Section = function SecondaryNavSection({
           disabled={layout === NavLayout.MOBILE}
         >
           <SectionTitleLabelWrap>{title}</SectionTitleLabelWrap>
-          <TrailingItems
-            onClick={e => {
-              e.stopPropagation();
-            }}
-          >
-            {trailingItems
-              ? trailingItems
-              : layout === NavLayout.SIDEBAR && (
-                  <IconChevron
-                    direction={isCollapsed ? 'down' : 'up'}
-                    size="xs"
-                    color="subText"
-                  />
-                )}
+          <TrailingItems>
+            {trailingItems ? (
+              <div
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+              >
+                {trailingItems}
+              </div>
+            ) : (
+              layout === NavLayout.SIDEBAR && (
+                <IconChevron
+                  direction={isCollapsed ? 'down' : 'up'}
+                  size="xs"
+                  color="subText"
+                />
+              )
+            )}
           </TrailingItems>
         </SectionTitle>
       )}

--- a/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/codecov/codecovSecondaryNav.tsx
@@ -31,7 +31,7 @@ function CodecovSecondaryNav() {
         {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.CODECOV].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
-        <SecondaryNav.Section>
+        <SecondaryNav.Section id="codecov-main">
           <SecondaryNav.Item
             to={`${coveragePathname}commits/`}
             activeTo={coveragePathname}
@@ -42,7 +42,7 @@ function CodecovSecondaryNav() {
             {t('Tests')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        <SecondaryNav.Section title={t('Configure')}>
+        <SecondaryNav.Section id="codecov-configure" title={t('Configure')}>
           <SecondaryNav.Item to={`${tokensPathName}`} activeTo={tokensPathName}>
             {t('Tokens')}
           </SecondaryNav.Item>

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -30,12 +30,12 @@ export function DashboardsSecondaryNav() {
         {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.DASHBOARDS].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
-        <SecondaryNav.Section>
+        <SecondaryNav.Section id="dashboards-all">
           <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="dashboards_all">
             {t('All Dashboards')}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        <SecondaryNav.Section title={t('Starred Dashboards')}>
+        <SecondaryNav.Section id="dashboards-starred" title={t('Starred Dashboards')}>
           {starredDashboards.data?.map(dashboard => (
             <SecondaryNav.Item
               key={dashboard.id}

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -28,7 +28,7 @@ export function ExploreSecondaryNav() {
         {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.EXPLORE].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
-        <SecondaryNav.Section>
+        <SecondaryNav.Section id="explore-main">
           <Feature features={['performance-trace-explorer', 'performance-view']}>
             <SecondaryNav.Item
               to={`${baseUrl}/traces/`}
@@ -76,12 +76,12 @@ export function ExploreSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <Feature features={['performance-trace-explorer', 'performance-view']}>
-          <SecondaryNav.Section>
+          <SecondaryNav.Section id="explore-all-queries">
             <SecondaryNav.Item to={`${baseUrl}/saved-queries/`}>
               {t('All Queries')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>
-          <SecondaryNav.Section title={t('Starred Queries')}>
+          <SecondaryNav.Section id="explore-starred-queries" title={t('Starred Queries')}>
             {starredQueries && starredQueries.length > 0 && (
               <ExploreSavedQueryNavItems queries={starredQueries} />
             )}

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -67,7 +67,7 @@ export function InsightsSecondaryNav() {
         {PRIMARY_NAV_GROUP_CONFIG[PrimaryNavGroup.INSIGHTS].label}
       </SecondaryNav.Header>
       <SecondaryNav.Body>
-        <SecondaryNav.Section>
+        <SecondaryNav.Section id="insights-main">
           <SecondaryNav.Item
             isActive={
               !isProjectDetailsRedirectActive &&
@@ -101,7 +101,7 @@ export function InsightsSecondaryNav() {
             {AI_SIDEBAR_LABEL}
           </SecondaryNav.Item>
         </SecondaryNav.Section>
-        <SecondaryNav.Section>
+        <SecondaryNav.Section id="insights-projects-all">
           <SecondaryNav.Item
             to={`${baseUrl}/projects/`}
             end
@@ -111,6 +111,7 @@ export function InsightsSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <SecondaryNav.Section
+          id="insights-starred-projects"
           title={displayStarredProjects ? t('Starred Projects') : t('Projects')}
           trailingItems={
             <AddProjectButtonLink

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewNavItems.tsx
@@ -64,8 +64,13 @@ export function IssueViewNavItems({sectionRef}: IssueViewNavItemsProps) {
 
   return (
     <SecondaryNav.Section
+      id="issues-starred-views"
       title={t('Starred Views')}
-      trailingItems={<IssueViewAddViewButton />}
+      trailingItems={
+        organization.features.includes('enforce-stacked-navigation') ? null : (
+          <IssueViewAddViewButton />
+        )
+      }
     >
       <Reorder.Group
         as="div"

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -25,7 +25,7 @@ export function IssuesSecondaryNav() {
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         {!hasIssueTaxonomy && (
-          <SecondaryNav.Section>
+          <SecondaryNav.Section id="issues-feed">
             <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="issues_feed">
               {t('Feed')}
             </SecondaryNav.Item>
@@ -39,12 +39,12 @@ export function IssuesSecondaryNav() {
         )}
         {hasIssueTaxonomy && (
           <Fragment>
-            <SecondaryNav.Section>
+            <SecondaryNav.Section id="issues-feed">
               <SecondaryNav.Item to={`${baseUrl}/`} end analyticsItemName="issues_feed">
                 {t('Feed')}
               </SecondaryNav.Item>
             </SecondaryNav.Section>
-            <SecondaryNav.Section>
+            <SecondaryNav.Section id="issues-types">
               {Object.values(ISSUE_TAXONOMY_CONFIG).map(({key, label}) => (
                 <SecondaryNav.Item
                   key={key}
@@ -65,7 +65,7 @@ export function IssuesSecondaryNav() {
           </Fragment>
         )}
         {organization.features.includes('enforce-stacked-navigation') && (
-          <SecondaryNav.Section>
+          <SecondaryNav.Section id="issues-views-all">
             <SecondaryNav.Item to={`${baseUrl}/views/`} end>
               {t('All Views')}
             </SecondaryNav.Item>
@@ -83,7 +83,7 @@ export function IssuesSecondaryNav() {
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
   const hasWorkflowEngine = useWorkflowEngineFeatureGate();
   return (
-    <StickyBottomSection title={t('Configure')}>
+    <StickyBottomSection id="issues-configure" title={t('Configure')}>
       {hasWorkflowEngine ? (
         <Fragment>
           <SecondaryNav.Item

--- a/static/app/views/settings/account/navigationConfiguration.tsx
+++ b/static/app/views/settings/account/navigationConfiguration.tsx
@@ -19,6 +19,7 @@ function getConfiguration({organization}: ConfigParams): NavigationSection[] {
   return [
     {
       name: t('Account'),
+      id: 'settings-account',
       items: [
         {
           path: `${pathPrefix}/details/`,
@@ -73,6 +74,7 @@ function getConfiguration({organization}: ConfigParams): NavigationSection[] {
       ],
     },
     {
+      id: 'settings-api',
       name: t('API'),
       items: [
         {

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -48,7 +48,11 @@ function SettingsNavigationGroup(props: NavigationGroupProps) {
     return null;
   }
 
-  return <SecondaryNav.Section title={name}>{navLinks}</SecondaryNav.Section>;
+  return (
+    <SecondaryNav.Section id={props.id} title={name}>
+      {navLinks}
+    </SecondaryNav.Section>
+  );
 }
 
 export default SettingsNavigationGroup;

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -22,6 +22,7 @@ export function getOrganizationNavigationConfiguration({
 
   return [
     {
+      id: 'settings-user',
       name: t('User Settings'),
       items: [
         {
@@ -33,6 +34,7 @@ export function getOrganizationNavigationConfiguration({
       ],
     },
     {
+      id: 'settings-organization',
       name: t('Organization'),
       items: [
         {
@@ -155,6 +157,7 @@ export function getOrganizationNavigationConfiguration({
       ],
     },
     {
+      id: 'settings-developer',
       name: t('Developer Settings'),
       items: [
         {

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -15,6 +15,7 @@ export function getUserOrgNavigationConfiguration({
 }): NavigationSection[] {
   return [
     {
+      id: 'settings-account',
       name: t('Account'),
       items: [
         {
@@ -70,6 +71,7 @@ export function getUserOrgNavigationConfiguration({
       ],
     },
     {
+      id: 'settings-organization',
       name: t('Organization'),
       items: [
         {
@@ -184,6 +186,7 @@ export function getUserOrgNavigationConfiguration({
       ],
     },
     {
+      id: 'settings-developer',
       name: t('Developer Settings'),
       items: [
         {
@@ -201,6 +204,7 @@ export function getUserOrgNavigationConfiguration({
       ],
     },
     {
+      id: 'settings-api',
       name: t('API'),
       items: [
         {

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -23,6 +23,7 @@ export default function getConfiguration({
   const isSelfHosted = ConfigStore.get('isSelfHosted');
   return [
     {
+      id: 'settings-project',
       name: t('Project'),
       items: [
         {
@@ -79,6 +80,7 @@ export default function getConfiguration({
       ],
     },
     {
+      id: 'settings-processing',
       name: t('Processing'),
       items: [
         {
@@ -136,6 +138,7 @@ export default function getConfiguration({
       ],
     },
     {
+      id: 'settings-sdk',
       name: t('SDK Setup'),
       items: [
         {
@@ -159,6 +162,7 @@ export default function getConfiguration({
       ],
     },
     {
+      id: 'settings-legacy-integrations',
       name: t('Legacy Integrations'),
       items: [
         {

--- a/static/app/views/settings/types.tsx
+++ b/static/app/views/settings/types.tsx
@@ -53,6 +53,10 @@ export type NavigationItem = {
 };
 
 export type NavigationSection = {
+  /**
+   * Unique identifier for the navigation section, used to save collapsed state
+   */
+  id: string;
   items: NavigationItem[];
   /**
    * Heading of the navigation section

--- a/static/gsApp/components/gsBillingNavigationConfig.tsx
+++ b/static/gsApp/components/gsBillingNavigationConfig.tsx
@@ -70,6 +70,7 @@ class GSBillingNavigationConfig extends Component<Props> {
     ];
 
     return {
+      id: 'settings-usage-billing',
       name: t('Usage & Billing'),
       items,
     };


### PR DESCRIPTION
- Use darker color for section titles
- Make section titles clickable to expand/collapse

Most of the changes are adding an `id` to sections so that we can use that for the local storage key to remember the collapsed state.

![CleanShot 2025-05-07 at 10 24 02@2x](https://github.com/user-attachments/assets/9662dda2-70f3-480d-aa5c-372b92041f2f)![CleanShot 2025-05-07 at 10 24 07@2x](https://github.com/user-attachments/assets/02569330-4f23-499f-9be5-176f369526fe)
