### PR TITLE
feat(crons): Remove backdating date_added via duration behavior

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, wait
 from copy import deepcopy
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import partial
 from typing import Any, Literal, NotRequired, TypedDict
 
@@ -811,12 +811,6 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
             # 03-B
             # Create a brand new check-in object
             except MonitorCheckIn.DoesNotExist:
-                # Infer the original start time of the check-in from the duration.
-                # Note that the clock of this worker may be off from what Relay is reporting.
-                date_added = start_time
-                if duration is not None:
-                    date_added -= timedelta(milliseconds=duration)
-
                 # When was this check-in expected to have happened?
                 expected_time = monitor_environment.next_checkin
 
@@ -824,7 +818,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                 # Useful to show details about the configuration of the
                 # monitor at the time of the check-in
                 monitor_config = monitor.get_validated_config()
-                timeout_at = get_timeout_at(monitor_config, status, date_added)
+                timeout_at = get_timeout_at(monitor_config, status, start_time)
 
                 # The "date_clock" is recorded as the "clock time" of when the
                 # check-in was processed. The clock time is derived from the
@@ -839,9 +833,9 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                     defaults={
                         "duration": duration,
                         "status": status,
-                        "date_added": date_added,
-                        "date_clock": clock_time,
+                        "date_added": start_time,
                         "date_updated": start_time,
+                        "date_clock": clock_time,
                         "expected_time": expected_time,
                         "timeout_at": timeout_at,
                         "monitor_config": monitor_config,

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -465,14 +465,25 @@ class MonitorCheckIn(Model):
     check-in.
     """
 
+    date_created = models.DateTimeField(default=timezone.now, null=True)
+    """
+    Represents when the check-in was actually recorded into the database. This
+    is a real wall-clock time and is not tied to the "clock" time that
+    check-ins are processed in the context of.
+    """
+
     date_added = models.DateTimeField(default=timezone.now, db_index=True)
     """
-    Represents the time the checkin was made. This CAN BE back-dated in some
-    cases, and does not necessarily represent the insertion time of the row in
-    the database.
+    Represents the time the checkin was made. This date comes from the time
+    relay received the envelope containing the check-in.
+    """
 
-    This date comes from the time relay reiceved the envelope containing the
-    check-in.
+    date_updated = models.DateTimeField(default=timezone.now)
+    """
+    Represents the last time a check-in was updated by . This will typically be by the terminal state
+    Currently only updated when a in_progress check-in is sent with this
+    check-in's guid. Can be used to extend the lifetime of a check-in so that
+    it does not time out.
     """
 
     date_clock = models.DateTimeField(null=True)
@@ -482,20 +493,6 @@ class MonitorCheckIn(Model):
     moves forward as we process kafka messages, this time represents the time
     at which we processed this check-in, in relation to all other tasks (such
     as detecting misses)
-    """
-
-    date_created = models.DateTimeField(default=timezone.now, null=True)
-    """
-    Represents when the check-in was actually recorded into the database. This
-    is a real wall-clock time and is not tied to the "clock" time that
-    check-ins are processed in the contenxt of.
-    """
-
-    date_updated = models.DateTimeField(default=timezone.now)
-    """
-    Currently only updated when a in_progress check-in is sent with this
-    check-in's guid. Can be used to extend the lifetime of a check-in so that
-    it does not time out.
     """
 
     expected_time = models.DateTimeField(null=True)

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -310,6 +310,16 @@ class MonitorConsumerTest(TestCase):
             checkin.date_added
         )
 
+    def test_check_in_no_in_progress(self):
+        now = datetime.now()
+
+        monitor = self._create_monitor(slug="my-monitor")
+        self.send_checkin(monitor.slug, ts=now, status="ok", duration=10)
+
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.status == CheckInStatus.OK
+        assert checkin.date_added == now.replace(tzinfo=UTC)
+
     def test_check_in_date_clock(self):
         monitor = self._create_monitor(slug="my-monitor")
         now = datetime.now()


### PR DESCRIPTION
Before this change when an opening check-in with duration was sent, we would back-date the `date_added` to be the `start_time - duration`, where the start time is the timestamp the check-in was received by relay.

This is relatively confusing in cases where the OK came too late and a miss was created. But because we back-date. That miss would end up looking like it's created _after_ the check in already started potentially.

This removes that behavior. In a second PR we will update the frontend to call this date the "received" time instead of the "start" time.

Part of [NEW-320: Stop backdating the `date_added` column](https://linear.app/getsentry/issue/NEW-320/stop-backdating-the-date-added-column)