### PR TITLE
chore(aci): add group_id and event_id to workflow logs to make querying easier

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -440,6 +440,8 @@ def fire_actions_for_groups(
                 "workflow_ids": [workflow.id for workflow in workflows],
                 "actions": filtered_actions,
                 "event_data": event_data,
+                "group_id": group.id,
+                "event_id": event_data.event.event_id,
             },
         )
 
@@ -502,7 +504,11 @@ def process_delayed_workflows(
 
     logger.info(
         "delayed_workflow.workflows",
-        extra={"data": workflow_event_dcg_data, "workflows": set(dcg_to_workflow.values())},
+        extra={
+            "data": workflow_event_dcg_data,
+            "workflows": set(dcg_to_workflow.values()),
+            "project_id": project_id,
+        },
     )
 
     # Get unique query groups to query Snuba
@@ -531,7 +537,7 @@ def process_delayed_workflows(
     }
     logger.info(
         "delayed_workflow.condition_group_results",
-        extra={"condition_group_results": serialized_results},
+        extra={"condition_group_results": serialized_results, "project_id": project_id},
     )
 
     # Evaluate DCGs
@@ -545,7 +551,7 @@ def process_delayed_workflows(
 
     logger.info(
         "delayed_workflow.groups_to_fire",
-        extra={"groups_to_dcgs": groups_to_dcgs},
+        extra={"groups_to_dcgs": groups_to_dcgs, "project_id": project_id},
     )
 
     dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -96,6 +96,16 @@ def enqueue_workflow(
         value=value,
     )
 
+    logger.info(
+        "workflow_engine.enqueue_workflow",
+        extra={
+            "workflow": workflow.id,
+            "group_id": event.group_id,
+            "event_id": event.event_id,
+            "delayed_conditions": [condition.id for condition in delayed_conditions],
+        },
+    )
+
 
 def evaluate_workflow_triggers(
     workflows: set[Workflow], event_data: WorkflowEventData
@@ -249,6 +259,8 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
             logger.info(
                 "workflow_engine.process_workflows.triggered_workflows",
                 extra={
+                    "group_id": event_data.event.group_id,
+                    "event_id": event_data.event.event_id,
                     "event_data": asdict(event_data),
                     "event_environment_id": environment.id,
                     "triggered_workflows": [workflow.id for workflow in triggered_workflows],
@@ -268,6 +280,8 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
         logger.info(
             "workflow_engine.process_workflows.actions (all)",
             extra={
+                "group_id": event_data.event.group_id,
+                "event_id": event_data.event.event_id,
                 "workflow_ids": [workflow.id for workflow in triggered_workflows],
                 "action_ids": [action.id for action in actions],
                 "detector_type": detector.type,
@@ -290,6 +304,8 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
         logger.info(
             "workflow_engine.process_workflows.triggered_actions (batch)",
             extra={
+                "group_id": event_data.event.group_id,
+                "event_id": event_data.event.event_id,
                 "workflow_ids": [workflow.id for workflow in triggered_workflows],
                 "action_ids": [action.id for action in actions],
                 "detector_type": detector.type,

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -101,6 +101,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_logger.info.assert_called_with(
             "workflow_engine.process_workflows.triggered_actions (batch)",
             extra={
+                "group_id": self.group.id,
+                "event_id": self.event.event_id,
                 "workflow_ids": [self.error_workflow.id],
                 "action_ids": [self.action.id],
                 "detector_type": self.error_detector.type,


### PR DESCRIPTION
I am seeing some weird behavior I want to investigate. It would be nice to be able to trace an event through workflow engine, so adding it to logs