### PR TITLE
fix(ui): Silence .less deprecation warnings

### DIFF
--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -266,7 +266,7 @@ div.traceback > ul {
       .package {
         font-size: 12px;
         font-weight: bold;
-        .truncate;
+        .truncate();
         flex-basis: 120px;
         flex-grow: 0;
         flex-shrink: 0;

--- a/static/less/includes/bootstrap/buttons.less
+++ b/static/less/includes/bootstrap/buttons.less
@@ -18,9 +18,8 @@
   cursor: pointer;
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid transparent;
-  .button-size(
-    @padding-base-vertical; @padding-base-horizontal; @font-size-base; @line-height-base;
-      @btn-border-radius-base
+  .button-size(@padding-base-vertical; @padding-base-horizontal; @font-size-base; @line-height-base;
+    @btn-border-radius-base
   );
   user-select: none;
 
@@ -133,22 +132,19 @@
 
 .btn-lg {
   // line-height: ensure even-numbered height of button next to large input
-  .button-size(
-    @padding-large-vertical; @padding-large-horizontal; @font-size-large;
-      @line-height-large; @btn-border-radius-large
+  .button-size(@padding-large-vertical; @padding-large-horizontal; @font-size-large;
+    @line-height-large; @btn-border-radius-large
   );
 }
 .btn-sm {
   // line-height: ensure proper height of button next to small input
-  .button-size(
-    @padding-small-vertical; @padding-small-horizontal; @font-size-small;
-      @line-height-small; @btn-border-radius-small
+  .button-size(@padding-small-vertical; @padding-small-horizontal; @font-size-small;
+    @line-height-small; @btn-border-radius-small
   );
 }
 .btn-xs {
-  .button-size(
-    @padding-xs-vertical; @padding-xs-horizontal; @font-size-small; @line-height-small;
-      @btn-border-radius-small
+  .button-size(@padding-xs-vertical; @padding-xs-horizontal; @font-size-small; @line-height-small;
+    @btn-border-radius-small
   );
 }
 

--- a/static/less/releases.less
+++ b/static/less/releases.less
@@ -21,7 +21,7 @@
     }
 
     h6 {
-      .nav-header;
+      .nav-header();
       margin-bottom: 10px;
     }
   }

--- a/static/less/result-grid.less
+++ b/static/less/result-grid.less
@@ -2,7 +2,7 @@
   clear: both;
 
   .table-grid {
-    .table;
+    .table();
   }
 
   .table-grid .label {
@@ -47,8 +47,8 @@
   }
 
   .result-grid-search {
-    .pull-right;
-    .form-inline;
+    .pull-right();
+    .form-inline();
 
     .input-search {
       padding: 3px 8px 3px;

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -559,7 +559,7 @@ body.theme-system {
     padding-top: 9px;
     padding-bottom: 8px;
     position: relative;
-    .clearfix;
+    .clearfix();
 
     &:hover .permalink {
       display: inline-block;
@@ -1055,7 +1055,7 @@ header + .alert {
   font-size: 12px;
   color: @gray-light;
   letter-spacing: 0.1px;
-  .clearfix;
+  .clearfix();
 
   a.help-link,
   span.help-link a {

--- a/static/less/shared/forms.less
+++ b/static/less/shared/forms.less
@@ -388,9 +388,8 @@ output {
 // issue documented in https://github.com/twbs/bootstrap/issues/15074.
 
 .input-sm {
-  .input-size(
-      @input-height-small; @padding-small-vertical; @padding-small-horizontal;
-        @font-size-small; @line-height-small; @input-border-radius-small
+  .input-size(@input-height-small; @padding-small-vertical; @padding-small-horizontal;
+      @font-size-small; @line-height-small; @input-border-radius-small
     );
 }
 .form-group-sm {
@@ -419,9 +418,8 @@ output {
 }
 
 .input-lg {
-  .input-size(
-      @input-height-large; @padding-large-vertical; @padding-large-horizontal;
-        @font-size-large; @line-height-large; @input-border-radius-large
+  .input-size(@input-height-large; @padding-large-vertical; @padding-large-horizontal;
+      @font-size-large; @line-height-large; @input-border-radius-large
     );
 }
 .form-group-lg {

--- a/static/less/shared/panel.less
+++ b/static/less/shared/panel.less
@@ -235,39 +235,34 @@
 
 // Contextual variations
 .panel-default {
-  .panel-variant(
-      @panel-default-border; @panel-default-text; @panel-default-heading-bg;
-        @panel-default-border
-    );
+  .panel-variant(@panel-default-border; @panel-default-text; @panel-default-heading-bg;
+    @panel-default-border
+  );
 }
 .panel-primary {
-  .panel-variant(
-      @panel-primary-border; @panel-primary-text; @panel-primary-heading-bg;
-        @panel-primary-border
-    );
+  .panel-variant(@panel-primary-border; @panel-primary-text; @panel-primary-heading-bg;
+    @panel-primary-border
+  );
 }
 .panel-success {
-  .panel-variant(
-      @panel-success-border; @panel-success-text; @panel-success-heading-bg;
-        @panel-success-border
-    );
+  .panel-variant(@panel-success-border; @panel-success-text; @panel-success-heading-bg;
+    @panel-success-border
+  );
 }
 .panel-info {
-  .panel-variant(
-      @panel-info-border; @panel-info-text; @panel-info-heading-bg; @panel-info-border
-    );
+  .panel-variant(@panel-info-border; @panel-info-text; @panel-info-heading-bg;
+    @panel-info-border
+  );
 }
 .panel-warning {
-  .panel-variant(
-      @panel-warning-border; @panel-warning-text; @panel-warning-heading-bg;
-        @panel-warning-border
-    );
+  .panel-variant(@panel-warning-border; @panel-warning-text; @panel-warning-heading-bg;
+    @panel-warning-border
+  );
 }
 .panel-danger {
-  .panel-variant(
-      @panel-danger-border; @panel-danger-text; @panel-danger-heading-bg;
-        @panel-danger-border
-    );
+  .panel-variant(@panel-danger-border; @panel-danger-text; @panel-danger-heading-bg;
+    @panel-danger-border
+  );
 }
 
 //

--- a/static/less/stream.less
+++ b/static/less/stream.less
@@ -127,7 +127,7 @@
       ul {
         list-style: none;
         margin-left: -9px;
-        .clearfix;
+        .clearfix();
 
         li {
           float: left;


### PR DESCRIPTION
mixins without parenthesis and for some reason whitespace after parenthesis
