### PR TITLE
feat(taskbroker): Add delay to RetryState

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -68,7 +68,7 @@ rfc3986-validator>=0.1.1
 sentry-arroyo>=2.21.0
 sentry-kafka-schemas>=1.2.0
 sentry-ophio>=1.1.3
-sentry-protos==0.1.74
+sentry-protos==0.2.0
 sentry-redis-tools>=0.5.0
 sentry-relay>=0.9.9
 sentry-sdk[http2]>=2.25.1

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -189,7 +189,7 @@ sentry-forked-djangorestframework-stubs==3.15.3.post1
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.2.0
 sentry-ophio==1.1.3
-sentry-protos==0.1.74
+sentry-protos==0.2.0
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.9
 sentry-sdk==2.27.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -127,7 +127,7 @@ sentry-arroyo==2.21.0
 sentry-forked-email-reply-parser==0.5.12.post1
 sentry-kafka-schemas==1.2.0
 sentry-ophio==1.1.3
-sentry-protos==0.1.74
+sentry-protos==0.2.0
 sentry-redis-tools==0.5.0
 sentry-relay==0.9.9
 sentry-sdk==2.27.0

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -73,11 +73,13 @@ class Retry:
         on: tuple[type[BaseException], ...] | None = None,
         ignore: tuple[type[BaseException], ...] | None = None,
         times_exceeded: LastAction = LastAction.Discard,
+        delay: int | None = None,
     ):
         self._times = times
         self._allowed_exception_types: tuple[type[BaseException], ...] = on or ()
         self._denied_exception_types: tuple[type[BaseException], ...] = ignore or ()
         self._times_exceeded = times_exceeded
+        self._delay = delay
 
     def should_retry(self, state: RetryState, exc: Exception) -> bool:
         # We subtract one, as attempts starts at 0, but `times`
@@ -105,4 +107,5 @@ class Retry:
             attempts=0,
             max_attempts=self._times,
             on_attempts_exceeded=self._times_exceeded.to_proto(),
+            delay_on_retry=self._delay,
         )

--- a/tests/sentry/taskworker/test_retry.py
+++ b/tests/sentry/taskworker/test_retry.py
@@ -41,6 +41,14 @@ def test_initial_state__deadletter() -> None:
     assert proto.on_attempts_exceeded == ON_ATTEMPTS_EXCEEDED_DEADLETTER
 
 
+def test_initial_state__delay_on_retry() -> None:
+    retry = Retry(times=5, delay=1)
+    proto = retry.initial_state()
+
+    assert proto.attempts == 0
+    assert proto.delay_on_retry == 1
+
+
 def test_should_retry_no_matching_error() -> None:
     retry = Retry(times=5)
     state = retry.initial_state()


### PR DESCRIPTION
Bumps the proto version to 0.2.0, which adds the new fields to allow tasks to define delay upon a retry.

Broker changes
https://github.com/getsentry/taskbroker/pull/350