### PR TITLE
ref(dashboards): Add `TimeSeries` `interval` property

### DIFF
--- a/static/app/utils/timeSeries/getTimeSeriesInterval.tsx
+++ b/static/app/utils/timeSeries/getTimeSeriesInterval.tsx
@@ -3,9 +3,9 @@ import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 /**
  * The interval of a TimeSeries is the difference in the timestamps between the data points. This function only works for zerofilled `TimeSeries` objects, which in practice should be all of them. This function is only useful when converting older-style server responses to newer-styled responses, since newer style responses return the interval as part of the response meta.
  */
-export function getTimeSeriesInterval(timeSeries: TimeSeries): number {
-  const penultimateDatum = timeSeries.values.at(-2);
-  const finalDatum = timeSeries.values.at(-1);
+export function getTimeSeriesInterval(timeSeriesValues: TimeSeries['values']): number {
+  const penultimateDatum = timeSeriesValues.at(-2);
+  const finalDatum = timeSeriesValues.at(-1);
 
   let bucketSize = 0;
   if (penultimateDatum && finalDatum) {

--- a/static/app/utils/timeSeries/getTimeSeriesInterval.tsx
+++ b/static/app/utils/timeSeries/getTimeSeriesInterval.tsx
@@ -1,0 +1,18 @@
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+
+/**
+ * The interval of a TimeSeries is the difference in the timestamps between the data points. This function only works for zerofilled `TimeSeries` objects, which in practice should be all of them. This function is only useful when converting older-style server responses to newer-styled responses, since newer style responses return the interval as part of the response meta.
+ */
+export function getTimeSeriesInterval(timeSeries: TimeSeries): number {
+  const penultimateDatum = timeSeries.values.at(-2);
+  const finalDatum = timeSeries.values.at(-1);
+
+  let bucketSize = 0;
+  if (penultimateDatum && finalDatum) {
+    bucketSize =
+      new Date(finalDatum.timestamp).getTime() -
+      new Date(penultimateDatum.timestamp).getTime();
+  }
+
+  return bucketSize;
+}

--- a/static/app/utils/timeSeries/markDelayedData.tsx
+++ b/static/app/utils/timeSeries/markDelayedData.tsx
@@ -11,7 +11,7 @@ export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeri
     return timeSeries;
   }
 
-  const bucketSize = getTimeSeriesInterval(timeSeries);
+  const bucketSize = getTimeSeriesInterval(timeSeries.values);
 
   const ingestionDelayTimestamp = Date.now() - delay * 1000;
 

--- a/static/app/utils/timeSeries/markDelayedData.tsx
+++ b/static/app/utils/timeSeries/markDelayedData.tsx
@@ -4,14 +4,12 @@
 
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
-import {getTimeSeriesInterval} from './getTimeSeriesInterval';
-
 export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeries {
   if (delay === 0) {
     return timeSeries;
   }
 
-  const bucketSize = getTimeSeriesInterval(timeSeries.values);
+  const bucketSize = timeSeries.meta.interval;
 
   const ingestionDelayTimestamp = Date.now() - delay * 1000;
 

--- a/static/app/utils/timeSeries/markDelayedData.tsx
+++ b/static/app/utils/timeSeries/markDelayedData.tsx
@@ -4,12 +4,14 @@
 
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
+import {getTimeSeriesInterval} from './getTimeSeriesInterval';
+
 export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeries {
   if (delay === 0) {
     return timeSeries;
   }
 
-  const bucketSize = getTimeSeriesBucketSize(timeSeries);
+  const bucketSize = getTimeSeriesInterval(timeSeries);
 
   const ingestionDelayTimestamp = Date.now() - delay * 1000;
 
@@ -28,18 +30,4 @@ export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeri
       };
     }),
   };
