### PR TITLE
ref: Move queue Open PR comment logic into CommitContextIntegration

### DIFF
--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -210,7 +210,7 @@ class CommitContextIntegration(ABC):
         """
         return self.get_blame_for_files(files, extra)
 
-    def queue_comment_task_if_needed(
+    def queue_pr_comment_task_if_needed(
         self,
         project: Project,
         commit: Commit,
@@ -351,6 +351,36 @@ class CommitContextIntegration(ABC):
                     cache.set(cache_key, True, PR_COMMENT_TASK_TTL)
 
                     pr_comment_workflow.queue_task(pr=pr, project_id=group_owner.project_id)
+
+    def queue_open_pr_comment_task_if_needed(
+        self, pr: PullRequest, organization: Organization
+    ) -> None:
+        try:
+            open_pr_comment_workflow = self.get_open_pr_comment_workflow()
+        except NotImplementedError:
+            return
+
+        if not OrganizationOption.objects.get_value(
+            organization=organization,
+            key=open_pr_comment_workflow.organization_option_key,
+            default=True,
+        ):
+            logger.info(
+                _open_pr_comment_log(
+                    integration_name=self.integration_name, suffix="option_missing"
+                ),
+                extra={"organization_id": organization.id},
+            )
+            return
+
+        metrics.incr(
+            OPEN_PR_METRICS_BASE.format(integration=self.integration_name, key="queue_task")
+        )
+        logger.info(
+            _open_pr_comment_log(integration_name=self.integration_name, suffix="queue_task"),
+            extra={"pr_id": pr.id},
+        )
+        open_pr_comment_workflow.queue_task(pr=pr)
 
     def create_or_update_comment(
         self,
@@ -586,7 +616,9 @@ class OpenPRCommentWorkflow(ABC):
         raise NotImplementedError
 
     def queue_task(self, pr: PullRequest) -> None:
-        raise NotImplementedError
+        from sentry.integrations.source_code_management.tasks import open_pr_comment_workflow
+
+        open_pr_comment_workflow.delay(pr_id=pr.id)
 
     @abstractmethod
     def get_pr_files_safe_for_comment(

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -190,7 +190,7 @@ def process_commit_context(
             )
 
             if installation and isinstance(installation, CommitContextIntegration):
-                installation.queue_comment_task_if_needed(project, commit, group_owner, group_id)
+                installation.queue_pr_comment_task_if_needed(project, commit, group_owner, group_id)
 
             ProjectOwnership.handle_auto_assignment(
                 project_id=project.id,

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -651,8 +651,8 @@ class PullRequestEventWebhook(APITestCase):
 
         assert_failure_metric(mock_record, error)
 
-    @patch("sentry.integrations.github.webhook.open_pr_comment_workflow.delay")
-    @patch("sentry.integrations.github.webhook.metrics")
+    @patch("sentry.integrations.source_code_management.tasks.open_pr_comment_workflow.delay")
+    @patch("sentry.integrations.source_code_management.commit_context.metrics")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_opened(self, mock_record, mock_metrics, mock_delay):
         project = self.project  # force creation

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -1215,13 +1215,13 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
         assert isinstance(install, CommitContextIntegration)
 
         with self.tasks():
-            install.queue_comment_task_if_needed(
+            install.queue_pr_comment_task_if_needed(
                 project=self.project,
                 commit=self.commit,
                 group_owner=groupowner,
                 group_id=self.event.group_id,
             )
-            install.queue_comment_task_if_needed(
+            install.queue_pr_comment_task_if_needed(
                 project=self.project,
                 commit=self.commit,
                 group_owner=groupowner,
@@ -1275,13 +1275,13 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
         )
 
         with self.tasks():
-            install.queue_comment_task_if_needed(
+            install.queue_pr_comment_task_if_needed(
                 project=self.project,
                 commit=self.commit,
                 group_owner=groupowner,
                 group_id=self.event.group_id,
             )
-            install.queue_comment_task_if_needed(
+            install.queue_pr_comment_task_if_needed(
                 project=self.project,
                 commit=self.commit,
                 group_owner=groupowner,


### PR DESCRIPTION
Move queue Open PR comment logic into CommitContextIntegration.

This follows the same structure as queue_pr_comment_task_if_needed.