### PR TITLE
feat(issue-taxonomy): Add descriptions to issue categories in search

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -2,6 +2,7 @@ import type {LocationDescriptor} from 'history';
 
 import type {SearchGroup} from 'sentry/components/deprecatedSmartSearchBar/types';
 import type {TitledPlugin} from 'sentry/components/group/pluginActions';
+import {t} from 'sentry/locale';
 import type {FieldKind} from 'sentry/utils/fields';
 
 import type {Actor, TimeseriesValue} from './core';
@@ -101,6 +102,22 @@ export enum IssueCategory {
   DB_QUERY = 'db_query',
   MOBILE = 'mobile',
 }
+
+export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {
+  [IssueCategory.ERROR]: t('Runtime errors or exceptions.'),
+  [IssueCategory.OUTAGE]: t('Uptime or cron monitoring issues.'),
+  [IssueCategory.METRIC]: t('Performance regressions or metric threshold violations.'),
+  [IssueCategory.FRONTEND]: t('Frontend performance or usability issues.'),
+  [IssueCategory.HTTP_CLIENT]: t('Inefficient or problematic outgoing HTTP requests.'),
+  [IssueCategory.DB_QUERY]: t('Inefficient or problematic database queries.'),
+  [IssueCategory.MOBILE]: t('Mobile performance or usability issues.'),
+  [IssueCategory.FEEDBACK]: t('Feedback submitted directly by users.'),
+  [IssueCategory.METRIC_ALERT]: '',
+  [IssueCategory.PERFORMANCE]: '',
+  [IssueCategory.CRON]: '',
+  [IssueCategory.REPLAY]: '',
+  [IssueCategory.UPTIME]: '',
+};
 
 export enum IssueType {
   // Error

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -7,6 +7,7 @@ import {
 } from 'sentry/components/deprecatedSmartSearchBar/types';
 import {
   getIssueTitleFromType,
+  ISSUE_CATEGORY_TO_DESCRIPTION,
   IssueCategory,
   PriorityLevel,
   type Tag,
@@ -290,7 +291,15 @@ function builtInIssuesFields({
             IssueCategory.HTTP_CLIENT,
             IssueCategory.FRONTEND,
             IssueCategory.MOBILE,
-          ]
+          ].map(value => ({
+            icon: null,
+            title: value,
+            name: value,
+            documentation: ISSUE_CATEGORY_TO_DESCRIPTION[value],
+            value,
+            type: ItemType.TAG_VALUE,
+            children: [],
+          }))
         : [
             IssueCategory.ERROR,
             IssueCategory.PERFORMANCE,


### PR DESCRIPTION
There are a couple issues I'll try to fix in another PR: selected items don't show the description, and the width of the menu is a little small.

![CleanShot 2025-05-08 at 10 42 45](https://github.com/user-attachments/assets/333a6d9a-c886-4d5a-94f6-1e1d73d44646)
