### PR TITLE
feat(nav, resizing): Make secondary nav resizible with new performant hook

### DIFF
--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -1,9 +1,9 @@
 import type {RefObject} from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-export const RESIZABLE_DEFAULT_WIDTH = 200;
-export const RESIZABLE_MIN_WIDTH = 100;
-export const RESIZABLE_MAX_WIDTH = Infinity;
+const RESIZABLE_DEFAULT_WIDTH = 200;
+const RESIZABLE_MIN_WIDTH = 100;
+const RESIZABLE_MAX_WIDTH = Infinity;
 
 interface UseResizableOptions {
   /**
@@ -38,12 +38,6 @@ interface UseResizableOptions {
    * Triggered when the user starts dragging the resize handle.
    */
   onResizeStart?: () => void;
-
-  /**
-   * The local storage key used to persist the size of the container. If not provided,
-   * the size will not be persisted and the defaultWidth will be used.
-   */
-  sizeStorageKey?: string;
 }
 
 /**
@@ -51,14 +45,13 @@ interface UseResizableOptions {
  *
  * Currently only supports resizing width and not height.
  */
-export const useResizable = ({
+const useResizable = ({
   ref,
   initialSize = RESIZABLE_DEFAULT_WIDTH,
   maxWidth = RESIZABLE_MAX_WIDTH,
   minWidth = RESIZABLE_MIN_WIDTH,
   onResizeEnd,
   onResizeStart,
-  sizeStorageKey,
 }: UseResizableOptions): {
   /**
    * Whether the drag handle is held.
@@ -86,14 +79,9 @@ export const useResizable = ({
 
   useEffect(() => {
     if (ref.current) {
-      const storedSize = sizeStorageKey
-        ? parseInt(localStorage.getItem(sizeStorageKey) ?? '', 10)
-        : undefined;
-
-      ref.current.style.width = `${storedSize ?? initialSize}px`;
+      ref.current.style.width = `${initialSize}px`;
     }
-    console.log(ref.current?.style.width);
-  }, [ref, initialSize, sizeStorageKey]);
+  }, [ref, initialSize]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -139,10 +127,7 @@ export const useResizable = ({
     document.body.style.cursor = '';
     document.body.style.userSelect = '';
     onResizeEnd?.(newSize);
-    if (sizeStorageKey) {
-      localStorage.setItem(sizeStorageKey, newSize.toString());
-    }
-  }, [onResizeEnd, ref, sizeStorageKey, initialSize]);
+  }, [onResizeEnd, ref, initialSize]);
 
   useEffect(() => {
     document.addEventListener('mousemove', handleMouseMove);

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -1,0 +1,171 @@
+import type {RefObject} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+export const RESIZABLE_DEFAULT_WIDTH = 200;
+export const RESIZABLE_MIN_WIDTH = 100;
+export const RESIZABLE_MAX_WIDTH = Infinity;
+
+interface UseResizableOptions {
+  /**
+   * The ref to the element to be resized.
+   */
+  ref: RefObject<HTMLElement | null>;
+
+  /**
+   * The starting size of the container, and the size that is set in the onDoubleClick handler.
+   *
+   * If `sizeStorageKey` is provided and exists in local storage,
+   * then this will be ignored in favor of the size stored in local storage.
+   */
+  initialSize?: number;
+
+  /**
+   * The maximum width the container can be resized to. Defaults to Infinity.
+   */
+  maxWidth?: number;
+
+  /**
+   * The minimum width the container can be resized to. Defaults to 100.
+   */
+  minWidth?: number;
+
+  /**
+   * Triggered when the user finishes dragging the resize handle.
+   */
+  onResizeEnd?: (newWidth: number) => void;
+
+  /**
+   * Triggered when the user starts dragging the resize handle.
+   */
+  onResizeStart?: () => void;
+
+  /**
+   * The local storage key used to persist the size of the container. If not provided,
+   * the size will not be persisted and the defaultWidth will be used.
+   */
+  sizeStorageKey?: string;
+}
+
+/**
+ * Performant hook to support draggable container resizing.
+ *
+ * Currently only supports resizing width and not height.
+ */
+export const useResizable = ({
+  ref,
+  initialSize = RESIZABLE_DEFAULT_WIDTH,
+  maxWidth = RESIZABLE_MAX_WIDTH,
+  minWidth = RESIZABLE_MIN_WIDTH,
+  onResizeEnd,
+  onResizeStart,
+  sizeStorageKey,
+}: UseResizableOptions): {
+  /**
+   * Whether the drag handle is held.
+   */
+  isHeld: boolean;
+  /**
+   * Apply this to the drag handle element to include 'reset' functionality.
+   */
+  onDoubleClick: () => void;
+  /**
+   * Attach this to the drag handle element's onMouseDown handler.
+   */
+  onMouseDown: (e: React.MouseEvent) => void;
+  /**
+   * The current size of the container. This is NOT updated during the drag
+   * event, only after the user finishes dragging.
+   */
+  size: number;
+} => {
+  const [isHeld, setIsHeld] = useState(false);
+
+  const isDraggingRef = useRef<boolean>(false);
+  const startXRef = useRef<number>(0);
+  const startWidthRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (ref.current) {
+      const storedSize = sizeStorageKey
+        ? parseInt(localStorage.getItem(sizeStorageKey) ?? '', 10)
+        : undefined;
+
+      ref.current.style.width = `${storedSize ?? initialSize}px`;
+    }
+    console.log(ref.current?.style.width);
+  }, [ref, initialSize, sizeStorageKey]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      setIsHeld(true);
+      e.preventDefault();
+
+      const currentWidth = ref.current
+        ? parseInt(getComputedStyle(ref.current).width, 10)
+        : 0;
+
+      isDraggingRef.current = true;
+      startXRef.current = e.clientX;
+      startWidthRef.current = currentWidth;
+
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+      onResizeStart?.();
+    },
+    [ref, onResizeStart]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+
+      const deltaX = e.clientX - startXRef.current;
+      const newWidth = Math.max(
+        minWidth,
+        Math.min(maxWidth, startWidthRef.current + deltaX)
+      );
+
+      if (ref.current) {
+        ref.current.style.width = `${newWidth}px`;
+      }
+    },
+    [ref, minWidth, maxWidth]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsHeld(false);
+    const newSize = ref.current?.offsetWidth ?? initialSize;
+    isDraggingRef.current = false;
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    onResizeEnd?.(newSize);
+    if (sizeStorageKey) {
+      localStorage.setItem(sizeStorageKey, newSize.toString());
+    }
+  }, [onResizeEnd, ref, sizeStorageKey, initialSize]);
+
+  useEffect(() => {
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
+
+  const onDoubleClick = useCallback(() => {
+    if (ref.current) {
+      ref.current.style.width = `${initialSize}px`;
+    }
+  }, [ref, initialSize]);
+
+  return {
+    isHeld,
+    size: ref.current?.offsetWidth ?? initialSize,
+    onMouseDown: handleMouseDown,
+    onDoubleClick,
+  };
+};
+
+export default useResizable;

--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -2,6 +2,8 @@ export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-co
 
 export const PRIMARY_SIDEBAR_WIDTH = 74;
 export const SECONDARY_SIDEBAR_WIDTH = 190;
+export const SECONDARY_SIDEBAR_MIN_WIDTH = 100;
+export const SECONDARY_SIDEBAR_MAX_WIDTH = 500;
 
 // Slightly delay closing the nav to prevent accidental dismissal
 export const NAV_SIDEBAR_COLLAPSE_DELAY_MS = 200;

--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -2,7 +2,7 @@ export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-co
 
 export const PRIMARY_SIDEBAR_WIDTH = 74;
 export const SECONDARY_SIDEBAR_WIDTH = 190;
-export const SECONDARY_SIDEBAR_MIN_WIDTH = 100;
+export const SECONDARY_SIDEBAR_MIN_WIDTH = 150;
 export const SECONDARY_SIDEBAR_MAX_WIDTH = 500;
 
 // Slightly delay closing the nav to prevent accidental dismissal

--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import useResizable from 'sentry/utils/useResizable';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {
   SECONDARY_SIDEBAR_MAX_WIDTH,
   SECONDARY_SIDEBAR_MIN_WIDTH,
@@ -25,16 +26,23 @@ export function SecondarySidebar() {
   const resizableContainerRef = useRef<HTMLDivElement>(null);
   const resizeHandleRef = useRef<HTMLDivElement>(null);
 
+  const [secondarySidebarWidth, setSecondarySidebarWidth] = useSyncedLocalStorageState(
+    'secondary-sidebar-width',
+    SECONDARY_SIDEBAR_WIDTH
+  );
+
   const {
     onMouseDown: handleStartResize,
     size,
     onDoubleClick,
   } = useResizable({
     ref: resizableContainerRef,
-    initialSize: SECONDARY_SIDEBAR_WIDTH,
+    initialSize: secondarySidebarWidth,
     minWidth: SECONDARY_SIDEBAR_MIN_WIDTH,
     maxWidth: SECONDARY_SIDEBAR_MAX_WIDTH,
-    sizeStorageKey: 'secondary-sidebar-width',
+    onResizeEnd: newWidth => {
+      setSecondarySidebarWidth(newWidth);
+    },
   });
 
   const {activePrimaryNavGroup} = useNavContext();

--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -1,7 +1,13 @@
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
-import {SECONDARY_SIDEBAR_WIDTH} from 'sentry/views/nav/constants';
+import useResizable from 'sentry/utils/useResizable';
+import {
+  SECONDARY_SIDEBAR_MAX_WIDTH,
+  SECONDARY_SIDEBAR_MIN_WIDTH,
+  SECONDARY_SIDEBAR_WIDTH,
+} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {SecondaryNavContent} from 'sentry/views/nav/secondary/secondaryNavContent';
@@ -16,42 +22,67 @@ import {useActiveNavGroup} from 'sentry/views/nav/useActiveNavGroup';
 export function SecondarySidebar() {
   const {currentStepId} = useStackedNavigationTour();
   const stepId = currentStepId ?? StackedNavigationTour.ISSUES;
+  const resizableContainerRef = useRef<HTMLDivElement>(null);
+  const resizeHandleRef = useRef<HTMLDivElement>(null);
+
+  const {
+    onMouseDown: handleStartResize,
+    size,
+    onDoubleClick,
+  } = useResizable({
+    ref: resizableContainerRef,
+    initialSize: SECONDARY_SIDEBAR_WIDTH,
+    minWidth: SECONDARY_SIDEBAR_MIN_WIDTH,
+    maxWidth: SECONDARY_SIDEBAR_MAX_WIDTH,
+    sizeStorageKey: 'secondary-sidebar-width',
+  });
+
   const {activePrimaryNavGroup} = useNavContext();
   const defaultActiveNavGroup = useActiveNavGroup();
 
   const activeNavGroup = activePrimaryNavGroup ?? defaultActiveNavGroup;
 
   return (
-    <SecondarySidebarWrapper
-      id={stepId}
-      description={STACKED_NAVIGATION_TOUR_CONTENT[stepId].description}
-      title={STACKED_NAVIGATION_TOUR_CONTENT[stepId].title}
-    >
-      <AnimatePresence mode="wait" initial={false}>
-        <MotionDiv
-          key={activeNavGroup}
-          initial={{x: -4, opacity: 0}}
-          animate={{x: 0, opacity: 1}}
-          exit={{x: 4, opacity: 0}}
-          transition={{duration: 0.06}}
-        >
-          <SecondarySidebarInner>
-            <SecondaryNavContent group={activeNavGroup} />
-          </SecondarySidebarInner>
-        </MotionDiv>
-      </AnimatePresence>
-    </SecondarySidebarWrapper>
+    <ResizeWrapper ref={resizableContainerRef} onMouseDown={handleStartResize}>
+      <NavTourElement
+        id={stepId}
+        description={STACKED_NAVIGATION_TOUR_CONTENT[stepId].description}
+        title={STACKED_NAVIGATION_TOUR_CONTENT[stepId].title}
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          <MotionDiv
+            key={activeNavGroup}
+            initial={{x: -4, opacity: 0}}
+            animate={{x: 0, opacity: 1}}
+            exit={{x: 4, opacity: 0}}
+            transition={{duration: 0.06}}
+          >
+            <SecondarySidebarInner>
+              <SecondaryNavContent group={activeNavGroup} />
+            </SecondarySidebarInner>
+            <ResizeHandle
+              ref={resizeHandleRef}
+              onMouseDown={handleStartResize}
+              onDoubleClick={onDoubleClick}
+              atMinWidth={size === SECONDARY_SIDEBAR_MIN_WIDTH}
+              atMaxWidth={size === SECONDARY_SIDEBAR_MAX_WIDTH}
+            />
+          </MotionDiv>
+        </AnimatePresence>
+      </NavTourElement>
+    </ResizeWrapper>
   );
 }
 
-const SecondarySidebarWrapper = styled(NavTourElement)`
+const ResizeWrapper = styled('div')`
   position: relative;
+  right: 0;
   border-right: 1px solid
     ${p => (p.theme.isChonk ? p.theme.border : p.theme.translucentGray200)};
   background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface200)};
-  width: ${SECONDARY_SIDEBAR_WIDTH}px;
   z-index: ${p => p.theme.zIndex.sidebarPanel};
   height: 100%;
+  width: ${SECONDARY_SIDEBAR_WIDTH}px;
 `;
 
 const SecondarySidebarInner = styled(SecondaryNav)`
@@ -61,4 +92,34 @@ const SecondarySidebarInner = styled(SecondaryNav)`
 const MotionDiv = styled(motion.div)`
   height: 100%;
   width: 100%;
+`;
+
+const ResizeHandle = styled('div')<{atMaxWidth: boolean; atMinWidth: boolean}>`
+  position: absolute;
+  right: 0px;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  border-radius: 8px;
+  z-index: ${p => p.theme.zIndex.drawer + 2};
+  cursor: ${p => (p.atMinWidth ? 'e-resize' : p.atMaxWidth ? 'w-resize' : 'ew-resize')};
+
+  &:hover,
+  &:active {
+    &::after {
+      background: ${p => p.theme.purple400};
+    }
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    right: -2px;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    opacity: 0.8;
+    background: transparent;
+    transition: background 0.25s ease 0.1s;
+  }
 `;

--- a/static/app/views/nav/sidebar.tsx
+++ b/static/app/views/nav/sidebar.tsx
@@ -11,6 +11,7 @@ import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {PRIMARY_SIDEBAR_WIDTH, SECONDARY_SIDEBAR_WIDTH} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 import {OrgDropdown} from 'sentry/views/nav/orgDropdown';
@@ -36,6 +37,11 @@ export function Sidebar() {
   const forceExpanded = tourIsActive;
   const isCollapsed = forceExpanded ? false : isCollapsedState;
   const {isOpen} = useCollapsedNav();
+
+  const [secondarySidebarWidth] = useSyncedLocalStorageState(
+    'secondary-sidebar-width',
+    SECONDARY_SIDEBAR_WIDTH
+  );
 
   useTourModal();
 
@@ -63,9 +69,15 @@ export function Sidebar() {
           animate={isOpen ? 'visible' : 'hidden'}
           variants={{
             visible: {x: 0},
-            hidden: {x: -SECONDARY_SIDEBAR_WIDTH - 10},
+            hidden: {x: -secondarySidebarWidth - 10},
           }}
-          transition={{duration: 0.15, ease: 'easeOut'}}
+          transition={{
+            type: 'spring',
+            damping: 50,
+            stiffness: 700,
+            bounce: 0,
+            visualDuration: 0.1,
+          }}
           data-test-id="collapsed-secondary-sidebar"
           data-visible={isOpen}
         >


### PR DESCRIPTION
Makes the secondary nav resizable via a new hook, `useResizable`. 

`useResizable` consumes a container ref and updates its width directly, rather than storing and returning a `size` state like the previous `useResizableDrawer`, making it feel significantly more performant. It also ensures that the cursor is always attached to the drag handle while dragging, which was an issue with `useResizableDrawer`. Besides these changes, the API is similar to `useResizableDrawer` and supports params like `onResizeStart`, `onResizeEnd`, and a `isHeld` return param.

This hook only supports horizontal dragging, but it shouldn't be too hard to extend it to support vertical dragging as well. 

https://github.com/user-attachments/assets/c5b5c00f-d258-4750-a4e2-b68b60844729

