### PR TITLE
chore(search-query): Remove flag and update in test fixtures

### DIFF
--- a/fixtures/search-syntax/aggregate_rel_time_filter.json
+++ b/fixtures/search-syntax/aggregate_rel_time_filter.json
@@ -67,7 +67,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "-2w", "quoted": false}
+        "value": {"type": "valueText", "value": "-2w", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/basic_fallthrough.json
+++ b/fixtures/search-syntax/basic_fallthrough.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "<hello", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "<hello",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "<512.1.0", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "<512.1.0",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +49,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "2018-01-01", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "2018-01-01",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +69,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "+7d", "quoted": false}
+        "value": {"type": "valueText", "value": "+7d", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -69,7 +84,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">2018-01-01", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">2018-01-01",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -84,7 +104,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hello", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "hello",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -99,7 +124,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/custom_explicit_tag.json
+++ b/fixtures/search-syntax/custom_explicit_tag.json
@@ -13,7 +13,12 @@
           "key": {"type": "keySimple", "value": "fruit", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "apple", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -22,7 +27,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -35,7 +45,7 @@
           "key": {"type": "keySimple", "value": "project_id", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/custom_tag.json
+++ b/fixtures/search-syntax/custom_tag.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "fruit", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "apple", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -18,7 +23,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -33,7 +43,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "p95", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">5s", "quoted": false}
+        "value": {"type": "valueText", "value": ">5s", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -48,7 +58,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "p95", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">5k", "quoted": false}
+        "value": {"type": "valueText", "value": ">5k", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/disallow_wildcard_filter.json
+++ b/fixtures/search-syntax/disallow_wildcard_filter.json
@@ -57,7 +57,8 @@
               "value": {
                 "quoted": false,
                 "type": "valueText",
-                "value": "*"
+                "value": "*",
+                "contains": false
               }
             }
           ],
@@ -94,7 +95,8 @@
         "value": {
           "type": "valueText",
           "value": "*",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         },
         "invalid": {
           "type": "wildcard-not-allowed",

--- a/fixtures/search-syntax/duration_on_non_duration_field.json
+++ b/fixtures/search-syntax/duration_on_non_duration_field.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "500s", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "500s",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/empty_filter_value.json
+++ b/fixtures/search-syntax/empty_filter_value.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "", "quoted": true}
+        "value": {"type": "valueText", "value": "", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -28,7 +28,7 @@
         },
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "", "quoted": false}
+        "value": {"type": "valueText", "value": "", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/empty_spaces_stripped_correctly.json
+++ b/fixtures/search-syntax/empty_spaces_stripped_correctly.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "event.type", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "transaction", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "transaction",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": "   "},
       {
@@ -21,7 +26,8 @@
         "value": {
           "type": "valueText",
           "value": "/organizations/:orgId/discover/results/",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {"type": "spaces", "value": ""}

--- a/fixtures/search-syntax/escaped_quote_value.json
+++ b/fixtures/search-syntax/escaped_quote_value.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\\\"", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "\\\"",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "te\\\"st", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "te\\\"st",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -40,7 +50,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "te", "quoted": true}
+        "value": {"type": "valueText", "value": "te", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": ""},
       {"type": "freeText", "value": "st", "quoted": false, "invalid": null},

--- a/fixtures/search-syntax/escaped_quotes.json
+++ b/fixtures/search-syntax/escaped_quotes.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\\\"thing\\\"", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\\\"thing\\\"",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\\\"\\\"release", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\\\"\\\"release",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/explicit_number_tag.json
+++ b/fixtures/search-syntax/explicit_number_tag.json
@@ -13,7 +13,7 @@
           "key": {"type": "keySimple", "value": "foo", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "456", "quoted": false}
+        "value": {"type": "valueText", "value": "456", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {
@@ -22,7 +22,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -35,7 +40,7 @@
           "key": {"type": "keySimple", "value": "project_id", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/explicit_number_tags_in_filter.json
+++ b/fixtures/search-syntax/explicit_number_tags_in_filter.json
@@ -18,11 +18,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "123", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "123",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "456", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "456",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -31,4 +41,3 @@
     ]
   }
 ]
-

--- a/fixtures/search-syntax/explicit_string_tag.json
+++ b/fixtures/search-syntax/explicit_string_tag.json
@@ -13,7 +13,12 @@
           "key": {"type": "keySimple", "value": "fruit", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "apple", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "apple",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -22,7 +27,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -35,7 +45,7 @@
           "key": {"type": "keySimple", "value": "project_id", "quoted": false}
         },
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/explicit_string_tags_in_filter.json
+++ b/fixtures/search-syntax/explicit_string_tags_in_filter.json
@@ -18,11 +18,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "apple",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -49,11 +59,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple wow", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "apple wow",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -62,4 +82,3 @@
     ]
   }
 ]