-}
-
-function getTimeSeriesBucketSize(timeSeries: TimeSeries): number {
-  const penultimateDatum = timeSeries.values.at(-2);
-  const finalDatum = timeSeries.values.at(-1);
-
-  let bucketSize = 0;
-  if (penultimateDatum && finalDatum) {
-    bucketSize =
-      new Date(finalDatum.timestamp).getTime() -
-      new Date(penultimateDatum.timestamp).getTime();
-  }
-
-  return bucketSize;
 }

--- a/static/app/utils/timeSeries/scaleTimeSeriesData.spec.tsx
+++ b/static/app/utils/timeSeries/scaleTimeSeriesData.spec.tsx
@@ -16,6 +16,7 @@ describe('scaleTimeSeriesData', () => {
       meta: {
         valueType: 'string',
         valueUnit: null,
+        interval: 800,
       },
     };
 
@@ -39,6 +40,7 @@ describe('scaleTimeSeriesData', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.SECOND,
+        interval: 800,
       },
     };
 
@@ -57,6 +59,7 @@ describe('scaleTimeSeriesData', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.SECOND,
+        interval: 800,
       },
     };
 
@@ -71,6 +74,7 @@ describe('scaleTimeSeriesData', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.MILLISECOND,
+        interval: 800,
       },
     });
   });
@@ -87,6 +91,7 @@ describe('scaleTimeSeriesData', () => {
       meta: {
         valueType: 'size',
         valueUnit: SizeUnit.MEBIBYTE,
+        interval: 800,
       },
     };
 
@@ -101,6 +106,7 @@ describe('scaleTimeSeriesData', () => {
       meta: {
         valueType: 'size',
         valueUnit: SizeUnit.BYTE,
+        interval: 800,
       },
     });
   });

--- a/static/app/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete.spec.tsx
+++ b/static/app/utils/timeSeries/splitSeriesIntoCompleteAndIncomplete.spec.tsx
@@ -34,6 +34,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.MILLISECOND,
+        interval: 1 * 1000,
       },
     };
 
@@ -84,6 +85,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.MILLISECOND,
+        interval: 5 * 1000,
       },
     };
 
@@ -142,6 +144,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.MILLISECOND,
+        interval: 1 * 60 * 1000,
       },
     };
 
