### PR TITLE
fix(issues): Move source maps / images loaded to bottom

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -403,6 +403,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       )}
       actions={actions}
       initialCollapse
+      disableCollapsePersistence
     >
       {isOpen || hasStreamlinedUI ? (
         <Fragment>

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -403,7 +403,6 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       )}
       actions={actions}
       initialCollapse
-      disableCollapsePersistence
     >
       {isOpen || hasStreamlinedUI ? (
         <Fragment>

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -296,16 +296,6 @@ export function EventDetailsContent({
           </GuideAnchor>
         )}
       </ClassNames>
-      {defined(eventEntries[EntryType.DEBUGMETA]) && (
-        <EntryErrorBoundary type={EntryType.DEBUGMETA}>
-          <DebugMeta
-            event={event}
-            projectSlug={projectSlug}
-            groupId={group?.id}
-            data={eventEntries[EntryType.DEBUGMETA].data}
-          />
-        </EntryErrorBoundary>
-      )}
       {hasStreamlinedUI && (
         <ScreenshotDataSection event={event} projectSlug={project.slug} />
       )}
@@ -450,6 +440,16 @@ export function EventDetailsContent({
       <EventSdk sdk={event.sdk} meta={event._meta?.sdk} />
       {hasStreamlinedUI && (
         <EventProcessingErrors event={event} project={project} isShare={false} />
+      )}
+      {defined(eventEntries[EntryType.DEBUGMETA]) && (
+        <EntryErrorBoundary type={EntryType.DEBUGMETA}>
+          <DebugMeta
+            event={event}
+            projectSlug={projectSlug}
+            groupId={group?.id}
+            data={eventEntries[EntryType.DEBUGMETA].data}
+          />
+        </EntryErrorBoundary>
       )}
       {event.groupID && (
         <EventGroupingInfoSection


### PR DESCRIPTION
Moves it next to grouping info. Disables persistence of user expand / collapse

from this thread https://sentry.slack.com/archives/C04KZQBNQ2U/p1747075128130089