### PR TITLE
fix: Remove parameter compatibility from sentryapp webhook

### DIFF
--- a/src/sentry/sentry_apps/tasks/service_hooks.py
+++ b/src/sentry/sentry_apps/tasks/service_hooks.py
@@ -50,7 +50,7 @@ def get_payload_v0(event):
 )
 @retry
 def process_service_hook(
-    servicehook_id: int, project_id: int, group_id: int, event_id: str, **kwargs
+    servicehook_id: int, project_id: int, group_id: int, event_id: str
 ) -> None:
     try:
         servicehook = ServiceHook.objects.get(id=servicehook_id)

--- a/src/sentry/sentry_apps/tasks/service_hooks.py
+++ b/src/sentry/sentry_apps/tasks/service_hooks.py
@@ -1,6 +1,5 @@
 import logging
 from time import time
-from typing import Any
 
 from sentry import nodestore
 from sentry.api.serializers import serialize
@@ -51,33 +50,22 @@ def get_payload_v0(event):
 )
 @retry
 def process_service_hook(
-    servicehook_id: int,
-    event: Any | None = None,
-    project_id: int | None = None,
-    group_id: int | None = None,
-    event_id: str | None = None,
-    **kwargs,
-):
+    servicehook_id: int, project_id: int, group_id: int, event_id: str, **kwargs
+) -> None:
     try:
         servicehook = ServiceHook.objects.get(id=servicehook_id)
     except ServiceHook.DoesNotExist:
         return
 
-    if not project_id and event:
-        project_id = event.project_id
-
-    if project_id and group_id and event_id:
-        node_id = Event.generate_node_id(project_id, event_id)
-        group = Group.objects.get_from_cache(id=group_id)
-        nodedata = nodestore.backend.get(node_id)
-        event = GroupEvent(
-            project_id=project_id,
-            event_id=event_id,
-            group=group,
-            data=nodedata,
-        )
-
-    assert event, "Event must exist at this point"
+    node_id = Event.generate_node_id(project_id, event_id)
+    group = Group.objects.get_from_cache(id=group_id)
+    nodedata = nodestore.backend.get(node_id)
+    event = GroupEvent(
+        project_id=project_id,
+        event_id=event_id,
+        group=group,
+        data=nodedata,
+    )
     if servicehook.version == 0:
         payload = json.dumps(get_payload_v0(event))
     else:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -18,7 +18,6 @@ from sentry.exceptions import PluginError
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
-from sentry.options.rollout import in_random_rollout
 from sentry.replays.lib.event_linking import transform_event_for_linking_payload
 from sentry.replays.lib.kafka import initialize_replays_publisher
 from sentry.sentry_metrics.client import generic_metrics_backend
@@ -1194,19 +1193,14 @@ def process_service_hooks(job: PostProcessJob) -> None:
         if has_alert:
             allowed_events.add("event.alert")
 
-        if in_random_rollout("process_service_hook.payload.rollout"):
-            for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
-                if any(e in allowed_events for e in events):
-                    process_service_hook.delay(
-                        servicehook_id=servicehook_id,
-                        project_id=event.project_id,
-                        group_id=event.group_id,
-                        event_id=event.event_id,
-                    )
-        else:
-            for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
-                if any(e in allowed_events for e in events):
-                    process_service_hook.delay(servicehook_id=servicehook_id, event=event)
+        for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
+            if any(e in allowed_events for e in events):
+                process_service_hook.delay(
+                    servicehook_id=servicehook_id,
+                    project_id=event.project_id,
+                    group_id=event.group_id,
+                    event_id=event.event_id,
+                )
 
 
 def process_resource_change_bounds(job: PostProcessJob) -> None:

--- a/tests/sentry/sentry_apps/tasks/test_servicehooks.py
+++ b/tests/sentry/sentry_apps/tasks/test_servicehooks.py
@@ -25,7 +25,12 @@ class TestServiceHooks(TestCase):
             data={"timestamp": before_now(minutes=1).isoformat()}, project_id=self.project.id
         )
 
-        process_service_hook(self.hook.id, event)
+        process_service_hook(
+            self.hook.id,
+            project_id=self.project.id,
+            group_id=event.group_id,
+            event_id=event.event_id,
+        )
 
         body = json.dumps(get_payload_v0(event))
 
@@ -45,7 +50,12 @@ class TestServiceHooks(TestCase):
             data={"timestamp": before_now(minutes=1).isoformat()}, project_id=self.project.id
         )
 
-        process_service_hook(self.hook.id, event)
+        process_service_hook(
+            self.hook.id,
+            project_id=self.project.id,
+            group_id=event.group_id,
+            event_id=event.event_id,
+        )
 
         ((_, kwargs),) = safe_urlopen.call_args_list
         data = json.loads(kwargs["data"])
@@ -97,7 +107,12 @@ class TestServiceHooks(TestCase):
         )
         assert event.group is not None
 
-        process_service_hook(self.hook.id, event)
+        process_service_hook(
+            self.hook.id,
+            project_id=self.project.id,
+            group_id=event.group_id,
+            event_id=event.event_id,
+        )
         body = get_payload_v0(event)
         assert (
             body["group"]["url"]

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -499,9 +499,8 @@ class RuleProcessorTestMixin(BasePostProgressGroupMixin):
 
 
 class ServiceHooksTestMixin(BasePostProgressGroupMixin):
-    @override_options({"process_service_hook.payload.rollout": 1.0})
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
-    def test_service_hook_fires_on_new_event_payload_param(self, mock_process_service_hook):
+    def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
         event = self.create_event(data={}, project_id=self.project.id)
         hook = self.create_service_hook(
             project=self.project,
@@ -523,29 +522,6 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
             project_id=self.project.id,
             group_id=event.group_id,
             event_id=event.event_id,
-        )
-
-    @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
-    def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
-        event = self.create_event(data={}, project_id=self.project.id)
-        hook = self.create_service_hook(
-            project=self.project,
-            organization=self.project.organization,
-            actor=self.user,
-            events=["event.created"],
-        )
-
-        with self.feature("projects:servicehooks"):
-            self.call_post_process_group(
-                is_new=False,
-                is_regression=False,
-                is_new_group_environment=False,
-                event=event,
-            )
-
-        mock_process_service_hook.delay.assert_called_once_with(
-            servicehook_id=hook.id,
-            event=EventMatcher(event),
         )
 
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")
@@ -575,7 +551,9 @@ class ServiceHooksTestMixin(BasePostProgressGroupMixin):
 
         mock_process_service_hook.delay.assert_called_once_with(
             servicehook_id=hook.id,
-            event=EventMatcher(event),
+            project_id=self.project.id,
+            group_id=event.group_id,
+            event_id=event.event_id,
         )
 
     @patch("sentry.sentry_apps.tasks.service_hooks.process_service_hook")


### PR DESCRIPTION
With the new signature enabled, and no ratelimiting happening, we can transition to the new signature for this task.