### PR TITLE
ref(workflow_engine): Refactor the StatefulGroupingDetectorHandler class pt 2

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -18,7 +18,7 @@ from sentry.workflow_engine.handlers.detector import (
 )
 from sentry.workflow_engine.handlers.detector.base import EvidenceData
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.types import DetectorGroupKey, DetectorSettings
+from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorSettings
 
 COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
@@ -31,7 +31,9 @@ class MetricIssueEvidenceData(EvidenceData):
 
 class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscriptionUpdate, int]):
     def create_occurrence(
-        self, group_key: DetectorGroupKey, new_status: PriorityLevel
+        self,
+        value: int,
+        priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:
         # Returning a placeholder for now, this may require us passing more info
         occurrence = DetectorOccurrence(

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -53,6 +53,9 @@ class MetricAlertDetectorHandler(StatefulGroupingDetectorHandler[QuerySubscripti
     def extract_dedupe_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
         return int(data_packet.packet.get("timestamp", datetime.now(UTC)).timestamp())
 
+    def extract_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
+        return data_packet.packet["values"]["value"]
+
     def extract_group_values(
         self, data_packet: DataPacket[MetricDetectorUpdate]
     ) -> dict[DetectorGroupKey, int]:

--- a/src/sentry/workflow_engine/handlers/detector/__init__.py
+++ b/src/sentry/workflow_engine/handlers/detector/__init__.py
@@ -1,4 +1,6 @@
 __all__ = [
+    "DataPacketEvaluationType",
+    "DataPacketType",
     "DetectorEvaluationResult",
     "DetectorHandler",
     "DetectorOccurrence",
@@ -6,5 +8,11 @@ __all__ = [
     "StatefulGroupingDetectorHandler",
 ]
 
-from .base import DetectorEvaluationResult, DetectorHandler, DetectorOccurrence
+from .base import (
+    DataPacketEvaluationType,
+    DataPacketType,
+    DetectorEvaluationResult,
+    DetectorHandler,
+    DetectorOccurrence,
+)
 from .stateful import DetectorStateData, StatefulGroupingDetectorHandler

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 DataPacketType = TypeVar("DataPacketType")
 DataPacketEvaluationType = TypeVar("DataPacketEvaluationType")
-EventData = dict[str, Any] | None
+EventData = dict[str, Any]
 
 
 @dataclass
@@ -87,7 +87,8 @@ class DetectorEvaluationResult:
     event_data: dict[str, Any] | None = None
 
 
-class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
+# TODO - take the type for eval
+class DetectorHandler(abc.ABC, Generic[DataPacketType]):
     def __init__(self, detector: Detector):
         self.detector = detector
         if detector.workflow_condition_group_id is not None:
@@ -109,30 +110,4 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]
     def evaluate(
         self, data_packet: DataPacket[DataPacketType]
     ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
-        pass
-
-    @abc.abstractmethod
-    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
-        """
-        Extracts the deduplication value from a passed data packet. This duplication
-        value is used to determine if we've already processed data to this point or not.
-
-        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
-        """
-        pass
-
-    @abc.abstractmethod
-    def create_occurrence(
-        self,
-        value: DataPacketEvaluationType,
-        data_packet: DataPacketType,
-    ) -> tuple[DetectorOccurrence, EventData]:
-        """
-        This method provides the value that was evaluated against, the data packet that was
-        used to get the data, and the condition(s) that are failing.
-
-        To implement this, you will need to create a new `DetectorOccurrence` object,
-        to represent the issue that was detected. Additionally, you can return any
-        event_data to associate with the occurrence.
-        """
         pass

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -111,3 +111,32 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType]):
         self, data_packet: DataPacket[DataPacketType]
     ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
         pass
+
+    @abc.abstractmethod
+    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
+        """
+        Extracts the deduplication value from a passed data packet. This duplication
+        value is used to determine if we've already processed data to this point or not.
+
+        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
+        """
+        pass
+
+    # TODO - move to detector handler base
+    @abc.abstractmethod
+    def create_occurrence(
+        self,
+        # data_packet: DataPacketType, # TODO - having access to all the data being evaluated seems good
+        # data_conditions: list[DataCondition], # TODO - list of the failing conditions might be nice
+        value: DataPacketEvaluationType,
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, EventData]:
+        """
+        This method provides the value that was evaluated against, the data packet that was
+        used to get the data, and the condition(s) that are failing.
+
+        To implement this, you will need to create a new `DetectorOccurrence` object,
+        to represent the issue that was detected. Additionally, you can return any
+        event_data to associate with the occurrence.
+        """
+        pass

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -87,8 +87,8 @@ class DetectorEvaluationResult:
     event_data: dict[str, Any] | None = None
 
 
-# TODO - take the type for eval
-class DetectorHandler(abc.ABC, Generic[DataPacketType]):
+# TODO - DetectorHandler -> AbstractDetectorHandler? (then DetectorHandler is the base implementation)
+class DetectorHandler(abc.ABC, Generic[DataPacketType, DataPacketEvaluationType]):
     def __init__(self, detector: Detector):
         self.detector = detector
         if detector.workflow_condition_group_id is not None:
@@ -110,26 +110,18 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType]):
     def evaluate(
         self, data_packet: DataPacket[DataPacketType]
     ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
-        pass
-
-    @abc.abstractmethod
-    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
         """
-        Extracts the deduplication value from a passed data packet. This duplication
-        value is used to determine if we've already processed data to this point or not.
-
-        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
+        This method is used to evaluate the data packet's value against the conditions on the detector.
         """
         pass
 
-    # TODO - move to detector handler base
     @abc.abstractmethod
     def create_occurrence(
         self,
-        # data_packet: DataPacketType, # TODO - having access to all the data being evaluated seems good
-        # data_conditions: list[DataCondition], # TODO - list of the failing conditions might be nice
         value: DataPacketEvaluationType,
         priority: DetectorPriorityLevel,
+        # data_packet: DataPacketType, # TODO - having access to all the data being evaluated seems good
+        # data_conditions: list[DataCondition], # TODO - list of the failing conditions might be nice
     ) -> tuple[DetectorOccurrence, EventData]:
         """
         This method provides the value that was evaluated against, the data packet that was
@@ -138,5 +130,25 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType]):
         To implement this, you will need to create a new `DetectorOccurrence` object,
         to represent the issue that was detected. Additionally, you can return any
         event_data to associate with the occurrence.
+        """
+        pass
+
+    @abc.abstractmethod
+    def extract_value(self, data_packet: DataPacket[DataPacketType]) -> DataPacketEvaluationType:
+        """
+        Extracts the evaluation value from the data packet to be processed.
+
+        This value is used to determine if the data condition group is in a triggered state.
+        """
+        pass
+
+    # TODO should this be a required method? :thinking:
+    @abc.abstractmethod
+    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
+        """
+        Extracts the deduplication value from a passed data packet. This duplication
+        value is used to determine if we've already processed data to this point or not.
+
+        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
         """
         pass

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -1,7 +1,7 @@
 import abc
 import dataclasses
 from datetime import UTC, datetime, timedelta
-from typing import Any, Generic
+from typing import Generic
 from uuid import uuid4
 
 from django.conf import settings
@@ -18,8 +18,6 @@ from sentry.workflow_engine.handlers.detector.base import (
     DataPacketType,
     DetectorEvaluationResult,
     DetectorHandler,
-    DetectorOccurrence,
-    EventData,
 )
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
@@ -389,33 +387,3 @@ class StatefulGroupingDetectorHandler(
             DetectorState.objects.bulk_update(updated_detector_states, ["is_triggered", "state"])
 
         self.state_manager.state_updates.clear()
-
-    # TODO move to DetectorHandler base
-    @abc.abstractmethod
-    def extract_dedupe_value(self, data_packet: DataPacket[DataPacketType]) -> int:
-        """
-        Extracts the deduplication value from a passed data packet. This duplication
-        value is used to determine if we've already processed data to this point or not.
-
-        This is normally a timestamp, but could be any sortable value; (e.g. a sequence number, timestamp, etc).
-        """
-        pass
-
-    # TODO - move to detector handler base
-    @abc.abstractmethod
-    def create_occurrence(
-        self,
-        # data_packet: DataPacketType, # TODO - having access to all the data being evaluated seems good
-        # data_conditions: list[DataCondition], # TODO - list of the failing conditions might be nice
-        value: Any,
-        priority: DetectorPriorityLevel,
-    ) -> tuple[DetectorOccurrence, EventData]:
-        """
-        This method provides the value that was evaluated against, the data packet that was
-        used to get the data, and the condition(s) that are failing.
-
-        To implement this, you will need to create a new `DetectorOccurrence` object,
-        to represent the issue that was detected. Additionally, you can return any
-        event_data to associate with the occurrence.
-        """
-        pass

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -212,17 +212,17 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         That method will save pending updates to the storage, and clear the pending updates.
         """
         if dedupe_value is not None:
-            assert handler.dedupe_updates.get(group_key) == dedupe_value
+            assert handler.state_manager.dedupe_updates.get(group_key) == dedupe_value
         else:
             assert group_key not in handler.dedupe_updates
         if counter_updates is not None:
-            assert handler.counter_updates.get(group_key) == counter_updates
+            assert handler.state_manager.counter_updates.get(group_key) == counter_updates
         else:
             assert group_key not in handler.counter_updates
         if is_triggered is not None or priority is not None:
-            assert handler.state_updates.get(group_key) == (is_triggered, priority)
+            assert handler.state_manager.state_updates.get(group_key) == (is_triggered, priority)
         else:
-            assert group_key not in handler.state_updates
+            assert group_key not in handler.state_manager.state_updates
 
     def detector_to_issue_occurrence(
         self,

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -206,7 +206,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         """
         Use this method when testing state updates that have been executed by evaluate
         """
-        saved_state = handler.get_state_data([group_key])
+        saved_state = handler.state_manager.get_state_data([group_key])
         state_data = saved_state.get(group_key)
 
         if not state_data:

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -221,33 +221,44 @@ class TestKeyBuilders(unittest.TestCase):
         return MockDetectorStateHandler(detector)
 
     def test(self):
-        assert self.build_handler().build_dedupe_value_key("test") == "123:test:dedupe_value"
-        assert self.build_handler().build_counter_value_key("test", "name_1") == "123:test:name_1"
+        assert (
+            self.build_handler().build_key_for_group("test", "dedupe_value")
+            == "123:test:dedupe_value"
+        )
+        assert self.build_handler().build_key_for_group("test", "name_1") == "123:test:name_1"
 
     def test_different_dedupe_keys(self):
         handler = self.build_handler()
         handler_2 = self.build_handler(Detector(id=456))
-        assert handler.build_dedupe_value_key("test") != handler_2.build_dedupe_value_key("test")
-        assert handler.build_dedupe_value_key("test") != handler_2.build_dedupe_value_key("test2")
-        assert handler.build_dedupe_value_key("test") == handler.build_dedupe_value_key("test")
-        assert handler.build_dedupe_value_key("test") != handler.build_dedupe_value_key("test_2")
+        assert handler.build_key_for_group("test", "dedupe_value") != handler_2.build_key_for_group(
+            "test", "dedupe_value"
+        )
+        assert handler.build_key_for_group("test", "dedupe_value") != handler_2.build_key_for_group(
+            "test2", "dedupe_value"
+        )
+        assert handler.build_key_for_group("test", "dedupe_value") == handler.build_key_for_group(
+            "test", "dedupe_value"
+        )
+        assert handler.build_key_for_group("test", "dedupe_value") != handler.build_key_for_group(
+            "test_2", "dedupe_value"
+        )
 
     def test_different_counter_value_keys(self):
         handler = self.build_handler()
         handler_2 = self.build_handler(Detector(id=456))
-        assert handler.build_counter_value_key(
-            "test", "name_1"
-        ) != handler_2.build_counter_value_key("test", "name_1")
-        assert handler.build_counter_value_key("test", "name_1") == handler.build_counter_value_key(
+        assert handler.build_key_for_group("test", "name_1") != handler_2.build_key_for_group(
             "test", "name_1"
         )
-        assert handler.build_counter_value_key("test", "name_1") != handler.build_counter_value_key(
+        assert handler.build_key_for_group("test", "name_1") == handler.build_key_for_group(
+            "test", "name_1"
+        )
+        assert handler.build_key_for_group("test", "name_1") != handler.build_key_for_group(
             "test2", "name_1"
         )
-        assert handler.build_counter_value_key("test", "name_1") != handler.build_counter_value_key(
+        assert handler.build_key_for_group("test", "name_1") != handler.build_key_for_group(
             "test", "name_2"
         )
-        assert handler.build_counter_value_key("test", "name_1") != handler.build_counter_value_key(
+        assert handler.build_key_for_group("test", "name_1") != handler.build_key_for_group(
             "test2", "name_2"
         )
 
@@ -256,7 +267,7 @@ class TestGetStateData(BaseDetectorHandlerTest):
     def test_new(self):
         handler = self.build_handler()
         key = "test_key"
-        assert handler.get_state_data([key]) == {
+        assert handler.state_manager.get_state_data([key]) == {
             key: DetectorStateData(
                 key, False, DetectorPriorityLevel.OK, 0, {"test1": None, "test2": None}
             )
@@ -275,8 +286,8 @@ class TestGetStateData(BaseDetectorHandlerTest):
         handler.state_manager.enqueue_state_update(
             state_data.group_key, state_data.is_triggered, state_data.status
         )
-        handler.commit_state_updates()
-        assert handler.get_state_data([key]) == {key: state_data}
+        handler.state_manager.commit_state_updates()
+        assert handler.state_manager.get_state_data([key]) == {key: state_data}
 
     def test_multi(self):
         handler = self.build_handler()
@@ -304,8 +315,8 @@ class TestGetStateData(BaseDetectorHandlerTest):
         state_data_uncommitted = DetectorStateData(
             key_uncommitted, False, DetectorPriorityLevel.OK, 0, {"test1": None, "test2": None}
         )
-        handler.commit_state_updates()
-        assert handler.get_state_data([key_1, key_2, key_uncommitted]) == {
+        handler.state_manager.commit_state_updates()
+        assert handler.state_manager.get_state_data([key_1, key_2, key_uncommitted]) == {
             key_1: state_data_1,
             key_2: state_data_2,
             key_uncommitted: state_data_uncommitted,
@@ -320,9 +331,10 @@ class TestCommitStateUpdateData(BaseDetectorHandlerTest):
         assert not DetectorState.objects.filter(
             detector=handler.detector, detector_group_key=group_key
         ).exists()
-        dedupe_key = handler.build_dedupe_value_key(group_key)
-        counter_key_1 = handler.build_counter_value_key(group_key, "some_counter")
-        counter_key_2 = handler.build_counter_value_key(group_key, "another_counter")
+        dedupe_key = handler.build_key_for_group(group_key, "dedupe_value")
+        counter_key_1 = handler.build_key_for_group(group_key, "some_counter")
+        counter_key_2 = handler.build_key_for_group(group_key, "another_counter")
+
         assert not redis.exists(dedupe_key)
         assert not redis.exists(counter_key_1)
         assert not redis.exists(counter_key_2)
@@ -331,7 +343,7 @@ class TestCommitStateUpdateData(BaseDetectorHandlerTest):
             group_key, {"some_counter": 1, "another_counter": 2}
         )
         handler.state_manager.enqueue_state_update(group_key, True, DetectorPriorityLevel.OK)
-        handler.commit_state_updates()
+        handler.state_manager.commit_state_updates()
         assert DetectorState.objects.filter(
             detector=handler.detector,
             detector_group_key=group_key,
@@ -347,7 +359,7 @@ class TestCommitStateUpdateData(BaseDetectorHandlerTest):
             group_key, {"some_counter": None, "another_counter": 20}
         )
         handler.state_manager.enqueue_state_update(group_key, False, DetectorPriorityLevel.OK)
-        handler.commit_state_updates()
+        handler.state_manager.commit_state_updates()
         assert DetectorState.objects.filter(
             detector=handler.detector,
             detector_group_key=group_key,
@@ -402,7 +414,7 @@ class TestEvaluate(BaseDetectorHandlerTest):
     def test_above_below_threshold(self):
         handler = self.build_handler()
         assert handler.evaluate(DataPacket("1", {"dedupe": 1, "group_vals": {"val1": 0}})) == {}
-        handler.commit_state_updates()
+        handler.state_manager.commit_state_updates()
 
         detector_occurrence, _ = build_mock_occurrence_and_event(
             handler, "val1", PriorityLevel.HIGH

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -268,9 +268,11 @@ class TestGetStateData(BaseDetectorHandlerTest):
         state_data = DetectorStateData(
             key, True, DetectorPriorityLevel.OK, 10, {"test1": 5, "test2": 200}
         )
-        handler.enqueue_dedupe_update(state_data.group_key, state_data.dedupe_value)
-        handler.enqueue_counter_update(state_data.group_key, state_data.counter_updates)
-        handler.enqueue_state_update(
+        handler.state_manager.enqueue_dedupe_update(state_data.group_key, state_data.dedupe_value)
+        handler.state_manager.enqueue_counter_update(
+            state_data.group_key, state_data.counter_updates
+        )
+        handler.state_manager.enqueue_state_update(
             state_data.group_key, state_data.is_triggered, state_data.status
         )
         handler.commit_state_updates()
@@ -282,17 +284,21 @@ class TestGetStateData(BaseDetectorHandlerTest):
         state_data_1 = DetectorStateData(
             key_1, True, DetectorPriorityLevel.OK, 100, {"test1": 50, "test2": 300}
         )
-        handler.enqueue_dedupe_update(key_1, state_data_1.dedupe_value)
-        handler.enqueue_counter_update(key_1, state_data_1.counter_updates)
-        handler.enqueue_state_update(key_1, state_data_1.is_triggered, state_data_1.status)
+        handler.state_manager.enqueue_dedupe_update(key_1, state_data_1.dedupe_value)
+        handler.state_manager.enqueue_counter_update(key_1, state_data_1.counter_updates)
+        handler.state_manager.enqueue_state_update(
+            key_1, state_data_1.is_triggered, state_data_1.status
+        )
 
         key_2 = "test_key_2"
         state_data_2 = DetectorStateData(
             key_2, True, DetectorPriorityLevel.OK, 10, {"test1": 55, "test2": 12}
         )
-        handler.enqueue_dedupe_update(key_2, state_data_2.dedupe_value)
-        handler.enqueue_counter_update(key_2, state_data_2.counter_updates)
-        handler.enqueue_state_update(key_2, state_data_2.is_triggered, state_data_2.status)
+        handler.state_manager.enqueue_dedupe_update(key_2, state_data_2.dedupe_value)
+        handler.state_manager.enqueue_counter_update(key_2, state_data_2.counter_updates)
+        handler.state_manager.enqueue_state_update(
+            key_2, state_data_2.is_triggered, state_data_2.status
+        )
 
         key_uncommitted = "test_key_uncommitted"
         state_data_uncommitted = DetectorStateData(
@@ -320,9 +326,11 @@ class TestCommitStateUpdateData(BaseDetectorHandlerTest):
         assert not redis.exists(dedupe_key)
         assert not redis.exists(counter_key_1)
         assert not redis.exists(counter_key_2)
-        handler.enqueue_dedupe_update(group_key, 100)
-        handler.enqueue_counter_update(group_key, {"some_counter": 1, "another_counter": 2})
-        handler.enqueue_state_update(group_key, True, DetectorPriorityLevel.OK)
+        handler.state_manager.enqueue_dedupe_update(group_key, 100)
+        handler.state_manager.enqueue_counter_update(
+            group_key, {"some_counter": 1, "another_counter": 2}
+        )
+        handler.state_manager.enqueue_state_update(group_key, True, DetectorPriorityLevel.OK)
         handler.commit_state_updates()
         assert DetectorState.objects.filter(
             detector=handler.detector,
@@ -334,9 +342,11 @@ class TestCommitStateUpdateData(BaseDetectorHandlerTest):
         assert redis.get(counter_key_1) == "1"
         assert redis.get(counter_key_2) == "2"
 
-        handler.enqueue_dedupe_update(group_key, 150)
-        handler.enqueue_counter_update(group_key, {"some_counter": None, "another_counter": 20})
-        handler.enqueue_state_update(group_key, False, DetectorPriorityLevel.OK)
+        handler.state_manager.enqueue_dedupe_update(group_key, 150)
+        handler.state_manager.enqueue_counter_update(
+            group_key, {"some_counter": None, "another_counter": 20}
+        )
+        handler.state_manager.enqueue_state_update(group_key, False, DetectorPriorityLevel.OK)
         handler.commit_state_updates()
         assert DetectorState.objects.filter(
             detector=handler.detector,


### PR DESCRIPTION
## Description
This PR will refactor the StatefulGroupingDetectorHandler to pull the state class into it's own composed class. This is creating a smidge of an awkward middle-ground with encapsulation.

Up next, refactor the handler so there's a StatefulDetectorHandler that doesn't use grouping. The final update will be a GroupDetectorHandler that utilizes the StatefulDetectorHandler.