-

--- a/fixtures/search-syntax/explicit_tags_in_filter.json
+++ b/fixtures/search-syntax/explicit_tags_in_filter.json
@@ -18,11 +18,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "apple",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -49,11 +59,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "apple wow", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "apple wow",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "pear", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "pear",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }

--- a/fixtures/search-syntax/free_text_search_anywhere.json
+++ b/fixtures/search-syntax/free_text_search_anywhere.json
@@ -11,7 +11,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "where ", "quoted": false, "invalid": null},
@@ -22,7 +27,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "when", "quoted": false, "invalid": null},
@@ -65,7 +75,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "there", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "bye", "quoted": false}
+        "value": {"type": "valueText", "value": "bye", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/has_tag.json
+++ b/fixtures/search-syntax/has_tag.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "release", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "release",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +31,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hi:there", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "hi:there",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -42,7 +52,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hi there", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "hi there",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_boolean_filter.json
+++ b/fixtures/search-syntax/invalid_boolean_filter.json
@@ -14,7 +14,7 @@
         },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "lol", "quoted": false}
+        "value": {"type": "valueText", "value": "lol", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -34,7 +34,7 @@
         },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +54,12 @@
         },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">true", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">true",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_date_formats.json
+++ b/fixtures/search-syntax/invalid_date_formats.json
@@ -14,7 +14,12 @@
         },
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hello", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "hello",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -34,7 +39,7 @@
         },
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "123", "quoted": false}
+        "value": {"type": "valueText", "value": "123", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +59,12 @@
         },
         "key": {"type": "keySimple", "value": "timestamp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "2018-01-01T00:01ZZ", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "2018-01-01T00:01ZZ",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_duration_filter.json
+++ b/fixtures/search-syntax/invalid_duration_filter.json
@@ -14,7 +14,12 @@
         },
         "key": {"quoted": false, "type": "keySimple", "value": "transaction.duration"},
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": ">..500s"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": ">..500s",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_numeric_fields.json
+++ b/fixtures/search-syntax/invalid_numeric_fields.json
@@ -14,7 +14,7 @@
         },
         "key": {"type": "keySimple", "value": "project.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "one", "quoted": false}
+        "value": {"type": "valueText", "value": "one", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -34,7 +34,7 @@
         },
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "two", "quoted": false}
+        "value": {"type": "valueText", "value": "two", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +54,12 @@
         },
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">hotdog", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">hotdog",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -74,7 +79,12 @@
         },
         "key": {"type": "keySimple", "value": "measurements.lcp", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">hotdog", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">hotdog",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -94,7 +104,12 @@
         },
         "key": {"type": "keySimple", "value": "spans.db", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">hotdog", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">hotdog",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/invalid_numeric_shorthand.json
+++ b/fixtures/search-syntax/invalid_numeric_shorthand.json
@@ -14,7 +14,7 @@
         },
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">3s", "quoted": false}
+        "value": {"type": "valueText", "value": ">3s", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/multiple_quotes.json
+++ b/fixtures/search-syntax/multiple_quotes.json
@@ -9,7 +9,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "", "quoted": true}
+        "value": {"type": "valueText", "value": "", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {
@@ -18,7 +18,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "Chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "Chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -33,7 +38,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\\\"", "quoted": true}
+        "value": {"type": "valueText", "value": "\\\"", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {
@@ -42,7 +47,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser.name", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "Chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "Chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/negated_duration_on_non_duration_field.json
+++ b/fixtures/search-syntax/negated_duration_on_non_duration_field.json
@@ -9,7 +9,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "500s", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "500s",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/negated_on_boolean_values_and_non_boolean_field.json
+++ b/fixtures/search-syntax/negated_on_boolean_values_and_non_boolean_field.json
@@ -9,7 +9,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "true", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "true",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "user.id", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1", "quoted": false}
+        "value": {"type": "valueText", "value": "1", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/newline_within_quote.json
+++ b/fixtures/search-syntax/newline_within_quote.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\nrelease", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\nrelease",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/not_has_tag.json
+++ b/fixtures/search-syntax/not_has_tag.json
@@ -10,7 +10,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "release", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "release",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +31,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "has", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "hi:there", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "hi:there",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_filter.json
+++ b/fixtures/search-syntax/numeric_filter.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random_field", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">500", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">500",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -26,7 +31,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "random_field", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">500", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">500",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -41,7 +51,7 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "random_field", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "500", "quoted": false}
+        "value": {"type": "valueText", "value": "500", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/numeric_in_filter.json
+++ b/fixtures/search-syntax/numeric_in_filter.json
@@ -293,15 +293,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "500", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "500",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "501", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "501",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "502", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "502",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }

--- a/fixtures/search-syntax/other_dates.json
+++ b/fixtures/search-syntax/other_dates.json
@@ -54,7 +54,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "random", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": ">2015-05-18", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": ">2015-05-18",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/quoted_free_text_search_anywhere.json
+++ b/fixtures/search-syntax/quoted_free_text_search_anywhere.json
@@ -11,7 +11,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "general kenobi", "quoted": true, "invalid": null},

--- a/fixtures/search-syntax/quoted_key.json
+++ b/fixtures/search-syntax/quoted_key.json
@@ -9,7 +9,12 @@
         "key": {"quoted": true, "type": "keySimple", "value": "hi:there"},
         "operator": "",
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": "value"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "value",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "key": {"quoted": true, "type": "keySimple", "value": "hi:there"},
         "operator": "",
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": "value"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "value",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/quoted_val.json
+++ b/fixtures/search-syntax/quoted_val.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a release", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a release",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "negated": true,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a release", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a release",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -44,7 +54,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -67,11 +82,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "b release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "b release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -94,15 +119,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ",    ",
-              "value": {"type": "valueText", "value": "b release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "b release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "c release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "c release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -125,11 +165,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "b release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "b release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -152,7 +202,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a release", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "a release",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }
@@ -169,7 +224,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "123", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "123",
+                "quoted": true,
+                "contains": false
+              }
             }
           ]
         }

