### PR TITLE
fix(flags): align suspect in grid

### DIFF
--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -363,8 +363,9 @@ const SuspectLabel = styled('div')`
 `;
 
 const ValueWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 1fr 0.5fr;
+  justify-items: start;
 
   .invisible {
     visibility: hidden;

--- a/static/app/components/events/featureFlags/flagActionDropdown.tsx
+++ b/static/app/components/events/featureFlags/flagActionDropdown.tsx
@@ -83,8 +83,10 @@ const StyledDropdownMenu = styled(DropdownMenu)`
   }
 
   .flag-button {
-    height: 20px;
-    min-height: 20px;
+    height: 15px;
+    min-height: 15px;
+    width: 25px;
+    margin-top: ${space(0.5)};
     padding: 0 ${space(0.75)};
     border-radius: ${space(0.5)};
     z-index: 0;


### PR DESCRIPTION
before:
<img width="666" alt="SCR-20250514-mycu" src="https://github.com/user-attachments/assets/d6aaa767-74ae-4837-986f-4ebffb848875" />


after: 
<img width="568" alt="SCR-20250514-mysp" src="https://github.com/user-attachments/assets/a45c73c0-0910-4c73-baa9-475f2316025c" />
<img width="1088" alt="SCR-20250514-myox" src="https://github.com/user-attachments/assets/b4f013e7-9342-43dd-879d-7ba3680a2a51" />
