### PR TITLE
chore(tabs): revert variant and reduce header spacing with tabs

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -59,13 +59,9 @@ export const HeaderContent = styled('div')<{unified?: boolean}>`
   display: flex;
   flex-direction: column;
   justify-content: normal;
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(1)};
   overflow: hidden;
   max-width: 100%;
-
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    margin-bottom: ${space(1)};
-  }
 
   ${p =>
     p.unified &&

--- a/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
+++ b/static/app/views/discover/savedQuery/datasetSelectorTabs.tsx
@@ -151,7 +151,7 @@ export function DatasetSelectorTabs(props: Props) {
         });
       }}
     >
-      <TabList variant="filled" hideBorder>
+      <TabList hideBorder>
         {options.map(option => (
           <TabList.Item key={option.value}>{option.label}</TabList.Item>
         ))}


### PR DESCRIPTION
**Before & After:**

- Reverting variant from Discover
![Screenshot 2025-05-07 at 11 12 10 AM](https://github.com/user-attachments/assets/7df7f4b4-87e8-4083-bcbe-8c4bb0e30935)

- Reducing header spacing when there are tabs
![Screenshot 2025-05-07 at 11 12 25 AM](https://github.com/user-attachments/assets/7efef6c3-ae85-4076-9fb9-110424e05579)