### PR TITLE
fix(ui): Wrap css template tags where missing

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -2,7 +2,7 @@ import {useCallback, useId, useState} from 'react';
 import type {MentionsInputProps} from 'react-mentions';
 import {Mention, MentionsInput} from 'react-mentions';
 import type {Theme} from '@emotion/react';
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -315,12 +315,15 @@ const FooterButton = styled(Button)<{error?: boolean}>`
 
   ${p =>
     p.error &&
-    `
-  &, &:active, &:focus, &:hover {
-  border-bottom-color: ${p.theme.error};
-  border-right-color: ${p.theme.error};
-  }
-  `}
+    css`
+      &,
+      &:active,
+      &:focus,
+      &:hover {
+        border-bottom-color: ${p.theme.error};
+        border-right-color: ${p.theme.error};
+      }
+    `}
 `;
 
 const ErrorMessage = styled('span')`

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useMemo} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
@@ -244,7 +245,7 @@ const DropdownButton = styled(Button)`
   ${p =>
     // Chonk tags have a smaller border radius, so we need make sure it matches.
     p.theme.isChonk &&
-    `
+    css`
       > span > div {
         border-radius: 20px;
       }

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import Prism from 'prismjs';
 
@@ -225,20 +226,20 @@ const Header = styled('div')<{isSolid: boolean}>`
 
   ${p =>
     p.isSolid
-      ? `
-      padding: 0 ${space(0.5)};
-      border-bottom: solid 1px ${p.theme.innerBorder};
-    `
-      : `
-      justify-content: flex-end;
-      position: absolute;
-      top: 0;
-      right: 0;
-      width: max-content;
-      height: max-content;
-      max-height: 100%;
-      padding: ${space(0.5)};
-    `}
+      ? css`
+          padding: 0 ${space(0.5)};
+          border-bottom: solid 1px ${p.theme.innerBorder};
+        `
+      : css`
+          justify-content: flex-end;
+          position: absolute;
+          top: 0;
+          right: 0;
+          width: max-content;
+          height: max-content;
+          max-height: 100%;
+          padding: ${space(0.5)};
+        `}
 `;
 
 const FileName = styled('span')`

--- a/static/app/components/core/compactSelect/styles.tsx
+++ b/static/app/components/core/compactSelect/styles.tsx
@@ -2,6 +2,7 @@
 // Styled components used by both ListBox and GridList
 //
 
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -118,14 +119,14 @@ export const SectionToggleButton = styled(Button)<{visible: boolean}>`
 
   ${p =>
     p.visible
-      ? `
-    opacity: 1;
-    pointer-events: all;
-  `
-      : `
-    opacity: 0;
-    pointer-events: none;
-  `}
+      ? css`
+          opacity: 1;
+          pointer-events: all;
+        `
+      : css`
+          opacity: 0;
+          pointer-events: none;
+        `}
 
   li[role="rowgroup"]:hover &,
   li[role="presentation"]:hover & {

--- a/static/app/components/core/input/inputGroup.chonk.tsx
+++ b/static/app/components/core/input/inputGroup.chonk.tsx
@@ -37,20 +37,18 @@ const chonkInputStyles = ({
   theme,
 }: InputStyleProps & {theme: DO_NOT_USE_ChonkTheme}): StrictCSSObject => css`
   ${leadingWidth &&
-  `
+  css`
     padding-left: calc(
-      ${theme.formPadding[size].paddingLeft}px
-      + ${chonkItemsPadding[size]}px
-      + ${leadingWidth}px
+      ${theme.formPadding[size].paddingLeft}px + ${chonkItemsPadding[size]}px +
+        ${leadingWidth}px
     );
   `}
 
   ${trailingWidth &&
-  `
+  css`
     padding-right: calc(
-      ${theme.formPadding[size].paddingRight}px
-      + ${chonkItemsPadding[size]}px
-      + ${trailingWidth}px
+      ${theme.formPadding[size].paddingRight}px + ${chonkItemsPadding[size]}px +
+        ${trailingWidth}px
     );
   `}
 `;

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -231,18 +231,16 @@ const getInputStyles = ({
   theme,
 }: InputStyleProps & {theme: Theme}) => css`
   ${leadingWidth &&
-  `
+  css`
     padding-left: calc(
-      ${theme.formPadding[size ?? 'md'].paddingLeft}px * 1.5
-      + ${leadingWidth}px
+      ${theme.formPadding[size ?? 'md'].paddingLeft}px * 1.5 + ${leadingWidth}px
     );
   `}
 
   ${trailingWidth &&
-  `
+  css`
     padding-right: calc(
-      ${theme.formPadding[size ?? 'md'].paddingRight}px * 1.5
-      + ${trailingWidth}px
+      ${theme.formPadding[size ?? 'md'].paddingRight}px * 1.5 + ${trailingWidth}px
     );
   `}
 `;

--- a/static/app/components/core/menuListItem/index.chonk.tsx
+++ b/static/app/components/core/menuListItem/index.chonk.tsx
@@ -1,5 +1,5 @@
 import isPropValid from '@emotion/is-prop-valid';
-import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
+import {css, type DO_NOT_USE_ChonkTheme} from '@emotion/react';
 
 import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
@@ -92,13 +92,13 @@ export const ChonkInnerWrap = chonkStyled('div', {
 
     ${p =>
       p.isFocused &&
-      `
-      z-index: 1;
-      /* Background to hide the previous item's divider */
-      ::before {
-        background: ${p.theme.backgroundElevated};
-      }
-    `}
+      css`
+        z-index: 1;
+        /* Background to hide the previous item's divider */
+        ::before {
+          background: ${p.theme.backgroundElevated};
+        }
+      `}
   `;
 
 export const ChonkContentWrap = chonkStyled('div')<{

--- a/static/app/components/core/segmentedControl/index.tsx
+++ b/static/app/components/core/segmentedControl/index.tsx
@@ -1,5 +1,5 @@
 import {useMemo, useRef} from 'react';
-import {type Theme, useTheme} from '@emotion/react';
+import {css, type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaRadioProps} from '@react-aria/radio';
 import {useRadio, useRadioGroup} from '@react-aria/radio';
@@ -272,15 +272,15 @@ const SegmentWrap = withChonk(
 
     ${p =>
       !p.isDisabled &&
-      `
-    &:hover {
-      background-color: inherit;
+      css`
+        &:hover {
+          background-color: inherit;
 
-      [role='separator'] {
-        opacity: 0;
-      }
-    }
-  `}
+          [role='separator'] {
+            opacity: 0;
+          }
+        }
+      `}
 
     ${p => p.isSelected && `z-index: 1;`}
   `,

--- a/static/app/components/core/select/index.chonk.tsx
+++ b/static/app/components/core/select/index.chonk.tsx
@@ -1,4 +1,4 @@
-import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
+import {css, type DO_NOT_USE_ChonkTheme} from '@emotion/react';
 import omit from 'lodash/omit';
 
 import {Button} from 'sentry/components/core/button';
@@ -275,27 +275,23 @@ export const ChonkCheckWrap = chonkStyled('div')<{
 
   ${p =>
     p.isMultiple
-      ? `
-      padding: 1px;
-      border: solid 1px ${p.theme.border};
-      background: ${p.theme.backgroundElevated};;
-      border-radius: 2px;
-      height: 1em;
-      margin-top: 2px;
-      ${
-        p.isSelected &&
+      ? css`
+          padding: 1px;
+          border: solid 1px ${p.theme.border};
+          background: ${p.theme.backgroundElevated};
+          border-radius: 2px;
+          height: 1em;
+          margin-top: 2px;
+          ${p.isSelected &&
+          css`
+            background: ${p.theme.purple300};
+            border-color: ${p.theme.purple300};
+          `}
         `
-        background: ${p.theme.purple300};
-        border-color: ${p.theme.purple300};
-       `
-      }
-    `
-      : `
-      ${
-        p.isSelected &&
-        `
-        color: ${p.theme.colors.content.accent};
-       `
-      }
-    `}
+      : css`
+          ${p.isSelected &&
+          css`
+            color: ${p.theme.colors.content.accent};
+          `}
+        `}
 `;

--- a/static/app/components/core/select/option.tsx
+++ b/static/app/components/core/select/option.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {ClassNames, useTheme} from '@emotion/react';
+import {ClassNames, css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {MenuListItem} from 'sentry/components/core/menuListItem';
@@ -96,27 +96,25 @@ const CheckWrap = withChonk(
 
     ${p =>
       p.isMultiple
-        ? `
-      width: 1em;
-      height: 1em;
-      padding: 1px;
-      border: solid 1px ${p.theme.border};
-      background: ${p.theme.backgroundElevated};
-      border-radius: 2px;
-      box-shadow: inset ${p.theme.dropShadowMedium};
-      ${
-        p.isSelected &&
-        `
-        background: ${p.theme.purple300};
-        border-color: ${p.theme.purple300};
-       `
-      }
-    `
-        : `
-      width: 1em;
-      height: 1.4em;
-      padding-bottom: 1px;
-    `}
+        ? css`
+            width: 1em;
+            height: 1em;
+            padding: 1px;
+            border: solid 1px ${p.theme.border};
+            background: ${p.theme.backgroundElevated};
+            border-radius: 2px;
+            box-shadow: inset ${p.theme.dropShadowMedium};
+            ${p.isSelected &&
+            css`
+              background: ${p.theme.purple300};
+              border-color: ${p.theme.purple300};
+            `}
+          `
+        : css`
+            width: 1em;
+            height: 1.4em;
+            padding-bottom: 1px;
+          `}
   `,
   ChonkCheckWrap
 );

--- a/static/app/components/core/textarea/index.tsx
+++ b/static/app/components/core/textarea/index.tsx
@@ -1,5 +1,6 @@
 import TextareaAutosize, {type TextareaAutosizeProps} from 'react-textarea-autosize';
 import isPropValid from '@emotion/is-prop-valid';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {InputStylesProps} from 'sentry/components/core/input';
@@ -55,7 +56,7 @@ const StyledTextArea = styled(TextAreaControl, {
   /** Allow react-textarea-autosize to freely control height based on props. */
   ${p =>
     p.autosize &&
-    `
+    css`
       height: unset;
       min-height: unset;
     `}

--- a/static/app/components/deprecatedSmartSearchBar/searchDropdown.tsx
+++ b/static/app/components/deprecatedSmartSearchBar/searchDropdown.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tag} from 'sentry/components/core/badge/tag';
@@ -535,13 +536,13 @@ const SearchItemsList = styled('ul')<{maxMenuHeight?: number}>`
   margin-bottom: 0;
   ${p => {
     if (p.maxMenuHeight !== undefined) {
-      return `
+      return css`
         max-height: ${p.maxMenuHeight}px;
         overflow-y: scroll;
       `;
     }
 
