### PR TITLE
fix(onboarding): Empty user feedback sidebar

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.spec.tsx
@@ -171,7 +171,7 @@ describe('useCurrentProjectState', () => {
     expect(result.current.currentProject).toBe(javascript);
   });
 
-  it('should return undefined if no selection and no projects have onboarding', () => {
+  it('should return the first project if no selection and no projects have onboarding', () => {
     ProjectsStore.loadInitialData([rust_1, rust_2]);
     mockPageFilterStore([]);
     const {result} = renderHook(useCurrentProjectState, {
@@ -183,7 +183,7 @@ describe('useCurrentProjectState', () => {
       },
       wrapper: createWrapper(),
     });
-    expect(result.current.currentProject).toBeUndefined();
+    expect(result.current.currentProject).toBe(rust_1);
   });
 
   it('should override current project if setCurrentProjects is called', () => {

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.tsx
@@ -91,11 +91,7 @@ function useCurrentProjectState({
 
     const selectedProjects = getSelectedProjectList(selection.projects, projects);
 
-    return (
-      getDefaultCurrentProjectFromSelection(selectedProjects) ??
-      projectsWithOnboarding.at(0) ??
-      supportedProjects.at(0)
-    );
+    return getDefaultCurrentProjectFromSelection(selectedProjects);
   }, [
     getDefaultCurrentProjectFromSelection,
     isActive,

--- a/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/useCurrentProjectState.tsx
@@ -5,6 +5,7 @@ import type {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {PlatformKey, Project} from 'sentry/types/project';
+import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHaveField';
 import useProjects from 'sentry/utils/useProjects';
 import useUrlParams from 'sentry/utils/useUrlParams';
 
@@ -38,12 +39,12 @@ function useCurrentProjectState({
   }, [projects, allPlatforms]);
 
   const getDefaultCurrentProjectFromSelection = useCallback(
-    (selectionProjects: number[]): Project | undefined => {
-      if (!isActive || !selectionProjects.length) {
+    (selectedProjects: Project[]): Project | undefined => {
+      if (!isActive || !selectedProjects.length) {
         return undefined;
       }
 
-      const selectedProjectIds = selectionProjects.map(String);
+      const selectedProjectIds = selectedProjects.map(p => p.id);
 
       // If we selected something that has onboarding instructions, pick that first
       const projectForOnboarding = projectsWithOnboarding.find(p =>
@@ -64,9 +65,9 @@ function useCurrentProjectState({
       }
 
       // Otherwise, just pick the first selected project
-      return projects.find(p => selectedProjectIds.includes(p.id));
+      return selectedProjects[0];
     },
-    [isActive, projects, projectsWithOnboarding, supportedProjects]
+    [isActive, projectsWithOnboarding, supportedProjects]
   );
 
   const getDefaultCurrentProject = useCallback((): Project | undefined => {
@@ -88,8 +89,10 @@ function useCurrentProjectState({
       return projects.find(p => p.id === projectId);
     }
 
+    const selectedProjects = getSelectedProjectList(selection.projects, projects);
+
     return (
-      getDefaultCurrentProjectFromSelection(selection.projects) ??
+      getDefaultCurrentProjectFromSelection(selectedProjects) ??
       projectsWithOnboarding.at(0) ??
       supportedProjects.at(0)
     );
@@ -121,11 +124,12 @@ function useCurrentProjectState({
 
   // Update the current project when the page filters store changes
   useEffect(() => {
-    const newSelectionProject = getDefaultCurrentProjectFromSelection(selection.projects);
+    const selectedProjects = getSelectedProjectList(selection.projects, projects);
+    const newSelectionProject = getDefaultCurrentProjectFromSelection(selectedProjects);
     if (newSelectionProject) {
       setCurrentProject(newSelectionProject);
     }
-  }, [selection.projects, getDefaultCurrentProjectFromSelection]);
+  }, [selection.projects, getDefaultCurrentProjectFromSelection, projects]);
 
   return {
     projects: supportedProjects,


### PR DESCRIPTION
The previous logic did not handle the case where all projects where selected, resulting in a blank sidebar.