### PR TITLE
feat(issues): Keep search/filter controls sticky inside Distributions drawer

### DIFF
--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -61,7 +61,7 @@ export const EventNavigator = styled('div')`
   background: ${p => p.theme.background};
   z-index: 1;
   min-height: ${MIN_NAV_HEIGHT}px;
-  box-shadow: ${p => p.theme.translucentBorder} 0 1px;
+  border-bottom: 1px solid ${p => p.theme.translucentBorder};
 `;
 
 export const EventDrawerBody = styled(DrawerBody)`

--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -59,9 +59,9 @@ export const EventNavigator = styled('div')`
   column-gap: ${space(1)};
   padding: ${space(0.75)} 24px;
   background: ${p => p.theme.background};
-  z-index: 1;
+  z-index: 2;
   min-height: ${MIN_NAV_HEIGHT}px;
-  border-bottom: 1px solid ${p => p.theme.translucentBorder};
+  box-shadow: ${p => p.theme.translucentBorder} 0 1px;
 `;
 
 export const EventDrawerBody = styled(DrawerBody)`

--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -64,6 +64,17 @@ export const EventNavigator = styled('div')`
   box-shadow: ${p => p.theme.translucentBorder} 0 1px;
 `;
 
+export const EventStickyControls = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  position: sticky;
+  top: -${space(2)};
+  margin-block: -${space(2)};
+  padding-block: ${space(2)};
+  background: ${p => p.theme.background};
+  z-index: 1;
+`;
+
 export const EventDrawerBody = styled(DrawerBody)`
   overflow: auto;
   overscroll-behavior: contain;

--- a/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
@@ -207,8 +207,11 @@ const StickyControls = styled('div')`
   display: flex;
   justify-content: space-between;
   position: sticky;
-  top: 0;
+  top: -${space(2)};
+  margin-block: -${space(2)};
+  padding-block: ${space(2)};
   background: ${p => p.theme.background};
+  z-index: 1;
 `;
 
 const Label = styled('label')`

--- a/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
@@ -142,7 +142,7 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
         ) : null}
 
         {tagKey ? null : (
-          <Flex justify="space-between">
+          <StickyControls>
             <TagFlagPicker setTab={setTab} tab={DrawerTab.FEATURE_FLAGS} />
 
             <ButtonBar gap={1}>
@@ -179,7 +179,7 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
                 sortByOptions={sortByOptions}
               />
             </ButtonBar>
-          </Flex>
+          </StickyControls>
         )}
 
         {tagKey ? (
@@ -202,6 +202,14 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
     </Fragment>
   );
 }
+
+const StickyControls = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  background: ${p => p.theme.background};
+`;
 
 const Label = styled('label')`
   display: flex;

--- a/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/flagsDistributionDrawer.tsx
@@ -5,7 +5,11 @@ import AnalyticsArea from 'sentry/components/analyticsArea';
 import {Flex} from 'sentry/components/container/flex';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Checkbox} from 'sentry/components/core/checkbox';
-import {EventDrawerBody, EventNavigator} from 'sentry/components/events/eventDrawer';
+import {
+  EventDrawerBody,
+  EventNavigator,
+  EventStickyControls,
+} from 'sentry/components/events/eventDrawer';
 import FeatureFlagSort from 'sentry/components/events/featureFlags/featureFlagSort';
 import {OrderBy, SortBy} from 'sentry/components/events/featureFlags/utils';
 import SuspectTable from 'sentry/components/issues/suspect/suspectTable';
@@ -142,7 +146,7 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
         ) : null}
 
         {tagKey ? null : (
-          <StickyControls>
+          <EventStickyControls>
             <TagFlagPicker setTab={setTab} tab={DrawerTab.FEATURE_FLAGS} />
 
             <ButtonBar gap={1}>
@@ -179,7 +183,7 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
                 sortByOptions={sortByOptions}
               />
             </ButtonBar>
-          </StickyControls>
+          </EventStickyControls>
         )}
 
         {tagKey ? (
@@ -202,17 +206,6 @@ export default function FlagsDistributionDrawer({group, organization, setTab}: P
     </Fragment>
   );
 }
-
-const StickyControls = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  position: sticky;
-  top: -${space(2)};
-  margin-block: -${space(2)};
-  padding-block: ${space(2)};
-  background: ${p => p.theme.background};
-  z-index: 1;
-`;
 
 const Label = styled('label')`
   display: flex;

--- a/static/app/views/issueDetails/groupDistributions/groupDistributionsSearchInput.tsx
+++ b/static/app/views/issueDetails/groupDistributions/groupDistributionsSearchInput.tsx
@@ -1,5 +1,4 @@
 import type {Dispatch, SetStateAction} from 'react';
-import styled from '@emotion/styled';
 
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {IconSearch} from 'sentry/icons';
@@ -18,7 +17,7 @@ export default function GroupDistributionsSearchInput({
 }: Props) {
   return (
     <InputGroup>
-      <SearchInput
+      <InputGroup.Input
         size="xs"
         value={search}
         onChange={e => {
@@ -36,9 +35,3 @@ export default function GroupDistributionsSearchInput({
     </InputGroup>
   );
 }
-
-const SearchInput = styled(InputGroup.Input)`
-  border: 0;
-  box-shadow: unset;
-  color: inherit;
-`;

--- a/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
@@ -1,12 +1,13 @@
 import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/container/flex';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {EventDrawerBody, EventNavigator} from 'sentry/components/events/eventDrawer';
 import SuspectTable from 'sentry/components/issues/suspect/suspectTable';
 import {IconSort} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -72,7 +73,7 @@ export default function TagsDistributionDrawer({
         ) : null}
 
         {tagKey ? null : (
-          <Flex justify="space-between">
+          <StickyControls>
             <TagFlagPicker setTab={setTab} tab={DrawerTab.TAGS} />
 
             <ButtonBar gap={1}>
@@ -95,7 +96,7 @@ export default function TagsDistributionDrawer({
                 </Fragment>
               ) : null}
             </ButtonBar>
-          </Flex>
+          </StickyControls>
         )}
 
         {tagKey ? (
@@ -113,3 +114,14 @@ export default function TagsDistributionDrawer({
     </Fragment>
   );
 }
+
+const StickyControls = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  position: sticky;
+  top: -${space(2)};
+  margin-block: -${space(2)};
+  padding-block: ${space(2)};
+  background: ${p => p.theme.background};
+  z-index: 1;
+`;

