### PR TITLE
feat(insights): add analytics event when eap is toggled

### DIFF
--- a/static/app/utils/analytics/insightAnalyticEvents.tsx
+++ b/static/app/utils/analytics/insightAnalyticEvents.tsx
@@ -1,4 +1,5 @@
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
+import type {ModuleName} from 'sentry/views/insights/types';
 
 export type InsightEventParameters = {
   'insight.app_start.select_start_type': {type: string};
@@ -40,6 +41,11 @@ export type InsightEventParameters = {
   'insight.vital.overview.toggle_tab': {tab: string};
   'insight.vital.select_browser_value': {browsers: string[]};
   'insight.vital.vital_sidebar_opened': {vital: string};
+  'insights.eap.toggle': {
+    isEapEnabled: boolean;
+    page: ModuleName | 'overview';
+    view: DomainView | undefined;
+  };
   'insights.page_loads.overview': {domain: DomainView | undefined; platforms: string[]};
   'insights.session_health_tour.dismissed': Record<string, unknown>;
 };
@@ -89,4 +95,5 @@ export const insightEventMap: Record<InsightEventKey, string | null> = {
   'insight.general.select_region_value': 'Insights: Select value in region selector',
   'insight.general.create_alert': 'Insights: Create Alert clicked',
   'insights.session_health_tour.dismissed': 'Insights: Session Health Tour Dismissed',
+  'insights.eap.toggle': 'Insights: EAP Toggle',
 };

--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -14,6 +14,7 @@ import {TabList} from 'sentry/components/tabs';
 import type {TabListItemProps} from 'sentry/components/tabs/item';
 import {IconBusiness, IconLab} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -26,6 +27,7 @@ import {
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
 import {useIsNextJsInsightsEnabled} from 'sentry/views/insights/pages/platform/nextjs/features';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   isModuleConsideredNew,
   isModuleEnabled,
@@ -67,10 +69,17 @@ export function DomainViewHeader({
   const isLaravelInsightsAvailable = useIsLaravelInsightsAvailable();
   const [isNextJsInsightsEnabled] = useIsNextJsInsightsEnabled();
   const useEap = useInsightsEap();
+  const {view} = useDomainViewFilters();
   const hasEapFlag = organization.features.includes('insights-modules-use-eap');
 
   const toggleUseEap = () => {
     const newState = !useEap;
+    trackAnalytics('insights.eap.toggle', {
+      organization,
+      isEapEnabled: newState,
+      page: selectedModule || 'overview',
+      view,
+    });
 
     navigate({
       ...location,


### PR DESCRIPTION
Track when eap is toggled or un-toggled in insights so we know if users are switching off of the dataset or not.