### PR TITLE
feat(explore): Allow autofocusing search query builder

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -180,6 +180,7 @@ export function SpanSearchQueryBuilder({
 export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {
   numberTags: TagCollection;
   stringTags: TagCollection;
+  autofocus?: boolean;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   onChange?: (query: string, state: CallbackSearchState) => void;
   portalTarget?: HTMLElement | null;

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -180,7 +180,7 @@ export function SpanSearchQueryBuilder({
 export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {
   numberTags: TagCollection;
   stringTags: TagCollection;
-  autofocus?: boolean;
+  autoFocus?: boolean;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   onChange?: (query: string, state: CallbackSearchState) => void;
   portalTarget?: HTMLElement | null;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3303,16 +3303,15 @@ describe('SearchQueryBuilder', function () {
       render(
         <SearchQueryBuilder
           {...defaultProps}
-          autofocus
+          autoFocus
           initialQuery=""
           onChange={mockOnChange}
           onSearch={mockOnSearch}
         />
       );
-      // Must await something to prevent act warnings
-      await act(tick);
-
-      expect(getLastInput()).toHaveFocus();
+      await waitFor(() => {
+        expect(getLastInput()).toHaveFocus();
+      });
     });
 
     it('should autofocus with non-empty initial query', async function () {
@@ -3321,16 +3320,15 @@ describe('SearchQueryBuilder', function () {
       render(
         <SearchQueryBuilder
           {...defaultProps}
-          autofocus
+          autoFocus
           initialQuery="browser.name:firefox"
           onChange={mockOnChange}
           onSearch={mockOnSearch}
         />
       );
-      // Must await something to prevent act warnings
-      await act(tick);
-
-      expect(getLastInput()).toHaveFocus();
+      await waitFor(() => {
+        expect(getLastInput()).toHaveFocus();
+      });
     });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3295,4 +3295,42 @@ describe('SearchQueryBuilder', function () {
       expect(await screen.findByText('foo bar baz')).toBeInTheDocument();
     });
   });
+
+  describe('autofocus', function () {
+    it('should autofocus with empty initial query', async function () {
+      const mockOnChange = jest.fn();
+      const mockOnSearch = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          autofocus
+          initialQuery=""
+          onChange={mockOnChange}
+          onSearch={mockOnSearch}
+        />
+      );
+      // Must await something to prevent act warnings
+      await act(tick);
+
+      expect(getLastInput()).toHaveFocus();
+    });
+
+    it('should autofocus with non-empty initial query', async function () {
+      const mockOnChange = jest.fn();
+      const mockOnSearch = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          autofocus
+          initialQuery="browser.name:firefox"
+          onChange={mockOnChange}
+          onSearch={mockOnSearch}
+        />
+      );
+      // Must await something to prevent act warnings
+      await act(tick);
+
+      expect(getLastInput()).toHaveFocus();
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -40,7 +40,7 @@ export interface SearchQueryBuilderProps {
    * Indicates the usage of the search bar for analytics
    */
   searchSource: string;
-  autofocus?: boolean;
+  autoFocus?: boolean;
   className?: string;
   disabled?: boolean;
   /**
@@ -181,7 +181,7 @@ function ActionButtons({
 }
 
 function SearchQueryBuilderUI({
-  autofocus,
+  autoFocus,
   className,
   disabled = false,
   label,
@@ -222,7 +222,7 @@ function SearchQueryBuilderUI({
           <PlainTextQueryInput label={label} />
         ) : (
           <TokenizedQueryGrid
-            autofocus={autofocus || false}
+            autoFocus={autoFocus || false}
             label={label}
             actionBarWidth={actionBarWidth}
           />

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -40,6 +40,7 @@ export interface SearchQueryBuilderProps {
    * Indicates the usage of the search bar for analytics
    */
   searchSource: string;
+  autofocus?: boolean;
   className?: string;
   disabled?: boolean;
   /**
@@ -180,6 +181,7 @@ function ActionButtons({
 }
 
 function SearchQueryBuilderUI({
+  autofocus,
   className,
   disabled = false,
   label,
@@ -219,7 +221,11 @@ function SearchQueryBuilderUI({
         {!parsedQuery || queryInterface === QueryInterfaceType.TEXT ? (
           <PlainTextQueryInput label={label} />
         ) : (
-          <TokenizedQueryGrid label={label} actionBarWidth={actionBarWidth} />
+          <TokenizedQueryGrid
+            autofocus={autofocus || false}
+            label={label}
+            actionBarWidth={actionBarWidth}
+          />
         )}
         {size !== 'small' && (
           <ActionButtons ref={actionBarRef} trailingItems={trailingItems} />

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -23,13 +23,34 @@ import {space} from 'sentry/styles/space';
 
 interface TokenizedQueryGridProps {
   actionBarWidth: number;
+  autofocus: boolean;
   label?: string;
 }
 
 interface GridProps extends AriaGridListOptions<ParseResultToken> {
   actionBarWidth: number;
+  autofocus: boolean;
   children: CollectionChildren<ParseResultToken>;
   items: ParseResultToken[];
+}
+
+function useAutofocus(autofocus: boolean, state: ListState<ParseResultToken>) {
+  const {dispatch} = useSearchQueryBuilder();
+  const autofocused = useRef(!autofocus);
+
+  useLayoutEffect(() => {
+    if (autofocused.current) {
+      return; // already focused
+    }
+
+    if (!state.selectionManager) {
+      return;
+    }
+
+    state.selectionManager.setFocused(true);
+    state.selectionManager.setFocusedKey(state.collection.getLastKey());
+    autofocused.current = true;
+  }, [dispatch, state.collection, state.selectionManager]);
 }
 
 function useApplyFocusOverride(state: ListState<ParseResultToken>) {
@@ -74,6 +95,7 @@ function Grid(props: GridProps) {
     selectionKeyHandlerRef,
     undo,
   });
+  useAutofocus(props.autofocus, state);
   useApplyFocusOverride(state);
   useSelectOnDrag(state);
 
@@ -134,7 +156,11 @@ function Grid(props: GridProps) {
   );
 }
 
-export function TokenizedQueryGrid({label, actionBarWidth}: TokenizedQueryGridProps) {
+export function TokenizedQueryGrid({
+  autofocus,
+  label,
+  actionBarWidth,
+}: TokenizedQueryGridProps) {
   const {parsedQuery} = useSearchQueryBuilder();
 
   // Shouldn't ever get here since we will render the plain text input instead
@@ -145,6 +171,7 @@ export function TokenizedQueryGrid({label, actionBarWidth}: TokenizedQueryGridPr
   return (
     <KeyboardSelection>
       <Grid
+        autofocus={autofocus}
         aria-label={label ?? t('Create a search query')}
         items={parsedQuery}
         selectionMode="multiple"

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -43,10 +43,6 @@ function useAutofocus(autofocus: boolean, state: ListState<ParseResultToken>) {
       return; // already focused
     }
 
-    if (!state.selectionManager) {
-      return;
-    }
-
     state.selectionManager.setFocused(true);
     state.selectionManager.setFocusedKey(state.collection.getLastKey());
     autofocused.current = true;

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -23,29 +23,29 @@ import {space} from 'sentry/styles/space';
 
 interface TokenizedQueryGridProps {
   actionBarWidth: number;
-  autofocus: boolean;
+  autoFocus: boolean;
   label?: string;
 }
 
 interface GridProps extends AriaGridListOptions<ParseResultToken> {
   actionBarWidth: number;
-  autofocus: boolean;
+  autoFocus: boolean;
   children: CollectionChildren<ParseResultToken>;
   items: ParseResultToken[];
 }
 
-function useAutofocus(autofocus: boolean, state: ListState<ParseResultToken>) {
+function useAutoFocus(autoFocus: boolean, state: ListState<ParseResultToken>) {
   const {dispatch} = useSearchQueryBuilder();
-  const autofocused = useRef(!autofocus);
+  const autoFocused = useRef(!autoFocus);
 
   useLayoutEffect(() => {
-    if (autofocused.current) {
+    if (autoFocused.current) {
       return; // already focused
     }
 
     state.selectionManager.setFocused(true);
     state.selectionManager.setFocusedKey(state.collection.getLastKey());
-    autofocused.current = true;
+    autoFocused.current = true;
   }, [dispatch, state.collection, state.selectionManager]);
 }
 
@@ -91,7 +91,7 @@ function Grid(props: GridProps) {
     selectionKeyHandlerRef,
     undo,
   });
-  useAutofocus(props.autofocus, state);
+  useAutoFocus(props.autoFocus, state);
   useApplyFocusOverride(state);
   useSelectOnDrag(state);
 
@@ -153,7 +153,7 @@ function Grid(props: GridProps) {
 }
 
 export function TokenizedQueryGrid({
-  autofocus,
+  autoFocus,
   label,
   actionBarWidth,
 }: TokenizedQueryGridProps) {
@@ -167,7 +167,7 @@ export function TokenizedQueryGrid({
   return (
     <KeyboardSelection>
       <Grid
-        autofocus={autofocus}
+        autoFocus={autoFocus}
         aria-label={label ?? t('Create a search query')}
         items={parsedQuery}
         selectionMode="multiple"

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -101,7 +101,7 @@ export function useSearchQueryBuilderProps({
  * once spans support has been added to the trace-items attribute endpoints.
  */
 export function TraceItemSearchQueryBuilder({
-  autofocus,
+  autoFocus,
   initialQuery,
   numberAttributes,
   searchSource,
@@ -131,7 +131,7 @@ export function TraceItemSearchQueryBuilder({
     supportedAggregates,
   });
 
-  return <SearchQueryBuilder autofocus={autofocus} {...searchQueryBuilderProps} />;
+  return <SearchQueryBuilder autoFocus={autoFocus} {...searchQueryBuilderProps} />;
 }
 
 function useFunctionTags(

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -101,6 +101,7 @@ export function useSearchQueryBuilderProps({
  * once spans support has been added to the trace-items attribute endpoints.
  */
 export function TraceItemSearchQueryBuilder({
+  autofocus,
   initialQuery,
   numberAttributes,
   searchSource,
@@ -130,7 +131,7 @@ export function TraceItemSearchQueryBuilder({
     supportedAggregates,
   });
 
-  return <SearchQueryBuilder {...searchQueryBuilderProps} />;
+  return <SearchQueryBuilder autofocus={autofocus} {...searchQueryBuilderProps} />;
 }
 
 function useFunctionTags(

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -200,7 +200,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
               <EnvironmentPageFilter />
               <DatePageFilter {...datePageFilterProps} />
             </StyledPageFilterBar>
-            <EAPSpanSearchQueryBuilder {...eapSpanSearchQueryBuilderProps} />
+            <EAPSpanSearchQueryBuilder autofocus {...eapSpanSearchQueryBuilderProps} />
           </FilterSection>
           <StyledSchemaHintsSection>
             <SchemaHintsList

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -200,7 +200,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
               <EnvironmentPageFilter />
               <DatePageFilter {...datePageFilterProps} />
             </StyledPageFilterBar>
-            <EAPSpanSearchQueryBuilder autofocus {...eapSpanSearchQueryBuilderProps} />
+            <EAPSpanSearchQueryBuilder autoFocus {...eapSpanSearchQueryBuilderProps} />
           </FilterSection>
           <StyledSchemaHintsSection>
             <SchemaHintsList


### PR DESCRIPTION
When visiting explore, we should autofocus the search bar.

Closes EXP-221