### PR TITLE
fix(eap): Handle quotes in typed attributes

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -801,7 +801,8 @@ class SearchResolver:
                 field_type = "string"
             else:
                 field_type = None
-            field = tag_match.group("tag") if tag_match else column
+            # make sure to remove surrounding quotes if it's a tag
+            field = tag_match.group("tag").strip('"') if tag_match else column
             if field is None:
                 raise InvalidSearchQuery(f"Could not parse {column}")
             # Assume string if a type isn't passed. eg. tags[foo]


### PR DESCRIPTION
Colons were introduced to the tag keys and needs to be quoted. This makes sure the quoting is properly handled by removing it before using it as a key.