### PR TITLE
add godot script syntax highlight

### DIFF
--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -75,6 +75,8 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   arb: 'json',
   ps1: 'powershell',
   jinja: 'jinja2',
+  // Godot Script - e.g: "file": "res://script_with_errors.gd"
+  gd: 'gdscript',
 };
 
 export const getPrismLanguage = (lang: string) => {


### PR DESCRIPTION
Prism supports Godot Script since 2019:
* https://github.com/PrismJS/prism/pull/2006/


[See example event](https://sentry-sdks.sentry.io/issues/6592081213/?project=6680910&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0)

![image](https://github.com/user-attachments/assets/45a7db5a-680f-47cb-b659-17c608f6c5e2)
