### PR TITLE
feat(seer): Add org default autofix setting

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -45,6 +45,7 @@ from sentry.constants import (
     ALERTS_MEMBER_WRITE_DEFAULT,
     ATTACHMENTS_ROLE_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
+    DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     GITHUB_COMMENT_BOT_DEFAULT,
     GITLAB_COMMENT_BOT_DEFAULT,
@@ -221,6 +222,13 @@ ORG_OPTIONS = (
     ("targetSampleRate", "sentry:target_sample_rate", float, TARGET_SAMPLE_RATE_DEFAULT),
     ("samplingMode", "sentry:sampling_mode", str, SAMPLING_MODE_DEFAULT),
     ("rollbackEnabled", "sentry:rollback_enabled", bool, ROLLBACK_ENABLED_DEFAULT),
+    (
+        # Sets the default value for new projects created in this organization
+        "defaultAutofixAutomationTuning",
+        "sentry:default_autofix_automation_tuning",
+        str,
+        DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+    ),
 )
 
 DELETION_STATUSES = frozenset(
@@ -832,6 +840,11 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
         min_value=PROJECT_RATE_LIMIT_DEFAULT, required=False
     )
     apdexThreshold = serializers.IntegerField(required=False)
+    defaultAutofixAutomationTuning = serializers.ChoiceField(
+        choices=["off", "low", "medium", "high", "always"],
+        required=False,
+        help_text="The default automation tuning setting for new projects.",
+    )
 
 
 # NOTE: We override the permission class of this endpoint in getsentry with the OrganizationDetailsPermission class

--- a/src/sentry/api/endpoints/organization_projects_experiment.py
+++ b/src/sentry/api/endpoints/organization_projects_experiment.py
@@ -17,7 +17,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
-from sentry.api.endpoints.team_projects import ProjectPostSerializer
+from sentry.api.endpoints.team_projects import ProjectPostSerializer, apply_default_project_settings
 from sentry.api.exceptions import ConflictError, ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import ProjectSummarySerializer
@@ -201,6 +201,9 @@ class OrganizationProjectsExperimentEndpoint(OrganizationEndpoint):
                 event=audit_log.get_event_id("PROJECT_ADD"),
                 data={**project.get_audit_log_data()},
             )
+
+        apply_default_project_settings(organization, project)
+
         project_created.send_robust(
             project=project,
             user=request.user,

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -29,11 +29,28 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.team import Team
-from sentry.seer.similarity.utils import project_is_seer_eligible
+from sentry.seer.similarity.utils import (
+    project_is_seer_eligible,
+    set_default_project_autofix_automation_tuning,
+)
 from sentry.signals import project_created
 from sentry.utils.snowflake import MaxSnowflakeRetryError
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
+
+
+def apply_default_project_settings(organization: Organization, project: Project) -> None:
+    # Turns on some inbound filters by default for new Javascript platform projects
+    if project.platform and project.platform.startswith("javascript"):
+        set_default_inbound_filters(project, organization)
+
+    set_default_symbol_sources(project)
+
+    # Create project option to turn on ML similarity feature for new EA projects
+    if project_is_seer_eligible(project):
+        project.update_option("sentry:similarity_backfill_completed", int(time.time()))
+
+    set_default_project_autofix_automation_tuning(organization, project)
 
 
 class ProjectPostSerializer(serializers.Serializer):
@@ -215,13 +232,7 @@ class TeamProjectsEndpoint(TeamEndpoint):
             else:
                 project.add_team(team)
 
-            # XXX: create sample event?
-
-            # Turns on some inbound filters by default for new Javascript platform projects
-            if project.platform and project.platform.startswith("javascript"):
-                set_default_inbound_filters(project, team.organization)
-
-            set_default_symbol_sources(project)
+            apply_default_project_settings(team.organization, project)
 
             common_audit_data: AuditData = {
                 "request": request,
@@ -253,10 +264,6 @@ class TeamProjectsEndpoint(TeamEndpoint):
                 origin=origin,
                 sender=self,
             )
-
-            # Create project option to turn on ML similarity feature for new EA projects
-            if project_is_seer_eligible(project):
-                project.update_option("sentry:similarity_backfill_completed", int(time.time()))
 
         return Response(
             serialize(project, request.user, ProjectSummarySerializer(collapse=["unusedFeatures"])),

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -552,6 +552,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     requiresSso: bool
     rollbackEnabled: bool
     streamlineOnly: bool
+    defaultAutofixAutomationTuning: str
 
 
 class DetailedOrganizationSerializer(OrganizationSerializer):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -34,6 +34,7 @@ from sentry.constants import (
     ATTACHMENTS_ROLE_DEFAULT,
     DATA_CONSENT_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
+    DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     GITHUB_COMMENT_BOT_DEFAULT,
     GITLAB_COMMENT_BOT_DEFAULT,
@@ -696,6 +697,10 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             ),
             "rollbackEnabled": bool(
                 obj.get_option("sentry:rollback_enabled", ROLLBACK_ENABLED_DEFAULT)
+            ),
+            "defaultAutofixAutomationTuning": obj.get_option(
+                "sentry:default_autofix_automation_tuning",
+                DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
             ),
             "streamlineOnly": obj.get_option("sentry:streamline_ui_only", None),
             "trustedRelays": [

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -322,6 +322,7 @@ class OrganizationExamples:
                 "githubNudgeInvite": True,
                 "gitlabPRBot": True,
                 "aggregatedDataConsent": False,
+                "defaultAutofixAutomationTuning": "off",
                 "issueAlertsThreadFlag": True,
                 "metricAlertsThreadFlag": True,
                 "trustedRelays": [],

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -706,6 +706,7 @@ UPTIME_AUTODETECTION = True
 TARGET_SAMPLE_RATE_DEFAULT = 1.0
 SAMPLING_MODE_DEFAULT = "organization"
 ROLLBACK_ENABLED_DEFAULT = True
+DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT = "off"
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope
 EVENTS_MEMBER_ADMIN_DEFAULT = True

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -8,6 +8,7 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.grouping.api import get_contributing_variant_and_component
 from sentry.grouping.variants import BaseVariant, ComponentVariant
 from sentry.killswitches import killswitch_matches_context
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.utils.safe import get_path
@@ -421,3 +422,15 @@ def project_is_seer_eligible(project: Project) -> bool:
     is_region_enabled = options.get("similarity.new_project_seer_grouping.enabled")
 
     return not is_backfill_completed and is_region_enabled
+
+
+def set_default_project_autofix_automation_tuning(
+    organization: Organization, project: Project
+) -> None:
+    org_default_autofix_automation_tuning = organization.get_option(
+        "sentry:default_autofix_automation_tuning"
+    )
+    if org_default_autofix_automation_tuning and org_default_autofix_automation_tuning != "off":
+        project.update_option(
+            "sentry:default_autofix_automation_tuning", org_default_autofix_automation_tuning
+        )


### PR DESCRIPTION
Adds a default value for new projects within an organization. If set to "high", new projects created should default to "high".

frontend #91205