--- a/fixtures/search-syntax/quotes_filtered_on_raw.json
+++ b/fixtures/search-syntax/quotes_filtered_on_raw.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "thinger", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "unknown", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "unknown",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "what is this?", "quoted": true, "invalid": null},

--- a/fixtures/search-syntax/rel_time_filter.json
+++ b/fixtures/search-syntax/rel_time_filter.json
@@ -85,7 +85,8 @@
         "value": {
           "type": "valueText",
           "value": "-2w",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {

--- a/fixtures/search-syntax/semver.json
+++ b/fixtures/search-syntax/semver.json
@@ -9,7 +9,12 @@
         "negated": false,
         "operator": ">",
         "type": "filter",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -24,7 +29,12 @@
         "key": {"quoted": false, "type": "keySimple", "value": "release.version"},
         "negated": false,
         "operator": ">",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3-hi"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3-hi",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -39,7 +49,12 @@
         "key": {"quoted": false, "type": "keySimple", "value": "release.version"},
         "negated": false,
         "operator": ">=",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3-hi"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3-hi",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -54,7 +69,12 @@
         "key": {"quoted": false, "type": "keySimple", "value": "release.version"},
         "negated": false,
         "operator": "",
-        "value": {"quoted": false, "type": "valueText", "value": "1.2.3-hi"}
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "1.2.3-hi",
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/simple.json
+++ b/fixtures/search-syntax/simple.json
@@ -10,7 +10,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -19,7 +24,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "hello", "quoted": false, "invalid": null},
@@ -38,7 +48,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "user.email", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "foo@example.com", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "foo@example.com",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -47,7 +62,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "1.2.1", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "1.2.1",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/simple_in.json
+++ b/fixtures/search-syntax/simple_in.json
@@ -14,7 +14,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -31,7 +36,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "hello", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "hello",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -54,15 +64,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "test2@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test2@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",",
-              "value": {"type": "valueText", "value": "test3@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test3@test.com",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -79,7 +104,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "hello", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "hello",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -102,15 +132,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "test@test2.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test2.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ",     ",
-              "value": {"type": "valueText", "value": "test@test3.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test3.com",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -127,7 +172,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "hello", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "hello",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -145,7 +195,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "h[e]llo]", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "h[e]llo]",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -160,7 +215,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h[e]llo", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "[h[e]llo",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -175,7 +235,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h]", "quoted": true}
+        "value": {"type": "valueText", "value": "[h]", "quoted": true, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -190,7 +250,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h]*", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "[h]*",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -205,7 +270,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[h", "quoted": false}
+        "value": {"type": "valueText", "value": "[h", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": " "},
       {"type": "freeText", "value": "e]", "quoted": false, "invalid": null},
@@ -222,7 +287,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "test", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "[]", "quoted": false}
+        "value": {"type": "valueText", "value": "[]", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""}
     ]
@@ -242,15 +307,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "hi", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "hi",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "1", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "1",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -273,15 +353,30 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "hi", "quoted": true}
+              "value": {
+                "type": "valueText",
+                "value": "hi",
+                "quoted": true,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "1.0", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "1.0",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -304,7 +399,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "[h]", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "[h]",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -327,11 +427,21 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "a", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "a",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",
-              "value": {"type": "valueText", "value": "[h]", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "[h]",
+                "quoted": false,
+                "contains": false
+              }
             }
           ]
         }
