### PR TITLE
fix(alerts): Better casing for issue category alert rule filter

### DIFF
--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -10,7 +10,7 @@ from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
 from sentry.types.condition_activity import ConditionActivity
 
-CATEGORY_CHOICES = OrderedDict([(f"{gc.value}", str(gc.name).title()) for gc in GroupCategory])
+CATEGORY_CHOICES = OrderedDict([(f"{gc.value}", str(gc.name).lower()) for gc in GroupCategory])
 
 
 class IssueCategoryForm(forms.Form):


### PR DESCRIPTION
Tiny change, noticed that the casing was strange for the issue category dropdown. Especially for categories with an underscore. Lowercase matches what users see in the search bar on issues.

Before:

![CleanShot 2025-05-13 at 11 58 25](https://github.com/user-attachments/assets/ed664cd3-a100-458f-8440-7105a430331c)

After:

![CleanShot 2025-05-13 at 11 58 02](https://github.com/user-attachments/assets/e8fee34a-267f-4c41-b06c-b490b67ec3a6)