### PR TITLE
perf(alerts): Limit GroupEvent processing to relevant groups

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -297,12 +297,17 @@ def get_group_to_groupevent(
     groups = Group.objects.filter(id__in=group_ids)
     group_id_to_group = {group.id: group for group in groups}
 
+    # Filter down to only the event data for the groups we've been asked to process.
+    relevant_rulegroup_to_event_data = {
+        key: value for key, value in parsed_rulegroup_to_event_data.items() if key[1] in group_ids
+    }
+
     # Use a list comprehension for event_ids
     event_ids: list[str] = [
         event_id
         for event_id in (
             instance_data.get("event_id")
-            for instance_data in parsed_rulegroup_to_event_data.values()
+            for instance_data in relevant_rulegroup_to_event_data.values()
         )
         if event_id is not None
     ]
@@ -312,7 +317,7 @@ def get_group_to_groupevent(
         occurrence_id
         for occurrence_id in (
             instance_data.get("occurrence_id")
-            for instance_data in parsed_rulegroup_to_event_data.values()
+            for instance_data in relevant_rulegroup_to_event_data.values()
         )
         if occurrence_id is not None
     ]
@@ -325,7 +330,7 @@ def get_group_to_groupevent(
     }
 
     return build_group_to_groupevent(
-        parsed_rulegroup_to_event_data,
+        relevant_rulegroup_to_event_data,
         bulk_event_id_to_events,
         bulk_occurrence_id_to_occurrence,
         group_id_to_group,


### PR DESCRIPTION
Restrict our rulegroup_to_eventdata mapping in `get_group_to_groupevent` to relevant groups early on.
This means that instead of fetching every event and occurrence for every rule, it only fetches those for the groups currently being processed.
Logic below in `build_group_to_groupevent` already walks this mapping and drops any that aren't in our set of passed in Groups (logging them as missing), so the end result should be the same (though with less log noise).

It's not clear how much perf benefit we expect to see from this, but it does make the behavior a bit clearer, avoids suspicious logs in a situation that is expected, and potentially asks significantly less work of our nodestore bulk fetches, so it seems promising.