### PR TITLE
ref(platform-insights): Move query handling into widgets

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -227,24 +227,23 @@ function EAPBackendOverviewPage() {
                       title={t('Requests')}
                       trafficSeriesName={t('Requests')}
                       baseQuery={'span.op:http.server'}
-                      query={searchBarQuery}
                     />
-                    <DurationWidget query={searchBarQuery} />
+                    <DurationWidget />
                   </StackedWidgetWrapper>
                 </ModuleLayout.Third>
                 <ModuleLayout.TwoThirds>
-                  <IssuesWidget query={searchBarQuery} />
+                  <IssuesWidget />
                 </ModuleLayout.TwoThirds>
                 <ModuleLayout.Full>
                   <TripleRowWidgetWrapper>
                     <ModuleLayout.Third>
-                      <JobsWidget query={searchBarQuery} />
+                      <JobsWidget />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
-                      <QueriesWidget query={searchBarQuery} />
+                      <QueriesWidget />
                     </ModuleLayout.Third>
                     <ModuleLayout.Third>
-                      <CachesWidget query={searchBarQuery} />
+                      <CachesWidget />
                     </ModuleLayout.Third>
                   </TripleRowWidgetWrapper>
                 </ModuleLayout.Full>

--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -24,14 +24,16 @@ import {
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {HighestCacheMissRateTransactionsWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 function isColumnNotFoundError(error: QueryError | null) {
   return error?.message === 'Column cache.hit was not found in metrics indexer';
 }
-export function CachesWidget({query}: {query?: string}) {
+export function CachesWidget() {
   const theme = useTheme();
   const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
   const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams();
 

--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -12,7 +12,6 @@ import {PlatformLandingPageLayout} from 'sentry/views/insights/pages/platform/sh
 import {PathsTable} from 'sentry/views/insights/pages/platform/shared/pathsTable';
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
 import {TrafficWidget} from 'sentry/views/insights/pages/platform/shared/trafficWidget';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 export function LaravelOverviewPage() {
   const organization = useOrganization();
@@ -24,8 +23,6 @@ export function LaravelOverviewPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const {query, setTransactionFilter} = useTransactionNameQuery();
-
   return (
     <PlatformLandingPageLayout performanceType={'backend'}>
       <WidgetGrid>
@@ -34,26 +31,25 @@ export function LaravelOverviewPage() {
             title={t('Requests')}
             trafficSeriesName={t('Requests')}
             baseQuery={'span.op:http.server'}
-            query={query}
           />
         </WidgetGrid.Position1>
         <WidgetGrid.Position2>
-          <DurationWidget query={query} />
+          <DurationWidget />
         </WidgetGrid.Position2>
         <WidgetGrid.Position3>
-          <IssuesWidget query={query} />
+          <IssuesWidget />
         </WidgetGrid.Position3>
         <WidgetGrid.Position4>
-          <JobsWidget query={query} />
+          <JobsWidget />
         </WidgetGrid.Position4>
         <WidgetGrid.Position5>
-          <QueriesWidget query={query} />
+          <QueriesWidget />
         </WidgetGrid.Position5>
         <WidgetGrid.Position6>
-          <CachesWidget query={query} />
+          <CachesWidget />
         </WidgetGrid.Position6>
       </WidgetGrid>
-      <PathsTable handleAddTransactionFilter={setTransactionFilter} query={query} />
+      <PathsTable />
     </PlatformLandingPageLayout>
   );
 }

--- a/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsWidget.tsx
@@ -24,10 +24,12 @@ import {
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {QueuesWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
-export function JobsWidget({query}: {query?: string}) {
+export function JobsWidget() {
   const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
   const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams({
     granularity: 'spans-low',

--- a/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
@@ -26,6 +26,7 @@ import {
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {ModuleName} from 'sentry/views/insights/types';
 import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
@@ -33,9 +34,10 @@ function getSeriesName(item: {'span.group': string; transaction: string}) {
   return `${item.transaction},${item['span.group']}`;
 }
 
-export function QueriesWidget({query}: {query?: string}) {
+export function QueriesWidget() {
   const theme = useTheme();
   const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
   const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams();
 

--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -16,6 +16,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
 import {SlowSSRWidget} from 'sentry/views/insights/pages/platform/nextjs/slowSsrWidget';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {
   SelectorLink,
   transformSelectorQuery,
@@ -23,9 +24,10 @@ import {
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
 
-export function DeadRageClicksWidget({query}: {query?: string}) {
-  const organization = useOrganization();
+export function DeadRageClicksWidget() {
   const location = useLocation();
+  const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
   const fullQuery = `!count_dead_clicks:0 ${query}`.trim();
 
   const {isLoading, error, data} = useDeadRageSelectors({

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -19,7 +19,6 @@ import {PagesTable} from 'sentry/views/insights/pages/platform/shared/pagesTable
 import {PathsTable} from 'sentry/views/insights/pages/platform/shared/pathsTable';
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
 import {TrafficWidget} from 'sentry/views/insights/pages/platform/shared/trafficWidget';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 type View = 'api' | 'pages';
 type SpanOperation = 'pageload' | 'navigation';
@@ -74,8 +73,6 @@ export function NextJsOverviewPage({
     });
   }, [organization, activeView, spanOperationFilter]);
 
-  const {query, setTransactionFilter} = useTransactionNameQuery();
-
   return (
     <PlatformLandingPageLayout performanceType={performanceType}>
       <WidgetGrid>
@@ -84,20 +81,19 @@ export function NextJsOverviewPage({
             title={t('Traffic')}
             trafficSeriesName={t('Page views')}
             baseQuery={'span.op:[navigation,pageload]'}
-            query={query}
           />
         </WidgetGrid.Position1>
         <WidgetGrid.Position2>
-          <DurationWidget query={query} />
+          <DurationWidget />
         </WidgetGrid.Position2>
         <WidgetGrid.Position3>
-          <IssuesWidget query={query} />
+          <IssuesWidget />
         </WidgetGrid.Position3>
         <WidgetGrid.Position4>
-          <WebVitalsWidget query={query} />
+          <WebVitalsWidget />
         </WidgetGrid.Position4>
         <WidgetGrid.Position5>
-          <DeadRageClicksWidget query={query} />
+          <DeadRageClicksWidget />
         </WidgetGrid.Position5>
         <WidgetGrid.Position6>
           <SSRTreeWidget />
@@ -126,21 +122,10 @@ export function NextJsOverviewPage({
       </ControlsWrapper>
 
       {activeView === 'api' && (
-        <PathsTable
-          handleAddTransactionFilter={setTransactionFilter}
-          query={query}
-          showHttpMethodColumn={false}
-          showUsersColumn={false}
-        />
+        <PathsTable showHttpMethodColumn={false} showUsersColumn={false} />
       )}
 
-      {activeView === 'pages' && (
-        <PagesTable
-          spanOperationFilter={spanOperationFilter}
-          handleAddTransactionFilter={setTransactionFilter}
-          query={query}
-        />
-      )}
+      {activeView === 'pages' && <PagesTable spanOperationFilter={spanOperationFilter} />}
     </PlatformLandingPageLayout>
   );
 }

--- a/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
@@ -18,6 +18,7 @@ import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/la
 import {getPreviousPeriod} from 'sentry/views/insights/pages/platform/nextjs/utils';
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 
 const FIELDS: EAPSpanProperty[] = [
@@ -135,9 +136,9 @@ function usePerformanceScoreData({query}: {query?: string}): ProjectScoreQuery {
   };
 }
 
-export function WebVitalsWidget({query}: {query?: string}) {
+export function WebVitalsWidget() {
   const organization = useOrganization();
-
+  const {query} = useTransactionNameQuery();
   const {data, isLoading, error} = usePerformanceScoreData({query});
 
   const isEmpty = !isLoading && data?.projectScore.totalScore === 0;

--- a/static/app/views/insights/pages/platform/shared/durationWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/durationWidget.tsx
@@ -16,9 +16,11 @@ import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/la
 import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
-export function DurationWidget({query}: {query?: string}) {
+export function DurationWidget() {
   const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
   const pageFilterChartParams = usePageFilterChartParams();
   const releaseBubbleProps = useReleaseBubbleProps();
 

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -36,6 +36,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import {RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from 'sentry/views/alerts/rules/metric/details/relatedIssuesNotAvailable';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 const defaultProps = {
   canSelectGroups: true,
@@ -319,8 +320,9 @@ const HeaderContainer = styled('div')`
   z-index: ${p => p.theme.zIndex.header};
 `;
 
-export function IssuesWidget({query = ''}: {query?: string}) {
+export function IssuesWidget() {
   const location = useLocation();
+  const {query} = useTransactionNameQuery();
   const queryWithDefault = new MutableSearch(['is:unresolved', 'event.type:error']);
   if (query) {
     queryWithDefault.setFilterValues('transaction', [query]);

--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -27,6 +27,7 @@ import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/componen
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 type SortableField =
@@ -109,9 +110,7 @@ function useTableSortParams() {
 }
 
 interface PagesTableProps {
-  handleAddTransactionFilter: (value: string) => void;
   spanOperationFilter: 'pageload' | 'navigation';
-  query?: string;
 }
 
 const CURSOR_PARAM_NAMES: Record<PagesTableProps['spanOperationFilter'], string> = {
@@ -119,12 +118,9 @@ const CURSOR_PARAM_NAMES: Record<PagesTableProps['spanOperationFilter'], string>
   navigation: 'navigationCursor',
 };
 
-export function PagesTable({
-  spanOperationFilter,
-  query,
-  handleAddTransactionFilter,
-}: PagesTableProps) {
+export function PagesTable({spanOperationFilter}: PagesTableProps) {
   const location = useLocation();
+  const {query, setTransactionFilter} = useTransactionNameQuery();
   const pageFilterChartParams = usePageFilterChartParams();
   const {sortField, sortOrder} = useTableSortParams();
   const currentCursorParamName = CURSOR_PARAM_NAMES[spanOperationFilter];
@@ -210,11 +206,11 @@ export function PagesTable({
         <BodyCell
           column={column}
           dataRow={dataRow}
-          handleAddTransactionFilter={handleAddTransactionFilter}
+          handleAddTransactionFilter={setTransactionFilter}
         />
       );
     },
-    [handleAddTransactionFilter]
+    [setTransactionFilter]
   );
 
   const pagesTablePageLinks = spansRequest.pageLinks;

--- a/static/app/views/insights/pages/platform/shared/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pathsTable.tsx
@@ -25,6 +25,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 interface TableData {
@@ -107,20 +108,17 @@ function useTableSortParams() {
 }
 
 interface PathsTableProps {
-  handleAddTransactionFilter: (value: string) => void;
-  query?: string;
   showHttpMethodColumn?: boolean;
   showUsersColumn?: boolean;
 }
 
 export function PathsTable({
-  query,
-  handleAddTransactionFilter,
   showHttpMethodColumn = true,
   showUsersColumn = true,
 }: PathsTableProps) {
   const location = useLocation();
   const navigate = useNavigate();
+  const {query, setTransactionFilter} = useTransactionNameQuery();
   const [columnOrder, setColumnOrder] = useState(() => {
     let columns = [...defaultColumnOrder];
 
@@ -240,11 +238,11 @@ export function PathsTable({
         <BodyCell
           column={column}
           dataRow={dataRow}
-          handleAddTransactionFilter={handleAddTransactionFilter}
+          handleAddTransactionFilter={setTransactionFilter}
         />
       );
     },
-    [handleAddTransactionFilter]
+    [setTransactionFilter]
   );
 
   return (

--- a/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/trafficWidget.tsx
@@ -18,21 +18,21 @@ import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/la
 import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 export function TrafficWidget({
   title,
   trafficSeriesName,
   baseQuery,
-  query,
 }: {
   title: string;
   trafficSeriesName: string;
   baseQuery?: string;
-  query?: string;
 }) {
   const organization = useOrganization();
   const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams({granularity: 'spans-low'});
+  const {query} = useTransactionNameQuery();
   const theme = useTheme();
 
   const fullQuery = `${baseQuery} ${query}`.trim();


### PR DESCRIPTION
- part of [TET-379: Make widgets re-usable in releases drawer](https://linear.app/getsentry/issue/TET-379/make-widgets-re-usable-in-releases-drawer)