### PR TITLE
fix(celery): Report unserializable args in celery

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -116,7 +116,8 @@ class SentryTask(Task):
                 logger.exception(
                     "Task args contain unserializable objects",
                 )
-                raise
+                if should_complain:
+                    raise
 
         with metrics.timer("jobs.delay", instance=self.name):
             return Task.apply_async(self, *args, **kwargs)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -736,6 +736,7 @@ CELERY_ALWAYS_EAGER = False
 # Complain about bad use of pickle.  See sentry.celery.SentryTask.apply_async for how
 # this works.
 CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE = False
+CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE = 0.01
 
 # We use the old task protocol because during benchmarking we noticed that it's faster
 # than the new protocol. If we ever need to bump this it should be fine, there were no


### PR DESCRIPTION
Create errors in sentry to track args in celery tasks that can't be serialized to JSON. Include a
sample rate that can be increased as the errors are fixed.