### PR TITLE
feat(nextjs-insights): don't show dash for folders

### DIFF
--- a/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.tsx
@@ -247,7 +247,7 @@ function TreeNodeRenderer({item, indent = 0}: {item: TreeNode; indent?: number})
           <TextOverflow>{item.name}</TextOverflow>
         </PathWrapper>
       </div>
-      <div>{'–'}</div>
+      <div>{}</div>
       {!isCollapsed &&
         item.children
           .toSorted(sortTreeChildren)

--- a/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.tsx
@@ -247,7 +247,7 @@ function TreeNodeRenderer({item, indent = 0}: {item: TreeNode; indent?: number})
           <TextOverflow>{item.name}</TextOverflow>
         </PathWrapper>
       </div>
-      <div>{}</div>
+      <div />
       {!isCollapsed &&
         item.children
           .toSorted(sortTreeChildren)


### PR DESCRIPTION
Before:
<img width="461" alt="Screenshot 2025-05-09 at 11 23 42" src="https://github.com/user-attachments/assets/a9acacb2-1629-4adc-8a66-28f6282ad244" />

After:
<img width="400" alt="Screenshot 2025-05-09 at 11 23 27" src="https://github.com/user-attachments/assets/b6aff2c0-ba34-4de0-8bed-c5fc87ee30a6" />

