### PR TITLE
fix(taskworker): Have statistical detector tasks send strings instead…

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -379,8 +379,11 @@ def detect_transaction_trends(
     ),
 )
 def detect_transaction_change_points(
-    transactions: list[tuple[int, str | int]], start: datetime, *args, **kwargs
+    transactions: list[tuple[int, str | int]], start: datetime | str, *args, **kwargs
 ) -> None:
+    if isinstance(start, str):
+        start = datetime.fromisoformat(start)
+
     _detect_transaction_change_points(transactions, start, *args, **kwargs)
 
 
@@ -430,9 +433,12 @@ def _detect_transaction_change_points(
         namespace=profiling_tasks,
     ),
 )
-def detect_function_trends(project_ids: list[int], start: datetime, *args, **kwargs) -> None:
+def detect_function_trends(project_ids: list[int], start: datetime | str, *args, **kwargs) -> None:
     if not options.get("statistical_detectors.enable"):
         return
+
+    if isinstance(start, str):
+        start = datetime.fromisoformat(start)
 
     FunctionRegressionDetector.configure_tags()
 
@@ -472,8 +478,11 @@ def detect_function_trends(project_ids: list[int], start: datetime, *args, **kwa
     ),
 )
 def detect_function_change_points(
-    functions_list: list[tuple[int, int]], start: datetime, *args, **kwargs
+    functions_list: list[tuple[int, int]], start: datetime | str, *args, **kwargs
 ) -> None:
+    if isinstance(start, str):
+        start = datetime.fromisoformat(start)
+
     _detect_function_change_points(functions_list, start, *args, **kwargs)
 
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -169,7 +169,7 @@ def dispatch_performance_projects(
                 args=[
                     [],
                     projects,
-                    timestamp,
+                    timestamp.isoformat(),
                 ],
                 countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
             )
@@ -183,7 +183,7 @@ def dispatch_performance_projects(
             args=[
                 [],
                 projects,
-                timestamp,
+                timestamp.isoformat(),
             ],
             countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
         )
@@ -210,7 +210,7 @@ def dispatch_profiling_projects(
 
         if len(projects) >= PROJECTS_PER_BATCH:
             detect_function_trends.apply_async(
-                args=[projects, timestamp],
+                args=[projects, timestamp.isoformat()],
                 countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
             )
             projects = []
@@ -220,7 +220,7 @@ def dispatch_profiling_projects(
     # make sure to dispatch a task to handle the remaining projects
     if projects:
         detect_function_trends.apply_async(
-            args=[projects, timestamp],
+            args=[projects, timestamp.isoformat()],
             countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
         )
 
@@ -361,7 +361,7 @@ def detect_transaction_trends(
         detect_transaction_change_points.apply_async(
             args=[
                 [(bundle.payload.project_id, bundle.payload.group) for bundle in regression_chunk],
-                delayed_start,
+                delayed_start.isoformat(),
             ],
             # delay the check by delay hours because we want to make sure there
             # will be enough data after the potential change point to be confident
@@ -460,7 +460,7 @@ def detect_function_trends(project_ids: list[int], start: datetime | str, *args,
         detect_function_change_points.apply_async(
             args=[
                 [(bundle.payload.project_id, bundle.payload.group) for bundle in regression_chunk],
-                delayed_start,
+                delayed_start.isoformat(),
             ],
             # delay the check by delay hours because we want to make sure there
             # will be enough data after the potential change point to be confident

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -125,7 +125,7 @@ def test_run_detection_options(
     if expected_performance_project:
         assert detect_transaction_trends.apply_async.called
         detect_transaction_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[], [project.id], timestamp], countdown=0)]
+            [mock.call(args=[[], [project.id], timestamp.isoformat()], countdown=0)]
         )
     else:
         assert not detect_transaction_trends.apply_async.called
@@ -133,7 +133,7 @@ def test_run_detection_options(
     if expected_profiling_project:
         assert detect_function_trends.apply_async.called
         detect_function_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[project.id], timestamp], countdown=0)]
+            [mock.call(args=[[project.id], timestamp.isoformat()], countdown=0)]
         )
     else:
         assert not detect_function_trends.apply_async.called
@@ -173,7 +173,7 @@ def test_run_detection_options_multiple_batches(
                 args=[
                     [],
                     [project.id for project in projects[i : i + 5]],
-                    timestamp,
+                    timestamp.isoformat(),
                 ],
                 countdown=countdown,
             )
