### PR TITLE
feat(confirm-modal): Add async confirmation actions

### DIFF
--- a/static/app/components/confirm.stories.tsx
+++ b/static/app/components/confirm.stories.tsx
@@ -105,6 +105,38 @@ export default storyBook('Confirm', story => {
     </Fragment>
   ));
 
+  story('Async Confirmations', () => {
+    return (
+      <Fragment>
+        <p>
+          If you pass a promise to <JSXProperty name="onConfirm" value={Function} />, the
+          modal will not close until the promise is resolved. This is useful if you have
+          actions that require a endpoint to respond before the modal can be closed, such
+          as when confirming the deletion of the page you are on.
+        </p>
+        <Confirm
+          onConfirm={() => new Promise(resolve => setTimeout(resolve, 1000))}
+          header="Are you sure?"
+          message="This confirmation takes 1 second to complete"
+        >
+          <Button>This confirmation takes 1 second to complete</Button>
+        </Confirm>
+        <p>
+          This also allows you to respond to display errors in the modal in the case of
+          network errors.
+        </p>
+        <Confirm
+          onConfirm={() => new Promise((_, reject) => setTimeout(reject, 1000))}
+          header="Are you sure?"
+          message="This confirmation will error"
+          errorMessage="Custom error message"
+        >
+          <Button>This confirmation will error</Button>
+        </Confirm>
+      </Fragment>
+    );
+  });
+
   story('Callbacks & bypass={true}', () => {
     const [callbacks, setCallbacks] = useState<string[]>([]);
     return (

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1204,7 +1204,9 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
                 disabled={disabled}
                 priority="danger"
                 confirmText={t('Delete Rule')}
-                onConfirm={this.handleDeleteRule}
+                onConfirm={() => {
+                  this.handleDeleteRule();
+                }}
                 header={<h5>{t('Delete Alert Rule?')}</h5>}
                 message={t(
                   'Are you sure you want to delete "%s"? You won\'t be able to view the history of this alert once it\'s deleted.',

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1352,7 +1352,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
                       header={<h5>{t('Delete Alert Rule?')}</h5>}
                       priority="danger"
                       confirmText={t('Delete Rule')}
-                      onConfirm={this.handleDeleteRule}
+                      onConfirm={() => {
+                        this.handleDeleteRule();
+                      }}
                     >
                       <Button priority="danger">{t('Delete Rule')}</Button>
                     </Confirm>

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -109,8 +109,10 @@ function AccountClose() {
         data: {organizations: Array.from(orgsToRemove)},
       });
 
-      openModal(GoodbyeModalContent, {
-        onClose: leaveRedirect,
+      requestAnimationFrame(() => {
+        openModal(GoodbyeModalContent, {
+          onClose: leaveRedirect,
+        });
       });
 
       // Redirect after 10 seconds

--- a/static/app/views/settings/account/confirmAccountClose.tsx
+++ b/static/app/views/settings/account/confirmAccountClose.tsx
@@ -13,7 +13,9 @@ export function ConfirmAccountClose({
       message={t(
         'WARNING! This is permanent and cannot be undone, are you really sure you want to do this?'
       )}
-      onConfirm={handleRemoveAccount}
+      onConfirm={() => {
+        handleRemoveAccount();
+      }}
     >
       <Button priority="danger">{t('Close Account')}</Button>
     </Confirm>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -318,13 +318,15 @@ export default function SentryApplicationDetails(props: Props) {
   };
 
   const rotateClientSecret = async () => {
-    try {
-      const rotateResponse = await api.requestPromise(
-        `/sentry-apps/${appSlug}/rotate-secret/`,
-        {
-          method: 'POST',
-        }
-      );
+    const rotateResponse = await api.requestPromise(
+      `/sentry-apps/${appSlug}/rotate-secret/`,
+      {
+        method: 'POST',
+      }
+    );
+
+    // Ensures that the modal is opened after the confirmation modal closes itself
+    requestAnimationFrame(() => {
       openModal(({Body, Header}) => (
         <Fragment>
           <Header>{t('Your new Client Secret')}</Header>
@@ -340,9 +342,7 @@ export default function SentryApplicationDetails(props: Props) {
           </Body>
         </Fragment>
       ));
-    } catch {
-      addErrorMessage(t('Error rotating secret'));
-    }
+    });
   };
 
   const onFieldChange = (name: string, value: FieldValue): void => {
@@ -546,6 +546,7 @@ export default function SentryApplicationDetails(props: Props) {
                             message={t(
                               'Are you sure you want to rotate the client secret? The current one will not be usable anymore, and this cannot be undone.'
                             )}
+                            errorMessage={t('Error rotating secret')}
                           >
                             <Button priority="danger">Rotate client secret</Button>
                           </Confirm>

--- a/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedPlugin.tsx
@@ -143,7 +143,9 @@ class InstalledPlugin extends Component<Props> {
               onConfirming={this.handleUninstallClick}
               disabled={!hasAccess}
               confirmText="Delete Installation"
-              onConfirm={() => this.handleReset()}
+              onConfirm={() => {
+                this.handleReset();
+              }}
               message={this.getConfirmMessage()}
             >
               <StyledButton

--- a/static/app/views/settings/organizationTeams/teamSettings/index.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.tsx
@@ -126,7 +126,9 @@ function TeamSettings({team, params}: TeamSettingsProps) {
           <div>
             <Confirm
               disabled={isIdpProvisioned || !hasTeamAdmin}
-              onConfirm={handleRemoveTeam}
+              onConfirm={() => {
+                handleRemoveTeam();
+              }}
               priority="danger"
               message={tct('Are you sure you want to remove the team [team]?', {
                 team: `#${team.slug}`,

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -172,7 +172,9 @@ export function KeySettings({
                     message={t(
                       'Are you sure you want to revoke this key? This will immediately remove and suspend the credentials.'
                     )}
-                    onConfirm={handleRemove}
+                    onConfirm={() => {
+                      handleRemove();
+                    }}
                     confirmText={t('Revoke Key')}
                     disabled={!hasAccess}
                   >

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -214,7 +214,9 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
 
         {isOrgOwner && !isInternal && (
           <Confirm
-            onConfirm={handleTransferProject}
+            onConfirm={() => {
+              handleTransferProject();
+            }}
             priority="danger"
             confirmText={t('Transfer project')}
             renderMessage={({confirm}) => (

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -129,7 +129,7 @@ function UserDetails() {
 
     openConfirmModal({
       message: 'Are you sure you want to remove this authenticator?',
-      onConfirm: () =>
+      onConfirm: () => {
         api.request(endpoint, {
           method: 'DELETE',
           success: () => {
@@ -144,7 +144,8 @@ function UserDetails() {
           error: () => {
             addErrorMessage('Unable to remove authenticator from account.');
           },
-        }),
+        });
+      },
     });
   };
 
@@ -167,7 +168,7 @@ function UserDetails() {
         (identity.status === UserIdentityStatus.NEEDED_FOR_ORG_AUTH
           ? ' (Caution: User may be locked out of org access.)'
           : ''),
-      onConfirm: () =>
+      onConfirm: () => {
         api.request(endpoint, {
           method: 'DELETE',
           success: () => {
@@ -185,7 +186,8 @@ function UserDetails() {
           error: () => {
             addErrorMessage('Unable to remove identity from account.');
           },
-        }),
+        });
+      },
     });
   };
 

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -488,7 +488,9 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
         )}
       {!isLoading && orgEnabledFlag && canViewSpendAllocation && (
         <Confirm
-          onConfirm={disableSpendAllocations}
+          onConfirm={() => {
+            disableSpendAllocations();
+          }}
           renderMessage={confirmDisableContent}
         >
           <Button

--- a/static/gsApp/views/spikeProtection/spikeProtectionProjects.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionProjects.tsx
@@ -204,7 +204,9 @@ function SpikeProtectionProjects({subscription}: Props) {
     );
     return (
       <Confirm
-        onConfirm={() => updateAllProjects(isEnabling)}
+        onConfirm={() => {
+          updateAllProjects(isEnabling);
+        }}
         message={confirmationText}
         disabled={!hasOrgWrite}
       >


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/91386,  now without flaky tests after this change https://github.com/getsentry/sentry/pull/91556