@@ -352,7 +462,8 @@
         "value": {
           "type": "valueText",
           "value": "[test@test.com]user.email:hello@hello.com",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {"type": "spaces", "value": ""}
@@ -377,7 +488,12 @@
           "items": [
             {
               "separator": "",
-              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+              "value": {
+                "type": "valueText",
+                "value": "test@test.com",
+                "quoted": false,
+                "contains": false
+              }
             },
             {
               "separator": ", ",

--- a/fixtures/search-syntax/sooo_many_quotes.json
+++ b/fixtures/search-syntax/sooo_many_quotes.json
@@ -12,7 +12,8 @@
         "value": {
           "type": "valueText",
           "value": "\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"\\\"",
-          "quoted": true
+          "quoted": true,
+          "contains": false
         }
       },
       {"type": "spaces", "value": ""}

--- a/fixtures/search-syntax/specific_time_filter.json
+++ b/fixtures/search-syntax/specific_time_filter.json
@@ -119,7 +119,8 @@
         "value": {
           "type": "valueText",
           "value": "2018-01-01T05:06:07",
-          "quoted": false
+          "quoted": false,
+          "contains": false
         }
       },
       {

--- a/fixtures/search-syntax/supported_tags.json
+++ b/fixtures/search-syntax/supported_tags.json
@@ -19,7 +19,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -32,7 +37,12 @@
         },
         "key": {"type": "keySimple", "value": "os", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "*windows*", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "*windows*",
+          "quoted": false,
+          "contains": true
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -57,7 +67,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "browser", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "chrome", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "chrome",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {

--- a/fixtures/search-syntax/tab_outside_quote.json
+++ b/fixtures/search-syntax/tab_outside_quote.json
@@ -10,7 +10,7 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a", "quoted": false}
+        "value": {"type": "valueText", "value": "a", "quoted": false, "contains": false}
       },
       {"type": "spaces", "value": ""},
       {"quoted": false, "type": "freeText", "value": "\trelease", "invalid": null},

--- a/fixtures/search-syntax/tab_within_quote.json
+++ b/fixtures/search-syntax/tab_within_quote.json
@@ -9,7 +9,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "release", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "a\trelease", "quoted": true}
+        "value": {
+          "type": "valueText",
+          "value": "a\trelease",
+          "quoted": true,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/trailing_quote_value.json
+++ b/fixtures/search-syntax/trailing_quote_value.json
@@ -13,7 +13,12 @@
         },
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\"test", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "\"test",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -32,7 +37,12 @@
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "test\"", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "test\"",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -51,7 +61,12 @@
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "\"test", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "\"test",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -60,7 +75,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "transaction", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "abadcafe", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "abadcafe",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]
@@ -79,7 +99,12 @@
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "te\"st", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "te\"st",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": " "},
       {
@@ -88,7 +113,12 @@
         "negated": false,
         "key": {"type": "keySimple", "value": "transaction", "quoted": false},
         "operator": "",
-        "value": {"type": "valueText", "value": "abadcafe", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "abadcafe",
+          "quoted": false,
+          "contains": false
+        }
       },
       {"type": "spaces", "value": ""}
     ]

