### PR TITLE
fix(aci): Make sort order stable with duplicate field values

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -89,7 +89,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                     )
                 )
 
-        queryset = queryset.order_by(sort_by.db_order_by)
+        queryset = queryset.order_by(*sort_by.db_order_by)
 
         return self.paginate(
             request=request,

--- a/src/sentry/workflow_engine/endpoints/project_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/project_detector_index.py
@@ -99,7 +99,7 @@ class ProjectDetectorIndexEndpoint(ProjectEndpoint):
         if sort_by.db_field_name == "connected_workflows":
             queryset = queryset.annotate(connected_workflows=Count("detectorworkflow"))
 
-        queryset = queryset.order_by(sort_by.db_order_by)
+        queryset = queryset.order_by(*sort_by.db_order_by)
 
         return self.paginate(
             request=request,

--- a/src/sentry/workflow_engine/endpoints/utils/sortby.py
+++ b/src/sentry/workflow_engine/endpoints/utils/sortby.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from rest_framework.exceptions import ValidationError
@@ -10,14 +10,16 @@ class SortByParam:
     SortByParam assists in parsing a 'sortBy' parameter from the request,
     validating it against an endpoint-specific config, and providing the
     values that should be passed along to QuerySet.order_by and the Paginator.
+    To guarantee stable results with potentially duplicated sort keys, 'id' is
+    used as a fallback sort key.
 
     The parameter is expected to be in the format of "[-]<field_name>", where
     the optional "-" prefix indicates descending order and the field_name
     must be a key in the provided mapping.
     """
 
-    "The value we should pass to the QuerySet order_by method."
-    db_order_by: str
+    "The sort keys that should be passed to the QuerySet order_by method."
+    db_order_by: Sequence[str]
     "The name of the database field we should use to sort the queryset."
     db_field_name: str
 
@@ -35,4 +37,8 @@ class SortByParam:
         if sort_field not in api_to_db_map:
             raise ValidationError({"sortBy": ["Invalid sort field"]})
         db_field_name = api_to_db_map[sort_field]
-        return SortByParam(order_prefix + db_field_name, db_field_name)
+        field_order_by = order_prefix + db_field_name
+        if db_field_name == "id":
+            return SortByParam((field_order_by,), db_field_name)
+        else:
+            return SortByParam((field_order_by, order_prefix + "id"), db_field_name)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -47,6 +47,18 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
             workflow_two.name,
         ]
 
+    def test_sort_by_duplicated_name(self):
+        self.create_workflow(organization_id=self.organization.id, name="Name")
+        self.create_workflow(organization_id=self.organization.id, name="Name")
+        self.create_workflow(organization_id=self.organization.id, name="Name")
+
+        response1 = self.get_success_response(self.organization.slug, qs_params={"sortBy": "name"})
+        assert len(response1.data) == 3
+        response2 = self.get_success_response(self.organization.slug, qs_params={"sortBy": "-name"})
+        assert [w["id"] for w in response2.data] == list(
+            reversed([w["id"] for w in response1.data])
+        )
+
     def test_sort_by_connected_detectors(self):
         workflow = self.create_workflow(
             organization_id=self.organization.id, name="A Test Workflow"

--- a/tests/sentry/workflow_engine/endpoints/utils/test_sortby.py
+++ b/tests/sentry/workflow_engine/endpoints/utils/test_sortby.py
@@ -6,16 +6,17 @@ from sentry.workflow_engine.endpoints.utils.sortby import SortByParam
 
 def test_sortby_parse():
     SORT_ATTRS = {
+        "id": "id",
         "name": "name",
         "specialThing": "special_thing",
     }
     sort_by = SortByParam.parse("name", SORT_ATTRS)
     assert sort_by.db_field_name == "name"
-    assert sort_by.db_order_by == "name"
+    assert sort_by.db_order_by == ("name", "id")
 
     sort_by = SortByParam.parse("-specialThing", SORT_ATTRS)
     assert sort_by.db_field_name == "special_thing"
-    assert sort_by.db_order_by == "-special_thing"
+    assert sort_by.db_order_by == ("-special_thing", "-id")
 
     with pytest.raises(ValidationError, match=".*sortBy.*"):
         SortByParam.parse("not_a_valid_field", SORT_ATTRS)


### PR DESCRIPTION
Some fields we sort on are likely to have duplicates (for example, the aggregate counts), and in those cases the result order within groups of duplicate values is whatever the database chooses.
Ideally, reversing the sort order reverses the result order, so here we use `id` (which every model should have) as a secondary key to achieve that.