### PR TITLE
:recycle: ref(aci): rename azure devops action type to vsts

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -49,7 +49,7 @@ class Action(DefaultFieldsModel, JSONConfigBase):
         GITHUB_ENTERPRISE = "github_enterprise"
         JIRA = "jira"
         JIRA_SERVER = "jira_server"
-        AZURE_DEVOPS = "azure_devops"
+        AZURE_DEVOPS = "vsts"
 
         EMAIL = "email"
         SENTRY_APP = "sentry_app"

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -56,7 +56,7 @@ class ActionType(StrEnum):
     GITHUB_ENTERPRISE = "github_enterprise"
     JIRA = "jira"
     JIRA_SERVER = "jira_server"
-    AZURE_DEVOPS = "azure_devops"
+    AZURE_DEVOPS = "vsts"
 
     EMAIL = "email"
     SENTRY_APP = "sentry_app"


### PR DESCRIPTION
we are going to match the str representation of the Azure DevOps action to match the `IntegrationProviderSlug` for it (vsts) since we use `vsts` everywhere else in our codebase and matching it makes mapping things much easier.

the first step is to fix the leaky bucket and prevent new actions from being created with the old type