### PR TITLE
fix(explore): Hard code release as always defined key

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -54,6 +54,7 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanIndexedField.TRACE,
   SpanIndexedField.IS_TRANSACTION, // boolean field but we can expose it as a string
   SpanIndexedField.NORMALIZED_DESCRIPTION,
+  SpanIndexedField.RELEASE, // temporary as orgs with >1k keys still want releases
   SpanFields.PROJECT_ID,
 ];
 


### PR DESCRIPTION
We currently only use the first 1000 keys. So if an org has more, those keys don't show up. For now, hard code release into the list so it's always available even if it's not set. Long term, we'll need to support more than 1000 keys.
