### PR TITLE
:bug: fix(aci): fix sentry app action handling for test notifications and action handling

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -615,11 +615,16 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         # If the future comes from a rule with a UI component form in the schema, append the issue alert payload
         # TODO(ecosystem): We need to change this payload format after alerts create issues
         id = f.rule.id
+
         # if we are using the new workflow engine, we need to use the legacy rule id
-        if features.has("organizations:workflow-engine-trigger-actions", event.group.organization):
-            id = get_key_from_rule_data(f.rule, "legacy_rule_id")
-        elif features.has("organizations:workflow-engine-ui-links", event.group.organization):
-            id = get_key_from_rule_data(f.rule, "workflow_id")
+        # Ignore test notifications
+        if int(id) != -1:
+            if features.has("organizations:workflow-engine-ui-links", event.group.organization):
+                id = get_key_from_rule_data(f.rule, "workflow_id")
+            elif features.has(
+                "organizations:workflow-engine-trigger-actions", event.group.organization
+            ):
+                id = get_key_from_rule_data(f.rule, "legacy_rule_id")
 
         settings = f.kwargs.get("schema_defined_settings")
         if settings:

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -710,7 +710,7 @@ class SentryAppFormConfigDataBlob(DataBlob):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SentryAppFormConfigDataBlob:
         if not isinstance(data.get("name"), str) or not isinstance(
-            data.get("value"), (str, type(None))
+            data.get("value"), (str, type(None), int)
         ):
             raise ValueError("Sentry app config must contain name and value keys")
         return cls(name=data["name"], value=data["value"], label=data.get("label"))


### PR DESCRIPTION
this fixes 2 bugs
1. We can't query for `rule_id` in test notifications b/c its -1
2. loosened the `isinstance` check when invoking the noa since we can have integer values in sentry apps.