### PR TITLE
feat(codecov): Add sunburst chart to coverage file explorer

### DIFF
--- a/static/app/views/codecov/coverage/coverage.tsx
+++ b/static/app/views/codecov/coverage/coverage.tsx
@@ -1,11 +1,98 @@
 import styled from '@emotion/styled';
 
+import {TreeCoverageSunburstChart} from 'sentry/components/charts/treeCoverageSunburstChart';
 import {space} from 'sentry/styles/space';
+
+const SAMPLE_DATA = {
+  name: 'project-root',
+  fullPath: 'project-root',
+  coverage: 75, // Overall coverage percentage for the root directory
+  children: [
+    {
+      name: 'src',
+      fullPath: 'project-root/src',
+      coverage: 82, // Coverage for the src directory
+      children: [
+        {
+          name: 'components',
+          fullPath: 'project-root/src/components',
+          coverage: 90,
+          children: [
+            {
+              name: 'Button.tsx',
+              fullPath: 'project-root/src/components/Button.tsx',
+              value: 1, // File nodes have a value of 1
+              coverage: 95, // Coverage percentage for this file
+              children: [],
+            },
+            {
+              name: 'Input.tsx',
+              fullPath: 'project-root/src/components/Input.tsx',
+              value: 1,
+              coverage: 85,
+              children: [],
+            },
+          ],
+        },
+        {
+          name: 'utils',
+          fullPath: 'project-root/src/utils',
+          coverage: 75,
+          children: [
+            {
+              name: 'helpers.ts',
+              fullPath: 'project-root/src/utils/helpers.ts',
+              value: 1,
+              coverage: 78,
+              children: [],
+            },
+            {
+              name: 'formatters.ts',
+              fullPath: 'project-root/src/utils/formatters.ts',
+              value: 1,
+              coverage: 72,
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'tests',
+      fullPath: 'project-root/tests',
+      coverage: 68,
+      children: [
+        {
+          name: 'unit',
+          fullPath: 'project-root/tests/unit',
+          coverage: 68,
+          children: [
+            {
+              name: 'test1.spec.ts',
+              fullPath: 'project-root/tests/unit/test1.spec.ts',
+              value: 1,
+              coverage: 55,
+              children: [],
+            },
+            {
+              name: 'test2.spec.ts',
+              fullPath: 'project-root/tests/unit/test2.spec.ts',
+              value: 1,
+              coverage: 81,
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 
 export default function CoveragePage() {
   return (
     <LayoutGap>
       <p>Coverage Analytics</p>
+      <TreeCoverageSunburstChart data={SAMPLE_DATA} />
     </LayoutGap>
   );
 }


### PR DESCRIPTION
Use the sunburst chart component that has been built out so that it isn't flagged as an unused file.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
