### PR TITLE
chore(autofix): Replace "set up seer" with "find root cause" on button

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -101,7 +101,7 @@ describe('SeerSection', () => {
   });
 
   describe('Seer button text', () => {
-    it('shows "Set Up Seer" with summary when Seer needs setup', async () => {
+    it('shows "Find Root Cause" with summary when Seer needs setup and no run already', async () => {
       const customOrganization = OrganizationFixture({
         hideAiFeatures: false,
         features: ['gen-ai-features'],
@@ -130,7 +130,7 @@ describe('SeerSection', () => {
       });
 
       expect(await screen.findByText('Test summary')).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Set Up Seer'})).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Find Root Cause'})).toBeInTheDocument();
     });
 
     it('shows "Find Root Cause" even when autofix needs setup', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -147,10 +147,6 @@ export function SeerSectionCtaButton({
     autofixData?.steps?.some(step => step.type === type);
 
   const getButtonText = () => {
-    if (aiConfig.needsGenAiAcknowledgement) {
-      return t('Set Up Seer');
-    }
-
     if (!aiConfig.hasAutofix) {
       return t('Open Resources');
     }


### PR DESCRIPTION
Don't have a special set up CTA anymore so we communicate the value inside the drawer better.