### PR TITLE
Add logging for connection username in migrations

### DIFF
--- a/src/sentry/runner/commands/migrations.py
+++ b/src/sentry/runner/commands/migrations.py
@@ -49,8 +49,11 @@ def run_for_connection(app_name: str, migration_name: str, connection_name: str)
         at_end=False,
     )
 
-    migration_user = connection.settings_dict['USER']
-    click.secho(f"Running post-deployment migration for connection {connection_name} as {migration_user}:", fg="cyan")
+    migration_user = connection.settings_dict["USER"]
+    click.secho(
+        f"Running post-deployment migration for connection {connection_name} as {migration_user}:",
+        fg="cyan",
+    )
     click.secho(f"  {migration.name}", bold=True)
     with connection.schema_editor() as schema_editor:
         # Enable 'safe' migration execution. This enables concurrent mode on index creation

--- a/src/sentry/runner/commands/migrations.py
+++ b/src/sentry/runner/commands/migrations.py
@@ -49,7 +49,8 @@ def run_for_connection(app_name: str, migration_name: str, connection_name: str)
         at_end=False,
     )
 
-    click.secho(f"Running post-deployment migration for {connection_name}:", fg="cyan")
+    migration_user = connection.settings_dict['USER']
+    click.secho(f"Running post-deployment migration for connection {connection_name} as {migration_user}:", fg="cyan")
     click.secho(f"  {migration.name}", bold=True)
     with connection.schema_editor() as schema_editor:
         # Enable 'safe' migration execution. This enables concurrent mode on index creation

--- a/tests/sentry/runner/commands/test_migrations.py
+++ b/tests/sentry/runner/commands/test_migrations.py
@@ -33,8 +33,14 @@ class MigrationsRunTest(TransactionTestCase):
             result = self.invoke("run", "migration_test_app", "0001")
 
             assert result.exit_code == 0, result.output
-            assert "Running post-deployment migration for default" in result.output
-            assert "Running post-deployment migration for control" in result.output
+            assert (
+                "Running post-deployment migration for connection default as postgres"
+                in result.output
+            )
+            assert (
+                "Running post-deployment migration for connection control as postgres"
+                in result.output
+            )
             assert "Migration complete" in result.output
 
             connection = connections["default"]


### PR DESCRIPTION
Add a little bit more logging to our migrations output to help debug connectivity / permission issues.