### PR TITLE
feat(issues): Use the KL Divergence score algorithm for suspect tags

### DIFF
--- a/src/sentry/issues/suspect_tags.py
+++ b/src/sentry/issues/suspect_tags.py
@@ -4,7 +4,7 @@ from typing import NamedTuple
 import sentry_sdk
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
-from sentry.seer.workflows.compare import KeyedValueCount, keyed_rrf_score
+from sentry.seer.workflows.compare import KeyedValueCount, keyed_kl_score
 from sentry.utils.snuba import raw_snql_query
 
 
@@ -36,7 +36,7 @@ def get_suspect_tag_scores(
 
     return [
         Score(key=key, score=score)
-        for key, score in keyed_rrf_score(
+        for key, score in keyed_kl_score(
             baseline,
             outliers,
             total_baseline=baseline_count,

--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
@@ -44,8 +44,8 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.json() == {
             "data": [
-                {"tag": "key", "score": 0.01634056054997356},
-                {"tag": "other", "score": 0.016181914331041776},
+                {"tag": "key", "score": 2.7622287114272543},
+                {"tag": "other", "score": 0.0},
             ]
         }
 

--- a/tests/sentry/issues/test_suspect_tags.py
+++ b/tests/sentry/issues/test_suspect_tags.py
@@ -66,4 +66,4 @@ class SuspectTagsTest(TestCase, SnubaTestCase):
         self.mock_event(today, hash="a" * 32, tags={"key": False, "other": False}, group_id=2)
 
         results = get_suspect_tag_scores(1, 1, before, later, envs=[], group_id=1)
-        assert results == [("key", 0.01634056054997356), ("other", 0.016181914331041776)]
+        assert results == [("key", 2.7622287114272543), ("other", 0.0)]


### PR DESCRIPTION
I want to switch the Tags endpoint over to use the KL algorithm that Flags is using, so we can have some semblance of a suspect list in the ui, and reasonable cutoffs for when not to show anything at all.

Once the UI is in place, with some conditions for showing/hiding Tags & Flags, just Tags, just Flags, then we can iterate on the algorithms further and make things different. I don't think RRF is working well given our issues dataset and we will need some data analysis and iteration.

The existing algo, RRF, isn't returning useful data imo

I'm getting stuff like this which is not close to what i'd expect the suspect list to be for an issue i've specifically selected to test with:
```
{
    "data": [
        {
            "tag": "plan.total_members",
            "score": 0.01623975409836066
        },
        {
            "tag": "transaction",
            "score": 0.016181914331041776
        },
        {
            "tag": "organization.slug",
            "score": 0.015775335775335776
        },
        {
            "tag": "customerDomain.subdomain",
            "score": 0.015441176470588236
        },
        {
            "tag": "browser",
            "score": 0.015347018572825026
        },
        ... snip ...
```


