### PR TITLE
fix(ui): drop unselected tab items to content.muted in sidebar

### DIFF
--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -343,7 +343,7 @@ const ChonkNavLink = chonkStyled(Link, {
   gap: ${p => (p.isMobile ? space(1) : space(0.5))};
 
   /* Disable default link styles and only apply them to the icon container */
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.muted};
   outline: none;
   box-shadow: none;
   transition: none;
@@ -380,7 +380,7 @@ const ChonkNavLink = chonkStyled(Link, {
   }
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.muted};
     ${NavLinkIconContainer} {
       background-color: ${p => p.theme.colors.gray100};
     }

--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -295,7 +295,7 @@ const ChonkItem = chonkStyled(Link)<ItemProps>`
   justify-content: center;
   align-items: center;
   position: relative;
-  color: ${p => p.theme.textColor};
+  color: ${p => p.theme.tokens.content.muted};
   padding: ${p => (p.layout === NavLayout.MOBILE ? `${space(0.75)} ${space(1.5)} ${space(0.75)} 48px` : `${space(0.75)} ${space(1.5)}`)};
   border-radius: ${p => (p.layout === NavLayout.MOBILE ? '0' : p.theme.radius.lg)};
 
@@ -320,7 +320,7 @@ const ChonkItem = chonkStyled(Link)<ItemProps>`
   }
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.tokens.content.muted};
     background-color: ${p => p.theme.colors.gray100};
   }
 


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-05-08 at 13 10 28](https://github.com/user-attachments/assets/058b0b31-d33e-4b94-84bf-dcb9bb7db1c6) | ![Screenshot 2025-05-08 at 13 09 59](https://github.com/user-attachments/assets/6366bb93-d921-4963-a6e3-00652dca237c) | 