### PR TITLE
feat(issue-taxonomy): Modify issue category alert condition to also check category_v2

### DIFF
--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -30,8 +30,8 @@ class IssueCategoryFilter(EventFilter):
         except (TypeError, ValueError):
             return False
 
-        if group and group.issue_category:
-            return bool(value == group.issue_category)
+        if group:
+            return value == group.issue_category or value == group.issue_category_v2
 
         return False
 

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -30,7 +30,8 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
 
         try:
             issue_category = group.issue_category
+            issue_category_v2 = group.issue_category_v2
         except ValueError:
             return False
 
-        return bool(value == issue_category)
+        return bool(value == issue_category or value == issue_category_v2)

--- a/tests/sentry/rules/filters/test_issue_category.py
+++ b/tests/sentry/rules/filters/test_issue_category.py
@@ -57,3 +57,8 @@ class IssueCategoryFilterPerformanceTest(
         tx_event = self.create_performance_issue()
         assert tx_event.group
         self.assertPasses(self.get_rule(data={"value": GroupCategory.PERFORMANCE.value}), tx_event)
+
+    def test_transaction_category_v2(self):
+        tx_event = self.create_performance_issue()
+        assert tx_event.group
+        self.assertPasses(self.get_rule(data={"value": GroupCategory.DB_QUERY.value}), tx_event)


### PR DESCRIPTION
Simple change that ensures the new issue categories will work with the IssueCategory rule.

The v2 and v1 categories have so overlap, so it is okay to do a simple check for both. This keeps backward compatibility with the old categories.