### PR TITLE
fix(queryClient): useInfiniteApiQuery should require unique queryKeys, not create them

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -52,7 +52,7 @@ export default function FeedbackList() {
     loadMoreRows,
     hits,
   } = useFetchInfiniteListData<FeedbackIssueListItem>({
-    queryKey: listQueryKey ?? [''],
+    queryKey: listQueryKey ?? ['infinite', ''],
     uniqueField: 'id',
     enabled: Boolean(listQueryKey),
   });

--- a/static/app/components/feedback/useFeedbackCache.tsx
+++ b/static/app/components/feedback/useFeedbackCache.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 
 import type {ApiResult} from 'sentry/api';
 import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
@@ -23,10 +23,6 @@ function isIssueEndpointUrl(query: any) {
 export default function useFeedbackCache() {
   const queryClient = useQueryClient();
   const {getItemQueryKeys, listQueryKey} = useFeedbackQueryKeys();
-  const infiniteListQueryKey = useMemo(
-    () => (listQueryKey ? [...listQueryKey, 'infinite'] : undefined),
-    [listQueryKey]
-  );
 
   const updateCachedQueryKey = useCallback(
     (queryKey: ApiQueryKey, payload: Partial<FeedbackIssue>) => {
@@ -57,10 +53,10 @@ export default function useFeedbackCache() {
 
   const updateCachedListPage = useCallback(
     (ids: TFeedbackIds, payload: Partial<FeedbackIssue>) => {
-      if (!infiniteListQueryKey) {
+      if (!listQueryKey) {
         return;
       }
-      const listData = queryClient.getQueryData<ListCache>(infiniteListQueryKey);
+      const listData = queryClient.getQueryData<ListCache>(listQueryKey);
       if (listData) {
         const pages = listData.pages.map(([data, statusText, resp]) => [
           data.map(item =>
@@ -69,10 +65,10 @@ export default function useFeedbackCache() {
           statusText,
           resp,
         ]);
-        queryClient.setQueryData(infiniteListQueryKey, {...listData, pages});
+        queryClient.setQueryData(listQueryKey, {...listData, pages});
       }
     },
-    [infiniteListQueryKey, queryClient]
+    [listQueryKey, queryClient]
   );
 
   const updateCached = useCallback(
@@ -100,17 +96,17 @@ export default function useFeedbackCache() {
 
   const invalidateCachedListPage = useCallback(
     (ids: TFeedbackIds) => {
-      if (!infiniteListQueryKey) {
+      if (!listQueryKey) {
         return;
       }
       if (ids === 'all') {
         queryClient.invalidateQueries({
-          queryKey: infiniteListQueryKey,
+          queryKey: listQueryKey,
           type: 'all',
         });
       } else {
         queryClient.refetchQueries({
-          queryKey: infiniteListQueryKey,
+          queryKey: listQueryKey,
           predicate: query => {
             // Check if any of the pages contain the items we want to invalidate
             return Boolean(
@@ -122,7 +118,7 @@ export default function useFeedbackCache() {
         });
       }
     },
-    [infiniteListQueryKey, queryClient]
+    [listQueryKey, queryClient]
   );
 
   const invalidateCached = useCallback(

--- a/static/app/components/feedback/useFeedbackQueryKeys.tsx
+++ b/static/app/components/feedback/useFeedbackQueryKeys.tsx
@@ -4,20 +4,23 @@ import {createContext, useCallback, useContext, useRef, useState} from 'react';
 import getFeedbackItemQueryKey from 'sentry/components/feedback/getFeedbackItemQueryKey';
 import useFeedbackListQueryKey from 'sentry/components/feedback/useFeedbackListQueryKey';
 import type {Organization} from 'sentry/types/organization';
+import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/queryClient';
 
 interface Props {
   children: ReactNode;
   organization: Organization;
 }
 
-type ListQueryKey = ReturnType<typeof useFeedbackListQueryKey>;
-type ItemQueryKeys = ReturnType<typeof getFeedbackItemQueryKey>;
+type ItemQueryKeys = {
+  eventQueryKey: ApiQueryKey | undefined;
+  issueQueryKey: ApiQueryKey | undefined;
+};
 
 interface TContext {
   getItemQueryKeys: (id: string) => ItemQueryKeys;
   listHeadTime: number;
-  listPrefetchQueryKey: ListQueryKey;
-  listQueryKey: ListQueryKey;
+  listPrefetchQueryKey: ApiQueryKey | undefined;
+  listQueryKey: InfiniteApiQueryKey | undefined;
   resetListHeadTime: () => void;
 }
 
@@ -75,7 +78,7 @@ export function FeedbackQueryKeys({children, organization}: Props) {
         getItemQueryKeys,
         listHeadTime,
         listPrefetchQueryKey,
-        listQueryKey,
+        listQueryKey: listQueryKey ? ['infinite', ...listQueryKey] : undefined,
         resetListHeadTime,
       }}
     >

--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -52,7 +52,7 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
     if (issueResult.isFetched && issueData && !issueData.hasSeen) {
       markAsRead(true);
     }
-  }, [issueResult.isFetched]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [issueData, issueResult.isFetched, markAsRead]);
 
   return {
     eventData,

--- a/static/app/components/feedback/useMutateFeedback.tsx
+++ b/static/app/components/feedback/useMutateFeedback.tsx
@@ -48,7 +48,7 @@ export default function useMutateFeedback({
       const options = isSingleId
         ? {}
         : ids === 'all'
-          ? listQueryKey?.[1]!
+          ? listQueryKey?.[2]!
           : {query: {id: ids, project: projectIds}};
       return fetchMutation(['PUT', url, options, payload]);
     },

--- a/static/app/utils/api/useFetchInfiniteListData.tsx
+++ b/static/app/utils/api/useFetchInfiniteListData.tsx
@@ -1,7 +1,8 @@
 import {useCallback, useMemo} from 'react';
 import type {Index, IndexRange} from 'react-virtualized';
 
-import {type ApiQueryKey, useInfiniteApiQuery} from 'sentry/utils/queryClient';
+import type {InfiniteApiQueryKey} from 'sentry/utils/queryClient';
+import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
 
 function uniqueItems<Data extends Record<string, unknown>>(
   items: Data[],
@@ -18,7 +19,7 @@ function uniqueItems<Data extends Record<string, unknown>>(
 }
 
 interface Props {
-  queryKey: NonNullable<ApiQueryKey | undefined>;
+  queryKey: NonNullable<InfiniteApiQueryKey | undefined>;
   uniqueField: string;
   enabled?: boolean;
 }

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -258,14 +258,7 @@ export function useInfiniteApiQuery<TResponseData>({
   staleTime?: number;
 }) {
   return useInfiniteQuery({
-    // We append an additional string to the queryKey here to prevent a hard
-    // crash due to a cache conflict between normal queries and "infinite"
-    // queries. Read more
-    // here: https://tkdodo.eu/blog/effective-react-query-keys#caching-data
     queryKey,
-    // queryKey.length === 1
-    //   ? ([...queryKey, {}, 'infinite'] as const)
-    //   : ([...queryKey, 'infinite'] as const),
     queryFn: ({
       pageParam,
       queryKey: [, url, endpointOptions],

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -49,6 +49,17 @@ export type ApiQueryKey =
         Record<string, any>
       >,
     ];
+export type InfiniteApiQueryKey =
+  | readonly ['infinite', url: string]
+  | readonly [
+      'infinite',
+      url: string,
+      options: QueryKeyEndpointOptions<
+        Record<string, string>,
+        Record<string, any>,
+        Record<string, any>
+      >,
+    ];
 
 export interface UseApiQueryOptions<TApiResponse, TError = RequestError>
   extends Omit<
@@ -242,7 +253,7 @@ export function useInfiniteApiQuery<TResponseData>({
   enabled,
   staleTime,
 }: {
-  queryKey: ApiQueryKey;
+  queryKey: InfiniteApiQueryKey;
   enabled?: boolean;
   staleTime?: number;
 }) {
@@ -251,13 +262,13 @@ export function useInfiniteApiQuery<TResponseData>({
     // crash due to a cache conflict between normal queries and "infinite"
     // queries. Read more
     // here: https://tkdodo.eu/blog/effective-react-query-keys#caching-data
-    queryKey:
-      queryKey.length === 1
-        ? ([...queryKey, {}, 'infinite'] as const)
-        : ([...queryKey, 'infinite'] as const),
+    queryKey,
+    // queryKey.length === 1
+    //   ? ([...queryKey, {}, 'infinite'] as const)
+    //   : ([...queryKey, 'infinite'] as const),
     queryFn: ({
       pageParam,
-      queryKey: [url, endpointOptions],
+      queryKey: [, url, endpointOptions],
     }): Promise<ApiResult<TResponseData>> => {
       return QUERY_API_CLIENT.requestPromise(url, {
         includeAllArgs: true,

--- a/static/app/utils/useReleaseStats.tsx
+++ b/static/app/utils/useReleaseStats.tsx
@@ -45,6 +45,7 @@ export function useReleaseStats(
     data,
   } = useInfiniteApiQuery<ReleaseMetaBasic[]>({
     queryKey: [
+      'infinite' as const,
       `/organizations/${organization.slug}/releases/stats/`,
       {
         query: {


### PR DESCRIPTION
What was previously happening since https://github.com/getsentry/sentry/pull/86421 is that we would silently change the queryKey that was passed into `useInfiniteApiQuery` to have `'infinite'` suffixed to the end. This was leaky if any code wanted to interact with the query cache it had to add the same suffix.

Well, now the suffix is a prefix, and is required when you call `useInfiniteApiQuery()`. This will ensure that all queryKeys for useInfiniteApiQuery are unique (as we did before) but also will make sure that the same queryKey will work for fetching the data and interacting with the cache.

Replaces https://github.com/getsentry/sentry/pull/91596
Followup to https://github.com/getsentry/sentry/pull/86421