### PR TITLE
:wrench: chore(integrations): use `IntegrationProviderSlug` for Integration `key`

### DIFF
--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -22,6 +22,7 @@ from sentry.integrations.base import (
 from sentry.integrations.discord.client import DiscordClient
 from sentry.integrations.discord.types import DiscordPermissions
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.base import Pipeline
 from sentry.pipeline.views.base import PipelineView
@@ -117,7 +118,7 @@ class DiscordIntegration(IntegrationInstallation):
 
 
 class DiscordIntegrationProvider(IntegrationProvider):
-    key = "discord"
+    key = IntegrationProviderSlug.DISCORD
     name = "Discord"
     metadata = metadata
     integration_cls = DiscordIntegration

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -118,7 +118,7 @@ class DiscordIntegration(IntegrationInstallation):
 
 
 class DiscordIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.DISCORD
+    key = IntegrationProviderSlug.DISCORD.value
     name = "Discord"
     metadata = metadata
     integration_cls = DiscordIntegration

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -48,6 +48,7 @@ from sentry.integrations.source_code_management.language_parsers import PATCH_PA
 from sentry.integrations.source_code_management.repo_trees import RepoTreesIntegration
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
@@ -638,7 +639,7 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
 
 
 class GitHubIntegrationProvider(IntegrationProvider):
-    key = "github"
+    key = IntegrationProviderSlug.GITHUB
     name = "GitHub"
     metadata = metadata
     integration_cls: type[IntegrationInstallation] = GitHubIntegration

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -639,7 +639,7 @@ class GitHubOpenPRCommentWorkflow(OpenPRCommentWorkflow):
 
 
 class GitHubIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.GITHUB
+    key = IntegrationProviderSlug.GITHUB.value
     name = "GitHub"
     metadata = metadata
     integration_cls: type[IntegrationInstallation] = GitHubIntegration

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -26,6 +26,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import NestedPipelineView, Pipeline, PipelineView
@@ -155,7 +156,7 @@ class GitHubEnterpriseIntegration(
 
     @property
     def integration_name(self) -> str:
-        return "github_enterprise"
+        return IntegrationProviderSlug.GITHUB_ENTERPRISE
 
     def get_client(self):
         if not self.org_integration:
@@ -371,7 +372,7 @@ class InstallationConfigView(PipelineView):
 
 
 class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
-    key = "github_enterprise"
+    key = IntegrationProviderSlug.GITHUB_ENTERPRISE
     name = "GitHub Enterprise"
     metadata = metadata
     integration_cls = GitHubEnterpriseIntegration

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -156,7 +156,7 @@ class GitHubEnterpriseIntegration(
 
     @property
     def integration_name(self) -> str:
-        return IntegrationProviderSlug.GITHUB_ENTERPRISE
+        return IntegrationProviderSlug.GITHUB_ENTERPRISE.value
 
     def get_client(self):
         if not self.org_integration:
@@ -372,7 +372,7 @@ class InstallationConfigView(PipelineView):
 
 
 class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
-    key = IntegrationProviderSlug.GITHUB_ENTERPRISE
+    key = IntegrationProviderSlug.GITHUB_ENTERPRISE.value
     name = "GitHub Enterprise"
     metadata = metadata
     integration_cls = GitHubEnterpriseIntegration

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -28,6 +28,7 @@ from sentry.integrations.mixins.issues import MAX_CHAR, IssueSyncIntegration, Re
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
@@ -1106,7 +1107,7 @@ class JiraIntegration(IssueSyncIntegration):
 
 
 class JiraIntegrationProvider(IntegrationProvider):
-    key = "jira"
+    key = IntegrationProviderSlug.JIRA
     name = "Jira"
     metadata = metadata
     integration_cls = JiraIntegration

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -1107,7 +1107,7 @@ class JiraIntegration(IssueSyncIntegration):
 
 
 class JiraIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.JIRA
+    key = IntegrationProviderSlug.JIRA.value
     name = "Jira"
     metadata = metadata
     integration_cls = JiraIntegration

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1372,7 +1372,7 @@ class JiraServerIntegration(IssueSyncIntegration):
 
 
 class JiraServerIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.JIRA_SERVER
+    key = IntegrationProviderSlug.JIRA_SERVER.value
     name = "Jira Server"
     metadata = metadata
     integration_cls = JiraServerIntegration

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -34,7 +34,7 @@ from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import ExternalProviders
+from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.organizations.services.organization.service import organization_service
 from sentry.pipeline import Pipeline, PipelineView
@@ -1372,7 +1372,7 @@ class JiraServerIntegration(IssueSyncIntegration):
 
 
 class JiraServerIntegrationProvider(IntegrationProvider):
-    key = "jira_server"
+    key = IntegrationProviderSlug.JIRA_SERVER
     name = "Jira Server"
     metadata = metadata
     integration_cls = JiraServerIntegration

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -18,6 +18,7 @@ from sentry.integrations.base import (
     IntegrationProvider,
 )
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import Pipeline, PipelineView
 
@@ -79,7 +80,7 @@ class MsTeamsIntegration(IntegrationInstallation):
 
 
 class MsTeamsIntegrationProvider(IntegrationProvider):
-    key = "msteams"
+    key = IntegrationProviderSlug.MSTEAMS
     name = "Microsoft Teams"
     can_add = False
     metadata = metadata

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -80,7 +80,7 @@ class MsTeamsIntegration(IntegrationInstallation):
 
 
 class MsTeamsIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.MSTEAMS
+    key = IntegrationProviderSlug.MSTEAMS.value
     name = "Microsoft Teams"
     can_add = False
     metadata = metadata

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -232,7 +232,7 @@ class OpsgenieIntegration(IntegrationInstallation):
 
 
 class OpsgenieIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.OPSGENIE
+    key = IntegrationProviderSlug.OPSGENIE.value
     name = "Opsgenie"
     metadata = metadata
     integration_cls = OpsgenieIntegration

--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -24,6 +24,7 @@ from sentry.integrations.models.organization_integration import OrganizationInte
 from sentry.integrations.on_call.metrics import OnCallIntegrationsHaltReason, OnCallInteractionType
 from sentry.integrations.opsgenie.metrics import record_event
 from sentry.integrations.opsgenie.tasks import migrate_opsgenie_plugin
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import Pipeline, PipelineView
 from sentry.shared_integrations.exceptions import (
@@ -231,7 +232,7 @@ class OpsgenieIntegration(IntegrationInstallation):
 
 
 class OpsgenieIntegrationProvider(IntegrationProvider):
-    key = "opsgenie"
+    key = IntegrationProviderSlug.OPSGENIE
     name = "Opsgenie"
     metadata = metadata
     integration_cls = OpsgenieIntegration

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -168,7 +168,7 @@ class PagerDutyIntegration(IntegrationInstallation):
 
 
 class PagerDutyIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.PAGERDUTY
+    key = IntegrationProviderSlug.PAGERDUTY.value
     name = "PagerDuty"
     metadata = metadata
     features = frozenset([IntegrationFeatures.ALERT_RULE, IntegrationFeatures.INCIDENT_MANAGEMENT])

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -24,6 +24,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.on_call.metrics import OnCallInteractionType
 from sentry.integrations.pagerduty.metrics import record_event
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import Pipeline, PipelineView
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -167,7 +168,7 @@ class PagerDutyIntegration(IntegrationInstallation):
 
 
 class PagerDutyIntegrationProvider(IntegrationProvider):
-    key = "pagerduty"
+    key = IntegrationProviderSlug.PAGERDUTY
     name = "PagerDuty"
     metadata = metadata
     features = frozenset([IntegrationFeatures.ALERT_RULE, IntegrationFeatures.INCIDENT_MANAGEMENT])

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -101,7 +101,7 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation):
 
 
 class SlackIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.SLACK
+    key = IntegrationProviderSlug.SLACK.value
     name = "Slack"
     metadata = metadata
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -26,6 +26,7 @@ from sentry.integrations.slack.metrics import (
 )
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.tasks.link_slack_user_identities import link_slack_user_identities
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import NestedPipelineView
 from sentry.pipeline.views.base import PipelineView
@@ -100,7 +101,7 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation):
 
 
 class SlackIntegrationProvider(IntegrationProvider):
-    key = "slack"
+    key = IntegrationProviderSlug.SLACK
     name = "Slack"
     metadata = metadata
     features = frozenset([IntegrationFeatures.CHAT_UNFURL, IntegrationFeatures.ALERT_RULE])

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -399,7 +399,7 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
 
 
 class VstsIntegrationProvider(IntegrationProvider):
-    key = IntegrationProviderSlug.AZURE_DEVOPS
+    key = IntegrationProviderSlug.AZURE_DEVOPS.value
     name = "Azure DevOps"
     metadata = metadata
     api_version = "4.1"

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -33,6 +33,7 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository import RpcRepository, repository_service
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.tasks.migrate_repo import migrate_repo
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineHaltReason,
     IntegrationPipelineViewEvent,
@@ -398,7 +399,7 @@ class VstsIntegration(RepositoryIntegration, VstsIssuesSpec):
 
 
 class VstsIntegrationProvider(IntegrationProvider):
-    key = "vsts"
+    key = IntegrationProviderSlug.AZURE_DEVOPS
     name = "Azure DevOps"
     metadata = metadata
     api_version = "4.1"


### PR DESCRIPTION
standardizing the `keys` of `Integration` so we can use the StrEnum for future mappings