### PR TITLE
test(aci): Stop using a lambda to get accurate typing

### DIFF
--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -28,8 +28,14 @@ class ProcessedDataConditionGroup:
 DataConditionGroupResult = tuple[ProcessedDataConditionGroup, list[DataCondition]]
 
 
+# We use a defined function rather than a lambda below because otherwise
+# parameter type becomes Any.
+def _group_id_from_condition(condition: DataCondition) -> tuple[int]:
+    return (condition.condition_group_id,)
+
+
 @cache_func_for_models(
-    [(DataCondition, lambda condition: (condition.condition_group_id,))],
+    [(DataCondition, _group_id_from_condition)],
     recalculate=False,
 )
 def get_data_conditions_for_group(data_condition_group_id: int) -> list[DataCondition]:


### PR DESCRIPTION
Use an annotated function for the `cache_invalidators` Callable in `cache_func_for_models` so that the parameter to `get_data_conditions_for_group` is interpreted as `int` rather than `Any`.
It's not clear exactly why the lambda trips up the generic tuple parameter type checking, but empirically this fixes that, it's easy enough to do, and it eliminates a (small, admittedly) class of possible mistakes.

Will follow up to see if Mypy can fix this.
