### PR TITLE
feat(query): Add a way to make bulk table queries

### DIFF
--- a/src/sentry/snuba/ourlogs.py
+++ b/src/sentry/snuba/ourlogs.py
@@ -14,7 +14,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import zerofill
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.query_sources import QuerySource
-from sentry.snuba.rpc_dataset_common import run_table_query
+from sentry.snuba.rpc_dataset_common import TableQuery, run_table_query
 from sentry.utils import snuba_rpc
 from sentry.utils.snuba import SnubaTSResult
 
@@ -68,18 +68,20 @@ def query(
         if precise_timestamp not in selected_columns:
             selected_columns.append(precise_timestamp)
     return run_table_query(
-        query_string=query or "",
-        selected_columns=selected_columns,
-        orderby=orderby,
-        offset=offset or 0,
-        limit=limit,
-        referrer=referrer or "referrer unset",
-        sampling_mode=None,
-        resolver=get_resolver(
-            params=snuba_params,
-            config=SearchResolverConfig(
-                auto_fields=False,
-                use_aggregate_conditions=use_aggregate_conditions,
+        TableQuery(
+            query_string=query or "",
+            selected_columns=selected_columns,
+            orderby=orderby,
+            offset=offset or 0,
+            limit=limit,
+            referrer=referrer or "referrer unset",
+            sampling_mode=None,
+            resolver=get_resolver(
+                params=snuba_params,
+                config=SearchResolverConfig(
+                    auto_fields=False,
+                    use_aggregate_conditions=use_aggregate_conditions,
+                ),
             ),
         ),
         debug=debug,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -8,7 +8,11 @@ from sentry_protos.snuba.v1.endpoint_time_series_pb2 import (
     TimeSeries,
     TimeSeriesRequest,
 )
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceItemTableRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+    TraceItemTableResponse,
+)
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import AndFilter, TraceItemFilter
@@ -163,33 +167,59 @@ def validate_granularity(
         )
 
 
+@dataclass
+class TableQuery:
+    query_string: str
+    selected_columns: list[str]
+    orderby: list[str] | None
+    offset: int
+    limit: int
+    referrer: str
+    sampling_mode: SAMPLING_MODES | None
+    resolver: SearchResolver
+
+
+@dataclass
+class TableRequest:
+    """Container for rpc requests"""
+
+    rpc_request: TraceItemTableRequest
+    columns: list[
+        ResolvedAttribute | ResolvedAggregate | ResolvedConditionalAggregate | ResolvedFormula
+    ]
+
+
 @sentry_sdk.trace
-def run_table_query(
-    query_string: str,
-    selected_columns: list[str],
-    orderby: list[str] | None,
-    offset: int,
-    limit: int,
-    referrer: str,
-    sampling_mode: SAMPLING_MODES | None,
-    resolver: SearchResolver,
-    debug: bool = False,
-) -> EAPResponse:
+def run_bulk_table_queries(queries: dict[str, TableQuery]):
+    prepared_queries = {name: get_table_rpc_request(query) for name, query in queries.items()}
+    """Run the qurey"""
+    responses = snuba_rpc.table_rpc([query.rpc_request for query in prepared_queries.values()])
+    results = {
+        name: process_table_response(response, request)
+        for name, request, response in zip(
+            prepared_queries.keys(), prepared_queries.values(), responses
+        )
+    }
+    return results
+
+
+def get_table_rpc_request(query: TableQuery) -> TableRequest:
     """Make the query"""
-    sentry_sdk.set_tag("query.sampling_mode", sampling_mode)
-    meta = resolver.resolve_meta(referrer=referrer, sampling_mode=sampling_mode)
-    where, having, query_contexts = resolver.resolve_query(query_string)
-    columns, column_contexts = resolver.resolve_columns(selected_columns)
+    resolver = query.resolver
+    sentry_sdk.set_tag("query.sampling_mode", query.sampling_mode)
+    meta = resolver.resolve_meta(referrer=query.referrer, sampling_mode=query.sampling_mode)
+    where, having, query_contexts = resolver.resolve_query(query.query_string)
+    columns, column_contexts = resolver.resolve_columns(query.selected_columns)
     contexts = resolver.resolve_contexts(query_contexts + column_contexts)
     # We allow orderby function_aliases if they're a selected_column
     # eg. can orderby sum_span_self_time, assuming sum(span.self_time) is selected
     orderby_aliases = {
         get_function_alias(column_name): resolved_column
-        for resolved_column, column_name in zip(columns, selected_columns)
+        for resolved_column, column_name in zip(columns, query.selected_columns)
     }
     # Orderby is only applicable to TraceItemTableRequest
     resolved_orderby = []
-    orderby_columns = orderby if orderby is not None else []
+    orderby_columns = query.orderby if query.orderby is not None else []
     for orderby_column in orderby_columns:
         stripped_orderby = orderby_column.lstrip("-")
         if stripped_orderby in orderby_aliases:
@@ -207,29 +237,47 @@ def run_table_query(
 
     labeled_columns = [categorize_column(col) for col in columns]
 
-    """Run the query"""
-    rpc_request = TraceItemTableRequest(
-        meta=meta,
-        filter=where,
-        aggregation_filter=having,
-        columns=labeled_columns,
-        group_by=(
-            [
-                col.proto_definition
-                for col in columns
-                if isinstance(col.proto_definition, AttributeKey)
-            ]
-            if has_aggregations
-            else []
+    return TableRequest(
+        TraceItemTableRequest(
+            meta=meta,
+            filter=where,
+            aggregation_filter=having,
+            columns=labeled_columns,
+            group_by=(
+                [
+                    col.proto_definition
+                    for col in columns
+                    if isinstance(col.proto_definition, AttributeKey)
+                ]
+                if has_aggregations
+                else []
+            ),
+            order_by=resolved_orderby,
+            limit=query.limit,
+            page_token=PageToken(offset=query.offset),
+            virtual_column_contexts=[context for context in contexts if context is not None],
         ),
-        order_by=resolved_orderby,
-        limit=limit,
-        page_token=PageToken(offset=offset),
-        virtual_column_contexts=[context for context in contexts if context is not None],
+        columns,
     )
+
+
+@sentry_sdk.trace
+def run_table_query(
+    query: TableQuery,
+    debug: bool = False,
+) -> EAPResponse:
+    """Run the query"""
+    table_request = get_table_rpc_request(query)
+    rpc_request = table_request.rpc_request
     rpc_response = snuba_rpc.table_rpc([rpc_request])[0]
     sentry_sdk.set_tag("query.storage_meta.tier", rpc_response.meta.downsampled_storage_meta.tier)
 
+    return process_table_response(rpc_response, table_request)
+
+
+def process_table_response(
+    rpc_response: TraceItemTableResponse, table_request: TableRequest, debug: bool = False
+) -> EAPResponse:
     """Process the results"""
     final_data: SnubaData = []
     final_confidence: ConfidenceData = []
@@ -238,7 +286,7 @@ def run_table_query(
         full_scan=handle_downsample_meta(rpc_response.meta.downsampled_storage_meta),
     )
     # Mapping from public alias to resolved column so we know type etc.
-    columns_by_name = {col.public_alias: col for col in columns}
+    columns_by_name = {col.public_alias: col for col in table_request.columns}
 
     for column_value in rpc_response.column_values:
         attribute = column_value.attribute_name
@@ -280,6 +328,6 @@ def run_table_query(
     sentry_sdk.set_measurement("SearchResolver.result_size.final_data", len(final_data))
 
     if debug:
-        final_meta["query"] = json.loads(MessageToJson(rpc_request))
+        final_meta["query"] = json.loads(MessageToJson(table_request.rpc_request))
 
     return {"data": final_data, "meta": final_meta, "confidence": final_confidence}

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -51,14 +51,16 @@ def run_table_query(
     debug: bool = False,
 ) -> EAPResponse:
     return rpc_dataset_common.run_table_query(
-        query_string,
-        selected_columns,
-        orderby,
-        offset,
-        limit,
-        referrer,
-        sampling_mode,
-        search_resolver or get_resolver(params, config),
+        rpc_dataset_common.TableQuery(
+            query_string=query_string,
+            selected_columns=selected_columns,
+            orderby=orderby,
+            offset=offset,
+            limit=limit,
+            referrer=referrer,
+            sampling_mode=sampling_mode,
+            resolver=search_resolver or get_resolver(params, config),
+        ),
         debug,
     )
 

--- a/src/sentry/snuba/uptime_checks.py
+++ b/src/sentry/snuba/uptime_checks.py
@@ -9,7 +9,7 @@ from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.query_sources import QuerySource
-from sentry.snuba.rpc_dataset_common import run_table_query
+from sentry.snuba.rpc_dataset_common import TableQuery, run_table_query
 
 logger = logging.getLogger("sentry.snuba.uptime_checks")
 
@@ -51,18 +51,20 @@ def query(
     query_source: QuerySource | None = None,
 ) -> EventsResponse:
     return run_table_query(
-        query_string=query or "",
-        selected_columns=selected_columns,
-        orderby=orderby,
-        offset=offset or 0,
-        limit=limit,
-        referrer=referrer or "referrer unset",
-        sampling_mode=None,
-        resolver=get_resolver(
-            params=snuba_params,
-            config=SearchResolverConfig(
-                auto_fields=False,
-                use_aggregate_conditions=use_aggregate_conditions,
+        TableQuery(
+            query_string=query or "",
+            selected_columns=selected_columns,
+            orderby=orderby,
+            offset=offset or 0,
+            limit=limit,
+            referrer=referrer or "referrer unset",
+            sampling_mode=None,
+            resolver=get_resolver(
+                params=snuba_params,
+                config=SearchResolverConfig(
+                    auto_fields=False,
+                    use_aggregate_conditions=use_aggregate_conditions,
+                ),
             ),
-        ),
+        )
     )

--- a/tests/sentry/snuba/test_rpc_dataset_common.py
+++ b/tests/sentry/snuba/test_rpc_dataset_common.py
@@ -1,0 +1,63 @@
+import pytest
+
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.rpc_dataset_common import TableQuery, run_bulk_table_queries
+from sentry.snuba.spans_rpc import get_resolver
+from sentry.testutils.cases import TestCase
+
+
+class TestBulkTableQueries(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.snuba_params = SnubaParams()
+        self.config = SearchResolverConfig()
+        self.resolver = get_resolver(self.snuba_params, self.config)
+
+    def test_missing_name(self):
+        with pytest.raises(ValueError):
+            run_bulk_table_queries(
+                [
+                    TableQuery("test", ["test"], None, 0, 1, "TestReferrer", None, self.resolver),
+                    TableQuery(
+                        "test",
+                        ["test"],
+                        None,
+                        0,
+                        1,
+                        "TestReferrer",
+                        None,
+                        self.resolver,
+                        name="test",
+                    ),
+                ]
+            )
+
+    def test_duplicate_name(self):
+        with pytest.raises(ValueError):
+            run_bulk_table_queries(
+                [
+                    TableQuery(
+                        "test",
+                        ["test"],
+                        None,
+                        0,
+                        1,
+                        "TestReferrer",
+                        None,
+                        self.resolver,
+                        name="test",
+                    ),
+                    TableQuery(
+                        "test1",
+                        ["test1"],
+                        None,
+                        0,
+                        1,
+                        "TestReferrer",
+                        None,
+                        self.resolver,
+                        name="test",
+                    ),
+                ]
+            )


### PR DESCRIPTION
- This adds a way so that endpoints can construct multiple TableQueries and fire them off in parallel instead of individually