### PR TITLE
fix(insights): fix issue with fcp and ttfb not rendering properly on eap Webvitals

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesCategorizedQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesCategorizedQuery.tsx
@@ -78,9 +78,9 @@ export function useSpanSamplesCategorizedQuery({
 
   const isLoading = isGoodDataLoading || isMehDataLoading || isBadDataLoading;
 
-  const spanSamplesTableData: SpanSampleRowWithScore[] = data.sort(
-    (a, b) => a.totalScore - b.totalScore
-  );
+  const spanSamplesTableData: SpanSampleRowWithScore[] = defined(webVital)
+    ? data.sort((a, b) => a[`${webVital}Score`] - b[`${webVital}Score`])
+    : data.sort((a, b) => a.totalScore - b.totalScore);
 
   return {
     data: spanSamplesTableData,

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -133,6 +133,8 @@ export function useSpanSamplesWebVitalsQuery({
             inpScore: Math.round((row[SpanIndexedField.INP_SCORE_RATIO] ?? 0) * 100),
             lcpScore: Math.round((row[SpanIndexedField.LCP_SCORE_RATIO] ?? 0) * 100),
             clsScore: Math.round((row[SpanIndexedField.CLS_SCORE_RATIO] ?? 0) * 100),
+            fcpScore: Math.round((row[SpanIndexedField.FCP_SCORE_RATIO] ?? 0) * 100),
+            ttfbScore: Math.round((row[SpanIndexedField.TTFB_SCORE_RATIO] ?? 0) * 100),
             projectSlug: row[SpanIndexedField.PROJECT],
           };
         })

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -60,9 +60,7 @@ type SpanSampleRow = {
   [SpanIndexedField.CLS_SOURCE]?: string;
 };
 
-export type SpanSampleRowWithScore = SpanSampleRow & {
-  totalScore: number;
-};
+export type SpanSampleRowWithScore = SpanSampleRow & Score;
 
 export type Opportunity = {
   opportunity: number;


### PR DESCRIPTION
Fixes issues with FCP and TTFB samples not displaying properly on EAP Webvitals. This was due to some parts of the table in the samples slideout still using transaction metrics based data. Updates so that the slideout only uses spans data and handling.