### PR TITLE
feat(integrations): Improve GitHub label sorting

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -301,7 +301,8 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         def natural_sort_pair(pair: tuple[str, str]) -> list[str | int]:
             return [
-                int(text) if text.isdecimal() else text.lower() for text in re.split("([0-9]+)", pair[0])
+                int(text) if text.isdecimal() else text.lower()
+                for text in re.split("([0-9]+)", pair[0])
             ]
 
         # sort alphabetically

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -301,7 +301,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         def natural_sort_pair(pair: tuple[str, str]) -> list[str | int]:
             return [
-                int(text) if text.isdecimal() else text for text in re.split("([0-9]+)", pair[0])
+                int(text) if text.isdecimal() else text.lower() for text in re.split("([0-9]+)", pair[0])
             ]
 
         # sort alphabetically

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -159,6 +159,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "https://api.github.com/repos/getsentry/sentry/labels",
             json=[
                 {"name": "bug"},
+                {"name": "Big Bug"},
                 {"name": "enhancement"},
                 {"name": "duplicate"},
                 {"name": "1"},
@@ -174,6 +175,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             ("1", "1"),
             ("2", "2"),
             ("10", "10"),
+            ("Big Bug", "Big Bug"),
             ("bug", "bug"),
             ("duplicate", "duplicate"),
             ("enhancement", "enhancement"),


### PR DESCRIPTION
Ignore the case of labels name when sorting them.

Not sure if this should be added or not given the workaround is to just be consistent with your labels and either capitalize or not. Currently if someone has the labels `App`, `api`, `Backend` it would result in `Api`, `Backend`, `api`.

But I thought I just open a small PR since the change is pretty small quickly

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
