### PR TITLE
dev: Upgrade stripe to v6

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -204,7 +204,7 @@ sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
 sqlparse==0.5.0
 statsd==3.3.0
-stripe==5.5.0
+stripe==6.7.0
 structlog==22.1.0
 supervisor==4.2.5
 symbolic==12.14.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -141,7 +141,7 @@ snuba-sdk==3.0.43
 soupsieve==2.3.2.post1
 sqlparse==0.5.0
 statsd==3.3.0
-stripe==5.5.0
+stripe==6.7.0
 structlog==22.1.0
 symbolic==12.14.1
 tiktoken==0.8.0

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -11,4 +11,4 @@ iso3166
 pycountry==17.5.14
 pyvat==1.3.15
 reportlab==4.4.0
-stripe==5.5.0
+stripe==6.7.0


### PR DESCRIPTION
This PR aims to upgrade our stripe version from 5.5 -> 6.7

One interesting thing with this version is that now stripe pins the API to the latest version with each new version of the python SDK that gets released. We can "opt-out" of this by explicitly setting the API version to be whatever we want, allowing us to upgrade the python SDK independently of the stripe API. Which I _think_ will give us better typing on the SDK when we accurately type the code. And auto completion, etc.

[Notion](https://www.notion.so/sentry/Upgrading-Stripe-from-v3-to-latest-1c88b10e4b5d80adbf87f574c2929d27)

[Change log](https://github.com/stripe/stripe-python/blob/v6.7.0/CHANGELOG.md)

Our API version is pinned here: https://github.com/getsentry/getsentry/blob/084007241f7138359786fa0efa23dbf372be59f3/getsentry/settings.py#L29-L30

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
