### PR TITLE
chore(aci): update WorkflowFireHistory has_passed_filters column for rollout

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -64,7 +64,10 @@ def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action
 
 
 def update_workflow_fire_histories(
-    actions_to_fire: BaseQuerySet[Action], event_data: WorkflowEventData
+    actions_to_fire: BaseQuerySet[Action],
+    event_data: WorkflowEventData,
+    has_passed_filters: bool | None = None,
+    has_fired_actions: bool | None = None,
 ) -> int:
     # Update WorkflowFireHistory objects for workflows with actions to fire
     fired_workflows = set(
@@ -73,11 +76,17 @@ def update_workflow_fire_histories(
         ).values_list("workflow_id", flat=True)
     )
 
+    updates: dict[str, bool] = {}
+    if has_passed_filters is not None:
+        updates["has_passed_filters"] = has_passed_filters
+    if has_fired_actions is not None:
+        updates["has_fired_actions"] = has_fired_actions
+
     updated_rows = WorkflowFireHistory.objects.filter(
         workflow_id__in=fired_workflows,
         group=event_data.event.group,
         event_id=event_data.event.event_id,
-    ).update(has_fired_actions=True)
+    ).update(**updates)
 
     return updated_rows
 
@@ -90,6 +99,8 @@ def filter_recently_fired_workflow_actions(
     actions = Action.objects.filter(
         dataconditiongroupaction__condition_group__in=filtered_action_groups
     ).distinct()
+
+    update_workflow_fire_histories(actions, event_data, has_passed_filters=True)
     group = event_data.event.group
 
     now = timezone.now()
@@ -115,7 +126,7 @@ def filter_recently_fired_workflow_actions(
     actions_without_statuses_ids = {action.id for action in actions_without_statuses}
     filtered_actions = actions.filter(id__in=actions_to_include | actions_without_statuses_ids)
 
-    update_workflow_fire_histories(filtered_actions, event_data)
+    update_workflow_fire_histories(filtered_actions, event_data, has_fired_actions=True)
 
     return filtered_actions
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -30,8 +30,8 @@ EnqueuedAction = tuple[DataConditionGroup, list[DataCondition]]
 
 
 class WorkflowFireHistoryUpdates(TypedDict):
-    has_passed_filters: bool | None
-    has_fired_actions: bool | None
+    has_passed_filters: bool
+    has_fired_actions: bool
 
 
 def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action], group: Group):

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -69,7 +69,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             status.refresh_from_db()
             assert status.date_updated == timezone.now()
 
-    def test_update_workflow_fire_histories(self):
+    def test_update_workflow_fire_histories_has_fired_actions(self):
         WorkflowFireHistory.objects.create(
             workflow=self.workflow,
             group=self.group,
@@ -80,13 +80,37 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         actions = Action.objects.all()
         assert actions.count() == 1
 
-        update_workflow_fire_histories(actions, self.event_data)
+        update_workflow_fire_histories(actions, self.event_data, has_fired_actions=True)
         assert (
             WorkflowFireHistory.objects.filter(
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,
                 has_fired_actions=True,
+            ).count()
+            == 1
+        )
+
+    def test_update_workflow_fire_histories_has_passed_filters(self):
+        WorkflowFireHistory.objects.create(
+            workflow=self.workflow,
+            group=self.group,
+            event_id=self.group_event.event_id,
+            has_passed_filters=None,
+            has_fired_actions=False,
+        )
+
+        actions = Action.objects.all()
+        assert actions.count() == 1
+
+        update_workflow_fire_histories(actions, self.event_data, has_passed_filters=True)
+        assert (
+            WorkflowFireHistory.objects.filter(
+                workflow=self.workflow,
+                group=self.group,
+                event_id=self.group_event.event_id,
+                has_passed_filters=True,
+                has_fired_actions=False,
             ).count()
             == 1
         )

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -6,6 +6,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import (
+    WorkflowFireHistoryUpdates,
     filter_recently_fired_workflow_actions,
     update_workflow_fire_histories,
 )
@@ -80,7 +81,11 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         actions = Action.objects.all()
         assert actions.count() == 1
 
-        update_workflow_fire_histories(actions, self.event_data, has_fired_actions=True)
+        update_workflow_fire_histories(
+            actions,
+            self.event_data,
+            WorkflowFireHistoryUpdates(has_passed_filters=True, has_fired_actions=True),
+        )
         assert (
             WorkflowFireHistory.objects.filter(
                 workflow=self.workflow,
@@ -103,7 +108,11 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         actions = Action.objects.all()
         assert actions.count() == 1
 
-        update_workflow_fire_histories(actions, self.event_data, has_passed_filters=True)
+        update_workflow_fire_histories(
+            actions,
+            self.event_data,
+            WorkflowFireHistoryUpdates(has_passed_filters=True, has_fired_actions=False),
+        )
         assert (
             WorkflowFireHistory.objects.filter(
                 workflow=self.workflow,

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -828,12 +828,14 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         )
 
         wfh.refresh_from_db()
+        assert wfh.has_passed_filters is True
         assert wfh.has_fired_actions is True
 
         assert WorkflowFireHistory.objects.filter(
             workflow=self.workflow1,
             group_id=self.group1.id,
             event_id=self.event1.event_id,
+            has_passed_filters=True,
             has_fired_actions=True,
         ).exists()
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/91102

Update the `has_passed_filters` column for `WorkflowFireHistory` if the workflow passes the trigger and filter conditions.