### PR TITLE
fix(dashboards): Prevent scroll on widget builder actions

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -649,7 +649,7 @@ class DashboardDetail extends Component<Props, State> {
     const {
       organization,
       dashboard,
-      router,
+      navigate,
       location,
       params: {dashboardId},
     } = this.props;
@@ -667,7 +667,7 @@ class DashboardDetail extends Component<Props, State> {
         if (!defined(dashboardId)) {
           pathname = `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/new/`;
         }
-        router.push(
+        navigate(
           normalizeUrl({
             // TODO: Replace with the old widget builder path when swapping over
             pathname,
@@ -679,7 +679,8 @@ class DashboardDetail extends Component<Props, State> {
                     getDefaultWidget(DATA_SET_TO_WIDGET_TYPE[dataset ?? DataSet.ERRORS])
                   )),
             },
-          })
+          }),
+          {preventScrollReset: true}
         );
       }
     );
@@ -778,18 +779,19 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   handleCloseWidgetBuilder = () => {
-    const {organization, router, location, params} = this.props;
+    const {organization, navigate, location, params} = this.props;
 
     this.setState({
       isWidgetBuilderOpen: false,
       openWidgetTemplates: undefined,
     });
-    router.push(
+    navigate(
       getDashboardLocation({
         organization,
         dashboardId: params.dashboardId,
         location,
-      })
+      }),
+      {preventScrollReset: true}
     );
   };
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -689,7 +689,7 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onEditWidget = (widget: Widget) => {
-    const {router, organization, params, location, dashboard} = this.props;
+    const {navigate, organization, params, location, dashboard} = this.props;
     const {modifiedDashboard} = this.state;
     const currentDashboard = modifiedDashboard ?? dashboard;
     const {dashboardId} = params;
@@ -717,14 +717,15 @@ class DashboardDetail extends Component<Props, State> {
     const path = defined(dashboardId)
       ? `/organizations/${organization.slug}/dashboard/${dashboardId}/widget-builder/widget/${widgetIndex}/edit/`
       : `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/${widgetIndex}/edit/`;
-    router.push(
+    navigate(
       normalizeUrl({
         pathname: path,
         query: {
           ...location.query,
           ...convertWidgetToBuilderStateParams(widget),
         },
-      })
+      }),
+      {preventScrollReset: true}
     );
   };
 

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
@@ -43,7 +43,7 @@ describe('DatasetSelector', function () {
         ...router.location,
         query: expect.objectContaining({dataset: 'issue'}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.spec.tsx
@@ -43,7 +43,7 @@ describe('DatasetSelector', function () {
         ...router.location,
         query: expect.objectContaining({dataset: 'issue'}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -2,9 +2,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
-import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {ReleasesProvider} from 'sentry/utils/releases/releasesProvider';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -15,35 +13,22 @@ function WidgetBuilderFilterBar() {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   return (
-    <PageFiltersContainer
-      skipLoadLastUsed
-      disablePersistence
-      defaultSelection={{
-        datetime: {
-          start: null,
-          end: null,
-          utc: false,
-          period: DEFAULT_STATS_PERIOD,
-        },
-      }}
+    <Tooltip
+      title={t('Changes to these filters can only be made at the dashboard level')}
     >
-      <Tooltip
-        title={t('Changes to these filters can only be made at the dashboard level')}
-      >
-        <PageFilterBar>
-          <ProjectPageFilter disabled onChange={() => {}} />
-          <EnvironmentPageFilter disabled onChange={() => {}} />
-          <DatePageFilter disabled onChange={() => {}} />
-          <ReleasesProvider organization={organization} selection={selection}>
-            <ReleasesSelectControl
-              isDisabled
-              handleChangeFilter={() => {}}
-              selectedReleases={[]}
-            />
-          </ReleasesProvider>
-        </PageFilterBar>
-      </Tooltip>
-    </PageFiltersContainer>
+      <PageFilterBar>
+        <ProjectPageFilter disabled onChange={() => {}} />
+        <EnvironmentPageFilter disabled onChange={() => {}} />
+        <DatePageFilter disabled onChange={() => {}} />
+        <ReleasesProvider organization={organization} selection={selection}>
+          <ReleasesSelectControl
+            isDisabled
+            handleChangeFilter={() => {}}
+            selectedReleases={[]}
+          />
+        </ReleasesProvider>
+      </PageFilterBar>
+    </Tooltip>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -2,7 +2,9 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {ReleasesProvider} from 'sentry/utils/releases/releasesProvider';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,22 +15,36 @@ function WidgetBuilderFilterBar() {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   return (
-    <Tooltip
-      title={t('Changes to these filters can only be made at the dashboard level')}
+    <PageFiltersContainer
+      skipLoadLastUsed
+      skipInitializeUrlParams
+      disablePersistence
+      defaultSelection={{
+        datetime: {
+          start: null,
+          end: null,
+          utc: false,
+          period: DEFAULT_STATS_PERIOD,
+        },
+      }}
     >
-      <PageFilterBar>
-        <ProjectPageFilter disabled onChange={() => {}} />
-        <EnvironmentPageFilter disabled onChange={() => {}} />
-        <DatePageFilter disabled onChange={() => {}} />
-        <ReleasesProvider organization={organization} selection={selection}>
-          <ReleasesSelectControl
-            isDisabled
-            handleChangeFilter={() => {}}
-            selectedReleases={[]}
-          />
-        </ReleasesProvider>
-      </PageFilterBar>
-    </Tooltip>
+      <Tooltip
+        title={t('Changes to these filters can only be made at the dashboard level')}
+      >
+        <PageFilterBar>
+          <ProjectPageFilter disabled onChange={() => {}} />
+          <EnvironmentPageFilter disabled onChange={() => {}} />
+          <DatePageFilter disabled onChange={() => {}} />
+          <ReleasesProvider organization={organization} selection={selection}>
+            <ReleasesSelectControl
+              isDisabled
+              handleChangeFilter={() => {}}
+              selectedReleases={[]}
+            />
+          </ReleasesProvider>
+        </PageFilterBar>
+      </Tooltip>
+    </PageFiltersContainer>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -48,7 +48,7 @@ describe('WidgetBuilder', () => {
         ...router.location,
         query: expect.objectContaining({title: 'some name'}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
 
     await userEvent.click(await screen.findByTestId('add-description'));
@@ -62,7 +62,7 @@ describe('WidgetBuilder', () => {
         ...router.location,
         query: expect.objectContaining({description: 'some description'}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.spec.tsx
@@ -48,7 +48,7 @@ describe('WidgetBuilder', () => {
         ...router.location,
         query: expect.objectContaining({title: 'some name'}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
 
     await userEvent.click(await screen.findByTestId('add-description'));
@@ -62,7 +62,7 @@ describe('WidgetBuilder', () => {
         ...router.location,
         query: expect.objectContaining({description: 'some description'}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -125,7 +125,7 @@ describe('WidgetBuilderSortBySelector', function () {
         ...router.location,
         query: expect.objectContaining({sort: ['-count()']}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
 
     await userEvent.click(sortDirectionSelector);
@@ -135,7 +135,7 @@ describe('WidgetBuilderSortBySelector', function () {
         ...router.location,
         query: expect.objectContaining({sort: ['count()']}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -209,7 +209,7 @@ describe('WidgetBuilderSortBySelector', function () {
       expect.objectContaining({
         query: expect.objectContaining({limit: 3}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -271,7 +271,7 @@ describe('WidgetBuilderSortBySelector', function () {
       expect.objectContaining({
         query: expect.objectContaining({sort: ['-count_unique(span.op)']}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -125,7 +125,7 @@ describe('WidgetBuilderSortBySelector', function () {
         ...router.location,
         query: expect.objectContaining({sort: ['-count()']}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
 
     await userEvent.click(sortDirectionSelector);
@@ -135,7 +135,7 @@ describe('WidgetBuilderSortBySelector', function () {
         ...router.location,
         query: expect.objectContaining({sort: ['count()']}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -209,7 +209,7 @@ describe('WidgetBuilderSortBySelector', function () {
       expect.objectContaining({
         query: expect.objectContaining({limit: 3}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -271,7 +271,7 @@ describe('WidgetBuilderSortBySelector', function () {
       expect.objectContaining({
         query: expect.objectContaining({sort: ['-count_unique(span.op)']}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -42,7 +42,7 @@ describe('Thresholds', () => {
           thresholds: undefined,
         }),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -66,7 +66,7 @@ describe('Thresholds', () => {
           thresholds: '{"max_values":{"max1":100,"max2":200},"unit":null}',
         }),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -97,7 +97,7 @@ describe('Thresholds', () => {
           thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"second"}',
         }),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -149,7 +149,7 @@ describe('Thresholds', () => {
           thresholds: '{"max_values":{"max1":0.5,"max2":100.5456},"unit":null}',
         }),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -42,7 +42,7 @@ describe('Thresholds', () => {
           thresholds: undefined,
         }),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -66,7 +66,7 @@ describe('Thresholds', () => {
           thresholds: '{"max_values":{"max1":100,"max2":200},"unit":null}',
         }),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -97,7 +97,7 @@ describe('Thresholds', () => {
           thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"second"}',
         }),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -149,7 +149,7 @@ describe('Thresholds', () => {
           thresholds: '{"max_values":{"max1":0.5,"max2":100.5456},"unit":null}',
         }),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -46,7 +46,7 @@ describe('TypeSelector', () => {
         ...router.location,
         query: expect.objectContaining({displayType: 'bar'}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.spec.tsx
@@ -46,7 +46,7 @@ describe('TypeSelector', () => {
         ...router.location,
         query: expect.objectContaining({displayType: 'bar'}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -492,7 +492,7 @@ describe('Visualize', () => {
     );
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({query: expect.objectContaining({field: ['count()']})}),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -532,7 +532,7 @@ describe('Visualize', () => {
       expect.objectContaining({
         query: expect.objectContaining({field: ['count_miserable(user,300)']}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -892,7 +892,7 @@ describe('Visualize', () => {
       expect.objectContaining({
         query: expect.objectContaining({selectedAggregate: undefined}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -492,7 +492,7 @@ describe('Visualize', () => {
     );
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({query: expect.objectContaining({field: ['count()']})}),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -532,7 +532,7 @@ describe('Visualize', () => {
       expect.objectContaining({
         query: expect.objectContaining({field: ['count_miserable(user,300)']}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -892,7 +892,7 @@ describe('Visualize', () => {
       expect.objectContaining({
         query: expect.objectContaining({selectedAggregate: undefined}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -468,7 +468,10 @@ describe('WidgetBuilderSlideout', () => {
 
     await userEvent.click(await screen.findByText('Add Widget'));
 
-    expect(onSave).toHaveBeenCalledWith({index: undefined, widget: expect.any(Object)});
+    expect(onSave).toHaveBeenCalledWith({
+      index: undefined,
+      widget: expect.any(Object),
+    });
   });
 
   it('should render the widget template title if templates selected', () => {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -149,12 +149,15 @@ function WidgetBuilderSlideout({
         setCustomizeFromLibrary(false);
         setOpenWidgetTemplates(true);
         // clears the widget to start fresh on the library page
-        navigate({
-          pathname: location.pathname,
-          query: {
-            ...pick(location.query, [...Object.values(URL_PARAM)]),
+        navigate(
+          {
+            pathname: location.pathname,
+            query: {
+              ...pick(location.query, [...Object.values(URL_PARAM)]),
+            },
           },
-        });
+          {preventScrollReset: true}
+        );
       }}
     >
       {t('Widget Library')}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -125,7 +125,7 @@ describe('WidgetTemplatesList', () => {
           dataset: 'transactions-like',
         }),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -125,7 +125,7 @@ describe('WidgetTemplatesList', () => {
           dataset: 'transactions-like',
         }),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 

--- a/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.spec.tsx
@@ -44,7 +44,7 @@ describe('UrlParamBatchProvider', () => {
       expect.objectContaining({
         query: {foo: 'bar', potato: 'test'},
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.tsx
+++ b/static/app/views/dashboards/widgetBuilder/contexts/urlParamBatchContext.tsx
@@ -48,7 +48,7 @@ export function UrlParamBatchProvider({children}: {children: React.ReactNode}) {
 
       // TODO: Use replace until we can sync the state of the widget
       // when the user navigates back
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
     setPendingUpdates({});
   }, [location, navigate, pendingUpdates]);

--- a/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useQueryParamState.spec.tsx
@@ -58,7 +58,7 @@ describe('useQueryParamState', () => {
         ...LocationFixture(),
         query: {testField: 'initial state'},
       },
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
 
     // Run the timers to trigger queued updates
@@ -70,7 +70,7 @@ describe('useQueryParamState', () => {
         ...LocationFixture(),
         query: {testField: 'newValue'},
       },
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
 
     // The local state should be still reflect the new value
@@ -123,7 +123,7 @@ describe('useQueryParamState', () => {
         ...LocationFixture(),
         query: {testField: 'newValue - 2 - true'},
       },
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -156,7 +156,7 @@ describe('useQueryParamState', () => {
         ...LocationFixture(),
         query: {sort: ['testField']},
       },
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -74,13 +74,13 @@ describe('useWidgetBuilderState', () => {
       expect.objectContaining({
         query: expect.objectContaining({title: 'new title'}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({description: 'new description'}),
       }),
-      {replace: true}
+      {replace: true, preventScrollReset: true}
     );
   });
 
@@ -131,7 +131,7 @@ describe('useWidgetBuilderState', () => {
         expect.objectContaining({
           query: expect.objectContaining({displayType: DisplayType.AREA}),
         }),
-        {replace: true}
+        {replace: true, preventScrollReset: true}
       );
     });
 
@@ -835,7 +835,7 @@ describe('useWidgetBuilderState', () => {
         expect.objectContaining({
           query: expect.objectContaining({dataset: WidgetType.METRICS}),
         }),
-        {replace: true}
+        {replace: true, preventScrollReset: true}
       );
     });
 
@@ -1788,7 +1788,7 @@ describe('useWidgetBuilderState', () => {
         expect.objectContaining({
           query: expect.objectContaining({selectedAggregate: undefined}),
         }),
-        {replace: true}
+        {replace: true, preventScrollReset: true}
       );
     });
   });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -74,13 +74,13 @@ describe('useWidgetBuilderState', () => {
       expect.objectContaining({
         query: expect.objectContaining({title: 'new title'}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
     expect(mockNavigate).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({description: 'new description'}),
       }),
-      {replace: true, preventScrollReset: true}
+      expect.anything()
     );
   });
 
@@ -131,7 +131,7 @@ describe('useWidgetBuilderState', () => {
         expect.objectContaining({
           query: expect.objectContaining({displayType: DisplayType.AREA}),
         }),
-        {replace: true, preventScrollReset: true}
+        expect.anything()
       );
     });
 
@@ -835,7 +835,7 @@ describe('useWidgetBuilderState', () => {
         expect.objectContaining({
           query: expect.objectContaining({dataset: WidgetType.METRICS}),
         }),
-        {replace: true, preventScrollReset: true}
+        expect.anything()
       );
     });
 
@@ -1788,7 +1788,7 @@ describe('useWidgetBuilderState', () => {
         expect.objectContaining({
           query: expect.objectContaining({selectedAggregate: undefined}),
         }),
-        {replace: true, preventScrollReset: true}
+        expect.anything()
       );
     });
   });


### PR DESCRIPTION
There are a few places I had to pass `preventScrollReset: true` to avoid the scroll from resetting on URL changes.

- Prevent it for adding a new widget
- Prevent it for editing a widget
- Prevent it for closing the widget builder
- Prevent it for any of the URL query param updates through the widget builder state hooks

~I also had to remove the page filter container because it should already be synced to a higher component with the page filters on the dashboard level. It was triggering some URL param updates that I couldn't just add `preventScrollReset: true` to.~

I set the page filter container in the filter bar section of the builder to skip initializing the URL params to prevent a navigation that we couldn't apply `preventScrollReset` to