### PR TITLE
fix(issues): Prevent double click on tag; route not found

### DIFF
--- a/static/app/components/issues/suspect/suspectTable.tsx
+++ b/static/app/components/issues/suspect/suspectTable.tsx
@@ -18,6 +18,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DrawerTab} from 'sentry/views/issueDetails/groupDistributions/types';
 import useGroupFlagDrawerData from 'sentry/views/issueDetails/groupFeatureFlags/hooks/useGroupFlagDrawerData';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
 interface Props {
   debugSuspectScores: boolean;
@@ -29,6 +31,7 @@ export default function SuspectTable({debugSuspectScores, environments, group}: 
   const organization = useOrganization();
   const location = useLocation();
   const [threshold, setThreshold] = useSuspectFlagScoreThreshold();
+  const {baseUrl} = useGroupDetailsRoute();
 
   const {displayFlags, isPending} = useGroupFlagDrawerData({
     environments,
@@ -110,7 +113,7 @@ export default function SuspectTable({debugSuspectScores, environments, group}: 
               >
                 <StyledLink
                   to={{
-                    pathname: `${location.pathname}${flag.key}/`,
+                    pathname: `${baseUrl}${TabPaths[Tab.DISTRIBUTIONS]}${flag.key}/`,
                     query: {
                       ...location.query,
                       tab: DrawerTab.FEATURE_FLAGS,

--- a/static/app/views/issueDetails/groupFeatureFlags/details/flagDetailsLink.tsx
+++ b/static/app/views/issueDetails/groupFeatureFlags/details/flagDetailsLink.tsx
@@ -4,6 +4,8 @@ import Link from 'sentry/components/links/link';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DrawerTab} from 'sentry/views/issueDetails/groupDistributions/types';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
 interface Props {
   children: React.ReactNode;
@@ -12,11 +14,12 @@ interface Props {
 
 export default function FlagDetailsLink({flag, children}: Props) {
   const location = useLocation();
+  const {baseUrl} = useGroupDetailsRoute();
 
   return (
     <StyledLink
       to={{
-        pathname: `${location.pathname}${flag.key}/`,
+        pathname: `${baseUrl}${TabPaths[Tab.DISTRIBUTIONS]}${flag.key}/`,
         query: {
           ...location.query,
           tab: DrawerTab.FEATURE_FLAGS,

--- a/static/app/views/issueDetails/groupTags/tagDetailsLink.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsLink.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import Link from 'sentry/components/links/link';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
+import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 import {usePrefetchTagValues} from 'sentry/views/issueDetails/utils';
 
 export default function TagDetailsLink({
@@ -18,6 +20,7 @@ export default function TagDetailsLink({
   const location = useLocation();
   const [prefetchEnabled, setPrefetchEnabled] = useState(false);
   const hoverTimeoutRef = useRef<number | undefined>(undefined);
+  const {baseUrl} = useGroupDetailsRoute();
 
   usePrefetchTagValues(tag.key, groupId, prefetchEnabled);
 
@@ -47,7 +50,7 @@ export default function TagDetailsLink({
   return (
     <StyledLink
       to={{
-        pathname: `${location.pathname}${tag.key}/`,
+        pathname: `${baseUrl}${TabPaths[Tab.DISTRIBUTIONS]}${tag.key}/`,
         query: location.query,
       }}
       onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
Some users were double clicking on these links somehow and getting to routes that do not exist. like `/distributions/handled/handled/`.

[see replay](https://sentry.sentry.io/explore/replays/f323c6802ed04c5983342a2b4799bcb7/?referrer=%2Fexplore%2Freplays%2F%3AreplaySlug%2F&t=0&t_main=errors)

fixes JAVASCRIPT-2WH1