### PR TITLE
fix(issues): Sticky distribution controls should 100% cover things scrolling behind it

### DIFF
--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -59,7 +59,7 @@ export const EventNavigator = styled('div')`
   column-gap: ${space(1)};
   padding: ${space(0.75)} 24px;
   background: ${p => p.theme.background};
-  z-index: 2;
+  z-index: 2; /* Just above EventStickyControls */
   min-height: ${MIN_NAV_HEIGHT}px;
   box-shadow: ${p => p.theme.translucentBorder} 0 1px;
 `;
@@ -72,7 +72,11 @@ export const EventStickyControls = styled('div')`
   margin-block: -${space(2)};
   padding-block: ${space(2)};
   background: ${p => p.theme.background};
-  z-index: 1;
+  z-index: 1; /* Just below EventNavigator */
+
+  /* Make this full-width inside DrawerBody */
+  margin-inline: -24px;
+  padding-inline: 24px;
 `;
 
 export const EventDrawerBody = styled(DrawerBody)`


### PR DESCRIPTION
**Before**

Before the sticky div was as wide as the content column itself.
<img width="615" alt="SCR-20250512-kjvb" src="https://github.com/user-attachments/assets/e97c8935-f2f9-49d2-870a-1e461eb5a341" />


**After**
Now the sticky div is edge-to-edge with it's container. So if there's any sub-pixel anit-aliasing applied on the left or right edge, we'll cover it with the background color.
<img width="709" alt="SCR-20250512-kjnw" src="https://github.com/user-attachments/assets/1fffa0fb-3639-4c6c-80f3-8f4816ba87fa" />
