### PR TITLE
chore(issue summary): Ignore user ack for issue summary

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -13,6 +13,7 @@ interface AiConfigResult {
   hasSummary: boolean;
   isAutofixSetupLoading: boolean;
   needsGenAiAcknowledgement: boolean;
+  orgNeedsGenAiAcknowledgement: boolean;
 }
 
 export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
@@ -41,10 +42,16 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     (isSummaryEnabled || isAutofixEnabled) &&
     areAiFeaturesAllowed;
 
+  const orgNeedsGenAiAcknowledgement =
+    !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
+    (isSummaryEnabled || isAutofixEnabled) &&
+    areAiFeaturesAllowed;
+
   return {
     hasSummary,
     hasAutofix,
     needsGenAiAcknowledgement,
+    orgNeedsGenAiAcknowledgement,
     hasResources,
     isAutofixSetupLoading,
     areAiFeaturesAllowed,

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -161,7 +161,7 @@ export default function SeerSection({
       preventCollapse={!hasStreamlinedUI}
     >
       <SeerSectionContainer>
-        {aiConfig.needsGenAiAcknowledgement && !aiConfig.isAutofixSetupLoading ? (
+        {aiConfig.orgNeedsGenAiAcknowledgement && !aiConfig.isAutofixSetupLoading ? (
           <Summary>{t('Explore potential root causes and solutions with Seer.')}</Summary>
         ) : aiConfig.hasAutofix || aiConfig.hasSummary ? (
           <SeerSectionContent group={group} project={project} event={event} />


### PR DESCRIPTION
Only check org acknowledgement before showing issue summary. Users who have not individually enabled seer will still see the summary as long as their org has enabled it.