### PR TITLE
ref(crons): Restrict time picker to 30 days

### DIFF
--- a/static/app/views/alerts/rules/crons/details.tsx
+++ b/static/app/views/alerts/rules/crons/details.tsx
@@ -141,11 +141,6 @@ function MonitorDetails({params, location}: Props) {
 
   const envsSortedByLastCheck = sortBy(monitor.environments, e => e.lastCheckIn);
 
-  // TODO(epurkhiser): Remove once we've restricted history to 30days in the backend
-  const maxPickableDays = organization.features.includes('crons-30-days-ui')
-    ? 30
-    : undefined;
-
   return (
     <Layout.Page>
       <SentryDocumentTitle title={`${monitor.name} — Alerts`} />
@@ -153,7 +148,7 @@ function MonitorDetails({params, location}: Props) {
       <Layout.Body>
         <Layout.Main>
           <StyledPageFilterBar condensed>
-            <DatePageFilter maxPickableDays={maxPickableDays} />
+            <DatePageFilter maxPickableDays={30} />
             <EnvironmentPageFilter />
           </StyledPageFilterBar>
           {monitor.status === 'disabled' && (

--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -105,11 +105,6 @@ function CronsOverview() {
 
   const showAddMonitor = !isValidPlatform(platform) || !isValidGuide(guide);
 
-  // TODO(epurkhiser): Remove once we've restricted history to 30days in the backend
-  const maxPickableDays = organization.features.includes('crons-30-days-ui')
-    ? 30
-    : undefined;
-
   return (
     <Fragment>
       <CronsListPageHeader organization={organization} />
@@ -165,7 +160,7 @@ function CronsOverview() {
             <PageFilterBar>
               <ProjectPageFilter resetParamsOnChange={['cursor']} />
               <EnvironmentPageFilter resetParamsOnChange={['cursor']} />
-              <DatePageFilter maxPickableDays={maxPickableDays} />
+              <DatePageFilter maxPickableDays={30} />
             </PageFilterBar>
             <SearchBar
               query={decodeScalar(qs.parse(location.search)?.query, '')}


### PR DESCRIPTION
Closes [NEW-206: Update UI to limit date filtering to 30 days](https://linear.app/getsentry/issue/NEW-206/update-ui-to-limit-date-filtering-to-30-days)