@@ -207,6 +210,7 @@ describe('splitSeriesIntoCompleteAndIncomplete', () => {
       meta: {
         valueType: 'duration',
         valueUnit: DurationUnit.MILLISECOND,
+        interval: 1 * 60 * 60 * 1000,
       },
     };
 

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -21,6 +21,10 @@ type AttributeValueUnit = DataUnit | null;
 type TimeSeriesValueType = AttributeValueType;
 export type TimeSeriesValueUnit = AttributeValueUnit;
 export type TimeSeriesMeta = {
+  /**
+   * Difference between the timestamps of the datapoints, in milliseconds
+   */
+  interval: number;
   valueType: TimeSeriesValueType;
   valueUnit: TimeSeriesValueUnit;
   isOther?: boolean;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleDurationTimeSeries.ts
@@ -6,6 +6,7 @@ export const sampleDurationTimeSeries: TimeSeries = {
   meta: {
     valueType: 'duration',
     valueUnit: DurationUnit.MILLISECOND,
+    interval: 1_800_000, // 30 minutes
   },
   values: [
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleScoreTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleScoreTimeSeries.ts
@@ -5,6 +5,7 @@ export const sampleScoreTimeSeries: TimeSeries = {
   meta: {
     valueType: 'score',
     valueUnit: null,
+    interval: 1_800_000, // 30 minutes
   },
   values: [
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries.ts
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/fixtures/sampleThroughputTimeSeries.ts
@@ -6,6 +6,7 @@ export const sampleThroughputTimeSeries: TimeSeries = {
   meta: {
     valueType: 'rate',
     valueUnit: RateUnit.PER_SECOND,
+    interval: 1_800_000, // 30 minutes
   },
   values: [
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -359,6 +359,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                   ...sampleThroughputTimeSeries,
                   field: 'equation|spm() + 1',
                   meta: {
+                    ...sampleThroughputTimeSeries.meta,
                     valueType: 'number',
                     valueUnit: null,
                   },
@@ -379,6 +380,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                   ...sampleDurationTimeSeries,
                   field: 'custom_agg(duration)',
                   meta: {
+                    ...sampleThroughputTimeSeries.meta,
                     valueType: 'number',
                     valueUnit: null,
                   },
@@ -387,6 +389,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                   ...sampleDurationTimeSeriesP50,
                   field: 'custom_agg2(duration)',
                   meta: {
+                    ...sampleThroughputTimeSeries.meta,
                     valueType: 'integer',
                     valueUnit: null,
                   },
@@ -395,6 +398,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
                   ...sampleThroughputTimeSeries,
                   field: 'custom_agg3(duration)',
                   meta: {
+                    ...sampleThroughputTimeSeries.meta,
                     valueType: 'duration',
                     valueUnit: DurationUnit.MILLISECOND,
                   },
@@ -442,6 +446,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
         };
       }),
       meta: {
+        ...sampleThroughputTimeSeries.meta,
         valueType: 'duration',
         valueUnit: DurationUnit.SECOND,
       },
@@ -731,6 +736,7 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
       ...sampleThroughputTimeSeries,
       field: 'error_rate()',
       meta: {
+        ...sampleThroughputTimeSeries.meta,
         valueType: 'rate',
         valueUnit: RateUnit.PER_SECOND,
       },
@@ -1102,4 +1108,5 @@ function hasTimestamp(release: Partial<Release>): release is Release {
 const NULL_META: TimeSeriesMeta = {
   valueType: null,
   valueUnit: null,
+  interval: 0,
 };

--- a/static/app/views/insights/common/utils/convertSeriesToTimeseries.tsx
+++ b/static/app/views/insights/common/utils/convertSeriesToTimeseries.tsx
@@ -1,25 +1,31 @@
 import type {DataUnit} from 'sentry/utils/discover/fields';
+import {getTimeSeriesInterval} from 'sentry/utils/timeSeries/getTimeSeriesInterval';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 
 export function convertSeriesToTimeseries(series: DiscoverSeries): TimeSeries {
+  const values = (series?.data ?? []).map(datum => {
+    const timestamp =
+      typeof datum.name === 'number'
+        ? datum.name * 1000 // Timestamps from `events-stats` are in seconds
+        : new Date(datum.name).getTime();
+
+    return {
+      timestamp,
+      value: datum.value,
+    };
+  });
+
+  const interval = getTimeSeriesInterval(values);
+
   return {
     field: series.seriesName,
+    values,
     meta: {
       // This behavior is a little awkward. Normally `meta` shouldn't be missing, but we sometime return blank meta from helper hooks
       valueType: series.meta?.fields?.[series.seriesName] ?? null,
       valueUnit: (series.meta?.units?.[series.seriesName] ?? null) as DataUnit,
+      interval,
     },
-    values: (series?.data ?? []).map(datum => {
-      const timestamp =
-        typeof datum.name === 'number'
-          ? datum.name * 1000 // Timestamps from `events-stats` are in seconds
-          : new Date(datum.name).getTime();
-
-      return {
-        timestamp,
-        value: datum.value,
-      };
-    }),
   };
 }

--- a/tests/js/fixtures/timeSeries.ts
+++ b/tests/js/fixtures/timeSeries.ts
@@ -7,6 +7,7 @@ export function TimeSeriesFixture(params: Partial<TimeSeries> = {}): TimeSeries 
     meta: {
       valueType: 'rate',
       valueUnit: RateUnit.PER_SECOND,
+      interval: 1_800_000, // 30 minutes
     },
     values: [
       {


### PR DESCRIPTION
`/events-timeseries` returns this handy property! It's not actually used anywhere, so adding it doesn't do anything _yet_, but I'm introducing the property and calculating the interval so all the data conforms to the type.