### PR TITLE
ref(crons): Use dateAdded over dateCreated

### DIFF
--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -121,14 +121,14 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
                       disabled={!customTimezone}
                       title={
                         <DateTime
-                          date={checkIn.dateCreated}
+                          date={checkIn.dateAdded}
                           forcedTimezone={monitor.config.timezone ?? 'UTC'}
                           timeZone
                           seconds
                         />
                       }
                     >
-                      <DateTime date={checkIn.dateCreated} timeZone seconds />
+                      <DateTime date={checkIn.dateAdded} timeZone seconds />
                     </Tooltip>
                   </div>
                 )}

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -142,9 +142,9 @@ export interface MonitorStat {
 
 export interface CheckIn {
   /**
-   * Date the opening check-in was sent
+   * Date the opening check-in was received.
    */
-  dateCreated: string;
+  dateAdded: string;
   /**
    * Duration (in milliseconds)
    */

--- a/static/app/views/issueDetails/groupCheckIns.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.tsx
@@ -91,7 +91,7 @@ export default function GroupCheckIns() {
         emptyMessage={t('No matching check-ins found')}
         data={cronData}
         columnOrder={[
-          {key: 'dateCreated', width: 225, name: t('Timestamp')},
+          {key: 'dateAdded', width: 225, name: t('Timestamp')},
           {key: 'status', width: 100, name: t('Status')},
           {key: 'duration', width: 130, name: t('Duration')},
           {key: 'environment', width: 120, name: t('Environment')},
@@ -146,7 +146,7 @@ function CheckInCell({
   }
 
   switch (columnKey) {
-    case 'dateCreated': {
+    case 'dateAdded': {
       const format = userOptions.clock24Hours
         ? 'MMM D, YYYY HH:mm:ss z'
         : 'MMM D, YYYY h:mm:ss A z';
@@ -176,7 +176,7 @@ function CheckInCell({
               </LabelledTooltip>
             }
           >
-            {FIELD_FORMATTERS.date.renderFunc('dateCreated', dataRow)}
+            {FIELD_FORMATTERS.date.renderFunc('dateAdded', dataRow)}
           </Tooltip>
         </HoverableCell>
       );

--- a/tests/js/fixtures/checkIn.ts
+++ b/tests/js/fixtures/checkIn.ts
@@ -6,7 +6,7 @@ export function CheckInFixture(params: Partial<CheckIn> = {}): CheckIn {
     status: CheckInStatus.ERROR,
     duration: 767,
     environment: 'production',
-    dateCreated: '2025-01-01T00:00:00Z',
+    dateAdded: '2025-01-01T00:00:00Z',
     expectedTime: '2025-01-01T00:00:00Z',
     id: '97f0e440-317c-5bb5-b5e0-024ca202a61d',
     monitorConfig: {


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/91665 to be merged first

Part of [NEW-319: Display more date details on cron check-in list](https://linear.app/getsentry/issue/NEW-319/display-more-date-details-on-cron-check-in-list)