### PR TITLE
fix(aci): fix available actions endpoint to return pagerduty services and opsgenie teams

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -91,10 +91,13 @@ class ActionHandlerSerializer(Serializer):
 
         integrations = kwargs.get("integrations")
         if integrations:
-            result["integrations"] = [
-                {"id": str(integration.id), "name": integration.name}
-                for integration in integrations
-            ]
+            integrations_result = []
+            for i in integrations:
+                i_result = {"id": str(i["integration"].id), "name": i["integration"].name}
+                if i["services"]:
+                    i_result["services"] = [{"id": s[0], "name": s[1]} for s in i["services"]]
+                integrations_result.append(i_result)
+            result["integrations"] = integrations_result
 
         sentry_app_context = kwargs.get("sentry_app_context")
         if sentry_app_context:

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -95,7 +95,7 @@ class ActionHandlerSerializer(Serializer):
             for i in integrations:
                 i_result = {"id": str(i["integration"].id), "name": i["integration"].name}
                 if i["services"]:
-                    i_result["services"] = [{"id": s[0], "name": s[1]} for s in i["services"]]
+                    i_result["services"] = [{"id": id, "name": name} for id, name in i["services"]]
                 integrations_result.append(i_result)
             result["integrations"] = integrations_result
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from sentry.constants import ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.integrations.services.integration import RpcIntegration, integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -185,11 +186,12 @@ def get_notification_plugins_for_org(organization: Organization) -> list[PluginS
 
 def get_integration_services(organization_id: int) -> dict[int, list[tuple[int, str]]]:
     """
-    Get all Pagerduty services and OpsGenie teams for an organization's integrations.
+    Get all Pagerduty services and Opsgenie teams for an organization's integrations.
     """
 
     org_ints = integration_service.get_organization_integrations(
-        organization_id=organization_id, providers=["opsgenie", "pagerduty"]
+        organization_id=organization_id,
+        providers=[IntegrationProviderSlug.PAGERDUTY, IntegrationProviderSlug.OPSGENIE],
     )
 
     services: dict[int, list[tuple[int, str]]] = defaultdict(list)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -2,14 +2,17 @@ from dataclasses import dataclass
 from unittest.mock import ANY, patch
 
 from sentry.constants import SentryAppStatus
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.notification_action.action_handler_registry.base import (
     IntegrationActionHandler,
 )
 from sentry.plugins.base.manager import PluginManager
 from sentry.plugins.sentry_webhooks.plugin import WebHooksPlugin
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.types import ActionHandler
@@ -97,6 +100,79 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             config_schema = {}
             data_schema = {}
 
+    def setup_integrations_with_services(self):
+        @self.registry.register(Action.Type.PAGERDUTY)
+        @dataclass(frozen=True)
+        class PagerdutyActionHandler(IntegrationActionHandler):
+            group = ActionHandler.Group.TICKET_CREATION
+            provider_slug = IntegrationProviderSlug.PAGERDUTY
+            config_schema = {}
+            data_schema = {}
+
+        services = [
+            {
+                "type": "service",
+                "integration_key": "PND4F9",
+                "service_id": "123",
+                "service_name": "moo-deng",
+            },
+            {
+                "type": "service",
+                "integration_key": "PND4F98",
+                "service_id": "234",
+                "service_name": "moo-waan",
+            },
+        ]
+        self.pagerduty_integration, org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="pagerduty",
+            name="Example PagerDuty",
+            external_id="example-pagerduty",
+            metadata={"services": services},
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.pagerduty_service_1 = add_service(
+                org_integration,
+                service_name=services[0]["service_name"],
+                integration_key=services[0]["integration_key"],
+            )
+            self.pagerduty_service_2 = add_service(
+                org_integration,
+                service_name=services[1]["service_name"],
+                integration_key=services[1]["integration_key"],
+            )
+
+        @self.registry.register(Action.Type.OPSGENIE)
+        @dataclass(frozen=True)
+        class OpsgenieActionHandler(IntegrationActionHandler):
+            group = ActionHandler.Group.TICKET_CREATION
+            provider_slug = IntegrationProviderSlug.OPSGENIE
+            config_schema = {}
+            data_schema = {}
+
+        metadata = {
+            "api_key": "1234-ABCD",
+            "base_url": "https://api.opsgenie.com/",
+            "domain_name": "test-app.app.opsgenie.com",
+        }
+        self.og_team = {"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}
+        self.opsgenie_integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="opsgenie",
+            name="test-app",
+            external_id="test-app",
+            metadata=metadata,
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.opsgenie_integration.add_organization(self.organization, self.user)
+            self.org_integration = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=self.opsgenie_integration.id
+            )
+            self.org_integration.config = {"team_table": [self.og_team]}
+            self.org_integration.save()
+
     def setup_sentry_apps(self):
         @self.registry.register(Action.Type.SENTRY_APP)
         @dataclass(frozen=True)
@@ -178,7 +254,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             }
         ]
 
