### PR TITLE
feat(ourlogs): Alias the remaining SDK-sent attributes

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -57,7 +57,6 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         simple_sentry_field("sdk.name"),
         simple_sentry_field("sdk.version"),
         simple_sentry_field("origin"),
-        simple_sentry_field("server.address"),
         # Deprecated
         ResolvedAttribute(
             public_alias="log.body",

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -51,6 +51,13 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
         ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("environment"),
+        simple_sentry_field("message.template"),
+        simple_sentry_field("release"),
+        simple_sentry_field("trace.parent_span_id"),
+        simple_sentry_field("sdk.name"),
+        simple_sentry_field("sdk.version"),
+        simple_sentry_field("origin"),
+        simple_sentry_field("server.address"),
         # Deprecated
         ResolvedAttribute(
             public_alias="log.body",


### PR DESCRIPTION
These would show up as red in the search bar because they were using internal aliases