### PR TITLE
fix(alerts): Persist selected time window if valid (and pick better default)

### DIFF
--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -1,7 +1,9 @@
-import {t} from 'sentry/locale';
+import pick from 'lodash/pick';
+
+import {t, tct} from 'sentry/locale';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {AggregationKeyWithAlias, LooseFieldKey} from 'sentry/utils/discover/fields';
-import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/discover/fields';
+import {parseFunction, SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/discover/fields';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {AggregationKey, MobileVital} from 'sentry/utils/fields';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
@@ -15,6 +17,7 @@ import {
   EventTypes,
   TimeWindow,
 } from 'sentry/views/alerts/rules/metric/types';
+import {isCrashFreeAlert} from 'sentry/views/alerts/rules/metric/utils/isCrashFreeAlert';
 import {
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
   getQueryDatasource,
@@ -22,7 +25,7 @@ import {
 } from 'sentry/views/alerts/utils';
 import type {AlertType, WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
 
-export const DEFAULT_COUNT_TIME_WINDOW = 1; // 1min
+export const DEFAULT_COUNT_TIME_WINDOW = 5; // 5min (lowest common denominator supported for all datasets)
 export const DEFAULT_CHANGE_TIME_WINDOW = 60; // 1h
 export const DEFAULT_DYNAMIC_TIME_WINDOW = 60; // 1h
 export const DEFAULT_CHANGE_COMP_DELTA = 10080; // 1w
@@ -113,6 +116,61 @@ export const COMPARISON_DELTA_OPTIONS = [
   {value: 10080, label: t('same time one week ago')}, // one week
   {value: 43200, label: t('same time one month ago')}, // 30 days
 ];
+
+const TIME_WINDOW_MAP: Record<TimeWindow, string> = {
+  [TimeWindow.ONE_MINUTE]: t('1 minute'),
+  [TimeWindow.FIVE_MINUTES]: t('5 minutes'),
+  [TimeWindow.TEN_MINUTES]: t('10 minutes'),
+  [TimeWindow.FIFTEEN_MINUTES]: t('15 minutes'),
+  [TimeWindow.THIRTY_MINUTES]: t('30 minutes'),
+  [TimeWindow.ONE_HOUR]: t('1 hour'),
+  [TimeWindow.TWO_HOURS]: t('2 hours'),
+  [TimeWindow.FOUR_HOURS]: t('4 hours'),
+  [TimeWindow.ONE_DAY]: t('24 hours'),
+};
+
+export function getTimeWindowOptions(
+  dataset: Dataset,
+  comparisonType: AlertRuleComparisonType
+) {
+  let options: Record<string, string> = TIME_WINDOW_MAP;
+
+  if (isCrashFreeAlert(dataset)) {
+    options = pick(TIME_WINDOW_MAP, [
+      // TimeWindow.THIRTY_MINUTES, leaving this option out until we figure out the sub-hour session resolution chart limitations
+      TimeWindow.ONE_HOUR,
+      TimeWindow.TWO_HOURS,
+      TimeWindow.FOUR_HOURS,
+      TimeWindow.ONE_DAY,
+    ]);
+  }
+
+  if (comparisonType === AlertRuleComparisonType.DYNAMIC) {
+    options = pick(TIME_WINDOW_MAP, [
+      TimeWindow.FIFTEEN_MINUTES,
+      TimeWindow.THIRTY_MINUTES,
+      TimeWindow.ONE_HOUR,
+    ]);
+  } else if (dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
+    options = pick(TIME_WINDOW_MAP, [
+      TimeWindow.FIVE_MINUTES,
+      TimeWindow.TEN_MINUTES,
+      TimeWindow.FIFTEEN_MINUTES,
+      TimeWindow.THIRTY_MINUTES,
+      TimeWindow.ONE_HOUR,
+      TimeWindow.TWO_HOURS,
+      TimeWindow.FOUR_HOURS,
+      TimeWindow.ONE_DAY,
+    ]);
+  }
+
+  return Object.entries(options).map(([value, label]) => ({
+    value: parseInt(value, 10),
+    label: tct('[timeWindow] interval', {
+      timeWindow: label.slice(-1) === 's' ? label.slice(0, -1) : label,
+    }),
+  }));
+}
 
 export function getWizardAlertFieldConfig(
   alertType: AlertType,
@@ -272,6 +330,11 @@ export function getThresholdUnits(
     comparisonType === AlertRuleComparisonType.CHANGE
   ) {
     return '%';
+  }
+
+  const parsed = parseFunction(aggregate);
+  if (parsed && parsed.name === 'count') {
+    return '';
   }
 
   if (aggregate.includes('measurements.cls')) {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -2,7 +2,6 @@ import {Fragment, PureComponent} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
-import pick from 'lodash/pick';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
@@ -75,21 +74,12 @@ import {
 } from 'sentry/views/explore/contexts/spanTagsContext';
 import {hasEAPAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 
-import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
-import {DEFAULT_AGGREGATE, DEFAULT_TRANSACTION_AGGREGATE} from './constants';
-import {AlertRuleComparisonType, Dataset, Datasource, TimeWindow} from './types';
-
-const TIME_WINDOW_MAP: Record<TimeWindow, string> = {
-  [TimeWindow.ONE_MINUTE]: t('1 minute'),
-  [TimeWindow.FIVE_MINUTES]: t('5 minutes'),
-  [TimeWindow.TEN_MINUTES]: t('10 minutes'),
-  [TimeWindow.FIFTEEN_MINUTES]: t('15 minutes'),
-  [TimeWindow.THIRTY_MINUTES]: t('30 minutes'),
-  [TimeWindow.ONE_HOUR]: t('1 hour'),
-  [TimeWindow.TWO_HOURS]: t('2 hours'),
-  [TimeWindow.FOUR_HOURS]: t('4 hours'),
-  [TimeWindow.ONE_DAY]: t('24 hours'),
-};
+import {
+  DEFAULT_AGGREGATE,
+  DEFAULT_TRANSACTION_AGGREGATE,
+  getTimeWindowOptions,
+} from './constants';
+import {AlertRuleComparisonType, Dataset, Datasource} from './types';
 
 type Props = {
   aggregate: string;
@@ -248,48 +238,6 @@ class RuleConditionsForm extends PureComponent<Props, State> {
 
     return values.filter(({name}) => defined(name)).map(({name}) => name);
   };
-
-  get timeWindowOptions() {
-    let options: Record<string, string> = TIME_WINDOW_MAP;
-
-    if (isCrashFreeAlert(this.props.dataset)) {
-      options = pick(TIME_WINDOW_MAP, [
-        // TimeWindow.THIRTY_MINUTES, leaving this option out until we figure out the sub-hour session resolution chart limitations
-        TimeWindow.ONE_HOUR,
-        TimeWindow.TWO_HOURS,
-        TimeWindow.FOUR_HOURS,
-        TimeWindow.ONE_DAY,
-      ]);
-    }
-
-    if (this.props.comparisonType === AlertRuleComparisonType.DYNAMIC) {
-      options = pick(TIME_WINDOW_MAP, [
-        TimeWindow.FIFTEEN_MINUTES,
-        TimeWindow.THIRTY_MINUTES,
-        TimeWindow.ONE_HOUR,
-      ]);
-    }
-
-    if (this.props.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
-      options = pick(TIME_WINDOW_MAP, [
-        TimeWindow.FIVE_MINUTES,
-        TimeWindow.TEN_MINUTES,
-        TimeWindow.FIFTEEN_MINUTES,
-        TimeWindow.THIRTY_MINUTES,
-        TimeWindow.ONE_HOUR,
-        TimeWindow.TWO_HOURS,
-        TimeWindow.FOUR_HOURS,
-        TimeWindow.ONE_DAY,
-      ]);
-    }
-
-    return Object.entries(options).map(([value, label]) => ({
-      value: parseInt(value, 10),
-      label: tct('[timeWindow] interval', {
-        timeWindow: label.slice(-1) === 's' ? label.slice(0, -1) : label,
-      }),
-    }));
-  }
 
   get searchPlaceholder() {
     switch (this.props.dataset) {
@@ -481,8 +429,16 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   renderInterval() {
-    const {organization, timeWindow, disabled, alertType, project, onTimeWindowChange} =
-      this.props;
+    const {
+      organization,
+      timeWindow,
+      disabled,
+      alertType,
+      project,
+      dataset,
+      comparisonType,
+      onTimeWindowChange,
+    } = this.props;
 
     return (
       <Fragment>
@@ -511,7 +467,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
           <Select
             name="timeWindow"
             styles={this.selectControlStyles}
-            options={this.timeWindowOptions}
+            options={getTimeWindowOptions(dataset, comparisonType)}
             isDisabled={disabled}
             value={timeWindow}
             onChange={({value}: any) => onTimeWindowChange(value)}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -79,6 +79,7 @@ import {
   DEFAULT_CHANGE_TIME_WINDOW,
   DEFAULT_COUNT_TIME_WINDOW,
   DEFAULT_DYNAMIC_TIME_WINDOW,
+  getTimeWindowOptions,
 } from './constants';
 import RuleConditionsForm from './ruleConditionsForm';
 import {
@@ -884,13 +885,19 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
   handleComparisonTypeChange = (value: AlertRuleComparisonType) => {
     let updateState = {};
+    const {timeWindow, dataset} = this.state;
+    const supportedTimeWindows = getTimeWindowOptions(dataset, value).map(
+      windows => windows.value
+    );
     switch (value) {
       case AlertRuleComparisonType.DYNAMIC:
         updateState = {
           comparisonType: value,
           comparisonDelta: undefined,
           thresholdType: AlertRuleThresholdType.ABOVE_AND_BELOW,
-          timeWindow: DEFAULT_DYNAMIC_TIME_WINDOW,
+          timeWindow: supportedTimeWindows.includes(timeWindow)
+            ? timeWindow
+            : DEFAULT_DYNAMIC_TIME_WINDOW,
           sensitivity: AlertRuleSensitivity.MEDIUM,
           seasonality: AlertRuleSeasonality.AUTO,
         };
@@ -900,7 +907,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
           comparisonType: value,
           comparisonDelta: DEFAULT_CHANGE_COMP_DELTA,
           thresholdType: AlertRuleThresholdType.ABOVE,
-          timeWindow: DEFAULT_CHANGE_TIME_WINDOW,
+          timeWindow: supportedTimeWindows.includes(timeWindow)
+            ? timeWindow
+            : DEFAULT_CHANGE_TIME_WINDOW,
           sensitivity: undefined,
           seasonality: undefined,
         };
@@ -910,7 +919,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
           comparisonType: value,
           comparisonDelta: undefined,
           thresholdType: AlertRuleThresholdType.ABOVE,
-          timeWindow: DEFAULT_COUNT_TIME_WINDOW,
+          timeWindow: supportedTimeWindows.includes(timeWindow)
+            ? timeWindow
+            : DEFAULT_COUNT_TIME_WINDOW,
           sensitivity: undefined,
           seasonality: undefined,
         };


### PR DESCRIPTION
EAP alerts don't support 1 minute time intervals, but that was the
default when switching between comparison types.
This PR pulls out "getTimeWindowOptions" out of the RuleForm class
so we can use it to validate time periods as someone switches between
alert comparison types. 

Also updates trigger text label to check aggregate `count` correctly
so we don't append duration units. Duration units get added to count
in EAP because we're aggregating `count` on `span.duration` under
the hood.