### PR TITLE
fix(laravel-insights): width of time spent column

### DIFF
--- a/static/app/views/insights/pages/platform/shared/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pathsTable.tsx
@@ -71,7 +71,7 @@ const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'failure_rate()', name: t('Error Rate'), width: 124},
   {key: 'avg(span.duration)', name: t('AVG'), width: 90},
   {key: 'p95(span.duration)', name: t('P95'), width: 90},
-  {key: 'sum(span.duration)', name: t('Time Spent'), width: 90},
+  {key: 'sum(span.duration)', name: t('Time Spent'), width: 120},
   {key: 'count_unique(user)', name: t('Users'), width: 90},
 ];
 


### PR DESCRIPTION
Before:
<img width="196" alt="Screenshot 2025-05-09 at 10 10 37" src="https://github.com/user-attachments/assets/1c7cc94f-6bb9-4ff9-a86e-289aa901b97b" />


After:
<img width="220" alt="Screenshot 2025-05-09 at 10 10 24" src="https://github.com/user-attachments/assets/6dd70b67-b817-4e35-853e-5edb498f06af" />
<img width="229" alt="Screenshot 2025-05-09 at 10 10 31" src="https://github.com/user-attachments/assets/400d7dd2-1e3c-4a6a-97cb-88fad583915d" />
