### PR TITLE
fix(gen-ai): Remove de check on settings

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -2,17 +2,14 @@ import type {FieldObject} from 'sentry/components/forms/types';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 
 export const defaultEnableSeerFeaturesValue = (organization: Organization) => {
   const isBaa = false; // TODO: add check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
-  const isDeRegion = getRegionDataFromOrganization(organization)?.name === 'de';
-  return !organization.hideAiFeatures && !(isDeRegion || isBaa);
+  return !organization.hideAiFeatures && !isBaa;
 };
 
 export const makeHideAiFeaturesField = (organization: Organization): FieldObject => {
   const isBaa = false; // TODO: add a check here once we have a way to check if the org is a BAA customer. Leave it as false for now.
-  const isDeRegion = getRegionDataFromOrganization(organization)?.name === 'de';
 
   return {
     name: 'hideAiFeatures',
@@ -24,7 +21,7 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
       ),
     }),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
-    disabled: ({access}) => isDeRegion || !access.has('org:write'),
+    disabled: ({access}) => !access.has('org:write'),
     getValue: value => {
       // Reversing value because the field was previously called hideAiFeatures and we've inverted the behavior.
       return !value;
@@ -33,8 +30,6 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
       ? t(
           'To remain HIPAA compliant, Generative AI features are disabled for BAA customers'
         )
-      : isDeRegion
-        ? t('Generative AI features are currently not supported for the EU')
-        : null,
+      : null,
   };
 };

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -223,7 +223,7 @@ describe('OrganizationSettingsForm', function () {
     });
   });
 
-  it('disables hideAiFeatures toggle and shows tooltip for DE region', function () {
+  it('shows hideAiFeatures togglefor DE region', function () {
     // Mock the region util to return DE region
     jest.mocked(RegionUtils.getRegionDataFromOrganization).mockImplementation(() => ({
       name: 'de',
@@ -246,6 +246,6 @@ describe('OrganizationSettingsForm', function () {
     );
 
     const toggle = screen.getByRole('checkbox', {name: 'Enable Generative AI features'});
-    expect(toggle).toBeDisabled();
+    expect(toggle).toBeEnabled();
   });
 });


### PR DESCRIPTION
EU customer had a weird state where Seer was showing even though the toggle was set to false. They also couldn't toggle the toggle. But since we're rolled out in EU, this check should be removed.
<img width="883" alt="Screenshot 2025-05-09 at 6 28 17 AM" src="https://github.com/user-attachments/assets/7f4ae0fa-7050-4f58-be6a-b9e06792329f" />

Note for reviewer: pls double check that this isn't gonna cause a weird state too with the inversion logic we have going on. Like the switch isn't going to do the opposite of what it says in EU now? (and on that note, if it defaulted to false, why was Seer showing up anyway?)
