### PR TITLE
ref(aci): create WorkflowFireHistory only when Workflow fires Actions

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -74,37 +74,27 @@ def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action
     return statuses
 
 
-def update_workflow_fire_histories(
-    actions_to_fire: BaseQuerySet[Action],
-    event_data: WorkflowEventData,
-    updates: WorkflowFireHistoryUpdates,
-) -> int:
-    # Update WorkflowFireHistory objects for workflows with actions to fire
-    fired_workflows = set(
+def create_workflow_fire_histories(
+    actions_to_fire: BaseQuerySet[Action], event_data: WorkflowEventData
+) -> list[WorkflowFireHistory]:
+    # Create WorkflowFireHistory objects for workflows we fire actions for
+    workflow_ids = set(
         WorkflowDataConditionGroup.objects.filter(
             condition_group__dataconditiongroupaction__action__in=actions_to_fire
         ).values_list("workflow_id", flat=True)
     )
 
-    logger.info(
-        "workflow_engine.workflow_fire_history.update",
-        extra={
-            "actions": [action.id for action in actions_to_fire],
-            "workflow_ids": list(fired_workflows),
-            "group_id": event_data.event.group_id,
-            "event_id": event_data.event.event_id,
-            "has_passed_filters": updates["has_passed_filters"],
-            "has_fired_actions": updates["has_fired_actions"],
-        },
-    )
-
-    updated_rows = WorkflowFireHistory.objects.filter(
-        workflow_id__in=fired_workflows,
-        group=event_data.event.group,
-        event_id=event_data.event.event_id,
-    ).update(**updates)
-
-    return updated_rows
+    fire_histories = [
+        WorkflowFireHistory(
+            workflow_id=workflow_id,
+            group=event_data.event.group,
+            event_id=event_data.event.event_id,
+            has_passed_filters=True,
+            has_fired_actions=True,
+        )
+        for workflow_id in workflow_ids
+    ]
+    return WorkflowFireHistory.objects.bulk_create(fire_histories)
 
 
 # TODO(cathy): only reinforce workflow frequency for certain issue types
@@ -116,8 +106,6 @@ def filter_recently_fired_workflow_actions(
         dataconditiongroupaction__condition_group__in=filtered_action_groups
     ).distinct()
 
-    wfh_updates = WorkflowFireHistoryUpdates(has_passed_filters=True, has_fired_actions=False)
-    update_workflow_fire_histories(actions, event_data, wfh_updates)
     group = event_data.event.group
 
     now = timezone.now()
@@ -143,8 +131,7 @@ def filter_recently_fired_workflow_actions(
     actions_without_statuses_ids = {action.id for action in actions_without_statuses}
     filtered_actions = actions.filter(id__in=actions_to_include | actions_without_statuses_ids)
 
-    wfh_updates["has_fired_actions"] = True
-    update_workflow_fire_histories(filtered_actions, event_data, wfh_updates)
+    create_workflow_fire_histories(filtered_actions, event_data)
 
     return filtered_actions
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -1,7 +1,6 @@
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import TypedDict
 
 from django.db.models import DurationField, ExpressionWrapper, F, IntegerField, Value
 from django.db.models.fields.json import KeyTextTransform
@@ -32,11 +31,6 @@ from sentry.workflow_engine.types import WorkflowEventData
 logger = logging.getLogger(__name__)
 
 EnqueuedAction = tuple[DataConditionGroup, list[DataCondition]]
-
-
-class WorkflowFireHistoryUpdates(TypedDict):
-    has_passed_filters: bool
-    has_fired_actions: bool
 
 
 def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action], group: Group):

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -49,7 +49,6 @@ from sentry.workflow_engine.processors.data_condition_group import evaluate_data
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-    create_workflow_fire_histories,
     evaluate_workflows_action_filters,
 )
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -430,8 +429,6 @@ def fire_actions_for_groups(
         # process workflow_triggers
         workflows = set(Workflow.objects.filter(when_condition_group_id__in=workflow_triggers))
 
-        # create WorkflowFireHistory (updated in evaluate_workflows_action_filters)
-        create_workflow_fire_histories(workflows, event_data)
         filtered_actions = filtered_actions.union(
             evaluate_workflows_action_filters(workflows, event_data)
         )

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -17,7 +17,6 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     Detector,
     Workflow,
-    WorkflowFireHistory,
 )
 from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
@@ -58,19 +57,6 @@ def delete_workflow(workflow: Workflow) -> bool:
         workflow.delete()
 
     return True
