### PR TITLE
feat(trace-tabs-ui): Putting attributes tree and logs into panels

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceContextTags.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextTags.tsx
@@ -5,6 +5,7 @@ import EventTagsTree from 'sentry/components/events/eventTags/eventTagsTree';
 import {associateTagsWithMeta} from 'sentry/components/events/eventTags/util';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Panel from 'sentry/components/panels/panel';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -32,35 +33,34 @@ export function TraceContextTags({rootEventResults}: Props) {
   }
 
   const eventDetails = rootEventResults.data!;
-  return (
-    <TagsContainer hasTraceTabsUi={hasTraceTabsUi}>
-      {isTraceItemDetailsResponse(eventDetails) ? (
-        <AttributesTree
-          attributes={eventDetails.attributes}
-          rendererExtra={{
-            theme,
-            location,
-            organization,
-          }}
-        />
-      ) : (
-        <EventTagsTree
-          event={eventDetails}
-          projectSlug={eventDetails.projectSlug ?? ''}
-          tags={associateTagsWithMeta({
-            tags: eventDetails.tags,
-            meta: eventDetails._meta?.tags,
-          })}
-        />
-      )}
-    </TagsContainer>
+  const rendered = isTraceItemDetailsResponse(eventDetails) ? (
+    <AttributesTree
+      attributes={eventDetails.attributes}
+      rendererExtra={{
+        theme,
+        location,
+        organization,
+      }}
+    />
+  ) : (
+    <EventTagsTree
+      event={eventDetails}
+      projectSlug={eventDetails.projectSlug ?? ''}
+      tags={associateTagsWithMeta({
+        tags: eventDetails.tags,
+        meta: eventDetails._meta?.tags,
+      })}
+    />
   );
+
+  if (hasTraceTabsUi) {
+    return <StyledPanel>{rendered}</StyledPanel>;
+  }
+
+  return rendered;
 }
 
-const TagsContainer = styled('div')<{hasTraceTabsUi: boolean}>`
-  ${p =>
-    p.hasTraceTabsUi &&
-    `
-      padding: 0 ${space(1)};
-    `}
+const StyledPanel = styled(Panel)`
+  padding: ${space(2)} ${space(2)} ${space(2)} 24px;
+  margin: 0;
 `;

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import Panel from 'sentry/components/panels/panel';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -51,9 +52,9 @@ export function TraceViewLogsSection() {
 
   if (hasTraceTabsUi) {
     return (
-      <LogsContentWrapper>
+      <StyledPanel>
         <LogsSectionContent tableData={tableData.logsData} />
-      </LogsContentWrapper>
+      </StyledPanel>
     );
   }
 
@@ -104,9 +105,7 @@ const TableContainer = styled('div')`
   margin-top: ${space(2)};
 `;
 
-const LogsContentWrapper = styled('div')`
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(1)};
-  overflow: hidden;
+const StyledPanel = styled(Panel)`
+  padding: ${space(2)};
+  margin: 0;
 `;


### PR DESCRIPTION
<img width="1242" alt="Screenshot 2025-05-14 at 4 29 47 PM" src="https://github.com/user-attachments/assets/f7622a8b-00b8-4c68-86c7-b8087cb2eef7" />

============================

<img width="1235" alt="Screenshot 2025-05-14 at 4 45 51 PM" src="https://github.com/user-attachments/assets/47ef7a76-fffc-4f9c-afe7-c8dd92b44bfe" />
