### PR TITLE
feat(taskworker): Add retry delays to taskworker config

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -51,6 +51,7 @@ logger = logging.getLogger(__name__)
         namespace=export_tasks,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -20,7 +20,13 @@ from sentry.taskworker.retry import Retry
     max_retries=MAX_RETRIES,
     acks_late=True,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=deletion_tasks, retry=Retry(times=MAX_RETRIES)),
+    taskworker_config=TaskworkerConfig(
+        namespace=deletion_tasks,
+        retry=Retry(
+            times=MAX_RETRIES,
+            delay=60 * 5,
+        ),
+    ),
 )
 @retry(exclude=(DeleteAborted,))
 @track_group_async_operation

--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -110,7 +110,11 @@ def _run_scheduled_deletions(model_class: type[BaseScheduledDeletion], process_t
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=deletion_control_tasks,
-        retry=Retry(times=MAX_RETRIES, times_exceeded=LastAction.Discard),
+        retry=Retry(
+            times=MAX_RETRIES,
+            times_exceeded=LastAction.Discard,
+            delay=60 * 5,
+        ),
     ),
 )
 @retry(exclude=(DeleteAborted,))
@@ -132,7 +136,11 @@ def run_deletion_control(deletion_id: int, first_pass: bool = True, **kwargs: An
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=deletion_tasks,
-        retry=Retry(times=MAX_RETRIES, times_exceeded=LastAction.Discard),
+        retry=Retry(
+            times=MAX_RETRIES,
+            times_exceeded=LastAction.Discard,
+            delay=60 * 5,
+        ),
     ),
 )
 @retry(exclude=(DeleteAborted,))

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -99,7 +99,7 @@ OrgProjectVolumes = tuple[OrganizationId, ProjectId, int, DecisionKeepCount, Dec
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=10 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -178,7 +178,7 @@ def partition_by_measure(
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=3 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -228,7 +228,7 @@ def boost_low_volume_projects_of_org_with_query(
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=3 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -101,7 +101,7 @@ class ProjectTransactionsTotals(TypedDict, total=True):
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=6 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -164,7 +164,7 @@ def boost_low_volume_transactions(context: TaskContext) -> None:
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=4 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task

--- a/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
+++ b/src/sentry/dynamic_sampling/tasks/custom_rule_notifications.py
@@ -39,7 +39,7 @@ MIN_SAMPLES_FOR_NOTIFICATION = 10
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=1 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -196,7 +196,7 @@ def create_discover_link(rule: CustomDynamicSamplingRule, projects: list[int]) -
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=3 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -54,7 +54,7 @@ from sentry.taskworker.retry import Retry
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=1 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)
@@ -99,7 +99,7 @@ def recalibrate_orgs(context: TaskContext) -> None:
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=6 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task
@@ -183,7 +183,7 @@ def recalibrate_org(org_id: OrganizationId, total: int, indexed: int) -> None:
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=2 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -38,7 +38,7 @@ from sentry.taskworker.retry import Retry
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=15 * 60 + 5,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 @dynamic_sampling_task_with_context(max_task_execution=MAX_TASK_SECONDS)

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -86,7 +86,9 @@ def handle_snuba_query_update(
     max_retries=5,
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
-        namespace=alerts_tasks, retry=Retry(times=5), processing_deadline_duration=30
+        namespace=alerts_tasks,
+        retry=Retry(times=5, delay=60),
+        processing_deadline_duration=30,
     ),
 )
 def handle_trigger_action(
@@ -147,7 +149,7 @@ def handle_trigger_action(
     default_retry_delay=60,
     max_retries=2,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=2)),
+    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=2, delay=60)),
 )
 def auto_resolve_snapshot_incidents(alert_rule_id: int, **kwargs: Any) -> None:
     from sentry.incidents.logic import update_incident_status

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -48,7 +48,7 @@ CLUSTERING_TIMEOUT_PER_PROJECT = 0.3
     max_retries=5,  # copied from release monitor
     taskworker_config=TaskworkerConfig(
         namespace=performance_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 def spawn_clusterers(**kwargs: Any) -> None:
@@ -73,7 +73,7 @@ def spawn_clusterers(**kwargs: Any) -> None:
     taskworker_config=TaskworkerConfig(
         namespace=performance_tasks,
         processing_deadline_duration=int(PROJECTS_PER_TASK * CLUSTERING_TIMEOUT_PER_PROJECT + 2),
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=5),
     ),
 )
 def cluster_projects(project_ids: Sequence[int]) -> None:

--- a/src/sentry/integrations/jira/tasks.py
+++ b/src/sentry/integrations/jira/tasks.py
@@ -24,7 +24,7 @@ from sentry.utils.rollback_metrics import incr_rollback_metrics
     max_retries=5,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(Integration.DoesNotExist))
