### PR TITLE
ref(feedback): remove 'new' from onboarding and whats new banners

### DIFF
--- a/static/app/components/feedback/feedbackSetupPanel.tsx
+++ b/static/app/components/feedback/feedbackSetupPanel.tsx
@@ -29,7 +29,7 @@ export default function FeedbackSetupPanel() {
         </IlloBox>
         <StyledBox>
           <Fragment>
-            <h3>{t('Introducing the New User Feedback')}</h3>
+            <h3>{t('Set Up User Feedback')}</h3>
             <p>
               {t(
                 'Allow your users to create bug reports so they can let you know about these sneaky issues right away. Every report will automatically include related replays, tags, and errors, making fixing the issue dead simple.'

--- a/static/app/components/feedback/feedbackWhatsNewBanner.tsx
+++ b/static/app/components/feedback/feedbackWhatsNewBanner.tsx
@@ -54,7 +54,7 @@ export default function FeedbackWhatsNewBanner({className, style}: Props) {
       description={t(
         'Users can submit feedback anytime they’re having a problem with your app via our feedback widget.'
       )}
-      heading={t('Introducing the New User Feedback')}
+      heading={t('Introducing User Feedback')}
       icon={<IconBroadcast size="sm" />}
       image={replaysDeadRageBackground}
       title={t('What’s new')}


### PR DESCRIPTION
UF has been GA for a while and the "new" is a bit confusing. The "go to old user feedback" button and route `/user-feedback/` have been removed.