### PR TITLE
feat(resizing): Add new performant useResizable hook

### DIFF
--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -1,0 +1,170 @@
+import type {RefObject} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+export const RESIZABLE_DEFAULT_WIDTH = 200;
+export const RESIZABLE_MIN_WIDTH = 100;
+export const RESIZABLE_MAX_WIDTH = Infinity;
+
+interface UseResizableOptions {
+  /**
+   * The ref to the element to be resized.
+   */
+  ref: RefObject<HTMLElement | null>;
+
+  /**
+   * The starting size of the container, and the size that is set in the onDoubleClick handler.
+   *
+   * If `sizeStorageKey` is provided and exists in local storage,
+   * then this will be ignored in favor of the size stored in local storage.
+   */
+  initialSize?: number;
+
+  /**
+   * The maximum width the container can be resized to. Defaults to Infinity.
+   */
+  maxWidth?: number;
+
+  /**
+   * The minimum width the container can be resized to. Defaults to 100.
+   */
+  minWidth?: number;
+
+  /**
+   * Triggered when the user finishes dragging the resize handle.
+   */
+  onResizeEnd?: (newWidth: number) => void;
+
+  /**
+   * Triggered when the user starts dragging the resize handle.
+   */
+  onResizeStart?: () => void;
+
+  /**
+   * The local storage key used to persist the size of the container. If not provided,
+   * the size will not be persisted and the defaultWidth will be used.
+   */
+  sizeStorageKey?: string;
+}
+
+/**
+ * Performant hook to support draggable container resizing.
+ *
+ * Currently only supports resizing width and not height.
+ */
+export const useResizable = ({
+  ref,
+  initialSize = RESIZABLE_DEFAULT_WIDTH,
+  maxWidth = RESIZABLE_MAX_WIDTH,
+  minWidth = RESIZABLE_MIN_WIDTH,
+  onResizeEnd,
+  onResizeStart,
+  sizeStorageKey,
+}: UseResizableOptions): {
+  /**
+   * Whether the drag handle is held.
+   */
+  isHeld: boolean;
+  /**
+   * Apply this to the drag handle element to include 'reset' functionality.
+   */
+  onDoubleClick: () => void;
+  /**
+   * Attach this to the drag handle element's onMouseDown handler.
+   */
+  onMouseDown: (e: React.MouseEvent) => void;
+  /**
+   * The current size of the container. This is NOT updated during the drag
+   * event, only after the user finishes dragging.
+   */
+  size: number;
+} => {
+  const [isHeld, setIsHeld] = useState(false);
+
+  const isDraggingRef = useRef<boolean>(false);
+  const startXRef = useRef<number>(0);
+  const startWidthRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (ref.current) {
+      const storedSize = sizeStorageKey
+        ? parseInt(localStorage.getItem(sizeStorageKey) ?? '', 10)
+        : undefined;
+
+      ref.current.style.width = `${storedSize ?? initialSize}px`;
+    }
+  }, [ref, initialSize, sizeStorageKey]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      setIsHeld(true);
+      e.preventDefault();
+
+      const currentWidth = ref.current
+        ? parseInt(getComputedStyle(ref.current).width, 10)
+        : 0;
+
+      isDraggingRef.current = true;
+      startXRef.current = e.clientX;
+      startWidthRef.current = currentWidth;
+
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+      onResizeStart?.();
+    },
+    [ref, onResizeStart]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+
+      const deltaX = e.clientX - startXRef.current;
+      const newWidth = Math.max(
+        minWidth,
+        Math.min(maxWidth, startWidthRef.current + deltaX)
+      );
+
+      if (ref.current) {
+        ref.current.style.width = `${newWidth}px`;
+      }
+    },
+    [ref, minWidth, maxWidth]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsHeld(false);
+    const newSize = ref.current?.offsetWidth ?? initialSize;
+    isDraggingRef.current = false;
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    onResizeEnd?.(newSize);
+    if (sizeStorageKey) {
+      localStorage.setItem(sizeStorageKey, newSize.toString());
+    }
+  }, [onResizeEnd, ref, sizeStorageKey, initialSize]);
+
+  useEffect(() => {
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
+
+  const onDoubleClick = useCallback(() => {
+    if (ref.current) {
+      ref.current.style.width = `${initialSize}px`;
+    }
+  }, [ref, initialSize]);
+
+  return {
+    isHeld,
+    size: ref.current?.offsetWidth ?? initialSize,
+    onMouseDown: handleMouseDown,
+    onDoubleClick,
+  };
+};
+
+export default useResizable;

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -9,32 +9,26 @@ interface UseResizableOptions {
    * then this will be ignored in favor of the size stored in local storage.
    */
   initialSize: number;
-
   /**
    * The maximum width the container can be resized to. Defaults to Infinity.
    */
   maxWidth: number;
-
   /**
    * The minimum width the container can be resized to. Defaults to 100.
    */
   minWidth: number;
-
   /**
    * The ref to the element to be resized.
    */
   ref: RefObject<HTMLElement | null>;
-
   /**
    * Triggered when the user finishes dragging the resize handle.
    */
   onResizeEnd?: (newWidth: number) => void;
-
   /**
    * Triggered when the user starts dragging the resize handle.
    */
   onResizeStart?: () => void;
-
   /**
    * The local storage key used to persist the size of the container. If not provided,
    * the size will not be persisted and the defaultWidth will be used.

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -116,15 +116,17 @@ export const useResizable = ({
     (e: MouseEvent) => {
       if (!isDraggingRef.current) return;
 
-      const deltaX = e.clientX - startXRef.current;
-      const newWidth = Math.max(
-        minWidth,
-        Math.min(maxWidth, startWidthRef.current + deltaX)
-      );
+      window.requestAnimationFrame(() => {
+        const deltaX = e.clientX - startXRef.current;
+        const newWidth = Math.max(
+          minWidth,
+          Math.min(maxWidth, startWidthRef.current + deltaX)
+        );
 
-      if (ref.current) {
-        ref.current.style.width = `${newWidth}px`;
-      }
+        if (ref.current) {
+          ref.current.style.width = `${newWidth}px`;
+        }
+      });
     },
     [ref, minWidth, maxWidth]
   );

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -1,33 +1,29 @@
 import type {RefObject} from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-export const RESIZABLE_DEFAULT_WIDTH = 200;
-export const RESIZABLE_MIN_WIDTH = 100;
-export const RESIZABLE_MAX_WIDTH = Infinity;
-
 interface UseResizableOptions {
-  /**
-   * The ref to the element to be resized.
-   */
-  ref: RefObject<HTMLElement | null>;
-
   /**
    * The starting size of the container, and the size that is set in the onDoubleClick handler.
    *
    * If `sizeStorageKey` is provided and exists in local storage,
    * then this will be ignored in favor of the size stored in local storage.
    */
-  initialSize?: number;
+  initialSize: number;
 
   /**
    * The maximum width the container can be resized to. Defaults to Infinity.
    */
-  maxWidth?: number;
+  maxWidth: number;
 
   /**
    * The minimum width the container can be resized to. Defaults to 100.
    */
-  minWidth?: number;
+  minWidth: number;
+
+  /**
+   * The ref to the element to be resized.
+   */
+  ref: RefObject<HTMLElement | null>;
 
   /**
    * Triggered when the user finishes dragging the resize handle.
@@ -53,9 +49,9 @@ interface UseResizableOptions {
  */
 export const useResizable = ({
   ref,
-  initialSize = RESIZABLE_DEFAULT_WIDTH,
-  maxWidth = RESIZABLE_MAX_WIDTH,
-  minWidth = RESIZABLE_MIN_WIDTH,
+  initialSize,
+  maxWidth,
+  minWidth,
   onResizeEnd,
   onResizeStart,
   sizeStorageKey,

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -86,26 +86,6 @@ export const useResizable = ({
     }
   }, [ref, initialSize, sizeStorageKey]);
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      setIsHeld(true);
-      e.preventDefault();
-
-      const currentWidth = ref.current
-        ? parseInt(getComputedStyle(ref.current).width, 10)
-        : 0;
-
-      isDraggingRef.current = true;
-      startXRef.current = e.clientX;
-      startWidthRef.current = currentWidth;
-
-      document.body.style.cursor = 'ew-resize';
-      document.body.style.userSelect = 'none';
-      onResizeStart?.();
-    },
-    [ref, onResizeStart]
-  );
-
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       if (!isDraggingRef.current) return;
@@ -132,20 +112,34 @@ export const useResizable = ({
     document.body.style.cursor = '';
     document.body.style.userSelect = '';
     onResizeEnd?.(newSize);
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
     if (sizeStorageKey) {
       localStorage.setItem(sizeStorageKey, newSize.toString());
     }
-  }, [onResizeEnd, ref, sizeStorageKey, initialSize]);
+  }, [handleMouseMove, onResizeEnd, ref, sizeStorageKey, initialSize]);
 
