### PR TITLE
feat(perf-issues): Run N+1 MongoDB experiment

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
@@ -70,7 +70,7 @@ class NPlusOneDBSpanExperimentalDetector(PerformanceDetector):
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 
-    def is_creation_allowed_for_system(self) -> bool:
+    def is_detection_allowed_for_system(self) -> bool:
         # Defer to the issue platform for whether to create issues
         # See https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type
         return True

--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_db_span_detector.py
@@ -70,7 +70,8 @@ class NPlusOneDBSpanExperimentalDetector(PerformanceDetector):
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 
-    def is_detection_allowed_for_system(self) -> bool:
+    @classmethod
+    def is_detection_allowed_for_system(cls) -> bool:
         # Defer to the issue platform for whether to create issues
         # See https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type
         return True

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -10,12 +10,20 @@ from sentry.models.release import Release
 from sentry.spans.consumers.process_segments.message import process_segment
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.utils.performance_issues.performance_detection import DETECTOR_CLASSES
 from tests.sentry.spans.consumers.process import build_mock_span
 
 
 class TestSpansTask(TestCase):
     def setUp(self):
         self.project = self.create_project()
+        # Exclude experimental detectors from _detect_performance_problems in this test suite
+        self.patch_detector_classes = mock.patch(
+            "sentry.utils.performance_issues.performance_detection.DETECTOR_CLASSES",
+            [cls for cls in DETECTOR_CLASSES if "Experimental" not in cls.__name__],
+        )
+        self.patch_detector_classes.start()
+        self.addCleanup(self.patch_detector_classes.stop)
 
     def generate_basic_spans(self):
         segment_span = build_mock_span(

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -100,8 +100,7 @@ class PerformanceDetectionTest(TestCase):
         self.addCleanup(patch_organization.stop)
 
         self.project = self.create_project()
-
-        # Patch DETECTOR_CLASSES to exclude experimental detectors
+        # Exclude experimental detectors from detection in this test suite
         self.patch_detector_classes = patch(
             "sentry.utils.performance_issues.performance_detection.DETECTOR_CLASSES",
             [cls for cls in DETECTOR_CLASSES if "Experimental" not in cls.__name__],

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -19,6 +19,7 @@ from sentry.utils.performance_issues.detectors.n_plus_one_db_span_detector impor
     NPlusOneDBSpanDetector,
 )
 from sentry.utils.performance_issues.performance_detection import (
+    DETECTOR_CLASSES,
     EventPerformanceProblem,
     _detect_performance_problems,
     detect_performance_problems,
@@ -99,6 +100,14 @@ class PerformanceDetectionTest(TestCase):
         self.addCleanup(patch_organization.stop)
 
         self.project = self.create_project()
+
+        # Patch DETECTOR_CLASSES to exclude experimental detectors
+        self.patch_detector_classes = patch(
+            "sentry.utils.performance_issues.performance_detection.DETECTOR_CLASSES",
+            [cls for cls in DETECTOR_CLASSES if "Experimental" not in cls.__name__],
+        )
+        self.patch_detector_classes.start()
+        self.addCleanup(self.patch_detector_classes.stop)
 
     @patch("sentry.utils.performance_issues.performance_detection._detect_performance_problems")
     def test_options_disabled(self, mock):


### PR DESCRIPTION
🙃  I thought this had been running, but with all the changes last week I didn't realize the override function was named incorrectly.

This will allow the experimental detector to run in production, won't create issues since `released=False` and none of those flags are set yet.