### PR TITLE
fix(replay): prevent search bar from expanding infinitely

### DIFF
--- a/static/app/views/replays/list/listContent.tsx
+++ b/static/app/views/replays/list/listContent.tsx
@@ -100,6 +100,7 @@ const FiltersContainer = styled('div')`
 `;
 
 const SearchWrapper = styled(FiltersContainer)`
-  flex-grow: 1;
+  flex: 1;
+  min-width: 0;
   flex-wrap: nowrap;
 `;

--- a/static/app/views/replays/list/search.tsx
+++ b/static/app/views/replays/list/search.tsx
@@ -37,8 +37,10 @@ export default function ReplaysSearch() {
 }
 
 const SearchContainer = styled('div')`
-  flex-grow: 1;
+  flex: 1;
   min-width: 400px;
+  max-width: 100%;
+  width: auto;
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     min-width: auto;


### PR DESCRIPTION
prevent the search bar on replay index from growing infinitely if the search input is too long

before:


https://github.com/user-attachments/assets/630b2cd8-b1b4-4f1d-aa40-2c915517fe95

after:

https://github.com/user-attachments/assets/9f4e2870-4f5b-4ec9-af76-1855bf9772ef


closes https://github.com/getsentry/sentry/issues/80340