### PR TITLE
fix(getting-started): disable initial animation

### DIFF
--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
+import {AnimatePresence} from 'framer-motion';
 import partition from 'lodash/partition';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
@@ -24,7 +24,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {DemoTour, useDemoTours} from 'sentry/utils/demoMode/demoTours';
 import {updateDemoWalkthroughTask} from 'sentry/utils/demoMode/guides';
-import testableTransition from 'sentry/utils/testableTransition';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
@@ -258,26 +257,7 @@ function Task({task, hidePanel}: TaskProps) {
   }, [task.status]);
 
   return (
-    <TaskWrapper
-      initial
-      animate="animate"
-      layout={showSkipConfirmation ? false : true}
-      variants={{
-        initial: {
-          opacity: 0,
-          y: 40,
-        },
-        animate: {
-          opacity: 1,
-          y: 0,
-          transition: testableTransition({
-            delay: 0.8,
-            when: 'beforeChildren',
-            staggerChildren: 0.3,
-          }),
-        },
-      }}
-    >
+    <TaskWrapper>
       <TaskCard
         onClick={
           task.status === 'complete' || task.status === 'skipped'
@@ -592,7 +572,7 @@ const TaskGroupBody = styled('ul')`
   margin: 0;
 `;
 
-const TaskWrapper = styled(motion.li)`
+const TaskWrapper = styled('li')`
   gap: ${space(1)};
   p {
     color: ${p => p.theme.subText};

--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -188,7 +188,7 @@ function Task({task, hidePanel}: TaskProps) {
   }, []);
 
   // We want layout animation to be disabled initially, and if the skip confirmation is open
-  // but we want to animate the task card the task status changes
+  // but we want to animate the task card when the task status changes
   const shouldLayoutAnimate = useMemo(() => {
     return enableLayoutAnimation && !showSkipConfirmation;
   }, [enableLayoutAnimation, showSkipConfirmation]);


### PR DESCRIPTION
closes [TET-387: Quick Start: Weird animation when opening the sidebar in the new sidebar nav](https://linear.app/getsentry/issue/TET-387/quick-start-weird-animation-when-opening-the-sidebar-in-the-new)