### PR TITLE
fix(search-bar): Allow selection of typed in item

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1537,6 +1537,38 @@ describe('SearchQueryBuilder', function () {
         await screen.findByRole('row', {name: 'browser.name:firefox'})
       ).toBeInTheDocument();
     });
+
+    it('selects the value when pressing enter after typing it in', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+      );
+
+      // Click into filter value (button to edit will no longer exist)
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).not.toBeInTheDocument();
+
+      await userEvent.type(screen.getByRole('combobox'), 'randomValue');
+
+      const listBox = screen.getByRole('checkbox', {name: 'Toggle randomValue'});
+      expect(listBox).not.toBeChecked();
+
+      await userEvent.keyboard('{arrowdown}{enter}');
+
+      // Re-open filter value
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).not.toBeInTheDocument();
+
+      const updatedListBox = screen.getByRole('checkbox', {name: 'Toggle randomValue'});
+      expect(updatedListBox).toBeChecked();
+    });
   });
 
   describe('token values', function () {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1590,6 +1590,44 @@ describe('SearchQueryBuilder', function () {
         await screen.findByRole('row', {name: 'custom_tag_name:tag_value_one'})
       ).toBeInTheDocument();
     });
+
+    it('sets the value as not selected when no comma is present', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+      );
+
+      // Click into filter value (button to edit will no longer exist)
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).not.toBeInTheDocument();
+
+      await userEvent.type(screen.getByRole('combobox'), 'randomValue');
+
+      const listBox = screen.getByRole('checkbox', {name: 'Toggle randomValue'});
+      expect(listBox).not.toBeChecked();
+    });
+
+    it('sets the value as selected when a trailing comma is present', async function () {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+      );
+
+      // Click into filter value (button to edit will no longer exist)
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).not.toBeInTheDocument();
+
+      await userEvent.type(screen.getByRole('combobox'), 'randomValue,');
+
+      const listBox = screen.getByRole('checkbox', {name: 'Toggle randomValue'});
+      expect(listBox).toBeChecked();
+    });
   });
 
   describe('filter types', function () {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -141,6 +141,10 @@ function getSelectedValuesFromText(
       const value =
         (escaped ? item.value?.text : unescapeTagValue(item.value?.value ?? '')) ?? '';
 
+      // Check if this value is selected by looking at the character after the value in
+      // the text. If there's a comma after the value, it means this value is selected.
+      // We need to check the text content to ensure that we account for any quotes the
+      // user may have added.
       const valueText = item.value?.text ?? '';
       const selected = text.charAt(text.indexOf(valueText) + valueText.length) === ',';
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -651,10 +651,7 @@ export function SearchQueryBuilderValueCombobox({
         if (selectedValuesUnescaped.includes(value)) {
           const newValue = prepareInputValueForSaving(
             getFilterValueType(token, fieldDefinition),
-            selectedValuesUnescaped
-              .filter(v => v !== value)
-              .map(escapeTagValue)
-              .join(',')
+            selectedValuesUnescaped.map(escapeTagValue).join(',')
           );
 
           dispatch({


### PR DESCRIPTION
This PR fixes an issue where this `.filter(v => v !== value)` call was removing the value from included in the `newValue` string and so on to be included in the filter.

To fix this, we now check to see if a typed in value is considered `selected`, a value is now considered `selected` when it has a trailing comma. If a value is not `selected`, we won't display it in the list with a checkbox, and the user is able to select it and submit their search.

Closes EXP-249

Before:

https://github.com/user-attachments/assets/36228e40-f5b0-432c-a4ff-4580aa9765e5

After:

https://github.com/user-attachments/assets/380ffd10-e31f-4a5f-8cbd-d659599388b5