### PR TITLE
fix(workflow): Add missing page filters container

### DIFF
--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import {Flex} from 'sentry/components/container/flex';
 import {LinkButton} from 'sentry/components/core/button';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -20,12 +21,14 @@ export default function AutomationsList() {
 
   return (
     <SentryDocumentTitle title={t('Automations')} noSuffix>
-      <ActionsProvider actions={<Actions />}>
-        <ListLayout>
-          <TableHeader />
-          <AutomationListTable />
-        </ListLayout>
-      </ActionsProvider>
+      <PageFiltersContainer>
+        <ActionsProvider actions={<Actions />}>
+          <ListLayout>
+            <TableHeader />
+            <AutomationListTable />
+          </ListLayout>
+        </ActionsProvider>
+      </PageFiltersContainer>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import {Flex} from 'sentry/components/container/flex';
 import {LinkButton} from 'sentry/components/core/button';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -20,12 +21,14 @@ export default function DetectorsList() {
 
   return (
     <SentryDocumentTitle title={t('Monitors')} noSuffix>
-      <ActionsProvider actions={<Actions />}>
-        <ListLayout>
-          <TableHeader />
-          <DetectorListTable detectors={[]} />
-        </ListLayout>
-      </ActionsProvider>
+      <PageFiltersContainer>
+        <ActionsProvider actions={<Actions />}>
+          <ListLayout>
+            <TableHeader />
+            <DetectorListTable detectors={[]} />
+          </ListLayout>
+        </ActionsProvider>
+      </PageFiltersContainer>
     </SentryDocumentTitle>
   );
 }


### PR DESCRIPTION
In order to use the ProjectPageFilter we expect the page filters to be initialized via this poorly named container thing.

Fixes an issue where the project selector gets stuck loading when refreshing the page.

![image](https://github.com/user-attachments/assets/9f0a2038-7ec3-4990-8481-a50ab0665122)