--- a/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
@@ -1,13 +1,15 @@
 import {Fragment, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Tooltip} from 'sentry/components/core/tooltip';
-import {EventDrawerBody, EventNavigator} from 'sentry/components/events/eventDrawer';
+import {
+  EventDrawerBody,
+  EventNavigator,
+  EventStickyControls,
+} from 'sentry/components/events/eventDrawer';
 import SuspectTable from 'sentry/components/issues/suspect/suspectTable';
 import {IconSort} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -73,7 +75,7 @@ export default function TagsDistributionDrawer({
         ) : null}
 
         {tagKey ? null : (
-          <StickyControls>
+          <EventStickyControls>
             <TagFlagPicker setTab={setTab} tab={DrawerTab.TAGS} />
 
             <ButtonBar gap={1}>
@@ -96,7 +98,7 @@ export default function TagsDistributionDrawer({
                 </Fragment>
               ) : null}
             </ButtonBar>
-          </StickyControls>
+          </EventStickyControls>
         )}
 
         {tagKey ? (
@@ -114,14 +116,3 @@ export default function TagsDistributionDrawer({
     </Fragment>
   );
 }
-
-const StickyControls = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  position: sticky;
-  top: -${space(2)};
-  margin-block: -${space(2)};
-  padding-block: ${space(2)};
-  background: ${p => p.theme.background};
-  z-index: 1;
-`;


### PR DESCRIPTION
The suspect table can scroll away, and controls stick around. If there's no suspect table then you'll never know it's happening.

also took the chance to give the search box it's border, so it's more discoverable.

<img width="521" alt="SCR-20250509-oist" src="https://github.com/user-attachments/assets/217adf61-c52d-42f7-952a-b9b1947dd175" />