@@ -184,7 +184,7 @@ def test_run_detection_options_multiple_batches(
     detect_function_trends.apply_async.assert_has_calls(
         [
             mock.call(
-                args=[[project.id for project in projects[i : i + 5]], timestamp],
+                args=[[project.id for project in projects[i : i + 5]], timestamp.isoformat()],
                 countdown=countdown,
             )
             for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=0, step=17))
@@ -221,40 +221,7 @@ def test_detect_transaction_trends_options(
     }
 
     with override_options(options):
-        detect_transaction_trends([project.organization_id], [project.id], timestamp)
-    assert query_transactions.called == (task_enabled and option_enabled)
-
-
-@pytest.mark.parametrize(
-    ["task_enabled", "option_enabled"],
-    [
-        pytest.param(True, True, id="both enabled"),
-        pytest.param(False, False, id="both disabled"),
-        pytest.param(True, False, id="option disabled"),
-        pytest.param(False, True, id="task disabled"),
-    ],
-)
-@mock.patch("sentry.tasks.statistical_detectors.query_transactions")
-@django_db_all
-def test_detect_transaction_trends_options_with_str_datetime(
-    query_transactions,
-    task_enabled,
-    option_enabled,
-    timestamp,
-    project,
-):
-    ProjectOption.objects.set_value(
-        project=project,
-        key="sentry:performance_issue_settings",
-        value={InternalProjectOptions.TRANSACTION_DURATION_REGRESSION.value: option_enabled},
-    )
-
-    options = {
-        "statistical_detectors.enable": task_enabled,
-    }
-
-    with override_options(options):
-        detect_transaction_trends([project.organization_id], [project.id], str(timestamp))
+        detect_transaction_trends([project.organization_id], [project.id], timestamp.isoformat())
     assert query_transactions.called == (task_enabled and option_enabled)
 
 
@@ -287,30 +254,8 @@ def test_detect_function_trends_options(
     }
 
     with override_options(options):
-        detect_function_trends([project.id], timestamp)
-    assert query_functions.called == (task_enabled and option_enabled)
-
-
-@mock.patch("sentry.tasks.statistical_detectors.query_functions")
-@django_db_all
-def test_detect_function_trends_options_with_str(
-    query_functions,
-    timestamp,
-    project,
-):
-    ProjectOption.objects.set_value(
-        project=project,
-        key="sentry:performance_issue_settings",
-        value={InternalProjectOptions.FUNCTION_DURATION_REGRESSION.value: True},
-    )
-
-    options = {
-        "statistical_detectors.enable": True,
-    }
-
-    with override_options(options):
         detect_function_trends([project.id], timestamp.isoformat())
-    assert query_functions.called == (True and True)
+    assert query_functions.called == (task_enabled and option_enabled)
 
 
 @mock.patch("sentry.snuba.functions.query")
@@ -321,7 +266,7 @@ def test_detect_function_trends_query_timerange(functions_query, timestamp, proj
     }
 
     with override_options(options):
-        detect_function_trends([project.id], timestamp)
+        detect_function_trends([project.id], timestamp.isoformat())
 
     assert functions_query.called
     params = functions_query.mock_calls[0].kwargs["snuba_params"]
@@ -367,7 +312,7 @@ def test_detect_transaction_trends(
 
     with override_options(options):
         for ts in timestamps:
-            detect_transaction_trends([project.organization.id], [project.id], ts)
+            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
 
     if should_emit:
         assert detect_transaction_change_points.apply_async.called
@@ -412,7 +357,7 @@ def test_detect_transaction_trends_auto_resolution(
 
     with override_options(options):
         for ts in timestamps[:50]:
-            detect_transaction_trends([project.organization.id], [project.id], ts)
+            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
 
     assert detect_transaction_change_points.apply_async.called
 
@@ -428,7 +373,7 @@ def test_detect_transaction_trends_auto_resolution(
             regressed=300,
         )
         for ts in timestamps[50:]:
-            detect_transaction_trends([project.organization.id], [project.id], ts)
+            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
 
     status_change = StatusChangeMessage(
         fingerprint=[generate_fingerprint(RegressionType.ENDPOINT, "/123")],
@@ -497,7 +442,7 @@ def test_detect_transaction_trends_ratelimit(
 
     with override_options(options):
         for ts in timestamps:
-            detect_transaction_trends([project.organization.id], [project.id], ts)
+            detect_transaction_trends([project.organization.id], [project.id], ts.isoformat())
 
     if expected_calls > 0:
         assert detect_transaction_change_points.apply_async.call_count == 1
@@ -740,7 +685,7 @@ def test_get_regression_versions_active(
         "evidence_data": {},
         "evidence_display": [],
         "type": issue_type.type_id,
-        "detection_time": timestamp.isoformat(),
+        "detection_time": timestamp,
         "level": "info",
         "culprit": "",
         "payload_type": PayloadType.OCCURRENCE.value,
@@ -828,7 +773,7 @@ def test_detect_function_trends(
 
     with override_options(options):
         for ts in timestamps:
-            detect_function_trends([project.id], ts)
+            detect_function_trends([project.id], ts.isoformat())
 
     if should_emit:
         assert detect_function_change_points.apply_async.called
@@ -871,7 +816,7 @@ def test_detect_function_trends_auto_resolution(
 
     with override_options(options):
         for ts in timestamps[:50]:
-            detect_function_trends([project.id], ts)
+            detect_function_trends([project.id], ts.isoformat())
 
     assert detect_function_change_points.apply_async.called
 
@@ -887,7 +832,7 @@ def test_detect_function_trends_auto_resolution(
             regressed=300,
         )
         for ts in timestamps[50:]:
-            detect_function_trends([project.id], ts)
+            detect_function_trends([project.id], ts.isoformat())
 
     assert produce_occurrence_to_kafka.called
 
@@ -947,7 +892,7 @@ def test_detect_function_trends_ratelimit(
 
     with override_options(options):
         for ts in timestamps:
-            detect_function_trends([project.id], ts)
+            detect_function_trends([project.id], ts.isoformat())
 
     if expected_calls > 0:
         assert detect_function_change_points.apply_async.call_count == 1
@@ -971,67 +916,6 @@ def test_detect_function_trends_ratelimit(
 @mock.patch("sentry.search.events.builder.base.raw_snql_query")
 @django_db_all
 def test_detect_function_change_points(
-    mock_raw_snql_query,
-    mock_detect_breakpoints,
-    mock_emit_function_regression_issue,
-    timestamp,
-    project,
-):
-    start_of_hour = timestamp.replace(minute=0, second=0, microsecond=0)
-
-    fingerprint = 12345
-
-    mock_raw_snql_query.return_value = {
-        "data": [
-            {
-                "time": (start_of_hour - timedelta(days=day, hours=hour)).isoformat(),
-                "project.id": project.id,
-                "fingerprint": fingerprint,
-                "p95": 2 if day < 1 and hour < 8 else 1,
-            }
-            for day in reversed(range(14))
-            for hour in reversed(range(24))
-        ],
-        "meta": [
-            {"name": "time", "type": "DateTime"},
-            {"name": "project.id", "type": "UInt64"},
-            {"name": "fingerprint", "type": "UInt32"},
-            {"name": "p95", "type": "Float64"},
-        ],
-    }
-
-    mock_detect_breakpoints.return_value = {
-        "data": [
-            {
-                "absolute_percentage_change": 5.0,
-                "aggregate_range_1": 100000000.0,
-                "aggregate_range_2": 500000000.0,
-                "breakpoint": 1687323600,
-                "change": "regression",
-                "project": str(project.id),
-                "transaction": str(fingerprint),
-                "trend_difference": 400000000.0,
-                "trend_percentage": 5.0,
-                "unweighted_p_value": 0.0,
-                "unweighted_t_value": -float("inf"),
-            },
-        ]
-    }
-
-    options = {
-        "statistical_detectors.enable": True,
-    }
-
-    with override_options(options):
-        detect_function_change_points([(project.id, fingerprint)], timestamp)
-    assert mock_emit_function_regression_issue.called
-
-
-@mock.patch("sentry.tasks.statistical_detectors.emit_function_regression_issue")
-@mock.patch("sentry.statistical_detectors.detector.detect_breakpoints")
-@mock.patch("sentry.search.events.builder.base.raw_snql_query")
-@django_db_all
-def test_detect_function_change_points_with_str(
     mock_raw_snql_query,
     mock_detect_breakpoints,
     mock_emit_function_regression_issue,
@@ -1982,42 +1866,6 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
     @mock.patch("sentry.tasks.statistical_detectors.send_regression_to_platform")
     @mock.patch("sentry.statistical_detectors.detector.detect_breakpoints")
     def test_transaction_change_point_detection(
-        self, mock_detect_breakpoints, mock_send_regression_to_platform
-    ) -> None:
-        mock_detect_breakpoints.return_value = {
-            "data": [
-                {
-                    "absolute_percentage_change": 5.0,
-                    "aggregate_range_1": 100000000.0,
-                    "aggregate_range_2": 500000000.0,
-                    "breakpoint": 1687323600,
-                    "change": "regression",
-                    "project": str(self.projects[0].id),
-                    "transaction": "transaction_1",
-                    "trend_difference": 400000000.0,
-                    "trend_percentage": 5.0,
-                    "unweighted_p_value": 0.0,
-                    "unweighted_t_value": -float("inf"),
-                },
-            ]
-        }
-
-        options = {"statistical_detectors.enable": True}
-
-        with override_options(options):
-            detect_transaction_change_points(
-                [
-                    (self.projects[0].id, "transaction_1"),
-                    (self.projects[0].id, "transaction_2"),
-                    (self.projects[1].id, "transaction_1"),
-                ],
-                self.now,
-            )
-        assert mock_send_regression_to_platform.called
-
-    @mock.patch("sentry.tasks.statistical_detectors.send_regression_to_platform")
-    @mock.patch("sentry.statistical_detectors.detector.detect_breakpoints")
-    def test_transaction_change_point_detection_with_str(
         self, mock_detect_breakpoints, mock_send_regression_to_platform
     ) -> None:
         mock_detect_breakpoints.return_value = {


### PR DESCRIPTION
… of datetimes

Migrate the task to also send strings instead of datetimes. Depends on https://github.com/getsentry/sentry/pull/91462