### PR TITLE
fix(widget-builder): Disable chart zoom in widget preview

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -344,6 +344,7 @@ class ChartZoom extends Component<Props> {
         utc,
         start,
         end,
+        isGroupedByDate: true,
         ...props,
       });
     }

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -115,6 +115,7 @@ function WidgetPreview({
       showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
       // ensure table columns are at least a certain width (helps with lack of truncation on large fields)
       minTableColumnWidth={MIN_TABLE_COLUMN_WIDTH}
+      disableZoom
     />
   );
 }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -83,6 +83,7 @@ type WidgetCardChartProps = Pick<
   widgetLegendState: WidgetLegendSelectionState;
   chartGroup?: string;
   confidence?: Confidence;
+  disableZoom?: boolean;
   expandNumbers?: boolean;
   isMobile?: boolean;
   isSampled?: boolean | null;
@@ -283,6 +284,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
       showConfidenceWarning,
       sampleCount,
       isSampled,
+      disableZoom,
     } = this.props;
 
     if (errorMessage) {
@@ -505,7 +507,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
             : 0)
         : undefined;
     return (
-      <ChartZoom period={period} start={start} end={end} utc={utc}>
+      <ChartZoom period={period} start={start} end={end} utc={utc} disabled={disableZoom}>
         {zoomRenderProps => {
           return (
             <ReleaseSeries

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -411,6 +411,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
     const chartOptions = {
       autoHeightResize: shouldResize ?? true,
       useMultilineDate: true,
+      isGroupedByDate: true,
       grid: {
         left: 0,
         right: 4,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -411,7 +411,6 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
     const chartOptions = {
       autoHeightResize: shouldResize ?? true,
       useMultilineDate: true,
-      isGroupedByDate: true,
       grid: {
         left: 0,
         right: 4,

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -68,6 +68,7 @@ type Props = WithRouterProps & {
   borderless?: boolean;
   dashboardFilters?: DashboardFilters;
   disableFullscreen?: boolean;
+  disableZoom?: boolean;
   forceDescriptionTooltip?: boolean;
   hasEditAccess?: boolean;
   index?: string;
@@ -139,6 +140,7 @@ function WidgetCard(props: Props) {
     disableFullscreen,
     showConfidenceWarning,
     minTableColumnWidth,
+    disableZoom,
   } = props;
 
   if (widget.displayType === DisplayType.TOP_N) {
@@ -275,6 +277,7 @@ function WidgetCard(props: Props) {
             widgetLegendState={widgetLegendState}
             showConfidenceWarning={showConfidenceWarning}
             minTableColumnWidth={minTableColumnWidth}
+            disableZoom={disableZoom}
           />
         </WidgetFrame>
       </VisuallyCompleteWithData>

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -34,6 +34,7 @@ type Props = {
   widgetLegendState: WidgetLegendSelectionState;
   chartGroup?: string;
   dashboardFilters?: DashboardFilters;
+  disableZoom?: boolean;
   expandNumbers?: boolean;
   isMobile?: boolean;
   legendOptions?: LegendComponentOption;
@@ -83,6 +84,7 @@ export function WidgetCardChartContainer({
   showConfidenceWarning,
   minTableColumnWidth,
   onDataFetchStart,
+  disableZoom,
 }: Props) {
   const location = useLocation();
 
@@ -144,6 +146,7 @@ export function WidgetCardChartContainer({
               ? renderErrorMessage(errorMessage)
               : null}
             <WidgetCardChart
+              disableZoom={disableZoom}
               timeseriesResults={modifiedTimeseriesResults}
               tableResults={tableResults}
               errorMessage={errorMessage}


### PR DESCRIPTION
Pass along a flag to disable the chart zoom component. Only disable it in the widget builder preview because the default experience is that zooming affects the global filters and the builder shouldn't allow you edit global filters.

Not adding a test because I don't think we can meaningfully test the click and drag functionality here.