### PR TITLE
feat(replay): Make OTA Updates field discoverable for replays search

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2240,6 +2240,9 @@ export const REPLAY_FIELDS = [
   FieldKey.USER_IP,
   FieldKey.USER_USERNAME,
   ReplayFieldKey.VIEWED_BY_ME,
+  FieldKey.OTA_UPDATES_CHANNEL,
+  FieldKey.OTA_UPDATES_RUNTIME_VERSION,
+  FieldKey.OTA_UPDATES_UPDATE_ID,
 ];
 
 const REPLAY_FIELD_DEFINITIONS: Record<ReplayFieldKey, FieldDefinition> = {


### PR DESCRIPTION
<img width="845" alt="Screenshot 2025-05-08 at 11 41 43" src="https://github.com/user-attachments/assets/fcfcd24f-0b98-40b1-807e-485f404aa32b" />

This is part of Sentry Expo integration.

We want replays filterable using the OTA Updates properties.

Making Replays filterable:
- https://github.com/getsentry/relay/pull/4711
- https://github.com/getsentry/snuba/pull/7163
- https://github.com/getsentry/snuba/pull/7164
- https://github.com/getsentry/snuba/pull/7165
- https://github.com/getsentry/snuba/pull/7166
- https://github.com/getsentry/sentry/pull/91163
- (this) https://github.com/getsentry/sentry/pull/91214

~Related changes for making `release.version` searchable:~
`release.version` can be replaced by `release:*${VERSION}*`
- https://github.com/getsentry/relay/pull/4714

For Errors and Transactions this context was added in:
- https://github.com/getsentry/relay/pull/4690
- https://github.com/getsentry/sentry/pull/90148
- https://github.com/getsentry/sentry/pull/90162
- https://github.com/getsentry/sentry/pull/90475