### PR TITLE
fix(ourlogs): Fix rows with undefined values for columns

### DIFF
--- a/static/app/views/explore/logs/logsTableRow.tsx
+++ b/static/app/views/explore/logs/logsTableRow.tsx
@@ -188,7 +188,7 @@ export function LogRowContent({
           const value = dataRow[field];
 
           if (!defined(value)) {
-            return null;
+            return <LogTableBodyCell key={field} />;
           }
 
           const discoverColumn: TableColumn<keyof TableDataRow> = {


### PR DESCRIPTION
If you pick a column that only has undefined values, the rows don't render correctly. This rendered an empty cell instead of null.
