### PR TITLE
feat(ui): Turn `refetchOnReconnect` off by default

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -19,6 +19,7 @@ import type RequestError from 'sentry/utils/requestError/requestError';
 export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
   defaultOptions: {
     queries: {
+      refetchOnReconnect: false,
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
This is causing too many refetches that lead to users reaching Sentrys API rate limit.

In the case of the organization details endpoint, an error means that the
OrganizationStore will not have an organization, which leads to
useOrganization throwning because organization is undefined. This ultimately
leads to a "crash" for the user (e.g. blank page w/ an error message).

See https://sentry.sentry.io/issues/6585868468/?project=11276&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20useOrganization&referrer=issue-stream&sort=user&stream_index=1 for an example.


Fixes JAVASCRIPT-2ZWC
Fixes JAVASCRIPT-2ZVF
Fixes JAVASCRIPT-2ZWG
Fixes JAVASCRIPT-2Y08