@@ -130,7 +130,7 @@ def migrate_issues(integration_id: int, organization_id: int) -> None:
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=20),
     ),
 )
 @retry(on=(IntegrationError,), exclude=(Integration.DoesNotExist,))

--- a/src/sentry/integrations/opsgenie/tasks.py
+++ b/src/sentry/integrations/opsgenie/tasks.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
     max_retries=5,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(Integration.DoesNotExist, OrganizationIntegration.DoesNotExist))

--- a/src/sentry/integrations/tasks/create_comment.py
+++ b/src/sentry/integrations/tasks/create_comment.py
@@ -23,7 +23,7 @@ from sentry.types.activity import ActivityType
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(Integration.DoesNotExist))

--- a/src/sentry/integrations/tasks/kick_off_status_syncs.py
+++ b/src/sentry/integrations/tasks/kick_off_status_syncs.py
@@ -14,7 +14,7 @@ from sentry.taskworker.retry import Retry
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry()

--- a/src/sentry/integrations/tasks/migrate_repo.py
+++ b/src/sentry/integrations/tasks/migrate_repo.py
@@ -21,7 +21,7 @@ from sentry.taskworker.retry import Retry
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(Integration.DoesNotExist, Repository.DoesNotExist, Organization.DoesNotExist))

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -29,7 +29,7 @@ from sentry.users.services.user.service import user_service
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(

--- a/src/sentry/integrations/tasks/sync_status_inbound.py
+++ b/src/sentry/integrations/tasks/sync_status_inbound.py
@@ -195,7 +195,7 @@ def group_was_recently_resolved(group: Group) -> bool:
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(Integration.DoesNotExist,))

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -23,7 +23,7 @@ from sentry.taskworker.retry import Retry
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(Integration.DoesNotExist,))

--- a/src/sentry/integrations/tasks/update_comment.py
+++ b/src/sentry/integrations/tasks/update_comment.py
@@ -23,7 +23,7 @@ from sentry.types.activity import ActivityType
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 # TODO(jess): Add more retry exclusions once ApiClients have better error handling

--- a/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/kickoff_subscription_check.py
@@ -18,7 +18,7 @@ from sentry.taskworker.retry import Retry
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry()

--- a/src/sentry/integrations/vsts/tasks/subscription_check.py
+++ b/src/sentry/integrations/vsts/tasks/subscription_check.py
@@ -21,7 +21,7 @@ from sentry.taskworker.retry import Retry
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_tasks,
-        retry=Retry(times=5),
+        retry=Retry(times=5, delay=60 * 5),
     ),
 )
 @retry(exclude=(ApiError, ApiUnauthorized, Integration.DoesNotExist))

--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -121,7 +121,7 @@ class _AsyncSlackDispatcher(_AsyncRegionDispatcher):
     record_timing=True,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_tasks,
-        retry=Retry(times=2),
+        retry=Retry(times=2, delay=5),
     ),
 )
 def convert_to_async_slack_response(
@@ -153,7 +153,7 @@ class _AsyncDiscordDispatcher(_AsyncRegionDispatcher):
     default_retry_delay=5,
     taskworker_config=TaskworkerConfig(
         namespace=integrations_control_tasks,
-        retry=Retry(times=2),
+        retry=Retry(times=2, delay=5),
     ),
 )
 def convert_to_async_discord_response(

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -103,7 +103,7 @@ def encode_payload(message: dict[str, Any]) -> str:
     taskworker_config=TaskworkerConfig(
         namespace=ingest_profiling_tasks,
         processing_deadline_duration=60,
-        retry=Retry(times=2),
+        retry=Retry(times=2, delay=5),
     ),
 )
 def process_profile_task(

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("sentry.tasks.releasemonitor")
     default_retry_delay=5,
     max_retries=5,
     taskworker_config=TaskworkerConfig(
-        namespace=release_health_tasks, retry=Retry(times=5, on=(Exception,))
+        namespace=release_health_tasks, retry=Retry(times=5, on=(Exception,), delay=5)
     ),
 )
 def monitor_release_adoption(**kwargs) -> None:
@@ -51,7 +51,7 @@ def monitor_release_adoption(**kwargs) -> None:
     default_retry_delay=5,
     max_retries=5,
     taskworker_config=TaskworkerConfig(
-        namespace=release_health_tasks, retry=Retry(times=5, on=(Exception,))
+        namespace=release_health_tasks, retry=Retry(times=5, on=(Exception,), delay=5)
     ),
 )
 def process_projects_with_sessions(org_id, project_ids) -> None:

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -29,6 +29,7 @@ from sentry.utils.pubsub import KafkaPublisher
         namespace=replays_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )
