### PR TITLE
feat(workflow): Normalize monitor/automation pathnames

### DIFF
--- a/static/app/components/workflowEngine/gridCell/connectionCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/connectionCell.tsx
@@ -8,6 +8,9 @@ import Link from 'sentry/components/links/link';
 import {EmptyCell} from 'sentry/components/workflowEngine/gridCell/emptyCell';
 import {tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 export type ConnectionCellProps = {
   ids: string[];
@@ -20,9 +23,12 @@ const labels: Record<ConnectionCellProps['type'], (n: number) => string> = {
   detector: count => tn('%s monitor', '%s monitors', count),
   workflow: count => tn('%s automation', '%s automations', count),
 };
-const links: Record<ConnectionCellProps['type'], (id: string) => string> = {
-  detector: id => `/issues/monitors/${id}/`,
-  workflow: id => `/issues/automations/${id}/`,
+const links: Record<
+  ConnectionCellProps['type'],
+  (orgSlug: string, id: string) => string
+> = {
+  detector: (orgSlug, id) => makeMonitorDetailsPathname(orgSlug, id),
+  workflow: (orgSlug, id) => makeAutomationDetailsPathname(orgSlug, id),
 };
 
 export function ConnectionCell({
@@ -46,10 +52,12 @@ export function ConnectionCell({
 
 function Overlay(props: ConnectionCellProps) {
   const {ids, type} = props;
+  const organization = useOrganization();
+
   const createLink = links[type];
   // TODO(natemoo-re): fetch data for each id
   return ids.map((id, index) => {
-    const link = createLink(id);
+    const link = createLink(organization.slug, id);
     const description = 'description';
     return (
       <Fragment key={id}>

--- a/static/app/components/workflowEngine/gridCell/index.spec.tsx
+++ b/static/app/components/workflowEngine/gridCell/index.spec.tsx
@@ -66,7 +66,10 @@ describe('Connection Cell Component', function () {
     const overlay = await screen.findByRole('link');
     expect(overlay).toBeInTheDocument();
     expect(overlay).toHaveAttribute('href');
-    expect(overlay).toHaveAttribute('href', '/issues/monitors/12345/');
+    expect(overlay).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/monitors/12345/'
+    );
   });
 
   it('renders workflow hovercard', async function () {
@@ -78,7 +81,10 @@ describe('Connection Cell Component', function () {
     const overlay = await screen.findByRole('link');
     expect(overlay).toBeInTheDocument();
     expect(overlay).toHaveAttribute('href');
-    expect(overlay).toHaveAttribute('href', '/issues/automations/12345/');
+    expect(overlay).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/automations/12345/'
+    );
   });
 });
 

--- a/static/app/views/automations/components/automationListRow.tsx
+++ b/static/app/views/automations/components/automationListRow.tsx
@@ -12,7 +12,7 @@ import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useAutomationActions} from 'sentry/views/automations/hooks/utils';
-import {makeAutomationDetailsUrl} from 'sentry/views/automations/makeAutomationDetailsUrl';
+import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
 
 type AutomationListRowProps = {
   automation: Automation;
@@ -39,7 +39,7 @@ export function AutomationListRow({
           }}
         />
         <CellWrapper>
-          <TitleCell to={makeAutomationDetailsUrl(organization.slug, id)}>
+          <TitleCell to={makeAutomationDetailsPathname(organization.slug, id)}>
             {name}
           </TitleCell>
         </CellWrapper>

--- a/static/app/views/automations/components/automationListRow.tsx
+++ b/static/app/views/automations/components/automationListRow.tsx
@@ -10,8 +10,9 @@ import {ConnectionCell} from 'sentry/components/workflowEngine/gridCell/connecti
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useAutomationActions} from 'sentry/views/automations/hooks/utils';
-import {AUTOMATIONS_BASE_URL} from 'sentry/views/automations/routes';
+import {makeAutomationDetailsUrl} from 'sentry/views/automations/makeAutomationDetailsUrl';
 
 type AutomationListRowProps = {
   automation: Automation;
@@ -24,6 +25,7 @@ export function AutomationListRow({
   handleSelect,
   selected,
 }: AutomationListRowProps) {
+  const organization = useOrganization();
   const actions = useAutomationActions(automation);
   const {id, name, disabled, lastTriggered, detectorIds = []} = automation;
   return (
@@ -37,7 +39,9 @@ export function AutomationListRow({
           }}
         />
         <CellWrapper>
-          <TitleCell to={`${AUTOMATIONS_BASE_URL}/${id}/`}>{name}</TitleCell>
+          <TitleCell to={makeAutomationDetailsUrl(organization.slug, id)}>
+            {name}
+          </TitleCell>
         </CellWrapper>
       </Flex>
       <CellWrapper className="last-triggered">

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -7,7 +7,8 @@ import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpl
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
-import {MONITORS_BASE_URL} from 'sentry/views/detectors/routes';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 type Props = {
   monitors: Detector[];
@@ -20,13 +21,14 @@ export default function ConnectedMonitorsList({
   connectedMonitorIds,
   toggleConnected,
 }: Props) {
-  const canEdit = connectedMonitorIds && toggleConnected;
+  const organization = useOrganization();
+  const canEdit = connectedMonitorIds && !!toggleConnected;
 
   const data = monitors.map(monitor => ({
     title: {
       name: monitor.name,
       projectId: monitor.projectId,
-      link: `${MONITORS_BASE_URL}/${monitor.id}/`,
+      link: makeMonitorDetailsPathname(organization.slug, monitor.id),
     },
     type: monitor.type,
     lastIssue: undefined, // TODO: call API to get last issue

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -16,9 +16,11 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import AutomationHistoryList from 'sentry/views/automations/components/automationHistoryList';
 import ConditionsPanel from 'sentry/views/automations/components/conditionsPanel';
 import ConnectedMonitorsList from 'sentry/views/automations/components/connectedMonitorsList';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 function HistoryAndConnectedMonitors() {
   return (
@@ -80,11 +82,17 @@ function Details() {
 }
 
 export default function AutomationDetail() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
     <SentryDocumentTitle title={t('Automation')} noSuffix>
-      <BreadcrumbsProvider crumb={{label: t('Automations'), to: '/issues/automations'}}>
+      <BreadcrumbsProvider
+        crumb={{
+          label: t('Automations'),
+          to: makeAutomationBasePathname(organization.slug),
+        }}
+      >
         <ActionsProvider actions={<Actions />}>
           <DetailLayout>
             <DetailLayout.Main>

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -8,13 +8,21 @@ import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/bread
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 export default function AutomationEdit() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
     <SentryDocumentTitle title={t('Edit Automation')} noSuffix>
-      <BreadcrumbsProvider crumb={{label: t('Automations'), to: '/issues/automations'}}>
+      <BreadcrumbsProvider
+        crumb={{
+          label: t('Automations'),
+          to: makeAutomationBasePathname(organization.slug),
+        }}
+      >
         <ActionsProvider actions={<Actions />}>
           <EditLayout>
             <h2>Edit Automation</h2>

--- a/static/app/views/automations/layouts/new.tsx
+++ b/static/app/views/automations/layouts/new.tsx
@@ -4,12 +4,20 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 export default function NewAutomationLayout({children}: {children: React.ReactNode}) {
+  const organization = useOrganization();
   const [title, setTitle] = useState(t('New Automation'));
   return (
     <SentryDocumentTitle title={title} noSuffix>
-      <BreadcrumbsProvider crumb={{label: t('Automations'), to: '/issues/automations'}}>
+      <BreadcrumbsProvider
+        crumb={{
+          label: t('Automations'),
+          to: makeAutomationBasePathname(organization.slug),
+        }}
+      >
         <EditLayout onTitleChange={value => setTitle(value)}>{children}</EditLayout>
       </BreadcrumbsProvider>
     </SentryDocumentTitle>

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -11,7 +11,9 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import AutomationListTable from 'sentry/views/automations/components/automationListTable';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 export default function AutomationsList() {
   useWorkflowEngineFeatureGate({redirect: true});
@@ -40,10 +42,11 @@ function TableHeader() {
 }
 
 function Actions() {
+  const organization = useOrganization();
   return (
     <Fragment>
       <LinkButton
-        to="/issues/automations/new/"
+        to={`${makeAutomationBasePathname(organization.slug)}new/`}
         priority="primary"
         icon={<IconAdd isCircled />}
       >

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -7,10 +7,13 @@ import {
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import AutomationForm from 'sentry/views/automations/components/automationForm';
 import NewAutomationLayout from 'sentry/views/automations/layouts/new';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 export default function AutomationNewSettings() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
@@ -19,7 +22,10 @@ export default function AutomationNewSettings() {
       <StickyFooter>
         <StickyFooterLabel>{t('Step 2 of 2')}</StickyFooterLabel>
         <Flex gap={space(1)}>
-          <LinkButton priority="default" to="/issues/automations/new/">
+          <LinkButton
+            priority="default"
+            to={`${makeAutomationBasePathname(organization.slug)}new/`}
+          >
             {t('Back')}
           </LinkButton>
           <Button priority="primary">{t('Create Automation')}</Button>

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -11,10 +11,13 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import EditConnectedMonitors from 'sentry/views/automations/components/editConnectedMonitors';
 import NewAutomationLayout from 'sentry/views/automations/layouts/new';
+import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
 
 export default function AutomationNew() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
@@ -32,7 +35,10 @@ export default function AutomationNew() {
       <StyledStickyFooter>
         <StickyFooterLabel>{t('Step 1 of 2')}</StickyFooterLabel>
         <Flex gap={space(1)}>
-          <LinkButton priority="default" to="/issues/automations">
+          <LinkButton
+            priority="default"
+            to={makeAutomationBasePathname(organization.slug)}
+          >
             {t('Cancel')}
           </LinkButton>
           <LinkButton priority="primary" to="settings">

--- a/static/app/views/automations/pathnames.tsx
+++ b/static/app/views/automations/pathnames.tsx
@@ -1,0 +1,9 @@
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+export const makeAutomationBasePathname = (orgSlug: string) => {
+  return normalizeUrl(`/organizations/${orgSlug}/issues/automations/`);
+};
+
+export const makeAutomationDetailsPathname = (orgSlug: string, automationId: string) => {
+  return normalizeUrl(`/organizations/${orgSlug}/issues/automations/${automationId}/`);
+};

--- a/static/app/views/automations/routes.tsx
+++ b/static/app/views/automations/routes.tsx
@@ -20,5 +20,3 @@ export const automationRoutes = (
     </Route>
   </Route>
 );
-
-export const AUTOMATIONS_BASE_URL = '/issues/automations';

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -5,17 +5,16 @@ import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpl
 import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {useAutomationActions} from 'sentry/views/automations/hooks/utils';
-import {AUTOMATIONS_BASE_URL} from 'sentry/views/automations/routes';
 
-const columns = defineColumns<Automation>({
+interface ConnectedAutomationData extends Automation {
+  link: string;
+}
+
+const columns = defineColumns<ConnectedAutomationData>({
   name: {
     Header: () => t('Name'),
     Cell: ({value, row}) => (
-      <TitleCell
-        name={value}
-        link={`${AUTOMATIONS_BASE_URL}/${row.id}/`}
-        projectId={row.detectorIds[0]}
-      />
+      <TitleCell name={value} link={row.link} projectId={row.detectorIds[0]} />
     ),
     width: 'minmax(0, 3fr)',
   },
@@ -33,11 +32,9 @@ const columns = defineColumns<Automation>({
 });
 
 export interface ConnectedAutomationsListProps {
-  automations: Automation[];
+  automations: ConnectedAutomationData[];
 }
-export function ConnectedAutomationsList({
-  automations = [],
-}: ConnectedAutomationsListProps) {
+export function ConnectedAutomationsList({automations}: ConnectedAutomationsListProps) {
   return (
     <SimpleTable
       data={automations}

--- a/static/app/views/detectors/components/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListRow.tsx
@@ -13,6 +13,8 @@ import {UserCell} from 'sentry/components/workflowEngine/gridCell/userCell';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 
 interface DetectorListRowProps {
   detector: Detector;
@@ -25,7 +27,8 @@ export function DetectorListRow({
   handleSelect,
   selected,
 }: DetectorListRowProps) {
-  const link = `/issues/monitors/${id}/`;
+  const organization = useOrganization();
+  const link = makeMonitorDetailsPathname(organization.slug, id);
   const issues: Group[] = [];
   return (
     <RowWrapper disabled={disabled}>

--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -16,9 +16,11 @@ import {IconArrow, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getDuration from 'sentry/utils/duration/getDuration';
+import useOrganization from 'sentry/utils/useOrganization';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 import DetailsPanel from 'sentry/views/detectors/components/detailsPanel';
 import IssuesList from 'sentry/views/detectors/components/issuesList';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 type Priority = {
   sensitivity: string;
@@ -31,11 +33,14 @@ const priorities: Priority[] = [
 ];
 
 export default function DetectorDetail() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
     <SentryDocumentTitle title={'/endpoint'} noSuffix>
-      <BreadcrumbsProvider crumb={{label: t('Monitors'), to: '/issues/monitors'}}>
+      <BreadcrumbsProvider
+        crumb={{label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)}}
+      >
         <ActionsProvider actions={<Actions />}>
           <DetailLayout project={{slug: 'project-slug', platform: 'javascript-astro'}}>
             <DetailLayout.Main>

--- a/static/app/views/detectors/edit.tsx
+++ b/static/app/views/detectors/edit.tsx
@@ -8,13 +8,18 @@ import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/bread
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function DetectorEdit() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
     <SentryDocumentTitle title={t('Edit Monitor')} noSuffix>
-      <BreadcrumbsProvider crumb={{label: t('Monitors'), to: '/issues/monitors'}}>
+      <BreadcrumbsProvider
+        crumb={{label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)}}
+      >
         <ActionsProvider actions={<Actions />}>
           <EditLayout>
             <h2>Edit Monitor</h2>

--- a/static/app/views/detectors/layouts/new.tsx
+++ b/static/app/views/detectors/layouts/new.tsx
@@ -4,12 +4,17 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function NewDetectorLayout({children}: {children: React.ReactNode}) {
+  const organization = useOrganization();
   const [title, setTitle] = useState(t('New Monitor'));
   return (
     <SentryDocumentTitle title={title} noSuffix>
-      <BreadcrumbsProvider crumb={{label: t('Monitors'), to: '/issues/monitors'}}>
+      <BreadcrumbsProvider
+        crumb={{label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)}}
+      >
         <EditLayout onTitleChange={value => setTitle(value)}>{children}</EditLayout>
       </BreadcrumbsProvider>
     </SentryDocumentTitle>

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -11,7 +11,9 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import DetectorListTable from 'sentry/views/detectors/components/detectorListTable';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function DetectorsList() {
   useWorkflowEngineFeatureGate({redirect: true});
@@ -40,10 +42,11 @@ function TableHeader() {
 }
 
 function Actions() {
+  const organization = useOrganization();
   return (
     <Fragment>
       <LinkButton
-        to="/issues/monitors/new"
+        to={`${makeMonitorBasePathname(organization.slug)}new/`}
         priority="primary"
         icon={<IconAdd isCircled />}
       >

--- a/static/app/views/detectors/new-settings.tsx
+++ b/static/app/views/detectors/new-settings.tsx
@@ -7,9 +7,12 @@ import {
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import NewDetectorLayout from 'sentry/views/detectors/layouts/new';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function DetectorNewSettings() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
@@ -17,7 +20,10 @@ export default function DetectorNewSettings() {
       <StickyFooter>
         <StickyFooterLabel>{t('Step 2 of 2')}</StickyFooterLabel>
         <Flex gap={space(1)}>
-          <LinkButton priority="default" to="/issues/monitors/new">
+          <LinkButton
+            priority="default"
+            to={`${makeMonitorBasePathname(organization.slug)}new/`}
+          >
             {t('Back')}
           </LinkButton>
           <Button priority="primary">{t('Create Monitor')}</Button>

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -7,10 +7,13 @@ import {
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
 import {DetectorTypeForm} from 'sentry/views/detectors/components/detectorTypeForm';
 import NewDetectorLayout from 'sentry/views/detectors/layouts/new';
+import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function DetectorNew() {
+  const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
 
   return (
@@ -19,7 +22,7 @@ export default function DetectorNew() {
       <StickyFooter>
         <StickyFooterLabel>{t('Step 1 of 2')}</StickyFooterLabel>
         <Flex gap={space(1)}>
-          <LinkButton priority="default" to="/issues/monitors">
+          <LinkButton priority="default" to={makeMonitorBasePathname(organization.slug)}>
             {t('Cancel')}
           </LinkButton>
           <LinkButton priority="primary" to="settings">

--- a/static/app/views/detectors/pathnames.tsx
+++ b/static/app/views/detectors/pathnames.tsx
@@ -1,0 +1,8 @@
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+
+export const makeMonitorBasePathname = (orgSlug: string) => {
+  return normalizeUrl(`/organizations/${orgSlug}/issues/monitors/`);
+};
+export const makeMonitorDetailsPathname = (orgSlug: string, monitorId: string) => {
+  return normalizeUrl(`/organizations/${orgSlug}/issues/monitors/${monitorId}/`);
+};

--- a/static/app/views/detectors/pathnames.tsx
+++ b/static/app/views/detectors/pathnames.tsx
@@ -3,6 +3,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 export const makeMonitorBasePathname = (orgSlug: string) => {
   return normalizeUrl(`/organizations/${orgSlug}/issues/monitors/`);
 };
+
 export const makeMonitorDetailsPathname = (orgSlug: string, monitorId: string) => {
   return normalizeUrl(`/organizations/${orgSlug}/issues/monitors/${monitorId}/`);
 };

--- a/static/app/views/detectors/routes.tsx
+++ b/static/app/views/detectors/routes.tsx
@@ -17,5 +17,3 @@ export const detectorRoutes = (
     </Route>
   </Route>
 );
-
-export const MONITORS_BASE_URL = '/issues/monitors';


### PR DESCRIPTION
With hybrid cloud we can use urls without `/organization/org-slug` but other environments like self hosted will all still want the full path.

Moved out of routes file since jest will compile all files linked from there.