### PR TITLE
fix(insights): update mobile overview query to be correct

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -116,7 +116,7 @@ function EAPOverviewPage() {
   const existingQuery = new MutableSearch(searchBarQuery);
   // TODO - this query is getting complicated, once were on EAP, we should consider moving this to the backend
   existingQuery.addOp('(');
-  existingQuery.addDisjunctionFilterValues('span.op', EAP_OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addFilterValue('span.op', `[${EAP_OVERVIEW_PAGE_ALLOWED_OPS.join(',')}]`);
   // add disjunction filter creates a very long query as it seperates conditions with OR, project ids are numeric with no spaces, so we can use a comma seperated list
   if (selectedFrontendProjects.length > 0) {
     existingQuery.addOp('OR');

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -88,7 +88,8 @@ function EAPMobileOverviewPage() {
     categorizeProjects(getSelectedProjectList(selection.projects, projects));
 
   const existingQuery = new MutableSearch(eventView.query);
-  existingQuery.addDisjunctionFilterValues('span.op', OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addOp('(');
+  existingQuery.addFilterValue('span.op', `[${OVERVIEW_PAGE_ALLOWED_OPS.join(',')}]`);
   if (selectedMobileProjects.length > 0) {
     existingQuery.addOp('OR');
     existingQuery.addFilterValue(
@@ -96,6 +97,7 @@ function EAPMobileOverviewPage() {
       `[${selectedMobileProjects.map(({id}) => id).join(',')}]`
     );
   }
+  existingQuery.addOp(')');
 
   eventView.query = existingQuery.formatString();
 


### PR DESCRIPTION
1. Updates mobile and frontend overview span op filters syntax to be `span.op:[ a , b , c]` instead of `span.op:a or span.op:b ...`, this makes the query use multi select when you open in explore (closes DAIN-479)
<img width="556" alt="image" src="https://github.com/user-attachments/assets/25f4437a-523d-44ed-b75d-cbc7ec44c6fa" />

2. Update the mobile overview to wrap the conditions in a bracket so that the `is_transaction` filter is applied correctly, we want the results to **only** include transaction spans
before
`span.op:[1,23,4] or project:1232 is_transaction:true`
after
`(span.op:[1,23,4] or project:1232) is_transaction:true`