### PR TITLE
feat(explore): Use unstacked bar graph if multiple series

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -152,6 +152,7 @@ export function ExploreCharts({
       return {
         chartIcon: <IconGraph type={chartIcon} />,
         chartType: visualize.chartType,
+        stack: visualize.stack,
         label: visualize.label,
         yAxes: visualize.yAxes,
         formattedYAxes,
@@ -318,7 +319,7 @@ export function ExploreCharts({
                     return new DataPlottableConstructor(timeSeries, {
                       delay: INGESTION_DELAY,
                       color: isTimeSeriesOther(timeSeries) ? theme.chartOther : undefined,
-                      stack: 'all',
+                      stack: chartInfo.stack,
                     });
                   })}
                   legendSelection={{

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.spec.tsx
@@ -7,8 +7,15 @@ describe('Visualize', function () {
     function (yAxis) {
       const visualize = new Visualize([yAxis]);
       expect(visualize.chartType).toEqual(ChartType.BAR);
+      expect(visualize.stack).toBeDefined();
     }
   );
+
+  it('uses unstacked bar graph', function () {
+    const visualize = new Visualize(['count(span.duration)', 'count_unique(span.op)']);
+    expect(visualize.chartType).toEqual(ChartType.BAR);
+    expect(visualize.stack).toBeUndefined();
+  });
 
   it.each([
     'avg(span.duration)',
@@ -23,11 +30,13 @@ describe('Visualize', function () {
   ])('defaults to bar charts for %s', function (yAxis) {
     const visualize = new Visualize([yAxis]);
     expect(visualize.chartType).toEqual(ChartType.LINE);
+    expect(visualize.stack).toBeDefined();
   });
 
   it('uses selected chart type', function () {
     const visualize = new Visualize(['count(span.duration)'], '', ChartType.AREA);
     expect(visualize.chartType).toEqual(ChartType.AREA);
+    expect(visualize.stack).toBeDefined();
   });
 
   it('uses the dominant chart type', function () {
@@ -38,6 +47,7 @@ describe('Visualize', function () {
       'p90(span.duration)',
     ]);
     expect(visualize.chartType).toEqual(ChartType.LINE);
+    expect(visualize.stack).toBeDefined();
   });
 
   it('clones', function () {

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -32,6 +32,7 @@ export class Visualize {
   chartType: ChartType;
   label: string;
   yAxes: readonly string[];
+  stack?: string;
   private selectedChartType?: ChartType;
 
   constructor(yAxes: readonly string[], label = '', chartType?: ChartType) {
@@ -39,6 +40,8 @@ export class Visualize {
     this.yAxes = yAxes;
     this.selectedChartType = chartType;
     this.chartType = this.selectedChartType ?? determineDefaultChartType(this.yAxes);
+    this.stack =
+      this.chartType === ChartType.BAR && this.yAxes.length > 1 ? undefined : 'all';
   }
 
   clone(): Visualize {


### PR DESCRIPTION
If there are multiple aggregate functions on a single graph and we are using a bar graph, we should unstack them. If there is only 1 aggregate function on a single graph but with a group by, we should continue to stack them.

Closes EXP-251