### PR TITLE
ref(auth): Rename U2F -> Passkey / Biometrics / Security Key

### DIFF
--- a/fixtures/emails/mfa_added.txt
+++ b/fixtures/emails/mfa_added.txt
@@ -11,7 +11,7 @@ Account: foo@example.com
 IP: <IP_ADDRESS>
 When: Jan. 20, 2017, 9:39 p.m. UTC
 
-Authenticator: U2F (Universal 2nd Factor)
+Authenticator: Passkey / Biometric / Security Key
 Device: Home computer
 
 

--- a/fixtures/emails/mfa_removed.txt
+++ b/fixtures/emails/mfa_removed.txt
@@ -11,7 +11,7 @@ Account: foo@example.com
 IP: <IP_ADDRESS>
 When: Jan. 20, 2017, 9:39 p.m. UTC
 
-Authenticator: U2F (Universal 2nd Factor)
+Authenticator: Passkey / Biometric / Security Key
 Device: Home computer
 
 

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -50,13 +50,9 @@ class U2fInterface(AuthenticatorInterface):
     type = 3
     interface_id = "u2f"
     configure_button = _("Configure")
-    name = _("U2F (Universal 2nd Factor)")
+    name = _("Passkey / Biometric / Security Key")
     description = _(
-        "Authenticate with a U2F hardware device. This is a "
-        "device like a Yubikey or something similar which "
-        "supports FIDO's U2F specification. This also requires "
-        "a browser which supports this system (like Google "
-        "Chrome)."
+        "Authenticate using a Passkey, Biometrics, or a physical security key such as a YubiKey."
     )
     allow_multi_enrollment = True
 


### PR DESCRIPTION
The U2fInterface we've implemented actually supports both modern
WebAuthn credential authentication as well as backwards compatibility
with legacy u2f, since we still store u2f style device authentication
for this interface.

We probably should have created a new webauthn interface when we built
this instead of using this interface for both.

Since this interface will now ONLY store WebAuthn authentication
credentials, let's rename this to make it clear that you can use it for
Passkeys, Biometrics, or hardware authentication devices.