### PR TITLE
fix(taskworker): Make statistical detector tasks JSON compatible

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -379,8 +379,11 @@ def detect_transaction_trends(
     ),
 )
 def detect_transaction_change_points(
-    transactions: list[tuple[int, str | int]], start: datetime, *args, **kwargs
+    transactions: list[tuple[int, str | int]], start: datetime | str, *args, **kwargs
 ) -> None:
+    if isinstance(start, str):
+        start = datetime.fromisoformat(start)
+
     _detect_transaction_change_points(transactions, start, *args, **kwargs)
 
 
@@ -430,9 +433,12 @@ def _detect_transaction_change_points(
         namespace=profiling_tasks,
     ),
 )
-def detect_function_trends(project_ids: list[int], start: datetime, *args, **kwargs) -> None:
+def detect_function_trends(project_ids: list[int], start: datetime | str, *args, **kwargs) -> None:
     if not options.get("statistical_detectors.enable"):
         return
+
+    if isinstance(start, str):
+        start = datetime.fromisoformat(start)
 
     FunctionRegressionDetector.configure_tags()
 
@@ -472,8 +478,11 @@ def detect_function_trends(project_ids: list[int], start: datetime, *args, **kwa
     ),
 )
 def detect_function_change_points(
-    functions_list: list[tuple[int, int]], start: datetime, *args, **kwargs
+    functions_list: list[tuple[int, int]], start: datetime | str, *args, **kwargs
 ) -> None:
+    if isinstance(start, str):
+        start = datetime.fromisoformat(start)
+
     _detect_function_change_points(functions_list, start, *args, **kwargs)
 
 


### PR DESCRIPTION
These tasks are using datetimes which aren't JSON-serializable. Change them to also accept str
datetimes. There will be a follow up PR to actually call these with str parameters.