### PR TITLE
fix(ui): use gray400 for the scrubber

### DIFF
--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -113,7 +113,7 @@ function Scrubber({className, showZoomIndicators = false}: Props) {
 }
 
 const Meter = styled(Progress.Meter)`
-  background: ${p => p.theme.gray200};
+  background: 'rebeccapurple';
 `;
 
 const RangeWrapper = styled('div')`
@@ -258,7 +258,7 @@ export const PlayerScrubber = styled(Scrubber)`
      *      MouseTrackingValue @ 10s
      */
     :after {
-      background: ${p => p.theme.gray300};
+      background: ${p => p.theme.gray400};
     }
   }
 

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -113,7 +113,7 @@ function Scrubber({className, showZoomIndicators = false}: Props) {
 }
 
 const Meter = styled(Progress.Meter)`
-  background: 'rebeccapurple';
+  background: ${p => p.theme.gray200};
 `;
 
 const RangeWrapper = styled('div')`


### PR DESCRIPTION
This is the suggested solution as described in DE-69.

| before | after |
|--------|--------|
| ![Screenshot 2025-05-13 at 15 34 38](https://github.com/user-attachments/assets/61aa6150-f0d0-4d6f-8238-bb3db9d6a072) | ![Screenshot 2025-05-13 at 15 34 11](https://github.com/user-attachments/assets/fc968c80-371f-4fa4-9bc6-977a6ecdb5a3) | 