-    return `
+    return css`
       height: auto;
     `;
   }}
@@ -557,7 +558,7 @@ const SearchListItem = styled('li')<{isChild?: boolean; isDisabled?: boolean}>`
 
   ${p => {
     if (!p.isDisabled) {
-      return `
+      return css`
         cursor: pointer;
 
         &:hover,

--- a/static/app/components/dropdownBubble.tsx
+++ b/static/app/components/dropdownBubble.tsx
@@ -83,15 +83,15 @@ const DropdownBubble = styled(
 
   ${p =>
     p.detached
-      ? `
-    top: 100%;
-    margin-top: ${space(1)};
-    box-shadow: ${p.theme.dropShadowHeavy};
-  `
-      : `
-    top: calc(100% - 1px);
-    box-shadow: ${p.theme.dropShadowMedium};
-  `};
+      ? css`
+          top: 100%;
+          margin-top: ${space(1)};
+          box-shadow: ${p.theme.dropShadowHeavy};
+        `
+      : css`
+          top: calc(100% - 1px);
+          box-shadow: ${p.theme.dropShadowMedium};
+        `};
 
   ${getMenuBorderRadius};
 

--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -231,7 +232,7 @@ const Wrapper = styled('div')<{isDisabled: boolean; isEditing: boolean}>`
 
   ${p =>
     p.isDisabled &&
-    `
+    css`
       ${InnerLabel} {
         border-bottom-color: transparent;
       }

--- a/static/app/components/events/autofix/autofixProgressBar.tsx
+++ b/static/app/components/events/autofix/autofixProgressBar.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {SeerLoadingIcon, SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
@@ -68,9 +69,11 @@ const ProgressBarContainer = styled('div')<{hasData: boolean}>`
 
   ${p =>
     p.hasData &&
-    `&:hover {
-      height: 30px;
-    }`}
+    css`
+      &:hover {
+        height: 30px;
+      }
+    `}
 `;
 
 const ProgressBarWrapper = styled('div')`
@@ -110,10 +113,11 @@ const ProgressBarHoverContent = styled('div')<{hasData: boolean}>`
 
   ${p =>
     p.hasData &&
-    `
-    ${ProgressBarContainer}:hover & {
-      opacity: 1;
-    }`}
+    css`
+      ${ProgressBarContainer}:hover & {
+        opacity: 1;
+      }
+    `}
 `;
 
 const ProgressText = styled('span')`

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -1,5 +1,6 @@
 import type {ReactEventHandler} from 'react';
 import {Fragment, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {useRole} from 'sentry/components/acl/useRole';
@@ -216,10 +217,10 @@ const StyledPanelBody = styled(PanelBody)<{hasHeader: boolean}>`
 
   ${p =>
     !p.hasHeader &&
-    `
-  border-top-left-radius: ${p.theme.borderRadius};
-  border-top-right-radius: ${p.theme.borderRadius};
-  `}
+    css`
+      border-top-left-radius: ${p.theme.borderRadius};
+      border-top-right-radius: ${p.theme.borderRadius};
+    `}
 `;
 
 const StyledPanelFooter = styled(PanelFooter)`

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -53,11 +54,11 @@ export const GroupingComponentListItem = styled('li')<{isCollapsible?: boolean}>
 
   ${p =>
     p.isCollapsible &&
-    `
-    border-left: 1px solid ${p.theme.innerBorder};
-    margin: 0 0 -${space(0.25)} ${space(1)};
-    padding-left: ${space(0.5)};
-  `}
+    css`
+      border-left: 1px solid ${p.theme.innerBorder};
+      margin: 0 0 -${space(0.25)} ${space(1)};
+      padding-left: ${space(0.5)};
+    `}
 `;
 
 export const GroupingValue = styled('code')<{valueType: string}>`
