### PR TITLE
fix(widget-viewer): Prevent scroll on open, close, sorting, pagination

### DIFF
--- a/static/app/components/gridEditable/sortLink.tsx
+++ b/static/app/components/gridEditable/sortLink.tsx
@@ -15,6 +15,7 @@ type Props = {
   generateSortLink: () => LocationDescriptorObject | undefined;
   title: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  preventScrollReset?: boolean;
   replace?: boolean;
 };
 
@@ -26,6 +27,7 @@ function SortLink({
   onClick,
   direction,
   replace,
+  preventScrollReset,
 }: Props) {
   const target = generateSortLink();
   const navigate = useNavigate();
@@ -41,13 +43,18 @@ function SortLink({
   const handleOnClick: React.MouseEventHandler<HTMLAnchorElement> = e => {
     if (replace) {
       e.preventDefault();
-      navigate(target, {replace: true});
+      navigate(target, {replace: true, preventScrollReset});
     }
     onClick?.(e);
   };
 
   return (
-    <StyledLink align={align} to={target} onClick={handleOnClick}>
+    <StyledLink
+      align={align}
+      to={target}
+      onClick={handleOnClick}
+      preventScrollReset={preventScrollReset}
+    >
       {title} {arrow}
     </StyledLink>
   );

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -527,7 +527,7 @@ function WidgetViewerModal(props: Props) {
                     [WidgetViewerQueryField.CURSOR]: newCursor,
                   },
                 },
-                {replace: true}
+                {replace: true, preventScrollReset: true}
               );
 
               if (widget.displayType === DisplayType.TABLE) {

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -96,6 +96,7 @@ export const renderIssueGridHeaderCell = ({
             order: 'desc',
           });
         }}
+        preventScrollReset
       />
     );
   };
@@ -324,6 +325,7 @@ export const renderReleaseGridHeaderCell = ({
             order: sort?.kind === 'desc' ? 'asc' : 'desc',
           });
         }}
+        preventScrollReset
       />
     );
   };

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -169,6 +169,7 @@ export const renderDiscoverGridHeaderCell = ({
             order: currentSort?.kind === 'desc' ? 'asc' : 'desc',
           });
         }}
+        preventScrollReset
       />
     );
   };

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -297,6 +297,7 @@ class DashboardDetail extends Component<Props, State> {
       dashboard,
       location,
       router,
+      navigate,
     } = this.props;
     const {
       seriesData,
@@ -337,10 +338,13 @@ class DashboardDetail extends Component<Props, State> {
           onClose: () => {
             // Filter out Widget Viewer Modal query params when exiting the Modal
             const query = omit(location.query, Object.values(WidgetViewerQueryField));
-            router.push({
-              pathname: location.pathname.replace(/widget\/[0-9]+\/$/, ''),
-              query,
-            });
+            navigate(
+              {
+                pathname: location.pathname.replace(/widget\/[0-9]+\/$/, ''),
+                query,
+              },
+              {preventScrollReset: true}
+            );
           },
           onEdit: () => {
             const widgetIndex = dashboard.widgets.findIndex(

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -21,6 +21,7 @@ import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
@@ -109,6 +110,7 @@ type Data = {
 function WidgetCard(props: Props) {
   const [data, setData] = useState<Data>();
   const {setData: setWidgetViewerData} = useContext(WidgetViewerContext);
+  const navigate = useNavigate();
 
   const onDataFetched = (newData: Data) => {
     const {...rest} = newData;
@@ -180,12 +182,15 @@ function WidgetCard(props: Props) {
         isSampled: data?.isSampled,
       });
 
-      props.router.push({
-        pathname: `${location.pathname}${
-          location.pathname.endsWith('/') ? '' : '/'
-        }widget/${props.index}/`,
-        query: location.query,
-      });
+      navigate(
+        {
+          pathname: `${location.pathname}${
+            location.pathname.endsWith('/') ? '' : '/'
+          }widget/${props.index}/`,
+          query: location.query,
+        },
+        {preventScrollReset: true}
+      );
     }
   };
 


### PR DESCRIPTION
These actions shouldn't result in the page scroll resetting when the URL changes. Add the `preventScrollReset` option so we can opt out of scroll resetting. The covered actions are:
- opening and closing the widget viewer
- sorting columns in the viewer
- paginating the events table in the viewer