### PR TITLE
fix(debug-images): Show always 'ok' when source maps files

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -126,9 +126,7 @@ describe('DebugMeta', function () {
     const searchBar = screen.getByRole('textbox');
     await userEvent.type(searchBar, 'some jibberish');
     expect(screen.queryByText(imageName)).not.toBeInTheDocument();
-    expect(
-      screen.getByText('Sorry, no images match your search query')
-    ).toBeInTheDocument();
+    expect(screen.getByText(/no images match your search query/i)).toBeInTheDocument();
     await userEvent.clear(searchBar);
     expect(screen.getByText(imageName)).toBeInTheDocument();
     await userEvent.type(searchBar, codeFile);

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -138,6 +138,8 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
   const [isOpen, setIsOpen] = useState(false);
   const hasStreamlinedUI = useHasStreamlinedUI();
 
+  const isJSPlatform = event.platform?.includes('javascript');
+
   const getRelevantImages = useCallback(() => {
     // There are a bunch of images in debug_meta that are not relevant to this
     // component. Filter those out to reduce the noise. Most importantly, this
@@ -165,7 +167,10 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       releventImage => {
         return {
           ...releventImage,
-          status: combineStatus(releventImage.debug_status, releventImage.unwind_status),
+          // 'debug_status' and 'unwind_status' are only used by native platforms
+          status: isJSPlatform
+            ? ImageStatus.FOUND
+            : combineStatus(releventImage.debug_status, releventImage.unwind_status),
         };
       }
     );
@@ -209,7 +214,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       filterOptions,
       filterSelections: defaultFilterSelections,
     });
-  }, [data]);
+  }, [data, isJSPlatform]);
 
   const handleReprocessEvent = useCallback(
     (id: Group['id']) => {
@@ -252,7 +257,9 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
         const hasActiveFilter = filterSelections.length > 0;
 
         return {
-          emptyMessage: t('Sorry, no images match your search query'),
+          emptyMessage: isJSPlatform
+            ? t('No source maps match your search query')
+            : t('No images match your search query'),
           emptyAction: hasActiveFilter ? (
             <Button
               onClick={() => setFilterState(fs => ({...fs, filterSelections: []}))}
@@ -269,10 +276,12 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       }
 
       return {
-        emptyMessage: t('There are no images to be displayed'),
+        emptyMessage: isJSPlatform
+          ? t('There are no source maps to be displayed')
+          : t('There are no images to be displayed'),
       };
     },
-    [filterState, searchTerm]
+    [filterState, searchTerm, isJSPlatform]
   );
 
   const handleOpenImageDetailsModal = useCallback(
@@ -384,8 +393,6 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       }}
     />
   );
-
-  const isJSPlatform = event.platform?.includes('javascript');
 
   return (
     <InterimSection


### PR DESCRIPTION
**This PR**

- Assumes that if a source map file is available, it’s valid `ok` - though ideally, we should confirm this.
- Also updates some copy related to source map display. 

**Note**
The 'view' modal experience is currently a bit broken: it shows debug files, and the 'Open Settings' button redirects to debug file settings. I’ll follow up on that separately.