### PR TITLE
feat(discover): Submit "Save as" on enter key

### DIFF
--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -209,7 +209,7 @@ describe('Discover > SaveQueryButtonGroup', function () {
       );
 
       // Click on Save in the Dropdown
-      await userEvent.click(screen.getByRole('button', {name: 'Save for Org'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Save for Organization'}));
 
       expect(mockUtils).toHaveBeenCalledWith(
         expect.anything(), // api
@@ -257,7 +257,7 @@ describe('Discover > SaveQueryButtonGroup', function () {
       // Do not fill in Input
 
       // Click on Save in the Dropdown
-      await userEvent.click(screen.getByRole('button', {name: 'Save for Org'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Save for Organization'}));
 
       // Check that EventView has a name
       expect(errorsView.name).toBe('Errors by Title');
@@ -440,7 +440,9 @@ describe('Discover > SaveQueryButtonGroup', function () {
         await userEvent.type(screen.getByPlaceholderText('Display name'), 'Forked Query');
 
         // Click on Save in the Dropdown
-        await userEvent.click(screen.getByRole('button', {name: 'Save for Org'}));
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Save for Organization'})
+        );
 
         expect(mockUtils).toHaveBeenCalledWith(
           expect.anything(), // api

--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -223,6 +223,31 @@ describe('Discover > SaveQueryButtonGroup', function () {
       );
     });
 
+    it('saves on enter', async () => {
+      mount(location, organization, router, errorsView, undefined, yAxis);
+
+      // Click on ButtonSaveAs to open dropdown
+      await userEvent.click(screen.getByRole('button', {name: 'Save as'}));
+
+      // Fill in the Input
+      const input = screen.getByPlaceholderText('Display name');
+      await userEvent.type(input, 'My New Query');
+
+      // Press Enter
+      await userEvent.keyboard('{enter}');
+
+      expect(mockUtils).toHaveBeenCalledWith(
+        expect.anything(),
+        organization,
+        expect.objectContaining({
+          ...errorsView,
+          name: 'My New Query',
+        }),
+        yAxis,
+        true
+      );
+    });
+
     it('rejects if query.name is empty', async () => {
       mount(location, organization, router, errorsView, undefined, yAxis);
 

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -117,7 +117,7 @@ function SaveAsDropdown({
                     priority="primary"
                     disabled={disabled || !queryName}
                   >
-                    {t('Save for Org')}
+                    {t('Save for Organization')}
                   </SaveAsButton>
                 </form>
               </FocusScope>

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -70,7 +70,9 @@ const renderDisabled = (p: any) => (
 
 type SaveAsDropdownProps = {
   disabled: boolean;
-  modifiedHandleCreateQuery: (e: React.MouseEvent<Element>) => void;
+  modifiedHandleCreateQuery: (
+    e: React.MouseEvent<Element> | React.FormEvent<HTMLFormElement>
+  ) => void;
   onChangeInput: (e: React.FormEvent<HTMLInputElement>) => void;
   queryName: string;
 };
@@ -97,27 +99,30 @@ function SaveAsDropdown({
       </Button>
       <AnimatePresence>
         {isOpen && (
-          <FocusScope contain restoreFocus autoFocus>
-            <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
-              <StyledOverlay arrowProps={arrowProps} animated>
-                <SaveAsInput
-                  type="text"
-                  name="query_name"
-                  placeholder={t('Display name')}
-                  value={queryName || ''}
-                  onChange={onChangeInput}
-                  disabled={disabled}
-                />
-                <SaveAsButton
-                  onClick={modifiedHandleCreateQuery}
-                  priority="primary"
-                  disabled={disabled || !queryName}
-                >
-                  {t('Save for Org')}
-                </SaveAsButton>
-              </StyledOverlay>
-            </PositionWrapper>
-          </FocusScope>
+          <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
+            <StyledOverlay arrowProps={arrowProps} animated>
+              <FocusScope contain restoreFocus autoFocus>
+                <form onSubmit={modifiedHandleCreateQuery}>
+                  <SaveAsInput
+                    type="text"
+                    name="query_name"
+                    placeholder={t('Display name')}
+                    value={queryName || ''}
+                    onChange={onChangeInput}
+                    disabled={disabled}
+                  />
+                  <SaveAsButton
+                    type="submit"
+                    onClick={modifiedHandleCreateQuery}
+                    priority="primary"
+                    disabled={disabled || !queryName}
+                  >
+                    {t('Save for Org')}
+                  </SaveAsButton>
+                </form>
+              </FocusScope>
+            </StyledOverlay>
+          </PositionWrapper>
         )}
       </AnimatePresence>
     </div>
@@ -245,7 +250,9 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
    * 1) Creating a query from scratch and saving it
    * 2) Modifying an existing query and saving it
    */
-  handleCreateQuery = (event: React.MouseEvent<Element>) => {
+  handleCreateQuery = (
+    event: React.MouseEvent<Element> | React.FormEvent<HTMLFormElement>
+  ) => {
     event.preventDefault();
     event.stopPropagation();
 

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -11,6 +11,7 @@ import Feature from 'sentry/components/acl/feature';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Banner from 'sentry/components/banner';
+import {Flex} from 'sentry/components/container/flex';
 import {Button, LinkButton} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
@@ -83,7 +84,9 @@ function SaveAsDropdown({
   onChangeInput,
   modifiedHandleCreateQuery,
 }: SaveAsDropdownProps) {
-  const {isOpen, triggerProps, overlayProps, arrowProps} = useOverlay();
+  const {isOpen, triggerProps, overlayProps, arrowProps} = useOverlay({
+    position: 'bottom',
+  });
   const theme = useTheme();
 
   return (
@@ -103,22 +106,24 @@ function SaveAsDropdown({
             <StyledOverlay arrowProps={arrowProps} animated>
               <FocusScope contain restoreFocus autoFocus>
                 <form onSubmit={modifiedHandleCreateQuery}>
-                  <SaveAsInput
-                    type="text"
-                    name="query_name"
-                    placeholder={t('Display name')}
-                    value={queryName || ''}
-                    onChange={onChangeInput}
-                    disabled={disabled}
-                  />
-                  <SaveAsButton
-                    type="submit"
-                    onClick={modifiedHandleCreateQuery}
-                    priority="primary"
-                    disabled={disabled || !queryName}
-                  >
-                    {t('Save for Organization')}
-                  </SaveAsButton>
+                  <Flex gap={space(1)} column>
+                    <Input
+                      type="text"
+                      name="query_name"
+                      placeholder={t('Display name')}
+                      value={queryName || ''}
+                      onChange={onChangeInput}
+                      disabled={disabled}
+                    />
+                    <SaveAsButton
+                      type="submit"
+                      onClick={modifiedHandleCreateQuery}
+                      priority="primary"
+                      disabled={disabled || !queryName}
+                    >
+                      {t('Save for Organization')}
+                    </SaveAsButton>
+                  </Flex>
                 </form>
               </FocusScope>
             </StyledOverlay>
@@ -655,10 +660,6 @@ const StyledOverlay = styled(Overlay)`
 
 const SaveAsButton = styled(Button)`
   width: 100%;
-`;
-
-const SaveAsInput = styled(Input)`
-  margin-bottom: ${space(1)};
 `;
 
 const IconUpdate = styled('div')`

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -534,7 +534,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             # Fill out name and submit form.
             self.browser.element('input[name="query_name"]').send_keys(query_name)
-            self.browser.element('[aria-label="Save for Org"]').click()
+            self.browser.element('[aria-label="Save for Organization"]').click()
 
             self.browser.wait_until(f'[data-test-id="discover2-query-name-{query_name}"]')
 


### PR DESCRIPTION
Wraps the input with a form and submit button to capture enter key presses and submit the form.
Moves focus scope down to the form instead of the entire overlay span

its this form in discover
![image](https://github.com/user-attachments/assets/15e36d09-5e02-43d0-80af-b26eea2e3e45)

