### PR TITLE
ref: avoid setting scope_list=None in SentryApp creation

### DIFF
--- a/src/sentry/sentry_apps/logic.py
+++ b/src/sentry/sentry_apps/logic.py
@@ -367,7 +367,6 @@ class SentryAppCreator:
             "application_id": api_app.id,
             "owner_id": self.organization_id,
             "proxy_user_id": proxy.id,
-            "scope_list": self.scopes,
             "events": expand_events(self.events),
             "schema": self.schema or {},
             "webhook_url": self.webhook_url,
@@ -381,6 +380,8 @@ class SentryAppCreator:
             or user.username,  # email is not required for some users (sentry apps)
             "metadata": self.metadata if self.metadata else {},
         }
+        if self.scopes is not None:
+            kwargs["scope_list"] = self.scopes
 
         if self.is_internal:
             kwargs["status"] = SentryAppStatus.INTERNAL


### PR DESCRIPTION
when switching to django's ArrayField it helpfully points out that this doesn't make sense as null

<!-- Describe your PR here. -->