### PR TITLE
feat(aci): Add detector filtering parameter to Detector index endpoint

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -419,6 +419,14 @@ class DetectorParams:
         description="The ID of the detector you'd like to query.",
     )
 
+    QUERY = OpenApiParameter(
+        name="query",
+        location="query",
+        required=False,
+        type=str,
+        description="An optional search query for filtering detectors.",
+    )
+
     SORT = OpenApiParameter(
         name="sortBy",
         location="query",

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1,4 +1,5 @@
 from sentry.api.serializers import serialize
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.environment import Environment
 from sentry.testutils.cases import APITestCase
@@ -118,3 +119,74 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             detector_2.name,
             detector.name,
         ]
+
+    def test_query_by_name(self):
+        detector = self.create_detector(
+            project_id=self.project.id, name="Apple Detector", type=MetricIssue.slug
+        )
+        detector2 = self.create_detector(
+            project_id=self.project.id, name="Green Apple Detector", type=MetricIssue.slug
+        )
+        self.create_detector(
+            project_id=self.project.id, name="Banana Detector", type=MetricIssue.slug
+        )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"project": self.project.id, "query": "apple"}
+        )
+        assert {d["name"] for d in response.data} == {detector.name, detector2.name}
+
+        # Exact insensitive match when explicitly by name
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"project": self.project.id, "query": 'name:"Apple Detector"'},
+        )
+        assert {d["name"] for d in response.data} == {detector.name}
+
+    def test_query_by_type(self):
+        detector = self.create_detector(
+            project_id=self.project.id, name="Detector 1", type=MetricIssue.slug
+        )
+        detector2 = self.create_detector(
+            project_id=self.project.id,
+            name="Detector 2",
+            type=ErrorGroupType.slug,
+        )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"project": self.project.id, "query": "type:error"}
+        )
+        assert {d["name"] for d in response.data} == {detector2.name}
+
+        # Query for multiple types.
+        response2 = self.get_success_response(
+            self.organization.slug,
+            qs_params={"project": self.project.id, "query": "type:error type:metric_issue"},
+        )
+        assert {d["name"] for d in response2.data} == {detector.name, detector2.name}
+
+    def test_general_query(self):
+        detector = self.create_detector(
+            project_id=self.project.id,
+            name="Lookfor 1",
+            type=MetricIssue.slug,
+            description="Delicious",
+        )
+        detector2 = self.create_detector(
+            project_id=self.project.id,
+            name="Lookfor 2",
+            type=ErrorGroupType.slug,
+            description="Exciting",
+        )
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"project": self.project.id, "query": "delicious"}
+        )
+        assert {d["name"] for d in response.data} == {detector.name}
+
+        response2 = self.get_success_response(
+            self.organization.slug, qs_params={"project": self.project.id, "query": "metric"}
+        )
+        assert {d["name"] for d in response2.data} == {detector.name}
+
+        response3 = self.get_success_response(
+            self.organization.slug, qs_params={"project": self.project.id, "query": "lookfor"}
+        )
+        assert {d["name"] for d in response3.data} == {detector.name, detector2.name}


### PR DESCRIPTION
Add 'query' parameter to be used for filtering results by name, type, and description.
