### PR TITLE
chore(issues): Scaffold experiment for MN+1 

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -419,6 +419,17 @@ class PerformanceMNPlusOneDBQueriesGroupType(PerformanceGroupTypeDefaults, Group
 
 
 @dataclass(frozen=True)
+class PerformanceMNPlusOneDBQueriesExperimentalGroupType(PerformanceGroupTypeDefaults, GroupType):
+    type_id = 1911
+    slug = "performance_m_n_plus_one_db_queries_experimental"
+    description = "MN+1 Query (Experimental)"
+    category = GroupCategory.PERFORMANCE.value
+    category_v2 = GroupCategory.DB_QUERY.value
+    default_priority = PriorityLevel.LOW
+    released = False
+
+
+@dataclass(frozen=True)
 class PerformanceUncompressedAssetsGroupType(PerformanceGroupTypeDefaults, GroupType):
     type_id = 1012
     slug = "performance_uncompressed_assets"

--- a/src/sentry/testutils/performance_issues/experiments.py
+++ b/src/sentry/testutils/performance_issues/experiments.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from sentry.testutils.cases import TestCase
+from sentry.utils.performance_issues.performance_detection import DETECTOR_CLASSES
+
+
+def exclude_experimental_detectors(cls: type[TestCase]):
+    """
+    Modifies the setUp method of a given TestCase to exclude any experimental detectors. It does so
+    by patching the DETECTOR_CLASSES variable, which is read by methods like `_detect_performance_problems`.
+
+    Use as a decorator for the TestCase class:
+    ```
+    @exclude_experimental_detectors
+    class SomeTestCase(TestCase):
+        ...
+    ```
+    """
+    cls_setUp = cls.setUp
+
+    def exclude_experimental_detectors_setUp(self, *args, **kwargs):
+        self.patch_detector_classes = patch(
+            "sentry.utils.performance_issues.performance_detection.DETECTOR_CLASSES",
+            [cls for cls in DETECTOR_CLASSES if "Experimental" not in cls.__name__],
+        )
+        self.patch_detector_classes.start()
+        self.addCleanup(self.patch_detector_classes.stop)
+        cls_setUp(self, *args, **kwargs)
+
+    cls.setUp = exclude_experimental_detectors_setUp
+    return cls

--- a/src/sentry/testutils/performance_issues/experiments.py
+++ b/src/sentry/testutils/performance_issues/experiments.py
@@ -27,5 +27,5 @@ def exclude_experimental_detectors(cls: type[TestCase]):
         self.addCleanup(self.patch_detector_classes.stop)
         cls_setUp(self, *args, **kwargs)
 
-    cls.setUp = exclude_experimental_detectors_setUp
+    cls.setUp = exclude_experimental_detectors_setUp  # type: ignore[method-assign]
     return cls

--- a/src/sentry/utils/performance_issues/base.py
+++ b/src/sentry/utils/performance_issues/base.py
@@ -31,6 +31,7 @@ class DetectorType(Enum):
     HTTP_OVERHEAD = "http_overhead"
     EXPERIMENTAL_N_PLUS_ONE_API_CALLS = "experimental_n_plus_one_api_calls"
     EXPERIMENTAL_N_PLUS_ONE_DB_QUERIES = "experimental_n_plus_one_db_queries"
+    EXPERIMENTAL_M_N_PLUS_ONE_DB_QUERIES = "experimental_m_n_plus_one_db_queries"
 
 
 # Detector and the corresponding system option must be added to this list to have issues created.

--- a/src/sentry/utils/performance_issues/detectors/experiments/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/mn_plus_one_db_span_detector.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from collections import deque
+from collections.abc import Sequence
+from typing import Any
+
+from sentry.issues.grouptype import (
+    PerformanceMNPlusOneDBQueriesExperimentalGroupType,
+    PerformanceNPlusOneExperimentalGroupType,
+)
+from sentry.issues.issue_occurrence import IssueEvidence
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.utils.performance_issues.base import (
+    DetectorType,
+    PerformanceDetector,
+    get_notification_attachment_body,
+    get_span_evidence_value,
+    total_span_time,
+)
+from sentry.utils.performance_issues.performance_problem import PerformanceProblem
+from sentry.utils.performance_issues.types import Span
+
+
+class MNPlusOneState(ABC):
+    """Abstract base class for the MNPlusOneDBSpanDetector state machine."""
+
+    @abstractmethod
+    def next(self, span: Span) -> tuple[MNPlusOneState, PerformanceProblem | None]:
+        raise NotImplementedError
+
+    def finish(self) -> PerformanceProblem | None:
+        return None
+
+    def _equivalent(self, a: Span, b: Span) -> bool:
+        """db spans are equivalent if their ops and hashes match. Other spans are
+        equivalent if their ops match."""
+        first_op = a.get("op") or None
+        second_op = b.get("op") or None
+        if not first_op or not second_op or first_op != second_op:
+            return False
+
+        if first_op.startswith("db"):
+            return a.get("hash") == b.get("hash")
+
+        return True
+
+
+class SearchingForMNPlusOne(MNPlusOneState):
+    """
+    The initial state for the MN+1 DB Query detector, and the state we return to
+    whenever there is no active repeating pattern being checked.
+
+    Keeps a list of recently seen spans until a repeat is found, at which point
+    it transitions to the ContinuingMNPlusOne state.
+    """
+
+    __slots__ = ("settings", "event", "recent_spans")
+
+    def __init__(
+        self,
+        settings: dict[str, Any],
+        event: dict[str, Any],
+        initial_spans: Sequence[Span] | None = None,
+    ) -> None:
+        self.settings = settings
+        self.event = event
+        self.recent_spans = deque(initial_spans or [], self.settings["max_sequence_length"])
+
+    def next(self, span: Span) -> tuple[MNPlusOneState, PerformanceProblem | None]:
+        # Can't be a potential MN+1 without at least 2 previous spans.
+        if len(self.recent_spans) <= 1:
+            self.recent_spans.append(span)
+            return (self, None)
+
+        # Has an MN pattern begun to repeat itself? If so, transition to the
+        # ContinuingMNPlusOne state.
+        # Convert the recent_spans deque into a list for slicing. Skip the last
+        # item in the list because that would find an N+1 instead.
+        recent_span_list = list(self.recent_spans)
+        for i, recent_span in enumerate(recent_span_list[:-1]):
+            if self._equivalent(span, recent_span):
+                pattern = recent_span_list[i:]
+                if self._is_valid_pattern(pattern):
+                    return (ContinuingMNPlusOne(self.settings, self.event, pattern, span), None)
+
+        # We haven't found a pattern yet, so remember this span and keep
+        # looking.
+        self.recent_spans.append(span)
+        return (self, None)
+
+    def _is_valid_pattern(self, pattern: Sequence[Span]) -> bool:
+        """A valid pattern contains at least one db operation and is not all equivalent."""
+        found_db_op = False
+        found_different_span = False
+
+        for span in pattern:
+            op = span.get("op") or ""
+            description = span.get("description") or ""
+            found_db_op = found_db_op or bool(
+                op.startswith("db")
+                and not op.startswith("db.redis")
+                and description
+                and not description.endswith("...")
+            )
+            found_different_span = found_different_span or not self._equivalent(pattern[0], span)
+            if found_db_op and found_different_span:
+                return True
+
+        return False
+
+
+class ContinuingMNPlusOne(MNPlusOneState):
+    """
+    The state for when we think we might have found a pattern: a sequence of
+    spans that has begun to repeat.
+
+    When the sequence is broken (either by a mismatched span or span iteration
+    finishing), returns to the SearchingMNPlusOne state, possibly returning a
+    PerformanceProblem if the detected sequence met our thresholds.
+    """
+
+    __slots__ = ("settings", "event", "pattern", "spans", "pattern_index")
+
+    def __init__(
+        self, settings: dict[str, Any], event: dict[str, Any], pattern: list[Span], first_span: Span
+    ) -> None:
+        self.settings = settings
+        self.event = event
+        self.pattern = pattern
+
+        # The full list of spans involved in the MN pattern.
+        self.spans = pattern.copy()
+        self.spans.append(first_span)
+        self.pattern_index = 1
+
+    def next(self, span: Span) -> tuple[MNPlusOneState, PerformanceProblem | None]:
+        # If the MN pattern is continuing, carry on in this state.
+        pattern_span = self.pattern[self.pattern_index]
+        if self._equivalent(pattern_span, span):
+            self.spans.append(span)
+            self.pattern_index += 1
+            if self.pattern_index >= len(self.pattern):
+                self.pattern_index = 0
+            return (self, None)
+
+        # We've broken the MN pattern, so return to the Searching state. If it
+        # is a significant problem, also return a PerformanceProblem.
+        times_occurred = int(len(self.spans) / len(self.pattern))
+        start_index = len(self.pattern) * times_occurred
+        remaining_spans = self.spans[start_index:] + [span]
+        return (
+            SearchingForMNPlusOne(self.settings, self.event, remaining_spans),
+            self._maybe_performance_problem(),
+        )
+
+    def finish(self) -> PerformanceProblem | None:
+        return self._maybe_performance_problem()
+
+    def _maybe_performance_problem(self) -> PerformanceProblem | None:
+        times_occurred = int(len(self.spans) / len(self.pattern))
+        minimum_occurrences_of_pattern = self.settings["minimum_occurrences_of_pattern"]
+        if times_occurred < minimum_occurrences_of_pattern:
+            return None
+
+        offender_span_count = len(self.pattern) * times_occurred
+        offender_spans = self.spans[:offender_span_count]
+
+        # Consider all spans when evaluating the duration threshold, however at least 10 percent
+        # of the total duration of offenders should be from db spans.
+        total_duration_threshold = self.settings["total_duration_threshold"]
+        total_spans_duration = total_span_time(offender_spans)
+
+        offender_db_spans = [span for span in offender_spans if span["op"].startswith("db")]
+        total_db_spans_duration = total_span_time(offender_db_spans)
+        pct_db_spans = total_db_spans_duration / total_spans_duration if total_spans_duration else 0
+
+        if total_spans_duration < total_duration_threshold or pct_db_spans < 0.1:
+            return None
+
+        parent_span = self._find_common_parent_span(offender_spans)
+        if not parent_span:
+            return None
+
+        db_span = self._first_db_span()
+        if not db_span:
+            return None
+        return PerformanceProblem(
+            fingerprint=self._fingerprint(db_span["hash"], parent_span),
+            op="db",
+            desc=db_span["description"],
+            type=PerformanceNPlusOneExperimentalGroupType,
+            parent_span_ids=[parent_span["span_id"]],
+            cause_span_ids=[],
+            offender_span_ids=[span["span_id"] for span in offender_spans],
+            evidence_data={
+                "op": "db",
+                "parent_span_ids": [parent_span["span_id"]],
+                "cause_span_ids": [],
+                "offender_span_ids": [span["span_id"] for span in offender_spans],
+                "transaction_name": self.event.get("transaction", ""),
+                "parent_span": get_span_evidence_value(parent_span),
+                "repeating_spans": get_span_evidence_value(offender_spans[0]),
+                "repeating_spans_compact": get_span_evidence_value(
+                    offender_spans[0], include_op=False
+                ),
+                "number_repeating_spans": str(len(offender_spans)),
+            },
+            evidence_display=[
+                IssueEvidence(
+                    name="Offending Spans",
+                    value=get_notification_attachment_body(
+                        "db",
+                        db_span["description"],
+                    ),
+                    # Has to be marked important to be displayed in the notifications
+                    important=True,
+                )
+            ],
+        )
+
+    def _first_db_span(self) -> Span | None:
+        for span in self.spans:
+            if span["op"].startswith("db"):
+                return span
+        return None
+
+    def _find_common_parent_span(self, spans: Sequence[Span]) -> Span | None:
+        parent_span_id = spans[0].get("parent_span_id")
+        if not parent_span_id:
+            return None
+        for id in [span.get("parent_span_id") for span in spans[1:]]:
+            if not id or id != parent_span_id:
+                return None
+
+        all_spans = self.event.get("spans") or []
+        for span in all_spans:
+            if span.get("span_id") == parent_span_id:
+                return span
+        return None
+
+    def _fingerprint(self, db_hash: str, parent_span: Span) -> str:
+        parent_op = parent_span.get("op") or ""
+        parent_hash = parent_span.get("hash") or ""
+        full_fingerprint = hashlib.sha1(
+            (parent_op + parent_hash + db_hash).encode("utf8")
+        ).hexdigest()
+        return f"1-{PerformanceMNPlusOneDBQueriesExperimentalGroupType.type_id}-{full_fingerprint}"
+
+
+class MNPlusOneDBSpanExperimentalDetector(PerformanceDetector):
+    """
+    Detects N+1 DB query issues where the repeated query is interspersed with
+    other spans (which may or may not be other queries) that all repeat together
+    (hence, MN+1).
+
+    Currently does not consider parent or source spans, and only looks for a
+    repeating pattern of spans (A B C A B C etc).
+
+    Uses a small state machine internally.
+    """
+
+    __slots__ = ("stored_problems", "state")
+
+    type = DetectorType.EXPERIMENTAL_M_N_PLUS_ONE_DB_QUERIES
+    settings_key = DetectorType.EXPERIMENTAL_M_N_PLUS_ONE_DB_QUERIES
+
+    def __init__(self, settings: dict[DetectorType, Any], event: dict[str, Any]) -> None:
+        super().__init__(settings, event)
+
+        self.stored_problems = {}
+        self.state: MNPlusOneState = SearchingForMNPlusOne(self.settings, self.event())
+
+    @classmethod
+    def is_detection_allowed_for_system(cls) -> bool:
+        # Defer to the issue platform for whether to create issues
+        # See https://develop.sentry.dev/backend/issue-platform/#releasing-your-issue-type
+        return True
+
+    def is_creation_allowed_for_organization(self, organization: Organization | None) -> bool:
+        return True
+
+    def is_creation_allowed_for_project(self, project: Project) -> bool:
+        return self.settings["detection_enabled"]
+
+    def visit_span(self, span: Span) -> None:
+        self.state, performance_problem = self.state.next(span)
+        if performance_problem:
+            self.stored_problems[performance_problem.fingerprint] = performance_problem
+
+    def on_complete(self) -> None:
+        if performance_problem := self.state.finish():
+            self.stored_problems[performance_problem.fingerprint] = performance_problem

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -17,6 +17,9 @@ from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION
 from sentry.utils import metrics
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.event_frames import get_sdk_name
+from sentry.utils.performance_issues.detectors.experiments.mn_plus_one_db_span_detector import (
+    MNPlusOneDBSpanExperimentalDetector,
+)
 from sentry.utils.performance_issues.detectors.experiments.n_plus_one_db_span_detector import (
     NPlusOneDBSpanExperimentalDetector,
 )
@@ -295,6 +298,12 @@ def get_detection_settings(project_id: int | None = None) -> dict[DetectorType, 
             "max_sequence_length": 5,
             "detection_enabled": settings["n_plus_one_db_queries_detection_enabled"],
         },
+        DetectorType.EXPERIMENTAL_M_N_PLUS_ONE_DB_QUERIES: {
+            "total_duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
+            "minimum_occurrences_of_pattern": 3,
+            "max_sequence_length": 5,
+            "detection_enabled": settings["n_plus_one_db_queries_detection_enabled"],
+        },
         DetectorType.UNCOMPRESSED_ASSETS: {
             "size_threshold_bytes": settings["uncompressed_asset_size_threshold"],
             "duration_threshold": settings["uncompressed_asset_duration_threshold"],  # ms
@@ -335,6 +344,7 @@ DETECTOR_CLASSES: list[type[PerformanceDetector]] = [
     NPlusOneAPICallsDetector,
     NPlusOneAPICallsExperimentalDetector,
     MNPlusOneDBSpanDetector,
+    MNPlusOneDBSpanExperimentalDetector,
     UncompressedAssetSpanDetector,
     LargeHTTPPayloadDetector,
     HTTPOverheadDetector,

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -10,20 +10,14 @@ from sentry.models.release import Release
 from sentry.spans.consumers.process_segments.message import process_segment
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.utils.performance_issues.performance_detection import DETECTOR_CLASSES
+from sentry.testutils.performance_issues.experiments import exclude_experimental_detectors
 from tests.sentry.spans.consumers.process import build_mock_span
 
 
+@exclude_experimental_detectors
 class TestSpansTask(TestCase):
     def setUp(self):
         self.project = self.create_project()
-        # Exclude experimental detectors from _detect_performance_problems in this test suite
-        self.patch_detector_classes = mock.patch(
-            "sentry.utils.performance_issues.performance_detection.DETECTOR_CLASSES",
-            [cls for cls in DETECTOR_CLASSES if "Experimental" not in cls.__name__],
-        )
-        self.patch_detector_classes.start()
-        self.addCleanup(self.patch_detector_classes.stop)
 
     def generate_basic_spans(self):
         segment_span = build_mock_span(

--- a/tests/sentry/utils/performance_issues/experiments/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/experiments/test_m_n_plus_one_db_detector.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock, call
+
+import pytest
+
+from sentry.issues.grouptype import (
+    PerformanceMNPlusOneDBQueriesExperimentalGroupType,
+    PerformanceNPlusOneExperimentalGroupType,
+)
+from sentry.models.options.project_option import ProjectOption
+from sentry.testutils.cases import TestCase
+from sentry.testutils.performance_issues.event_generators import get_event
+from sentry.utils.performance_issues.base import DetectorType
+from sentry.utils.performance_issues.detectors.experiments.mn_plus_one_db_span_detector import (
+    MNPlusOneDBSpanExperimentalDetector,
+)
+from sentry.utils.performance_issues.performance_detection import (
+    _detect_performance_problems,
+    get_detection_settings,
+    run_detector_on_data,
+)
+from sentry.utils.performance_issues.performance_problem import PerformanceProblem
+
+
+@pytest.mark.django_db
+class MNPlusOneDBDetectorTest(TestCase):
+    detector = MNPlusOneDBSpanExperimentalDetector
+    fingerprint_type_id = PerformanceMNPlusOneDBQueriesExperimentalGroupType.type_id
+    group_type = PerformanceNPlusOneExperimentalGroupType
+
+    def setUp(self):
+        super().setUp()
+        self._settings = get_detection_settings()
+
+    def find_problems(
+        self, event: dict[str, Any], settings: dict[DetectorType, Any] | None = None
+    ) -> list[PerformanceProblem]:
+        detector_settings = settings or self._settings
+        detector = self.detector(detector_settings, event)
+        run_detector_on_data(detector, event)
+        return list(detector.stored_problems.values())
+
+    def test_detects_parallel_m_n_plus_one(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
+
+        problems = self.find_problems(event)
+        assert problems == [
+            PerformanceProblem(
+                fingerprint=f"1-{self.fingerprint_type_id}-6807a9d5bedb6fdb175b006448cddf8cdf18fbd8",
+                op="db",
+                type=self.group_type,
+                desc="SELECT id, name FROM authors INNER JOIN book_authors ON author_id = id WHERE book_id = $1",
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=[
+                    "9c5049407f37a364",
+                    "ad1453eb469473f5",
+                    "9ac8fee795f25a28",
+                    "aacda642ff6787c0",
+                    "b231fb2367a40bb2",
+                    "9abcfbac864d1b09",
+                    "a4acb0c08f6c5392",
+                    "a1dbea4273c7a8cf",
+                    "b8467be28b0edef0",
+                    "9677584719fa33f9",
+                    "8c6aa95b24d15772",
+                    "be7d04a1731d5d10",
+                    "baa57006cb44092a",
+                    "a383cd625dff4809",
+                    "9c48fda36f28cb0a",
+                    "82253694a3a68c93",
+                    "8831cccebb865893",
+                    "a2339eabb5c4cf07",
+                    "8ea362c64d8b9fd9",
+                    "b8f8a99b783f7b48",
+                    "87a6041001b4e8f6",
+                    "ab99c67643fd85cf",
+                    "a96783f2f544024a",
+                    "8e110c4aa54e4aa0",
+                ],
+                evidence_data={
+                    "op": "db",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": [
+                        "9c5049407f37a364",
+                        "ad1453eb469473f5",
+                        "9ac8fee795f25a28",
+                        "aacda642ff6787c0",
+                        "b231fb2367a40bb2",
+                        "9abcfbac864d1b09",
+                        "a4acb0c08f6c5392",
+                        "a1dbea4273c7a8cf",
+                        "b8467be28b0edef0",
+                        "9677584719fa33f9",
+                        "8c6aa95b24d15772",
+                        "be7d04a1731d5d10",
+                        "baa57006cb44092a",
+                        "a383cd625dff4809",
+                        "9c48fda36f28cb0a",
+                        "82253694a3a68c93",
+                        "8831cccebb865893",
+                        "a2339eabb5c4cf07",
+                        "8ea362c64d8b9fd9",
+                        "b8f8a99b783f7b48",
+                        "87a6041001b4e8f6",
+                        "ab99c67643fd85cf",
+                        "a96783f2f544024a",
+                        "8e110c4aa54e4aa0",
+                    ],
+                },
+                evidence_display=[],
+            )
+        ]
+        assert problems[0].title == "N+1 Query (Experimental)"
+
+    def test_does_not_detect_truncated_m_n_plus_one(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql-truncated")
+        assert self.find_problems(event) == []
+
+    def test_does_not_detect_n_plus_one(self):
+        event = get_event("n-plus-one-in-django-index-view")
+        assert self.find_problems(event) == []
+
+    def test_does_not_detect_when_parent_is_transaction(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql-transaction-parent")
+        assert self.find_problems(event) == []
+
+    def test_m_n_plus_one_detector_enabled(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
+        sdk_span_mock = Mock()
+        _detect_performance_problems(event, sdk_span_mock, self.create_project())
+        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
+            [
+                # Current + Experimental Detector
+                call("_pi_all_issue_count", 2),
+                call("_pi_sdk_name", "sentry.javascript.node"),
+                call("is_standalone_spans", False),
+                call("_pi_transaction", "3818ae4f54ba4fa6ac6f68c9e32793c4"),
+                # Current Detector
+                call("_pi_m_n_plus_one_db_fp", "1-1011-6807a9d5bedb6fdb175b006448cddf8cdf18fbd8"),
+                call("_pi_m_n_plus_one_db", "9c5049407f37a364"),
+                # Experimental Detector
+                call(
+                    "_pi_experimental_m_n_plus_one_db_queries_fp",
+                    f"1-{self.fingerprint_type_id}-6807a9d5bedb6fdb175b006448cddf8cdf18fbd8",
+                ),
+                call("_pi_experimental_m_n_plus_one_db_queries", "9c5049407f37a364"),
+            ]
+        )
+
+    def test_m_n_plus_one_does_not_include_extra_span(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-off-by-one")
+        assert self.find_problems(event) == []
+
+    def test_m_n_plus_one_ignores_redis(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-redis")
+        assert self.find_problems(event) == []
+
+    def test_m_n_plus_one_ignores_mostly_not_db(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-mostly-http")
+        assert self.find_problems(event) == []
+
+    def test_respects_project_option(self):
+        project = self.create_project()
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
+        event["project_id"] = project.id
+
+        settings = get_detection_settings(project.id)
+        detector = self.detector(settings, event)
+
+        assert detector.is_creation_allowed_for_project(project)
+
+        ProjectOption.objects.set_value(
+            project=project,
+            key="sentry:performance_issue_settings",
+            value={"n_plus_one_db_queries_detection_enabled": False},
+        )
+
+        settings = get_detection_settings(project.id)
+        detector = self.detector(settings, event)
+
+        assert not detector.is_creation_allowed_for_project(project)
+
+    def test_respects_n_plus_one_db_duration_threshold(self):
+        project = self.create_project()
+
+        # Total duration subceeds the threshold
+        ProjectOption.objects.set_value(
+            project=project,
+            key="sentry:performance_issue_settings",
+            value={"n_plus_one_db_duration_threshold": 500},
+        )
+
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
+        event["project_id"] = project.id
+
+        settings = get_detection_settings(project_id=project.id)
+        assert self.find_problems(event, settings) == []
+
+        # Total duration exceeds the threshold
+        ProjectOption.objects.set_value(
+            project=project,
+            key="sentry:performance_issue_settings",
+            value={"n_plus_one_db_duration_threshold": 100},
+        )
+
+        settings = get_detection_settings(project_id=project.id)
+        assert len(self.find_problems(event, settings)) == 1
+
+    # The mocked event has span duration that doesn't make up at least 10% of the total offender spans duration.
+    def test_db_spans_duration_subceeds_pct(self):
+        event = get_event("m-n-plus-one-db/m-n-plus-one-db-spans-duration-suceeds")
+        assert self.find_problems(event) == []

--- a/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/utils/performance_issues/test_m_n_plus_one_db_detector.py
@@ -9,6 +9,7 @@ from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TestCase
 from sentry.testutils.performance_issues.event_generators import get_event
+from sentry.testutils.performance_issues.experiments import exclude_experimental_detectors
 from sentry.utils.performance_issues.base import DetectorType
 from sentry.utils.performance_issues.detectors.mn_plus_one_db_span_detector import (
     MNPlusOneDBSpanDetector,
@@ -22,6 +23,7 @@ from sentry.utils.performance_issues.performance_problem import PerformanceProbl
 
 
 @pytest.mark.django_db
+@exclude_experimental_detectors
 class MNPlusOneDBDetectorTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -14,12 +14,12 @@ from sentry.issues.grouptype import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.performance_issues.event_generators import get_event
+from sentry.testutils.performance_issues.experiments import exclude_experimental_detectors
 from sentry.utils.performance_issues.base import DetectorType, total_span_time
 from sentry.utils.performance_issues.detectors.n_plus_one_db_span_detector import (
     NPlusOneDBSpanDetector,
 )
 from sentry.utils.performance_issues.performance_detection import (
-    DETECTOR_CLASSES,
     EventPerformanceProblem,
     _detect_performance_problems,
     detect_performance_problems,
@@ -83,6 +83,7 @@ def assert_n_plus_one_db_problem(perf_problems):
 
 
 @pytest.mark.django_db
+@exclude_experimental_detectors
 class PerformanceDetectionTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -100,13 +101,6 @@ class PerformanceDetectionTest(TestCase):
         self.addCleanup(patch_organization.stop)
 
         self.project = self.create_project()
-        # Exclude experimental detectors from detection in this test suite
-        self.patch_detector_classes = patch(
-            "sentry.utils.performance_issues.performance_detection.DETECTOR_CLASSES",
-            [cls for cls in DETECTOR_CLASSES if "Experimental" not in cls.__name__],
-        )
-        self.patch_detector_classes.start()
-        self.addCleanup(self.patch_detector_classes.stop)
 
     @patch("sentry.utils.performance_issues.performance_detection._detect_performance_problems")
     def test_options_disabled(self, mock):


### PR DESCRIPTION
Another experiment, this time for MN+1.

After chatting with @gggritso I have a way of applying the logical changes from https://github.com/getsentry/sentry/pull/90862 as an experiment rather than spinning a whole new detector, so this PR sets that up. My changes will allow the MN+1 detector to catch Prisma client N+1s and more generically, other clients as well.  Here's [the change if you're curious](https://github.com/getsentry/sentry/commit/766c1b2b548022a6808de22b5b7fc22f8a5291f9).

TBH this process for rolling experiments is very cumbersome and easy to mess up, not loving it but focusing on improving the actual detectors instead of the workflow at the moment.