### PR TITLE
fix(taskworker) Convert EmailAlternative to simple structures

### DIFF
--- a/src/sentry/utils/email/message_builder.py
+++ b/src/sentry/utils/email/message_builder.py
@@ -86,7 +86,11 @@ def message_to_dict(message: EmailMultiAlternatives) -> dict[str, Any]:
         "attachments": message.attachments,
         "headers": message.extra_headers,
         "reply_to": message.reply_to,
-        "alternatives": message.alternatives,
+        "alternatives": [
+            # Django 5.2 uses a class for alternatives. Previously it was a tuple
+            [msg[0], msg[1]]
+            for msg in message.alternatives
+        ],
     }
 
 


### PR DESCRIPTION
Django 5.2's EmailAlternative cannot be JSON encoded, so we need to unpack it into lists. Previous versions of Django used tuples for `message.alternatives`

Fixes SENTRY-FOR-SENTRY-ATR