### PR TITLE
fix(dashboards): Prevent release series triggering scroll to top of page

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -22,6 +22,7 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {IndexedEventsSelectionAlert} from 'sentry/views/dashboards/indexedEventsSelectionAlert';
 import type {
   DashboardDetails,
@@ -99,6 +100,7 @@ function AddToDashboardModal({
   allowCreateNewDashboard = true,
 }: Props) {
   const api = useApi();
+  const navigate = useNavigate();
   const [dashboards, setDashboards] = useState<DashboardListItem[] | null>(null);
   const [selectedDashboard, setSelectedDashboard] = useState<DashboardDetails | null>(
     null
@@ -240,7 +242,7 @@ function AddToDashboardModal({
 
   const widgetLegendState = new WidgetLegendSelectionState({
     location,
-    router,
+    navigate,
     organization,
     dashboard: selectedDashboard,
   });

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -59,7 +59,7 @@ async function renderModal({
     location: router.location,
     dashboard: DashboardFixture([widget], {id: 'new', title: 'Dashboard'}),
     organization,
-    router,
+    navigate: router.navigate,
   });
   const rendered = render(
     <div style={{padding: space(4)}}>
@@ -120,7 +120,7 @@ describe('Modals -> WidgetViewerModal', function () {
       location: initialData.router.location,
       dashboard: DashboardFixture([], {id: 'new', title: 'Dashboard'}),
       organization: initialData.organization,
-      router: initialData.router,
+      navigate: jest.fn(),
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/create.tsx
+++ b/static/app/views/dashboards/create.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useState} from 'react';
-import {useTheme} from '@emotion/react';
 
 import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
@@ -25,7 +24,6 @@ type Props = RouteComponentProps<{templateId?: string; widgetId?: string}> & {
 function CreateDashboard(props: Props) {
   const {location, organization} = props;
   const {templateId} = props.params;
-  const theme = useTheme();
   const [newWidget, setNewWidget] = useState<Widget | undefined>();
   function renderDisabled() {
     return (
@@ -61,7 +59,6 @@ function CreateDashboard(props: Props) {
       <ErrorBoundary>
         <DashboardDetail
           {...props}
-          theme={theme}
           initialState={initialState}
           dashboard={dashboard}
           dashboards={[]}

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -1,6 +1,5 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 import {ThemeFixture} from 'sentry-fixture/theme';
 import {UserFixture} from 'sentry-fixture/user';
@@ -73,7 +72,7 @@ describe('Dashboards > Dashboard', () => {
   const widgetLegendState = new WidgetLegendSelectionState({
     organization,
     dashboard: mockDashboard,
-    router: RouterFixture(),
+    navigate: jest.fn(),
     location: LocationFixture(),
   });
 

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -6,7 +6,6 @@ import {ReleaseFixture} from 'sentry-fixture/release';
 import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
-import {ThemeFixture} from 'sentry-fixture/theme';
 import {UserFixture} from 'sentry-fixture/user';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
@@ -2365,7 +2364,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.VIEW}
             dashboard={DashboardFixture([])}
             dashboards={[]}
@@ -2389,7 +2387,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.VIEW}
             dashboard={DashboardFixture([])}
             dashboards={[]}
@@ -2413,7 +2410,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.EDIT}
             dashboard={DashboardFixture([])}
             dashboards={[]}
@@ -2437,7 +2433,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.EDIT}
             dashboard={DashboardFixture([])}
             dashboards={[]}
@@ -2472,7 +2467,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.EDIT}
             dashboard={mockDashboard}
             dashboards={[]}
@@ -2520,7 +2514,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.EDIT}
             dashboard={mockDashboard}
             dashboards={[]}
@@ -2567,7 +2560,6 @@ describe('Dashboards > Detail', function () {
         render(
           <DashboardDetail
             {...RouteComponentPropsFixture()}
-            theme={ThemeFixture()}
             initialState={DashboardState.VIEW}
             dashboard={mockDashboard}
             dashboards={[]}
@@ -2623,7 +2615,6 @@ describe('Dashboards > Detail', function () {
         });
         render(
           <DashboardDetail
-            theme={ThemeFixture()}
             {...RouteComponentPropsFixture()}
             initialState={DashboardState.VIEW}
             dashboard={mockDashboard}

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -50,6 +50,8 @@ import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metr
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -116,6 +118,7 @@ type Props = RouteComponentProps<RouteParams> & {
   dashboard: DashboardDetails;
   dashboards: DashboardListItem[];
   initialState: DashboardState;
+  navigate: ReactRouter3Navigate;
   organization: Organization;
   projects: Project[];
   route: PlainRoute;
@@ -251,7 +254,7 @@ class DashboardDetail extends Component<Props, State> {
       dashboard: this.props.dashboard,
       organization: this.props.organization,
       location: this.props.location,
-      router: this.props.router,
+      navigate: this.props.navigate,
     }),
     isSavingDashboardFilters: false,
     isWidgetBuilderOpen: this.isRedesignedWidgetBuilder,
@@ -280,7 +283,7 @@ class DashboardDetail extends Component<Props, State> {
         widgetLegendState: new WidgetLegendSelectionState({
           organization: this.props.organization,
           location: this.props.location,
-          router: this.props.router,
+          navigate: this.props.navigate,
           dashboard: this.props.dashboard,
         }),
       });
@@ -1334,10 +1337,11 @@ const StyledPageHeader = styled('div')`
   }
 `;
 
-function DashboardDetailWithTheme(props: Props) {
+function DashboardDetailWithThemeAndNavigate(props: Omit<Props, 'theme' | 'navigate'>) {
   const theme = useTheme();
-  return <DashboardDetail {...props} theme={theme} />;
+  const navigate = useNavigate();
+  return <DashboardDetail {...props} theme={theme} navigate={navigate} />;
 }
 export default withPageFilters(
-  withProjects(withApi(withOrganization(DashboardDetailWithTheme)))
+  withProjects(withApi(withOrganization(DashboardDetailWithThemeAndNavigate)))
 );

--- a/static/app/views/dashboards/index.tsx
+++ b/static/app/views/dashboards/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import {useTheme} from '@emotion/react';
 
 import type {Client} from 'sentry/api';
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -23,7 +22,6 @@ type Props = RouteComponentProps & {
 
 function DashboardsV2Container(props: Props) {
   const {organization, children} = props;
-  const theme = useTheme();
 
   if (organization.features.includes('dashboards-edit')) {
     return <Fragment>{children}</Fragment>;
@@ -40,7 +38,6 @@ function DashboardsV2Container(props: Props) {
               <DashboardDetail
                 {...props}
                 key={dashboard.id}
-                theme={theme}
                 initialState={DashboardState.VIEW}
                 dashboard={dashboard}
                 dashboards={dashboards}

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -1,7 +1,6 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
-import {ThemeFixture} from 'sentry-fixture/theme';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -83,7 +82,6 @@ describe('OrgDashboards', () => {
         {({dashboard, dashboards}) => {
           return dashboard ? (
             <DashboardDetail
-              theme={ThemeFixture()}
               api={api}
               initialState={DashboardState.VIEW}
               dashboard={dashboard}
@@ -147,7 +145,6 @@ describe('OrgDashboards', () => {
         {({dashboard, dashboards}) => {
           return dashboard ? (
             <DashboardDetail
-              theme={ThemeFixture()}
               api={api}
               initialState={DashboardState.VIEW}
               dashboard={dashboard}
@@ -220,7 +217,6 @@ describe('OrgDashboards', () => {
         {({dashboard, dashboards}) => {
           return dashboard ? (
             <DashboardDetail
-              theme={ThemeFixture()}
               api={api}
               initialState={DashboardState.VIEW}
               dashboard={dashboard}
@@ -250,7 +246,6 @@ describe('OrgDashboards', () => {
         {({dashboard, dashboards}) => {
           return dashboard ? (
             <DashboardDetail
-              theme={ThemeFixture()}
               api={api}
               initialState={DashboardState.VIEW}
               dashboard={dashboard}
@@ -297,7 +292,6 @@ describe('OrgDashboards', () => {
         {({dashboard, dashboards}) => {
           return dashboard ? (
             <DashboardDetail
-              theme={ThemeFixture()}
               api={api}
               initialState={DashboardState.VIEW}
               dashboard={dashboard}
@@ -319,7 +313,6 @@ describe('OrgDashboards', () => {
         {({dashboard, dashboards}) => {
           return dashboard ? (
             <DashboardDetail
-              theme={ThemeFixture()}
               api={api}
               initialState={DashboardState.VIEW}
               dashboard={dashboard}

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useState} from 'react';
-import {useTheme} from '@emotion/react';
 import pick from 'lodash/pick';
 
 import {updateDashboardVisit} from 'sentry/actionCreators/dashboards';
@@ -42,7 +41,6 @@ type Props = RouteComponentProps<{
 
 function ViewEditDashboard(props: Props) {
   const api = useApi();
-  const theme = useTheme();
   const organization = useOrganization();
 
   const {params, location} = props;
@@ -81,7 +79,6 @@ function ViewEditDashboard(props: Props) {
               <DashboardDetail
                 {...props}
                 key={dashboard.id}
-                theme={theme}
                 organization={organization}
                 initialState={dashboardInitialState}
                 dashboard={dashboard}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -112,7 +112,7 @@ describe('VisualizationStep', function () {
     location: LocationFixture(),
     dashboard: DashboardFixture([], {id: 'new', title: 'Dashboard'}),
     organization,
-    router,
+    navigate: jest.fn(),
   });
 
   beforeEach(function () {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -2,9 +2,9 @@ import PanelAlert from 'sentry/components/panels/panelAlert';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useRouter from 'sentry/utils/useRouter';
 import {
   type DashboardDetails,
   type DashboardFilters,
@@ -36,7 +36,7 @@ function WidgetPreview({
 }: WidgetPreviewProps) {
   const organization = useOrganization();
   const location = useLocation();
-  const router = useRouter();
+  const navigate = useNavigate();
   const pageFilters = usePageFilters();
 
   const {state} = useWidgetBuilderContext();
@@ -47,7 +47,7 @@ function WidgetPreview({
     location,
     organization,
     dashboard,
-    router,
+    navigate,
   });
 
   // TODO: The way we create the widget here does not propagate a widget ID

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -3,6 +3,7 @@ import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
@@ -13,6 +14,7 @@ interface WidgetBuilderProps extends React.ComponentProps<typeof WidgetBuilder> 
 
 function WidgetBuilderContainer(props: WidgetBuilderProps) {
   const organization = useOrganization();
+  const navigate = useNavigate();
 
   return (
     <Feature
@@ -37,7 +39,7 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
               location: props.location,
               organization,
               dashboard: props.dashboard,
-              router: props.router,
+              navigate,
             })
           }
         />

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -92,7 +92,7 @@ describe('Dashboards > WidgetCard', function () {
     location: LocationFixture(),
     dashboard: DashboardFixture([multipleQueryWidget]),
     organization,
-    router,
+    navigate: jest.fn(),
   });
 
   beforeEach(function () {

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
@@ -78,7 +78,7 @@ describe('Dashboards > IssueWidgetCard', function () {
     location: LocationFixture(),
     dashboard: DashboardFixture([widget]),
     organization,
-    router,
+    navigate: jest.fn(),
   });
 
   beforeEach(function () {

--- a/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
@@ -63,7 +63,7 @@ describe('WidgetLegend functions util', () => {
         dashboard,
         location,
         organization,
-        router,
+        navigate: jest.fn(),
       });
     });
 

--- a/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.spec.tsx
@@ -2,9 +2,7 @@ import type {Location} from 'history';
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import type {DashboardDetails, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -22,8 +20,9 @@ describe('WidgetLegend functions util', () => {
     let location: Location;
     let organization: Organization;
     let dashboard: DashboardDetails;
-    let router: InjectedRouter;
+    let mockNavigate: jest.Mock;
     beforeEach(() => {
+      mockNavigate = jest.fn();
       widget = {
         id: '12345',
         title: 'Test Query',
@@ -55,15 +54,11 @@ describe('WidgetLegend functions util', () => {
         ...DashboardFixture([widget, {...widget, id: '23456'}]),
       };
 
-      router = {
-        ...RouterFixture({location}),
-      };
-
       legendFunctions = new WidgetLegendSelectionState({
         dashboard,
         location,
         organization,
-        navigate: jest.fn(),
+        navigate: mockNavigate,
       });
     });
 
@@ -75,9 +70,12 @@ describe('WidgetLegend functions util', () => {
 
     it('updates legend query param when legend option toggled', () => {
       legendFunctions.setWidgetSelectionState({'Releases:12345': true}, widget);
-      expect(router.replace).toHaveBeenCalledWith({
-        query: {unselectedSeries: [`12345${WIDGET_ID_DELIMITER}`]},
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {unselectedSeries: [`12345${WIDGET_ID_DELIMITER}`]},
+        }),
+        {preventScrollReset: true, replace: true}
+      );
     });
 
     it('updates legend query param when legend option toggled but not in query params', () => {
@@ -90,9 +88,12 @@ describe('WidgetLegend functions util', () => {
         },
         widget
       );
-      expect(router.replace).toHaveBeenCalledWith({
-        query: {unselectedSeries: [`12345${WIDGET_ID_DELIMITER}Releases`]},
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: {unselectedSeries: [`12345${WIDGET_ID_DELIMITER}Releases`]},
+        }),
+        {preventScrollReset: true, replace: true}
+      );
     });
 
     it('gives updated query param when widget change submitted', () => {

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -1,8 +1,8 @@
 import type {Location} from 'history';
 
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {decodeList} from 'sentry/utils/queryString';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 
 import {type DashboardDetails, DisplayType, type Widget} from './types';
@@ -10,8 +10,8 @@ import {type DashboardDetails, DisplayType, type Widget} from './types';
 type Props = {
   dashboard: DashboardDetails | null;
   location: Location;
+  navigate: ReactRouter3Navigate;
   organization: Organization;
-  router: InjectedRouter;
 };
 
 type LegendSelection = Record<string, boolean>;
@@ -25,18 +25,22 @@ class WidgetLegendSelectionState {
   dashboard: DashboardDetails | null;
   location: Location;
   organization: Organization;
-  router: InjectedRouter;
+  navigate: ReactRouter3Navigate;
 
   constructor(props: Props) {
     this.dashboard = props.dashboard;
     this.location = props.location;
     this.organization = props.organization;
-    this.router = props.router;
+    this.navigate = props.navigate;
   }
 
   // Updates legend param when a legend selection has been changed
   setWidgetSelectionState(selected: LegendSelection, widget: Widget) {
-    const [dashboard, location, router] = [this.dashboard, this.location, this.router];
+    const [dashboard, location, navigate] = [
+      this.dashboard,
+      this.location,
+      this.navigate,
+    ];
     const widgets = dashboard ? dashboard.widgets : [];
     let newLegendQuery: string[];
     if (!location.query.unselectedSeries && widgets) {
@@ -58,12 +62,16 @@ class WidgetLegendSelectionState {
         Object.values(selected).filter(value => value === false).length === 1;
 
       if (thisWidgetWithReleasesWasSelected || thisWidgetWithoutReleasesWasSelected) {
-        router.replace({
-          query: {
-            ...location.query,
-            unselectedSeries: newLegendQuery,
+        navigate(
+          {
+            ...location,
+            query: {
+              ...location.query,
+              unselectedSeries: newLegendQuery,
+            },
           },
-        });
+          {preventScrollReset: true}
+        );
       }
     } else if (Array.isArray(location.query.unselectedSeries)) {
       let isInQuery = false;
@@ -83,30 +91,42 @@ class WidgetLegendSelectionState {
             ...location.query.unselectedSeries,
             this.encodeLegendQueryParam(widget, selected),
           ];
-      router.replace({
-        query: {
-          ...location.query,
-          unselectedSeries,
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            unselectedSeries,
+          },
         },
-      });
+        {preventScrollReset: true}
+      );
     } else {
       if (location.query.unselectedSeries?.includes(widget.id!)) {
-        router.replace({
-          query: {
-            ...location.query,
-            unselectedSeries: [this.encodeLegendQueryParam(widget, selected)],
+        navigate(
+          {
+            ...location,
+            query: {
+              ...location.query,
+              unselectedSeries: [this.encodeLegendQueryParam(widget, selected)],
+            },
           },
-        });
+          {preventScrollReset: true}
+        );
       } else {
-        router.replace({
-          query: {
-            ...location.query,
-            unselectedSeries: [
-              location.query.unselectedSeries,
-              this.encodeLegendQueryParam(widget, selected),
-            ],
+        navigate(
+          {
+            ...location,
+            query: {
+              ...location.query,
+              unselectedSeries: [
+                location.query.unselectedSeries,
+                this.encodeLegendQueryParam(widget, selected),
+              ],
+            },
           },
-        });
+          {preventScrollReset: true}
+        );
       }
     }
   }

--- a/static/app/views/dashboards/widgetLegendSelectionState.tsx
+++ b/static/app/views/dashboards/widgetLegendSelectionState.tsx
@@ -70,7 +70,7 @@ class WidgetLegendSelectionState {
               unselectedSeries: newLegendQuery,
             },
           },
-          {preventScrollReset: true}
+          {replace: true, preventScrollReset: true}
         );
       }
     } else if (Array.isArray(location.query.unselectedSeries)) {
@@ -99,7 +99,7 @@ class WidgetLegendSelectionState {
             unselectedSeries,
           },
         },
-        {preventScrollReset: true}
+        {replace: true, preventScrollReset: true}
       );
     } else {
       if (location.query.unselectedSeries?.includes(widget.id!)) {
@@ -111,7 +111,7 @@ class WidgetLegendSelectionState {
               unselectedSeries: [this.encodeLegendQueryParam(widget, selected)],
             },
           },
-          {preventScrollReset: true}
+          {replace: true, preventScrollReset: true}
         );
       } else {
         navigate(
@@ -125,7 +125,7 @@ class WidgetLegendSelectionState {
               ],
             },
           },
-          {preventScrollReset: true}
+          {replace: true, preventScrollReset: true}
         );
       }
     }


### PR DESCRIPTION
Inside `static/app/views/organizationLayout/index.tsx` there's a component that's added called `ScrollRestoration`, this causes all navigations to scroll to the top of the page. We don't want this behaviour when URL params such as the legend series are toggled on/off.

docs for `ScrollRestoration`: https://reactrouter.com/6.30.0/components/scroll-restoration

The old code was using `router.replace` but now I've passed down the new `navigate` method from `useNavigate` and set it to prevent scrolling when series are toggled.