### PR TITLE
feat(insights): update table data when mutating starred segments

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -775,7 +775,7 @@ const SPECIAL_FIELDS: SpecialFields = {
       <StarredSegmentCell
         projectSlug={data.project}
         segmentName={data.transaction}
-        initialIsStarred={data.is_starred_transaction}
+        isStarred={data.is_starred_transaction}
       />
     ),
   },

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -86,7 +86,7 @@ type BaseDiscoverQueryProps = {
   options?: Omit<
     UseQueryOptions<[any, string | undefined, ResponseMeta<any> | undefined], QueryError>,
     'queryKey' | 'queryFn'
-  >;
+  > & {additionalQueryKey?: UseQueryOptions['queryKey']};
   /**
    * A container for query batching data and functions.
    */
@@ -423,10 +423,11 @@ export function useGenericDiscoverQuery<T, P>(props: Props<T, P>) {
   const {orgSlug, route, options} = props;
   const url = `/organizations/${orgSlug}/${route}/`;
   const apiPayload = getPayload<T, P>(props);
+  const additionalQueryKey = props.options?.additionalQueryKey ?? [];
 
   const res = useQuery<[T, string | undefined, ResponseMeta<T> | undefined], QueryError>({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
-    queryKey: [route, apiPayload],
+    queryKey: [...additionalQueryKey, route, apiPayload],
     queryFn: ({signal: _signal}) =>
       doDiscoverQuery<T>(api, url, apiPayload, {
         queryBatching: props.queryBatching,

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -35,6 +35,7 @@ export function StarredSegmentCell({segmentName, isStarred, projectSlug}: Props)
 
   const disabled = !project || !segmentName || isPending;
 
+  // Updates the corresponding table data with starred segments, this triggers a state update which stars the segment in the ui
   const updateTableData = (newIsStarred: boolean) => {
     queryClient.setQueriesData(
       {queryKey: STARRED_SEGMENT_TABLE_QUERY_KEY},

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -6,7 +6,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {useStarredSegment} from 'sentry/views/insights/common/utils/useStarredSegment';
 
 interface Props {
-  initialIsStarred: boolean;
+  isStarred: boolean;
   projectSlug: string;
   segmentName: string;
 }
@@ -14,7 +14,7 @@ interface Props {
 // The query key used for the starred segments table request, this key is used to reference that query and update the starred segment state
 export const STARRED_SEGMENT_TABLE_QUERY_KEY = ['starred-segment-table'];
 
-export function StarredSegmentCell({segmentName, initialIsStarred, projectSlug}: Props) {
+export function StarredSegmentCell({segmentName, isStarred, projectSlug}: Props) {
   const {projects} = useProjects();
   const project = projects.find(p => p.slug === projectSlug);
 
@@ -35,8 +35,8 @@ export function StarredSegmentCell({segmentName, initialIsStarred, projectSlug}:
         size="zero"
         icon={
           <IconStar
-            color={initialIsStarred ? 'yellow300' : 'gray200'}
-            isSolid={initialIsStarred}
+            color={isStarred ? 'yellow300' : 'gray200'}
+            isSolid={isStarred}
             data-test-id="starred-transaction-column"
           />
         }

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -11,14 +11,16 @@ interface Props {
   segmentName: string;
 }
 
+export const STARRED_SEGMENT_TABLE_QUERY_KEY = ['starred-segment-table'];
+
 export function StarredSegmentCell({segmentName, initialIsStarred, projectSlug}: Props) {
   const {projects} = useProjects();
   const project = projects.find(p => p.slug === projectSlug);
 
-  const {toggleStarredTransaction, isPending, isStarred} = useStarredSegment({
-    initialIsStarred,
+  const {toggleStarredTransaction, isPending} = useStarredSegment({
     projectId: project?.id,
     segmentName,
+    tableQueryKey: STARRED_SEGMENT_TABLE_QUERY_KEY,
   });
 
   const disabled = !project || !segmentName || isPending;
@@ -32,8 +34,8 @@ export function StarredSegmentCell({segmentName, initialIsStarred, projectSlug}:
         size="zero"
         icon={
           <IconStar
-            color={isStarred ? 'yellow300' : 'gray200'}
-            isSolid={isStarred}
+            color={initialIsStarred ? 'yellow300' : 'gray200'}
+            isSolid={initialIsStarred}
             data-test-id="starred-transaction-column"
           />
         }

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -11,6 +11,7 @@ interface Props {
   segmentName: string;
 }
 
+// The query key used for the starred segments table request, this key is used to reference that query and update the starred segment state
 export const STARRED_SEGMENT_TABLE_QUERY_KEY = ['starred-segment-table'];
 
 export function StarredSegmentCell({segmentName, initialIsStarred, projectSlug}: Props) {

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -22,6 +22,10 @@ import type {
   SpanMetricsResponse,
 } from 'sentry/views/insights/types';
 
+interface UseDiscoverQueryOptions {
+  additonalQueryKey?: string[];
+}
+
 interface UseDiscoverOptions<Fields> {
   cursor?: string;
   enabled?: boolean;
@@ -37,6 +41,7 @@ interface UseDiscoverOptions<Fields> {
    */
   search?: MutableSearch | string;
   sorts?: Sort[];
+  useQueryOptions?: UseDiscoverQueryOptions;
 }
 
 // The default sampling mode for eap queries
@@ -134,6 +139,7 @@ export const useDiscover = <
     projectIds,
     orderby,
     samplingMode = DEFAULT_SAMPLING_MODE,
+    useQueryOptions,
   } = options;
 
   // TODO: remove this check with eap
@@ -160,6 +166,7 @@ export const useDiscover = <
     cursor,
     noPagination,
     samplingMode: shouldSetSamplingMode ? samplingMode : undefined,
+    additionalQueryKey: useQueryOptions?.additonalQueryKey,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -223,6 +223,7 @@ function useWrappedDiscoverTimeseriesQueryWithoutPageFilters<T>(
 
 type WrappedDiscoverQueryProps<T> = {
   eventView: EventView;
+  additionalQueryKey?: string[];
   allowAggregateConditions?: boolean;
   cursor?: string;
   enabled?: boolean;
@@ -244,6 +245,7 @@ function useWrappedDiscoverQueryBase<T>({
   allowAggregateConditions,
   samplingMode,
   pageFiltersReady,
+  additionalQueryKey,
 }: WrappedDiscoverQueryProps<T> & {
   pageFiltersReady: boolean;
 }) {
@@ -281,6 +283,7 @@ function useWrappedDiscoverQueryBase<T>({
       retry: shouldRetryHandler,
       retryDelay: getRetryDelay,
       staleTime: usesRelativeDateRange ? staleTimeForRelativePeriod : Infinity,
+      additionalQueryKey,
     },
     queryExtras,
     noPagination,

--- a/static/app/views/insights/common/utils/useStarredSegment.tsx
+++ b/static/app/views/insights/common/utils/useStarredSegment.tsx
@@ -53,6 +53,7 @@ export function useStarredSegment({projectId, segmentName, tableQueryKey}: Props
 
   const onError = (message: string) => {
     addErrorMessage(message);
+    // TODO - revert table data if the mutation fails
   };
 
   const onSuccess = (message: string) => {

--- a/static/app/views/insights/common/utils/useStarredSegment.tsx
+++ b/static/app/views/insights/common/utils/useStarredSegment.tsx
@@ -1,14 +1,14 @@
-import {useState} from 'react';
-
 import {
   addErrorMessage,
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
-import {useMutation} from 'sentry/utils/queryClient';
+import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {useIsMutating, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {EAPSpanResponse} from 'sentry/views/insights/types';
 
 type StarTransactionParams = {
   project_id?: string;
@@ -18,15 +18,32 @@ type StarTransactionParams = {
 const URL_PREFIX = '/insights/starred-segments/';
 
 interface Props {
-  initialIsStarred: boolean;
   segmentName: string;
+  tableQueryKey: string[];
   projectId?: string | undefined;
 }
 
-export function useStarredSegment({initialIsStarred, projectId, segmentName}: Props) {
-  const [isStarred, setIsStarred] = useState(initialIsStarred);
+type TableRow = Partial<EAPSpanResponse> &
+  Pick<EAPSpanResponse, 'is_starred_transaction' | 'transaction'>;
+
+type TableResponse = [{confidence: any; data: TableRow[]; meta: EventsMetaType}];
+
+export function useStarredSegment({projectId, segmentName, tableQueryKey}: Props) {
+  const starredSegmentMutationKey = ['star-segment', segmentName];
+
+  const queryClient = useQueryClient();
   const organization = useOrganization();
   const api = useApi();
+  const isMutating = useIsMutating({mutationKey: starredSegmentMutationKey});
+
+  const tableData = queryClient.getQueriesData<TableResponse>({
+    queryKey: tableQueryKey,
+  })[0]?.[1]?.[0]?.data;
+
+  const isStarred =
+    tableData?.some(
+      row => row.transaction === segmentName && row.is_starred_transaction
+    ) || false;
 
   const url = `/organizations/${organization.slug}${URL_PREFIX}`;
   const data: StarTransactionParams = {
@@ -36,30 +53,28 @@ export function useStarredSegment({initialIsStarred, projectId, segmentName}: Pr
 
   const onError = (message: string) => {
     addErrorMessage(message);
-    setIsStarred(!isStarred);
   };
 
   const onSuccess = (message: string) => {
     addSuccessMessage(message);
   };
 
-  const {mutate: starTransaction, ...starTransactionResult} = useMutation({
+  const {mutate: starTransaction} = useMutation({
+    mutationKey: starredSegmentMutationKey,
     mutationFn: () => api.requestPromise(url, {method: 'POST', data}),
     onSuccess: () => onSuccess(t('Transaction starred')),
     onError: () => onError(t('Failed to star transaction')),
   });
 
-  const {mutate: unstarTransaction, ...unstarTransactionResult} = useMutation({
+  const {mutate: unstarTransaction} = useMutation({
+    mutationKey: starredSegmentMutationKey,
     mutationFn: () => api.requestPromise(url, {method: 'DELETE', data}),
     onSuccess: () => onSuccess(t('Transaction unstarred')),
     onError: () => onError(t('Failed to unstar transaction')),
   });
 
-  const isPending =
-    starTransactionResult.isPending || unstarTransactionResult.isPending || !projectId;
-
   const toggleStarredTransaction = () => {
-    if (isPending) {
+    if (isMutating) {
       return;
     }
 
@@ -70,12 +85,26 @@ export function useStarredSegment({initialIsStarred, projectId, segmentName}: Pr
     } else {
       starTransaction();
     }
-    setIsStarred(!isStarred);
+    queryClient.setQueriesData(
+      {queryKey: tableQueryKey},
+      (oldResponse: TableResponse) => {
+        const oldTableData = oldResponse[0]?.data || [];
+        const newData = oldTableData.map(row => {
+          if (row.transaction === segmentName) {
+            return {
+              ...row,
+              is_starred_transaction: !isStarred,
+            };
+          }
+          return row;
+        });
+        return [{...oldResponse[0], data: newData}] satisfies TableResponse;
+      }
+    );
   };
 
   return {
     toggleStarredTransaction,
-    isPending,
-    isStarred,
+    isPending: isMutating > 0,
   };
 }

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -24,6 +24,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
@@ -167,6 +168,7 @@ function EAPBackendOverviewPage() {
       search: existingQuery,
       sorts,
       cursor,
+      useQueryOptions: {additonalQueryKey: STARRED_SEGMENT_TABLE_QUERY_KEY},
       fields: [
         'is_starred_transaction',
         'request.method',

--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -199,7 +199,7 @@ function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
   return [
     <StarredSegmentCell
       key={row.transaction}
-      initialIsStarred={row.is_starred_transaction}
+      isStarred={row.is_starred_transaction}
       projectSlug={row.project}
       segmentName={row.transaction}
     />,

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -27,6 +27,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
@@ -193,6 +194,7 @@ function EAPOverviewPage() {
       search: existingQuery,
       sorts,
       cursor,
+      useQueryOptions: {additonalQueryKey: STARRED_SEGMENT_TABLE_QUERY_KEY},
       fields: [
         'is_starred_transaction',
         'transaction',

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -189,7 +189,7 @@ function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
   return [
     <StarredSegmentCell
       key={row.transaction}
-      initialIsStarred={row.is_starred_transaction}
+      isStarred={row.is_starred_transaction}
       projectSlug={row.project}
       segmentName={row.transaction}
     />,

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -25,6 +25,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
@@ -194,6 +195,7 @@ function EAPMobileOverviewPage() {
       search: existingQuery,
       sorts,
       cursor,
+      useQueryOptions: {additonalQueryKey: STARRED_SEGMENT_TABLE_QUERY_KEY},
       fields: [
         'is_starred_transaction',
         'transaction',

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -181,7 +181,7 @@ function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
   return [
     <StarredSegmentCell
       key={row.transaction}
-      initialIsStarred={row.is_starred_transaction}
+      isStarred={row.is_starred_transaction}
       projectSlug={row.project}
       segmentName={row.transaction}
     />,


### PR DESCRIPTION
1. Updates the `starredSegmentCell` to update the table data when we unstar/star segments.
2. The means the the cell component no longer needs to track state as we are using the table state as the source of truth rather then both the table state and a local `isStarredSegment` state.

Reasons for this change:
Because we group by both span.op and transaction, you might have two rows with the same transaction name, therefore we needed some global state between `StarredSegmentCell`. A context provider was an option here, but then we have to manage state in two places (the table and the context provider) and join them when displaying the table. This solution we just update the table data directly, which is a lot simpler.

closes DAIN-369