### PR TITLE
feat(autofix): Display file links in root cause and solution timelines

### DIFF
--- a/static/app/components/events/autofix/autofixInsightSources.tsx
+++ b/static/app/components/events/autofix/autofixInsightSources.tsx
@@ -22,7 +22,8 @@ import {MarkedText} from 'sentry/utils/marked/markedText';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 
 interface AutofixInsightSourcesProps {
-  sources: InsightSources | undefined;
+  codeUrls?: string[];
+  sources?: InsightSources;
   title?: string;
 }
 
@@ -65,7 +66,7 @@ function getCodeSourceName(url: string): string {
   return url.length > 30 ? url.substring(0, 27) + '...' : url;
 }
 
-function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
+function AutofixInsightSources({sources, title, codeUrls}: AutofixInsightSourcesProps) {
   const [showThoughtsPopup, setShowThoughtsPopup] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
   const thoughtsButtonRef = useRef<HTMLButtonElement>(null);
@@ -87,14 +88,14 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
     };
   }, [overlayRef, thoughtsButtonRef]);
 
-  if (!sources) {
+  if (!sources && !codeUrls) {
     return null;
   }
 
   const sourceCards = [];
 
   // Stacktrace Card
-  if (sources.stacktrace_used) {
+  if (sources?.stacktrace_used) {
     sourceCards.push(
       <SourceCard
         key="stacktrace"
@@ -111,7 +112,7 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   }
 
   // Breadcrumbs Card
-  if (sources.breadcrumbs_used) {
+  if (sources?.breadcrumbs_used) {
     sourceCards.push(
       <SourceCard
         key="breadcrumbs"
@@ -128,7 +129,7 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   }
 
   // HTTP Request Card
-  if (sources.http_request_used) {
+  if (sources?.http_request_used) {
     sourceCards.push(
       <SourceCard
         key="http-request"
@@ -145,12 +146,12 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   }
 
   // Trace Event Cards
-  sources.trace_event_ids_used?.forEach(id => {
+  sources?.trace_event_ids_used?.forEach(id => {
     sourceCards.push(
       <SourceCard
         key={`trace-${id}`}
         onClick={() => {
-          if (sources.event_trace_id) {
+          if (sources?.event_trace_id) {
             window.open(
               `/issues/trace/${sources.event_trace_id}?node=txn-${id}`,
               '_blank'
@@ -166,7 +167,7 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   });
 
   // Profile ID Cards
-  sources.profile_ids_used?.forEach(id => {
+  sources?.profile_ids_used?.forEach(id => {
     sourceCards.push(
       <SourceCard
         key={`profile-${id}`}
@@ -182,13 +183,13 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   });
 
   // Connected Error ID Cards
-  sources.connected_error_ids_used?.forEach(id => {
+  sources?.connected_error_ids_used?.forEach(id => {
     sourceCards.push(
       <SourceCard
         key={`error-${id}`}
         size="xs"
         onClick={() => {
-          if (sources.event_trace_id) {
+          if (sources?.event_trace_id) {
             window.open(
               `/issues/trace/${sources.event_trace_id}?node=error-${id}`,
               '_blank'
@@ -203,7 +204,7 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   });
 
   // Code URL Cards
-  sources.code_used_urls?.forEach((url, index) => {
+  sources?.code_used_urls?.forEach((url, index) => {
     sourceCards.push(
       <SourceCard
         key={`code-${index}`}
@@ -216,8 +217,23 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
     );
   });
 
+  if (codeUrls) {
+    codeUrls.forEach((url, index) => {
+      sourceCards.push(
+        <SourceCard
+          key={`passed-code-${index}`}
+          onClick={() => window.open(url, '_blank')}
+          size="xs"
+          icon={<IconCode size="xs" />}
+        >
+          {getCodeSourceName(url)}
+        </SourceCard>
+      );
+    });
+  }
+
   // Diff URL Cards
-  sources.diff_urls?.forEach((url, index) => {
+  sources?.diff_urls?.forEach((url, index) => {
     sourceCards.push(
       <SourceCard
         key={`diff-${index}`}
@@ -231,7 +247,7 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
   });
 
   // Thoughts Card
-  if (defined(sources.thoughts) && sources.thoughts.length > 0) {
+  if (defined(sources?.thoughts) && sources?.thoughts.length > 0) {
     sourceCards.push(
       <SourceCard
         key="thoughts"
@@ -255,7 +271,7 @@ function AutofixInsightSources({sources, title}: AutofixInsightSourcesProps) {
     <SourcesContainer>
       <CardsContainer aria-label="Autofix Insight Sources">{sourceCards}</CardsContainer>
       {showThoughtsPopup &&
-        sources.thoughts &&
+        sources?.thoughts &&
         document.body &&
         createPortal(
           <ThoughtsOverlay

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -195,6 +195,7 @@ function RootCauseDescription({
       {cause.root_cause_reproduction && (
         <AutofixTimeline
           events={cause.root_cause_reproduction}
+          eventCodeUrls={cause.reproduction_urls}
           groupId={groupId}
           runId={runId}
           stepIndex={previousDefaultStepIndex ?? 0}

--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -21,6 +21,7 @@ describe('AutofixSolution', () => {
       relevant_code_file: {
         file_path: 'src/file.js',
         repo_name: 'owner/repo',
+        url: 'https://github.com/owner/repo/blob/main/src/file.js',
       },
     },
   ];

--- a/static/app/components/events/autofix/autofixSolutionEventItem.tsx
+++ b/static/app/components/events/autofix/autofixSolutionEventItem.tsx
@@ -194,7 +194,7 @@ export function SolutionEventItem({
                 >
                   <StyledSpan text={event.code_snippet_and_analysis} inline />
                 </AutofixHighlightWrapper>
-                {event.relevant_code_file && (
+                {event.relevant_code_file && event.relevant_code_file.url && (
                   <SourcesWrapper>
                     <AutofixInsightSources codeUrls={[event.relevant_code_file.url]} />
                   </SourcesWrapper>

--- a/static/app/components/events/autofix/autofixSolutionEventItem.tsx
+++ b/static/app/components/events/autofix/autofixSolutionEventItem.tsx
@@ -6,6 +6,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
+import AutofixInsightSources from 'sentry/components/events/autofix/autofixInsightSources';
 import {type AutofixSolutionTimelineEvent} from 'sentry/components/events/autofix/types';
 import {Timeline, type TimelineItemProps} from 'sentry/components/timeline';
 import {
@@ -193,6 +194,11 @@ export function SolutionEventItem({
                 >
                   <StyledSpan text={event.code_snippet_and_analysis} inline />
                 </AutofixHighlightWrapper>
+                {event.relevant_code_file && (
+                  <SourcesWrapper>
+                    <AutofixInsightSources codeUrls={[event.relevant_code_file.url]} />
+                  </SourcesWrapper>
+                )}
               </Timeline.Text>
             </AnimatedContent>
           )}
@@ -201,6 +207,10 @@ export function SolutionEventItem({
     </Timeline.Item>
   );
 }
+
+const SourcesWrapper = styled('div')`
+  margin-top: ${space(2)};
+`;
 
 const StyledIconChevron = styled(IconChevron)`
   color: ${p => p.theme.subText};

--- a/static/app/components/events/autofix/autofixTimeline.tsx
+++ b/static/app/components/events/autofix/autofixTimeline.tsx
@@ -7,6 +7,7 @@ type Props = {
   events: AutofixTimelineEvent[];
   groupId: string;
   runId: string;
+  eventCodeUrls?: Array<string | null>;
   getCustomIcon?: (event: AutofixTimelineEvent) => React.ReactNode;
   retainInsightCardIndex?: number | null;
   stepIndex?: number;
@@ -19,6 +20,7 @@ export function AutofixTimeline({
   runId,
   stepIndex = 0,
   retainInsightCardIndex = null,
+  eventCodeUrls,
 }: Props) {
   if (!events?.length) {
     return null;
@@ -41,6 +43,7 @@ export function AutofixTimeline({
             runId={runId}
             stepIndex={stepIndex}
             retainInsightCardIndex={retainInsightCardIndex}
+            codeUrl={eventCodeUrls ? eventCodeUrls[index] : null}
           />
         );
       })}

--- a/static/app/components/events/autofix/autofixTimelineItem.tsx
+++ b/static/app/components/events/autofix/autofixTimelineItem.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
+import AutofixInsightSources from 'sentry/components/events/autofix/autofixInsightSources';
 import {replaceHeadersWithBold} from 'sentry/components/events/autofix/autofixRootCause';
 import type {TimelineItemProps} from 'sentry/components/timeline';
 import {Timeline} from 'sentry/components/timeline';
@@ -60,6 +61,7 @@ interface AutofixTimelineItemProps {
   retainInsightCardIndex: number | null | undefined;
   runId: string;
   stepIndex: number;
+  codeUrl?: string | null;
   getCustomIcon?: (event: AutofixTimelineEvent) => React.ReactNode | undefined;
 }
 
@@ -72,6 +74,7 @@ export function AutofixTimelineItem({
   retainInsightCardIndex,
   runId,
   stepIndex,
+  codeUrl,
 }: AutofixTimelineItemProps) {
   const theme = useTheme();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -128,6 +131,11 @@ export function AutofixTimelineItem({
                   inline
                 />
               </AutofixHighlightWrapper>
+              {codeUrl && (
+                <SourcesWrapper>
+                  <AutofixInsightSources codeUrls={[codeUrl]} />
+                </SourcesWrapper>
+              )}
             </Timeline.Text>
           </AnimatedContent>
         )}
@@ -146,6 +154,10 @@ const StyledSpan = styled(MarkedText)`
     background-color: transparent;
     display: inline-block;
   }
+`;
+
+const SourcesWrapper = styled('div')`
+  margin-top: ${space(2)};
 `;
 
 const StyledTimelineHeader = styled('div')<{isActive?: boolean}>`

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -201,7 +201,6 @@ export type AutofixRootCauseData = {
   id: string;
   description?: string;
   reproduction_urls?: Array<string | null>;
-  // TODO: this is for backwards compatibility with old runs, we should remove it soon
   root_cause_reproduction?: AutofixTimelineEvent[];
 };
 

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -177,7 +177,7 @@ type AutofixRelevantCodeFile = {
 };
 
 export type AutofixRelevantCodeFileWithUrl = AutofixRelevantCodeFile & {
-  url: string;
+  url?: string;
 };
 
 export type AutofixTimelineEvent = {

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -176,6 +176,10 @@ type AutofixRelevantCodeFile = {
   repo_name: string;
 };
 
+export type AutofixRelevantCodeFileWithUrl = AutofixRelevantCodeFile & {
+  url: string;
+};
+
 export type AutofixTimelineEvent = {
   code_snippet_and_analysis: string;
   relevant_code_file: AutofixRelevantCodeFile;
@@ -190,12 +194,14 @@ export type AutofixSolutionTimelineEvent = {
   code_snippet_and_analysis?: string;
   is_active?: boolean;
   is_most_important_event?: boolean;
-  relevant_code_file?: AutofixRelevantCodeFile;
+  relevant_code_file?: AutofixRelevantCodeFileWithUrl;
 };
 
 export type AutofixRootCauseData = {
   id: string;
-  description?: string; // TODO: this is for backwards compatibility with old runs, we should remove it soon
+  description?: string;
+  reproduction_urls?: Array<string | null>;
+  // TODO: this is for backwards compatibility with old runs, we should remove it soon
   root_cause_reproduction?: AutofixTimelineEvent[];
 };
 


### PR DESCRIPTION
Renders file links in the root cause and solution in the same way we do as in the insight cards

<img width="833" alt="Screenshot 2025-05-13 at 9 35 50 PM" src="https://github.com/user-attachments/assets/c7635d7a-815a-40cc-b3c2-88c6e1d5c876" />


<img width="823" alt="Screenshot 2025-05-13 at 9 31 51 PM" src="https://github.com/user-attachments/assets/8896f0e7-ae48-4b0f-bbac-6b6cb6edd12e" />