--- a/fixtures/search-syntax/wildcard_operators.json
+++ b/fixtures/search-syntax/wildcard_operators.json
@@ -1,0 +1,113 @@
+[
+  {
+    "desc": "Basic text filter, sets contains to false",
+    "query": "foo:bar",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "foo", "quoted": false},
+        "operator": "",
+        "value": {"type": "valueText", "value": "bar", "quoted": false, "contains": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "desc": "Single asterisk, sets contains to false",
+    "query": "foo:*",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "foo", "quoted": false},
+        "operator": "",
+        "value": {"type": "valueText", "value": "*", "quoted": false, "contains": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "desc": "Double asterisk, sets contains to false",
+    "query": "foo:**",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "foo", "quoted": false},
+        "operator": "",
+        "value": {"type": "valueText", "value": "**", "quoted": false, "contains": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "desc": "Value with asterisk, sets contains to true",
+    "query": "foo:*bar*",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "foo", "quoted": false},
+        "operator": "",
+        "value": {
+          "type": "valueText",
+          "value": "*bar*",
+          "quoted": false,
+          "contains": true
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "desc": "Value with quotes, sets contains to true",
+    "query": "foo:\"*em*\"",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "foo", "quoted": false},
+        "operator": "",
+        "value": {
+          "type": "valueText",
+          "value": "*em*",
+          "quoted": true,
+          "contains": true
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "desc": "Value with quotes and spaces, sets contains to true",
+    "query": "foo:\"*e m*\"",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": false,
+        "key": {"type": "keySimple", "value": "foo", "quoted": false},
+        "operator": "",
+        "value": {
+          "type": "valueText",
+          "value": "*e m*",
+          "quoted": true,
+          "contains": true
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  }
+]

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
@@ -97,9 +97,7 @@ describe('parseMultiSelectValue', function () {
 
   describe('contains', function () {
     it('sets contains to false when not wrapped in `*`', function () {
-      const result = parseMultiSelectFilterValue('a', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('a');
 
       expect(result).not.toBeNull();
       expect(result!.items).toHaveLength(1);
@@ -109,9 +107,7 @@ describe('parseMultiSelectValue', function () {
     });
 
     it('single value', function () {
-      const result = parseMultiSelectFilterValue('*a*', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('*a*');
 
       expect(result).not.toBeNull();
       expect(result!.items).toHaveLength(1);
@@ -121,9 +117,7 @@ describe('parseMultiSelectValue', function () {
     });
 
     it('multiple value', function () {
-      const result = parseMultiSelectFilterValue('*a*,*b*,c', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('*a*,*b*,c');
 
       expect(result).not.toBeNull();
 
@@ -142,9 +136,7 @@ describe('parseMultiSelectValue', function () {
     });
 
     it('quoted value', function () {
-      const result = parseMultiSelectFilterValue('a,"*b*",c', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('a,"*b*",c');
 
       expect(result).not.toBeNull();
 
@@ -160,9 +152,7 @@ describe('parseMultiSelectValue', function () {
     });
 
     it('just quotes', function () {
-      const result = parseMultiSelectFilterValue('"**"', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('"**"');
 
       expect(result).not.toBeNull();
 
@@ -175,9 +165,7 @@ describe('parseMultiSelectValue', function () {
     });
 
     it('single empty value', function () {
-      const result = parseMultiSelectFilterValue('**', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('**');
 
       expect(result).not.toBeNull();
 
@@ -190,9 +178,7 @@ describe('parseMultiSelectValue', function () {
     });
 
     it('spaces', function () {
-      const result = parseMultiSelectFilterValue('a,*b c*,d', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+      const result = parseMultiSelectFilterValue('a,*b c*,d');
 
       expect(result).not.toBeNull();
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
@@ -174,7 +174,7 @@ describe('parseMultiSelectValue', function () {
 
       expect(item!.value!.value).toBe('**');
       expect(item!.value!.text).toBe('**');
-      expect(item!.value!.contains).toBe(true);
+      expect(item!.value!.contains).toBe(false);
     });
 
     it('spaces', function () {

--- a/static/app/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue.tsx
@@ -12,9 +12,7 @@ export function replaceCommaSeparatedValue(
   cursorPosition: number | null,
   replacement: string
 ) {
-  const parsed = parseMultiSelectFilterValue(value, {
-    parseWildcardsCheckIsEnabled: false,
-  });
+  const parsed = parseMultiSelectFilterValue(value);
 
   if (!parsed) {
     return value;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -98,9 +98,7 @@ function getMultiSelectInputValue(token: TokenResult<Token.FILTER>) {
 }
 
 function prepareInputValueForSaving(valueType: FieldValueType, inputValue: string) {
-  const parsed = parseMultiSelectFilterValue(inputValue, {
-    parseWildcardsCheckIsEnabled: false,
-  });
+  const parsed = parseMultiSelectFilterValue(inputValue);
 
   if (!parsed) {
     return '""';
@@ -126,7 +124,7 @@ function getSelectedValuesFromText(
   text: string,
   {escaped = true}: {escaped?: boolean} = {}
 ) {
-  const parsed = parseMultiSelectFilterValue(text, {parseWildcardsCheckIsEnabled: false});
+  const parsed = parseMultiSelectFilterValue(text);
 
   if (!parsed) {
     return [];

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -83,7 +83,6 @@ export function parseQueryBuilderValue(
   return collapseTextTokens(
     parseSearch(value || ' ', {
       flattenParenGroups: true,
-      parseWildcardsCheckIsEnabled: false,
       disallowFreeText: options?.disallowFreeText,
       getFilterTokenWarning: options?.getFilterTokenWarning,
       validateKeys: options?.disallowUnsupportedFilters,

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -360,49 +360,4 @@ describe('searchSyntax/parser', function () {
       ]);
     });
   });
-
-  it('sets contains to false when not wrapped in `*`', function () {
-    const result = parseSearch('foo:bar');
-
-    expect(result).toHaveLength(3);
-
-    const bar = result?.[1] as TokenResult<Token.FILTER>;
-    expect(bar.value).toEqual(expect.objectContaining({contains: false}));
-  });
-
-  it('sets contains to true when wrapped in `*`', function () {
-    const result = parseSearch('foo:*bar*');
-
-    expect(result).toHaveLength(3);
-
-    const bar = result?.[1] as TokenResult<Token.FILTER>;
-    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '*bar*'}));
-  });
-
-  it('sets contains to true when quoted', function () {
-    const result = parseSearch('foo:"*bar*"');
-
-    expect(result).toHaveLength(3);
-
-    const bar = result?.[1] as TokenResult<Token.FILTER>;
-    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '*bar*'}));
-  });
-
-  it('spaces', function () {
-    const result = parseSearch('foo:"* *"');
-
-    expect(result).toHaveLength(3);
-
-    const bar = result?.[1] as TokenResult<Token.FILTER>;
-    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '* *'}));
-  });
-
-  it('just asterisks', function () {
-    const result = parseSearch('foo:**');
-
-    expect(result).toHaveLength(3);
-
-    const bar = result?.[1] as TokenResult<Token.FILTER>;
-    expect(bar.value).toEqual(expect.objectContaining({contains: false, value: '**'}));
-  });
 });

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -403,6 +403,6 @@ describe('searchSyntax/parser', function () {
     expect(result).toHaveLength(3);
 
     const bar = result?.[1] as TokenResult<Token.FILTER>;
-    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '**'}));
+    expect(bar.value).toEqual(expect.objectContaining({contains: false, value: '**'}));
   });
 });

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -105,9 +105,7 @@ describe('searchSyntax/parser', function () {
 
   Object.entries(testData).map(([name, cases]) =>
     describe(`${name}`, () => {
-      cases.map(c =>
-        registerTestCase(c, {parse: true, parseWildcardsCheckIsEnabled: false})
-      );
+      cases.map(c => registerTestCase(c, {parse: true}));
     })
   );
 
@@ -363,64 +361,48 @@ describe('searchSyntax/parser', function () {
     });
   });
 
-  describe('parseWildcardsCheckIsEnabled', () => {
-    it('sets contains to false when not wrapped in `*`', function () {
-      const result = parseSearch('foo:bar', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+  it('sets contains to false when not wrapped in `*`', function () {
+    const result = parseSearch('foo:bar');
 
-      expect(result).toHaveLength(3);
+    expect(result).toHaveLength(3);
 
-      const bar = result?.[1] as TokenResult<Token.FILTER>;
-      expect(bar.value).toEqual(expect.objectContaining({contains: false}));
-    });
+    const bar = result?.[1] as TokenResult<Token.FILTER>;
+    expect(bar.value).toEqual(expect.objectContaining({contains: false}));
+  });
 
-    it('sets contains to true when wrapped in `*`', function () {
-      const result = parseSearch('foo:*bar*', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+  it('sets contains to true when wrapped in `*`', function () {
+    const result = parseSearch('foo:*bar*');
 
-      expect(result).toHaveLength(3);
+    expect(result).toHaveLength(3);
 
-      const bar = result?.[1] as TokenResult<Token.FILTER>;
-      expect(bar.value).toEqual(
-        expect.objectContaining({contains: true, value: '*bar*'})
-      );
-    });
+    const bar = result?.[1] as TokenResult<Token.FILTER>;
+    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '*bar*'}));
+  });
 
-    it('sets contains to true when quoted', function () {
-      const result = parseSearch('foo:"*bar*"', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+  it('sets contains to true when quoted', function () {
+    const result = parseSearch('foo:"*bar*"');
 
-      expect(result).toHaveLength(3);
+    expect(result).toHaveLength(3);
 
-      const bar = result?.[1] as TokenResult<Token.FILTER>;
-      expect(bar.value).toEqual(
-        expect.objectContaining({contains: true, value: '*bar*'})
-      );
-    });
+    const bar = result?.[1] as TokenResult<Token.FILTER>;
+    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '*bar*'}));
+  });
 
-    it('spaces', function () {
-      const result = parseSearch('foo:"* *"', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+  it('spaces', function () {
+    const result = parseSearch('foo:"* *"');
 
-      expect(result).toHaveLength(3);
+    expect(result).toHaveLength(3);
 
-      const bar = result?.[1] as TokenResult<Token.FILTER>;
-      expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '* *'}));
-    });
+    const bar = result?.[1] as TokenResult<Token.FILTER>;
+    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '* *'}));
+  });
 
-    it('just asterisks', function () {
-      const result = parseSearch('foo:**', {
-        parseWildcardsCheckIsEnabled: true,
-      });
+  it('just asterisks', function () {
+    const result = parseSearch('foo:**');
 
-      expect(result).toHaveLength(3);
+    expect(result).toHaveLength(3);
 
-      const bar = result?.[1] as TokenResult<Token.FILTER>;
-      expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '**'}));
-    });
+    const bar = result?.[1] as TokenResult<Token.FILTER>;
+    expect(bar.value).toEqual(expect.objectContaining({contains: true, value: '**'}));
   });
 });

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -704,7 +704,7 @@ export class TokenConverter {
       type: Token.VALUE_TEXT as const,
       value,
       quoted,
-      ...(this.config.parseWildcardsCheckIsEnabled ? {contains: isContains} : {}),
+      contains: isContains,
     };
   };
 
@@ -774,14 +774,6 @@ export class TokenConverter {
    */
   predicateParenGroup = (): boolean => {
     return !this.config.flattenParenGroups;
-  };
-
-  /**
-   * When parseWildcardsCheckIsEnabled is enabled, the parser will check for the contains
-   * flag in text values. i.e. `*value*`
-   */
-  parseWildcardsCheckIsEnabled = (): boolean => {
-    return !!this.config.parseWildcardsCheckIsEnabled;
   };
 
   /**
@@ -1377,7 +1369,6 @@ export type SearchConfig = {
    * When true, the parser will not parse paren groups and will return individual paren tokens
    */
   flattenParenGroups?: boolean;
-
   /**
    * A function that returns a warning message for a given filter token key
    */
@@ -1386,15 +1377,6 @@ export type SearchConfig = {
    * Determines if user input values should be parsed
    */
   parse?: boolean;
-  /**
-   * When set to true, the parser will enable checks for different types of wildcard scenarios, and set the appropriate boolean fields on the token.
-   *
-   * Checks:
-   * - contains check: `*value*`
-   * - starts with check: `*value`
-   * - ends with check: `value*`
-   */
-  parseWildcardsCheckIsEnabled?: boolean;
   /**
    * If validateKeys is set to true, tag keys that don't exist in supportedTags will be consider invalid
    */

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -697,7 +697,8 @@ export class TokenConverter {
   });
 
   tokenValueText = (value: string, quoted: boolean) => {
-    const isContains = value.startsWith('*') && value.endsWith('*');
+    // We only want to consider a value to be `contains` if it is at least one character being wrapped in `*`
+    const isContains = value.length > 2 && value.startsWith('*') && value.endsWith('*');
 
     return {
       ...this.defaultTokenFields,

--- a/static/app/components/searchSyntax/renderer.spec.tsx
+++ b/static/app/components/searchSyntax/renderer.spec.tsx
@@ -32,6 +32,7 @@ const query: ParseResult = [
         end: {offset: 27, line: 1, column: 28},
         source: {},
       },
+      contains: false,
     },
     invalid: null,
     warning: null,


### PR DESCRIPTION
This PR removes the config flag stopping `contains` from being added to token text values, and updates the related test fixtures.

As well, this includes some small fixes around how determine `contains` to be truthy.