### PR TITLE
fix(issue summary): Add org acknowledgement check in alerts

### DIFF
--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -8,6 +8,7 @@ from sentry import features, options
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.seer.issue_summary import get_issue_summary
+from sentry.seer.seer_setup import get_seer_org_acknowledgement
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,8 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     if not features.has("organizations:gen-ai-features", group.organization):
         return None
     if not features.has("projects:trigger-issue-summary-on-alerts", group.project):
+        return None
+    if not get_seer_org_acknowledgement(org_id=group.organization.id):
         return None
 
     timeout = options.get("alerts.issue_summary_timeout") or 5

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -942,7 +942,13 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @override_options({"alerts.issue_summary_timeout": 5})
     @with_feature({"organizations:gen-ai-features", "projects:trigger-issue-summary-on-alerts"})
-    def test_build_group_block_with_ai_summary_with_feature_flag(self):
+    @patch(
+        "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    def test_build_group_block_with_ai_summary_with_feature_flag(
+        self, mock_get_seer_org_acknowledgement
+    ):
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -998,7 +1004,13 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             assert "This is a possible cause" in content_block
 
     @override_options({"alerts.issue_summary_timeout": 5})
-    def test_build_group_block_with_ai_summary_without_feature_flag(self):
+    @patch(
+        "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    def test_build_group_block_with_ai_summary_without_feature_flag(
+        self, mock_get_seer_org_acknowledgement
+    ):
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -1034,7 +1046,13 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @override_options({"alerts.issue_summary_timeout": 5})
     @with_feature({"organizations:gen-ai-features", "projects:trigger-issue-summary-on-alerts"})
-    def test_build_group_block_with_ai_summary_text_truncation(self):
+    @patch(
+        "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    def test_build_group_block_with_ai_summary_text_truncation(
+        self, mock_get_seer_org_acknowledgement
+    ):
         # Test case for multi-line exception text
         multiline_text = "First line of text\nSecond line of text\nThird line of text"
         event1 = self.store_event(
@@ -1165,6 +1183,38 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
                 blocks = SlackIssuesMessageBuilder(group_lb, event_lb.for_group(group_lb)).build()
                 title_block = blocks["blocks"][0]["text"]["text"]
                 assert f": {expected_headline_part}*>" in title_block, f"Failed for {name}"
+
+    @override_options({"alerts.issue_summary_timeout": 5})
+    @patch(
+        "sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement",
+        return_value=False,
+    )
+    @patch(
+        "sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary",
+        return_value=(None, 403),
+    )
+    @with_feature({"organizations:gen-ai-features", "projects:trigger-issue-summary-on-alerts"})
+    def test_build_group_block_with_ai_summary_without_org_acknowledgement(
+        self, mock_get_issue_summary, mock_get_seer_org_acknowledgement
+    ):
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "IntegrationError",
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        assert event.group
+        group = event.group
+        group.type = ErrorGroupType.type_id
+        group.save()
+        assert group.issue_category == GroupCategory.ERROR
+
+        mock_get_issue_summary.assert_not_called()
+
+        blocks = SlackIssuesMessageBuilder(group).build()
+        assert "IntegrationError" in blocks["blocks"][0]["text"]["text"]
 
 
 class BuildGroupAttachmentReplaysTest(TestCase):


### PR DESCRIPTION
Adding the Seer-enabled-by-org check before generating summaries in alerts.