### PR TITLE
fix(rules): Fix parsed_rulegroup_to_event_data logging

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -240,7 +240,9 @@ def build_group_to_groupevent(
             logger.info(
                 "delayed_processing.build_group_to_groupevent_input",
                 extra={
-                    "parsed_rulegroup_to_event_data": parsed_rulegroup_to_event_data,
+                    "parsed_rulegroup_to_event_data": {
+                        f"{k[0]}:{k[1]}": v for k, v in parsed_rulegroup_to_event_data.items()
+                    },
                     "bulk_event_id_to_events": bulk_event_id_to_events,
                     "bulk_occurrence_id_to_occurrence": bulk_occurrence_id_to_occurrence,
                     "group_id_to_group": group_id_to_group,


### PR DESCRIPTION
We try to log parsed_rulegroup_to_event_data in our extra data, but tuple keys aren't allowed and so it is dropped.
Switch the tuple to a string key, allowing the logging to succeed and avoiding a warning log.
