### PR TITLE
ref(dashboards): Add `TimeSeries.meta.order`

### DIFF
--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -28,6 +28,10 @@ export type TimeSeriesMeta = {
   valueType: TimeSeriesValueType;
   valueUnit: TimeSeriesValueUnit;
   isOther?: boolean;
+  /**
+   * For a top N request, the order is the position of this `TimeSeries` within the respective yAxis.
+   */
+  order?: number;
 };
 
 export type TimeSeriesItem = {

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -176,7 +176,8 @@ export function transformToSeriesMap(
         return convertEventsStatsToTimeSeriesData(
           hasMultipleYAxes ? seriesOrGroupName : yAxis[0]!,
           result[seriesOrGroupName]!,
-          hasMultipleYAxes ? undefined : seriesOrGroupName
+          hasMultipleYAxes ? undefined : seriesOrGroupName,
+          hasMultipleYAxes ? undefined : result[seriesOrGroupName]!.order
         );
       }
     );
@@ -212,12 +213,13 @@ export function transformToSeriesMap(
 
   return processedResults
     .sort(([, orderA], [, orderB]) => orderA - orderB)
-    .reduce((acc, [groupName, , groupData]) => {
+    .reduce((acc, [groupName, groupOrder, groupData]) => {
       Object.keys(groupData).forEach(seriesName => {
         const [, series] = convertEventsStatsToTimeSeriesData(
           seriesName,
           groupData[seriesName]!,
-          groupName
+          groupName,
+          groupOrder
         );
 
         if (acc[seriesName]) {
@@ -233,7 +235,8 @@ export function transformToSeriesMap(
 export function convertEventsStatsToTimeSeriesData(
   seriesName: string,
   seriesData: EventsStats,
-  alias?: string
+  alias?: string,
+  order?: number
 ): [number, TimeSeries] {
   const label = alias ?? (seriesName || FALLBACK_SERIES_NAME);
 
@@ -257,6 +260,10 @@ export function convertEventsStatsToTimeSeriesData(
     samplingRate: seriesData.meta?.accuracy?.samplingRate,
     dataScanned: seriesData.meta?.dataScanned,
   };
+
+  if (defined(order)) {
+    serie.meta.order = order;
+  }
 
   return [seriesData.order ?? 0, serie];
 }


### PR DESCRIPTION
More alignment with `/events-timeseries`. The `order` field is not currently in use, but it exists. It specifies the order of a given timeseries within its group in a top N request. Added `order` to the Explore part of the product as a reference.
