### PR TITLE
fix(insights): show - instead of null when metric value is null

### DIFF
--- a/static/app/views/insights/mobile/screens/utils.ts
+++ b/static/app/views/insights/mobile/screens/utils.ts
@@ -6,7 +6,7 @@ import type {MetricsProperty, SpanMetricsProperty} from 'sentry/views/insights/t
 import {VitalState} from 'sentry/views/performance/vitalDetail/utils';
 
 const formatMetricValue = (metric: MetricValue, field?: string | undefined): string => {
-  if (metric.value === undefined) {
+  if (metric.value === undefined || metric.value === null) {
     return '-';
   }
   if (typeof metric.value === 'number' && metric.type === 'duration' && metric.unit) {


### PR DESCRIPTION
Eap returns data back as `null` when there is no data, while metrics would always return 0.0. When eap returns back `null`, we should display `-` to represent no data instead of the text `null`

![image](https://github.com/user-attachments/assets/55f4a589-b795-40a7-a2f9-5e1763f320b3)