-  useEffect(() => {
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      setIsHeld(true);
+      e.preventDefault();
 
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, [handleMouseMove, handleMouseUp]);
+      const currentWidth = ref.current
+        ? parseInt(getComputedStyle(ref.current).width, 10)
+        : 0;
+
+      isDraggingRef.current = true;
+      startXRef.current = e.clientX;
+      startWidthRef.current = currentWidth;
+
+      document.body.style.cursor = 'ew-resize';
+      document.body.style.userSelect = 'none';
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      onResizeStart?.();
+    },
+    [ref, onResizeStart, handleMouseMove, handleMouseUp]
+  );
 
   const onDoubleClick = useCallback(() => {
     if (ref.current) {

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -61,7 +61,7 @@ interface UseResizableResult {
  *
  * Currently only supports resizing width and not height.
  */
-export const useResizable = ({
+const useResizable = ({
   ref,
   initialSize,
   maxWidth,

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -42,20 +42,7 @@ interface UseResizableOptions {
   sizeStorageKey?: string;
 }
 
-/**
- * Performant hook to support draggable container resizing.
- *
- * Currently only supports resizing width and not height.
- */
-export const useResizable = ({
-  ref,
-  initialSize,
-  maxWidth,
-  minWidth,
-  onResizeEnd,
-  onResizeStart,
-  sizeStorageKey,
-}: UseResizableOptions): {
+interface UseResizableResult {
   /**
    * Whether the drag handle is held.
    */
@@ -73,7 +60,22 @@ export const useResizable = ({
    * event, only after the user finishes dragging.
    */
   size: number;
-} => {
+}
+
+/**
+ * Performant hook to support draggable container resizing.
+ *
+ * Currently only supports resizing width and not height.
+ */
+export const useResizable = ({
+  ref,
+  initialSize,
+  maxWidth,
+  minWidth,
+  onResizeEnd,
+  onResizeStart,
+  sizeStorageKey,
+}: UseResizableOptions): UseResizableResult => {
   const [isHeld, setIsHeld] = useState(false);
 
   const isDraggingRef = useRef<boolean>(false);


### PR DESCRIPTION
Creates a new hook `useResizable`  

`useResizable` consumes a container ref and updates its width directly, rather than storing and returning a `size` state like the previous `useResizableDrawer`, making it feel significantly more performant. It also ensures that the cursor is always attached to the drag handle while dragging, which was an issue with `useResizableDrawer`. Besides these changes, the API is similar to `useResizableDrawer` and supports params like `onResizeStart`, `onResizeEnd`, and a `isHeld` return param.


Next steps would be to support vertical resizing, and replace as many usages of `useResizableDrawer` with this. 

Stories entry incoming 