### PR TITLE
fix(feedback): Update the feedback list when an item becomes read/unread

### DIFF
--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -52,7 +52,7 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
     if (issueResult.isFetched && issueData && !issueData.hasSeen) {
       markAsRead(true);
     }
-  }, [issueResult.isFetched]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [issueData, issueResult.isFetched, markAsRead]);
 
   return {
     eventData,


### PR DESCRIPTION
The problem seems to be that, because we're calling `useInfiniteQuery` the extra `'infinite'` string is added to the query key, so we need that in there when we look things up again to mutate the cache.

followup to https://github.com/getsentry/sentry/pull/86421