### PR TITLE
ref(shared-views): Do not send default starred view with stacked nav

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -58,7 +58,10 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         )
 
         # TODO(msun): Remove when tabbed views are deprecated
-        if not starred_views.exists():
+
+        if not starred_views.exists() and not features.has(
+            "organizations:enforce-stacked-navigation", organization
+        ):
             return self.paginate(
                 request=request,
                 paginator=SequencePaginator(


### PR DESCRIPTION
If the user has no starred views and has the enforce-stacked-nav flag, do not send the default view. 