### PR TITLE
chore(flags): add analytic for tracking num suspect flags

### DIFF
--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -22,16 +22,16 @@ export type FeatureFlagEventParameters = {
     direction: 'next' | 'prev';
     surface: string;
   };
-  'flags.new_suspect_flags_found': {
-    numSuspectFlags: number;
-    numTotalFlags: number;
-    threshold: number /* TODO: remove after suspect flags GA */;
-  };
   'flags.setup_sidebar_selection': {
     platform?: string;
     provider?: SdkProviderEnum;
   };
   'flags.sort_flags': {sortMethod: string};
+  'flags.suspect_flags_v2_found': {
+    numSuspectFlags: number;
+    numTotalFlags: number;
+    threshold: number /* TODO: remove after suspect flags GA */;
+  };
   'flags.table_rendered': {
     numFlags: number;
     orgSlug: string;
@@ -60,5 +60,5 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.view-all-clicked': 'Clicked View All Flags',
   'flags.view-setup-sidebar': 'Viewed Feature Flag Onboarding Sidebar',
   'flags.cta_read_more_clicked': 'Clicked Read More in Feature Flag CTA',
-  'flags.new_suspect_flags_found': 'New Suspect Flags Found',
+  'flags.suspect_flags_v2_found': 'Suspect Flags V2 Found',
 };

--- a/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/featureFlagAnalyticsEvents.tsx
@@ -22,6 +22,11 @@ export type FeatureFlagEventParameters = {
     direction: 'next' | 'prev';
     surface: string;
   };
+  'flags.new_suspect_flags_found': {
+    numSuspectFlags: number;
+    numTotalFlags: number;
+    threshold: number /* TODO: remove after suspect flags GA */;
+  };
   'flags.setup_sidebar_selection': {
     platform?: string;
     provider?: SdkProviderEnum;
@@ -55,4 +60,5 @@ export const featureFlagEventMap: Record<FeatureFlagEventKey, string | null> = {
   'flags.view-all-clicked': 'Clicked View All Flags',
   'flags.view-setup-sidebar': 'Viewed Feature Flag Onboarding Sidebar',
   'flags.cta_read_more_clicked': 'Clicked Read More in Feature Flag CTA',
+  'flags.new_suspect_flags_found': 'New Suspect Flags Found',
 };

--- a/static/app/views/issueDetails/groupDistributions/suspectTable.tsx
+++ b/static/app/views/issueDetails/groupDistributions/suspectTable.tsx
@@ -55,7 +55,7 @@ export default function SuspectTable({debugSuspectScores, environments, group}: 
 
   useEffect(() => {
     if (!isPending) {
-      trackAnalytics('flags.new_suspect_flags_found', {
+      trackAnalytics('flags.suspect_flags_v2_found', {
         numTotalFlags: displayFlags.length,
         numSuspectFlags: susFlags.length,
         organization,

--- a/static/app/views/issueDetails/groupDistributions/suspectTable.tsx
+++ b/static/app/views/issueDetails/groupDistributions/suspectTable.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
@@ -10,8 +11,10 @@ import {IconSentry} from 'sentry/icons/iconSentry';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import toRoundedPercent from 'sentry/utils/number/toRoundedPercent';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import useOrganization from 'sentry/utils/useOrganization';
 import FlagDetailsLink from 'sentry/views/issueDetails/groupFeatureFlags/details/flagDetailsLink';
 import useGroupFlagDrawerData from 'sentry/views/issueDetails/groupFeatureFlags/hooks/useGroupFlagDrawerData';
 
@@ -25,6 +28,8 @@ const SUSPECT_SCORE_LOCAL_STATE_KEY = 'flag-drawer-suspicion-score-threshold';
 const SUSPECT_SCORE_THRESHOLD = 7;
 
 export default function SuspectTable({debugSuspectScores, environments, group}: Props) {
+  const organization = useOrganization();
+
   const [threshold, setThreshold] = useLocalStorageState(
     SUSPECT_SCORE_LOCAL_STATE_KEY,
     SUSPECT_SCORE_THRESHOLD
@@ -46,6 +51,19 @@ export default function SuspectTable({debugSuspectScores, environments, group}: 
     </Flex>
   ) : null;
 
+  const susFlags = displayFlags.filter(flag => (flag.suspect.score ?? 0) > threshold);
+
+  useEffect(() => {
+    if (!isPending) {
+      trackAnalytics('flags.new_suspect_flags_found', {
+        numTotalFlags: displayFlags.length,
+        numSuspectFlags: susFlags.length,
+        organization,
+        threshold,
+      });
+    }
+  }, [isPending, organization, displayFlags.length, susFlags.length, threshold]);
+
   if (isPending) {
     return (
       <Alert type="muted">
@@ -57,8 +75,6 @@ export default function SuspectTable({debugSuspectScores, environments, group}: 
       </Alert>
     );
   }
-
-  const susFlags = displayFlags.filter(flag => (flag.suspect.score ?? 0) > threshold);
 
   if (!susFlags.length) {
     return (


### PR DESCRIPTION
the old analytic was only tracking the legacy suspect flags. add a new analytic to track suspect flags under the new algorithm