### PR TITLE
fix(ci): stop the pre-commit hook from removing unused lint directives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,7 @@ repos:
         name: eslint
         language: system
         files: \.(ts|js|tsx|jsx|mjs)$
-        entry: ./node_modules/.bin/eslint --config ./eslint-pre-commit.config.mjs --quiet --fix
+        entry: ./node_modules/.bin/eslint --config ./eslint-pre-commit.config.mjs --report-unused-disable-directives-severity off --quiet --fix
 
       - id: stylelint
         name: stylelint

--- a/eslint-pre-commit.config.mjs
+++ b/eslint-pre-commit.config.mjs
@@ -11,6 +11,9 @@ export default typescript.config([
         projectService: false,
       },
     },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off',
+    },
   },
   {
     name: typeAwareLintRules.name,


### PR DESCRIPTION
as the pre-commit hook doesn't run with the full set of rules right now, it would remove eslint-disable-line directives for typed-lint rules that we need when run with the full config