### PR TITLE
chore(perf-issues): Add a metric for dropping occurrences in post-process

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -665,7 +665,6 @@ def run_post_process_job(job: PostProcessJob) -> None:
     ):
         metrics.incr(
             "post_process.skipped_feature_disabled",
-            sample_rate=1.0,
             tags={"issue_type": group_event.group.issue_type.slug},
         )
         return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -663,6 +663,11 @@ def run_post_process_job(job: PostProcessJob) -> None:
     if group_event.group and not group_event.group.issue_type.allow_post_process_group(
         group_event.group.organization
     ):
+        metrics.incr(
+            "post_process.skipped_feature_disabled",
+            sample_rate=1.0,
+            tags={"issue_type": group_event.group.issue_type.slug},
+        )
         return
 
     if issue_category in GROUP_CATEGORY_POST_PROCESS_PIPELINE:


### PR DESCRIPTION
We already do this for [ingest](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/occurrence_consumer.py#L350-L357), I'd like to be able to see if this is happening in post-process as well so we can continue monitoring volume after allowing ingest. It'd also be useful to ensure we fully release all our detectors.

slug is also more readable than group type id