### PR TITLE
fix(replay): fix dead/rage click widget button label

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -227,7 +227,7 @@ function SearchButton({
   return (
     <StyledLinkButton
       {...props}
-      size="zero"
+      size="md"
       to={{
         pathname,
         query: {


### PR DESCRIPTION
before:
<img width="1148" alt="SCR-20250512-kahx" src="https://github.com/user-attachments/assets/994fff89-e409-4817-9b0d-562f73433d8e" />

after:

<img width="1213" alt="SCR-20250512-kedm" src="https://github.com/user-attachments/assets/3db4c09e-d5df-48c2-854a-399328e69f37" />
<img width="1217" alt="SCR-20250512-kebd" src="https://github.com/user-attachments/assets/513141e0-6ece-4ecb-9ba4-bf8e01edf345" />

