### PR TITLE
feat(ui): Separate 'inactive' orgs in the org dropdown

### DIFF
--- a/static/app/views/nav/orgDropdown.spec.tsx
+++ b/static/app/views/nav/orgDropdown.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
@@ -58,5 +58,48 @@ describe('OrgDropdown', function () {
       'href',
       `/organizations/org-2/issues/`
     );
+  });
+
+  it('Shows inactive orgs in their own section', async function () {
+    OrganizationsStore.addOrReplace(
+      OrganizationFixture({id: '1', name: 'Org 1', slug: 'org-1'})
+    );
+    OrganizationsStore.addOrReplace(
+      OrganizationFixture({
+        id: '2',
+        name: 'Deleting org',
+        slug: 'org-2',
+        status: {id: 'pending_deletion', name: 'pending deletion'},
+      })
+    );
+    OrganizationsStore.addOrReplace(
+      OrganizationFixture({
+        id: '3',
+        name: 'Disabled org',
+        slug: 'org-3',
+        status: {id: 'disabled', name: 'disabled'},
+      })
+    );
+
+    render(<OrgDropdown />, {organization});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle organization menu'}));
+    await userEvent.hover(screen.getByText('Switch Organization'));
+
+    const separator = await screen.findByRole('separator');
+    expect(separator).toBeInTheDocument();
+
+    const inactiveGroup = separator.nextElementSibling?.firstElementChild;
+    if (!(inactiveGroup instanceof HTMLElement)) {
+      throw new Error('Expected group of inactive organizations');
+    }
+
+    expect(inactiveGroup).toHaveRole('group');
+    expect(
+      within(inactiveGroup).getByRole('menuitemradio', {name: /Disabled org/})
+    ).toBeInTheDocument();
+    expect(
+      within(inactiveGroup).getByRole('menuitemradio', {name: /Deleting org/})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -1,16 +1,20 @@
+import {useCallback} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import orderBy from 'lodash/orderBy';
+import partition from 'lodash/partition';
 
 import {OrganizationAvatar} from 'sentry/components/core/avatar/organizationAvatar';
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import OrganizationBadge from 'sentry/components/idBadge/organizationBadge';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconAdd} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {Organization} from 'sentry/types/organization';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {localizeDomain, resolveRoute} from 'sentry/utils/resolveRoute';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -64,6 +68,28 @@ export function OrgDropdown({
   const hasBillingAccess = organization.access?.includes('org:billing');
 
   const {organizations} = useLegacyStore(OrganizationsStore);
+  const [activeOrgs, inactiveOrgs] = partition(
+    organizations,
+    org => org.status.id === 'active'
+  );
+
+  const makeOrganizationMenuItem = useCallback(
+    (org: Organization): MenuItemProps => ({
+      key: org.id,
+      label: <OrganizationBadge organization={org} />,
+      textValue: org.name,
+      to: resolveRoute(`/organizations/${org.slug}/issues/`, organization, org),
+    }),
+    [organization]
+  );
+
+  const makeInactiveOrganizationMenuItem = useCallback(
+    (org: Organization): MenuItemProps => ({
+      ...makeOrganizationMenuItem(org),
+      trailingItems: <QuestionTooltip size="sm" title={org.status.name} />,
+    }),
+    [makeOrganizationMenuItem]
+  );
 
   const {projects} = useProjects();
 
@@ -138,22 +164,20 @@ export function OrgDropdown({
               isSubmenu: true,
               hidden: config.singleOrganization || isDemoModeActive(),
               children: [
-                ...orderBy(organizations, ['status.id', 'name']).map(switchOrg => {
-                  const pendingDeletion = switchOrg.status.id === 'pending_deletion';
-
-                  return {
-                    key: switchOrg.id,
-                    label: <OrganizationBadge organization={switchOrg} />,
-                    textValue: switchOrg.name,
-                    to: resolveRoute(
-                      `/organizations/${switchOrg.slug}/issues/`,
-                      organization,
-                      switchOrg
-                    ),
-                    priority: pendingDeletion ? ('danger' as const) : undefined,
-                    tooltip: pendingDeletion ? t('Pending deletion') : undefined,
-                  };
-                }),
+                {
+                  key: 'active-orgs',
+                  children: orderBy(activeOrgs, ['name']).map(makeOrganizationMenuItem),
+                },
+                ...(inactiveOrgs.length === 0
+                  ? []
+                  : [
+                      {
+                        key: 'inactive-ogs',
+                        children: orderBy(inactiveOrgs, ['name']).map(
+                          makeInactiveOrganizationMenuItem
+                        ),
+                      },
+                    ]),
                 createOrganizationMenuItem(),
               ],
             },


### PR DESCRIPTION
Looks like this now:

<img alt="clipboard.png" width="595" src="https://i.imgur.com/L8OSZit.png" />