### PR TITLE
fix: Disable seat when disabling monitor rather than removing

### DIFF
--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -113,7 +113,7 @@ class UptimeSubscription(BaseRemoteSubscription, DefaultFieldsModelExisting):
     # How to sample traces for this monitor. Note that we always send a trace_id, so any errors will
     # be associated, this just controls the span sampling.
     trace_sampling = models.BooleanField(default=False, db_default=False)
-    # Tracks the curernt status of this subscrioption. This is possibly going
+    # Tracks the current status of this subscription. This is possibly going
     # to be replaced in the future with open-periods as we replace
     # ProjectUptimeSubscription with Detectors.
     uptime_status = models.PositiveSmallIntegerField(db_default=UptimeStatus.OK.value)

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -339,12 +339,12 @@ def update_project_uptime_subscription(
 
 def disable_uptime_detector(detector: Detector):
     """
-    Disables a uptime detector. The associated UptimeSubscription will also be disabled
-    longer has any active project subscriptions the subscription itself will
+    Disables a uptime detector. The associated ProjectUptimeSubscription will also be disabled,
+    and if the UptimeSubscription no longer has any active ProjectUptimeSubscriptions, it will
     also be disabled.
     """
     uptime_monitor = get_project_subscription(detector)
-    uptime_subscription = uptime_monitor.uptime_subscription
+    uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
 
     if uptime_monitor.status == ObjectStatus.DISABLED:
         return
@@ -360,7 +360,7 @@ def disable_uptime_detector(detector: Detector):
     uptime_monitor.update(status=ObjectStatus.DISABLED)
     detector.update(enabled=False)
 
-    quotas.backend.remove_seat(DataCategory.UPTIME, uptime_monitor)
+    quotas.backend.disable_seat(DataCategory.UPTIME, uptime_monitor)
 
     # Are there any other project subscriptions associated to the subscription
     # that are NOT disabled?
@@ -403,7 +403,7 @@ def enable_uptime_detector(detector: Detector, ensure_assignment: bool = False):
         disable_uptime_detector(detector)
         raise UptimeMonitorNoSeatAvailable(None)
 
-    uptime_subscription = uptime_monitor.uptime_subscription
+    uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
     uptime_monitor.update(status=ObjectStatus.ACTIVE)
     detector.update(enabled=True)
 
@@ -415,7 +415,7 @@ def enable_uptime_detector(detector: Detector, ensure_assignment: bool = False):
 
 def delete_uptime_detector(detector: Detector):
     uptime_monitor = get_project_subscription(detector)
-    uptime_subscription = uptime_monitor.uptime_subscription
+    uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
     quotas.backend.remove_seat(DataCategory.UPTIME, uptime_monitor)
     uptime_monitor.delete()
     RegionScheduledDeletion.schedule(detector, days=0)

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -700,8 +700,8 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
 
 
 class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
-    @mock.patch("sentry.quotas.backend.remove_seat")
-    def test(self, mock_remove_seat):
+    @mock.patch("sentry.quotas.backend.disable_seat")
+    def test(self, mock_disable_seat):
         proj_sub = create_project_uptime_subscription(
             self.project,
             self.environment,
@@ -719,13 +719,13 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         proj_sub.refresh_from_db()
         assert proj_sub.status == ObjectStatus.DISABLED
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
-        mock_remove_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_disable_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
 
         detector.refresh_from_db()
         assert not detector.enabled
 
-    @mock.patch("sentry.quotas.backend.remove_seat")
-    def test_disable_failed(self, mock_remove_seat):
+    @mock.patch("sentry.quotas.backend.disable_seat")
+    def test_disable_failed(self, mock_disable_seat):
         with (
             self.tasks(),
             self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()),
@@ -761,7 +761,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
         assert proj_sub.status == ObjectStatus.DISABLED
         assert proj_sub.uptime_subscription.uptime_status == UptimeStatus.OK
         assert proj_sub.uptime_subscription.status == UptimeSubscription.Status.DISABLED.value
-        mock_remove_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
+        mock_disable_seat.assert_called_with(DataCategory.UPTIME, proj_sub)
 
         detector.refresh_from_db()
         assert not detector.enabled


### PR DESCRIPTION
This PR aims to swap the remove_seat() function in disable_uptime_monitor() to disable_seat(). We believe that calling remove_seat() when a monitor is disabled could be leading to underreporting the number of seats that a client has used mid-period.

Partial fix for https://linear.app/getsentry/issue/BIL-475/create-reconciliation-task-for-syncing-seat-usage

Scenario where we're having some funkiness:
- User has an existing uptime monitor
- User goes to disable monitor
- Upon disabling monitor, the seat is "removed"

https://github.com/getsentry/getsentry/blob/3bccab8bfea85ffc45270af2c359861b9b154e1c/getsentry/models/billingseatassignment.py#L122-L139

This comment leads me to believe that the seat should only have the "Removed" status if the monitor has been deleted completely. When a monitor is disabled we want to keep the "Disabled_for_billing" status

https://github.com/getsentry/getsentry/blob/3bccab8bfea85ffc45270af2c359861b9b154e1c/getsentry/models/billingseatassignment.py#L368-L375

Here when we see that a seat has been disabled for billing and want to reallocate one, we check explicitly for overquota or disabled_for_billing statuses to reuse that seat


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
