### PR TITLE
fix(perf-issues): Do not paramaterize file extensions

### DIFF
--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -275,6 +275,8 @@ PARAMETERIZED_URL_REGEX = re.compile(
 """
 )  # Adapted from message.py
 
+FILE_EXTENSION_REGEX = re.compile(r"\.[a-z0-9]{2,6}$", re.I)
+
 # Finds dash-separated UUIDs. (Without dashes will be caught by
 # ASSET_HASH_REGEX).
 UUID_REGEX = re.compile(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", re.I)
@@ -330,13 +332,18 @@ def parameterize_url_with_result(url: str) -> ParameterizedUrl:
 
     path_fragments = []
     path_params = []
-    for fragment in parsed_url.path.split("/"):
-        path_param = PARAMETERIZED_URL_REGEX.search(fragment)
-        if path_param:
-            path_fragments.append("*")
-            path_params.append(path_param.group())
-        else:
-            path_fragments.append(str(fragment))
+
+    # If the path ends with a file extension, do not parameterize it.
+    if FILE_EXTENSION_REGEX.search(parsed_url.path):
+        path_fragments.append(parsed_url.path)
+    else:
+        for fragment in parsed_url.path.split("/"):
+            path_param = PARAMETERIZED_URL_REGEX.search(fragment)
+            if path_param:
+                path_fragments.append("*")
+                path_params.append(path_param.group())
+            else:
+                path_fragments.append(str(fragment))
 
     query = parse_qs(parsed_url.query)
 

--- a/tests/sentry/utils/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/experiments/test_n_plus_one_api_calls_detector.py
@@ -281,6 +281,13 @@ class NPlusOneAPICallsExperimentalDetectorTest(TestCase):
 
         assert problem1.fingerprint != problem2.fingerprint
 
+    def test_does_not_fingerprint_file_urls(self):
+        event = self.create_event(lambda i: f"GET /clients/info/{i}.json")
+        assert self.find_problems(event) == []
+
+        event = self.create_event(lambda i: f"GET /clients/{i}/info/file.json")
+        assert self.find_problems(event) == []
+
     def test_ignores_hostname_for_fingerprinting(self):
         event1 = self.create_event(lambda i: f"GET http://service.io/clients/{i}/info?id={i}")
         [problem1] = self.find_problems(event1)
@@ -324,6 +331,10 @@ class NPlusOneAPICallsExperimentalDetectorTest(TestCase):
         ),
         (
             "/clients/11/project/1343",
+            "/clients/*/project/*",
+        ),
+        (
+            "/clients/1.2/project/3.4.5",
             "/clients/*/project/*",
         ),
         (


### PR DESCRIPTION
If a call is made to a file extension, we can't parameterize it, since we don't know what kind of asset they're retrieving. 
- N+1 API Calls, assume that the caller is querying `/api/user/1/` and `/api/user/2` and there likely exists `/api/users` for them to consolidate.
 - It's a weaker assumption that when querying  `/api/user/1/info.json` and `/api/user/2/info.json` there exists an `/api/user/all-info.json`, so let's avoid parameterizing those.