### PR TITLE
ref(onboarding): Remove no longer used/referenced pending status

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -39,7 +39,6 @@ class OnboardingTask:
 
 class OnboardingTaskStatus:
     COMPLETE = 1
-    PENDING = 2
     SKIPPED = 3
 
 
@@ -71,7 +70,6 @@ class AbstractOnboardingTask(Model):
 
     STATUS_CHOICES = (
         (OnboardingTaskStatus.COMPLETE, "complete"),
-        (OnboardingTaskStatus.PENDING, "pending"),
         (OnboardingTaskStatus.SKIPPED, "skipped"),
     )
 

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -39,6 +39,8 @@ class OnboardingTask:
 
 class OnboardingTaskStatus:
     COMPLETE = 1
+    # deprecated - no longer used
+    PENDING = 2
     SKIPPED = 3
 
 

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -40,7 +40,7 @@ class OnboardingTask:
 class OnboardingTaskStatus:
     COMPLETE = 1
     # deprecated - no longer used
-    PENDING = 2
+    # PENDING = 2
     SKIPPED = 3
 
 

--- a/tests/acceptance/test_quick_start.py
+++ b/tests/acceptance/test_quick_start.py
@@ -24,23 +24,18 @@ class OrganizationQuickStartTest(AcceptanceTestCase):
         settings.PRIVACY_URL = "https://sentry.io/privacy/"
         settings.TERMS_URL = "https://sentry.io/terms/"
 
-        # navigate to the new organization page form
         self.browser.get("/organizations/new/")
 
-        # create new organization
         self.browser.element('input[name="name"]').send_keys("new org")
         self.browser.element('input[name="agreeTerms"]').click()
         self.browser.click('button[type="submit"]')
 
-        # create new project
         self.browser.wait_until_test_id("platform-javascript-react")
         self.browser.click('[data-test-id="platform-javascript-react"')
         self.browser.click('button[aria-label="Create Project"]')
 
-        # open the getting start docs for react
         self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
 
-        # verify that the quick start sidebar is not automatically opened
         assert not self.browser.element_exists_by_test_id("quick-start-content")
 
     @with_feature("organizations:onboarding")
@@ -54,35 +49,26 @@ class OrganizationQuickStartTest(AcceptanceTestCase):
                 date_completed=datetime(year=2024, month=12, day=25, tzinfo=timezone.utc),
             )
 
-        # Load the organization's page
         self.browser.get(f"/organizations/{self.organization.slug}/")
-
-        # Assert no error happen
         assert not self.browser.element_exists(xpath='//h1[text()="Oops! Something went wrong"]')
-
-        # Check that the quick start sidebar is NOT shown
         assert not self.browser.element_exists('[aria-label="Onboarding"]')
 
     @with_feature("organizations:onboarding")
-    def test_quick_start_rendered_because_not_all_tasks_are_done_even_if_all_overdue(self):
-        for task in list(OrganizationOnboardingTask.TASK_KEY_MAP.keys()):
-            # Record tasks with some marked as PENDING and others as COMPLETE, all overdue
-            status = OnboardingTaskStatus.COMPLETE
-            if task in [OnboardingTask.RELEASE_TRACKING, OnboardingTask.LINK_SENTRY_TO_SOURCE_CODE]:
-                status = OnboardingTaskStatus.PENDING
+    def test_quick_start_renders_even_when_all_tasks_are_overdue_but_one_is_missing_to_complete(
+        self,
+    ):
+        excluded_required_task = OnboardingTask.FIRST_TRANSACTION
+        tasks_to_process = list(
+            OrganizationOnboardingTask.TASK_KEY_MAP.keys() - {excluded_required_task}
+        )
 
+        for task in tasks_to_process:
             OrganizationOnboardingTask.objects.record(
                 organization_id=self.organization.id,
                 task=task,
-                status=status,
+                status=OnboardingTaskStatus.COMPLETE,
                 date_completed=datetime(year=2024, month=12, day=25, tzinfo=timezone.utc),
             )
 
-        # Load the organization's page
         self.browser.get(f"/organizations/{self.organization.slug}/")
-
-        # Assert no error happen
-        assert not self.browser.element_exists(xpath='//h1[text()="Oops! Something went wrong"]')
-
-        # Check that the quick start sidebar is shown
-        assert self.browser.element_exists('[aria-label="Onboarding"]')
+        self.browser.wait_until('[aria-label="Onboarding"]')

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -225,14 +225,14 @@ class OnboardingTasksSerializerTest(TestCase):
         task = OrganizationOnboardingTask.objects.create(
             organization_id=self.organization.id,
             task=OnboardingTask.FIRST_PROJECT,
-            status=OnboardingTaskStatus.PENDING,
+            status=OnboardingTaskStatus.COMPLETE,
             user_id=self.user.id,
             completion_seen=completion_seen,
         )
 
         result = serialize(task, self.user, serializer)
         assert result["task"] == "create_project"
-        assert result["status"] == "pending"
+        assert result["status"] == "complete"
         assert result["completionSeen"] == completion_seen
         assert result["data"] == {}
 
@@ -244,13 +244,13 @@ class TrustedRelaySerializer(TestCase):
         task = OrganizationOnboardingTask.objects.create(
             organization_id=self.organization.id,
             task=OnboardingTask.FIRST_PROJECT,
-            status=OnboardingTaskStatus.PENDING,
+            status=OnboardingTaskStatus.COMPLETE,
             user_id=self.user.id,
             completion_seen=completion_seen,
         )
 
         result = serialize(task, self.user, serializer)
         assert result["task"] == "create_project"
-        assert result["status"] == "pending"
+        assert result["status"] == "complete"
         assert result["completionSeen"] == completion_seen
         assert result["data"] == {}


### PR DESCRIPTION
Since the job [onboardingtasks_update_pending_second_platform_status_to_complete.py](https://github.com/getsentry/getsentry/blob/master/getsentry/jobs/onboardingtasks_update_pending_second_platform_status_to_complete.py) has been executed for all the regions we care about, do we still want to remove the pending status, given that it is no longer used or referenced?

more details: https://www.notion.so/sentry/Onboarding-Tasks-Jobs-1ed8b10e4b5d80abb67ec3a64ab77c27?pvs=4#1ed8b10e4b5d807083ced22525595e43

Related PRs: 
https://github.com/getsentry/sentry/pull/89719
https://github.com/getsentry/sentry/pull/89376

closes TET-288

