### PR TITLE
:bug: fix(notifications): add links to slack activity notifications

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -34,7 +34,6 @@ from sentry.integrations.slack.metrics import record_lifecycle_termination_level
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.threads.activity_notifications import (
-    AssignedActivityNotification,
     ExternalIssueCreatedActivityNotification,
 )
 from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
@@ -46,10 +45,10 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
 from sentry.notifications.notifications.activity.archive import ArchiveActivityNotification
-from sentry.notifications.notifications.activity.base import ActivityNotification
+from sentry.notifications.notifications.activity.assigned import AssignedActivityNotification
+from sentry.notifications.notifications.activity.base import GroupActivityNotification
 from sentry.notifications.notifications.activity.escalating import EscalatingActivityNotification
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
-from sentry.notifications.notifications.activity.release import ReleaseActivityNotification
 from sentry.notifications.notifications.activity.resolved import ResolvedActivityNotification
 from sentry.notifications.notifications.activity.resolved_in_pull_request import (
     ResolvedInPullRequestActivityNotification,
@@ -69,10 +68,9 @@ _default_logger = getLogger(__name__)
 
 
 DEFAULT_SUPPORTED_ACTIVITY_THREAD_NOTIFICATION_HANDLERS: dict[
-    ActivityType, type[ActivityNotification]
+    ActivityType, type[GroupActivityNotification]
 ] = {
     ActivityType.ASSIGNED: AssignedActivityNotification,
-    ActivityType.DEPLOY: ReleaseActivityNotification,
     ActivityType.SET_REGRESSION: RegressionActivityNotification,
     ActivityType.SET_RESOLVED: ResolvedActivityNotification,
     ActivityType.SET_RESOLVED_BY_AGE: ResolvedActivityNotification,
@@ -110,7 +108,7 @@ class SlackService:
         issue_alert_repository: IssueAlertNotificationMessageRepository,
         notification_action_repository: NotificationActionNotificationMessageRepository,
         message_block_builder: BlockSlackMessageBuilder,
-        activity_thread_notification_handlers: dict[ActivityType, type[ActivityNotification]],
+        activity_thread_notification_handlers: dict[ActivityType, type[GroupActivityNotification]],
         logger: Logger,
     ) -> None:
         self._issue_alert_repository = issue_alert_repository
@@ -187,6 +185,8 @@ class SlackService:
             )
             return None
 
+        # TODO: This will return None if there are multiple integrations for the same organization, meaning if there are multiple slack installations for the same organization.
+        # We need to associate integration with the threading logic in notif platform so we don't run into this issue.
         integration = get_active_integration_for_organization(
             organization_id=organization_id,
             provider=ExternalProviderEnum.SLACK,
@@ -396,6 +396,8 @@ class SlackService:
             thread_ts=message_identifier,
             text=notification_to_send,
             blocks=json_blocks,
+            unfurl_links=False,
+            unfurl_media=False,
         )
 
     def _get_notification_message_to_send(self, activity: Activity) -> str | None:
@@ -430,7 +432,7 @@ class SlackService:
             return None
 
         notification_obj = notification_cls(activity=activity)
-        context = notification_obj.get_context()
+        context = notification_obj.get_context(provider=ExternalProviders.SLACK)
         text_description = context.get("text_description", None)
         if not text_description:
             self._logger.info(

--- a/src/sentry/integrations/slack/threads/activity_notifications.py
+++ b/src/sentry/integrations/slack/threads/activity_notifications.py
@@ -3,25 +3,11 @@ from collections.abc import Mapping
 from typing import Any
 
 from sentry.models.activity import Activity
-from sentry.notifications.notifications.activity.assigned import (
-    AssignedActivityNotification as BaseAssignedActivityNotification,
-)
 from sentry.notifications.notifications.activity.base import GroupActivityNotification
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 
 _default_logger = logging.getLogger(__name__)
-
-
-class AssignedActivityNotification(BaseAssignedActivityNotification):
-    """
-    This notification overrides the base AssignedActivityNotification text template to remove the explicit issue name,
-    and instead leverages "this issue" since this notification is already attached to an existing notification where
-    the issue name exists.
-    """
-
-    def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
-        return "{author} assigned this issue to {assignee}", None, {"assignee": self.get_assignee()}
 
 
 class _ExternalIssueCreatedActivity:

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -119,14 +119,15 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
             **self.get_group_context(),
         }
 
-    def get_context(self) -> MutableMapping[str, Any]:
+    def get_context(self, provider: ExternalProviders | None = None) -> MutableMapping[str, Any]:
         """
         Context shared by every recipient of this notification. This may contain
         expensive computation so it should only be called once. Override this
         method if the notification does not need HTML/text descriptions.
         """
         text_template, html_template, params = self.get_description()
-        text_description = self.description_as_text(text_template, params)
+        should_add_url = provider is not None
+        text_description = self.description_as_text(text_template, params, should_add_url, provider)
         html_description = self.description_as_html(html_template or text_template, params)
         return {
             **self.get_base_context(),
@@ -170,7 +171,7 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
             name = "Sentry"
 
         issue_name = self.group.qualified_short_id or "an issue"
-        if url and self.group.qualified_short_id:
+        if provider and url and self.group.qualified_short_id:
             group_url = self.group.get_absolute_url(
                 params={
                     "referrer": "activity_notification",

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_assigned_activity_notification.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_assigned_activity_notification.py
@@ -1,5 +1,5 @@
-from sentry.integrations.slack.threads.activity_notifications import AssignedActivityNotification
 from sentry.models.activity import Activity
+from sentry.notifications.notifications.activity.assigned import AssignedActivityNotification
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 

--- a/tests/sentry/integrations/slack/threads/activity_notifications/test_assigned_activity_notification.py
+++ b/tests/sentry/integrations/slack/threads/activity_notifications/test_assigned_activity_notification.py
@@ -21,11 +21,11 @@ class _BaseTestCase(TestCase):
 class TestGetDescription(_BaseTestCase):
     def test_returns_correct_template(self) -> None:
         template, _, _ = self.obj.get_description()
-        assert template == "{author} assigned this issue to {assignee}"
+        assert template == "{author} assigned {an issue} to {assignee}"
 
 
 class TestDescriptionAsTest(_BaseTestCase):
     def test_returns_correct_text(self) -> None:
         template, _, params = self.obj.get_description()
         text = self.obj.description_as_text(template, params)
-        assert text == "admin@localhost assigned this issue to themselves"
+        assert text == f"admin@localhost assigned {self.group.qualified_short_id} to themselves"


### PR DESCRIPTION
Before:
<img width="437" alt="image" src="https://github.com/user-attachments/assets/8be63931-2263-46a6-98d5-bc0c6fe4bc6f" />


After:
<img width="420" alt="image" src="https://github.com/user-attachments/assets/83c56f68-c395-4bde-8b2b-82f3a651bbfd" />

This fixes a pet-peeve of mine where activity notifications just contain an issue's Short-ID and not a link to the issue.


sometimes when we get an activity notification in a channel as a new message,  u just see a random ID and have no context.

