### PR TITLE
fix(issue-details): Wider tool tips for file paths

### DIFF
--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -24,6 +24,11 @@ import type {PlatformKey} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {isUrl} from 'sentry/utils/string/isUrl';
 
+/**
+ * File paths can get very long, so increase it for the tooltips within this component.
+ */
+export const FRAME_TOOLTIP_MAX_WIDTH = 500;
+
 type Props = {
   frame: Frame;
   platform: PlatformKey;
@@ -122,6 +127,7 @@ function DefaultTitle({
           title={frame.absPath}
           disabled={!enablePathTooltip}
           delay={tooltipDelay}
+          maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
         >
           <code key="filename" className="filename" data-test-id="filename">
             {isPotentiallyThirdParty && frame.absPath ? (
@@ -143,7 +149,12 @@ function DefaultTitle({
     // we want to show a litle (?) icon that on hover shows the actual filename
     if (shouldPrioritizeModuleName && frame.filename) {
       title.push(
-        <Tooltip key={frame.filename} title={frame.filename} delay={tooltipDelay}>
+        <Tooltip
+          key={frame.filename}
+          title={frame.filename}
+          delay={tooltipDelay}
+          maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
+        >
           <a className="in-at real-filename">
             <IconQuestion size="xs" />
           </a>

--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -128,6 +128,7 @@ function DefaultTitle({
           disabled={!enablePathTooltip}
           delay={tooltipDelay}
           maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
+          position="auto-start"
         >
           <code key="filename" className="filename" data-test-id="filename">
             {isPotentiallyThirdParty && frame.absPath ? (
@@ -154,6 +155,7 @@ function DefaultTitle({
           title={frame.filename}
           delay={tooltipDelay}
           maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
+          position="auto-start"
         >
           <a className="in-at real-filename">
             <IconQuestion size="xs" />

--- a/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/static/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -27,7 +27,7 @@ import {isUrl} from 'sentry/utils/string/isUrl';
 /**
  * File paths can get very long, so increase it for the tooltips within this component.
  */
-export const FRAME_TOOLTIP_MAX_WIDTH = 500;
+export const FRAME_TOOLTIP_MAX_WIDTH = 750;
 
 type Props = {
   frame: Frame;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -315,10 +315,10 @@ function NativeFrame({
             )}
             <Tooltip
               title={frame.package ?? t('Go to images loaded')}
-              position="bottom"
               containerDisplayMode="inline-flex"
               delay={tooltipDelay}
               maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
+              position="auto-start"
             >
               <Package>
                 {frame.package ? trimPackage(frame.package) : `<${t('unknown')}>`}

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -6,6 +6,7 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import {FRAME_TOOLTIP_MAX_WIDTH} from 'sentry/components/events/interfaces/frame/defaultTitle';
 import {OpenInContextLine} from 'sentry/components/events/interfaces/frame/openInContextLine';
 import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
 import {
@@ -317,6 +318,7 @@ function NativeFrame({
               position="bottom"
               containerDisplayMode="inline-flex"
               delay={tooltipDelay}
+              maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
             >
               <Package>
                 {frame.package ? trimPackage(frame.package) : `<${t('unknown')}>`}
@@ -329,6 +331,7 @@ function NativeFrame({
                 title={addressTooltip}
                 disabled={!(foundByStackScanning || inlineFrame)}
                 delay={tooltipDelay}
+                maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
               >
                 {!relativeAddress || absolute ? frame.instructionAddr : relativeAddress}
               </Tooltip>
@@ -348,6 +351,7 @@ function NativeFrame({
                 disabled={!(defined(frame.absPath) && frame.absPath !== frame.filename)}
                 delay={tooltipDelay}
                 isHoverable
+                maxWidth={FRAME_TOOLTIP_MAX_WIDTH}
               >
                 <FileName>
                   {'('}


### PR DESCRIPTION
Wider max tooltip width for stack frames since they were pretty hard to read. It'll still wrap if the browser doesn't fit the full tip. Adjusted a few positions as well so they extend away from the left nav.

<img width="762" alt="image" src="https://github.com/user-attachments/assets/6a671690-9616-4736-9c42-f5263f5939c4" />

