### PR TITLE
chore(release): Update release code path codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -468,7 +468,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/auth/test_superuser.py                                    @getsentry/enterprise
 /tests/sentry/middleware/test_staff.py                                  @getsentry/enterprise
 /tests/sentry/tasks/integrations/github/                                @getsentry/enterprise
-/tests/sentry/models/releases/                                          @getsentry/replay-backend 
+/tests/sentry/models/releases/                                          @getsentry/replay-backend
 ## End of Enterprise
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,7 +176,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/views/settings/projectAlerts/                 @getsentry/alerts-notifications
 /static/app/views/alerts/                                 @getsentry/alerts-notifications
 /static/app/views/alerts/rules/uptime                     @getsentry/crons
-/static/app/views/releases/                               @getsentry/alerts-notifications
+/static/app/views/releases/                               @getsentry/replay-frontend
 /static/app/views/releases/drawer/                        @getsentry/replay-frontend
 /static/app/views/releases/releaseBubbles/                @getsentry/replay-frontend
 /src/sentry/rules/processing/delayed_processing.py        @getsentry/alerts-notifications
@@ -468,7 +468,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/auth/test_superuser.py                                    @getsentry/enterprise
 /tests/sentry/middleware/test_staff.py                                  @getsentry/enterprise
 /tests/sentry/tasks/integrations/github/                                @getsentry/enterprise
-/tests/sentry/models/releases/                                          @getsentry/alerts-notifications
+/tests/sentry/models/releases/                                          @getsentry/replay-frontend
 ## End of Enterprise
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -468,7 +468,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/auth/test_superuser.py                                    @getsentry/enterprise
 /tests/sentry/middleware/test_staff.py                                  @getsentry/enterprise
 /tests/sentry/tasks/integrations/github/                                @getsentry/enterprise
-/tests/sentry/models/releases/                                          @getsentry/replay-frontend
+/tests/sentry/models/releases/                                          @getsentry/replay-backend 
 ## End of Enterprise
 
 


### PR DESCRIPTION
The alerts and notifications team no longer owns releases so update the codeowners files to reflect the new owners.