### PR TITLE
feat(ACI): Conditionally call new serializers

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -470,6 +470,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Create links to the new UI when sending notifications in the workflow_engine
     manager.add("organizations:workflow-engine-ui-links", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine serializers to return data for old rule / incident endpoints
+    manager.add("organizations:workflow-engine-rule-serializers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition
     manager.add("organizations:event-unique-user-frequency-condition-with-conditions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use spans instead of transactions for dynamic sampling calculations. This will become the new default.

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -69,7 +69,7 @@ def fetch_alert_rule(
     if features.has("organizations:workflow-engine-rule-serializers", organization):
         try:
             detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
-            resp = Response(
+            return Response(
                 serialize(
                     detector,
                     request.user,
@@ -78,7 +78,6 @@ def fetch_alert_rule(
             )
         except Detector.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
-        return resp
 
     serialized_rule = serialize(
         alert_rule,

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -9,7 +9,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
-
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -47,6 +47,8 @@ from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import WorkflowEngineDetectorSerializer
+from sentry.workflow_engine.models import Detector
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +62,14 @@ def fetch_alert_rule(
 ) -> Response:
     # Serialize Alert Rule
     expand = request.GET.getlist("expand", [])
+
+    if features.has("organizations:workflow-engine-rule-serializers", organization):
+        try:
+            detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+            resp = Response(serialize(detector, request.user, WorkflowEngineDetectorSerializer(expand=expand, prepare_component_fields=True)))
+        except Detector.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
     serialized_rule = serialize(
         alert_rule,
         request.user,
@@ -87,7 +97,7 @@ def update_alert_rule(
     request: Request, organization: Organization, alert_rule: AlertRule
 ) -> Response:
     data = request.data
-    serializer = DrfAlertRuleSerializer(
+    validator = DrfAlertRuleSerializer(
         context={
             "organization": organization,
             "access": request.access,
@@ -101,9 +111,9 @@ def update_alert_rule(
         data=data,
         partial=True,
     )
-    if serializer.is_valid():
+    if validator.is_valid():
         try:
-            trigger_sentry_app_action_creators_for_incidents(serializer.validated_data)
+            trigger_sentry_app_action_creators_for_incidents(validator.validated_data)
         except SentryAppBaseError as e:
             return e.response_from_exception()
 
@@ -121,9 +131,13 @@ def update_alert_rule(
             # The user has requested a new Slack channel and we tell the client to check again in a bit
             return Response({"uuid": client.uuid}, status=202)
         else:
-            return Response(serialize(serializer.save(), request.user), status=status.HTTP_200_OK)
+            validator = validator.save()
+            # TODO what is this even, need to convert to Detector stuff
+            if features.has("organizations:workflow-engine-rule-serializers", organization):
+                return Response(serialize(validator, request.user, WorkflowEngineDetectorSerializer()), status=status.HTTP_200_OK)
+            return Response(serialize(validator, request.user), status=status.HTTP_200_OK)
 
-    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 def remove_alert_rule(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -123,17 +123,6 @@ def create_metric_alert(
         return Response({"uuid": client.uuid}, status=202)
     else:
         alert_rule = serializer.save()
-        if features.has("organizations:workflow-engine-rule-serializers", organization):
-            try:
-                detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
-                resp = Response(
-                    serialize(detector, request.user, WorkflowEngineDetectorSerializer()),
-                    status=status.HTTP_201_CREATED,
-                )
-            except Detector.DoesNotExist:
-                # print("no detector cause we didn't dual write you dum dum")
-                return Response(status=status.HTTP_404_NOT_FOUND)
-            return resp
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
 
@@ -178,7 +167,6 @@ class AlertRuleIndexMixin(Endpoint):
                 on_results=lambda x: serialize(x, request.user),
                 default_per_page=25,
             )
-
         response[ALERT_RULES_COUNT_HEADER] = len(alert_rules)
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG
         return response

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -72,6 +72,8 @@ from sentry.snuba.dataset import Dataset
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeStatus
 from sentry.uptime.types import ProjectUptimeSubscriptionMode
 from sentry.utils.cursors import Cursor, StringCursor
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import WorkflowEngineDetectorSerializer
+from sentry.workflow_engine.models import Detector
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +121,14 @@ def create_metric_alert(
         return Response({"uuid": client.uuid}, status=202)
     else:
         alert_rule = serializer.save()
+        if features.has("organizations:workflow-engine-rule-serializers", organization):
+            try:
+                detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+                resp = Response(serialize(detector, request.user, WorkflowEngineDetectorSerializer()), status=status.HTTP_201_CREATED)
+            except Detector.DoesNotExist:
+                print("no detector cause we didn't dual write you dum dum")
+                return Response(status=status.HTTP_404_NOT_FOUND)  
+            return resp      
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
 
@@ -140,14 +150,27 @@ class AlertRuleIndexMixin(Endpoint):
                 extra={"organization": organization.id},
             )
 
-        response = self.paginate(
-            request,
-            queryset=alert_rules,
-            order_by="-date_added",
-            paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
-            default_per_page=25,
-        )
+        if features.has("organizations:workflow-engine-rule-serializers", organization):
+            detectors = Detector.objects.filter(alertruledetector__alert_rule_id__in=[alert_rule.id for alert_rule in alert_rules])
+            if not len(detectors):
+                return Response(status=status.HTTP_404_NOT_FOUND) 
+            response = self.paginate(
+                request,
+                queryset=detectors,
+                order_by="-date_added",
+                paginator_cls=OffsetPaginator,
+                on_results=lambda x: serialize(x, request.user, WorkflowEngineDetectorSerializer()),
+                default_per_page=25,
+            )            
+        else:
+            response = self.paginate(
+                request,
+                queryset=alert_rules,
+                order_by="-date_added",
+                paginator_cls=OffsetPaginator,
+                on_results=lambda x: serialize(x, request.user),
+                default_per_page=25,
+            )
 
         response[ALERT_RULES_COUNT_HEADER] = len(alert_rules)
         response[MAX_QUERY_SUBSCRIPTIONS_HEADER] = settings.MAX_QUERY_SUBSCRIPTIONS_PER_ORG

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -1,15 +1,19 @@
 from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
+
 from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+    WorkflowEngineDetectorSerializer,
+)
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import WorkflowEngineDetectorSerializer
+from sentry.workflow_engine.models import Detector
 
 
 @region_silo_endpoint
@@ -40,8 +44,18 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
         if rule_id and status == "success":
             try:
                 alert_rule = AlertRule.objects.get(projects=project, id=rule_id)
-                if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-                    context["alertRule"] = serialize(alert_rule. request.user, WorkflowEngineDetectorSerializer())
+                if features.has(
+                    "organizations:workflow-engine-rule-serializers", project.organization
+                ):
+                    try:
+                        detector = Detector.objects.get(
+                            alertruledetector__alert_rule_id=alert_rule.id
+                        )
+                    except Detector.DoesNotExist:
+                        raise Http404
+                    context["alertRule"] = serialize(
+                        detector, request.user, WorkflowEngineDetectorSerializer()
+                    )
                 else:
                     context["alertRule"] = serialize(alert_rule, request.user)
             except AlertRule.DoesNotExist:

--- a/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_task_details.py
@@ -1,7 +1,7 @@
 from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
-
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -9,6 +9,7 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
 from sentry.api.serializers import serialize
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import WorkflowEngineDetectorSerializer
 
 
 @region_silo_endpoint
@@ -39,7 +40,10 @@ class ProjectAlertRuleTaskDetailsEndpoint(ProjectEndpoint):
         if rule_id and status == "success":
             try:
                 alert_rule = AlertRule.objects.get(projects=project, id=rule_id)
-                context["alertRule"] = serialize(alert_rule, request.user)
+                if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+                    context["alertRule"] = serialize(alert_rule. request.user, WorkflowEngineDetectorSerializer())
+                else:
+                    context["alertRule"] = serialize(alert_rule, request.user)
             except AlertRule.DoesNotExist:
                 raise Http404
         if status == "failed":

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -112,9 +112,9 @@ class WorkflowEngineDataConditionSerializer(Serializer):
                 obj.comparison,
             ),
             "resolveThreshold": (
-                AlertRuleThresholdType.BELOW
+                AlertRuleThresholdType.BELOW.value
                 if obj.type == Condition.GREATER
-                else AlertRuleThresholdType.ABOVE
+                else AlertRuleThresholdType.ABOVE.value
             ),
             "dateCreated": obj.date_added,
             "actions": attrs.get("actions", []),

--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -4,6 +4,12 @@ from django.urls import reverse
 
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.testutils.cases import APITestCase
+from sentry.workflow_engine.migration_helpers.alert_rule import (
+    migrate_alert_rule,
+    migrate_metric_action,
+    migrate_metric_data_conditions,
+    migrate_resolve_threshold_data_condition,
+)
 
 
 class ProjectAlertRuleTaskDetailsTest(APITestCase):
@@ -51,6 +57,32 @@ class ProjectAlertRuleTaskDetailsTest(APITestCase):
         self.set_value("success", self.rule.id)
         self.login_as(user=self.user)
         response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["status"] == "success"
+
+        rule_data = response.data["alertRule"]
+        assert rule_data["id"] == str(self.rule.id)
+        assert rule_data["name"] == self.rule.name
+
+    def test_workflow_engine_serializer(self):
+        self.set_value("success", self.rule.id)
+        self.login_as(user=self.user)
+
+        self.critical_trigger = self.create_alert_rule_trigger(
+            alert_rule=self.rule, label="critical"
+        )
+        self.critical_trigger_action = self.create_alert_rule_trigger_action(
+            alert_rule_trigger=self.critical_trigger
+        )
+        _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.rule)
+        self.critical_detector_trigger, _ = migrate_metric_data_conditions(self.critical_trigger)
+
+        self.critical_action, _, _ = migrate_metric_action(self.critical_trigger_action)
+        self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(self.rule)
+
+        with self.feature("organizations:workflow-engine-rule-serializers"):
+            response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["status"] == "success"

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -168,19 +168,25 @@ class AlertRuleIndexBase(AlertRuleBase):
                 "integration": self.integration.id,
             }
         ]
-        self.team = self.create_team(organization=self.organization, members=[self.user])
-        ProjectTeam.objects.create(project=self.project, team=self.team)
-        self.login_as(self.user)
 
 
 class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorklowEngineSerializer):
     def test_simple(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        alert_rule = self.create_alert_rule()
+
+        self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug)
 
-        assert resp.data == serialize([self.alert_rule])
+        assert resp.data == serialize([self.alert_rule, alert_rule])
 
     def test_workflow_engine_serializer(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        self.login_as(self.user)
+
         with (
             self.feature("organizations:incidents"),
             self.feature("organizations:workflow-engine-rule-serializers"),
@@ -192,10 +198,16 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorklowEngineSerializer)
         )
 
     def test_no_feature(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
         resp = self.get_response(self.organization.slug)
         assert resp.status_code == 404
 
     def test_response_headers(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        self.login_as(self.user)
+
         with self.feature("organizations:incidents"):
             resp = self.get_response(self.organization.slug)
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from datetime import timedelta
 from functools import cached_property
 from unittest.mock import patch
-from django.utils import timezone
+
 import orjson
 import pytest
 import responses
@@ -19,6 +19,9 @@ from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUB
 from sentry.api.serializers import serialize
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.hybridcloud.models.outbox import outbox_context
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+    WorkflowEngineDetectorSerializer,
+)
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
     AlertRule,
@@ -35,6 +38,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
+from sentry.models.projectteam import ProjectTeam
 from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.sentry_metrics import indexer
@@ -52,9 +56,13 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.models import Action, ActionAlertRuleTriggerAction, AlertRuleDetector
 from sentry.workflow_engine.models.data_condition import DataCondition
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import WorkflowEngineDetectorSerializer
 from tests.sentry.incidents.serializers.test_workflow_engine_base import TestWorklowEngineSerializer
-from sentry.models.projectteam import ProjectTeam
+from tests.sentry.workflow_engine.migration_helpers.test_migrate_alert_rule import (
+    assert_alert_rule_migrated,
+    assert_alert_rule_resolve_trigger_migrated,
+    assert_alert_rule_trigger_action_migrated,
+    assert_alert_rule_trigger_migrated,
+)
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
@@ -161,6 +169,7 @@ class AlertRuleIndexBase(AlertRuleBase):
             }
         ]
 
+
 class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorklowEngineSerializer):
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
@@ -177,10 +186,15 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorklowEngineSerializer)
         ProjectTeam.objects.create(project=self.project, team=team)
         self.login_as(self.user)
 
-        with self.feature("organizations:incidents"), self.feature("organizations:workflow-engine-rule-serializers"):
+        with (
+            self.feature("organizations:incidents"),
+            self.feature("organizations:workflow-engine-rule-serializers"),
+        ):
             resp = self.get_success_response(self.organization.slug)
 
-        assert resp.data[0] == serialize(self.detector, self.user, WorkflowEngineDetectorSerializer())
+        assert resp.data[0] == serialize(
+            self.detector, self.user, WorkflowEngineDetectorSerializer()
+        )
 
     def test_no_feature(self):
         self.create_team(organization=self.organization, members=[self.user])
@@ -201,7 +215,7 @@ class AlertRuleListEndpointTest(AlertRuleIndexBase, TestWorklowEngineSerializer)
 
 
 @freeze_time()
-class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase, TestWorklowEngineSerializer):
+class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     method = "post"
 
     @assume_test_silo_mode(SiloMode.CONTROL)
@@ -236,23 +250,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase, TestWorklow
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
-
-    def test_workflow_engine_serializer(self):
-        team = self.create_team(organization=self.organization, members=[self.user])
-        ProjectTeam.objects.create(project=self.project, team=team)
-        self.login_as(self.user)
-
-        with (
-            outbox_runner(),
-            self.feature(["organizations:incidents", "organizations:performance-view", "organizations:workflow-engine-rule-serializers"]),
-        ):
-            resp = self.get_success_response(
-                self.organization.slug,
-                status_code=201,
-                **self.alert_rule_dict,
-            )
-
-        assert resp.data[0] == serialize(self.detector, self.user, WorkflowEngineDetectorSerializer())
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_create_alert_rule_aci(self):

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -16,10 +16,13 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_resolve_threshold_data_condition,
 )
 from sentry.workflow_engine.models import ActionGroupStatus, IncidentGroupOpenPeriod
+from sentry.silo.base import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 @freeze_time("2024-12-11 03:21:34")
 class TestWorklowEngineSerializer(TestCase):
+    @assume_test_silo_mode(SiloMode.REGION)
     def setUp(self) -> None:
         self.now = timezone.now()
         self.alert_rule = self.create_alert_rule()

--- a/tests/sentry/incidents/serializers/test_workflow_engine_base.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_base.py
@@ -5,8 +5,10 @@ from sentry.incidents.models.incident import IncidentTrigger, TriggerStatus
 from sentry.issues.priority import PriorityChangeReason
 from sentry.models.activity import Activity
 from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.migration_helpers.alert_rule import (
@@ -16,8 +18,6 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
     migrate_resolve_threshold_data_condition,
 )
 from sentry.workflow_engine.models import ActionGroupStatus, IncidentGroupOpenPeriod
-from sentry.silo.base import SiloMode
-from sentry.testutils.silo import assume_test_silo_mode
 
 
 @freeze_time("2024-12-11 03:21:34")
@@ -61,7 +61,7 @@ class TestWorklowEngineSerializer(TestCase):
                 "label": "critical",
                 "thresholdType": AlertRuleThresholdType.ABOVE.value,
                 "alertThreshold": self.critical_detector_trigger.comparison,
-                "resolveThreshold": AlertRuleThresholdType.BELOW,
+                "resolveThreshold": AlertRuleThresholdType.BELOW.value,
                 "dateCreated": self.critical_trigger.date_added,
                 "actions": self.expected_critical_action,
             },
@@ -117,7 +117,7 @@ class TestWorklowEngineSerializer(TestCase):
             "label": "warning",
             "thresholdType": AlertRuleThresholdType.ABOVE.value,
             "alertThreshold": self.critical_detector_trigger.comparison,
-            "resolveThreshold": AlertRuleThresholdType.BELOW,
+            "resolveThreshold": AlertRuleThresholdType.BELOW.value,
             "dateCreated": self.critical_trigger.date_added,
             "actions": self.expected_warning_action,
         }


### PR DESCRIPTION
Conditionally call the new serializers that only read data from the workflow engine tables but return the same data one would expect from the old alert rule endpoints.