### PR TITLE
feat(processing): Report event count distribution in process_in_batches

### DIFF
--- a/src/sentry/rules/processing/buffer_processing.py
+++ b/src/sentry/rules/processing/buffer_processing.py
@@ -104,6 +104,7 @@ def process_in_batches(project_id: int, processing_type: str) -> None:
     metrics.incr(
         f"{processing_type}.num_groups", tags={"num_groups": bucket_num_groups(event_count)}
     )
+    metrics.distribution(f"{processing_type}.event_count", event_count)
 
     if event_count < batch_size:
         return task.delay(project_id)


### PR DESCRIPTION
Add a distribution tracker of event counts. We have an existing counter tagged by bucket magnitude, but we can get a bit more insight from percentiles/avg/max that are natively supported.