### PR TITLE
chore(rules): More logging in delayed_processing

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -271,6 +271,8 @@ def build_group_to_groupevent(
                         "rule": rule_group[0],
                         "project_id": project_id,
                         "event_id": event_id,
+                        "event_missing": event is None,
+                        "group_missing": group is None,
                         "group_id": group.id if group else None,
                     },
                 )
@@ -552,6 +554,10 @@ def cleanup_redis_buffer(
         filters["batch_key"] = batch_key
 
     buffer.backend.delete_hash(model=Project, filters=filters, fields=hashes_to_delete)
+    logger.info(
+        "delayed_processing.cleanup_redis_buffer",
+        extra={"hashes_to_delete": hashes_to_delete, "project_id": project_id},
+    )
 
 
 @instrumented_task(

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -544,20 +544,21 @@ def fire_rules(
 
 
 def cleanup_redis_buffer(
-    project_id: int, rules_to_groups: DefaultDict[int, set[int]], batch_key: str | None
+    project: Project, rules_to_groups: DefaultDict[int, set[int]], batch_key: str | None
 ) -> None:
     hashes_to_delete = [
         f"{rule}:{group}" for rule, groups in rules_to_groups.items() for group in groups
     ]
-    filters: dict[str, BufferField] = {"project_id": project_id}
+    filters: dict[str, BufferField] = {"project_id": project.id}
     if batch_key:
         filters["batch_key"] = batch_key
 
     buffer.backend.delete_hash(model=Project, filters=filters, fields=hashes_to_delete)
-    logger.info(
-        "delayed_processing.cleanup_redis_buffer",
-        extra={"hashes_to_delete": hashes_to_delete, "project_id": project_id},
-    )
+    if features.has("projects:num-events-issue-debugging", project):
+        logger.info(
+            "delayed_processing.cleanup_redis_buffer",
+            extra={"hashes_to_delete": hashes_to_delete, "project_id": project.id},
+        )
 
 
 @instrumented_task(
@@ -649,7 +650,7 @@ def apply_delayed(project_id: int, batch_key: str | None = None, *args: Any, **k
     with metrics.timer("delayed_processing.fire_rules.duration"):
         fire_rules(rules_to_fire, parsed_rulegroup_to_event_data, alert_rules, project)
 
-    cleanup_redis_buffer(project_id, rules_to_groups, batch_key)
+    cleanup_redis_buffer(project, rules_to_groups, batch_key)
 
 
 @delayed_processing_registry.register("delayed_processing")  # default delayed processing

--- a/tests/sentry/rules/processing/test_delayed_processing.py
+++ b/tests/sentry/rules/processing/test_delayed_processing.py
@@ -1363,7 +1363,7 @@ class CleanupRedisBufferTest(CreateEventTestCase):
         rules_to_groups: defaultdict[int, set[int]] = defaultdict(set)
         rules_to_groups[self.rule.id].add(self.group.id)
 
-        cleanup_redis_buffer(self.project.id, rules_to_groups, None)
+        cleanup_redis_buffer(self.project, rules_to_groups, None)
         rule_group_data = buffer.backend.get_hash(Project, {"project_id": self.project.id})
         assert rule_group_data == {}
 
@@ -1390,7 +1390,7 @@ class CleanupRedisBufferTest(CreateEventTestCase):
         rule_group_data = buffer.backend.get_hash(Project, {"project_id": self.project.id})
         assert rule_group_data == {}
 
-        cleanup_redis_buffer(self.project.id, rules_to_groups, batch_one_key)
+        cleanup_redis_buffer(self.project, rules_to_groups, batch_one_key)
 
         # Verify the batch we "executed" is removed
         rule_group_data = buffer.backend.get_hash(


### PR DESCRIPTION
Add a bit more logging to assist in investigations.
Confirmation of redis hash cleanup lets us rule out early termination in some repeated processing cases.
Clarification of what was missing in `missing_event_or_group` makes diagnosis of those cases simpler.
