### PR TITLE
chore(plugins): removing info logging

### DIFF
--- a/src/sentry/sentry_apps/tasks/service_hooks.py
+++ b/src/sentry/sentry_apps/tasks/service_hooks.py
@@ -1,4 +1,3 @@
-import logging
 from time import time
 
 from sentry import nodestore
@@ -14,8 +13,6 @@ from sentry.taskworker.namespaces import sentryapp_tasks
 from sentry.taskworker.retry import Retry
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import json
-
-logger = logging.getLogger(__name__)
 
 
 def get_payload_v0(event):
@@ -83,4 +80,3 @@ def process_service_hook(
     }
 
     safe_urlopen(url=servicehook.url, data=payload, headers=headers, timeout=5, verify_ssl=False)
-    logger.info("service_hook.success", extra={"project_id": project_id})

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1310,13 +1310,6 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         logger.info("post_process.process_error_ignored", extra={"exception": e})
     except Exception as e:
         logger.exception("post_process.process_error", extra={"exception": e})
-    logger.info(
-        "post_process.plugin_success",
-        extra={
-            "project_id": event.project_id,
-            "plugin_slug": plugin_slug,
-        },
-    )
 
 
 def feedback_filter_decorator(func):


### PR DESCRIPTION
Removing logs because I don't need them anymore. Plugins are now not installable by new customers anymore so old logs would do. Basically revert of: https://github.com/getsentry/sentry/pull/89829/files