### PR TITLE
fix(sso): disallow member invites when SSO is enabled

### DIFF
--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -78,6 +78,14 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
+        if request.access.requires_sso:
+            return Response(
+                {
+                    "detail": "Your organization must use its single sign-on provider to register new members."
+                },
+                status=400,
+            )
+
         result = serializer.validated_data
 
         with outbox_context(

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -237,3 +237,32 @@ class OrganizationInviteRequestCreateTest(
             "member_id": member.id,
             "member_email": "eric@localhost",
         }
+
+    def test_disallow_when_sso_required(self):
+        from sentry.models.authidentity import AuthIdentity
+        from sentry.models.authprovider import AuthProvider
+        from sentry.silo.base import SiloMode
+        from sentry.testutils.silo import assume_test_silo_mode
+        from sentry.utils.auth import SsoSession
+
+        self.member.flags["sso:linked"] = True
+        self.member.save()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            # Sets org-wise `requiresSso` to True
+            ap = AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
+            AuthIdentity.objects.create(auth_provider=ap, user=self.user)
+
+        sso_session = SsoSession.create(self.organization.id)
+        self.session[sso_session.session_key] = sso_session.to_dict()
+        self.save_session()
+
+        resp = self.client.post(
+            self.url, {"email": "eric@localhost", "role": "member", "teams": [self.team.slug]}
+        )
+
+        assert resp.status_code == 400
+        assert (
+            resp.data["detail"]
+            == "Your organization must use its single sign-on provider to register new members."
+        )


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/VULN-122

Currently, the frontend shows this restriction when trying to invite new members with SSO enabled:
![image](https://github.com/user-attachments/assets/bc676a32-2953-4667-a754-616ccc78d4df)

This PR enforces the requirement on the backend.