### PR TITLE
feat(explore): add project.id as searchable field

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -1,5 +1,5 @@
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields, SpanIndexedField} from 'sentry/views/insights/types';
 
 export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
   // NOTE: intentionally choose to not expose transaction id
@@ -42,6 +42,7 @@ export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
 export const SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS: string[] = [
   SpanIndexedField.SPAN_DURATION,
   SpanIndexedField.SPAN_SELF_TIME,
+  SpanFields.PROJECT_ID,
 ];
 
 export const SENTRY_SPAN_STRING_TAGS: string[] = [

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -42,7 +42,6 @@ export const SENTRY_SEARCHABLE_SPAN_STRING_TAGS: string[] = [
 export const SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS: string[] = [
   SpanIndexedField.SPAN_DURATION,
   SpanIndexedField.SPAN_SELF_TIME,
-  SpanFields.PROJECT_ID,
 ];
 
 export const SENTRY_SPAN_STRING_TAGS: string[] = [
@@ -55,6 +54,7 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanIndexedField.TRACE,
   SpanIndexedField.IS_TRANSACTION, // boolean field but we can expose it as a string
   SpanIndexedField.NORMALIZED_DESCRIPTION,
+  SpanFields.PROJECT_ID,
 ];
 
 export const SENTRY_SPAN_NUMBER_TAGS: string[] = [...SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS];

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -87,6 +87,7 @@ export enum SpanFields {
   SPAN_GROUP = 'span.group',
   SPAN_OP = 'span.op',
   RELEASE = 'release',
+  PROJECT_ID = 'project.id',
 }
 
 type WebVitalsMeasurements =


### PR DESCRIPTION
This makes it so the search bar won't show errors when you "open in explore" from the insight overview charts.