### PR TITLE
fix(widget-builder): Render release filter properly

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -11,7 +11,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ReleasesSelectControl from 'sentry/views/dashboards/releasesSelectControl';
 
-function WidgetBuilderFilterBar() {
+function WidgetBuilderFilterBar({releases}: {releases: string[]}) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   return (
@@ -38,7 +38,7 @@ function WidgetBuilderFilterBar() {
             <ReleasesSelectControl
               isDisabled
               handleChangeFilter={() => {}}
-              selectedReleases={[]}
+              selectedReleases={releases}
             />
           </ReleasesProvider>
         </PageFilterBar>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -232,7 +232,7 @@ function WidgetBuilderSlideout({
         ) : (
           <Fragment>
             <Section>
-              <WidgetBuilderFilterBar />
+              <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
             </Section>
             <Section>
               <WidgetBuilderDatasetSelector />


### PR DESCRIPTION
Releases weren't being passed down, so the release filter was always showing that All Releases was the filter