@@ -68,12 +69,12 @@ export const GroupingValue = styled('code')<{valueType: string}>`
   background: rgba(112, 163, 214, 0.1);
   color: ${p => p.theme.textColor};
 
-  ${({valueType}) =>
+  ${({valueType, theme}) =>
     (valueType === 'function' || valueType === 'symbol') &&
-    `
-    font-weight: ${(p: any) => p.theme.fontWeightBold};
-    color: ${(p: any) => p.theme.textColor};
-  `}
+    css`
+      font-weight: ${theme.fontWeightBold};
+      color: ${theme.textColor};
+    `}
 `;
 
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -3,6 +3,7 @@ import {Fragment, useCallback, useEffect, useMemo, useRef} from 'react';
 import type {ListProps} from 'react-virtualized';
 import {AutoSizer, CellMeasurer, CellMeasurerCache, List} from 'react-virtualized';
 import type {ListRowRenderer} from 'react-virtualized/dist/es/List';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -265,7 +266,7 @@ export const StyledBreadcrumbPanelTable = styled(PanelTable)`
       grid-column: 1/-1;
       ${p =>
         !p.isEmpty &&
-        `
+        css`
           padding: 0;
         `}
     }

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import type {ListRowProps} from 'react-virtualized';
 import {AutoSizer, CellMeasurer, CellMeasurerCache, List} from 'react-virtualized';
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openModal, openReprocessEventModal} from 'sentry/actionCreators/modal';
@@ -442,7 +442,7 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarWidth?: number}>`
       grid-column: 1/-1;
       ${p =>
         !p.isEmpty &&
-        `
+        css`
           display: grid;
           padding: 0;
         `}

