### PR TITLE
fix(ui): remove unnecessary translateY on segmentedControl

### DIFF
--- a/static/app/components/core/segmentedControl/index.chonk.tsx
+++ b/static/app/components/core/segmentedControl/index.chonk.tsx
@@ -90,7 +90,6 @@ export const ChonkStyledVisibleLabel = chonkStyled('span')<{
   ${p => p.theme.overflowEllipsis}
   user-select: none;
   font-weight: ${p => p.theme.fontWeightBold};
-  ${p => p.size !== 'md' && `transform: translateY(-1px)`};
   text-align: center;
   color: ${p => getTextColor(p)};
 `;


### PR DESCRIPTION
Seems like this was fixed in Button internally

| before | after |
|--------|--------|
| ![Screenshot 2025-05-14 at 14 03 33](https://github.com/user-attachments/assets/97f64698-54be-4279-acd8-5233b333a13e) | ![Screenshot 2025-05-14 at 14 03 59](https://github.com/user-attachments/assets/61325aab-233b-409b-9fc1-518b5712a229) | 