### PR TITLE
fix(replay): Remove duplicate navigation

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -6,8 +6,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 
 function getReplayTabs({
@@ -33,8 +31,6 @@ type Props = {
 
 function FocusTabs({isVideoReplay}: Props) {
   const organization = useOrganization();
-  const {pathname, query} = useLocation();
-  const navigate = useNavigate();
   const {getActiveTab, setActiveTab} = useActiveReplayTab({isVideoReplay});
   const activeTab = getActiveTab();
 
@@ -47,11 +43,8 @@ function FocusTabs({isVideoReplay}: Props) {
       <Tabs
         value={activeTab}
         onChange={tab => {
+          // Navigation is handled by setActiveTab
           setActiveTab(tab);
-          navigate({
-            pathname,
-            query: {...query, t_main: tab},
-          });
           trackAnalytics('replay.details-tab-changed', {
             tab,
             organization,


### PR DESCRIPTION
setActiveTab attempts to set the same path and this makes you hit the back button twice to go back

https://github.com/getsentry/sentry/blob/f96f3e8b45dc30867af51dfc410e25f1c42f1c4d/static/app/utils/replays/hooks/useActiveReplayTab.tsx#L45-L49