--- a/static/app/components/events/interfaces/searchBarAction.tsx
+++ b/static/app/components/events/interfaces/searchBarAction.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import type {
@@ -89,7 +90,7 @@ const StyledSearchBar = styled(SearchBar)<{blendWithFilter?: boolean}>`
 
   ${p =>
     p.blendWithFilter &&
-    `
+    css`
       input {
         border-radius: 0 ${p.theme.borderRadius} ${p.theme.borderRadius} 0;
         border-left-width: 0;

--- a/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
+++ b/static/app/components/events/interfaces/spans/spanFrequencyBox.tsx
@@ -1,4 +1,4 @@
-import type {Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -48,37 +48,37 @@ export function SpanFrequencyBox({span}: Props) {
 
 function getBoxColors(theme: Theme, frequency?: number) {
   if (!frequency || frequency >= 0.9) {
-    return `
+    return css`
       background: ${purples[3]};
       color: ${theme.white};
     `;
   }
 
   if (frequency >= 0.7) {
-    return `
+    return css`
       background: ${purples[2]};
       color: ${theme.white};
     `;
   }
 
   if (frequency >= 0.5) {
-    return `
+    return css`
       background: ${purples[1]};
       color: ${theme.black};
     `;
   }
 
   if (frequency >= 0.3) {
-    return `
+    return css`
       background: ${purples[0]};
       color: ${theme.black};
     `;
   }
 
-  return `
-      background: ${theme.white};
-      color: ${theme.black};
-    `;
+  return css`
+    background: ${theme.white};
+    color: ${theme.black};
+  `;
 }
 
 const StyledBox = styled('div')<{frequency?: number}>`

--- a/static/app/components/events/viewHierarchy/node.tsx
+++ b/static/app/components/events/viewHierarchy/node.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {IconAdd, IconSubtract} from 'sentry/icons';
@@ -56,9 +57,9 @@ const NodeTitle = styled('span')<{focused?: boolean}>`
   cursor: pointer;
   ${({focused, theme}) =>
     focused &&
-    `
-    color: ${theme.white};
-  `}
+    css`
+      color: ${theme.white};
+    `}
 `;
 
 const IconWrapper = styled('button')<{collapsible: boolean; isExpanded: boolean}>`
@@ -72,14 +73,14 @@ const IconWrapper = styled('button')<{collapsible: boolean; isExpanded: boolean}
   margin-right: 4px;
   ${p =>
     p.isExpanded
-      ? `
+      ? css`
           background: ${p.theme.gray300};
           border: 1px solid ${p.theme.gray300};
           &:hover {
             background: ${p.theme.gray400};
           }
         `
-      : `
+      : css`
           background: ${p.theme.blue300};
           border: 1px solid ${p.theme.blue300};
           &:hover {

--- a/static/app/components/forms/form.tsx
+++ b/static/app/components/forms/form.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
 
@@ -301,22 +302,22 @@ const StyledFooter = styled('div')<{saveOnBlur?: boolean}>`
 
   ${p =>
     !p.saveOnBlur &&
-    `
-  ${Panel} & {
-    margin-top: 0;
-    padding-right: ${space(2)}
-  }
+    css`
+      ${Panel} & {
+        margin-top: 0;
+        padding-right: ${space(2)};
+      }
 
-  /* Better padding with form inside of a modal */
-  [role='document'] & {
-    padding-right: 30px;
-    margin-left: -30px;
-    margin-right: -30px;
-    margin-bottom: -30px;
-    margin-top: 16px;
-    padding-bottom: 16px;
-  }
-  `};
+      /* Better padding with form inside of a modal */
+      [role='document'] & {
+        padding-right: 30px;
+        margin-left: -30px;
+        margin-right: -30px;
+        margin-bottom: -30px;
+        margin-top: 16px;
+        padding-bottom: 16px;
+      }
+    `};
 `;
 
 const DefaultButtons = styled('div')`

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
@@ -82,16 +83,16 @@ export const Grid = styled('table')<{height?: string | number; scrollable?: bool
   z-index: ${Z_INDEX_GRID};
   ${p =>
     p.scrollable &&
-    `
-    overflow-x: auto;
-    overflow-y: scroll;
+    css`
+      overflow-x: auto;
+      overflow-y: scroll;
     `}
   ${p =>
     p.height
-      ? `
-      height: 100%;
-      max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height}
-      `
+      ? css`
+          height: 100%;
+          max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height};
+        `
       : ''}
 `;
 

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -1,4 +1,4 @@
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {assignToActor, clearAssignment} from 'sentry/actionCreators/group';
@@ -131,7 +131,7 @@ const StyledDropdownButton = styled(Button)`
   ${p =>
     // Chonk tags have a smaller border radius, so we need make sure it matches.
     p.theme.isChonk &&
-    `
+    css`
       > span > div {
         border-radius: 20px;
       }

--- a/static/app/components/illustrations/NoProjectEmptyState.tsx
+++ b/static/app/components/illustrations/NoProjectEmptyState.tsx
@@ -194,11 +194,11 @@ const Smoke = styled('g')`
   }
 
   ${new Array(3).fill(0).map(
-    (_, i) => `
-  > :nth-child(${i + 1}) {
-    animation-delay: ${4 + i * 0.2}s
-  }
-  `
+    (_, i) => css`
+      > :nth-child(${i + 1}) {
+        animation-delay: ${4 + i * 0.2}s;
+      }
+    `
   )}
 `;
 

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -1,5 +1,6 @@
 import {Component} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -188,9 +189,9 @@ const StyledIssueDiff = styled('div', {
 
   ${p =>
     p.loading &&
-    `
-        background-color: ${p.theme.background};
-        justify-content: center;
-        align-items: center;
-      `};
+    css`
+      background-color: ${p.theme.background};
+      justify-content: center;
+      align-items: center;
+    `};
 `;

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tabs} from 'sentry/components/tabs';
@@ -41,7 +42,7 @@ export const Header = styled('header')<{
 
   ${p =>
     !p.unified &&
-    `
+    css`
       border-bottom: 1px ${p.borderStyle ?? 'solid'} ${p.theme.border};
     `}
 
@@ -65,7 +66,7 @@ export const HeaderContent = styled('div')<{unified?: boolean}>`
 
   ${p =>
     p.unified &&
-    `
+    css`
       margin-bottom: 0;
     `}
 `;

--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -1,4 +1,5 @@
 import {NavLink} from 'react-router-dom';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import type {LocationDescriptor} from 'history';
@@ -58,17 +59,17 @@ const StyledLi = styled('li', {
 })<{disabled?: boolean}>`
   ${p =>
     p.disabled &&
-    `
-  a {
-      color:${p.theme.disabled} !important;
-      :hover {
-        color: ${p.theme.disabled}  !important;
+    css`
+      a {
+        color: ${p.theme.disabled} !important;
+        :hover {
+          color: ${p.theme.disabled} !important;
+        }
+        cursor: default !important;
       }
-      cursor: default !important;
-    }
 
