### PR TITLE
feat(seer): include in stats

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -542,7 +542,7 @@ export const DATA_CATEGORY_INFO = {
     isBilledCategory: true,
     statsInfo: {
       ...DEFAULT_STATS_INFO,
-      showInternalStats: false, // TODO(Seer): update this for launch
+      showExternalStats: true,
     },
   },
   [DataCategoryExact.SEER_SCANNER]: {
@@ -556,7 +556,7 @@ export const DATA_CATEGORY_INFO = {
     isBilledCategory: true,
     statsInfo: {
       ...DEFAULT_STATS_INFO,
-      showInternalStats: false, // TODO(Seer): update this for launch
+      showExternalStats: true,
     },
   },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -518,6 +518,34 @@ describe('OrganizationStats', () => {
     expect(screen.getByRole('option', {name: 'Profiles'})).toBeInTheDocument();
   });
 
+  it('shows Seer categories when seer-billing feature flag is enabled', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: ['global-views', 'team-insights', 'seer-billing'],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />);
+
+    await userEvent.click(await screen.findByText('Category'));
+    expect(screen.getByRole('option', {name: 'Issue Fixes'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Issue Scans'})).toBeInTheDocument();
+  });
+
+  it('does not show Seer categories when seer-billing feature flag is disabled', async () => {
+    const newOrg = initializeOrg({
+      organization: {
+        features: ['global-views', 'team-insights'],
+      },
+    });
+
+    render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />);
+
+    await userEvent.click(await screen.findByText('Category'));
+    expect(screen.queryByRole('option', {name: 'Issue Fixes'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', {name: 'Issue Scans'})).not.toBeInTheDocument();
+  });
+
   it('denies access on no projects', async () => {
     act(() => ProjectsStore.loadInitialData([]));
 

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -273,6 +273,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if (opt.value === DataCategory.TRANSACTIONS) {
         return !organization.features.includes('spans-usage-tracking');
       }
+      if ([DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER].includes(opt.value)) {
+        return organization.features.includes('seer-billing');
+      }
       if ([DataCategory.LOG_BYTE, DataCategory.LOG_ITEM].includes(opt.value)) {
         return organization.features.includes('ourlogs-stats');
       }


### PR DESCRIPTION
- Adds Seer categories to the Stats & Usage chart dropdown for orgs that have the billing flag
- Adds Seer categories to internal stats component

![Screenshot 2025-05-07 at 5 26 17 PM](https://github.com/user-attachments/assets/bd5c1960-4853-46dd-a509-fe232edff816)

Actual data population is handled by https://github.com/getsentry/getsentry/pull/17351 and the full experience will be tested in a separate ticket

Closes https://linear.app/getsentry/issue/BIL-678/update-statsinfo-for-the-seer-categories-in-data-category-info
