### PR TITLE
fix(query-builder): Display description of selected items

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -411,7 +411,17 @@ function useFilterSuggestions({
       {
         sectionText: '',
         items: getItemsWithKeys([
-          ...selectedValues.map(value => createItem({value}, true)),
+          ...selectedValues.map(value => {
+            const matchingSuggestion = suggestionGroups
+              .flatMap(group => group.suggestions)
+              .find(suggestion => suggestion.value === value);
+
+            if (matchingSuggestion) {
+              return createItem(matchingSuggestion, true);
+            }
+
+            return createItem({value}, true);
+          }),
           ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
         ]),
       },


### PR DESCRIPTION
Matches selected text with any matching items in the list so we can preserve the description.

Before:

![CleanShot 2025-05-08 at 11 42 55](https://github.com/user-attachments/assets/bf9afd17-86eb-4bdd-9cbe-3c6b685591a2)

After:

![CleanShot 2025-05-08 at 11 42 32](https://github.com/user-attachments/assets/d2beea58-1e34-4d9e-8ba2-344b6f36b0a6)
