### PR TITLE
feat(aci): Reject attempts to set Action type to non-permitted integration actions

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.workflow_engine.endpoints.validators.utils import validate_json_schema
 from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.processors.action import is_action_permitted
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler
 
@@ -30,12 +31,32 @@ class BaseActionValidator(CamelSnakeSerializer):
         config_schema = self._get_action_handler().config_schema
         return validate_json_schema(value, config_schema)
 
+    def validate_type(self, value) -> Any:
+        try:
+            action_type = Action.Type(value)
+        except ValueError:
+            raise serializers.ValidationError(f"Invalid action type: {value}")
+        self._check_action_type(action_type)
+        return value
+
+    def _check_action_type(self, action_type: Action.Type) -> None:
+        organization = self.context.get("organization")
+        if not organization:
+            # ¯\_(ツ)_/¯
+            # TODO(kylec): Require organization to be in the context.
+            return
+        if not is_action_permitted(action_type, organization):
+            raise serializers.ValidationError(
+                f"Organization does not allow this action type: {action_type}"
+            )
+
     def create(self, validated_value: dict[str, Any]) -> Action:
-        """
-        TODO @saponifi3d -- add any org checks for creating actions here
-        """
+        """ """
+        self._check_action_type(Action.Type(validated_value["type"]))
         return Action.objects.create(**validated_value)
 
     def update(self, instance: Action, validated_value: dict[str, Any]) -> Action:
+        if instance.type != validated_value["type"]:
+            self._check_action_type(Action.Type(validated_value["type"]))
         instance.update(**validated_value)
         return instance

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -57,7 +57,9 @@ class WorkflowValidator(CamelSnakeSerializer):
             BaseDataConditionGroupValidator(data=condition_group).is_valid(raise_exception=True)
 
             for action in actions:
-                BaseActionValidator(data=action).is_valid(raise_exception=True)
+                BaseActionValidator(data=action, context=self.context).is_valid(
+                    raise_exception=True
+                )
 
         return value
 

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -57,6 +57,18 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         PLUGIN = "plugin"
         WEBHOOK = "webhook"
 
+        def is_integration(self) -> bool:
+            """
+            Returns True if the action is an integration action.
+            For those, the value should correspond to the integration key.
+            """
+            return self not in [
+                Action.Type.EMAIL,
+                Action.Type.SENTRY_APP,
+                Action.Type.PLUGIN,
+                Action.Type.WEBHOOK,
+            ]
+
     # The type field is used to denote the type of action we want to trigger
     type = models.TextField(choices=[(t.value, t.value) for t in Type])
     data = models.JSONField(default=dict)

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -7,8 +7,12 @@ from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Coalesce
 from django.utils import timezone
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.exceptions import NotRegistered
+from sentry.integrations.base import IntegrationFeatures
+from sentry.integrations.manager import default_manager as integrations_manager
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
@@ -188,3 +192,45 @@ def get_integration_services(organization_id: int) -> dict[int, list[tuple[int, 
             )
 
     return services
+
+
+def _get_integration_features(action_type: Action.Type) -> frozenset[IntegrationFeatures]:
+    """
+    Get the IntegrationFeatures for an integration-based action type.
+    """
+    assert action_type.is_integration()
+    integration_key = action_type.value  # action types should be match integration keys.
+    try:
+        integration = integrations_manager.get(integration_key)
+    except NotRegistered:
+        raise ValueError(f"No integration found for action type: {action_type}")
+    return integration.features
+
+
+# The features that are relevent to Action behaviors;
+# if the organization doesn't have access to all of the features an integration
+# requires that are in this list, the action should not be permitted.
+_ACTION_RELEVANT_INTEGRATION_FEATURES = {
+    IntegrationFeatures.ISSUE_BASIC,
+    IntegrationFeatures.ISSUE_SYNC,
+    IntegrationFeatures.TICKET_RULES,
+    IntegrationFeatures.ALERT_RULE,
+    IntegrationFeatures.ENTERPRISE_ALERT_RULE,
+    IntegrationFeatures.ENTERPRISE_INCIDENT_MANAGEMENT,
+    IntegrationFeatures.INCIDENT_MANAGEMENT,
+}
+
+
+def is_action_permitted(action_type: Action.Type, organization: Organization) -> bool:
+    """
+    Check if an action type is permitted for an organization.
+    """
+    if not action_type.is_integration():
+        return True
+    integration_features = _get_integration_features(action_type)
+    required_org_features = integration_features.intersection(_ACTION_RELEVANT_INTEGRATION_FEATURES)
+    feature_names = [
+        f"organizations:integrations-{integration_feature}"
+        for integration_feature in required_org_features
+    ]
+    return all(features.has(feature_name, organization) for feature_name in feature_names)

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -1,7 +1,6 @@
-from unittest import TestCase, mock
+from unittest import mock
 
-from sentry.models.organization import Organization
-from sentry.testutils.helpers.features import Feature
+from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
 from tests.sentry.workflow_engine.test_base import MockActionHandler
@@ -88,7 +87,7 @@ class TestBaseActionValidator(TestCase):
         assert result is False
 
     def test_validate_type__action_gated(self, mock_action_handler_get):
-        organization = Organization(slug="test-org")
+        organization = self.create_organization()
 
         def make_validator():
             return BaseActionValidator(
@@ -100,10 +99,10 @@ class TestBaseActionValidator(TestCase):
             )
 
         validator = make_validator()
-        with Feature({"organizations:integrations-alert-rule": False}):
+        with self.feature({"organizations:integrations-alert-rule": False}):
             assert not validator.is_valid()
 
         # Exact same one, but new, because validation is cached.
         validator2 = make_validator()
-        with Feature({"organizations:integrations-alert-rule": True}):
+        with self.feature("organizations:integrations-alert-rule"):
             assert validator2.is_valid()

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from django.utils import timezone
 
 from sentry.integrations.base import IntegrationFeatures
-from sentry.models.organization import Organization
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
@@ -105,7 +104,7 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
 class TestIsActionPermitted(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.action._get_integration_features")
     def test_basic(self, mock_get_features):
-        org = Organization(slug="test-org")
+        org = self.create_organization()
 
         # Test non-integration actions (should always be permitted)
         assert is_action_permitted(Action.Type.EMAIL, org)


### PR DESCRIPTION
Add a new `is_action_permitted` method for checking organization permissions to use action types.
Extend the action validator to require any action type being chosen to be permitted.