### PR TITLE
fix(github): Move multi org Skip config to frontend 

### DIFF
--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -7,13 +7,14 @@ import {BaseAvatar} from 'sentry/components/core/avatar/baseAvatar';
 import {Button} from 'sentry/components/core/button';
 import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type Installation = {
   avatar_url: string;
   github_account: string;
-  installation_id: number;
+  installation_id: string;
 };
 
 type GithubInstallationProps = {
@@ -23,6 +24,13 @@ type GithubInstallationProps = {
 export function GithubInstallationSelect({installation_info}: GithubInstallationProps) {
   const [installationID, setInstallationID] = useState<SelectKey>(-1);
   const [isSaving, setIsSaving] = useState<boolean>(false);
+
+  // Add an option for users to install on a new GH organization
+  installation_info.push({
+    installation_id: '-1',
+    github_account: 'Install integration on a new GitHub organization',
+    avatar_url: '',
+  });
 
   const handleSubmit = (e: React.MouseEvent, id?: SelectKey) => {
     e.preventDefault();
@@ -56,12 +64,16 @@ export function GithubInstallationSelect({installation_info}: GithubInstallation
       value: installation.installation_id,
       label: (
         <OptionLabelWrapper>
-          <StyledAvatar
-            type="upload"
-            uploadUrl={installation.avatar_url}
-            size={16}
-            title={installation.github_account}
-          />
+          {installation.installation_id === '-1' ? (
+            <IconAdd />
+          ) : (
+            <StyledAvatar
+              type="upload"
+              uploadUrl={installation.avatar_url}
+              size={16}
+              title={installation.github_account}
+            />
+          )}
           <span>{`${installation.github_account}`}</span>
         </OptionLabelWrapper>
       ),

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
@@ -24,13 +24,21 @@ type GithubInstallationProps = {
 export function GithubInstallationSelect({installation_info}: GithubInstallationProps) {
   const [installationID, setInstallationID] = useState<SelectKey>(-1);
   const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [installationInfo, setInstallationInfo] =
+    useState<Installation[]>(installation_info);
 
-  // Add an option for users to install on a new GH organization
-  installation_info.push({
-    installation_id: '-1',
-    github_account: 'Install integration on a new GitHub organization',
-    avatar_url: '',
-  });
+  useEffect(() => {
+    // Add an option for users to install on a new GH organization
+    const optionsWithSkip = [
+      ...installation_info,
+      {
+        installation_id: '-1',
+        github_account: 'Integrate with a new GitHub organization',
+        avatar_url: '',
+      },
+    ];
+    setInstallationInfo(optionsWithSkip);
+  }, [installation_info]);
 
   const handleSubmit = (e: React.MouseEvent, id?: SelectKey) => {
     e.preventDefault();
@@ -59,7 +67,7 @@ export function GithubInstallationSelect({installation_info}: GithubInstallation
     setInstallationID(value);
   };
 
-  const selectOptions = installation_info.map(
+  const selectOptions = installationInfo.map(
     (installation): SelectOption<SelectKey> => ({
       value: installation.installation_id,
       label: (

--- a/tests/js/fixtures/githubInstallationSelect.ts
+++ b/tests/js/fixtures/githubInstallationSelect.ts
@@ -1,20 +1,14 @@
 export const installation_info = [
   {
     github_account: 'sentaur',
-    installation_id: 1,
+    installation_id: '1',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/bufo-matrix.gif',
   },
   {
     github_account: 'bufo-bot',
-    installation_id: 2,
+    installation_id: '2',
     avatar_url:
       'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/awesomebufo.png',
-  },
-  {
-    github_account: 'Integrate with a new GitHub organization',
-    installation_id: -1,
-    avatar_url:
-      'https://github.com/knobiknows/all-the-bufo/raw/main/all-the-bufo/bufo-pog-surprise.png',
   },
 ];


### PR DESCRIPTION
I think it makes more sense to add the 'Skip' option config to the frontend since it's not something from GitHub. 
Also fixes some typing for the `Installation` object