### PR TITLE
fix(taskworker) Increase deadline for process_suspect_commits

### DIFF
--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -161,6 +161,7 @@ def _process_suspect_commits(
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=issues_tasks,
+        processing_deadline_duration=20,
         retry=Retry(
             times=5,
             delay=5,


### PR DESCRIPTION
This failed once, and some more time might help.

Fixes SENTRY-FOR-SENTRY-ATA