### PR TITLE
fix(dashboards): Add empty error state to dashboard widgets

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -543,7 +543,13 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
                             // Override default datazoom behaviour for updating Global Selection Header
                             ...(onZoom ? {onDataZoom: onZoom} : {}),
                             legend,
-                            series: [...series, ...(modifiedReleaseSeriesResults ?? [])],
+                            series: [
+                              ...series,
+                              // only add release series if there is series data
+                              ...(series?.length > 0
+                                ? (modifiedReleaseSeriesResults ?? [])
+                                : []),
+                            ],
                             onLegendSelectChanged,
                             ref,
                           }),

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -137,25 +137,6 @@ export function WidgetCardChartContainer({
         sampleCount,
         isSampled,
       }) => {
-        if (widget.widgetType === WidgetType.ISSUE) {
-          return (
-            <Fragment>
-              {typeof renderErrorMessage === 'function'
-                ? renderErrorMessage(errorMessage)
-                : null}
-              <LoadingScreen loading={loading} />
-              <IssueWidgetCard
-                transformedResults={tableResults?.[0]!.data ?? []}
-                loading={loading}
-                errorMessage={errorMessage}
-                widget={widget}
-                location={location}
-                selection={selection}
-              />
-            </Fragment>
-          );
-        }
-
         // Bind timeseries to widget for ability to control each widget's legend individually
         const modifiedTimeseriesResults =
           WidgetLegendNameEncoderDecoder.modifyTimeseriesNames(widget, timeseriesResults);
@@ -168,6 +149,25 @@ export function WidgetCardChartContainer({
               tableResults,
               widget.displayType
             );
+
+        if (widget.widgetType === WidgetType.ISSUE) {
+          return (
+            <Fragment>
+              {typeof renderErrorMessage === 'function'
+                ? renderErrorMessage(errorOrEmptyMessage)
+                : null}
+              <LoadingScreen loading={loading} />
+              <IssueWidgetCard
+                transformedResults={tableResults?.[0]!.data ?? []}
+                loading={loading}
+                errorMessage={errorOrEmptyMessage}
+                widget={widget}
+                location={location}
+                selection={selection}
+              />
+            </Fragment>
+          );
+        }
 
         return (
           <Fragment>

--- a/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
+++ b/static/app/views/dashboards/widgetLegendNameEncoderDecoder.tsx
@@ -13,7 +13,10 @@ const WidgetLegendNameEncoderDecoder = {
   },
 
   // change timeseries names to SeriesName:widgetID
-  modifyTimeseriesNames(widget: Widget, timeseriesResults?: Series[]) {
+  modifyTimeseriesNames(
+    widget: Widget,
+    timeseriesResults?: Series[]
+  ): Series[] | undefined {
     if (!timeseriesResults) {
       return undefined;
     }


### PR DESCRIPTION
Before if timeseries returned an empty array the widget would be completely blank. I've added an empty check to ensure an appropriate message is shown in the odd chance the endpoint returns nothing. Here's what it looks like 

![image](https://github.com/user-attachments/assets/bb033e8e-d15d-4b6b-aa6d-3b97c9cb6b9f)

Closes [DAIN-357](https://linear.app/getsentry/issue/DAIN-357/charts-should-inform-the-user-there-is-no-data-instead-of-rendering-a)