### PR TITLE
fix(eap-spans): division should work in group by

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -56,18 +56,24 @@ def get_total_span_count(settings: ResolverSettings) -> Column:
     )
 
 
-def division(args: ResolvedArguments, _: ResolverSettings) -> Column.BinaryFormula:
+def division(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:
     dividend = cast(AttributeKey, args[0])
     divisor = cast(AttributeKey, args[1])
+
+    extrapolation_mode = settings["extrapolation_mode"]
 
     return Column.BinaryFormula(
         default_value_double=0.0,
         left=Column(
-            aggregation=AttributeAggregation(aggregate=Function.FUNCTION_SUM, key=dividend)
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM, key=dividend, extrapolation_mode=extrapolation_mode
+            )
         ),
         op=Column.BinaryFormula.OP_DIVIDE,
         right=Column(
-            aggregation=AttributeAggregation(aggregate=Function.FUNCTION_SUM, key=divisor)
+            aggregation=AttributeAggregation(
+                aggregate=Function.FUNCTION_SUM, key=divisor, extrapolation_mode=extrapolation_mode
+            )
         ),
     )
 

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -62,9 +62,13 @@ def division(args: ResolvedArguments, _: ResolverSettings) -> Column.BinaryFormu
 
     return Column.BinaryFormula(
         default_value_double=0.0,
-        left=Column(key=dividend),
+        left=Column(
+            aggregation=AttributeAggregation(aggregate=Function.FUNCTION_SUM, key=dividend)
+        ),
         op=Column.BinaryFormula.OP_DIVIDE,
-        right=Column(key=divisor),
+        right=Column(
+            aggregation=AttributeAggregation(aggregate=Function.FUNCTION_SUM, key=divisor)
+        ),
     )
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3302,6 +3302,44 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["division(mobile.frozen_frames,mobile.total_frames)"] == 20 / 100
         assert meta["dataset"] == self.dataset
 
+    def test_division_with_groupby(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "measurements": {
+                            "frames.total": {"value": 100},
+                            "frames.slow": {"value": 10},
+                            "frames.frozen": {"value": 20},
+                        },
+                        "sentry_tags": {"transaction": "foo_transaction"},
+                    }
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "division(mobile.slow_frames,mobile.total_frames)",
+                    "division(mobile.frozen_frames,mobile.total_frames)",
+                ],
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["division(mobile.slow_frames,mobile.total_frames)"] == 10 / 100
+        assert data[0]["division(mobile.frozen_frames,mobile.total_frames)"] == 20 / 100
+        assert data[0]["transaction"] == "foo_transaction"
+        assert meta["dataset"] == self.dataset
+
     def test_opportunity_score_zero_scores(self):
         self.store_spans(
             [


### PR DESCRIPTION
We should use `sum` in the `division` function so that it works with `group_by` as well