### PR TITLE
feat(explore): Better default query when drilling down from aggregates

### DIFF
--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -35,6 +35,7 @@ import {
   useExploreGroupBys,
   useExploreQuery,
   useExploreSortBys,
+  useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
@@ -54,11 +55,11 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   const location = useLocation();
   const {projects} = useProjects();
 
-  const topEvents = useTopEvents();
-  const groupBys = useExploreGroupBys();
-
   const {result, eventView, fields} = aggregatesTableResult;
 
+  const topEvents = useTopEvents();
+  const groupBys = useExploreGroupBys();
+  const visualizes = useExploreVisualizes();
   const sorts = useExploreSortBys();
   const setSorts = useSetExploreSortBys();
   const query = useExploreQuery();
@@ -165,7 +166,13 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
             </TableStatus>
           ) : result.isFetched && result.data?.length ? (
             result.data?.map((row, i) => {
-              const target = viewSamplesTarget(location, query, groupBys, row, {
+              const target = viewSamplesTarget({
+                location,
+                query,
+                groupBys,
+                visualizes,
+                sorts,
+                row,
                 projects,
               });
               return (

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -1,121 +1,157 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {ProjectFixture} from 'sentry-fixture/project';
 
+import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {viewSamplesTarget} from 'sentry/views/explore/utils';
 
 describe('viewSamplesTarget', function () {
   const project = ProjectFixture();
-  const extras = {projects: [project]};
+  const projects = [project];
+  const visualize = new Visualize(['count(span.duration)']);
+  const sort = {
+    field: 'count(span.duration)',
+    kind: 'desc' as const,
+  };
 
   it('simple drill down with no group bys', function () {
     const location = LocationFixture();
-    const target = viewSamplesTarget(location, '', [], {}, extras);
+    const target = viewSamplesTarget({
+      location,
+      query: '',
+      groupBys: [],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {},
+      projects,
+    });
     expect(target).toMatchObject({
       query: {
+        field: ['span.duration'],
         mode: 'samples',
         query: '',
+        sort: ['-span.duration'],
       },
     });
   });
 
   it('simple drill down with single group by', function () {
     const location = LocationFixture();
-    const target = viewSamplesTarget(
+    const target = viewSamplesTarget({
       location,
-      '',
-      ['foo'],
-      {foo: 'foo', 'count()': 10},
-      extras
-    );
+      query: '',
+      groupBys: ['foo'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {foo: 'foo', 'count(span.duration)': 10},
+      projects,
+    });
     expect(target).toMatchObject({
       query: {
+        field: ['foo', 'span.duration'],
         mode: 'samples',
         query: 'foo:foo',
+        sort: ['-span.duration'],
       },
     });
   });
 
   it('simple drill down with multiple group bys', function () {
     const location = LocationFixture();
-    const target = viewSamplesTarget(
+    const target = viewSamplesTarget({
       location,
-      '',
-      ['foo', 'bar', 'baz'],
-      {
+      query: '',
+      groupBys: ['foo', 'bar', 'baz'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
         foo: 'foo',
         bar: 'bar',
         baz: 'baz',
-        'count()': 10,
+        'count(span.duration)': 10,
       },
-      extras
-    );
+      projects,
+    });
     expect(target).toMatchObject({
       query: {
+        field: ['foo', 'bar', 'baz', 'span.duration'],
         mode: 'samples',
         query: 'foo:foo bar:bar baz:baz',
+        sort: ['-span.duration'],
       },
     });
   });
 
   it('simple drill down with on environment', function () {
     const location = LocationFixture();
-    const target = viewSamplesTarget(
+    const target = viewSamplesTarget({
       location,
-      '',
-      ['environment'],
-      {
+      query: '',
+      groupBys: ['environment'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
         environment: 'prod',
-        'count()': 10,
+        'count(span.duration)': 10,
       },
-      extras
-    );
+      projects,
+    });
     expect(target).toMatchObject({
       query: {
+        field: ['environment', 'span.duration'],
         mode: 'samples',
         query: '',
         environment: 'prod',
+        sort: ['-span.duration'],
       },
     });
   });
 
   it('simple drill down with on project id', function () {
     const location = LocationFixture();
-    const target = viewSamplesTarget(
+    const target = viewSamplesTarget({
       location,
-      '',
-      ['project.id'],
-      {
+      query: '',
+      groupBys: ['project.id'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
         'project.id': 1,
-        'count()': 10,
+        'count(span.duration)': 10,
       },
-      extras
-    );
+      projects,
+    });
     expect(target).toMatchObject({
       query: {
+        field: ['project.id', 'span.duration'],
         mode: 'samples',
         query: '',
         project: '1',
+        sort: ['-span.duration'],
       },
     });
   });
 
   it('simple drill down with on project slug', function () {
     const location = LocationFixture();
-    const target = viewSamplesTarget(
+    const target = viewSamplesTarget({
       location,
-      '',
-      ['project'],
-      {
+      query: '',
+      groupBys: ['project'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
         project: project.slug,
-        'count()': 10,
+        'count(span.duration)': 10,
       },
-      extras
-    );
+      projects,
+    });
     expect(target).toMatchObject({
       query: {
+        field: ['project', 'span.duration'],
         mode: 'samples',
         query: '',
         project: String(project.id),
+        sort: ['-span.duration'],
       },
     });
   });

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -13,6 +13,8 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {encodeSort} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {parseFunction} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
@@ -208,22 +210,32 @@ export function combineConfidenceForSeries(
   return 'high';
 }
 
-export function viewSamplesTarget(
-  location: Location,
-  query: string,
-  groupBys: string[],
-  row: Record<string, any>,
-  extras: {
-    // needed to generate targets when `project` is in the group by
-    projects: Project[];
-  }
-) {
+export function viewSamplesTarget({
+  location,
+  query,
+  groupBys,
+  visualizes,
+  sorts,
+  row,
+  projects,
+}: {
+  groupBys: string[];
+  location: Location;
+  // needed to generate targets when `project` is in the group by
+  projects: Project[];
+  query: string;
+  row: Record<string, any>;
+  sorts: Sort[];
+  visualizes: Visualize[];
+}) {
   const search = new MutableSearch(query);
 
+  // first update the resulting query to filter for the target group
   for (const groupBy of groupBys) {
     const value = row[groupBy];
+    // some fields require special handling so make sure to handle it here
     if (groupBy === 'project' && typeof value === 'string') {
-      const project = extras.projects.find(p => p.slug === value);
+      const project = projects.find(p => p.slug === value);
       if (defined(project)) {
         location.query.project = project.id;
       }
@@ -236,9 +248,65 @@ export function viewSamplesTarget(
     }
   }
 
+  // all group bys will be used as columns
+  const fields = groupBys.filter(Boolean);
+  const seenFields = new Set(fields);
+
+  // add all the arguments of the visualizations as columns
+  for (const visualize of visualizes) {
+    for (const yAxis of visualize.yAxes) {
+      const parsedFunction = parseFunction(yAxis);
+      if (!parsedFunction?.arguments[0]) {
+        continue;
+      }
+      const field = parsedFunction.arguments[0];
+      if (seenFields.has(field)) {
+        continue;
+      }
+      fields.push(field);
+      seenFields.add(field);
+    }
+  }
+
+  // fall back, force timestamp to be a column so we
+  // always have at least 1 column
+  if (fields.length === 0) {
+    fields.push('timestamp');
+    seenFields.add('timestamp');
+  }
+
+  // fall back, sort the last column present
+  let sortBy: Sort = {
+    field: fields[fields.length - 1]!,
+    kind: 'desc' as const,
+  };
+
+  // find the first valid sort and sort on that
+  for (const sort of sorts) {
+    const parsedFunction = parseFunction(sort.field);
+    if (!parsedFunction?.arguments[0]) {
+      continue;
+    }
+    const field = parsedFunction.arguments[0];
+
+    // on the odd chance that this sorted column was not added
+    // already, make sure to add it
+    if (!seenFields.has(field)) {
+      fields.push(field);
+    }
+
+    sortBy = {
+      field,
+      kind: sort.kind,
+    };
+    break;
+  }
+
   return newExploreTarget(location, {
     mode: Mode.SAMPLES,
+    fields,
     query: search.formatString(),
+    sortBys: [sortBy],
   });
 }
 


### PR DESCRIPTION
This improves the default query when drilling down from aggregates.
1. add the arguments of the visualizations as columns
2. try to apply the same sort that the aggregates is sorting on

Closes EXP-248