### PR TITLE
ref(✂️): remove unused exports keywords

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -36,7 +36,7 @@ import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
-export interface BreadcrumbsDataSectionProps {
+interface BreadcrumbsDataSectionProps {
   event: Event;
   group: Group;
   project: Project;

--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -7,7 +7,7 @@ import TextOverflow from 'sentry/components/textOverflow';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 
-export type ScoreCardProps = {
+type ScoreCardProps = {
   title: React.ReactNode;
   className?: string;
   help?: React.ReactNode;

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -46,7 +46,7 @@ export interface TabsProps<T>
   value?: T;
 }
 
-export interface TabContext {
+interface TabContext {
   rootProps: Omit<TabsProps<any>, 'children' | 'className'>;
   setTabListState: (state: TabListState<any>) => void;
   tabListState?: TabListState<any>;

--- a/static/app/components/webAuthn/webAuthnEnroll.tsx
+++ b/static/app/components/webAuthn/webAuthnEnroll.tsx
@@ -13,7 +13,7 @@ interface WebAuthnParams {
   response: string;
 }
 
-export interface WebAuthnEnrollProps {
+interface WebAuthnEnrollProps {
   challengeData: ChallengeData;
   /**
    * Callback for when the webAuthn flow is completed.

--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -4,10 +4,6 @@ export interface NewAction {
   integrationId?: string;
 }
 
-export interface Action extends NewAction {
-  id: string;
-}
-
 export enum ActionType {
   SLACK = 'slack',
   MSTEAMS = 'msteams',

--- a/static/app/types/workflowEngine/automations.tsx
+++ b/static/app/types/workflowEngine/automations.tsx
@@ -1,6 +1,6 @@
 import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
 
-export interface NewAutomation {
+interface NewAutomation {
   actionFilters: DataConditionGroup[];
   detectorIds: string[];
   name: string;

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -1,6 +1,6 @@
 import type {PlatformKey} from 'sentry/types/project';
 
-export type ProfilingEventSource =
+type ProfilingEventSource =
   | 'discover.transactions_table'
   | 'performance.trace_view.details'
   | 'performance.trace_view.missing_instrumentation'

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -2,7 +2,7 @@ import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export interface UseAutomationsQueryOptions {
+interface UseAutomationsQueryOptions {
   query?: string;
   sort?: string;
 }

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -31,7 +31,7 @@ const columns = defineColumns<ConnectedAutomationData>({
   },
 });
 
-export interface ConnectedAutomationsListProps {
+interface ConnectedAutomationsListProps {
   automations: ConnectedAutomationData[];
 }
 export function ConnectedAutomationsList({automations}: ConnectedAutomationsListProps) {

--- a/static/app/views/explore/components/traceExploreAiQueryProvider.tsx
+++ b/static/app/views/explore/components/traceExploreAiQueryProvider.tsx
@@ -115,7 +115,7 @@ function QueryTokens({result}: QueryTokensProps) {
   return <React.Fragment>{tokens}</React.Fragment>;
 }
 
-export function AiQueryDrawer({initialQuery = ''}: {initialQuery?: string}) {
+function AiQueryDrawer({initialQuery = ''}: {initialQuery?: string}) {
   const [searchQuery, setSearchQuery] = useState(initialQuery);
   const [response, setResponse] = useState<React.ReactNode>(null);
   const [rawResult, setRawResult] = useState<any>(null);

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -60,7 +60,7 @@ const [_LogsPageParamsProvider, _useLogsPageParams, LogsPageParamsContext] =
     name: 'LogsPageParamsContext',
   });
 
-export interface LogsPageParamsProviderProps {
+interface LogsPageParamsProviderProps {
   analyticsPageSource: LogsAnalyticsPageSource;
   children: React.ReactNode;
   blockRowExpanding?: boolean;

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -63,16 +63,6 @@ interface WritablePageParams {
   visualizes?: BaseVisualize[] | null;
 }
 
-export interface SuggestedQuery {
-  fields: string[];
-  groupBys: string[];
-  mode: Mode;
-  query: string;
-  sortBys: Sort[];
-  title: string;
-  visualizes: BaseVisualize[];
-}
-
 function defaultPageParams(): ReadablePageParams {
   const dataset = defaultDataset();
   const fields = defaultFields();

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -63,6 +63,16 @@ interface WritablePageParams {
   visualizes?: BaseVisualize[] | null;
 }
 
+export interface SuggestedQuery {
+  fields: string[];
+  groupBys: string[];
+  mode: Mode;
+  query: string;
+  sortBys: Sort[];
+  title: string;
+  visualizes: BaseVisualize[];
+}
+
 function defaultPageParams(): ReadablePageParams {
   const dataset = defaultDataset();
   const fields = defaultFields();

--- a/static/app/views/explore/contexts/traceExploreAiQueryContext.tsx
+++ b/static/app/views/explore/contexts/traceExploreAiQueryContext.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext} from 'react';
 
-export interface TraceExploreAiQueryContextValue {
+interface TraceExploreAiQueryContextValue {
   onAiButtonClick: (initialQuery?: string) => void;
 }
 

--- a/static/app/views/explore/spans/tour.tsx
+++ b/static/app/views/explore/spans/tour.tsx
@@ -32,7 +32,7 @@ export const EXPLORE_SPANS_TOUR_GUIDE_KEY = 'tour.explore.spans';
 export const ExploreSpansTourContext =
   createContext<TourContextType<ExploreSpansTour> | null>(null);
 
-export function useExploreSpansTour(): TourContextType<ExploreSpansTour> {
+function useExploreSpansTour(): TourContextType<ExploreSpansTour> {
   const tourContext = useContext(ExploreSpansTourContext);
   if (!tourContext) {
     throw new Error('Must be used within a TourContextProvider<ExploreSpansTour>');

--- a/static/app/views/insights/common/components/tableCells/timeSpentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/timeSpentCell.tsx
@@ -33,7 +33,7 @@ export function TimeSpentCell({percentage, total, op, containerProps}: Props) {
   );
 }
 
-export function getTimeSpentExplanation(percentage: number, op?: string) {
+function getTimeSpentExplanation(percentage: number, op?: string) {
   const formattedPercentage = formatPercentage(clamp(percentage ?? 0, 0, 1));
 
   return tct(

--- a/static/app/views/insights/mobile/common/components/tables/screensTable.tsx
+++ b/static/app/views/insights/mobile/common/components/tables/screensTable.tsx
@@ -24,7 +24,7 @@ import {PercentChangeCell} from 'sentry/views/insights/common/components/tableCe
 import type {Row} from 'sentry/views/insights/mobile/screens/components/screensOverviewTable';
 import type {ModuleName} from 'sentry/views/insights/types';
 
-export type TableData = {
+type TableData = {
   data: Array<Record<string, string | number>>;
   meta?: MetaType;
 };

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -29,7 +29,7 @@ import {
 } from 'sentry/views/insights/mobile/screenload/constants';
 import {transformDeviceClassEvents} from 'sentry/views/insights/mobile/screenload/utils';
 
-export enum YAxis {
+enum YAxis {
   WARM_START = 0,
   COLD_START = 1,
   TTID = 2,

--- a/static/app/views/insights/pages/transactionNameSearchBar.tsx
+++ b/static/app/views/insights/pages/transactionNameSearchBar.tsx
@@ -22,7 +22,7 @@ import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {SpanFields} from 'sentry/views/insights/types';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
-export type SearchBarProps = {
+type SearchBarProps = {
   onSearch: (query: string) => void;
   organization: Organization;
   /** The project ids to search for */
@@ -260,18 +260,6 @@ const decodeValueToItem = (value: string): DataItem => {
 interface DataItem {
   transaction: string;
 }
-
-export const wrapQueryInWildcards = (query: string) => {
-  if (!query.startsWith('*')) {
-    query = '*' + query;
-  }
-
-  if (!query.endsWith('*')) {
-    query = query + '*';
-  }
-
-  return query;
-};
 
 const Container = styled('div')`
   position: relative;

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -268,10 +268,6 @@ export type SpanMetricsResponse = {
     [Property in SpanNumberFields as `avg_compare(${Property},${string},${string},${string})`]: number;
   };
 
-export type MetricsFilters = {
-  [Property in SpanStringFields as `${Property}`]?: string | string[];
-};
-
 export type SpanMetricsProperty = keyof SpanMetricsResponse;
 
 export type EAPSpanResponse = {

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -47,18 +47,6 @@ export type GroupSearchView = StarredGroupSearchView & {
   visibility: GroupSearchViewVisibility;
 };
 
-export interface UpdateGroupSearchViewPayload
-  extends Omit<
-    GroupSearchView,
-    'id' | 'lastVisited' | 'visibility' | 'starred' | 'dateCreated' | 'dateUpdated'
-  > {
-  environments: string[];
-  projects: number[];
-  timeFilters: PageFilters['datetime'];
-  id?: string;
-  isAllProjects?: boolean;
-}
-
 // Frontend sort options which map to multiple backend sorts
 export enum GroupSearchViewSort {
   VIEWED = 'visited',

--- a/static/app/views/issueList/types.tsx
+++ b/static/app/views/issueList/types.tsx
@@ -47,6 +47,18 @@ export type GroupSearchView = StarredGroupSearchView & {
   visibility: GroupSearchViewVisibility;
 };
 
+export interface UpdateGroupSearchViewPayload
+  extends Omit<
+    GroupSearchView,
+    'id' | 'lastVisited' | 'visibility' | 'starred' | 'dateCreated' | 'dateUpdated'
+  > {
+  environments: string[];
+  projects: number[];
+  timeFilters: PageFilters['datetime'];
+  id?: string;
+  isAllProjects?: boolean;
+}
+
 // Frontend sort options which map to multiple backend sorts
 export enum GroupSearchViewSort {
   VIEWED = 'visited',

--- a/static/app/views/issueList/utils/newTabContext.tsx
+++ b/static/app/views/issueList/utils/newTabContext.tsx
@@ -1,6 +1,6 @@
 import {createContext, useState} from 'react';
 
-export type NewView = {
+type NewView = {
   label: string;
   query: string;
   /**

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -324,7 +324,7 @@ export interface UsageStatsOrganizationProps {
   projectDetails?: React.ReactNode[];
 }
 
-export type CardMetadata = Record<
+type CardMetadata = Record<
   'total' | 'accepted' | 'filtered' | 'rateLimited' | 'invalid',
   {
     title: React.ReactNode;

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -54,7 +54,7 @@ function decodeTraceSlug(maybeSlug: string | undefined): string {
   return maybeSlug.trim();
 }
 
-export const TRACE_VIEW_PREFERENCES_KEY = 'trace-waterfall-preferences';
+const TRACE_VIEW_PREFERENCES_KEY = 'trace-waterfall-preferences';
 
 export function TraceView() {
   const params = useParams<{traceSlug?: string}>();

--- a/static/app/views/performance/newTraceDetails/traceState/tracePreferences.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/tracePreferences.tsx
@@ -118,7 +118,7 @@ function isValidMissingInstrumentation(
   return true;
 }
 
-export function loadTraceViewPreferences(key: string): StoredTracePreferences | null {
+function loadTraceViewPreferences(key: string): StoredTracePreferences | null {
   const stored = localStorage.getItem(key);
 
   if (stored) {

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -479,7 +479,7 @@ export default function TraceView({
   return traceView;
 }
 
-export const StyledTracePanel = styled(Panel)`
+const StyledTracePanel = styled(Panel)`
   height: 100%;
   overflow-x: visible;
 


### PR DESCRIPTION
This PR removes unused exports keywords from types, interfaces, enums and functions on symbols that are only used within the same file

a couple of types could then be removed completely because they weren't used within the file, so they are completely unused
