### PR TITLE
fix(taskworker) Remove pickle usage from sentryapp hooks

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3337,3 +3337,5 @@ register(
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.
 register("chunk-upload.no-compression", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+register("process_service_hook.payload.rollout", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -99,6 +99,23 @@ class EventMatcher:
         return matching_id
 
 
+class ServiceHookPayloadMatcher:
+    def __init__(self, event: Event):
+        self.event = event
+
+    def __eq__(self, other: Any) -> bool:
+        assert isinstance(other, str), "other should be a string"
+        assert self.event.group
+
+        payload = json.loads(other)
+        assert payload["event"]["id"] == self.event.event_id
+        assert payload["group"]["id"] == str(self.event.group.id)
+        assert "url" in payload["group"]
+        assert "tags" in payload["event"]
+        assert "project" in payload
+        return True
+
+
 class BasePostProgressGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_event(self, data, project_id, assert_no_errors=True):
@@ -499,6 +516,32 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 
 
 class ServiceHooksTestMixin(BasePostProgressGroupMixin):
+    @override_options({"process_service_hook.payload.rollout": 1.0})
+    @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
+    def test_service_hook_fires_on_new_event_payload_param(self, mock_process_service_hook):
+        event = self.create_event(data={}, project_id=self.project.id)
+        hook = self.create_service_hook(
+            project=self.project,
+            organization=self.project.organization,
+            actor=self.user,
+            events=["event.created"],
+        )
+
+        with self.feature("projects:servicehooks"):
+            self.call_post_process_group(
+                is_new=False,
+                is_regression=False,
+                is_new_group_environment=False,
+                event=event,
+            )
+
+        mock_process_service_hook.delay.assert_called_once_with(
+            servicehook_id=hook.id,
+            project_id=self.project.id,
+            event=EventMatcher(event),
+            payload=ServiceHookPayloadMatcher(event),
+        )
+
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
     def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
         event = self.create_event(data={}, project_id=self.project.id)
@@ -518,7 +561,8 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
             )
 
         mock_process_service_hook.delay.assert_called_once_with(
-            servicehook_id=hook.id, event=EventMatcher(event)
+            servicehook_id=hook.id,
+            event=EventMatcher(event),
         )
 
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
@@ -547,7 +591,8 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
             )
 
         mock_process_service_hook.delay.assert_called_once_with(
-            servicehook_id=hook.id, event=EventMatcher(event)
+            servicehook_id=hook.id,
+            event=EventMatcher(event),
         )
 
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -99,23 +99,6 @@ class EventMatcher:
         return matching_id
 
 
-class ServiceHookPayloadMatcher:
-    def __init__(self, event: Event):
-        self.event = event
-
-    def __eq__(self, other: Any) -> bool:
-        assert isinstance(other, str), "other should be a string"
-        assert self.event.group
-
-        payload = json.loads(other)
-        assert payload["event"]["id"] == self.event.event_id
-        assert payload["group"]["id"] == str(self.event.group.id)
-        assert "url" in payload["group"]
-        assert "tags" in payload["event"]
-        assert "project" in payload
-        return True
-
-
 class BasePostProgressGroupMixin(BaseTestCase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_event(self, data, project_id, assert_no_errors=True):
@@ -538,8 +521,8 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
         mock_process_service_hook.delay.assert_called_once_with(
             servicehook_id=hook.id,
             project_id=self.project.id,
-            event=EventMatcher(event),
-            payload=ServiceHookPayloadMatcher(event),
+            group_id=event.group_id,
+            event_id=event.event_id,
         )
 
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")


### PR DESCRIPTION
Redo of #91372 which was reverted because of rate limiting. This time around, use an option to control task variants, and only generate a payload when a hook is going to be sent. For projects with multiple service hooks, this should result in fewer snuba calls as events are only serialized once.