### PR TITLE
ref(feedback): rm old uf from sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -34,7 +34,6 @@ import {
   IconSettings,
   IconSiren,
   IconStats,
-  IconSupport,
   IconTelescope,
   IconTimer,
 } from 'sentry/icons';
@@ -240,18 +239,6 @@ function Sidebar() {
       to={`/organizations/${organization.slug}/releases/`}
       id="releases"
     />
-  );
-
-  const userFeedback = hasOrganization && (
-    <Feature features="old-user-feedback" organization={organization}>
-      <SidebarItem
-        {...sidebarItemProps}
-        icon={<IconSupport />}
-        label={t('User Feedback')}
-        to={`/organizations/${organization.slug}/user-feedback/`}
-        id="user-feedback"
-      />
-    </Feature>
   );
 
   const feedback = hasOrganization && (
@@ -468,7 +455,6 @@ function Sidebar() {
                       {discover}
                       {dashboards}
                       {releases}
-                      {userFeedback}
                     </SidebarSection>
                   </Fragment>
                 )}


### PR DESCRIPTION
the `old-user-feedback` flag is outdated and should be removed: https://github.com/getsentry/sentry-options-automator/blob/0b3a3d8f145573a1d82568d0a83dc7bbabcaf63e/options/default/flagpole.yml#L4760

relates to https://github.com/getsentry/sentry/issues/64706