### PR TITLE
feat(explore): Adds delete button to trace explorer when viewing saved query

### DIFF
--- a/static/app/utils/analytics/tracingEventMap.tsx
+++ b/static/app/utils/analytics/tracingEventMap.tsx
@@ -136,6 +136,7 @@ export type TracingEventParameters = {
   };
   'trace_explorer.add_span_condition': Record<string, unknown>;
   'trace_explorer.compare_queries': Record<string, unknown>;
+  'trace_explorer.delete_query': Record<string, unknown>;
   'trace_explorer.open_in_issues': Record<string, unknown>;
   'trace_explorer.open_trace': {
     source: 'trace explorer' | 'new explore';
@@ -243,4 +244,5 @@ export const tracingEventMap: Record<TracingEventKey, string | null> = {
   'trace_explorer.compare_queries': 'Trace Explorer: Compare',
   'trace_explorer.save_query_modal': 'Trace Explorer: Save Query Modal',
   'trace_explorer.star_query': 'Trace Explorer: Star Query',
+  'trace_explorer.delete_query': 'Trace Explorer: Delete Query',
 };

--- a/static/app/views/explore/multiQueryMode/index.tsx
+++ b/static/app/views/explore/multiQueryMode/index.tsx
@@ -8,10 +8,14 @@ import {NoAccess} from 'sentry/components/noAccess';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
 import {getTitleFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/title';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {MultiQueryModeContent} from 'sentry/views/explore/multiQueryMode/content';
+import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
 import {StarSavedQueryButton} from 'sentry/views/explore/starSavedQueryButton';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
@@ -22,6 +26,9 @@ export default function MultiQueryMode() {
   const title = getTitleFromLocation(location);
 
   const prefersStackedNav = usePrefersStackedNav();
+
+  const id = getIdFromLocation(location);
+  const {data: savedQuery} = useGetSavedQuery(id);
 
   return (
     <Feature
@@ -62,6 +69,7 @@ export default function MultiQueryMode() {
                 </LinkButton>
               )}
               <StarSavedQueryButton />
+              {defined(id) && savedQuery?.isPrebuilt === false && <SavedQueryEditMenu />}
               <FeedbackWidgetButton />
             </ButtonBar>
           </Layout.HeaderActions>

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -1,5 +1,12 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {SavedQueriesTable} from 'sentry/views/explore/savedQueries/savedQueriesTable';
 
@@ -106,9 +113,17 @@ describe('SavedQueriesTable', () => {
     render(<SavedQueriesTable mode="owned" title="title" />, {
       deprecatedRouterMocks: true,
     });
+    renderGlobalModal();
     await screen.findByText('Query Name');
     await userEvent.click(screen.getByLabelText('More options'));
     await userEvent.click(screen.getByText('Delete'));
+    await screen.findByText('Are you sure you want to delete the query "Query Name"?');
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Delete Query',
+      })
+    );
+
     await waitFor(() =>
       expect(deleteQueryMock).toHaveBeenCalledWith(
         `/organizations/${organization.slug}/explore/saved/1/`,

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -29,7 +29,10 @@ import {
 import {useSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
 import {useStarQuery} from 'sentry/views/explore/hooks/useStarQuery';
 import {ExploreParams} from 'sentry/views/explore/savedQueries/exploreParams';
-import {getExploreUrlFromSavedQueryUrl} from 'sentry/views/explore/utils';
+import {
+  confirmDeleteSavedQuery,
+  getExploreUrlFromSavedQueryUrl,
+} from 'sentry/views/explore/utils';
 
 type Props = {
   title: string;
@@ -273,16 +276,21 @@ export function SavedQueriesTable({
                         {
                           key: 'delete',
                           label: t('Delete'),
-                          onAction: async () => {
-                            addLoadingMessage(t('Deleting query...'));
-                            try {
-                              await deleteQuery(query.id);
-                              addSuccessMessage(t('Query deleted'));
-                            } catch (error) {
-                              addErrorMessage(t('Unable to delete query'));
-                            }
-                          },
                           priority: 'danger' as const,
+                          onAction: () => {
+                            confirmDeleteSavedQuery({
+                              handleDelete: async () => {
+                                addLoadingMessage(t('Deleting query...'));
+                                try {
+                                  await deleteQuery(query.id);
+                                  addSuccessMessage(t('Query deleted'));
+                                } catch (error) {
+                                  addErrorMessage(t('Unable to delete query'));
+                                }
+                              },
+                              savedQuery: query,
+                            });
+                          },
                         },
                       ]),
                 ]}

--- a/static/app/views/explore/savedQueryEditMenu.tsx
+++ b/static/app/views/explore/savedQueryEditMenu.tsx
@@ -1,0 +1,70 @@
+import {Button} from 'sentry/components/core/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconEllipsis} from 'sentry/icons/iconEllipsis';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
+import {useDeleteQuery} from 'sentry/views/explore/hooks/useDeleteQuery';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {confirmDeleteSavedQuery} from 'sentry/views/explore/utils';
+
+export function SavedQueryEditMenu() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const locationId = getIdFromLocation(location);
+  const {data: savedQuery} = useGetSavedQuery(locationId);
+  const navigate = useNavigate();
+  const {deleteQuery} = useDeleteQuery();
+
+  if (!savedQuery) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu
+      items={[
+        {
+          key: 'delete',
+          label: t('Delete View'),
+          priority: 'danger',
+          onAction: () => {
+            confirmDeleteSavedQuery({
+              handleDelete: async () => {
+                await deleteQuery(savedQuery.id);
+                if (location.pathname.endsWith('compare/')) {
+                  navigate(
+                    normalizeUrl(
+                      `/organizations/${organization.slug}/explore/traces/compare/`
+                    )
+                  );
+                } else {
+                  navigate(
+                    normalizeUrl(`/organizations/${organization.slug}/explore/traces/`)
+                  );
+                }
+                trackAnalytics('trace_explorer.delete_query', {
+                  organization,
+                });
+              },
+              savedQuery,
+            });
+          },
+        },
+      ]}
+      trigger={props => (
+        <Button
+          size="sm"
+          {...props}
+          icon={<IconEllipsis />}
+          aria-label={t('More saved query options')}
+        />
+      )}
+      position="bottom-end"
+      minMenuWidth={160}
+    />
+  );
+}

--- a/static/app/views/explore/savedQueryEditMenu.tsx
+++ b/static/app/views/explore/savedQueryEditMenu.tsx
@@ -29,7 +29,7 @@ export function SavedQueryEditMenu() {
       items={[
         {
           key: 'delete',
-          label: t('Delete View'),
+          label: t('Delete Query'),
           priority: 'danger',
           onAction: () => {
             confirmDeleteSavedQuery({

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -23,6 +23,8 @@ import {
   useExploreTitle,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
 import {SpansTabContent, SpansTabOnboarding} from 'sentry/views/explore/spans/spansTab';
 import {
   EXPLORE_SPANS_TOUR_GUIDE_KEY,
@@ -127,6 +129,7 @@ function SpansTabHeader({organization}: SpansTabHeaderProps) {
   const prefersStackedNav = usePrefersStackedNav();
   const id = useExploreId();
   const title = useExploreTitle();
+  const {data: savedQuery} = useGetSavedQuery(id);
 
   return (
     <Layout.Header unified={prefersStackedNav}>
@@ -154,6 +157,7 @@ function SpansTabHeader({organization}: SpansTabHeaderProps) {
             </LinkButton>
           )}
           <StarSavedQueryButton />
+          {defined(id) && savedQuery?.isPrebuilt === false && <SavedQueryEditMenu />}
           <FeedbackWidgetButton />
         </ButtonBar>
       </Layout.HeaderActions>

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -383,7 +383,7 @@ export function confirmDeleteSavedQuery({
   openConfirmModal({
     message: t('Are you sure you want to delete the query "%s"?', savedQuery.name),
     isDangerous: true,
-    confirmText: t('Delete View'),
+    confirmText: t('Delete Query'),
     priority: 'danger',
     onConfirm: handleDelete,
   });

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 import * as qs from 'query-string';
 
+import {openConfirmModal} from 'sentry/components/confirm';
 import type {SelectOptionWithKey} from 'sentry/components/core/compactSelect/types';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import {IconBusiness} from 'sentry/icons/iconBusiness';
@@ -371,3 +372,19 @@ const UpsellFooterHook = HookOrDefault({
   hookName: 'component:explore-date-range-query-limit-footer',
   defaultComponent: () => undefined,
 });
+
+export function confirmDeleteSavedQuery({
+  handleDelete,
+  savedQuery,
+}: {
+  handleDelete: () => void;
+  savedQuery: SavedQuery;
+}) {
+  openConfirmModal({
+    message: t('Are you sure you want to delete the query "%s"?', savedQuery.name),
+    isDangerous: true,
+    confirmText: t('Delete View'),
+    priority: 'danger',
+    onConfirm: handleDelete,
+  });
+}


### PR DESCRIPTION
Adds a delete button to the Trace Explorer for saved queries + delete confirmation modal.
Also updates the All Queries view delete option to use the delete modal.