### PR TITLE
ref(workflow_engine): Add DataCondition to the processing result

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -225,9 +225,10 @@ class StatefulGroupingDetectorHandler(
         if is_group_condition_met:
             # TODO - use the `_` as the condition to snapshot in the evidence data
             validated_condition_results: list[DetectorPriorityLevel] = [
-                result
-                for _, result in condition_results
-                if result is not None and isinstance(result, DetectorPriorityLevel)
+                condition_result
+                for _, condition_result in condition_results
+                if condition_result is not None
+                and isinstance(condition_result, DetectorPriorityLevel)
             ]
 
             new_status = max(new_status, *validated_condition_results)

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -216,19 +216,16 @@ class StatefulGroupingDetectorHandler(
         # store these in `DetectorStateData.counter_updates`, but we don't have anywhere to set the required
         # thresholds at the moment. Probably should be a field on the Detector? Could also be on the condition
         # level, but usually we want to set this at a higher level.
-        # TODO 2: Validate that we will never have slow conditions here.
+        # -- we can store the thresholds on the detector.config -- seems like a field we could use for only stateful detectors
         new_status = DetectorPriorityLevel.OK
-        (is_group_condition_met, condition_results), _ = process_data_condition_group(
-            self.condition_group.id, value
-        )
+        processed_data_condition, _ = process_data_condition_group(self.condition_group.id, value)
 
-        if is_group_condition_met:
-            # TODO - use the `_` as the condition to snapshot in the evidence data
+        if processed_data_condition.logic_result:
             validated_condition_results: list[DetectorPriorityLevel] = [
-                condition_result
-                for _, condition_result in condition_results
-                if condition_result is not None
-                and isinstance(condition_result, DetectorPriorityLevel)
+                condition_result.result
+                for condition_result in processed_data_condition.condition_results
+                if condition_result.result is not None
+                and isinstance(condition_result.result, DetectorPriorityLevel)
             ]
 
             new_status = max(new_status, *validated_condition_results)

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -223,9 +223,10 @@ class StatefulGroupingDetectorHandler(
         )
 
         if is_group_condition_met:
+            # TODO - use the `_` as the condition to snapshot in the evidence data
             validated_condition_results: list[DetectorPriorityLevel] = [
                 result
-                for result in condition_results
+                for _, result in condition_results
                 if result is not None and isinstance(result, DetectorPriorityLevel)
             ]
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -81,10 +81,10 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             return True, []
 
         workflow_event_data = replace(event_data, workflow_env=self.environment)
-        (evaluation, _), remaining_conditions = process_data_condition_group(
+        group_evaluation, remaining_conditions = process_data_condition_group(
             self.when_condition_group.id, workflow_event_data
         )
-        return evaluation, remaining_conditions
+        return group_evaluation.logic_result, remaining_conditions
 
 
 def get_slow_conditions(workflow: Workflow) -> list[DataCondition]:

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 from typing import TypeVar
 
@@ -10,9 +11,21 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-ProcessedDataConditionResult = tuple[bool, DataCondition, DataConditionResult]
-ProcessedDataConditionGroupResult = tuple[bool, list[tuple[DataCondition, DataConditionResult]]]
-DataConditionGroupResult = tuple[ProcessedDataConditionGroupResult, list[DataCondition]]
+
+@dataclasses.dataclass()
+class ProcessedDataCondition:
+    logic_result: bool
+    condition: DataCondition
+    result: DataConditionResult
+
+
+@dataclasses.dataclass()
+class ProcessedDataConditionGroup:
+    logic_result: bool
+    condition_results: list[ProcessedDataCondition]
+
+
+DataConditionGroupResult = tuple[ProcessedDataConditionGroup, list[DataCondition]]
 
 
 @cache_func_for_models(
@@ -24,11 +37,11 @@ def get_data_conditions_for_group(data_condition_group_id: int) -> list[DataCond
 
 
 def evaluate_condition_group_results(
-    results: list[ProcessedDataConditionResult],
+    condition_results: list[ProcessedDataCondition],
     logic_type: DataConditionGroup.Type,
-) -> ProcessedDataConditionGroupResult:
+) -> ProcessedDataConditionGroup:
     logic_result = False
-    condition_results: list[tuple[DataCondition, DataConditionResult]] = []
+    group_condition_results: list[ProcessedDataCondition] = []
 
     if logic_type == DataConditionGroup.Type.NONE:
         # if we get to this point, no conditions were met
@@ -36,34 +49,47 @@ def evaluate_condition_group_results(
         logic_result = True
 
     elif logic_type == DataConditionGroup.Type.ANY:
-        logic_result = any([result[0] for result in results])
+        logic_result = any(
+            [condition_result.logic_result for condition_result in condition_results]
+        )
 
         if logic_result:
-            condition_results = [(result[1], result[2]) for result in results if result[0]]
+            group_condition_results = [
+                condition_result
+                for condition_result in condition_results
+                if condition_result.logic_result
+            ]
 
     elif logic_type == DataConditionGroup.Type.ALL:
-        conditions_met = [result[0] for result in results]
+        conditions_met = [condition_result.logic_result for condition_result in condition_results]
         logic_result = all(conditions_met)
 
         if logic_result:
-            condition_results = [(result[1], result[2]) for result in results if result[0]]
+            group_condition_results = [
+                condition_result
+                for condition_result in condition_results
+                if condition_result.logic_result
+            ]
 
-    return logic_result, condition_results
+    return ProcessedDataConditionGroup(
+        logic_result=logic_result,
+        condition_results=group_condition_results,
+    )
 
 
 def evaluate_data_conditions(
     conditions_to_evaluate: list[tuple[DataCondition, T]],
     logic_type: DataConditionGroup.Type,
-) -> ProcessedDataConditionGroupResult:
+) -> ProcessedDataConditionGroup:
     """
     Evaluate a list of conditions, each condition is a tuple with the value to evalute the condition against.
     Then we apply the logic_type to get the results of the list of conditions.
     """
-    condition_results: list[tuple[bool, DataCondition, DataConditionResult]] = []
+    condition_results: list[ProcessedDataCondition] = []
 
     if len(conditions_to_evaluate) == 0:
         # if we don't have any conditions, always return True
-        return True, []
+        return ProcessedDataConditionGroup(logic_result=True, condition_results=[])
 
     for condition, value in conditions_to_evaluate:
         evaluation_result = condition.evaluate_value(value)
@@ -72,12 +98,26 @@ def evaluate_data_conditions(
         if is_condition_triggered:
             # Check for short-circuiting evaluations
             if logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-                return is_condition_triggered, [(condition, evaluation_result)]
+                condition_result = ProcessedDataCondition(
+                    logic_result=True,
+                    condition=condition,
+                    result=evaluation_result,
+                )
+
+                return ProcessedDataConditionGroup(
+                    logic_result=is_condition_triggered,
+                    condition_results=[condition_result],
+                )
 
             if logic_type == DataConditionGroup.Type.NONE:
-                return False, []
+                return ProcessedDataConditionGroup(logic_result=False, condition_results=[])
 
-        condition_results.append((is_condition_triggered, condition, evaluation_result))
+        result = ProcessedDataCondition(
+            logic_result=is_condition_triggered,
+            condition=condition,
+            result=evaluation_result,
+        )
+        condition_results.append(result)
 
     return evaluate_condition_group_results(
         condition_results,
@@ -90,9 +130,11 @@ def process_data_condition_group(
     value: T,
     is_fast: bool = True,
 ) -> DataConditionGroupResult:
-    invalid_group_result: DataConditionGroupResult = (False, []), []
-    logic_result: bool = False
-    condition_results: list[tuple[DataCondition, DataConditionResult]] = []
+    invalid_group = ProcessedDataConditionGroup(logic_result=False, condition_results=[])
+    remaining_conditions: list[DataCondition] = []
+    invalid_group_result: DataConditionGroupResult = (invalid_group, remaining_conditions)
+
+    condition_results: list[ProcessedDataCondition] = []
 
     try:
         group = DataConditionGroup.objects.get_from_cache(id=data_condition_group_id)
@@ -123,10 +165,16 @@ def process_data_condition_group(
     if not conditions and remaining_conditions:
         # there are only slow conditions to evaluate, do not evaluate an empty list of conditions
         # which would evaluate to True
-        return (logic_result, condition_results), remaining_conditions
+        condition_group_result = ProcessedDataConditionGroup(
+            logic_result=False,
+            condition_results=condition_results,
+        )
+        return condition_group_result, remaining_conditions
 
     conditions_to_evaluate = [(condition, value) for condition in conditions]
-    logic_result, condition_results = evaluate_data_conditions(conditions_to_evaluate, logic_type)
+    processed_condition_group = evaluate_data_conditions(conditions_to_evaluate, logic_type)
+
+    logic_result = processed_condition_group.logic_result
 
     # Check to see if we should return any remaining conditions based on the results
     is_short_circuit_all = not logic_result and logic_type == DataConditionGroup.Type.ALL
@@ -141,4 +189,4 @@ def process_data_condition_group(
         #  we can short-circuit any remaining conditions since we have a completed logic result
         remaining_conditions = []
 
-    return (logic_result, condition_results), remaining_conditions
+    return processed_condition_group, remaining_conditions

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -288,12 +288,12 @@ def get_groups_to_fire(
                 ]
                 conditions_to_evaluate.append((condition, query_values))
 
-            passes, _ = evaluate_data_conditions(conditions_to_evaluate, action_match)
+            evaluation = evaluate_data_conditions(conditions_to_evaluate, action_match)
             if (
-                passes and workflow_id is None
+                evaluation.logic_result and workflow_id is None
             ):  # TODO: detector trigger passes. do something like create issue
                 pass
-            elif passes:
+            elif evaluation.logic_result:
                 groups_to_fire[group_id].add(dcg)
 
     return groups_to_fire

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -150,7 +150,7 @@ def evaluate_workflows_action_filters(
                 workflow_event_data, workflow_env=workflow_data_condition_group.workflow.environment
             )
 
-        (evaluation, result), remaining_conditions = process_data_condition_group(
+        group_evaluation, remaining_conditions = process_data_condition_group(
             action_condition.id, workflow_event_data
         )
 
@@ -165,7 +165,7 @@ def evaluate_workflows_action_filters(
                     WorkflowDataConditionGroupType.ACTION_FILTER,
                 )
         else:
-            if evaluation:
+            if group_evaluation.logic_result:
                 filtered_action_groups.add(action_condition)
 
     return filter_recently_fired_workflow_actions(filtered_action_groups, event_data)

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -33,7 +33,6 @@ class DetectorPriorityLevel(IntEnum):
 DetectorGroupKey = str | None
 
 DataConditionResult = DetectorPriorityLevel | int | float | bool | None
-ProcessedDataConditionResult = tuple[bool, list[DataConditionResult]]
 
 
 @dataclass(frozen=True)

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -35,6 +35,7 @@ from sentry.workflow_engine.models.data_condition import (
     SLOW_CONDITIONS,
     Condition,
 )
+from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
 from sentry.workflow_engine.processors.delayed_workflow import (
     DataConditionGroupEvent,
     DataConditionGroupGroups,
@@ -804,7 +805,10 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
 
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_fire_actions_for_groups__workflow_fire_history(self, mock_process):
-        mock_process.return_value = (True, []), []
+        mock_process.return_value = (
+            ProcessedDataConditionGroup(logic_result=True, condition_results=[]),
+            [],
+        )
 
         self.trigger_group_to_dcg_model[DataConditionHandler.Group.WORKFLOW_TRIGGER] = {
             self.workflow1_dcgs[0].id: self.workflow1.id,


### PR DESCRIPTION
## Description
In the detector / possible other areas, it's helpful to have the DataCondition that is considered met.

This is currently needed in the detector processor where we'll want to expose any failing data conditions in the `create_occurrence` method, and we'll snapshot the data condition in the evidence data for the issue occurrence.