### PR TITLE
ref: Mark NVIDIA symbol source as having an index

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2940,6 +2940,7 @@ SENTRY_BUILTIN_SOURCES = {
         "filters": {"filetypes": ["pe", "pdb"]},
         "url": "https://driver-symbols.nvidia.com/",
         "is_public": True,
+        "has_index": True,
     },
     "chromium": {
         "type": "http",


### PR DESCRIPTION
We recently added support for Symstore indexes to symbol sources (see https://github.com/getsentry/symbolicator/pull/1663 and https://github.com/getsentry/sentry/pull/88890). Turns out the NVIDIA source has such an index. This lets us limit the requests we make to the source to the absolute minimum.