### PR TITLE
feat(issue stream): Add seer icon when autofix available

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -1,6 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {SeerIcon} from 'sentry/components/ai/SeerIcon';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {AUTOFIX_TTL_IN_DAYS} from 'sentry/components/events/autofix/types';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import ShortId from 'sentry/components/group/inboxBadges/shortId';
@@ -75,6 +78,19 @@ function EventOrGroupExtraDetails({data, showAssignee, showLifetime = true}: Pro
     data.issueCategory &&
     !!getReplayCountForIssue(data.id, data.issueCategory);
 
+  const seerAutofixLastTriggered = (data as Group).seerAutofixLastTriggered;
+  const autofixLastRunAsDate = seerAutofixLastTriggered
+    ? new Date(seerAutofixLastTriggered)
+    : null;
+  const autofixRanWithinTtl = autofixLastRunAsDate
+    ? autofixLastRunAsDate >
+      new Date(Date.now() - AUTOFIX_TTL_IN_DAYS * 24 * 60 * 60 * 1000)
+    : false;
+  const showSeer =
+    organization.features.includes('gen-ai-features') &&
+    !organization.hideAiFeatures &&
+    autofixRanWithinTtl;
+
   const {subtitle} = getTitle(data);
 
   const items = [
@@ -107,6 +123,13 @@ function EventOrGroupExtraDetails({data, showAssignee, showLifetime = true}: Pro
       </CommentsLink>
     ) : null,
     showReplayCount ? <IssueReplayCount group={data as Group} /> : null,
+    showSeer ? (
+      <Tooltip title="Seer has a potential fix for this issue" skipWrapper>
+        <CommentsLink to={{pathname: `${issuesPath}${id}`, query: {seerDrawer: true}}}>
+          <SeerIcon size="sm" />
+        </CommentsLink>
+      </Tooltip>
+    ) : null,
     logger ? (
       <LoggerAnnotation>
         <GlobalSelectionLink

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -266,3 +266,5 @@ export interface SeerRepoDefinition {
 export interface ProjectSeerPreferences {
   repositories: SeerRepoDefinition[];
 }
+
+export const AUTOFIX_TTL_IN_DAYS = 30;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -882,6 +882,8 @@ export interface BaseGroup {
   latestEventHasAttachments?: boolean;
   openPeriods?: GroupOpenPeriod[] | null;
   owners?: SuggestedOwner[] | null;
+  seerAutofixLastTriggered?: string | null;
+  seerFixabilityScore?: number | null;
   sentryAppIssues?: PlatformExternalIssue[];
   substatus?: GroupSubstatus | null;
 }


### PR DESCRIPTION
If an autofix run is present on an issue, show a little icon next to the comment and replay count icons. Clicking it will open the issue and the autofix drawer (same pattern as the comments icon). 

[Designs](https://www.figma.com/design/p2DOzd1RwAHQbq0v6KaYmF/Issue-Details?node-id=7729-53615&t=wzJejEaQM3rAARdV-1)

<img width="956" alt="Screenshot 2025-05-10 at 11 48 19 AM" src="https://github.com/user-attachments/assets/623f4a51-e912-45a7-bf2b-12f88d877da6" />
