### PR TITLE
feat(otel): Register flag for OTel-friendly UI

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -260,6 +260,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-transaction-summary-cleanup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the EAP-powered transactions summary view
     manager.add("organizations:performance-transaction-summary-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable OTel-friendly UI. Updates copy and small UI elements to align closer with OTel definitions and concepts
+    manager.add("organizations:performance-otel-friendly-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the new UI for span summary and the spans tab
     manager.add("organizations:performance-spans-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)


### PR DESCRIPTION
For customers who send us OTLP data (no one right now, we'll start soon, hopefully), we'll update the UI to align more closely with OTel concepts. This is mostly copy updates, but also some product changes like table columns. As the product gets closer and closer to first-class OTLP support, we'll start releasing these changes.

Contributes to [OPE-12: Create feature flag for OTLP-compatible UI](https://linear.app/getsentry/issue/OPE-12/create-feature-flag-for-otlp-compatible-ui)