### PR TITLE
fix(eap): Handle nans in rpc sampling rates

### DIFF
--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -61,8 +61,8 @@ def process_timeseries_list(timeseries_list: list[TimeSeries]) -> ProcessedTimes
         for index, data_point in enumerate(timeseries.data_points):
             result.timeseries[index][label] = process_value(data_point.data)
             result.confidence[index][label] = CONFIDENCES.get(data_point.reliability, None)
-            result.sampling_rate[index][label] = data_point.avg_sampling_rate
-            result.sample_count[index][label] = data_point.sample_count
+            result.sampling_rate[index][label] = process_value(data_point.avg_sampling_rate)
+            result.sample_count[index][label] = process_value(data_point.sample_count)
 
     return result
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -665,6 +665,27 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
         )
         assert response.status_code == 200, response.content
 
+    def test_count_unique_nans(self):
+        self.store_span(
+            self.create_span(start_ts=self.two_days_ago + timedelta(minutes=1)),
+            is_eap=self.is_eap,
+        )
+        response = self._do_request(
+            data={
+                "field": ["count_unique(foo)"],
+                "yAxis": ["count_unique(foo)"],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "excludeOther": 1,
+                "partial": 1,
+                "per_page": 50,
+                "interval": "1d",
+                "statsPeriod": "7d",
+                "transformAliasToInputFormat": 1,
+            },
+        )
+        assert response.status_code == 200, response.content
+
 
 class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetricsEndpointTest):
     is_eap = True


### PR DESCRIPTION
We can also have nans in the sampling rates so make sure to handle those appropriately.

Closes EXP-247