### PR TITLE
ref(issues-search): use join for groupenvironment instead of subquery

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -690,10 +690,8 @@ class SnubaSearchBackendBase(SearchBackend, metaclass=ABCMeta):
         if environments is not None:
             environment_ids = [environment.id for environment in environments]
             group_queryset = group_queryset.filter(
-                id__in=GroupEnvironment.objects.filter(environment__in=environment_ids).values_list(
-                    "group_id"
-                )
-            )
+                groupenvironment__environment_id__in=environment_ids
+            ).distinct()
         return group_queryset
 
     @abstractmethod


### PR DESCRIPTION
when this condition runs in a query with 1,000,000+ issues, it tends to timeout. doing an explain analyze, we have to do an index scan over hundreds of thousands of rows. from my testing on redash, rewriting the subquery to a join seems to have to scan far less rows than a subquery.