### PR TITLE
fix(query-builder): Prevent typed parens from firing onChange

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -70,6 +70,7 @@ type DeleteTokensAction = {
 };
 
 type UpdateFreeTextAction = {
+  shouldCommitQuery: boolean;
   text: string;
   tokens: ParseResultToken[];
   type: 'UPDATE_FREE_TEXT';
@@ -336,8 +337,7 @@ function updateFreeText(
   }
 
   // Only update the committed query if we aren't in the middle of creating a filter
-  const committedQuery =
-    action.focusOverride?.part === 'value' ? state.committedQuery : newQuery;
+  const committedQuery = action.shouldCommitQuery ? newQuery : state.committedQuery;
 
   return {
     ...state,
@@ -533,7 +533,6 @@ export function useQueryBuilderState({
     committedQuery: initialQuery,
     focusOverride: null,
   };
-
   const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
     (state, action): QueryBuilderState => {
       if (disabled) {

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -69,7 +69,7 @@ function useApplyFocusOverride(state: ListState<ParseResultToken>) {
 function Grid(props: GridProps) {
   const ref = useRef<HTMLDivElement>(null);
   const selectionKeyHandlerRef = useRef<HTMLInputElement>(null);
-  const {size} = useSearchQueryBuilder();
+  const {size, dispatch} = useSearchQueryBuilder();
   const state = useListState<ParseResultToken>({
     ...props,
     selectionBehavior: 'replace',
@@ -100,6 +100,13 @@ function Grid(props: GridProps) {
       {...gridProps}
       ref={ref}
       style={size === 'small' ? undefined : {paddingRight: props.actionBarWidth + 12}}
+      onBlur={e => {
+        if (ref.current?.contains(e.relatedTarget as Node)) {
+          return;
+        }
+
+        dispatch({type: 'COMMIT_QUERY'});
+      }}
     >
       <SelectionKeyHandler ref={selectionKeyHandlerRef} state={state} undo={undo} />
       {[...state.collection].map(item => {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -390,7 +390,12 @@ function SearchQueryBuilderInputInternal({
           }
 
           if (option.type === 'raw-search') {
-            dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: option.value});
+            dispatch({
+              type: 'UPDATE_FREE_TEXT',
+              tokens: [token],
+              text: option.value,
+              shouldCommitQuery: true,
+            });
             resetInputValue();
 
             // Because the query does not change until a subsequent render,
@@ -405,6 +410,7 @@ function SearchQueryBuilderInputInternal({
               tokens: [token],
               text: replaceFocusedWord(inputValue, selectionIndex, option.textValue),
               focusOverride: calculateNextFocusForInsertedToken(item),
+              shouldCommitQuery: true,
             });
             resetInputValue();
             return;
@@ -422,6 +428,7 @@ function SearchQueryBuilderInputInternal({
               getFieldDefinition
             ),
             focusOverride: calculateNextFocusForFilter(state),
+            shouldCommitQuery: false,
           });
           resetInputValue();
           const selectedKey = filterKeys[value];
@@ -446,6 +453,7 @@ function SearchQueryBuilderInputInternal({
               currentFocusedKey: item.key.toString(),
               value,
             }),
+            shouldCommitQuery: false,
           });
           resetInputValue();
         }}
@@ -458,6 +466,7 @@ function SearchQueryBuilderInputInternal({
               currentFocusedKey: item.key.toString(),
               value,
             }),
+            shouldCommitQuery: true,
           });
           resetInputValue();
 
@@ -467,7 +476,12 @@ function SearchQueryBuilderInputInternal({
         }}
         onExit={() => {
           if (inputValue !== token.value.trim()) {
-            dispatch({type: 'UPDATE_FREE_TEXT', tokens: [token], text: inputValue});
+            dispatch({
+              type: 'UPDATE_FREE_TEXT',
+              tokens: [token],
+              text: inputValue,
+              shouldCommitQuery: false,
+            });
             resetInputValue();
           }
         }}
@@ -490,6 +504,7 @@ function SearchQueryBuilderInputInternal({
               tokens: [token],
               text: e.target.value,
               focusOverride: calculateNextFocusForInsertedToken(item),
+              shouldCommitQuery: false,
             });
             resetInputValue();
             return;
@@ -513,6 +528,7 @@ function SearchQueryBuilderInputInternal({
                 getFieldDefinition
               ),
               focusOverride: calculateNextFocusForFilter(state),
+              shouldCommitQuery: false,
             });
             resetInputValue();
             trackAnalytics('search.key_manually_typed', {


### PR DESCRIPTION
This prevents a bug with the new `ui-search-on-change` flag. You can reproduce by typing `foo(` and the page would enter a redirect loop. The typed paren would cause the query to be committed, which caused a search to fire prematurely. What we really want is to wait to commit the query while the user is typing and only commit on enter or when the search is blurred (or a new token is created).

This PR adds more customizability to the actions so that we can hold off on committing changes in certain circumstances.