### PR TITLE
fix(replay): only reset video duration during playback

### DIFF
--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -429,7 +429,8 @@ export class VideoReplayer {
         videoElem.style.display = 'none';
         // resets the other videos to the beginning if it's ended so it starts from the beginning on restart
         // we don't do this for videos that have a duration of 0 because this will incorrectly cause handleSegmentEnd to fire.
-        if (videoElem.ended && videoElem.duration > 0) {
+        // We also don't want to reset during preview seeking operations
+        if (videoElem.ended && videoElem.duration > 0 && this._isPlaying) {
           this.setVideoTime(videoElem, 0);
         }
       }


### PR DESCRIPTION
before: wrong preview

<img width="1102" alt="SCR-20250509-lrrv" src="https://github.com/user-attachments/assets/365f65df-767c-4c5f-9c1f-5b84f2deaa35" />

video that shows what the correct preview should be - playing through the replay:


https://github.com/user-attachments/assets/2975f10d-8eaa-4b17-a011-93bd6d9d0716


after: correct preview

<img width="907" alt="SCR-20250509-ltgj" src="https://github.com/user-attachments/assets/fc0afacb-3a84-422d-a08c-634aba7ff12b" />



closes https://linear.app/getsentry/issue/MOBILE-972/when-sharing-a-link-to-a-mobile-replay-at-a-specific-timestamp-wrong