### PR TITLE
feat(issue stream): Return seer fields on issue stream

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -128,6 +128,8 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     platform: str | None
     priority: str | None
     priorityLockedAt: datetime | None
+    seerFixabilityScore: float | None
+    seerAutofixLastTriggered: datetime | None
     project: GroupProjectResponse
     type: str
     issueType: str
@@ -361,6 +363,8 @@ class GroupSerializerBase(Serializer, ABC):
             "issueCategory": issue_category,
             "priority": priority_label,
             "priorityLockedAt": obj.priority_locked_at,
+            "seerFixabilityScore": obj.seer_fixability_score,
+            "seerAutofixLastTriggered": obj.seer_autofix_last_triggered,
         }
 
         # This attribute is currently feature gated

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -278,6 +278,8 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     platform: NotRequired[str | None]
     priority: NotRequired[str | None]
     priorityLockedAt: NotRequired[datetime | None]
+    seerFixabilityScore: NotRequired[float | None]
+    seerAutofixLastTriggered: NotRequired[datetime | None]
     project: NotRequired[GroupProjectResponse]
     type: NotRequired[str]
     issueType: NotRequired[str]

--- a/src/sentry/apidocs/examples/issue_examples.py
+++ b/src/sentry/apidocs/examples/issue_examples.py
@@ -90,6 +90,8 @@ SIMPLE_ISSUE: StreamGroupSerializerSnubaResponse = {
         "firstSeen": datetime.fromisoformat("2018-11-06T21:19:55Z"),
         "lastSeen": datetime.fromisoformat("2018-12-06T21:19:55Z"),
     },
+    "seerAutofixLastTriggered": None,
+    "seerFixabilityScore": None,
     "status": "ignored",
     "substatus": "archived_until_condition_met",
     "statusDetails": {},


### PR DESCRIPTION
We already have Seer fields on the `Group` model. This PR just returns them along with the other fields for later use on the frontend issue feed (for now, just this frontend PR: #91413).