### PR TITLE
chore(deps): bump platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "moment-timezone": "0.5.44",
     "papaparse": "^5.3.2",
     "peggy": "^4.1.1",
-    "platformicons": "^8.0.1",
+    "platformicons": "^8.0.4",
     "po-catalog-loader": "2.1.0",
     "prettier": "3.5.3",
     "prismjs": "^1.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9941,10 +9941,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.1.tgz#440bfdfd8cc0eff1468215310d8eed705d8694f4"
-  integrity sha512-aHBu172vCSIg3ZnAaIrnMc4EyHgyslqF9XFhNz505f53CZsXmXKTAn5rUOvFhCbYT5Qp6SeUusRiVCrg8h/jOw==
+platformicons@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-8.0.4.tgz#f26e79b7bfbce1d8ae3af382215efe0ad6e19fcf"
+  integrity sha512-hvIWouaTtmnHv/JD42LwOg4MOd020q8Vf1Xs8uzqiA5+cqsiYqhR22WNV+Vzx6+T1K8ZLO9LV8+FvpFargKdlw==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
Bumps `platformicons` to the latest version.
The Rust icon has been improved, plus some new icons have been added.