-    def test_integrations(self):
+    def test_simple_integrations(self):
         self.setup_integrations()
 
         response = self.get_success_response(
@@ -205,6 +281,56 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                 "dataSchema": {},
                 "integrations": [
                     {"id": str(self.github_integration.id), "name": self.github_integration.name}
+                ],
+            },
+        ]
+
+    def test_integrations_with_services(self):
+        self.setup_integrations_with_services()
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 2
+        assert response.data == [
+            {
+                "type": Action.Type.OPSGENIE,
+                "handlerGroup": ActionHandler.Group.TICKET_CREATION.value,
+                "configSchema": {},
+                "dataSchema": {},
+                "integrations": [
+                    {
+                        "id": str(self.opsgenie_integration.id),
+                        "name": self.opsgenie_integration.name,
+                        "services": [
+                            {
+                                "id": self.og_team["id"],
+                                "name": self.og_team["team"],
+                            },
+                        ],
+                    }
+                ],
+            },
+            {
+                "type": Action.Type.PAGERDUTY,
+                "handlerGroup": ActionHandler.Group.TICKET_CREATION.value,
+                "configSchema": {},
+                "dataSchema": {},
+                "integrations": [
+                    {
+                        "id": str(self.pagerduty_integration.id),
+                        "name": self.pagerduty_integration.name,
+                        "services": [
+                            {
+                                "id": self.pagerduty_service_1["id"],
+                                "name": self.pagerduty_service_1["service_name"],
+                            },
+                            {
+                                "id": self.pagerduty_service_2["id"],
+                                "name": self.pagerduty_service_2["service_name"],
+                            },
+                        ],
+                    },
                 ],
             },
         ]
@@ -270,6 +396,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
 
         self.setup_sentry_apps()
         self.setup_integrations()
+        self.setup_integrations_with_services()
         self.setup_webhooks()
         self.setup_email()
 
@@ -285,7 +412,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             self.organization.slug,
             status_code=200,
         )
-        assert len(response.data) == 7
+        assert len(response.data) == 9
         assert response.data == [
             # notification actions, sorted alphabetically with email first
             {
@@ -353,6 +480,46 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                 "dataSchema": {},
                 "integrations": [
                     {"id": str(self.github_integration.id), "name": self.github_integration.name}
+                ],
+            },
+            {
+                "type": Action.Type.OPSGENIE,
+                "handlerGroup": ActionHandler.Group.TICKET_CREATION.value,
+                "configSchema": {},
+                "dataSchema": {},
+                "integrations": [
+                    {
+                        "id": str(self.opsgenie_integration.id),
+                        "name": self.opsgenie_integration.name,
+                        "services": [
+                            {
+                                "id": self.og_team["id"],
+                                "name": self.og_team["team"],
+                            },
+                        ],
+                    }
+                ],
+            },
+            {
+                "type": Action.Type.PAGERDUTY,
+                "handlerGroup": ActionHandler.Group.TICKET_CREATION.value,
+                "configSchema": {},
+                "dataSchema": {},
+                "integrations": [
+                    {
+                        "id": str(self.pagerduty_integration.id),
+                        "name": self.pagerduty_integration.name,
+                        "services": [
+                            {
+                                "id": self.pagerduty_service_1["id"],
+                                "name": self.pagerduty_service_1["service_name"],
+                            },
+                            {
+                                "id": self.pagerduty_service_2["id"],
+                                "name": self.pagerduty_service_2["service_name"],
+                            },
+                        ],
+                    }
                 ],
             },
         ]


### PR DESCRIPTION
we previously weren't returning the available services/teams for pagerduty and opsgenie integrations.

this introduces a new helper, `get_integration_services()` to get all services/teams for a specified organization. i combined and tweaked the logic of `get_pagerduty_services` and `get_opsgenie_teams` (code [here](https://github.com/getsentry/sentry/blob/3075ebf65730c977cc7181358755d0af36b739d5/src/sentry/incidents/logic.py#L1695-L1715)) so that we only make 1 RPC call to get information for the entire organization