-  a:active {
-    pointer-events: none;
-  }
-`}
+      a:active {
+        pointer-events: none;
+      }
+    `}
 `;

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -1,4 +1,4 @@
-import type {Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
@@ -179,7 +179,7 @@ interface MenuListItemProps extends React.HTMLAttributes<HTMLLIElement> {
 }
 
 function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
-  const common = `
+  const common = css`
     display: block;
     padding: ${space(0.5)} ${space(2)};
     &:focus {
@@ -188,7 +188,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
   `;
 
   if (props.disabled) {
-    return `
+    return css`
       ${common}
       color: ${props.theme.disabled};
       background: transparent;
@@ -197,7 +197,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
   }
 
   if (props.isActive) {
-    return `
+    return css`
       ${common}
       color: ${props.theme.white};
       background: ${props.theme.active};
@@ -208,7 +208,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
     `;
   }
 
-  return `
+  return css`
     ${common}
 
     &:hover {
@@ -222,7 +222,7 @@ function getChildStyles(props: MenuListItemProps & {theme: Theme}) {
     return '';
   }
 
-  return `
+  return css`
     & a {
       ${getListItemStyles(props)}
     }
@@ -241,29 +241,29 @@ const MenuListItem = styled('li')<MenuListItemProps>`
 
   ${p =>
     p.withBorder &&
-    `
-    border-bottom: 1px solid ${p.theme.innerBorder};
+    css`
+      border-bottom: 1px solid ${p.theme.innerBorder};
 
-    &:last-child {
-      border-bottom: none;
-    }
-  `};
+      &:last-child {
+        border-bottom: none;
+      }
+    `};
   ${p =>
     p.divider &&
-    `
-    height: 1px;
-    margin: ${space(0.5)} 0;
-    overflow: hidden;
-    background-color: ${p.theme.innerBorder};
-  `}
+    css`
+      height: 1px;
+      margin: ${space(0.5)} 0;
+      overflow: hidden;
+      background-color: ${p.theme.innerBorder};
+    `}
   ${p =>
     p.header &&
-    `
-    padding: ${space(0.25)} ${space(0.5)};
-    font-size: ${p.theme.fontSizeSmall};
-    line-height: 1.4;
-    color: ${p.theme.subText};
-  `}
+    css`
+      padding: ${space(0.25)} ${space(0.5)};
+      font-size: ${p.theme.fontSizeSmall};
+      line-height: 1.4;
+      color: ${p.theme.subText};
+    `}
 
   ${getChildStyles}
 `;

--- a/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
@@ -1,4 +1,5 @@
 import {createContext, Fragment, useContext, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -113,10 +114,11 @@ const Wrapper = styled('span')<{isInteractive: boolean}>`
 
   ${p =>
     p.isInteractive &&
-    `
-  cursor: pointer;
+    css`
+      cursor: pointer;
 
-  &:hover {
-    background: var(--prism-highlight-background);
-  }`}
+      &:hover {
+        background: var(--prism-highlight-background);
+      }
+    `}
 `;

--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -1,4 +1,5 @@
 import isPropValid from '@emotion/is-prop-valid';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -192,11 +193,11 @@ const PanelTableHeader = styled('div')<{sticky: boolean}>`
 
   ${p =>
     p.sticky &&
-    `
-    position: sticky;
-    top: 0;
-    z-index: ${p.theme.zIndex.initial};
-  `}
+    css`
+      position: sticky;
+      top: 0;
+      z-index: ${p.theme.zIndex.initial};
+    `}
 `;
 
 export {PanelTable, type PanelTableProps, PanelTableHeader};

--- a/static/app/components/performance/layouts.tsx
+++ b/static/app/components/performance/layouts.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -22,11 +23,11 @@ export const PerformanceLayoutBodyRow = styled('div')<{
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     ${p =>
       p.columns
-        ? `
-    grid-template-columns: repeat(${p.columns}, 1fr);
-    `
-        : `
-    grid-template-columns: repeat(auto-fit, minmax(${p.minSize}px, 1fr));
-    `}
+        ? css`
+            grid-template-columns: repeat(${p.columns}, 1fr);
+          `
+        : css`
+            grid-template-columns: repeat(auto-fit, minmax(${p.minSize}px, 1fr));
+          `}
   }
 `;

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -1,5 +1,5 @@
 import {memo} from 'react';
