### PR TITLE
:wrench: chore(aci): add logs for `action.trigger` and notification actions

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Collection, Sequence
+from dataclasses import asdict
 from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
@@ -263,6 +264,19 @@ class BaseIssueAlertHandler(ABC):
             # Create a rule
             rule = cls.create_rule_instance_from_action(action, detector, job)
 
+            logger.info(
+                "notification_action.execute_via_issue_alert_handler",
+                extra={
+                    "action_id": action.id,
+                    "detector_id": detector.id,
+                    "job": asdict(job),
+                    "rule_id": rule.id,
+                    "rule_project_id": rule.project.id,
+                    "rule_environment_id": rule.environment_id,
+                    "rule_label": rule.label,
+                    "rule_data": rule.data,
+                },
+            )
             # Get the futures
             futures = cls.get_rule_futures(job, rule, notification_uuid)
 
@@ -370,6 +384,19 @@ class BaseMetricAlertHandler(ABC):
 
             notification_uuid = str(uuid.uuid4())
 
+            logger.info(
+                "notification_action.execute_via_metric_alert_handler",
+                extra={
+                    "action_id": action.id,
+                    "detector_id": detector.id,
+                    "job": asdict(job),
+                    "notification_context": asdict(notification_context),
+                    "alert_context": asdict(alert_context),
+                    "metric_issue_context": asdict(metric_issue_context),
+                    "open_period_context": asdict(open_period_context),
+                    "trigger_status": trigger_status,
+                },
+            )
             cls.send_alert(
                 notification_context=notification_context,
                 alert_context=alert_context,

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+from dataclasses import asdict
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -17,6 +19,9 @@ from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models import Detector
+
+
+logger = logging.getLogger(__name__)
 
 
 @region_silo_model
@@ -68,6 +73,15 @@ class Action(DefaultFieldsModel, JSONConfigBase):
 
     def trigger(self, event_data: WorkflowEventData, detector: Detector) -> None:
         # get the handler for the action type
+        logger.info(
+            "workflow_engine.action.trigger",
+            extra={
+                "detector_id": detector.id,
+                "action_id": self.id,
+                "event_data": asdict(event_data),
+            },
+        )
+
         handler = self.get_handler()
         handler.execute(event_data, self, detector)
 

--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -72,7 +72,6 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         return action_handler_registry.get(action_type)
 
     def trigger(self, event_data: WorkflowEventData, detector: Detector) -> None:
-        # get the handler for the action type
         logger.info(
             "workflow_engine.action.trigger",
             extra={

--- a/tests/sentry/workflow_engine/models/test_action.py
+++ b/tests/sentry/workflow_engine/models/test_action.py
@@ -7,12 +7,12 @@ from jsonschema import ValidationError
 from sentry.eventstore.models import GroupEvent
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import ActionHandler
+from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
 
 
 class TestAction(TestCase):
     def setUp(self):
-        self.mock_event = Mock(spec=GroupEvent)
+        self.mock_event = WorkflowEventData(event=Mock(spec=GroupEvent))
         self.mock_detector = Mock(name="detector")
         self.action = Action(type=Action.Type.SLACK)
         self.config_schema = {


### PR DESCRIPTION
this prs adds logs for the workflow engine's `Action.trigger` method.

it also adds logs for the notification actions to help with debugging and validation during rollout