### PR TITLE
fix(2fa): Use isFetchedAfterMount for sudo modal authenticators

### DIFF
--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -103,14 +103,17 @@ function SudoModal({
   const bootstrapIsPending =
     isOrganizationFetching || isTeamsFetching || isProjectsFetching;
 
-  const {data: authenticators = [], isLoading: isAuthenticatorsLoading} = useApiQuery<
-    Authenticator[]
-  >(['/authenticators/'], {
-    // Fetch authenticators after preload requests to avoid overwriting session cookie
-    enabled: !bootstrapIsPending,
-    staleTime: 0,
-    retry: false,
-  });
+  // XXX(epurkhiser): Using isFetchedAfterMount here since the WebAuthn
+  // authenticator will always produce a new challenge. We don't want to render
+  // the WebAuthnAssert and then re-render with a different challenge, causing
+  // the prompt to trigger twice.
+  const {data: authenticators = [], isFetchedAfterMount: authenticatorsLoaded} =
+    useApiQuery<Authenticator[]>(['/authenticators/'], {
+      // Fetch authenticators after preload requests to avoid overwriting session cookie
+      enabled: !bootstrapIsPending,
+      staleTime: 0,
+      retry: false,
+    });
 
   const handleSubmitCOPS = () => {
     setState(prevState => ({
@@ -254,7 +257,7 @@ function SudoModal({
       return null;
     }
 
-    if (isAuthenticatorsLoading || bootstrapIsPending) {
+    if (!authenticatorsLoaded || bootstrapIsPending) {
       return <LoadingIndicator />;
     }
 


### PR DESCRIPTION
Using isLoading isn't right, since it means we'll render the webAuthnAssert before we have a fresh challenge. `isFetchedAfterMount` is more appropriate since we do not want to render anything until we've refetched our data.