### PR TITLE
ref(reserved budgets): Update types + constants

### DIFF
--- a/static/gsApp/__fixtures__/plan.tsx
+++ b/static/gsApp/__fixtures__/plan.tsx
@@ -9,6 +9,7 @@ export function PlanFixture(fields: Partial<Plan>): Plan {
     billingInterval: 'monthly',
     categories: [],
     checkoutCategories: [],
+    availableReservedBudgetTypes: {},
     contractInterval: 'monthly',
     description: '',
     features: [],

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -2144,82 +2144,13 @@ describe('GSBanner Overage Alerts', function () {
       'profile_duration',
       'profile_duration_ui',
       'uptime',
-    ]) {
-      overagePrompts.push(`${category}_overage_alert`);
-      warningPrompts.push(`${category}_warning_alert`);
-      if (
-        ['profile_duration', 'replays', 'spans', 'profile_duration_ui'].includes(category)
-      ) {
-        productTrialPrompts.push(`${category}_product_trial_alert`);
-      }
-    }
-
-    expect(promptsMock).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/prompts-activity/`,
-      expect.objectContaining({
-        query: {
-          feature: [
-            'deactivated_member_alert',
-            ...overagePrompts,
-            ...warningPrompts,
-            ...productTrialPrompts,
-          ],
-          organization_id: organization.id,
-        },
-      })
-    );
-  });
-
-  // TODO(Seer): remove this test after seer has been added to the fixtures
-  it('checks prompts for all billed categories on plan with seer', async function () {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'am3_team',
-    });
-    subscription.planDetails.categories = [
-      ...subscription.planDetails.categories,
-      DataCategory.SEER_AUTOFIX,
-      DataCategory.SEER_SCANNER,
-    ];
-    const promptsMock = MockApiClient.addMockResponse({
-      method: 'GET',
-      url: `/organizations/${organization.slug}/prompts-activity/`,
-    });
-    SubscriptionStore.set(organization.slug, subscription);
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-      deprecatedRouterMocks: true,
-    });
-    await act(tick);
-
-    const overagePrompts = [];
-    const warningPrompts = [];
-    const productTrialPrompts = [];
-    for (const category of [
-      'errors',
-      'attachments',
-      'replays',
-      'spans',
-      'monitor_seats',
-      'profile_duration',
-      'profile_duration_ui',
-      'uptime',
       'seer_autofix',
       'seer_scanner',
     ]) {
       overagePrompts.push(`${category}_overage_alert`);
       warningPrompts.push(`${category}_warning_alert`);
       if (
-        [
-          'profile_duration',
-          'replays',
-          'spans',
-          'profile_duration_ui',
-          'seer_autofix',
-          'seer_scanner',
-        ].includes(category)
+        ['profile_duration', 'replays', 'spans', 'profile_duration_ui'].includes(category)
       ) {
         productTrialPrompts.push(`${category}_product_trial_alert`);
       }

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -168,7 +168,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.SEER_AUTOFIX]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_AUTOFIX],
     canAllocate: false,
-    canProductTrial: true,
+    canProductTrial: false,
     maxAdminGift: 0,
     freeEventsMultiple: 0,
     feature: 'seer-billing',
@@ -176,7 +176,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.SEER_SCANNER]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_SCANNER],
     canAllocate: false,
-    canProductTrial: true,
+    canProductTrial: false,
     maxAdminGift: 0,
     freeEventsMultiple: 0,
     feature: 'seer-billing',

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -81,6 +81,10 @@ export enum ReservedBudgetCategoryType {
 
 export type ReservedBudgetCategory = {
   /**
+   * The API name of the budget
+   */
+  apiName: ReservedBudgetCategoryType;
+  /**
    * Backend name of the category (all caps, snake case)
    */
   budgetCategoryType: string;
@@ -95,7 +99,7 @@ export type ReservedBudgetCategory = {
   /**
    * Default budget for the category, in cents
    */
-  defaultBudget: number;
+  defaultBudget: number | null;
   /**
    * Link to the quotas documentation for the budget
    */
@@ -935,10 +939,6 @@ export type ReservedBudget = {
    */
   id: string;
   /**
-   * Information about the budget type
-   */
-  info: ReservedBudgetCategory;
-  /**
    * The percentage of the budget used, including gifted budget
    */
   percentUsed: number;
@@ -950,7 +950,7 @@ export type ReservedBudget = {
    * The amount of budget used in the associated usage cycle
    */
   totalReservedSpend: number;
-};
+} & ReservedBudgetCategory;
 
 export type ReservedBudgetMetricHistory = {
   reservedCpe: number; // in cents

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -74,6 +74,46 @@ export enum CheckoutType {
   BUNDLE = 'bundle',
 }
 
+export enum ReservedBudgetCategoryType {
+  DYNAMIC_SAMPLING = 'dynamicSampling',
+  SEER = 'seer',
+}
+
+export type ReservedBudgetCategory = {
+  /**
+   * Backend name of the category (all caps, snake case)
+   */
+  budgetCategoryType: string;
+  /**
+   * whether a customer can use product trials for this budget
+   */
+  canProductTrial: boolean;
+  /**
+   * the categories that are included in the budget
+   */
+  dataCategories: DataCategory[];
+  /**
+   * Default budget for the category, in cents
+   */
+  defaultBudget: number;
+  /**
+   * Link to the quotas documentation for the budget
+   */
+  docLink: string;
+  /**
+   * Whether the budget is fixed or variable
+   */
+  isFixed: boolean;
+  /**
+   * Display name of the budget
+   */
+  name: string;
+  /**
+   * the product associated with the budget
+   */
+  productName: string;
+};
+
 export type Plan = {
   allowAdditionalReservedEvents: boolean;
   allowOnDemand: boolean;
@@ -82,6 +122,9 @@ export type Plan = {
    * Can be used for category upsells.
    */
   availableCategories: DataCategory[];
+  availableReservedBudgetTypes: Partial<
+    Record<ReservedBudgetCategoryType, ReservedBudgetCategory>
+  >;
   basePrice: number;
   billingInterval: 'monthly' | 'annual';
   budgetTerm: 'pay-as-you-go' | 'on-demand';
@@ -879,11 +922,33 @@ type PendingReservedBudget = {
 };
 
 export type ReservedBudget = {
+  /**
+   * The categories included in the budget and their respective ReservedBudgetMetricHistory
+   */
   categories: Partial<Record<DataCategory, ReservedBudgetMetricHistory>>;
+  /**
+   * The amount of free budget gifted in the associated usage cycle
+   */
   freeBudget: number;
+  /**
+   * The id of the ReservedBudgetHistory object
+   */
   id: string;
+  /**
+   * Information about the budget type
+   */
+  info: ReservedBudgetCategory;
+  /**
+   * The percentage of the budget used, including gifted budget
+   */
   percentUsed: number;
+  /**
+   * The amount of budget in the associated usage cycle, excluding gifted budget
+   */
   reservedBudget: number;
+  /**
+   * The amount of budget used in the associated usage cycle
+   */
   totalReservedSpend: number;
 };
 

--- a/static/gsApp/utils/dataCategory.spec.tsx
+++ b/static/gsApp/utils/dataCategory.spec.tsx
@@ -246,7 +246,7 @@ describe('getReservedBudgetDisplayName', function () {
         hadCustomDynamicSampling: false,
       })
     ).toBe(
-      'attachments, cron monitors, errors, replays, transactions, and uptime monitors'
+      'attachments, cron monitors, errors, issue fixes, issue scans, replays, transactions, and uptime monitors'
     );
   });
 
@@ -258,7 +258,7 @@ describe('getReservedBudgetDisplayName', function () {
         hadCustomDynamicSampling: false,
       })
     ).toBe(
-      'attachments, continuous profile hours, cron monitors, errors, performance units, replays, UI profile hours, and uptime monitors'
+      'attachments, continuous profile hours, cron monitors, errors, issue fixes, issue scans, performance units, replays, UI profile hours, and uptime monitors'
     );
   });
 
@@ -270,7 +270,7 @@ describe('getReservedBudgetDisplayName', function () {
         hadCustomDynamicSampling: false,
       })
     ).toBe(
-      'attachments, continuous profile hours, cron monitors, errors, replays, spans, UI profile hours, and uptime monitors'
+      'attachments, continuous profile hours, cron monitors, errors, issue fixes, issue scans, replays, spans, UI profile hours, and uptime monitors'
     );
   });
 
@@ -300,7 +300,7 @@ describe('getReservedBudgetDisplayName', function () {
         shouldTitleCase: true,
       })
     ).toBe(
-      'Attachments, Continuous Profile Hours, Cron Monitors, Errors, Replays, Spans, UI Profile Hours, and Uptime Monitors'
+      'Attachments, Continuous Profile Hours, Cron Monitors, Errors, Issue Fixes, Issue Scans, Replays, Spans, UI Profile Hours, and Uptime Monitors'
     );
   });
 });

--- a/static/gsApp/views/amCheckout/checkoutOverviewV2.tsx
+++ b/static/gsApp/views/amCheckout/checkoutOverviewV2.tsx
@@ -182,89 +182,88 @@ function CheckoutOverviewV2({
       <Section>
         <Subtitle>{t('All Sentry Products')}</Subtitle>
         <ReservedVolumes>
-          {activePlan.categories.map(category => {
-            const eventBucket =
-              activePlan.planCategories[category] &&
-              activePlan.planCategories[category].length <= 1
-                ? null
-                : utils.getBucket({
-                    events: formData.reserved[category],
-                    buckets: activePlan.planCategories[category],
-                  });
-            const price = utils.displayPrice({
-              cents: eventBucket ? eventBucket.price : 0,
-            });
-            const isMoreThanIncluded =
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              formData.reserved[category] > activePlan.planCategories[category][0].events;
-            return (
-              <SpaceBetweenRow
-                key={category}
-                data-test-id={`${category}-reserved`}
-                style={{alignItems: 'center'}}
-              >
-                <ReservedItem>
-                  {
-                    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                    formData.reserved[category] > 0 && (
+          {activePlan.categories
+            .filter(category => activePlan.planCategories[category])
+            .map(category => {
+              const eventBucket =
+                activePlan.planCategories[category] &&
+                activePlan.planCategories[category].length <= 1
+                  ? null
+                  : utils.getBucket({
+                      events: formData.reserved[category],
+                      buckets: activePlan.planCategories[category],
+                    });
+              const price = utils.displayPrice({
+                cents: eventBucket ? eventBucket.price : 0,
+              });
+              const isMoreThanIncluded =
+                (formData.reserved[category] ?? 0) >
+                (activePlan.planCategories[category]?.[0]?.events ?? 0);
+              return (
+                <SpaceBetweenRow
+                  key={category}
+                  data-test-id={`${category}-reserved`}
+                  style={{alignItems: 'center'}}
+                >
+                  <ReservedItem>
+                    {(formData.reserved[category] ?? 0) > 0 && (
                       <Fragment>
                         <EmphasisText>
-                          {
-                            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-                            formatReservedWithUnits(formData.reserved[category], category)
-                          }
+                          {formatReservedWithUnits(
+                            formData.reserved[category] ?? 0,
+                            category
+                          )}
                         </EmphasisText>{' '}
                       </Fragment>
-                    )
-                  }
-                  {formData.reserved[category] === 1 &&
-                  category !== DataCategory.ATTACHMENTS
-                    ? getSingularCategoryName({
-                        plan: activePlan,
-                        category,
-                        title: true,
-                      })
-                    : getPlanCategoryName({
-                        plan: activePlan,
-                        category,
-                        title: true,
-                      })}
-                  {paygCategories.includes(category) ? (
-                    <QuestionTooltip
-                      size="xs"
-                      title={t(
-                        "%s use your pay-as-you-go budget. You'll only be charged for actual usage.",
-                        getPlanCategoryName({
+                    )}
+                    {formData.reserved[category] === 1 &&
+                    category !== DataCategory.ATTACHMENTS
+                      ? getSingularCategoryName({
                           plan: activePlan,
                           category,
+                          title: true,
                         })
-                      )}
-                    />
-                  ) : null}
-                </ReservedItem>
-                <Price>
-                  {isMoreThanIncluded ? (
-                    `+ ${price}/${shortInterval}`
-                  ) : (
-                    <Tag
-                      icon={
-                        hasPaygProducts ||
-                        activePlan.checkoutCategories.includes(category) ? undefined : (
-                          <IconLock locked size="xs" />
-                        )
-                      }
-                    >
-                      {activePlan.checkoutCategories.includes(category)
-                        ? t('Included')
-                        : hasPaygProducts
-                          ? t('Available')
-                          : t('Product not available')}
-                    </Tag>
-                  )}
-                </Price>
-              </SpaceBetweenRow>
-            );
-          })}
+                      : getPlanCategoryName({
+                          plan: activePlan,
+                          category,
+                          title: true,
+                        })}
+                    {paygCategories.includes(category) ? (
+                      <QuestionTooltip
+                        size="xs"
+                        title={t(
+                          "%s use your pay-as-you-go budget. You'll only be charged for actual usage.",
+                          getPlanCategoryName({
+                            plan: activePlan,
+                            category,
+                          })
+                        )}
+                      />
+                    ) : null}
+                  </ReservedItem>
+                  <Price>
+                    {isMoreThanIncluded ? (
+                      `+ ${price}/${shortInterval}`
+                    ) : (
+                      <Tag
+                        icon={
+                          hasPaygProducts ||
+                          activePlan.checkoutCategories.includes(category) ? undefined : (
+                            <IconLock locked size="xs" />
+                          )
+                        }
+                      >
+                        {activePlan.checkoutCategories.includes(category)
+                          ? t('Included')
+                          : hasPaygProducts
+                            ? t('Available')
+                            : t('Product not available')}
+                      </Tag>
+                    )}
+                  </Price>
+                </SpaceBetweenRow>
+              );
+            })}
         </ReservedVolumes>
       </Section>
     );

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -3,13 +3,19 @@ import {DataCategory} from 'sentry/types/core';
 import {ANNUAL, MONTHLY} from 'getsentry/constants';
 import {type Plan, ReservedBudgetCategoryType} from 'getsentry/types';
 
-const AM1_CATEGORIES = [
+const AM1_CHECKOUT_CATEGORIES = [
   'errors',
   'transactions',
   'replays',
   'attachments',
   'monitorSeats',
   'uptime',
+] as DataCategory[];
+
+const AM1_CATEGORIES = [
+  ...AM1_CHECKOUT_CATEGORIES,
+  'seerAutoFix',
+  'seerScanner',
 ] as DataCategory[];
 
 const AM1_CATEGORY_DISPLAY_NAMES = {
@@ -19,6 +25,8 @@ const AM1_CATEGORY_DISPLAY_NAMES = {
   attachments: {singular: 'attachment', plural: 'attachments'},
   monitorSeats: {singular: 'cron monitor', plural: 'cron monitors'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
+  seerAutoFix: {singular: 'issue fix', plural: 'issue fixes'},
+  seerScanner: {singular: 'issue scan', plural: 'issue scans'},
 };
 
 const AM1_AVAILABLE_RESERVED_BUDGET_TYPES = {
@@ -104,7 +112,7 @@ const AM1_PLANS: Record<string, Plan> = {
     description: '',
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: true,
     trialPlan: 'am1_t',
@@ -176,7 +184,7 @@ const AM1_PLANS: Record<string, Plan> = {
     description: '',
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: true,
     trialPlan: null,
@@ -248,7 +256,7 @@ const AM1_PLANS: Record<string, Plan> = {
     description: '',
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: true,
     trialPlan: null,
@@ -831,7 +839,7 @@ const AM1_PLANS: Record<string, Plan> = {
     trialPlan: null,
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: true,
     basePrice: 31200,
@@ -1413,7 +1421,7 @@ const AM1_PLANS: Record<string, Plan> = {
     trialPlan: null,
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: true,
     maxMembers: null,
@@ -1996,7 +2004,7 @@ const AM1_PLANS: Record<string, Plan> = {
     basePrice: 96000,
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: true,
     price: 96000,
@@ -2586,7 +2594,7 @@ const AM1_PLANS: Record<string, Plan> = {
     allowAdditionalReservedEvents: true,
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
-    checkoutCategories: AM1_CATEGORIES,
+    checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     availableCategories: AM1_CATEGORIES,
     onDemandCategories: AM1_CATEGORIES,
     hasOnDemandModes: false,

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -41,6 +41,7 @@ const AM1_AVAILABLE_RESERVED_BUDGET_TYPES = {
     dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
     productName: 'seer',
     canProductTrial: true,
+    apiName: ReservedBudgetCategoryType.SEER,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -1,7 +1,7 @@
-import {type DataCategory} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 
 import {ANNUAL, MONTHLY} from 'getsentry/constants';
-import type {Plan} from 'getsentry/types';
+import {type Plan, ReservedBudgetCategoryType} from 'getsentry/types';
 
 const AM1_CATEGORIES = [
   'errors',
@@ -19,6 +19,19 @@ const AM1_CATEGORY_DISPLAY_NAMES = {
   attachments: {singular: 'attachment', plural: 'attachments'},
   monitorSeats: {singular: 'cron monitor', plural: 'cron monitors'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
+};
+
+const AM1_AVAILABLE_RESERVED_BUDGET_TYPES = {
+  [ReservedBudgetCategoryType.SEER]: {
+    budgetCategoryType: 'SEER',
+    name: 'seer budget',
+    docLink: '',
+    isFixed: true,
+    defaultBudget: 20_00,
+    dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
+    productName: 'seer',
+    canProductTrial: true,
+  },
 };
 
 const AM1_FREE_FEATURES = [
@@ -150,6 +163,7 @@ const AM1_PLANS: Record<string, Plan> = {
     },
     features: AM1_FREE_FEATURES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am1_t: {
     allowAdditionalReservedEvents: false,
@@ -221,6 +235,7 @@ const AM1_PLANS: Record<string, Plan> = {
     },
     features: AM1_TRIAL_FEATURES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am1_team: {
     allowAdditionalReservedEvents: false,
@@ -802,6 +817,7 @@ const AM1_PLANS: Record<string, Plan> = {
     },
     features: AM1_TEAM_FEATURES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am1_team_auf: {
     allowAdditionalReservedEvents: false,
@@ -1383,6 +1399,7 @@ const AM1_PLANS: Record<string, Plan> = {
     },
     features: AM1_TEAM_FEATURES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am1_business: {
     allowAdditionalReservedEvents: false,
@@ -1964,6 +1981,7 @@ const AM1_PLANS: Record<string, Plan> = {
     },
     features: AM1_BUSINESS_FEATURES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am1_business_auf: {
     allowAdditionalReservedEvents: false,
@@ -2545,6 +2563,7 @@ const AM1_PLANS: Record<string, Plan> = {
     },
     features: AM1_BUSINESS_FEATURES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am1_business_ent: {
     id: 'am1_business_ent',
@@ -2623,6 +2642,7 @@ const AM1_PLANS: Record<string, Plan> = {
       ],
     },
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -12,8 +12,10 @@ const AM1_CHECKOUT_CATEGORIES = [
   'uptime',
 ] as DataCategory[];
 
+const AM1_ONDEMAND_CATEGORIES = [...AM1_CHECKOUT_CATEGORIES] as DataCategory[];
+
 const AM1_CATEGORIES = [
-  ...AM1_CHECKOUT_CATEGORIES,
+  ...AM1_ONDEMAND_CATEGORIES,
   'seerAutoFix',
   'seerScanner',
 ] as DataCategory[];
@@ -113,7 +115,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     trialPlan: 'am1_t',
     basePrice: 0,
@@ -185,7 +187,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     trialPlan: null,
     basePrice: 0,
@@ -257,7 +259,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     trialPlan: null,
     basePrice: 2900,
@@ -840,7 +842,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     basePrice: 31200,
     price: 31200,
@@ -1422,7 +1424,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     maxMembers: null,
     basePrice: 8900,
@@ -2005,7 +2007,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     price: 96000,
     maxMembers: null,
@@ -2596,7 +2598,7 @@ const AM1_PLANS: Record<string, Plan> = {
     categories: AM1_CATEGORIES,
     checkoutCategories: AM1_CHECKOUT_CATEGORIES,
     availableCategories: AM1_CATEGORIES,
-    onDemandCategories: AM1_CATEGORIES,
+    onDemandCategories: AM1_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     planCategories: {
       errors: [

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -13,10 +13,14 @@ const AM2_CHECKOUT_CATEGORIES = [
   'uptime',
 ] as DataCategory[];
 
-const AM2_CATEGORIES = [
+const AM2_ONDEMAND_CATEGORIES = [
   ...AM2_CHECKOUT_CATEGORIES,
   'profileDuration',
   'profileDurationUI',
+] as DataCategory[];
+
+const AM2_CATEGORIES = [
+  ...AM2_ONDEMAND_CATEGORIES,
   'seerAutoFix',
   'seerScanner',
 ] as DataCategory[];
@@ -135,7 +139,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [
@@ -854,7 +858,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [
@@ -941,7 +945,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [
@@ -1660,7 +1664,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [
@@ -1747,7 +1751,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     budgetTerm: BUDGET_TERM,
     availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
@@ -2429,7 +2433,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -3111,7 +3115,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [{events: 5000000, unitPrice: 0.015, price: 0}],
@@ -3150,7 +3154,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [{events: 50_000, unitPrice: 0.015, price: 0}],
@@ -3191,7 +3195,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     planCategories: {
       errors: [
@@ -3682,7 +3686,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -4224,7 +4228,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: true,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -4781,7 +4785,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -4868,7 +4872,7 @@ const AM2_PLANS: Record<string, Plan> = {
     categories: AM2_CATEGORIES,
     checkoutCategories: AM2_CHECKOUT_CATEGORIES,
     availableCategories: AM2_CATEGORIES,
-    onDemandCategories: AM2_CATEGORIES,
+    onDemandCategories: AM2_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -17,6 +17,8 @@ const AM2_CATEGORIES = [
   ...AM2_CHECKOUT_CATEGORIES,
   'profileDuration',
   'profileDurationUI',
+  'seerAutoFix',
+  'seerScanner',
 ] as DataCategory[];
 
 const AM2_CATEGORY_DISPLAY_NAMES = {
@@ -31,6 +33,8 @@ const AM2_CATEGORY_DISPLAY_NAMES = {
   },
   profileDurationUI: {plural: 'UI profile hours', singular: 'UI profile hour'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
+  seerAutoFix: {singular: 'issue fix', plural: 'issue fixes'},
+  seerScanner: {singular: 'issue scan', plural: 'issue scans'},
 };
 
 const AM2_AVAILABLE_RESERVED_BUDGET_TYPES = {

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -1,8 +1,8 @@
-import {type DataCategory} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 
 import {ANNUAL, MONTHLY} from 'getsentry/constants';
 import type {Plan} from 'getsentry/types';
-import {CheckoutType} from 'getsentry/types';
+import {CheckoutType, ReservedBudgetCategoryType} from 'getsentry/types';
 
 const AM2_CHECKOUT_CATEGORIES = [
   'errors',
@@ -31,6 +31,19 @@ const AM2_CATEGORY_DISPLAY_NAMES = {
   },
   profileDurationUI: {plural: 'UI profile hours', singular: 'UI profile hour'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
+};
+
+const AM2_AVAILABLE_RESERVED_BUDGET_TYPES = {
+  [ReservedBudgetCategoryType.SEER]: {
+    budgetCategoryType: 'SEER',
+    name: 'seer budget',
+    docLink: '',
+    isFixed: true,
+    defaultBudget: 20_00,
+    dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
+    productName: 'seer',
+    canProductTrial: true,
+  },
 };
 
 const AM2_FREE_FEATURES = [
@@ -811,6 +824,7 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
     },
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_f: {
     id: 'am2_f',
@@ -897,6 +911,7 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
     },
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_team: {
     id: 'am2_team',
@@ -1615,6 +1630,7 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
     },
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_t: {
     id: 'am2_t',
@@ -1701,6 +1717,7 @@ const AM2_PLANS: Record<string, Plan> = {
       ],
     },
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_team_auf: {
     id: 'am2_team_auf',
@@ -1729,6 +1746,7 @@ const AM2_PLANS: Record<string, Plan> = {
     onDemandCategories: AM2_CATEGORIES,
     hasOnDemandModes: true,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
     planCategories: {
       errors: [
         {
@@ -3063,6 +3081,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_sponsored: {
     // NOTE: being deprecated
@@ -3102,6 +3121,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_sponsored_team_auf: {
     id: 'am2_sponsored_team_auf',
@@ -3140,6 +3160,7 @@ const AM2_PLANS: Record<string, Plan> = {
     },
     categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_business_bundle: {
     id: 'am2_business_bundle',
@@ -3631,6 +3652,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_business_249_bundle: {
     id: 'am2_business_249_bundle',
@@ -4172,6 +4194,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_team_bundle: {
     id: 'am2_team_bundle',
@@ -4728,6 +4751,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_business_ent_auf: {
     id: 'am2_business_ent_auf',
@@ -4814,6 +4838,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am2_business_ent: {
     id: 'am2_business_ent',
@@ -4900,6 +4925,7 @@ const AM2_PLANS: Record<string, Plan> = {
         },
       ],
     },
+    availableReservedBudgetTypes: AM2_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -51,6 +51,7 @@ const AM2_AVAILABLE_RESERVED_BUDGET_TYPES = {
     dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
     productName: 'seer',
     canProductTrial: true,
+    apiName: ReservedBudgetCategoryType.SEER,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -11,10 +11,15 @@ const AM3_CHECKOUT_CATEGORIES = [
   'spans',
   'uptime',
 ] as DataCategory[];
-const AM3_CATEGORIES = [
+
+const AM3_ONDEMAND_CATEGORIES = [
   ...AM3_CHECKOUT_CATEGORIES,
   'profileDuration',
   'profileDurationUI',
+] as DataCategory[];
+
+const AM3_CATEGORIES = [
+  ...AM3_ONDEMAND_CATEGORIES,
   'seerAutofix',
   'seerScanner',
 ] as DataCategory[];
@@ -173,7 +178,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -886,7 +891,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -1383,7 +1388,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -1478,7 +1483,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -1779,7 +1784,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -1874,7 +1879,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -2072,7 +2077,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -2569,7 +2574,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {
@@ -3066,7 +3071,7 @@ const AM3_PLANS: Record<string, Plan> = {
     categories: AM3_CATEGORIES,
     checkoutCategories: AM3_CHECKOUT_CATEGORIES,
     availableCategories: AM3_CATEGORIES,
-    onDemandCategories: AM3_CATEGORIES,
+    onDemandCategories: AM3_ONDEMAND_CATEGORIES,
     hasOnDemandModes: false,
     budgetTerm: BUDGET_TERM,
     planCategories: {

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -1,7 +1,7 @@
-import {type DataCategory} from 'sentry/types/core';
+import {DataCategory} from 'sentry/types/core';
 
 import {ANNUAL, MONTHLY, UNLIMITED_RESERVED} from 'getsentry/constants';
-import {CheckoutType, type Plan} from 'getsentry/types';
+import {CheckoutType, type Plan, ReservedBudgetCategoryType} from 'getsentry/types';
 
 const AM3_CHECKOUT_CATEGORIES = [
   'errors',
@@ -15,6 +15,8 @@ const AM3_CATEGORIES = [
   ...AM3_CHECKOUT_CATEGORIES,
   'profileDuration',
   'profileDurationUI',
+  'seerAutofix',
+  'seerScanner',
 ] as DataCategory[];
 
 const AM3_DS_CHECKOUT_CATEGORIES = [
@@ -25,7 +27,36 @@ const AM3_DS_CATEGORIES = [
   ...AM3_DS_CHECKOUT_CATEGORIES,
   'profileDuration',
   'profileDurationUI',
+  'seerAutofix',
+  'seerScanner',
 ] as DataCategory[];
+
+const AM3_AVAILABLE_RESERVED_BUDGET_TYPES = {
+  [ReservedBudgetCategoryType.SEER]: {
+    budgetCategoryType: 'SEER',
+    name: 'seer budget',
+    docLink: '',
+    isFixed: true,
+    defaultBudget: 20_00,
+    dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
+    productName: 'seer',
+    canProductTrial: true,
+  },
+};
+
+const AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES = {
+  ...AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
+  [ReservedBudgetCategoryType.DYNAMIC_SAMPLING]: {
+    budgetCategoryType: 'DYNAMIC_SAMPLING',
+    name: 'spans budget',
+    docLink: '',
+    isFixed: true,
+    defaultBudget: 20_00,
+    dataCategories: [DataCategory.SPANS, DataCategory.SPANS_INDEXED],
+    productName: 'dynamic sampling',
+    canProductTrial: false,
+  },
+};
 
 const AM3_CATEGORY_DISPLAY_NAMES = {
   errors: {singular: 'error', plural: 'errors'},
@@ -39,6 +70,8 @@ const AM3_CATEGORY_DISPLAY_NAMES = {
   },
   profileDurationUI: {plural: 'UI profile hours', singular: 'UI profile hour'},
   uptime: {singular: 'uptime monitor', plural: 'uptime monitors'},
+  seerAutofix: {singular: 'issue fix', plural: 'issue fixes'},
+  seerScanner: {singular: 'issue scan', plural: 'issue scans'},
 };
 
 const AM3_DS_CATEGORY_DISPLAY_NAMES = {
@@ -828,6 +861,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_business_auf: {
     id: 'am3_business_auf',
@@ -1324,6 +1358,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_business_ent: {
     id: 'am3_business_ent',
@@ -1418,6 +1453,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_business_ent_auf: {
     id: 'am3_business_ent_auf',
@@ -1512,6 +1548,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_business_ent_ds: {
     id: 'am3_business_ent_ds',
@@ -1614,6 +1651,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_DS_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_business_ent_ds_auf: {
     id: 'am3_business_ent_ds_auf',
@@ -1716,6 +1754,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_DS_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_f: {
     id: 'am3_f',
@@ -1810,6 +1849,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_t_ent: {
     id: 'am3_t_ent',
@@ -1904,6 +1944,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_t_ent_ds: {
     id: 'am3_t_ent_ds',
@@ -2006,6 +2047,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_DS_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_team: {
     id: 'am3_team',
@@ -2502,6 +2544,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_team_auf: {
     id: 'am3_team_auf',
@@ -2998,6 +3041,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
   am3_t: {
     id: 'am3_t',
@@ -3084,6 +3128,7 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
     categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
+    availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -46,6 +46,7 @@ const AM3_AVAILABLE_RESERVED_BUDGET_TYPES = {
     dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
     productName: 'seer',
     canProductTrial: true,
+    apiName: ReservedBudgetCategoryType.SEER,
   },
 };
 
@@ -60,6 +61,7 @@ const AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES = {
     dataCategories: [DataCategory.SPANS, DataCategory.SPANS_INDEXED],
     productName: 'dynamic sampling',
     canProductTrial: false,
+    apiName: ReservedBudgetCategoryType.DYNAMIC_SAMPLING,
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/mm1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm1Plans.ts
@@ -54,6 +54,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   e1_auf: {
     isTestPlan: false,
@@ -97,6 +98,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   f1: {
     isTestPlan: false,
@@ -132,6 +134,7 @@ const MM1_PLANS: Record<string, Plan> = {
     retentionDays: 30,
     features: [],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   l1: {
     isTestPlan: false,
@@ -177,6 +180,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   l1_ac: {
     isTestPlan: false,
@@ -222,6 +226,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   l1_auf: {
     isTestPlan: false,
@@ -267,6 +272,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   m1: {
     isTestPlan: false,
@@ -309,6 +315,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   m1_ac: {
     isTestPlan: false,
@@ -351,6 +358,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   m1_auf: {
     isTestPlan: false,
@@ -393,6 +401,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   s1: {
     isTestPlan: false,
@@ -433,6 +442,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
   s1_ac: {
     isTestPlan: false,
@@ -473,6 +483,7 @@ const MM1_PLANS: Record<string, Plan> = {
       'extended-data-retention',
     ],
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/mm2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm2Plans.ts
@@ -66,6 +66,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-query',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_a_100k_ac: {
     isTestPlan: false,
@@ -121,6 +122,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-query',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_a_100k_auf: {
     isTestPlan: false,
@@ -176,6 +178,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-query',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_a_500k: {
     isTestPlan: false,
@@ -231,6 +234,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-query',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_a_500k_ac: {
     isTestPlan: false,
@@ -286,6 +290,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-query',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_a_500k_auf: {
     isTestPlan: false,
@@ -341,6 +346,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-query',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_b_100k: {
     isTestPlan: false,
@@ -385,6 +391,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-basic',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_b_100k_ac: {
     isTestPlan: false,
@@ -429,6 +436,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-basic',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_b_100k_auf: {
     isTestPlan: false,
@@ -473,6 +481,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-basic',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_b_500k: {
     isTestPlan: false,
@@ -518,6 +527,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-basic',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_b_500k_ac: {
     isTestPlan: false,
@@ -562,6 +572,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-basic',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_b_500k_auf: {
     isTestPlan: false,
@@ -606,6 +617,7 @@ const MM2_PLANS: Record<string, Plan> = {
       'discover-basic',
       'extended-data-retention',
     ],
+    availableReservedBudgetTypes: {},
   },
   mm2_f: {
     isTestPlan: false,
@@ -641,6 +653,7 @@ const MM2_PLANS: Record<string, Plan> = {
     onDemandEventPrice: 0,
     retentionDays: 30,
     features: ['advanced-search'],
+    availableReservedBudgetTypes: {},
   },
   mm2_a: {
     id: 'mm2_a',
@@ -702,6 +715,7 @@ const MM2_PLANS: Record<string, Plan> = {
     },
     categoryDisplayNames: MM2_CATEGORY_DISPLAY_NAMES,
     budgetTerm: BUDGET_TERM,
+    availableReservedBudgetTypes: {},
   },
 };
 

--- a/tests/js/getsentry-test/fixtures/reservedBudget.ts
+++ b/tests/js/getsentry-test/fixtures/reservedBudget.ts
@@ -1,12 +1,31 @@
+import {DataCategory} from 'sentry/types/core';
+
 import type {
   ReservedBudget as TReservedBudget,
-  ReservedBudgetMetricHistory,
+  ReservedBudgetCategory as TReservedBudgetCategory,
+  ReservedBudgetMetricHistory as TReservedBudgetMetricHistory,
 } from 'getsentry/types';
 
+type ReservedBudgetCategoryProps = Partial<TReservedBudgetCategory>;
 type BudgetProps = Partial<TReservedBudget>;
-type MetricHistoryProps = Partial<ReservedBudgetMetricHistory>;
+type MetricHistoryProps = Partial<TReservedBudgetMetricHistory>;
+
+export function ReservedBudgetCategoryFixture(props: ReservedBudgetCategoryProps) {
+  return {
+    budgetCategoryType: '',
+    name: '',
+    docLink: '',
+    isFixed: false,
+    defaultBudget: 0,
+    dataCategories: [],
+    productName: '',
+    canProductTrial: false,
+    ...props,
+  };
+}
 
 export function ReservedBudgetFixture(props: BudgetProps) {
+  const infoProps = props.info ?? {};
   return {
     id: '',
     reservedBudget: 0,
@@ -14,6 +33,7 @@ export function ReservedBudgetFixture(props: BudgetProps) {
     freeBudget: 0,
     percentUsed: 0,
     categories: {},
+    info: ReservedBudgetCategoryFixture(infoProps),
     ...props,
   };
 }
@@ -24,4 +44,35 @@ export function ReservedBudgetMetricHistoryFixture(props: MetricHistoryProps) {
     reservedSpend: 0,
     ...props,
   };
+}
+
+export function SeerReservedBudgetFixture(props: BudgetProps) {
+  const infoProps = props.info ?? {
+    budgetCategoryType: 'SEER',
+    name: 'seer budget',
+    docLink: '',
+    isFixed: true,
+    defaultBudget: 20_00,
+    dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
+    productName: 'seer',
+    canProductTrial: false,
+  };
+  const defaultProps = {
+    id: '',
+    reservedBudget: 20_00,
+    info: infoProps,
+    categories: {
+      [DataCategory.SEER_AUTOFIX]: ReservedBudgetMetricHistoryFixture({
+        reservedCpe: 1_00,
+        reservedSpend: 0,
+      }),
+      [DataCategory.SEER_SCANNER]: ReservedBudgetMetricHistoryFixture({
+        reservedCpe: 1,
+        reservedSpend: 0,
+      }),
+    },
+    ...props,
+  };
+
+  return ReservedBudgetFixture(defaultProps);
 }

--- a/tests/js/getsentry-test/fixtures/reservedBudget.ts
+++ b/tests/js/getsentry-test/fixtures/reservedBudget.ts
@@ -5,6 +5,7 @@ import type {
   ReservedBudgetCategory as TReservedBudgetCategory,
   ReservedBudgetMetricHistory as TReservedBudgetMetricHistory,
 } from 'getsentry/types';
+import {ReservedBudgetCategoryType} from 'getsentry/types';
 
 type ReservedBudgetCategoryProps = Partial<TReservedBudgetCategory>;
 type BudgetProps = Partial<TReservedBudget>;
@@ -25,7 +26,18 @@ export function ReservedBudgetCategoryFixture(props: ReservedBudgetCategoryProps
 }
 
 export function ReservedBudgetFixture(props: BudgetProps) {
-  const infoProps = props.info ?? {};
+  const defaultCategoryProps = {
+    apiName: ReservedBudgetCategoryType.DYNAMIC_SAMPLING,
+    budgetCategoryType: '',
+    name: '',
+    docLink: '',
+    isFixed: false,
+    defaultBudget: null,
+    dataCategories: [],
+    productName: '',
+    canProductTrial: false,
+  };
+
   return {
     id: '',
     reservedBudget: 0,
@@ -33,7 +45,7 @@ export function ReservedBudgetFixture(props: BudgetProps) {
     freeBudget: 0,
     percentUsed: 0,
     categories: {},
-    info: ReservedBudgetCategoryFixture(infoProps),
+    ...defaultCategoryProps,
     ...props,
   };
 }
@@ -47,20 +59,9 @@ export function ReservedBudgetMetricHistoryFixture(props: MetricHistoryProps) {
 }
 
 export function SeerReservedBudgetFixture(props: BudgetProps) {
-  const infoProps = props.info ?? {
-    budgetCategoryType: 'SEER',
-    name: 'seer budget',
-    docLink: '',
-    isFixed: true,
-    defaultBudget: 20_00,
-    dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
-    productName: 'seer',
-    canProductTrial: false,
-  };
   const defaultProps = {
     id: '',
     reservedBudget: 20_00,
-    info: infoProps,
     categories: {
       [DataCategory.SEER_AUTOFIX]: ReservedBudgetMetricHistoryFixture({
         reservedCpe: 1_00,
@@ -71,6 +72,14 @@ export function SeerReservedBudgetFixture(props: BudgetProps) {
         reservedSpend: 0,
       }),
     },
+    budgetCategoryType: 'SEER',
+    name: 'seer budget',
+    docLink: '',
+    isFixed: true,
+    defaultBudget: 20_00,
+    dataCategories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
+    productName: 'seer',
+    canProductTrial: false,
     ...props,
   };
 

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -10,7 +10,7 @@ import type {Organization} from 'sentry/types/organization';
 
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {Plan, Subscription as TSubscription} from 'getsentry/types';
-import {BillingType} from 'getsentry/types';
+import {BillingType, ReservedBudgetCategoryType} from 'getsentry/types';
 
 type Props = Partial<TSubscription> & {organization: Organization};
 
@@ -406,6 +406,15 @@ export function Am3DsEnterpriseSubscriptionFixture(props: Props): TSubscription 
   subscription.reservedBudgets = [
     ReservedBudgetFixture({
       id: '11',
+      apiName: ReservedBudgetCategoryType.DYNAMIC_SAMPLING,
+      budgetCategoryType: 'DYNAMIC_SAMPLING',
+      canProductTrial: false,
+      dataCategories: [DataCategory.SPANS, DataCategory.SPANS_INDEXED],
+      defaultBudget: null,
+      docLink: '',
+      isFixed: false,
+      name: 'spans budget',
+      productName: 'dynamic sampling',
       reservedBudget: 100_000_00,
       totalReservedSpend: 60_000_00,
       freeBudget: 0,


### PR DESCRIPTION
Dependent on:
- https://github.com/getsentry/getsentry/pull/17485

This information will be used for things such as product trial management, subscription usage cards, and other frontend rendering.