### PR TITLE
fix(ai trace query): Project Selection

### DIFF
--- a/static/app/views/explore/components/traceExploreAiQueryProvider.tsx
+++ b/static/app/views/explore/components/traceExploreAiQueryProvider.tsx
@@ -18,7 +18,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFieldDefinition} from 'sentry/utils/fields';
-import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import {useMutation} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
@@ -131,10 +130,12 @@ export function AiQueryDrawer({initialQuery = ''}: {initialQuery?: string}) {
 
   const {mutate: submitQuery, isPending} = useMutation({
     mutationFn: async (query: string) => {
-      const selectedProjects = getSelectedProjectList(
-        pageFilters.selection.projects,
-        memberProjects
-      ).map(p => p.id);
+      const selectedProjects =
+        pageFilters.selection.projects &&
+        pageFilters.selection.projects.length > 0 &&
+        pageFilters.selection.projects[0] !== -1
+          ? pageFilters.selection.projects
+          : memberProjects.map(p => p.id);
 
       const result = await api.requestPromise(
         `/api/0/organizations/${organization.slug}/trace-explorer-ai/query/`,
@@ -299,6 +300,7 @@ export function TraceExploreAiQueryProvider({children}: {children: React.ReactNo
   const pageFilters = usePageFilters();
   const client = useApi();
   const {projects} = useProjects();
+  const memberProjects = projects.filter(p => p.isMember);
 
   useEffect(() => {
     const selectedProjects =
@@ -306,7 +308,7 @@ export function TraceExploreAiQueryProvider({children}: {children: React.ReactNo
       pageFilters.selection.projects.length > 0 &&
       pageFilters.selection.projects[0] !== -1
         ? pageFilters.selection.projects
-        : projects.map(p => p.id);
+        : memberProjects.map(p => p.id);
 
     (async () => {
       try {
@@ -330,6 +332,7 @@ export function TraceExploreAiQueryProvider({children}: {children: React.ReactNo
     organization.slug,
     pageFilters.selection.projects,
     projects,
+    memberProjects,
   ]);
 
   return (


### PR DESCRIPTION
- Fixed propagation of project_id when selecting a project from the "other" category 
- Selecting all projects [-1] defaults to just the member's project to prevent timeouts due to fetching context