### PR TITLE
fix(ui): re-position ChonkCloseButton

### DIFF
--- a/static/app/components/core/button/index.chonk.tsx
+++ b/static/app/components/core/button/index.chonk.tsx
@@ -180,6 +180,10 @@ export function getChonkButtonStyles(
         display: 'none',
       },
 
+      '&:focus-visible': {
+        ...p.theme.focusRing,
+      },
+
       '> span:last-child': {
         transform: 'translateY(0px)',
       },

--- a/static/app/components/globalModal/components.tsx
+++ b/static/app/components/globalModal/components.tsx
@@ -5,10 +5,13 @@ import {Button} from 'sentry/components/core/button';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 
 const ModalHeader = styled('header')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${space(1)};
   position: relative;
   border-bottom: 1px solid ${p => p.theme.border};
   padding: ${space(3)} ${space(3)};
@@ -32,7 +35,7 @@ const ModalHeader = styled('header')`
   }
 `;
 
-const ChonkCloseButton = chonkStyled((p: Omit<ButtonProps, 'aria-label'>) => {
+function ChonkCloseButton(p: Omit<ButtonProps, 'aria-label'>) {
   return (
     <Button
       aria-label={t('Close Modal')}
@@ -42,19 +45,7 @@ const ChonkCloseButton = chonkStyled((p: Omit<ButtonProps, 'aria-label'>) => {
       {...p}
     />
   );
-})`
-  transform: translate(50%, -50%);
-  border-radius: 50%;
-  position: absolute;
-  top: 0;
-  right: 0;
-  background-color: ${p => p.theme.button.default.background};
-  border: 1px solid ${p => p.theme.button.default.border};
-
-  &:hover {
-    background-color: ${p => p.theme.button.default.background};
-  }
-`;
+}
 
 const CloseButton = withChonk(
   styled((p: Omit<ButtonProps, 'aria-label'>) => {


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-05-08 at 15 15 32](https://github.com/user-attachments/assets/bf320dbb-2275-44fe-a95a-0335813ee95e) | ![Screenshot 2025-05-08 at 15 15 39](https://github.com/user-attachments/assets/fa7daa33-5881-48d1-bd6c-d8e36b6e72f0) |

I also fixed the focus outline for borderless buttons:

| before | after |
|--------|--------|
| ![Screenshot 2025-05-08 at 15 15 12](https://github.com/user-attachments/assets/6dedacf9-b8ec-4a37-aca4-dec993f9ea95) | ![Screenshot 2025-05-08 at 15 14 54](https://github.com/user-attachments/assets/25f229b7-75d8-493f-85f9-298ebe29e734) |