### PR TITLE
feat(taskworker): Add ability to send extra bytes args to taskbroker

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -404,6 +404,12 @@ def run_taskworker(
     help="The namespace that the task is registered in",
     default=None,
 )
+@click.option(
+    "--extra-arg-bytes",
+    type=int,
+    help="Generater random args of specified size in bytes",
+    default=None,
+)
 def taskbroker_send_tasks(
     task_function_path: str,
     args: str,
@@ -412,6 +418,7 @@ def taskbroker_send_tasks(
     bootstrap_servers: str,
     kafka_topic: str,
     namespace: str,
+    extra_arg_bytes: int | None,
 ) -> None:
     from sentry import options
     from sentry.conf.server import KAFKA_CLUSTERS
@@ -426,8 +433,13 @@ def taskbroker_send_tasks(
     except Exception as e:
         click.echo(f"Error: {e}")
         raise click.Abort()
+
     task_args = [] if not args else eval(args)
     task_kwargs = {} if not kwargs else eval(kwargs)
+
+    if extra_arg_bytes is not None:
+        extra_padding_args = ["x" * extra_arg_bytes]
+        task_args.extend(extra_padding_args)
 
     checkmarks = {int(repeat * (i / 10)) for i in range(1, 10)}
     for i in range(repeat):


### PR DESCRIPTION
In INC-1158, we discovered that excessively large payloads have the ability to degrade taskbroker. We want to replicate this in our sandbox environment to properly root cause the issue. To accomplish this, we need to be able to generate large protobufs to be sent to kafka. This PR adds a CLI arg to `taskbroker_send_tasks` which adds extra padding bytes to the task's args.

### Testing
Locally tested and validated that big task activations are properly received by taskbroker.