### PR TITLE
:wrench: chore(notifications): use new field on IncidentGroupOpenPeriod model

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -588,13 +588,12 @@ def generate_incident_trigger_email_context(
         except IncidentGroupOpenPeriod.DoesNotExist:
             raise ValueError("IncidentGroupOpenPeriod does not exist")
 
-        incident = Incident.objects.get(id=incident_group_open_period.incident_id)
         alert_link = organization.absolute_url(
             reverse(
                 "sentry-metric-alert",
                 kwargs={
                     "organization_slug": organization.slug,
-                    "incident_id": incident.identifier,
+                    "incident_id": incident_group_open_period.incident_identifier,
                 },
             ),
             query=urlencode(alert_link_params),

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -240,11 +240,7 @@ def incident_attachment_info(
 
         workflow_engine_params = title_link_params.copy()
 
-        incident_identifier = Incident.objects.values_list("identifier", flat=True).get(
-            id=open_period_incident.incident_id
-        )
-
-        workflow_engine_params["alert"] = str(incident_identifier)
+        workflow_engine_params["alert"] = str(open_period_incident.incident_identifier)
 
         title_link = build_title_link(alert_rule_id, organization, workflow_engine_params)
 


### PR DESCRIPTION
after @ceorourke's pr to add `incident.identifier` to `IncidentGroupOpenPeriod`, we can remove the `Incident` lookup.