### PR TITLE
ref(relay): Add spans-ignore-trace-id-partitioning to global options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -586,6 +586,18 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Disable semantic partitioning of spans by trace ID. Use this in case there is
+# partition imbalance on the spans topic produced to by Relay (either
+# snuba-spans or ingest-spans). This will break the span buffer, and anything
+# that depends on segments being assembled by it (performance issue, etc). As
+# of 2025-05-06, the span buffer is not yet rolled out to most regions though.
+register(
+    "relay.spans-ignore-trace-id-partitioning",
+    type=Bool,
+    default=False,
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)
 register("analytics.options", default={}, flags=FLAG_NOSTORE)

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -27,6 +27,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.span-extraction.sample-rate",
     "relay.span-normalization.allowed_hosts",
     "relay.drop-transaction-attachments",
+    "relay.spans-ignore-trace-id-partitioning",
 ]
 
 


### PR DESCRIPTION
depends on 
https://github.com/getsentry/relay/pull/4706
https://github.com/getsentry/relay/pull/4716