### PR TITLE
fix(nextjs-insights): Prevent table from collapsing

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -30,6 +30,7 @@ interface UseDiscoverOptions<Fields> {
   cursor?: string;
   enabled?: boolean;
   fields?: Fields;
+  keepPreviousData?: boolean;
   limit?: number;
   noPagination?: boolean;
   orderby?: string | string[];
@@ -167,6 +168,7 @@ export const useDiscover = <
     noPagination,
     samplingMode: shouldSetSamplingMode ? samplingMode : undefined,
     additionalQueryKey: useQueryOptions?.additonalQueryKey,
+    keepPreviousData: options.keepPreviousData,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -10,6 +10,7 @@ import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuer
 import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import {keepPreviousData as keepPreviousDataFn} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -228,6 +229,7 @@ type WrappedDiscoverQueryProps<T> = {
   cursor?: string;
   enabled?: boolean;
   initialData?: T;
+  keepPreviousData?: boolean;
   limit?: number;
   noPagination?: boolean;
   referrer?: string;
@@ -238,6 +240,7 @@ function useWrappedDiscoverQueryBase<T>({
   eventView,
   initialData,
   enabled,
+  keepPreviousData,
   referrer,
   limit,
   cursor,
@@ -284,6 +287,7 @@ function useWrappedDiscoverQueryBase<T>({
       retryDelay: getRetryDelay,
       staleTime: usesRelativeDateRange ? staleTimeForRelativePeriod : Infinity,
       additionalQueryKey,
+      placeholderData: keepPreviousData ? keepPreviousDataFn : undefined,
     },
     queryExtras,
     noPagination,

--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -144,10 +144,13 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
   });
 
   const handleCursor: CursorHandler = (cursor, pathname, transactionQuery) => {
-    navigate({
-      pathname,
-      search: qs.stringify({...transactionQuery, [currentCursorParamName]: cursor}),
-    });
+    navigate(
+      {
+        pathname,
+        search: qs.stringify({...transactionQuery, [currentCursorParamName]: cursor}),
+      },
+      {replace: true, preventScrollReset: true}
+    );
   };
 
   const spansRequest = useEAPSpans(
@@ -176,6 +179,7 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
         typeof location.query[currentCursorParamName] === 'string'
           ? location.query[currentCursorParamName]
           : undefined,
+      keepPreviousData: true,
     },
     Referrer.PAGES_TABLE
   );
@@ -250,7 +254,7 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
     <Fragment>
       <GridEditableContainer>
         <GridEditable<TableData, SortableField>
-          isLoading={spansRequest.isLoading}
+          isLoading={spansRequest.isPending}
           error={spansRequest.error}
           data={tableData}
           columnOrder={columnOrder}
@@ -262,6 +266,7 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
             onResizeColumn: handleResizeColumn,
           }}
         />
+        {spansRequest.isPlaceholderData && <LoadingOverlay />}
       </GridEditableContainer>
       <Pagination pageLinks={pagesTablePageLinks} onCursor={handleCursor} />
     </Fragment>
@@ -290,6 +295,7 @@ const HeadCell = memo(function PagesTableHeadCell({
         }
         direction={sortField === column.key ? sortOrder : undefined}
         canSort
+        preventScrollReset
         generateSortLink={() => {
           const newQuery = {
             ...location.query,
@@ -368,7 +374,19 @@ const BodyCell = memo(function PagesBodyCell({
 });
 
 const GridEditableContainer = styled('div')`
+  position: relative;
   margin-bottom: ${space(1)};
+`;
+
+const LoadingOverlay = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${p => p.theme.background};
+  opacity: 0.5;
+  z-index: 1;
 `;
 
 const CellLink = styled(Link)`


### PR DESCRIPTION
Prevent the table from collapsing when sorting / changing pages.


https://github.com/user-attachments/assets/fff7925c-83c0-44d8-b301-bb2369e8ac54

- part of [TET-418: Pages Table: Scroll to top when switching](https://linear.app/getsentry/issue/TET-418/pages-table-scroll-to-top-when-switching)