@@ -51,6 +52,7 @@ def delete_recording_segments(project_id: int, replay_id: str, **kwargs: Any) ->
         namespace=replays_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -567,6 +567,7 @@ def cleanup_redis_buffer(
         processing_deadline_duration=60,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -126,7 +126,9 @@ def _webhook_event_data(
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.send_alert_webhook_v2",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **TASK_OPTIONS,
 )
 @retry_decorator
@@ -224,7 +226,9 @@ def send_alert_webhook_v2(
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.send_alert_webhook",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **TASK_OPTIONS,
 )
 @retry_decorator
@@ -394,7 +398,9 @@ def _does_project_filter_allow_project(service_hook_id: int, project_id: int) ->
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **TASK_OPTIONS,
 )
 @retry_decorator
@@ -406,7 +412,9 @@ def process_resource_change_bound(
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.installation_webhook",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_control_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_control_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **CONTROL_TASK_OPTIONS,
 )
 @retry_decorator
@@ -436,7 +444,9 @@ def installation_webhook(installation_id: int, user_id: int, *args: Any, **kwarg
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.clear_region_cache",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_control_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_control_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **CONTROL_TASK_OPTIONS,
 )
 def clear_region_cache(sentry_app_id: int, region_name: str) -> None:
@@ -480,7 +490,9 @@ def clear_region_cache(sentry_app_id: int, region_name: str) -> None:
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.workflow_notification",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **TASK_OPTIONS,
 )
 @retry_decorator
@@ -509,7 +521,9 @@ def workflow_notification(
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.build_comment_webhook",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **TASK_OPTIONS,
 )
 @retry_decorator
@@ -577,7 +591,9 @@ def get_webhook_data(
 
 @instrumented_task(
     name="sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **TASK_OPTIONS,
 )
 @retry_decorator
@@ -704,7 +720,9 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
 
 @instrumented_task(
     "sentry.sentry_apps.tasks.sentry_apps.create_or_update_service_hooks_for_sentry_app",
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_control_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_control_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
     **CONTROL_TASK_OPTIONS,
 )
 def create_or_update_service_hooks_for_sentry_app(

--- a/src/sentry/sentry_apps/tasks/service_hooks.py
+++ b/src/sentry/sentry_apps/tasks/service_hooks.py
@@ -37,7 +37,9 @@ def get_payload_v0(event):
     default_retry_delay=60 * 5,
     max_retries=5,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=sentryapp_tasks, retry=Retry(times=3)),
+    taskworker_config=TaskworkerConfig(
+        namespace=sentryapp_tasks, retry=Retry(times=3, delay=60 * 5)
+    ),
 )
 @retry
 def process_service_hook(servicehook_id, event, **kwargs):

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -43,7 +43,7 @@ class SubscriptionError(Exception):
     queue="subscriptions",
     default_retry_delay=5,
     max_retries=5,
-    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=5)),
+    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=5, delay=5)),
 )
 def create_subscription_in_snuba(query_subscription_id, **kwargs):
     """
@@ -89,7 +89,7 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
     queue="subscriptions",
     default_retry_delay=5,
     max_retries=5,
-    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=5)),
+    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=5, delay=5)),
 )
 def update_subscription_in_snuba(
     query_subscription_id,
@@ -164,7 +164,7 @@ def update_subscription_in_snuba(
     queue="subscriptions",
     default_retry_delay=5,
     max_retries=5,
-    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=5)),
+    taskworker_config=TaskworkerConfig(namespace=alerts_tasks, retry=Retry(times=5, delay=5)),
 )
 def delete_subscription_from_snuba(query_subscription_id, **kwargs):
     """

--- a/src/sentry/tasks/auth/auth.py
+++ b/src/sentry/tasks/auth/auth.py
@@ -17,6 +17,7 @@ from sentry.silo.safety import unguarded_write
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import auth_control_tasks, auth_tasks
+from sentry.taskworker.retry import Retry
 from sentry.types.region import RegionMappingNotFound
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -201,7 +202,7 @@ class TwoFactorComplianceTask(OrganizationComplianceTask):
     default_retry_delay=60 * 5,
     max_retries=5,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=auth_tasks),
+    taskworker_config=TaskworkerConfig(namespace=auth_tasks, retry=Retry(times=5, delay=60 * 5)),
 )
 @retry
 def remove_2fa_non_compliant_members(org_id, actor_id=None, actor_key_id=None, ip_address=None):

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -66,6 +66,7 @@ def log_error_if_queue_has_items(func):
         namespace=issues_tasks,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )
@@ -107,6 +108,7 @@ def schedule_auto_transition_to_ongoing() -> None:
         processing_deadline_duration=25 * 60,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )
