### PR TITLE
chore(eap): Remove alerts/dashboards eap flag

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.spec.tsx
@@ -9,7 +9,7 @@ import type {AlertType} from 'sentry/views/alerts/wizard/options';
 describe('RuleConditionsForm', () => {
   const {organization, projects, router} = initializeOrg({
     organization: {
-      features: ['search-query-builder-alerts', 'alerts-eap'],
+      features: ['search-query-builder-alerts', 'visibility-explore-view'],
     },
   });
   ProjectsStore.loadInitialData(projects);
@@ -88,7 +88,7 @@ describe('RuleConditionsForm', () => {
       {
         organization: {
           ...organization,
-          features: ['search-query-builder-alerts', 'alerts-eap'],
+          features: ['search-query-builder-alerts', 'visibility-explore-view'],
         },
       }
     );

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -524,7 +524,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
             <SpanTagsProvider
               dataset={DiscoverDatasets.SPANS_EAP}
               enabled={
-                organization.features.includes('alerts-eap') &&
+                organization.features.includes('visibility-explore-view') &&
                 alertType === 'eap_metrics'
               }
             >

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -213,7 +213,7 @@ describe('Incident Rules Create', () => {
 
   it('does a 7 day query for confidence data on the EAP dataset', async () => {
     const {organization, project, router} = initializeOrg({
-      organization: {features: ['alerts-eap']},
+      organization: {features: ['visibility-explore-view']},
     });
 
     render(

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.spec.tsx
@@ -16,7 +16,7 @@ describe('DataSetStep', () => {
       />,
       {
         organization: OrganizationFixture({
-          features: ['dashboards-eap'],
+          features: ['visibility-explore-view'],
         }),
       }
     );

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -94,7 +94,7 @@ export function DataSetStep({
     datasetChoices.set(DataSet.EVENTS, t('Errors and Transactions'));
   }
 
-  if (organization.features.includes('dashboards-eap')) {
+  if (organization.features.includes('visibility-explore-view')) {
     datasetChoices.set(
       DataSet.SPANS,
       <FeatureBadgeAlignmentWrapper aria-label={t('Spans')}>

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -25,7 +25,7 @@ function WidgetBuilderDatasetSelector() {
   datasetChoices.push([WidgetType.ERRORS, t('Errors')]);
   datasetChoices.push([WidgetType.TRANSACTIONS, t('Transactions')]);
 
-  if (organization.features.includes('dashboards-eap')) {
+  if (organization.features.includes('visibility-explore-view')) {
     datasetChoices.push([WidgetType.SPANS, t('Spans')]);
   }
   datasetChoices.push([WidgetType.ISSUE, t('Issues')]);

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -11,7 +11,7 @@ import WidgetBuilderV2 from 'sentry/views/dashboards/widgetBuilder/components/ne
 
 const {organization, projects, router} = initializeOrg({
   organization: {
-    features: ['global-views', 'open-membership', 'dashboards-eap'],
+    features: ['global-views', 'open-membership', 'visibility-explore-view'],
   },
   projects: [
     {id: '1', slug: 'project-1', isMember: true},

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -165,7 +165,7 @@ function WidgetBuilderV2({
                 >
                   <SpanTagsProvider
                     dataset={DiscoverDatasets.SPANS_EAP}
-                    enabled={organization.features.includes('dashboards-eap')}
+                    enabled={organization.features.includes('visibility-explore-view')}
                   >
                     <ContainerWithoutSidebar
                       sidebarCollapsed={sidebarCollapsed}

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -23,7 +23,9 @@ describe('WidgetBuilderSortBySelector', function () {
   let router: InjectedRouter<Record<string, string | undefined>, any>;
   beforeEach(function () {
     const setupOrg = initializeOrg({
-      organization: {features: ['global-views', 'open-membership', 'dashboards-eap']},
+      organization: {
+        features: ['global-views', 'open-membership', 'visibility-explore-view'],
+      },
       projects: [],
       router: {
         location: {
@@ -225,7 +227,9 @@ describe('WidgetBuilderSortBySelector', function () {
     });
 
     const setupOrg = initializeOrg({
-      organization: {features: ['global-views', 'open-membership', 'dashboards-eap']},
+      organization: {
+        features: ['global-views', 'open-membership', 'visibility-explore-view'],
+      },
       projects: [],
       router: {
         location: {

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -28,7 +28,7 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
     >
       <SpanTagsProvider
         dataset={DiscoverDatasets.SPANS_EAP}
-        enabled={organization.features.includes('dashboards-eap')}
+        enabled={organization.features.includes('visibility-explore-view')}
       >
         <WidgetBuilder
           {...props}

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -58,44 +58,40 @@ function ChartContextMenu({
 
   const items: MenuItemProps[] = [];
 
-  if (organization.features.includes('alerts-eap')) {
-    items.push({
-      key: 'create-alert',
-      label: t('Create an alert for'),
-      children: alertsUrls ?? [],
-      disabled: !alertsUrls || alertsUrls.length === 0,
-      isSubmenu: true,
-    });
-  }
+  items.push({
+    key: 'create-alert',
+    label: t('Create an alert for'),
+    children: alertsUrls ?? [],
+    disabled: !alertsUrls || alertsUrls.length === 0,
+    isSubmenu: true,
+  });
 
-  if (organization.features.includes('dashboards-eap')) {
-    const disableAddToDashboard = !organization.features.includes('dashboards-edit');
-    items.push({
-      key: 'add-to-dashboard',
-      textValue: t('Add to Dashboard'),
-      label: (
-        <Feature
-          hookName="feature-disabled:dashboards-edit"
-          features="organizations:dashboards-edit"
-          renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
-        >
-          {t('Add to Dashboard')}
-        </Feature>
-      ),
-      disabled: disableAddToDashboard,
-      onAction: () => {
-        if (disableAddToDashboard) {
-          return undefined;
-        }
-        trackAnalytics('trace_explorer.save_as', {
-          save_type: 'dashboard',
-          ui_source: 'chart',
-          organization,
-        });
-        return addToDashboard(visualizeIndex);
-      },
-    });
-  }
+  const disableAddToDashboard = !organization.features.includes('dashboards-edit');
+  items.push({
+    key: 'add-to-dashboard',
+    textValue: t('Add to Dashboard'),
+    label: (
+      <Feature
+        hookName="feature-disabled:dashboards-edit"
+        features="organizations:dashboards-edit"
+        renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
+      >
+        {t('Add to Dashboard')}
+      </Feature>
+    ),
+    disabled: disableAddToDashboard,
+    onAction: () => {
+      if (disableAddToDashboard) {
+        return undefined;
+      }
+      trackAnalytics('trace_explorer.save_as', {
+        save_type: 'dashboard',
+        ui_source: 'chart',
+        organization,
+      });
+      return addToDashboard(visualizeIndex);
+    },
+  });
 
   if (items.length === 0) {
     return null;

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -191,7 +191,7 @@ export function MultiQueryModeChart({
       ? projects[0]
       : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
-  if (organization.features.includes('alerts-eap') && defined(yAxes[0])) {
+  if (defined(yAxes[0])) {
     items.push({
       key: 'create-alert',
       textValue: t('Create an Alert'),
@@ -215,34 +215,32 @@ export function MultiQueryModeChart({
     });
   }
 
-  if (organization.features.includes('dashboards-eap')) {
-    const disableAddToDashboard = !organization.features.includes('dashboards-edit');
-    items.push({
-      key: 'add-to-dashboard',
-      textValue: t('Add to Dashboard'),
-      label: (
-        <Feature
-          hookName="feature-disabled:dashboards-edit"
-          features="organizations:dashboards-edit"
-          renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
-        >
-          {t('Add to Dashboard')}
-        </Feature>
-      ),
-      disabled: disableAddToDashboard,
-      onAction: () => {
-        if (disableAddToDashboard) {
-          return undefined;
-        }
-        trackAnalytics('trace_explorer.save_as', {
-          save_type: 'dashboard',
-          ui_source: 'compare chart',
-          organization,
-        });
-        return addToDashboard();
-      },
-    });
-  }
+  const disableAddToDashboard = !organization.features.includes('dashboards-edit');
+  items.push({
+    key: 'add-to-dashboard',
+    textValue: t('Add to Dashboard'),
+    label: (
+      <Feature
+        hookName="feature-disabled:dashboards-edit"
+        features="organizations:dashboards-edit"
+        renderDisabled={() => <DisabledText>{t('Add to Dashboard')}</DisabledText>}
+      >
+        {t('Add to Dashboard')}
+      </Feature>
+    ),
+    disabled: disableAddToDashboard,
+    onAction: () => {
+      if (disableAddToDashboard) {
+        return undefined;
+      }
+      trackAnalytics('trace_explorer.save_as', {
+        save_type: 'dashboard',
+        ui_source: 'compare chart',
+        organization,
+      });
+      return addToDashboard();
+    },
+  });
 
   const DataPlottableConstructor =
     chartInfo.chartType === ChartType.LINE

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('sentry/actionCreators/modal');
 
 describe('ExploreToolbar', function () {
   const organization = OrganizationFixture({
-    features: ['alerts-eap', 'dashboards-eap', 'dashboards-edit'],
+    features: ['dashboards-edit'],
   });
 
   beforeEach(function () {

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -138,61 +138,29 @@ export function ToolbarSaveAs() {
     },
   });
 
-  if (organization.features.includes('alerts-eap')) {
-    items.push({
-      key: 'create-alert',
-      label: t('An Alert for'),
-      textValue: t('An Alert for'),
-      children: alertsUrls ?? [],
-      disabled: !alertsUrls || alertsUrls.length === 0,
-      isSubmenu: true,
+  items.push({
+    key: 'create-alert',
+    label: t('An Alert for'),
+    textValue: t('An Alert for'),
+    children: alertsUrls ?? [],
+    disabled: !alertsUrls || alertsUrls.length === 0,
+    isSubmenu: true,
+  });
+
+  const disableAddToDashboard = !organization.features.includes('dashboards-edit');
+
+  const chartOptions = visualizes.map((chart, index) => {
+    const dedupedYAxes = dedupeArray(chart.yAxes);
+    const formattedYAxes = dedupedYAxes.map(yaxis => {
+      const func = parseFunction(yaxis);
+      return func ? prettifyParsedFunction(func) : undefined;
     });
-  }
 
-  if (organization.features.includes('dashboards-eap')) {
-    const disableAddToDashboard = !organization.features.includes('dashboards-edit');
-
-    const chartOptions = visualizes.map((chart, index) => {
-      const dedupedYAxes = dedupeArray(chart.yAxes);
-      const formattedYAxes = dedupedYAxes.map(yaxis => {
-        const func = parseFunction(yaxis);
-        return func ? prettifyParsedFunction(func) : undefined;
-      });
-
-      return {
-        key: chart.label,
-        label: t('%s - %s', chart.label, formattedYAxes.filter(Boolean).join(', ')),
-        onAction: () => {
-          if (disableAddToDashboard) {
-            return undefined;
-          }
-
-          trackAnalytics('trace_explorer.save_as', {
-            save_type: 'dashboard',
-            ui_source: 'toolbar',
-            organization,
-          });
-          return addToDashboard(index);
-        },
-      };
-    });
-    items.push({
-      key: 'add-to-dashboard',
-      textValue: t('A Dashboard widget'),
-      isSubmenu: chartOptions.length > 1 ? true : false,
-      label: (
-        <Feature
-          hookName="feature-disabled:dashboards-edit"
-          features="organizations:dashboards-edit"
-          renderDisabled={() => <DisabledText>{t('A Dashboard widget')}</DisabledText>}
-        >
-          {t('A Dashboard widget')}
-        </Feature>
-      ),
-      disabled: disableAddToDashboard,
-      children: chartOptions.length > 1 ? chartOptions : undefined,
+    return {
+      key: chart.label,
+      label: t('%s - %s', chart.label, formattedYAxes.filter(Boolean).join(', ')),
       onAction: () => {
-        if (disableAddToDashboard || chartOptions.length > 1) {
+        if (disableAddToDashboard) {
           return undefined;
         }
 
@@ -201,10 +169,38 @@ export function ToolbarSaveAs() {
           ui_source: 'toolbar',
           organization,
         });
-        return addToDashboard(0);
+        return addToDashboard(index);
       },
-    });
-  }
+    };
+  });
+  items.push({
+    key: 'add-to-dashboard',
+    textValue: t('A Dashboard widget'),
+    isSubmenu: chartOptions.length > 1 ? true : false,
+    label: (
+      <Feature
+        hookName="feature-disabled:dashboards-edit"
+        features="organizations:dashboards-edit"
+        renderDisabled={() => <DisabledText>{t('A Dashboard widget')}</DisabledText>}
+      >
+        {t('A Dashboard widget')}
+      </Feature>
+    ),
+    disabled: disableAddToDashboard,
+    children: chartOptions.length > 1 ? chartOptions : undefined,
+    onAction: () => {
+      if (disableAddToDashboard || chartOptions.length > 1) {
+        return undefined;
+      }
+
+      trackAnalytics('trace_explorer.save_as', {
+        save_type: 'dashboard',
+        ui_source: 'toolbar',
+        organization,
+      });
+      return addToDashboard(0);
+    },
+  });
 
   const shouldHighlightSaveButton = useMemo(() => {
     if (isLoadingSavedQuery || savedQuery === undefined || savedQuery?.isPrebuilt) {

--- a/static/app/views/insights/common/utils/hasEAPAlerts.tsx
+++ b/static/app/views/insights/common/utils/hasEAPAlerts.tsx
@@ -1,5 +1,5 @@
 import type {Organization} from 'sentry/types/organization';
 
 export function hasEAPAlerts(organization: Organization): boolean {
-  return organization.features.includes('alerts-eap');
+  return organization.features.includes('visibility-explore-view');
 }


### PR DESCRIPTION
These flags are the same as visibility-explore-view. So consolidate them. In the future, we may revamp it and make a single flag for all eap spans based views.