### PR TITLE
fix(autofix): Fix minor checks

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -135,16 +135,17 @@ export function GroupSummary({
     }
   }, [forceEvent, isPending, refresh]);
 
-  const isFixable = data?.scores?.isFixable ?? false;
+  const hasFixabilityScore =
+    data?.scores?.fixabilityScore !== null && data?.scores?.fixabilityScore !== undefined;
 
   useEffect(() => {
-    if (isFixable && !isPending && aiConfig.hasAutofix) {
+    if (hasFixabilityScore && !isPending && aiConfig.hasAutofix) {
       queryClient.invalidateQueries({
         queryKey: makeAutofixQueryKey(organization.slug, group.id),
       });
     }
   }, [
-    isFixable,
+    hasFixabilityScore,
     isPending,
     aiConfig.hasAutofix,
     group.id,

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -313,9 +313,14 @@ export const useOpenSeerDrawer = ({
   const {openDrawer} = useDrawer();
   const navigate = useNavigate();
   const location = useLocation();
+  const organization = useOrganization();
 
   const openSeerDrawer = useCallback(() => {
-    if (!event) {
+    if (
+      !event ||
+      !organization.features.includes('gen-ai-features') ||
+      organization.hideAiFeatures
+    ) {
       return;
     }
 
@@ -377,7 +382,7 @@ export const useOpenSeerDrawer = ({
         });
       },
     });
-  }, [openDrawer, buttonRef, event, group, project, location, navigate]);
+  }, [openDrawer, buttonRef, event, group, project, location, navigate, organization]);
 
   return {openSeerDrawer};
 };


### PR DESCRIPTION
Two small fixes: 
- invalidate autofix query when fixability score is present, not just when over certain threshold (because that threshold is now unused on the backend)
- check for gen ai features in seer drawer to prevent opening via url