### PR TITLE
fix(widget-builder): Bring the title and description to the top

### DIFF
--- a/static/app/views/dashboards/releasesSelectControl.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.tsx
@@ -18,6 +18,7 @@ type Props = {
   selectedReleases: string[];
   className?: string;
   handleChangeFilter?: (activeFilters: DashboardFilters) => void;
+  id?: string;
   isDisabled?: boolean;
 };
 
@@ -36,6 +37,7 @@ function ReleasesSelectControl({
   selectedReleases,
   className,
   isDisabled,
+  id,
 }: Props) {
   const {releases, loading, onSearch} = useReleases();
   const [activeReleases, setActiveReleases] = useState<string[]>(selectedReleases);
@@ -61,6 +63,7 @@ function ReleasesSelectControl({
       multiple
       clearable
       searchable
+      id={id}
       disabled={isDisabled}
       loading={loading}
       menuTitle={<MenuTitleWrapper>{t('Filter Releases')}</MenuTitleWrapper>}

--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -1,3 +1,6 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
@@ -32,21 +35,36 @@ function WidgetBuilderFilterBar({releases}: {releases: string[]}) {
         title={t('Changes to these filters can only be made at the dashboard level')}
         skipWrapper
       >
-        <PageFilterBar>
+        <StyledPageFilterBar>
           <ProjectPageFilter disabled onChange={() => {}} />
           <EnvironmentPageFilter disabled onChange={() => {}} />
           <DatePageFilter disabled onChange={() => {}} />
           <ReleasesProvider organization={organization} selection={selection}>
             <ReleasesSelectControl
               isDisabled
+              id="releases-select-control"
               handleChangeFilter={() => {}}
               selectedReleases={releases}
             />
           </ReleasesProvider>
-        </PageFilterBar>
+        </StyledPageFilterBar>
       </Tooltip>
     </PageFiltersContainer>
   );
 }
 
 export default WidgetBuilderFilterBar;
+
+// Override the styles of the trigger button of the releases selection
+// control under the chonk UI. This is because filter buttons are
+// translated back to slightly overlap the border, which causes
+// the last button not to extend the full width
+const StyledPageFilterBar = styled(PageFilterBar)`
+  ${p =>
+    p.theme.isChonk &&
+    css`
+      #releases-select-control button {
+        min-width: calc(100% + 3px);
+      }
+    `}
+`;

--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -29,6 +29,7 @@ function WidgetBuilderFilterBar() {
     >
       <Tooltip
         title={t('Changes to these filters can only be made at the dashboard level')}
+        skipWrapper
       >
         <PageFilterBar>
           <ProjectPageFilter disabled onChange={() => {}} />

--- a/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/filtersBar.tsx
@@ -30,6 +30,7 @@ function WidgetBuilderFilterBar({releases}: {releases: string[]}) {
     >
       <Tooltip
         title={t('Changes to these filters can only be made at the dashboard level')}
+        skipWrapper
       >
         <PageFilterBar>
           <ProjectPageFilter disabled onChange={() => {}} />

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -61,7 +61,7 @@ function WidgetBuilderNameAndDescription({
         inline={false}
       />
       {!isDescSelected && (
-        <AddDescriptionButton
+        <Button
           priority="link"
           aria-label={t('Add Widget Description')}
           onClick={() => {
@@ -70,7 +70,7 @@ function WidgetBuilderNameAndDescription({
           data-test-id={'add-description'}
         >
           {t('+ Add Widget Description')}
-        </AddDescriptionButton>
+        </Button>
       )}
       {isDescSelected && (
         <DescriptionTextArea
@@ -105,10 +105,6 @@ const StyledTextField = styled(TextField)`
   margin-bottom: ${space(1)};
   padding: 0;
   border: none;
-`;
-
-const AddDescriptionButton = styled(Button)`
-  margin-bottom: ${space(1)};
 `;
 
 const DescriptionTextArea = styled(TextArea)`

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -43,6 +43,7 @@ import {
   WIDGET_PREVIEW_DRAG_ID,
   type WidgetDragPositioning,
 } from 'sentry/views/dashboards/widgetBuilder/components/common/draggableUtils';
+import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
 import WidgetPreview from 'sentry/views/dashboards/widgetBuilder/components/widgetPreview';
 import {
@@ -384,6 +385,12 @@ export function WidgetPreviewContainer({
                     />
                   )}
                 </SampleWidgetCard>
+
+                {!isSmallScreen && (
+                  <FilterBarContainer>
+                    <WidgetBuilderFilterBar />
+                  </FilterBarContainer>
+                )}
               </DraggableWidgetContainer>
             </MEPSettingProvider>
           )}
@@ -541,4 +548,9 @@ const WidgetPreviewTitle = styled(motion.h5)`
   margin-left: ${space(1)};
   color: ${p => p.theme.white};
   font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const FilterBarContainer = styled('div')`
+  width: 100%;
+  margin-top: ${space(1)};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -43,6 +43,7 @@ import {
   WIDGET_PREVIEW_DRAG_ID,
   type WidgetDragPositioning,
 } from 'sentry/views/dashboards/widgetBuilder/components/common/draggableUtils';
+import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
 import WidgetPreview from 'sentry/views/dashboards/widgetBuilder/components/widgetPreview';
 import {
@@ -321,6 +322,13 @@ export function WidgetPreviewContainer({
     return PREVIEW_HEIGHT_PX;
   };
 
+  const animatedProps = {
+    initial: {opacity: 0, x: '50%', y: 0},
+    animate: {opacity: 1, x: 0, y: 0},
+    exit: {opacity: 0, x: '50%', y: 0},
+    transition: animationTransitionSettings,
+  };
+
   return (
     <DashboardsMEPProvider>
       <MetricsCardinalityProvider organization={organization} location={location}>
@@ -345,20 +353,12 @@ export function WidgetPreviewContainer({
                 {...listeners}
               >
                 {!isSmallScreen && (
-                  <WidgetPreviewTitle
-                    initial={{opacity: 0, x: '50%', y: 0}}
-                    animate={{opacity: 1, x: 0, y: 0}}
-                    exit={{opacity: 0, x: '50%', y: 0}}
-                    transition={animationTransitionSettings}
-                  >
+                  <WidgetPreviewTitle {...animatedProps}>
                     {t('Widget Preview')}
                   </WidgetPreviewTitle>
                 )}
                 <SampleWidgetCard
-                  initial={{opacity: 0, x: '50%', y: 0}}
-                  animate={{opacity: 1, x: 0, y: 0}}
-                  exit={{opacity: 0, x: '50%', y: 0}}
-                  transition={animationTransitionSettings}
+                  {...animatedProps}
                   style={{
                     width: isDragEnabled ? DRAGGABLE_PREVIEW_WIDTH_PX : undefined,
                     height: getPreviewHeight(),
@@ -384,6 +384,12 @@ export function WidgetPreviewContainer({
                     />
                   )}
                 </SampleWidgetCard>
+
+                {!isSmallScreen && (
+                  <FilterBarContainer {...animatedProps}>
+                    <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
+                  </FilterBarContainer>
+                )}
               </DraggableWidgetContainer>
             </MEPSettingProvider>
           )}
@@ -541,4 +547,10 @@ const WidgetPreviewTitle = styled(motion.h5)`
   margin-left: ${space(1)};
   color: ${p => p.theme.white};
   font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const FilterBarContainer = styled(motion.div)`
+  margin-top: ${space(1)};
+  background-color: ${p => p.theme.background};
+  border-radius: ${p => p.theme.borderRadius};
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -553,4 +553,17 @@ const FilterBarContainer = styled(motion.div)`
   margin-top: ${space(1)};
   background-color: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    width: 40vw;
+    min-width: 300px;
+    z-index: ${p => p.theme.zIndex.modal};
+    cursor: auto;
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints.large}) and (min-width: ${p =>
+      p.theme.breakpoints.medium}) {
+    width: 30vw;
+    min-width: 100px;
+  }
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -28,6 +28,7 @@ import {
 } from 'sentry/views/dashboards/types';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
+import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
 import {
@@ -224,6 +225,9 @@ function WidgetBuilderSlideout({
                 </Section>
               )}
             </div>
+            <Section>
+              <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
+            </Section>
             <WidgetTemplatesList
               onSave={onSave}
               setOpenWidgetTemplates={setOpenWidgetTemplates}
@@ -255,6 +259,11 @@ function WidgetBuilderSlideout({
                 </Section>
               )}
             </div>
+            {isSmallScreen && (
+              <Section>
+                <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
+              </Section>
+            )}
             <Section>
               <Visualize error={error} setError={setError} />
             </Section>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -28,7 +28,6 @@ import {
 } from 'sentry/views/dashboards/types';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
-import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
 import {
@@ -232,7 +231,7 @@ function WidgetBuilderSlideout({
         ) : (
           <Fragment>
             <Section>
-              <WidgetBuilderFilterBar />
+              <WidgetBuilderNameAndDescription error={error} setError={setError} />
             </Section>
             <Section>
               <WidgetBuilderDatasetSelector />
@@ -284,9 +283,6 @@ function WidgetBuilderSlideout({
                 <WidgetBuilderSortBySelector />
               </Section>
             )}
-            <Section>
-              <WidgetBuilderNameAndDescription error={error} setError={setError} />
-            </Section>
             <SaveButton isEditing={isEditing} onSave={onSave} setError={setError} />
           </Fragment>
         )}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -28,7 +28,6 @@ import {
 } from 'sentry/views/dashboards/types';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
-import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
 import {
@@ -235,7 +234,7 @@ function WidgetBuilderSlideout({
         ) : (
           <Fragment>
             <Section>
-              <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
+              <WidgetBuilderNameAndDescription error={error} setError={setError} />
             </Section>
             <Section>
               <WidgetBuilderDatasetSelector />
@@ -287,9 +286,6 @@ function WidgetBuilderSlideout({
                 <WidgetBuilderSortBySelector />
               </Section>
             )}
-            <Section>
-              <WidgetBuilderNameAndDescription error={error} setError={setError} />
-            </Section>
             <SaveButton isEditing={isEditing} onSave={onSave} setError={setError} />
           </Fragment>
         )}


### PR DESCRIPTION
Brings the title and description field to the top and adjusts some
styles to make sure it renders similarly to the other sections

I also added an `id` to the releases select control so I could override some of its styling with chonk UI. It's not the most robust but it works for now and maybe I'll look at pushing the change into filter bars generally. The issue was that each button gets translated to the left slightly to overlap the borders, but by the end of the widget there's now `-n px` of space. I've just extended the last trigger by 3px to account for the difference.