### PR TITLE
chore(taskworker) Simplify signature of email tasks

### DIFF
--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any
 
-from django.core.mail import EmailMultiAlternatives
-
 from sentry.auth import access
 from sentry.models.group import Group
 from sentry.silo.base import SiloMode
@@ -63,10 +61,9 @@ def process_inbound_email(mailfrom: str, group_id: int, payload: str) -> None:
         ),
     ),
 )
-def send_email(message: EmailMultiAlternatives | dict[str, Any]) -> None:
-    if not isinstance(message, EmailMultiAlternatives):
-        message = message_from_dict(message)
-    send_messages([message])
+def send_email(message: dict[str, Any]) -> None:
+    django_message = message_from_dict(message)
+    send_messages([django_message])
 
 
 @instrumented_task(
@@ -82,7 +79,6 @@ def send_email(message: EmailMultiAlternatives | dict[str, Any]) -> None:
         ),
     ),
 )
-def send_email_control(message: EmailMultiAlternatives | dict[str, Any]) -> None:
-    if not isinstance(message, EmailMultiAlternatives):
-        message = message_from_dict(message)
-    send_messages([message])
+def send_email_control(message: dict[str, Any]) -> None:
+    django_message = message_from_dict(message)
+    send_messages([django_message])


### PR DESCRIPTION
Complete the redo of work from #91394. I didn't include email tasks in #91541 as I wanted to understand email errors better. Having reviewed those errors, they were not caused by these changes.