### PR TITLE
ref: fix monkeypatch of post-deploy migrations

### DIFF
--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -80,6 +80,7 @@ else:
 
 
 def monkey_migrations():
+    from django.core.management.commands import migrate
     from django.db import models
 
     # This import needs to be below the other imports for `executor` and `writer` so
@@ -87,7 +88,7 @@ def monkey_migrations():
     from django.db.migrations import executor, migration, writer
 
     # monkeypatch Django's migration executor and template.
-    executor.MigrationExecutor = SentryMigrationExecutor  # type: ignore[misc]
+    migrate.MigrationExecutor = executor.MigrationExecutor = SentryMigrationExecutor  # type: ignore[attr-defined, misc]
     migration.Migration.initial = None
     writer.MIGRATION_TEMPLATE = SENTRY_MIGRATION_TEMPLATE
     models.Field.deconstruct = deconstruct  # type: ignore[method-assign]


### PR DESCRIPTION
```console
$ MIGRATION_SKIP_DANGEROUS=1 sentry django migrate
Operations to perform:
  Apply all migrations: auth, contenttypes, explore, feedback, flags, hybridcloud, insights, monitors, nodestore, remote_subscriptions, replays, sentry, sessions, sites, social_auth, tempest, uptime, workflow_engine
Running migrations:
23:14:34 [WARNING] sentry.new_migrations.monkey.executor: (skipping post deploy migration)
  Applying uptime.0041_uptime_backfill_detector_grouphash... FAKED
```

<!-- Describe your PR here. -->