### PR TITLE
feat(feature-flag): add feature flag for playstation ingestion

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -267,6 +267,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-vitals-standalone-cls-lcp", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable default explore queries in the new side nav
     manager.add("organizations:performance-default-explore-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables the playstation ingestion in relay
+    manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enabled for those orgs who participated in the profiling Beta program

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -70,6 +70,7 @@ EXPOSABLE_FEATURES = [
     "organizations:view-hierarchy-scrubbing",
     "projects:ourlogs-breadcrumb-extraction",
     "organizations:performance-issues-spans",
+    "organizations:relay-playstation-ingestion",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
Heavily inspired by: https://github.com/getsentry/sentry/pull/83912

Relay PR: https://github.com/getsentry/relay/pull/4736
Options Automator PR: https://github.com/getsentry/sentry-options-automator/pull/3887