-import type {Theme} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -60,12 +60,12 @@ const Pill = memo(({name, value, children, type, className}: Props) => {
 const getPillStyle = ({type, theme}: {theme: Theme; type?: PillType}) => {
   switch (type) {
     case 'error':
-      return `
+      return css`
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
       `;
     default:
-      return `
+      return css`
         border: 1px solid ${theme.border};
       `;
   }
@@ -74,30 +74,27 @@ const getPillStyle = ({type, theme}: {theme: Theme; type?: PillType}) => {
 const getPillValueStyle = ({type, theme}: {theme: Theme; type?: PillType}) => {
   switch (type) {
     case 'positive':
-      return `
+      return css`
         background: ${theme.green100};
         border: 1px solid ${theme.green300};
-        border-left-color: ${theme.green300};
         font-family: ${theme.text.familyMono};
         margin: -1px;
       `;
     case 'error':
-      return `
-        border-left-color: ${theme.red300};
+      return css`
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
         margin: -1px;
       `;
     case 'negative':
-      return `
-        border-left-color: ${theme.red300};
+      return css`
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
         font-family: ${theme.text.familyMono};
         margin: -1px;
       `;
     default:
-      return `
+      return css`
         background: ${theme.backgroundSecondary};
         font-family: ${theme.text.familyMono};
       `;

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -1,4 +1,5 @@
 import {useRef} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
@@ -115,11 +116,11 @@ const Grid = styled('div')<{isCompact: boolean}>`
   align-items: center;
   ${p =>
     p.isCompact
-      ? `
-        order: -1;
-        min-width: 100%;
-        margin-top: -8px;
-      `
+      ? css`
+          order: -1;
+          min-width: 100%;
+          margin-top: -8px;
+        `
       : ''}
 `;
 

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {cancelDeleteRepository, hideRepository} from 'sentry/actionCreators/integrations';
@@ -138,10 +139,10 @@ const StyledPanelItem = styled(PanelItem)<{status: RepositoryStatus}>`
 
   ${p =>
     p.status === RepositoryStatus.DISABLED &&
-    `
-    filter: grayscale(1);
-    opacity: 0.4;
-  `};
+    css`
+      filter: grayscale(1);
+      opacity: 0.4;
+    `};
 
   &:last-child {
     border-bottom: none;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useLayoutEffect, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
@@ -288,15 +289,15 @@ const FilterWrapper = styled('div')<{state: 'invalid' | 'warning' | 'valid'}>`
 
   ${p =>
     p.state === 'invalid'
-      ? `
-      border-color: ${p.theme.red200};
-      background-color: ${p.theme.red100};
-    `
+      ? css`
+          border-color: ${p.theme.red200};
+          background-color: ${p.theme.red100};
+        `
       : p.state === 'warning'
-        ? `
-      border-color: ${p.theme.gray300};
-      background-color: ${p.theme.gray100};
-    `
+        ? css`
+            border-color: ${p.theme.gray300};
+            background-color: ${p.theme.gray100};
+          `
         : ''}
 
   &[aria-selected='true'] {

--- a/static/app/components/segmentedLoadingBar.tsx
+++ b/static/app/components/segmentedLoadingBar.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -62,15 +63,15 @@ const LoadingBarSegment = styled('div')<{isActive?: boolean; isCompleted?: boole
   border: 1px solid ${p => p.theme.border};
   ${p =>
     p.isActive &&
-    `
-    background-color: ${p.theme.gray200};
-    animation: pulse 500ms ease-in-out infinite alternate-reverse;
-  `}
+    css`
+      background-color: ${p.theme.gray200};
+      animation: pulse 500ms ease-in-out infinite alternate-reverse;
+    `}
   ${p =>
     p.isCompleted &&
-    `
-    background-color: ${p.theme.gray200};
-  `}
+    css`
+      background-color: ${p.theme.gray200};
+    `}
 
   @keyframes pulse {
     0% {

--- a/static/app/components/slider/thumb.tsx
+++ b/static/app/components/slider/thumb.tsx
@@ -1,4 +1,5 @@
 import {useRef} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaSliderThumbOptions} from '@react-aria/slider';
 import {useSliderThumb} from '@react-aria/slider';
@@ -83,33 +84,33 @@ const SliderThumbWrap = styled('div')<{
 
   ${p =>
     p.error &&
-    `
-    background: ${p.theme.error};
-    color: ${p.theme.errorText};
-
-    &:hover {
+    css`
       background: ${p.theme.error};
-    }
-  `}
+      color: ${p.theme.errorText};
+
+      &:hover {
+        background: ${p.theme.error};
+      }
+    `}
 
   ${p =>
     p.isFocused &&
-    `
+    css`
       box-shadow: 0 0 0 2px ${p.error ? p.theme.errorFocus : p.theme.focus};
-      z-index:1;
+      z-index: 1;
     `}
 
     ${p =>
     p.isDisabled &&
-    `
-        cursor: initial;
-        background: ${p.theme.subText};
-        color: ${p.theme.subText};
+    css`
+      cursor: initial;
+      background: ${p.theme.subText};
+      color: ${p.theme.subText};
 
-        &:hover {
-          background: ${p.theme.subText};
-        }
-      `};
+      &:hover {
+        background: ${p.theme.subText};
+      }
+    `};
 
   /* Extend click area */
   &::before {

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -1,4 +1,5 @@
 import {createContext, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabListOptions} from '@react-aria/tabs';
 import type {TabListState, TabListStateOptions} from '@react-stately/tabs';
@@ -104,7 +105,7 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
 
   ${p =>
     p.orientation === 'vertical' &&
-    `
+    css`
       height: 100%;
       align-items: stretch;
     `};

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -1,4 +1,5 @@
 import {useContext, useEffect, useMemo, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabListOptions} from '@react-aria/tabs';
 import {useTabList} from '@react-aria/tabs';
@@ -309,20 +310,20 @@ const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
 
   ${p =>
     p.orientation === 'horizontal'
-      ? `
-        grid-auto-flow: column;
-        justify-content: start;
-        gap: ${p.variant === 'filled' || p.variant === 'floating' ? 0 : space(2)};
-        ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
-      `
-      : `
-        height: 100%;
-        grid-auto-flow: row;
-        align-content: start;
-        gap: 1px;
-        padding-right: ${space(2)};
-        ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
-      `};
+      ? css`
+          grid-auto-flow: column;
+          justify-content: start;
+          gap: ${p.variant === 'filled' || p.variant === 'floating' ? 0 : space(2)};
+          ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
+        `
+      : css`
+          height: 100%;
+          grid-auto-flow: row;
+          align-content: start;
+          gap: 1px;
+          padding-right: ${space(2)};
+          ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
+        `};
 `;
 
 const TabListOverflowWrap = styled('div')`

--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -1,4 +1,5 @@
 import type {CSSProperties} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 type Props = {
@@ -54,7 +55,7 @@ const TextOverflow = styled(
   ${p => p.theme.overflowEllipsis}
   ${p =>
     p.ellipsisDirection === 'left' &&
-    `
+    css`
       direction: rtl;
       text-align: left;
     `};

--- a/static/app/components/truncate.tsx
+++ b/static/app/components/truncate.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
@@ -109,9 +110,9 @@ const FullValue = styled('span')<{
 
   ${p =>
     p.expanded &&
-    `
-    z-index: ${p.theme.zIndex.truncationFullValue};
-    display: block;
+    css`
+      z-index: ${p.theme.zIndex.truncationFullValue};
+      display: block;
     `}
 `;
 

--- a/static/app/components/workflowEngine/gridCell/issueCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/issueCell.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
@@ -52,12 +53,12 @@ const IssueWrapper = styled(Link)<{disabled: boolean}>`
 
   ${p =>
     !p.disabled &&
-    `
-    &:hover ${Wrapper} {
-      color: ${p.theme.textColor};
-      text-decoration: underline;
-    }
-  `}
+    css`
+      &:hover ${Wrapper} {
+        color: ${p.theme.textColor};
+        text-decoration: underline;
+      }
+    `}
 `;
 
 const LastSeenWrapper = styled(Flex)`

--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -63,9 +63,9 @@ const Name = styled('div')<{disabled: boolean}>`
 
   ${p =>
     p.disabled &&
-    `
-    color: ${p.theme.disabled};
-  `}
+    css`
+      color: ${p.theme.disabled};
+    `}
 `;
 
 const TitleWrapper = styled(Link)<{disabled: boolean}>`
@@ -76,12 +76,12 @@ const TitleWrapper = styled(Link)<{disabled: boolean}>`
 
   ${p =>
     !p.disabled &&
-    `
-    &:hover ${Name} {
-      color: ${p.theme.textColor};
-      text-decoration: underline;
-    }
-  `};
+    css`
+      &:hover ${Name} {
+        color: ${p.theme.textColor};
+        text-decoration: underline;
+      }
+    `};
 `;
 
 const DetailsWrapper = styled('div')`

--- a/static/app/views/automations/components/automationListRow.tsx
+++ b/static/app/views/automations/components/automationListRow.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
@@ -88,7 +89,7 @@ const RowWrapper = styled('div')<{disabled?: boolean}>`
 
   ${p =>
     p.disabled &&
-    `
+    css`
       ${CellWrapper} {
         opacity: 0.6;
       }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment, type ReactNode, useMemo, useState} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -888,17 +889,17 @@ export const AggregateCompactSelect = styled(CompactSelect)<{
 }>`
   ${p =>
     p.hasColumnParameter
-      ? `
-    width: fit-content;
-    left: 1px;
+      ? css`
+          width: fit-content;
+          left: 1px;
 
-    ${TriggerLabel} {
-      overflow: visible;
-    }
-  `
-      : `
-    width: 100%;
-  `}
+          ${TriggerLabel} {
+            overflow: visible;
+          }
+        `
+      : css`
+          width: 100%;
+        `}
 
   > button {
     width: 100%;
@@ -938,10 +939,10 @@ export const PrimarySelectRow = styled('div')<{hasColumnParameter: boolean}>`
   & ${AggregateCompactSelect} button {
     ${p =>
       p.hasColumnParameter &&
-      `
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    `}
+      css`
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      `}
   }
 `;
 

--- a/static/app/views/detectors/components/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListRow.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/container/flex';
@@ -98,7 +99,7 @@ const RowWrapper = styled('div')<{disabled?: boolean}>`
 
   ${p =>
     p.disabled &&
-    `
+    css`
       ${CellWrapper}, ${StyledGraphCell} {
         opacity: 0.6;
       }

--- a/static/app/views/explore/multiQueryMode/components/miniTable.tsx
+++ b/static/app/views/explore/multiQueryMode/components/miniTable.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Body, Grid} from 'sentry/components/gridEditable/styles';
@@ -35,7 +36,7 @@ const _TableWrapper = styled(Body)`
 const _Table = styled(Grid)<{height?: string | number; scrollable?: boolean}>`
   ${p =>
     p.scrollable &&
-    `
-    overflow-y: auto;
-  `}
+    css`
+      overflow-y: auto;
+    `}
 `;

--- a/static/app/views/issueList/issueViews/issueViews.tsx
+++ b/static/app/views/issueList/issueViews/issueViews.tsx
@@ -8,6 +8,7 @@ import {
   useReducer,
   useState,
 } from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {TabListState} from '@react-stately/tabs';
 import type {Orientation} from '@react-types/shared';
@@ -718,7 +719,7 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
 
   ${p =>
     p.orientation === 'vertical' &&
-    `
+    css`
       height: 100%;
       align-items: stretch;
     `};

--- a/static/app/views/nav/projectIcon.tsx
+++ b/static/app/views/nav/projectIcon.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import PlatformIcon from 'platformicons/build/platformIcon';
 
@@ -76,16 +77,16 @@ const PlatformIconWrapper = styled('div')<{index: number}>`
   height: 14px;
   ${p =>
     p.index === 0 &&
-    `
-    top: 0;
-    left: 0;
-  `}
+    css`
+      top: 0;
+      left: 0;
+    `}
   ${p =>
     p.index === 1 &&
-    `
-    bottom: 0;
-    right: 0;
-  `}
+    css`
+      bottom: 0;
+      right: 0;
+    `}
 `;
 
 export default ProjectIcon;

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {isString} from '@sentry/core';
 import type {Location} from 'history';
@@ -338,17 +339,17 @@ const StyledAlert = styled(Alert)`
 const StyledBody = styled(Layout.Body)<{fillSpace?: boolean; hasError?: boolean}>`
   ${p =>
     p.fillSpace &&
-    `
-  display: flex;
-  flex-direction: column;
-  gap: ${space(3)};
+    css`
+      display: flex;
+      flex-direction: column;
+      gap: ${space(3)};
 
-  @media (min-width: ${p.theme.breakpoints.large}) {
-    display: flex;
-    flex-direction: column;
-    gap: ${space(3)};
-  }
-  `}
+      @media (min-width: ${p.theme.breakpoints.large}) {
+        display: flex;
+        flex-direction: column;
+        gap: ${space(3)};
+      }
+    `}
 `;
 
 export function redirectToPerformanceHomepage(

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptorObject} from 'history';
 
@@ -340,9 +341,9 @@ const LinkContainer = styled('div')<{disabled?: boolean}>`
   align-items: center;
   ${p =>
     p.disabled &&
-    `
-    opacity: 0.5;
-    color: ${p.theme.disabled};
-    cursor: default;
-  `}
+    css`
+      opacity: 0.5;
+      color: ${p.theme.disabled};
+      cursor: default;
+    `}
 `;

--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -89,10 +90,10 @@ const QuickLink = styled((p: any) =>
 
   ${p =>
     p.disabled &&
-    `
-    color: ${p.theme.gray200};
-    cursor: not-allowed;
-  `}
+    css`
+      color: ${p.theme.gray200};
+      cursor: not-allowed;
+    `}
 `;
 
 const QuickLinkText = styled('span')`

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import commitImage from 'sentry-images/spot/releases-tour-commits.svg';
@@ -407,7 +408,7 @@ const MenuItemWrapper = styled('div')<{
   font-size: 13px;
   ${p =>
     typeof p.py !== 'undefined' &&
-    `
+    css`
       padding-top: ${p.py};
       padding-bottom: ${p.py};
     `};

--- a/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -1,4 +1,5 @@
 import {Component, Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
@@ -203,14 +204,14 @@ const SourceGroup = styled('div')<{isExpanded: boolean}>`
   transition-property: height;
   ${p =>
     p.isExpanded &&
-    `
-    border-radius: ${p.theme.borderRadius};
-    border: 1px solid ${p.theme.border};
-    box-shadow: ${p.theme.dropShadowMedium};
-    margin: ${space(2)} 0 ${space(3)} 0;
-    padding: ${space(2)};
-    height: 180px;
-  `}
+    css`
+      border-radius: ${p.theme.borderRadius};
+      border: 1px solid ${p.theme.border};
+      box-shadow: ${p.theme.dropShadowMedium};
+      margin: ${space(2)} 0 ${space(3)} 0;
+      padding: ${space(2)};
+      height: 180px;
+    `}
 `;
 
 const RegularExpression = styled(Input)`

--- a/static/app/views/settings/components/dataScrubbing/organizationRules.tsx
+++ b/static/app/views/settings/components/dataScrubbing/organizationRules.tsx
@@ -1,4 +1,5 @@
 import {Component, createRef} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -127,7 +128,7 @@ const Wrapper = styled('div')<{contentHeight?: string; isCollapsed?: boolean}>`
   ${p =>
     !p.isCollapsed &&
     p.contentHeight &&
-    `
+    css`
       ${Content} {
         height: ${p.contentHeight};
       }

--- a/static/app/views/settings/components/dataScrubbing/rules.tsx
+++ b/static/app/views/settings/components/dataScrubbing/rules.tsx
@@ -1,3 +1,4 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ConfirmDelete from 'sentry/components/confirmDelete';
@@ -84,10 +85,10 @@ const List = styled('ul')<{
   margin-bottom: 0 !important;
   ${p =>
     p.isDisabled &&
-    `
+    css`
       color: ${p.theme.gray200};
       background: ${p.theme.backgroundSecondary};
-  `}
+    `}
 `;
 
 const ListItem = styled('li')`

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {useRole} from 'sentry/components/acl/useRole';
@@ -313,10 +314,10 @@ const StyledPanelTable = styled(PanelTable)<{hasTypeColumn: boolean}>`
     );
   ${p =>
     p.hasTypeColumn &&
-    `
-  grid-template-columns:
-    minmax(220px, 1fr) minmax(120px, max-content) minmax(120px, max-content)
-    minmax(74px, max-content);
+    css`
+      grid-template-columns:
+        minmax(220px, 1fr) minmax(120px, max-content) minmax(120px, max-content)
+        minmax(74px, max-content);
     `}
 `;
 

--- a/static/gsApp/components/features/illustrations/discoverBackground.tsx
+++ b/static/gsApp/components/features/illustrations/discoverBackground.tsx
@@ -1,4 +1,4 @@
-import {keyframes} from '@emotion/react';
+import {css, keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
@@ -115,11 +115,11 @@ const Smoke = styled('g')`
   }
 
   ${new Array(3).fill(0).map(
-    (_, i) => `
-  > :nth-child(${i + 1}) {
-    animation-delay: ${i * 0.8}s
-  }
-  `
+    (_, i) => css`
+      > :nth-child(${i + 1}) {
+        animation-delay: ${i * 0.8}s;
+      }
+    `
   )}
 `;
 


### PR DESCRIPTION
Enables minification and linting for the css inside the template

Blocks should be wrapped when they contain an entire css property like `border: 1px solid red`