### PR TITLE
ref(platform-insights): Move release fetching into widgets

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -9,7 +9,6 @@ import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -32,9 +31,10 @@ import {HighestCacheMissRateTransactionsWidgetEmptyStateWarning} from 'sentry/vi
 function isCacheHitError(error: QueryError | null) {
   return error?.message === 'Column cache.hit was not found in metrics indexer';
 }
-export function CachesWidget({query, releases}: {query?: string; releases?: Release[]}) {
+export function CachesWidget({query}: {query?: string}) {
   const theme = useTheme();
   const organization = useOrganization();
+  const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams();
 
   const cachesRequest = useEAPSpans(
@@ -125,7 +125,7 @@ export function CachesWidget({query, releases}: {query?: string; releases?: Rele
           (ts, index) =>
             new Line(convertSeriesToTimeseries(ts), {color: colorPalette[index]})
         ),
-        ...useReleaseBubbleProps(releases),
+        ...releaseBubbleProps,
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -3,8 +3,6 @@ import {useEffect} from 'react';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {CachesWidget} from 'sentry/views/insights/pages/platform/laravel/cachesWidget';
 import {JobsWidget} from 'sentry/views/insights/pages/platform/laravel/jobsWidget';
 import {QueriesWidget} from 'sentry/views/insights/pages/platform/laravel/queriesWidget';
@@ -18,13 +16,6 @@ import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shar
 
 export function LaravelOverviewPage() {
   const organization = useOrganization();
-  const pageFilters = usePageFilters();
-  const {releases: releasesWithDate} = useReleaseStats(pageFilters.selection);
-  const releases =
-    releasesWithDate?.map(({date, version}) => ({
-      timestamp: date,
-      version,
-    })) ?? [];
 
   useEffect(() => {
     trackAnalytics('laravel-insights.page-view', {
@@ -44,23 +35,22 @@ export function LaravelOverviewPage() {
             trafficSeriesName={t('Requests')}
             baseQuery={'span.op:http.server'}
             query={query}
-            releases={releases}
           />
         </WidgetGrid.Position1>
         <WidgetGrid.Position2>
-          <DurationWidget query={query} releases={releases} />
+          <DurationWidget query={query} />
         </WidgetGrid.Position2>
         <WidgetGrid.Position3>
           <IssuesWidget query={query} />
         </WidgetGrid.Position3>
         <WidgetGrid.Position4>
-          <JobsWidget query={query} releases={releases} />
+          <JobsWidget query={query} />
         </WidgetGrid.Position4>
         <WidgetGrid.Position5>
-          <QueriesWidget query={query} releases={releases} />
+          <QueriesWidget query={query} />
         </WidgetGrid.Position5>
         <WidgetGrid.Position6>
-          <CachesWidget query={query} releases={releases} />
+          <CachesWidget query={query} />
         </WidgetGrid.Position6>
       </WidgetGrid>
       <PathsTable handleAddTransactionFilter={setTransactionFilter} query={query} />

--- a/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
@@ -7,7 +7,7 @@ import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Release, TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -28,8 +28,9 @@ import {
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {QueuesWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
-export function JobsWidget({query, releases}: {query?: string; releases?: Release[]}) {
+export function JobsWidget({query}: {query?: string}) {
   const organization = useOrganization();
+  const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams({
     granularity: 'spans-low',
   });
@@ -110,7 +111,7 @@ export function JobsWidget({query, releases}: {query?: string; releases?: Releas
       visualizationProps={{
         showLegend: 'never',
         plottables,
-        ...useReleaseBubbleProps(releases),
+        ...releaseBubbleProps,
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
@@ -8,7 +8,6 @@ import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -36,12 +35,11 @@ function getSeriesName(item: {'span.group': string; transaction: string}) {
   return `${item.transaction},${item['span.group']}`;
 }
 
-export function QueriesWidget({query, releases}: {query?: string; releases?: Release[]}) {
+export function QueriesWidget({query}: {query?: string}) {
   const theme = useTheme();
   const organization = useOrganization();
-  const pageFilterChartParams = usePageFilterChartParams({
-    granularity: 'spans',
-  });
+  const releaseBubbleProps = useReleaseBubbleProps();
+  const pageFilterChartParams = usePageFilterChartParams();
 
   const fullQuery = `has:db.system ${query}`;
 
@@ -142,7 +140,7 @@ export function QueriesWidget({query, releases}: {query?: string; releases?: Rel
               alias: aliases[ts.seriesName],
             })
         ),
-        ...useReleaseBubbleProps(releases),
+        ...releaseBubbleProps,
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -12,7 +12,6 @@ import useDeadRageSelectors from 'sentry/utils/replays/hooks/useDeadRageSelector
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -24,13 +23,7 @@ import {
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
 
-export function DeadRageClicksWidget({
-  query,
-  releases,
-}: {
-  query?: string;
-  releases?: Release[];
-}) {
+export function DeadRageClicksWidget({query}: {query?: string}) {
   const organization = useOrganization();
   const location = useLocation();
   const fullQuery = `!count_dead_clicks:0 ${query}`.trim();
@@ -46,7 +39,7 @@ export function DeadRageClicksWidget({
   const isEmpty = !isLoading && data.length === 0;
 
   if (isEmpty) {
-    return <SlowSSRWidget query={query} releases={releases} />;
+    return <SlowSSRWidget query={query} />;
   }
 
   const visualization = (

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -9,8 +9,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {DeadRageClicksWidget} from 'sentry/views/insights/pages/platform/nextjs/deadRageClickWidget';
 import SSRTreeWidget from 'sentry/views/insights/pages/platform/nextjs/ssrTreeWidget';
 import {WebVitalsWidget} from 'sentry/views/insights/pages/platform/nextjs/webVitalsWidget';
@@ -42,13 +40,6 @@ export function NextJsOverviewPage({
   performanceType: 'backend' | 'frontend';
 }) {
   const organization = useOrganization();
-  const pageFilters = usePageFilters();
-  const {releases: releasesWithDate} = useReleaseStats(pageFilters.selection);
-  const releases =
-    releasesWithDate?.map(({date, version}) => ({
-      timestamp: date,
-      version,
-    })) ?? [];
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -94,11 +85,10 @@ export function NextJsOverviewPage({
             trafficSeriesName={t('Page views')}
             baseQuery={'span.op:[navigation,pageload]'}
             query={query}
-            releases={releases}
           />
         </WidgetGrid.Position1>
         <WidgetGrid.Position2>
-          <DurationWidget query={query} releases={releases} />
+          <DurationWidget query={query} />
         </WidgetGrid.Position2>
         <WidgetGrid.Position3>
           <IssuesWidget query={query} />
@@ -107,7 +97,7 @@ export function NextJsOverviewPage({
           <WebVitalsWidget query={query} />
         </WidgetGrid.Position4>
         <WidgetGrid.Position5>
-          <DeadRageClicksWidget query={query} releases={releases} />
+          <DeadRageClicksWidget query={query} />
         </WidgetGrid.Position5>
         <WidgetGrid.Position6>
           <SSRTreeWidget />

--- a/static/app/views/insights/pages/platform/nextjs/slowSsrWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/slowSsrWidget.tsx
@@ -10,7 +10,6 @@ import getDuration from 'sentry/utils/duration/getDuration';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -43,13 +42,12 @@ function renameMeta(meta: EventsMetaType, from: string, to: string): EventsMetaT
   };
 }
 
-export function SlowSSRWidget({query, releases}: {query?: string; releases?: Release[]}) {
+export function SlowSSRWidget({query}: {query?: string}) {
   const theme = useTheme();
   const {selection} = usePageFilters();
   const organization = useOrganization();
-  const pageFilterChartParams = usePageFilterChartParams({
-    granularity: 'spans',
-  });
+  const releaseBubbleProps = useReleaseBubbleProps();
+  const pageFilterChartParams = usePageFilterChartParams();
 
   const fullQuery = `span.op:function.nextjs ${query}`;
 
@@ -133,7 +131,7 @@ export function SlowSSRWidget({query, releases}: {query?: string; releases?: Rel
               alias: aliases[ts.seriesName],
             })
         ),
-        ...useReleaseBubbleProps(releases),
+        ...releaseBubbleProps,
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/durationWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/durationWidget.tsx
@@ -7,7 +7,6 @@ import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -22,16 +21,11 @@ import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 
-export function DurationWidget({
-  query,
-  releases,
-}: {
-  query?: string;
-  releases?: Release[];
-}) {
+export function DurationWidget({query}: {query?: string}) {
   const theme = useTheme();
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams();
+  const releaseBubbleProps = useReleaseBubbleProps();
 
   const fullQuery = `span.op:http.server ${query}`.trim();
 
@@ -93,7 +87,7 @@ export function DurationWidget({
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables,
-        ...useReleaseBubbleProps(releases),
+        ...releaseBubbleProps,
       }}
     />
   );

--- a/static/app/views/insights/pages/platform/shared/getReleaseBubbleProps.tsx
+++ b/static/app/views/insights/pages/platform/shared/getReleaseBubbleProps.tsx
@@ -1,8 +1,18 @@
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Release} from 'sentry/views/dashboards/widgets/common/types';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 
-export function useReleaseBubbleProps(releases: Release[] | undefined) {
+export function useReleaseBubbleProps() {
   const organization = useOrganization();
+  const pageFilters = usePageFilters();
+
+  const {releases: releasesWithDate} = useReleaseStats(pageFilters.selection);
+  const releases =
+    releasesWithDate?.map(({date, version}) => ({
+      timestamp: date,
+      version,
+    })) ?? [];
+
   return organization.features.includes('release-bubbles-ui')
     ? ({releases, showReleaseAs: 'bubble'} as const)
     : {};

--- a/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import type {Release, TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -26,15 +26,14 @@ export function TrafficWidget({
   trafficSeriesName,
   baseQuery,
   query,
-  releases,
 }: {
   title: string;
   trafficSeriesName: string;
   baseQuery?: string;
   query?: string;
-  releases?: Release[];
 }) {
   const organization = useOrganization();
+  const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams({granularity: 'spans-low'});
   const theme = useTheme();
 
@@ -111,7 +110,7 @@ export function TrafficWidget({
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
         plottables,
-        ...useReleaseBubbleProps(releases),
+        ...releaseBubbleProps,
       }}
     />
   );


### PR DESCRIPTION
- part of [TET-379: Make widgets re-usable in releases drawer](https://linear.app/getsentry/issue/TET-379/make-widgets-re-usable-in-releases-drawer)