### PR TITLE
fix(ui2): remove nav button cutoff

### DIFF
--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -191,7 +191,7 @@ export function OrgDropdown({
 const OrgDropdownTrigger = styled(Button)<{width: number}>`
   height: ${p => p.width}px;
   width: ${p => p.width}px;
-  padding: 0; /* fixes overflow behavior for avatar */
+  padding: 0; /* Without this the icon will be cutoff due to overflow */
 `;
 
 const StyledOrganizationAvatar = styled(OrganizationAvatar)`

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -191,6 +191,7 @@ export function OrgDropdown({
 const OrgDropdownTrigger = styled(Button)<{width: number}>`
   height: ${p => p.width}px;
   width: ${p => p.width}px;
+  padding: 0; /* fixes overflow behavior for avatar */
 `;
 
 const StyledOrganizationAvatar = styled(OrganizationAvatar)`

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -458,7 +458,7 @@ const ChonkNavButton = styled(Button, {
   justify-content: ${p => (p.isMobile ? 'flex-start' : 'center')};
   height: ${p => (p.isMobile ? 'auto' : '44px')};
   width: ${p => (p.isMobile ? '100%' : '44px')};
-  padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : undefined)};
+  padding: ${p => (p.isMobile ? `${space(1)} ${space(3)}` : space(0.5))};
 
   svg {
     margin-right: ${p => (p.isMobile ? space(1) : undefined)};


### PR DESCRIPTION
Fixes [DE-95](https://linear.app/getsentry/issue/DE-95/buttonlabel-overflow-in-nav-items).

**Before**
![avatar picker with cutoff avatar](https://github.com/user-attachments/assets/c8cb8380-c568-4159-b1c0-3546055fe6b2)

**After**

<img width="445" alt="avatar picker with fully visible avatar" src="https://github.com/user-attachments/assets/5b53aee1-f9b4-43ef-b877-f2f32eb91ec4" />


[DE-95]: https://getsentry.atlassian.net/browse/DE-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