### PR TITLE
chore(autofix): Don't wait for autofix state to load in sidebar unless group has run

### DIFF
--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {SeerIcon} from 'sentry/components/ai/SeerIcon';
 import {Tooltip} from 'sentry/components/core/tooltip';
-import {AUTOFIX_TTL_IN_DAYS} from 'sentry/components/events/autofix/types';
+import {getAutofixRunExists} from 'sentry/components/events/autofix/utils';
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import ShortId from 'sentry/components/group/inboxBadges/shortId';
@@ -78,18 +78,10 @@ function EventOrGroupExtraDetails({data, showAssignee, showLifetime = true}: Pro
     data.issueCategory &&
     !!getReplayCountForIssue(data.id, data.issueCategory);
 
-  const seerAutofixLastTriggered = (data as Group).seerAutofixLastTriggered;
-  const autofixLastRunAsDate = seerAutofixLastTriggered
-    ? new Date(seerAutofixLastTriggered)
-    : null;
-  const autofixRanWithinTtl = autofixLastRunAsDate
-    ? autofixLastRunAsDate >
-      new Date(Date.now() - AUTOFIX_TTL_IN_DAYS * 24 * 60 * 60 * 1000)
-    : false;
   const showSeer =
     organization.features.includes('gen-ai-features') &&
     !organization.hideAiFeatures &&
-    autofixRanWithinTtl;
+    getAutofixRunExists(data as Group);
 
   const {subtitle} = getTitle(data);
 

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -1,11 +1,13 @@
 import {formatRootCauseText} from 'sentry/components/events/autofix/autofixRootCause';
 import {formatSolutionText} from 'sentry/components/events/autofix/autofixSolution';
 import {
+  AUTOFIX_TTL_IN_DAYS,
   type AutofixCodebaseChange,
   type AutofixData,
   AutofixStatus,
   AutofixStepType,
 } from 'sentry/components/events/autofix/types';
+import type {Group} from 'sentry/types/group';
 
 export function getRootCauseDescription(autofixData: AutofixData) {
   const rootCause = autofixData.steps?.find(
@@ -168,4 +170,16 @@ export function getAutofixProgressDetails(
   return {
     overallProgress: progress,
   };
+}
+
+export function getAutofixRunExists(group: Group) {
+  const autofixLastRunAsDate = group.seerAutofixLastTriggered
+    ? new Date(group.seerAutofixLastTriggered)
+    : null;
+  const autofixRanWithinTtl = autofixLastRunAsDate
+    ? autofixLastRunAsDate >
+      new Date(Date.now() - AUTOFIX_TTL_IN_DAYS * 24 * 60 * 60 * 1000)
+    : false;
+
+  return autofixRanWithinTtl;
 }

--- a/static/app/components/group/groupSummaryWithAutofix.tsx
+++ b/static/app/components/group/groupSummaryWithAutofix.tsx
@@ -5,6 +5,7 @@ import {motion} from 'framer-motion';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {useAutofixData} from 'sentry/components/events/autofix/useAutofix';
 import {
+  getAutofixRunExists,
   getCodeChangesDescription,
   getCodeChangesIsLoading,
   getRootCauseCopyText,
@@ -100,7 +101,7 @@ export function GroupSummaryWithAutofix({
     [autofixData]
   );
 
-  if (isPending) {
+  if (isPending && getAutofixRunExists(group)) {
     return <Placeholder height="130px" />;
   }
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -9,6 +9,7 @@ import {
   AutofixStepType,
 } from 'sentry/components/events/autofix/types';
 import {useAiAutofix, useAutofixData} from 'sentry/components/events/autofix/useAutofix';
+import {getAutofixRunExists} from 'sentry/components/events/autofix/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import {IconChevron} from 'sentry/icons';
@@ -135,7 +136,8 @@ export function SeerSectionCtaButton({
     aiConfig.needsGenAiAcknowledgement ||
     aiConfig.hasAutofix ||
     (aiConfig.hasSummary && aiConfig.hasResources);
-  const isButtonLoading = aiConfig.isAutofixSetupLoading || isAutofixPending;
+  const isButtonLoading =
+    aiConfig.isAutofixSetupLoading || (isAutofixPending && getAutofixRunExists(group));
 
   const lastStep = autofixData?.steps?.[autofixData.steps.length - 1];
   const isAutofixInProgress = lastStep?.status === AutofixStatus.PROCESSING;


### PR DESCRIPTION
Refactors the check we have in the issue stream on whether or not we have an autofix run for an issue into a reusable util.

Uses this to skip the wait for loading the autofix state in the sidebar on issues that don't have a run. This speeds up loading time a lot.