### PR TITLE
feat(confirm-modal): Add async confirmation actions

### DIFF
--- a/static/app/components/confirm.spec.tsx
+++ b/static/app/components/confirm.spec.tsx
@@ -132,7 +132,7 @@ describe('Confirm', function () {
     expect(clickEvent.stopPropagation).toHaveBeenCalled();
   });
 
-  describe('onConfirmAsync', function () {
+  describe('async onConfirm', function () {
     it('should not close the modal until the promise is resolved', async function () {
       jest.useFakeTimers();
       const onConfirmAsync = jest.fn().mockImplementation(
@@ -143,7 +143,7 @@ describe('Confirm', function () {
       );
 
       render(
-        <Confirm message="Are you sure?" onConfirmAsync={onConfirmAsync}>
+        <Confirm message="Are you sure?" onConfirm={onConfirmAsync}>
           <button>Confirm?</button>
         </Confirm>
       );
@@ -180,7 +180,7 @@ describe('Confirm', function () {
       );
 
       render(
-        <Confirm message="Are you sure?" onConfirmAsync={onConfirmAsync}>
+        <Confirm message="Are you sure?" onConfirm={onConfirmAsync}>
           <button>Confirm?</button>
         </Confirm>
       );
@@ -205,6 +205,7 @@ describe('Confirm', function () {
       // Should show error message and not close the modal
       await screen.findByText(/something went wrong/i);
       expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Confirm'})).toBeEnabled();
     });
   });
 });

--- a/static/app/components/confirm.spec.tsx
+++ b/static/app/components/confirm.spec.tsx
@@ -1,16 +1,21 @@
 import {
+  act,
   createEvent,
   fireEvent,
   render,
   renderGlobalModal,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import Confirm from 'sentry/components/confirm';
 import ModalStore from 'sentry/stores/modalStore';
 
 describe('Confirm', function () {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
   afterEach(() => {
     ModalStore.reset();
   });
@@ -125,5 +130,81 @@ describe('Confirm', function () {
 
     fireEvent(button, clickEvent);
     expect(clickEvent.stopPropagation).toHaveBeenCalled();
+  });
+
+  describe('onConfirmAsync', function () {
+    it('should not close the modal until the promise is resolved', async function () {
+      jest.useFakeTimers();
+      const onConfirmAsync = jest.fn().mockImplementation(
+        () =>
+          new Promise(resolve => {
+            setTimeout(resolve, 1000);
+          })
+      );
+
+      render(
+        <Confirm message="Are you sure?" onConfirmAsync={onConfirmAsync}>
+          <button>Confirm?</button>
+        </Confirm>
+      );
+      renderGlobalModal();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm?'}), {
+        delay: null,
+      });
+
+      await screen.findByRole('dialog');
+
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}), {
+        delay: null,
+      });
+
+      // Should keep modal in view until the promise is resolved
+      expect(onConfirmAsync).toHaveBeenCalled();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      act(() => jest.runAllTimers());
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    it('displays an error message if the promise is rejected', async function () {
+      jest.useFakeTimers();
+      const onConfirmAsync = jest.fn().mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            setTimeout(reject, 1000);
+          })
+      );
+
+      render(
+        <Confirm message="Are you sure?" onConfirmAsync={onConfirmAsync}>
+          <button>Confirm?</button>
+        </Confirm>
+      );
+      renderGlobalModal();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm?'}), {
+        delay: null,
+      });
+
+      await screen.findByRole('dialog');
+
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}), {
+        delay: null,
+      });
+
+      // Should keep modal in view until the promise is resolved
+      expect(onConfirmAsync).toHaveBeenCalled();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      act(() => jest.runAllTimers());
+
+      // Should show error message and not close the modal
+      await screen.findByText(/something went wrong/i);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/confirm.stories.tsx
+++ b/static/app/components/confirm.stories.tsx
@@ -105,18 +105,17 @@ export default storyBook('Confirm', story => {
     </Fragment>
   ));
 
-  story('Async Confimations', () => {
+  story('Async Confirmations', () => {
     return (
       <Fragment>
         <p>
-          If you pass an async function to{' '}
-          <JSXProperty name="onConfirmAsync" value={Function} />, the modal will not close
-          until the promise is resolved. This is useful if you have actions that require a
-          endpoint to respond before the modal can be closed, such as when confirming the
-          deletion of the page you are on.
+          If you pass a promise to <JSXProperty name="onConfirm" value={Function} />, the
+          modal will not close until the promise is resolved. This is useful if you have
+          actions that require a endpoint to respond before the modal can be closed, such
+          as when confirming the deletion of the page you are on.
         </p>
         <Confirm
-          onConfirmAsync={() => new Promise(resolve => setTimeout(resolve, 1000))}
+          onConfirm={() => new Promise(resolve => setTimeout(resolve, 1000))}
           header="Are you sure?"
           message="This confirmation takes 1 second to complete"
         >
@@ -127,7 +126,7 @@ export default storyBook('Confirm', story => {
           network errors.
         </p>
         <Confirm
-          onConfirmAsync={() => new Promise((_, reject) => setTimeout(reject, 1000))}
+          onConfirm={() => new Promise((_, reject) => setTimeout(reject, 1000))}
           header="Are you sure?"
           message="This confirmation will error"
           errorMessage="Custom error message"

--- a/static/app/components/confirm.stories.tsx
+++ b/static/app/components/confirm.stories.tsx
@@ -105,6 +105,39 @@ export default storyBook('Confirm', story => {
     </Fragment>
   ));
 
+  story('Async Confimations', () => {
+    return (
+      <Fragment>
+        <p>
+          If you pass an async function to{' '}
+          <JSXProperty name="onConfirmAsync" value={Function} />, the modal will not close
+          until the promise is resolved. This is useful if you have actions that require a
+          endpoint to respond before the modal can be closed, such as when confirming the
+          deletion of the page you are on.
+        </p>
+        <Confirm
+          onConfirmAsync={() => new Promise(resolve => setTimeout(resolve, 1000))}
+          header="Are you sure?"
+          message="This confirmation takes 1 second to complete"
+        >
+          <Button>This confirmation takes 1 second to complete</Button>
+        </Confirm>
+        <p>
+          This also allows you to respond to display errors in the modal in the case of
+          network errors.
+        </p>
+        <Confirm
+          onConfirmAsync={() => new Promise((_, reject) => setTimeout(reject, 1000))}
+          header="Are you sure?"
+          message="This confirmation will error"
+          errorMessage="Custom error message"
+        >
+          <Button>This confirmation will error</Button>
+        </Confirm>
+      </Fragment>
+    );
+  });
+
   story('Callbacks & bypass={true}', () => {
     const [callbacks, setCallbacks] = useState<string[]>([]);
     return (

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -101,12 +101,11 @@ export type OpenConfirmOptions = {
   onClose?: () => void;
   /**
    * Callback when user confirms
+   *
+   * If you pass a promise, the modal will not close until it resolves.
+   * To customize the error message in case of rejection, pass the `errorMessage` prop.
    */
-  onConfirm?: () => void;
-  /**
-   * Prevents the modal from closing until the promise is resolved
-   */
-  onConfirmAsync?: () => Promise<unknown>;
+  onConfirm?: () => void | Promise<void>;
   /**
    * Callback function when user is in the confirming state called when the
    * confirm modal is opened
@@ -231,7 +230,6 @@ type ModalProps = ModalRenderProps &
     | 'header'
     | 'isDangerous'
     | 'onConfirm'
-    | 'onConfirmAsync'
     | 'onCancel'
     | 'disableConfirmButton'
     | 'onRender'
@@ -252,7 +250,6 @@ function ConfirmModal({
   disableConfirmButton,
   onCancel,
   onConfirm,
-  onConfirmAsync,
   renderMessage,
   message,
   errorMessage = t('Something went wrong. Please try again.'),
@@ -278,21 +275,22 @@ function ConfirmModal({
       return;
     }
 
+    isConfirmingRef.current = true;
     setShouldDisableConfirmButton(true);
 
-    if (onConfirmAsync) {
+    if (onConfirm) {
       try {
-        await onConfirmAsync();
+        await onConfirm();
       } catch (error) {
         setIsError(true);
+        setShouldDisableConfirmButton(disableConfirmButton ?? false);
         return;
+      } finally {
+        isConfirmingRef.current = false;
       }
-    } else if (onConfirm) {
-      onConfirm();
     }
 
     confirmCallbackRef.current();
-    isConfirmingRef.current = true;
     closeModal();
   };
 

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1204,7 +1204,9 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
                 disabled={disabled}
                 priority="danger"
                 confirmText={t('Delete Rule')}
-                onConfirm={this.handleDeleteRule}
+                onConfirm={() => {
+                  this.handleDeleteRule();
+                }}
                 header={<h5>{t('Delete Alert Rule?')}</h5>}
                 message={t(
                   'Are you sure you want to delete "%s"? You won\'t be able to view the history of this alert once it\'s deleted.',

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1352,7 +1352,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
                       header={<h5>{t('Delete Alert Rule?')}</h5>}
                       priority="danger"
                       confirmText={t('Delete Rule')}
-                      onConfirm={this.handleDeleteRule}
+                      onConfirm={() => {
+                        this.handleDeleteRule();
+                      }}
                     >
                       <Button priority="danger">{t('Delete Rule')}</Button>
                     </Confirm>

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -109,8 +109,10 @@ function AccountClose() {
         data: {organizations: Array.from(orgsToRemove)},
       });
 
-      openModal(GoodbyeModalContent, {
-        onClose: leaveRedirect,
+      requestAnimationFrame(() => {
+        openModal(GoodbyeModalContent, {
+          onClose: leaveRedirect,
+        });
       });
 
       // Redirect after 10 seconds

--- a/static/app/views/settings/account/confirmAccountClose.tsx
+++ b/static/app/views/settings/account/confirmAccountClose.tsx
@@ -13,7 +13,9 @@ export function ConfirmAccountClose({
       message={t(
         'WARNING! This is permanent and cannot be undone, are you really sure you want to do this?'
       )}
-      onConfirm={handleRemoveAccount}
+      onConfirm={() => {
+        handleRemoveAccount();
+      }}
     >
       <Button priority="danger">{t('Close Account')}</Button>
     </Confirm>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -318,13 +318,15 @@ export default function SentryApplicationDetails(props: Props) {
   };
 
   const rotateClientSecret = async () => {
-    try {
-      const rotateResponse = await api.requestPromise(
-        `/sentry-apps/${appSlug}/rotate-secret/`,
-        {
-          method: 'POST',
-        }
-      );
+    const rotateResponse = await api.requestPromise(
+      `/sentry-apps/${appSlug}/rotate-secret/`,
+      {
+        method: 'POST',
+      }
+    );
+
+    // Ensures that the modal is opened after the confirmation modal closes itself
+    requestAnimationFrame(() => {
       openModal(({Body, Header}) => (
         <Fragment>
           <Header>{t('Your new Client Secret')}</Header>
@@ -340,9 +342,7 @@ export default function SentryApplicationDetails(props: Props) {
           </Body>
         </Fragment>
       ));
-    } catch {
-      addErrorMessage(t('Error rotating secret'));
-    }
+    });
   };
 
   const onFieldChange = (name: string, value: FieldValue): void => {
@@ -546,6 +546,7 @@ export default function SentryApplicationDetails(props: Props) {
                             message={t(
                               'Are you sure you want to rotate the client secret? The current one will not be usable anymore, and this cannot be undone.'
                             )}
+                            errorMessage={t('Error rotating secret')}
                           >
                             <Button priority="danger">Rotate client secret</Button>
                           </Confirm>

--- a/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
@@ -143,7 +143,9 @@ class InstalledPlugin extends Component<Props> {
               onConfirming={this.handleUninstallClick}
               disabled={!hasAccess}
               confirmText="Delete Installation"
-              onConfirm={() => this.handleReset()}
+              onConfirm={() => {
+                this.handleReset();
+              }}
               message={this.getConfirmMessage()}
             >
               <StyledButton

--- a/static/app/views/settings/organizationTeams/teamSettings/index.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.tsx
@@ -126,7 +126,9 @@ function TeamSettings({team, params}: TeamSettingsProps) {
           <div>
             <Confirm
               disabled={isIdpProvisioned || !hasTeamAdmin}
-              onConfirm={handleRemoveTeam}
+              onConfirm={() => {
+                handleRemoveTeam();
+              }}
               priority="danger"
               message={tct('Are you sure you want to remove the team [team]?', {
                 team: `#${team.slug}`,

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -172,7 +172,9 @@ export function KeySettings({
                     message={t(
                       'Are you sure you want to revoke this key? This will immediately remove and suspend the credentials.'
                     )}
-                    onConfirm={handleRemove}
+                    onConfirm={() => {
+                      handleRemove();
+                    }}
                     confirmText={t('Revoke Key')}
                     disabled={!hasAccess}
                   >

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -214,7 +214,9 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
 
         {isOrgOwner && !isInternal && (
           <Confirm
-            onConfirm={handleTransferProject}
+            onConfirm={() => {
+              handleTransferProject();
+            }}
             priority="danger"
             confirmText={t('Transfer project')}
             renderMessage={({confirm}) => (

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -129,7 +129,7 @@ function UserDetails() {
 
     openConfirmModal({
       message: 'Are you sure you want to remove this authenticator?',
-      onConfirm: () =>
+      onConfirm: () => {
         api.request(endpoint, {
           method: 'DELETE',
           success: () => {
@@ -144,7 +144,8 @@ function UserDetails() {
           error: () => {
             addErrorMessage('Unable to remove authenticator from account.');
           },
-        }),
+        });
+      },
     });
   };
 
@@ -167,7 +168,7 @@ function UserDetails() {
         (identity.status === UserIdentityStatus.NEEDED_FOR_ORG_AUTH
           ? ' (Caution: User may be locked out of org access.)'
           : ''),
-      onConfirm: () =>
+      onConfirm: () => {
         api.request(endpoint, {
           method: 'DELETE',
           success: () => {
@@ -185,7 +186,8 @@ function UserDetails() {
           error: () => {
             addErrorMessage('Unable to remove identity from account.');
           },
-        }),
+        });
+      },
     });
   };
 

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -488,7 +488,9 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
         )}
       {!isLoading && orgEnabledFlag && canViewSpendAllocation && (
         <Confirm
-          onConfirm={disableSpendAllocations}
+          onConfirm={() => {
+            disableSpendAllocations();
+          }}
           renderMessage={confirmDisableContent}
         >
           <Button

--- a/static/gsApp/views/spikeProtection/spikeProtectionProjects.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionProjects.tsx
@@ -204,7 +204,9 @@ function SpikeProtectionProjects({subscription}: Props) {
     );
     return (
       <Confirm
-        onConfirm={() => updateAllProjects(isEnabling)}
+        onConfirm={() => {
+          updateAllProjects(isEnabling);
+        }}
         message={confirmationText}
         disabled={!hasOrgWrite}
       >


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/91362 being merged first

Adds the ability to pass an async function to the confirm modal and wait for it to complete before closing. I keep wanting something like this for things like deleting the page you are on, because it doesn't make sense to do that optimistically (and even worse if you have to wait without any sort of loading state). IMO most things that require a confirmation modal probably should wait for the action to complete before closing.

This adds a `onConfirmAsync` prop which will disable the confirm button and wait until the promise succeeds before closing. I've also added an error alert in the case of a failure.

https://github.com/user-attachments/assets/28e79d14-a942-4ad3-953a-a94ee71a2226

