### PR TITLE
chore(self-hosted/dev): Create kafka topics from sentry-kafka-schemas

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -417,10 +417,10 @@ def devserver(
             from sentry_kafka_schemas import list_topics
 
             from sentry.utils.batching_kafka_consumer import create_topics
-            from sentry.utils.kafka_config import get_topic_definition
+            from sentry.utils.kafka_config import get_topic_definition_from_name
 
             for topic in list_topics():
-                topic_defn = get_topic_definition(topic)
+                topic_defn = get_topic_definition_from_name(topic)
                 create_topics(topic_defn["cluster"], [topic_defn["real_topic_name"]])
 
             if dev_consumer:

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -414,11 +414,12 @@ def devserver(
             """
                 )
 
-            from sentry.conf.types.kafka_definition import Topic
+            from sentry_kafka_schemas import list_topics
+
             from sentry.utils.batching_kafka_consumer import create_topics
             from sentry.utils.kafka_config import get_topic_definition
 
-            for topic in Topic:
+            for topic in list_topics():
                 topic_defn = get_topic_definition(topic)
                 create_topics(topic_defn["cluster"], [topic_defn["real_topic_name"]])
 

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -87,10 +87,10 @@ def _upgrade(
         from sentry_kafka_schemas import list_topics
 
         from sentry.utils.batching_kafka_consumer import create_topics
-        from sentry.utils.kafka_config import get_topic_definition
+        from sentry.utils.kafka_config import get_topic_definition_from_name
 
         for topic in list_topics():
-            topic_defn = get_topic_definition(topic)
+            topic_defn = get_topic_definition_from_name(topic)
             create_topics(topic_defn["cluster"], [topic_defn["real_topic_name"]])
 
     if repair:

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -84,11 +84,12 @@ def _upgrade(
         nodestore.backend.bootstrap()
 
     if create_kafka_topics:
-        from sentry.conf.types.kafka_definition import Topic
+        from sentry_kafka_schemas import list_topics
+
         from sentry.utils.batching_kafka_consumer import create_topics
         from sentry.utils.kafka_config import get_topic_definition
 
-        for topic in Topic:
+        for topic in list_topics():
             topic_defn = get_topic_definition(topic)
             create_topics(topic_defn["cluster"], [topic_defn["real_topic_name"]])
 

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -97,8 +97,14 @@ def get_kafka_admin_cluster_options(
     )
 
 
-def get_topic_definition(topic: Topic) -> TopicDefinition:
+def get_topic_definition(topic: Topic | str) -> TopicDefinition:
+    if isinstance(topic, str):
+        topic_name = topic
+        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER[topic]
+    else:
+        topic_name = topic.value
+        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER[topic]
     return {
-        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER[topic.value],
-        "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic.value, topic.value),
+        "cluster": cluster_name,
+        "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic_name, topic_name),
     }

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -97,14 +97,15 @@ def get_kafka_admin_cluster_options(
     )
 
 
-def get_topic_definition(topic: Topic | str) -> TopicDefinition:
-    if isinstance(topic, str):
-        topic_name = topic
-        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER.get(topic_name, "default")
-    else:
-        topic_name = topic.value
-        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER[topic_name]
+def get_topic_definition(topic: Topic) -> TopicDefinition:
     return {
-        "cluster": cluster_name,
+        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER[topic.value],
+        "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic.value, topic.value),
+    }
+
+
+def get_topic_definition_from_name(topic_name: str) -> TopicDefinition:
+    return {
+        "cluster": settings.KAFKA_TOPIC_TO_CLUSTER.get(topic_name, "default"),
         "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic_name, topic_name),
     }

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -100,10 +100,10 @@ def get_kafka_admin_cluster_options(
 def get_topic_definition(topic: Topic | str) -> TopicDefinition:
     if isinstance(topic, str):
         topic_name = topic
-        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER[topic]
+        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER.get(topic_name, "default")
     else:
         topic_name = topic.value
-        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER[topic]
+        cluster_name = settings.KAFKA_TOPIC_TO_CLUSTER[topic_name]
     return {
         "cluster": cluster_name,
         "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic_name, topic_name),


### PR DESCRIPTION
This uses sentry-kafka-schemas to determine which topics to create. This avoids duplicate definitions