### PR TITLE
ref(replay): clamp touch move events for mobile replay

### DIFF
--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -170,6 +170,14 @@ export function isTouchEndFrame(frame: RecordingFrame) {
   );
 }
 
+export function isTouchMoveFrame(frame: RecordingFrame) {
+  return (
+    frame.type === EventType.IncrementalSnapshot &&
+    'source' in frame.data &&
+    frame.data.source === IncrementalSource.TouchMove
+  );
+}
+
 export function isMetaFrame(frame: RecordingFrame) {
   return frame.type === EventType.Meta;
 }


### PR DESCRIPTION
relates to https://linear.app/getsentry/issue/MOBILE-965/user-tap-annotation-not-seen-in-replay-video-react-native-android#comment-5fd8f140

we are already increasing the difference between `TouchStart` and `TouchEnd` events if they are sequential, but we weren't doing the same thing for `TouchMove` events which are sometimes in between those two. this change helps some more user tap events show up in the UI if they are too short.

before - no taps seen between 0:31 - 0:37


https://github.com/user-attachments/assets/94420bd7-3985-4416-9d6f-bf2f44903e89

after - can see some taps between 0:31 - 0:37

https://github.com/user-attachments/assets/70caf2fe-e68f-414d-a05a-e0487e0b0ef6