@@ -181,6 +183,7 @@ def schedule_auto_transition_issues_new_to_ongoing(
         processing_deadline_duration=25 * 60,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )
@@ -216,6 +219,7 @@ def run_auto_transition_issues_new_to_ongoing(
         processing_deadline_duration=25 * 60,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )
@@ -283,6 +287,7 @@ def schedule_auto_transition_issues_regressed_to_ongoing(
         processing_deadline_duration=25 * 60,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )
@@ -318,6 +323,7 @@ def run_auto_transition_issues_regressed_to_ongoing(
         processing_deadline_duration=25 * 60,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )
@@ -385,6 +391,7 @@ def schedule_auto_transition_issues_escalating_to_ongoing(
         processing_deadline_duration=25 * 60,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )

--- a/src/sentry/tasks/auto_source_code_config.py
+++ b/src/sentry/tasks/auto_source_code_config.py
@@ -18,6 +18,7 @@ from sentry.taskworker.retry import Retry
         namespace=issues_tasks,
         retry=Retry(
             times=3,
+            delay=60 * 10,
         ),
     ),
 )

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -730,7 +730,7 @@ def refresh_check_state(org_id):
     taskworker_config=TaskworkerConfig(
         namespace=telemetry_experience_tasks,
         processing_deadline_duration=TASK_SOFT_LIMIT_IN_SECONDS + 5,
-        retry=Retry(times=1),
+        retry=Retry(times=1, delay=5),
     ),
 )
 def run_compatibility_check_async(org_id):

--- a/src/sentry/tasks/check_new_issue_threshold_met.py
+++ b/src/sentry/tasks/check_new_issue_threshold_met.py
@@ -65,6 +65,7 @@ def calculate_threshold_met(project_id: int) -> bool:
         namespace=issues_tasks,
         retry=Retry(
             times=1,
+            delay=60,
         ),
     ),
 )

--- a/src/sentry/tasks/codeowners/code_owners_auto_sync.py
+++ b/src/sentry/tasks/codeowners/code_owners_auto_sync.py
@@ -23,6 +23,7 @@ from sentry.taskworker.retry import Retry
         namespace=issues_tasks,
         retry=Retry(
             times=1,
+            delay=60 * 5,
         ),
     ),
 )

--- a/src/sentry/tasks/codeowners/update_code_owners_schema.py
+++ b/src/sentry/tasks/codeowners/update_code_owners_schema.py
@@ -25,6 +25,7 @@ from sentry.taskworker.retry import Retry
         namespace=issues_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -82,6 +82,7 @@ def handle_invalid_identity(identity, commit_failure=False):
         processing_deadline_duration=60 * 15 + 5,
         retry=Retry(
             times=5,
+            delay=60 * 5,
         ),
     ),
 )

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -26,6 +26,7 @@ MAX_RETRIES = 5
         retry=Retry(
             times=MAX_RETRIES,
             on=(DatabaseError, IntegrityError),
+            delay=60 * 5,
         ),
     ),
 )
@@ -48,6 +49,7 @@ def delete_file_region(path, checksum, **kwargs):
         retry=Retry(
             times=MAX_RETRIES,
             on=(DatabaseError, IntegrityError),
+            delay=60 * 5,
         ),
     ),
 )
@@ -77,6 +79,7 @@ def delete_file(file_blob_model, path, checksum, **kwargs):
         namespace=deletion_tasks,
         retry=Retry(
             times=MAX_RETRIES,
+            delay=60 * 5,
         ),
     ),
 )
@@ -98,6 +101,7 @@ def delete_unreferenced_blobs_region(blob_ids):
         namespace=deletion_control_tasks,
         retry=Retry(
             times=MAX_RETRIES,
+            delay=60 * 5,
         ),
     ),
 )

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -163,6 +163,7 @@ def _process_suspect_commits(
         namespace=issues_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -64,6 +64,7 @@ def run_escalating_forecast() -> None:
         namespace=issues_tasks,
         retry=Retry(
             times=3,
+            delay=60,
         ),
     ),
 )

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -38,6 +38,7 @@ BROKEN_MONITOR_AGE_LIMIT = timedelta(days=7)
         namespace=uptime_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )
@@ -70,6 +71,7 @@ def create_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         namespace=uptime_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )
@@ -103,6 +105,7 @@ def update_remote_uptime_subscription(uptime_subscription_id, **kwargs):
         namespace=uptime_tasks,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -488,6 +488,7 @@ def cleanup_redis_buffer(
         processing_deadline_duration=60,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )


### PR DESCRIPTION
Now that taskbrokers support retry delays, add the retry delay param into the taskworker config.