### PR TITLE
chore(aci): add logs for group_to_groupevent and workflows passing filters

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from typing import TypedDict
 
@@ -25,6 +26,8 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import WorkflowEventData
+
+logger = logging.getLogger(__name__)
 
 EnqueuedAction = tuple[DataConditionGroup, list[DataCondition]]
 
@@ -79,6 +82,17 @@ def update_workflow_fire_histories(
         WorkflowDataConditionGroup.objects.filter(
             condition_group__dataconditiongroupaction__action__in=actions_to_fire
         ).values_list("workflow_id", flat=True)
+    )
+
+    logger.info(
+        "workflow_engine.workflow_fire_history.update",
+        extra={
+            "workflow_ids": list(fired_workflows),
+            "group_id": event_data.event.group_id,
+            "event_id": event_data.event.event_id,
+            "has_passed_filters": updates["has_passed_filters"],
+            "has_fired_actions": updates["has_fired_actions"],
+        },
     )
 
     updated_rows = WorkflowFireHistory.objects.filter(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -401,6 +401,17 @@ def fire_actions_for_groups(
     trigger_group_to_dcg_model: dict[DataConditionHandler.Group, dict[int, int]],
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
+    serialized_groups = {
+        group.id: group_event.event_id for group, group_event in group_to_groupevent.items()
+    }
+    logger.info(
+        "workflow_engine.delayed_workflow.fire_actions_for_groups",
+        extra={
+            "groups_to_fire": groups_to_fire,
+            "group_to_groupevent": serialized_groups,
+        },
+    )
+
     for group, group_event in group_to_groupevent.items():
         event_data = WorkflowEventData(event=group_event)
         detector = get_detector_by_event(event_data)


### PR DESCRIPTION
I am failing to locally reproduce (in a test) a default workflow passing trigger conditions on a group event but failing to pass filters (and there are no filter conditions).

I'm also unable to reproduce `WorkflowFireHistories` failing to create for a workflow passing a delayed trigger condition.

Add more logs to investigate the state.