### PR TITLE
chore(explore): Remove progressive loading normal mode flag

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -453,10 +453,6 @@ export default function MetricChart({
     ]
   );
 
-  const isUsingNormalSamplingMode = organization.features.includes(
-    'visibility-explore-progressive-loading-normal-sampling-mode'
-  );
-
   const {data: eventStats, isLoading: isLoadingEventStats} = useMetricEventStats(
     {
       project,
@@ -464,7 +460,7 @@ export default function MetricChart({
       timePeriod,
       referrer: 'api.alerts.alert-rule-chart',
       samplingMode:
-        isUsingNormalSamplingMode && rule.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
+        rule.dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
           ? SAMPLING_MODE.NORMAL
           : undefined,
     },

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -256,11 +256,7 @@ describe('Incident Rules Create', () => {
   });
 
   it('uses normal sampling for span alerts', async () => {
-    const {organization, project, router} = initializeOrg({
-      organization: {
-        features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-      },
-    });
+    const {organization, project, router} = initializeOrg();
 
     render(
       <TriggersChart

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -714,10 +714,6 @@ class TriggersChart extends PureComponent<Props, State> {
       partial: false,
     };
 
-    const isUsingNormalSamplingMode = organization.features.includes(
-      'visibility-explore-progressive-loading-normal-sampling-mode'
-    );
-
     return (
       <Fragment>
         {this.props.includeHistorical ? (
@@ -751,7 +747,7 @@ class TriggersChart extends PureComponent<Props, State> {
           period={period}
           dataLoadedCallback={onDataLoaded}
           sampling={
-            isUsingNormalSamplingMode && dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
+            dataset === Dataset.EVENTS_ANALYTICS_PLATFORM
               ? SAMPLING_MODE.NORMAL
               : undefined
           }

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -1,15 +1,15 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DisplayType} from 'sentry/views/dashboards/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import SpansWidgetQueries from './spansWidgetQueries';
 
 describe('spansWidgetQueries', () => {
+  const {organization} = initializeOrg();
   const api = new MockApiClient();
   let widget = WidgetFixture();
   const selection = PageFiltersFixture();
@@ -127,23 +127,18 @@ describe('spansWidgetQueries', () => {
     });
 
     render(
-      <OrganizationContext.Provider
-        value={OrganizationFixture({
-          features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-        })}
+      <SpansWidgetQueries
+        api={api}
+        widget={widget}
+        selection={{
+          ...selection,
+          datetime: {period: '24hr', end: null, start: null, utc: null},
+        }}
+        dashboardFilters={{}}
       >
-        <SpansWidgetQueries
-          api={api}
-          widget={widget}
-          selection={{
-            ...selection,
-            datetime: {period: '24hr', end: null, start: null, utc: null},
-          }}
-          dashboardFilters={{}}
-        >
-          {({timeseriesResults}) => <div>{timeseriesResults?.[0]?.data?.[0]?.value}</div>}
-        </SpansWidgetQueries>
-      </OrganizationContext.Provider>
+        {({timeseriesResults}) => <div>{timeseriesResults?.[0]?.data?.[0]?.value}</div>}
+      </SpansWidgetQueries>,
+      {organization}
     );
 
     expect(await screen.findByText('1')).toBeInTheDocument();
@@ -186,23 +181,18 @@ describe('spansWidgetQueries', () => {
     });
 
     render(
-      <OrganizationContext.Provider
-        value={OrganizationFixture({
-          features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-        })}
+      <SpansWidgetQueries
+        api={api}
+        widget={widget}
+        selection={{
+          ...selection,
+          datetime: {period: '24hr', end: null, start: null, utc: null},
+        }}
+        dashboardFilters={{}}
       >
-        <SpansWidgetQueries
-          api={api}
-          widget={widget}
-          selection={{
-            ...selection,
-            datetime: {period: '24hr', end: null, start: null, utc: null},
-          }}
-          dashboardFilters={{}}
-        >
-          {({tableResults}) => <div>{tableResults?.[0]?.data?.[0]?.a}</div>}
-        </SpansWidgetQueries>
-      </OrganizationContext.Provider>
+        {({tableResults}) => <div>{tableResults?.[0]?.data?.[0]?.a}</div>}
+      </SpansWidgetQueries>,
+      {organization}
     );
 
     expect(await screen.findByText('normal mode')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -151,13 +151,7 @@ function SpansWidgetQueriesSingleRequestImpl({
         dashboardFilters={dashboardFilters}
         onDataFetched={onDataFetched}
         afterFetchSeriesData={afterFetchSeriesData}
-        samplingMode={
-          organization.features.includes(
-            'visibility-explore-progressive-loading-normal-sampling-mode'
-          )
-            ? SAMPLING_MODE.NORMAL
-            : undefined
-        }
+        samplingMode={SAMPLING_MODE.NORMAL}
       >
         {props =>
           children({

--- a/static/app/views/explore/charts/confidenceFooter.spec.tsx
+++ b/static/app/views/explore/charts/confidenceFooter.spec.tsx
@@ -44,48 +44,6 @@ describe('ConfidenceFooter', () => {
         await screen.findByText(/You may not have enough samples for high accuracy./)
       ).toBeInTheDocument();
     });
-    it('renders for partial scan without grouping', async () => {
-      render(
-        <ConfidenceFooter
-          confidence="low"
-          sampleCount={100}
-          topEvents={undefined}
-          dataScanned="partial"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Based on 100 samples (Max. Limit)'
-      );
-      await userEvent.hover(screen.getByText('100'));
-      expect(
-        await screen.findByText(
-          /We could not scan all available data due to time or resource limits./
-        )
-      ).toBeInTheDocument();
-    });
-    it('renders for partial scan with grouping', async () => {
-      render(
-        <ConfidenceFooter
-          confidence="low"
-          sampleCount={100}
-          topEvents={5}
-          dataScanned="partial"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Top 5 groups based on 100 samples (Max. Limit)'
-      );
-      await userEvent.hover(screen.getByText('100'));
-      expect(
-        await screen.findByText(
-          /We could not scan all available data due to time or resource limits./
-        )
-      ).toBeInTheDocument();
-    });
   });
 
   describe('high confidence', () => {
@@ -116,48 +74,6 @@ describe('ConfidenceFooter', () => {
       expect(screen.getByTestId('wrapper')).toHaveTextContent(
         'Top 5 groups based on 100 samples'
       );
-    });
-    it('renders for partial scan without grouping', async () => {
-      render(
-        <ConfidenceFooter
-          confidence="high"
-          sampleCount={100}
-          topEvents={undefined}
-          dataScanned="partial"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Based on 100 samples (Max. Limit)'
-      );
-      await userEvent.hover(screen.getByText('100'));
-      expect(
-        await screen.findByText(
-          /We could not scan all available data due to time or resource limits./
-        )
-      ).toBeInTheDocument();
-    });
-    it('renders for partial scan with grouping', async () => {
-      render(
-        <ConfidenceFooter
-          confidence="high"
-          sampleCount={100}
-          topEvents={5}
-          dataScanned="partial"
-        />,
-        {wrapper: Wrapper}
-      );
-
-      expect(screen.getByTestId('wrapper')).toHaveTextContent(
-        'Top 5 groups based on 100 samples (Max. Limit)'
-      );
-      await userEvent.hover(screen.getByText('100'));
-      expect(
-        await screen.findByText(
-          /We could not scan all available data due to time or resource limits./
-        )
-      ).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/explore/charts/confidenceFooter.tsx
+++ b/static/app/views/explore/charts/confidenceFooter.tsx
@@ -5,7 +5,6 @@ import Count from 'sentry/components/count';
 import {t, tct} from 'sentry/locale';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   confidence?: Confidence;
@@ -16,23 +15,10 @@ type Props = {
 };
 
 export function ConfidenceFooter(props: Props) {
-  const organization = useOrganization();
-  const normalSamplingModeEnabled = organization.features.includes(
-    'visibility-explore-progressive-loading-normal-sampling-mode'
-  );
-  return (
-    <Container>{confidenceMessage({...props, normalSamplingModeEnabled})}</Container>
-  );
+  return <Container>{confidenceMessage(props)}</Container>;
 }
 
-function confidenceMessage({
-  sampleCount,
-  confidence,
-  topEvents,
-  isSampled,
-  dataScanned,
-  normalSamplingModeEnabled,
-}: Props & {normalSamplingModeEnabled: boolean}) {
+function confidenceMessage({sampleCount, confidence, topEvents, isSampled}: Props) {
   const isTopN = defined(topEvents) && topEvents > 1;
   if (!defined(sampleCount)) {
     return isTopN
@@ -42,24 +28,10 @@ function confidenceMessage({
 
   const noSampling = defined(isSampled) && !isSampled;
 
-  const partialScanTooltip = <_PartialScanTooltip />;
   const lowAccuracyFullSampleCount = <_LowAccuracyFullTooltip noSampling={noSampling} />;
   const sampleCountComponent = <Count value={sampleCount} />;
-  const showPartialScanMessage = dataScanned === 'partial' && !normalSamplingModeEnabled;
-
   if (confidence === 'low') {
     if (isTopN) {
-      if (showPartialScanMessage) {
-        return tct(
-          'Top [topEvents] groups based on [tooltip:[sampleCountComponent] samples (Max. Limit)]',
-          {
-            topEvents,
-            tooltip: partialScanTooltip,
-            sampleCountComponent,
-          }
-        );
-      }
-
       return tct(
         'Top [topEvents] groups based on [tooltip:[sampleCountComponent] samples]',
         {
@@ -70,13 +42,6 @@ function confidenceMessage({
       );
     }
 
-    if (showPartialScanMessage) {
-      return tct('Based on [tooltip:[sampleCountComponent] samples (Max. Limit)]', {
-        tooltip: partialScanTooltip,
-        sampleCountComponent,
-      });
-    }
-
     return tct('Based on [tooltip:[sampleCountComponent] samples]', {
       tooltip: lowAccuracyFullSampleCount,
       sampleCountComponent,
@@ -84,26 +49,8 @@ function confidenceMessage({
   }
 
   if (isTopN) {
-    if (showPartialScanMessage) {
-      return tct(
-        'Top [topEvents] groups based on [tooltip:[sampleCountComponent] samples (Max. Limit)]',
-        {
-          topEvents,
-          tooltip: partialScanTooltip,
-          sampleCountComponent,
-        }
-      );
-    }
-
     return tct('Top [topEvents] groups based on [sampleCountComponent] samples', {
       topEvents,
-      sampleCountComponent,
-    });
-  }
-
-  if (showPartialScanMessage) {
-    return tct('Based on [tooltip:[sampleCountComponent] samples (Max. Limit)]', {
-      tooltip: partialScanTooltip,
       sampleCountComponent,
     });
   }
@@ -138,27 +85,6 @@ function _LowAccuracyFullTooltip({
         </div>
       }
       disabled={noSampling}
-      maxWidth={270}
-      showUnderline
-    >
-      {children}
-    </Tooltip>
-  );
-}
-
-function _PartialScanTooltip({children}: {children?: React.ReactNode}) {
-  return (
-    <Tooltip
-      title={
-        <div>
-          {t('We could not scan all available data due to time or resource limits.')}
-          <br />
-          <br />
-          {t(
-            'Try reducing your time range or removing filters to get more accurate trends.'
-          )}
-        </div>
-      }
       maxWidth={270}
       showUnderline
     >

--- a/static/app/views/explore/charts/index.spec.tsx
+++ b/static/app/views/explore/charts/index.spec.tsx
@@ -37,9 +37,7 @@ describe('ExploreCharts', () => {
         dataset={DiscoverDatasets.SPANS_EAP}
       />,
       {
-        organization: OrganizationFixture({
-          features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-        }),
+        organization: OrganizationFixture(),
       }
     );
 

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -13,7 +13,6 @@ import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {isTimeSeriesOther} from 'sentry/utils/timeSeries/isTimeSeriesOther';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
@@ -82,7 +81,6 @@ export function ExploreCharts({
   dataset,
 }: ExploreChartsProps) {
   const theme = useTheme();
-  const organization = useOrganization();
   const [interval, setInterval, intervalOptions] = useChartInterval();
   const topEvents = useTopEvents();
   const isTopN = defined(topEvents) && topEvents > 0;
@@ -204,11 +202,7 @@ export function ExploreCharts({
 
           if (chartInfo.loading) {
             const loadingMessage =
-              organization.features.includes(
-                'visibility-explore-progressive-loading-normal-sampling-mode'
-              ) &&
-              timeseriesResult.isFetching &&
-              samplingMode === SAMPLING_MODE.HIGH_ACCURACY
+              timeseriesResult.isFetching && samplingMode === SAMPLING_MODE.HIGH_ACCURACY
                 ? t(
                     "Hey, we're scanning all the data we can to answer your query, so please wait a bit longer"
                   )

--- a/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
+++ b/static/app/views/explore/charts/widgetExtrapolationFooter.tsx
@@ -4,7 +4,6 @@ import {IconArrow, IconCheckmark} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import useOrganization from 'sentry/utils/useOrganization';
 import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 
 export function WidgetExtrapolationFooter({
@@ -22,13 +21,7 @@ export function WidgetExtrapolationFooter({
   sampleCount: number;
   topEvents: number | undefined;
 }) {
-  const organization = useOrganization();
-  if (
-    ![DiscoverDatasets.SPANS_EAP, DiscoverDatasets.SPANS_EAP_RPC].includes(dataset) ||
-    organization.features.includes(
-      'visibility-explore-progressive-loading-normal-sampling-mode'
-    )
-  ) {
+  if (![DiscoverDatasets.SPANS_EAP, DiscoverDatasets.SPANS_EAP_RPC].includes(dataset)) {
     return (
       <ConfidenceFooter
         sampleCount={sampleCount}

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -86,11 +86,7 @@ describe('useExploreTimeseries', () => {
           limit: 10,
         }),
       {
-        wrapper: createWrapper(
-          OrganizationFixture({
-            features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-          })
-        ),
+        wrapper: createWrapper(OrganizationFixture()),
       }
     );
 

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -76,11 +76,7 @@ describe('useExploreTimeseries', () => {
           enabled: true,
         }),
       {
-        wrapper: createWrapper(
-          OrganizationFixture({
-            features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-          })
-        ),
+        wrapper: createWrapper(OrganizationFixture()),
       }
     );
 

--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -55,39 +55,6 @@ function createWrapper(org: Organization) {
 }
 
 describe('useProgressiveQuery', function () {
-  describe('Preflight -> Best Effort', function () {
-    let mockRequestUrl: jest.Mock;
-    beforeEach(function () {
-      mockRequestUrl = MockApiClient.addMockResponse({
-        url: '/test',
-        body: 'test',
-      });
-
-      jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-    });
-
-    it('makes a single request when the feature flag is disabled', function () {
-      renderHook(
-        () =>
-          useProgressiveQuery({
-            queryHookImplementation: useMockHookImpl,
-            queryHookArgs: {enabled: true},
-          }),
-        {wrapper: createWrapper(OrganizationFixture())}
-      );
-
-      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
-      expect(mockRequestUrl).toHaveBeenCalledWith(
-        '/test',
-        expect.objectContaining({
-          query: {
-            samplingMode: undefined,
-          },
-        })
-      );
-    });
-  });
-
   describe('normal sampling mode', function () {
     let mockNormalRequestUrl: jest.Mock;
     beforeEach(function () {
@@ -146,11 +113,7 @@ describe('useProgressiveQuery', function () {
             },
           }),
         {
-          wrapper: createWrapper(
-            OrganizationFixture({
-              features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-            })
-          ),
+          wrapper: createWrapper(OrganizationFixture()),
         }
       );
 
@@ -205,11 +168,7 @@ describe('useProgressiveQuery', function () {
             },
           }),
         {
-          wrapper: createWrapper(
-            OrganizationFixture({
-              features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-            })
-          ),
+          wrapper: createWrapper(OrganizationFixture()),
         }
       );
 

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.spec.tsx
@@ -115,11 +115,7 @@ describe('useMultiQueryTable', () => {
             yAxes: [],
           }),
         {
-          wrapper: createWrapper(
-            OrganizationFixture({
-              features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-            })
-          ),
+          wrapper: createWrapper(OrganizationFixture()),
         }
       );
 

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTimeseries.spec.tsx
@@ -89,11 +89,7 @@ describe('useMultiQueryTimeseries', () => {
           index: 0,
         }),
       {
-        wrapper: createWrapper(
-          OrganizationFixture({
-            features: ['visibility-explore-progressive-loading-normal-sampling-mode'],
-          })
-        ),
+        wrapper: createWrapper(OrganizationFixture()),
       }
     );
 


### PR DESCRIPTION
We should be using the normal -> high accuracy strategy by default now.