-
-
-def create_workflow_fire_histories(
-    workflows: set[Workflow], event_data: WorkflowEventData
-) -> list[WorkflowFireHistory]:
-    # Create WorkflowFireHistory objects for triggered workflows
-    fire_histories = [
-        WorkflowFireHistory(
-            workflow=workflow, group=event_data.event.group, event_id=event_data.event.event_id
-        )
-        for workflow in workflows
-    ]
-    return WorkflowFireHistory.objects.bulk_create(fire_histories)
 
 
 def enqueue_workflow(
@@ -125,8 +111,6 @@ def evaluate_workflow_triggers(
         else:
             if evaluation:
                 triggered_workflows.add(workflow)
-
-    create_workflow_fire_histories(triggered_workflows, event_data)
 
     return triggered_workflows
 

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.workflow_engine.models import DataConditionGroup, WorkflowFireHistory
+from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import (
     create_workflow_fire_histories,
@@ -87,13 +87,14 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
         self.event_data = WorkflowEventData(event=self.group_event)
 
     def test_create_workflow_fire_histories(self):
-        create_workflow_fire_histories({self.action}, self.event_data)
+        create_workflow_fire_histories(Action.objects.filter(id=self.action.id), self.event_data)
         assert (
             WorkflowFireHistory.objects.filter(
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,
-                has_fired_actions=False,
+                has_passed_filters=True,
+                has_fired_actions=True,
             ).count()
             == 1
         )

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -820,20 +820,17 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.group1.id: {self.workflow1_dcgs[0]},
             self.group2.id: {self.workflow2_dcgs[1]},
         }
-        # WorkflowFireHistory for enqueued filter (already triggered)
-        wfh = WorkflowFireHistory.objects.create(
-            workflow=self.workflow2,
-            group_id=self.group2.id,
-            event_id=self.event2.event_id,
-        )
-
         fire_actions_for_groups(
             self.groups_to_dcgs, self.trigger_group_to_dcg_model, self.group_to_groupevent
         )
 
-        wfh.refresh_from_db()
-        assert wfh.has_passed_filters is True
-        assert wfh.has_fired_actions is True
+        assert WorkflowFireHistory.objects.filter(
+            workflow=self.workflow2,
+            group_id=self.group2.id,
+            event_id=self.event2.event_id,
+            has_passed_filters=True,
+            has_fired_actions=True,
+        ).exists()
 
         assert WorkflowFireHistory.objects.filter(
             workflow=self.workflow1,

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -26,7 +26,6 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
     WorkflowDataConditionGroupType,
-    create_workflow_fire_histories,
     delete_workflow,
     enqueue_workflow,
     evaluate_workflow_triggers,
@@ -584,37 +583,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
         # TODO @saponifi3d - Add a check to ensure the second condition is enqueued for later evaluation
 
-
-class TestWorkflowFireHistory(BaseWorkflowTest):
-    def setUp(self):
-        (
-            self.workflow,
-            self.detector,
-            self.detector_workflow,
-            self.workflow_triggers,
-        ) = self.create_detector_and_workflow()
-
-        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
-
-        self.group, self.event, self.group_event = self.create_group_event(
-            occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
-        )
-        self.event_data = WorkflowEventData(event=self.group_event)
-
-    def test_create_workflow_fire_histories(self):
-        create_workflow_fire_histories({self.workflow}, self.event_data)
-        assert (
-            WorkflowFireHistory.objects.filter(
-                workflow=self.workflow,
-                group=self.group,
-                event_id=self.group_event.event_id,
-                has_fired_actions=False,
-            ).count()
-            == 1
-        )
-
-    def test_evaluate_filters_updates_histories(self):
-        # only updates workflows that meet filters
+    def test_creates_histories(self):
         self.create_data_condition(
             condition_group=self.action_group,
             type=Condition.EVENT_SEEN_COUNT,
@@ -631,28 +600,18 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
             condition_result=True,
         )  # condition is not met
 
-        create_workflow_fire_histories({self.workflow, workflow}, self.event_data)
-
         triggered_actions = evaluate_workflows_action_filters(
             {self.workflow, workflow}, self.event_data
         )
         assert set(triggered_actions) == {self.action}
 
+        assert WorkflowFireHistory.objects.all().count() == 1
         assert (
             WorkflowFireHistory.objects.filter(
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,
                 has_fired_actions=True,
-            ).count()
-            == 1
-        )
-        assert (
-            WorkflowFireHistory.objects.filter(
-                workflow=workflow,
-                group=self.group,
-                event_id=self.group_event.event_id,
-                has_fired_actions=False,
             ).count()
             == 1
         )


### PR DESCRIPTION
We are creating a huge number of `WorkflowFireHistory` objects when we create them for every `Workflow` that meets its trigger conditions. This will not scale -- we created 1 million rows in an hour for LA orgs with ~130m events / 30 days.

This is an extra thing we added on top of the existing `RuleFireHistory` model, which only tracks when rules fire actions.

We can go back to that model of utilizing `WorkflowFireHistory` for only firing actions so as to not make the db explode when we scale.