### PR TITLE
ref(insights): remove `NONE` option from useDiscover sampling mode options

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -31,7 +31,7 @@ interface UseDiscoverOptions<Fields> {
   orderby?: string | string[];
   pageFilters?: PageFilters;
   projectIds?: number[];
-  samplingMode?: SamplingMode | 'NONE';
+  samplingMode?: SamplingMode;
   /**
    * TODO - ideally this probably would be only `Mutable Search`, but it doesn't handle some situations well
    */
@@ -159,8 +159,7 @@ export const useDiscover = <
     referrer,
     cursor,
     noPagination,
-    samplingMode:
-      samplingMode === 'NONE' || !shouldSetSamplingMode ? undefined : samplingMode,
+    samplingMode: shouldSetSamplingMode ? samplingMode : undefined,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -36,7 +36,7 @@ interface UseMetricsSeriesOptions<Fields> {
   interval?: string;
   overriddenRoute?: string;
   referrer?: string;
-  samplingMode?: SamplingMode | 'NONE';
+  samplingMode?: SamplingMode;
   search?: MutableSearch | string;
   // TODO: Remove string type and always require MutableSearch
   transformAliasToInputFormat?: boolean;
@@ -156,8 +156,7 @@ const useDiscoverSeries = <T extends string[]>(
       orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
       interval: eventView.interval,
       transformAliasToInputFormat: options.transformAliasToInputFormat ? '1' : '0',
-      sampling:
-        samplingMode === 'NONE' || !shouldSetSamplingMode ? undefined : samplingMode,
+      samplingMode: shouldSetSamplingMode ? samplingMode : undefined,
     }),
     options: {
       enabled: options.enabled && defaultPageFilters.isReady,

--- a/static/app/views/insights/common/queries/useTopNDiscoverMultiSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverMultiSeries.ts
@@ -40,7 +40,7 @@ interface UseMetricsSeriesOptions<YAxisFields, Fields> {
   interval?: string;
   overriddenRoute?: string;
   referrer?: string;
-  samplingMode?: SamplingMode | 'NONE';
+  samplingMode?: SamplingMode;
   search?: MutableSearch | string;
   // TODO: Remove string type and always require MutableSearch
   transformAliasToInputFormat?: boolean;
@@ -172,8 +172,7 @@ const useTopNDiscoverMultiSeries = <
       orderby: eventView.sorts?.[0] ? encodeSort(eventView.sorts?.[0]) : undefined,
       interval: eventView.interval,
       transformAliasToInputFormat: options.transformAliasToInputFormat ? '1' : '0',
-      sampling:
-        samplingMode === 'NONE' || !shouldSetSamplingMode ? undefined : samplingMode,
+      samplingMode: shouldSetSamplingMode ? samplingMode : undefined,
     }),
     options: {
       enabled: options.enabled && defaultPageFilters.isReady,

--- a/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
@@ -41,7 +41,7 @@ interface UseMetricsSeriesOptions<Fields> {
   interval?: string;
   overriddenRoute?: string;
   referrer?: string;
-  samplingMode?: SamplingMode | 'NONE';
+  samplingMode?: SamplingMode;
   search?: MutableSearch | string;
   sort?: Sort;
   // TODO: Remove string type and always require MutableSearch
@@ -159,8 +159,7 @@ const useTopNDiscoverSeries = <T extends string[]>(
       orderby: sort ? encodeSort(sort) : undefined,
       interval: eventView.interval,
       transformAliasToInputFormat: options.transformAliasToInputFormat ? '1' : '0',
-      sampling:
-        samplingMode === 'NONE' || !shouldSetSamplingMode ? undefined : samplingMode,
+      samplingMode: shouldSetSamplingMode ? samplingMode : undefined,
     }),
     options: {
       enabled: options.enabled && defaultPageFilters.isReady,


### PR DESCRIPTION
Feedback from https://github.com/getsentry/sentry/pull/91144#discussion_r2079954994