### PR TITLE
fix(eap-spans): division functions should return percentage in meta

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -809,7 +809,8 @@ SPAN_FORMULA_DEFINITIONS = {
         is_aggregate=True,
     ),
     "division_if": FormulaDefinition(
-        default_search_type="number",
+        default_search_type="percentage",
+        infer_search_type_from_arguments=False,
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={
@@ -836,7 +837,8 @@ SPAN_FORMULA_DEFINITIONS = {
         is_aggregate=True,
     ),
     "division": FormulaDefinition(
-        default_search_type="number",
+        default_search_type="percentage",
+        infer_search_type_from_arguments=False,
         arguments=[
             AttributeArgumentDefinition(
                 attribute_types={

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3318,6 +3318,10 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
             == 50 / 100
         )
         assert meta["dataset"] == self.dataset
+        assert meta["fields"] == {
+            "division_if(mobile.slow_frames,mobile.total_frames,browser.name,Chrome)": "percentage",
+            "division_if(mobile.slow_frames,mobile.total_frames,browser.name,Firefox)": "percentage",
+        }
 
     def test_total_performance_score(self):
         self.store_spans(
@@ -3444,6 +3448,10 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert data[0]["division(mobile.slow_frames,mobile.total_frames)"] == 10 / 100
         assert data[0]["division(mobile.frozen_frames,mobile.total_frames)"] == 20 / 100
         assert meta["dataset"] == self.dataset
+        assert meta["fields"] == {
+            "division(mobile.slow_frames,mobile.total_frames)": "percentage",
+            "division(mobile.frozen_frames,mobile.total_frames)": "percentage",
+        }
 
     def test_division_with_groupby(self):
         self.store_spans(


### PR DESCRIPTION
`division` and `division_if` should return "percentage", this is the same behaviour as the old metrics dataset(s).

One thing to note, technically dividing isn't always a percentage, especially on span samples. However, practically we only use it for percentages at the moment, so no reason to change this behaviour.