### PR TITLE
ref(grouping): Improve tagging of split enhancements timers

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -53,6 +53,7 @@ from sentry.grouping.api import (
     GroupingConfig,
     get_grouping_config_dict_for_project,
 )
+from sentry.grouping.enhancer import get_enhancements_version
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.grouping.ingest.config import is_in_transition, update_or_set_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
@@ -471,6 +472,7 @@ class EventManager:
                 "platform": job["event"].platform or "unknown",
                 "sdk": normalized_sdk_tag_from_event(job["event"].data),
                 "in_transition": job["in_grouping_transition"],
+                "split_enhancements": get_enhancements_version(project) == 3,
             }
             # This metric allows differentiating from all calls to the `event_manager.save` metric
             # and adds support for differentiating based on platforms

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -125,6 +125,7 @@ class GroupingConfigLoader:
                 enhancements_string,
                 bases=[enhancements_base] if enhancements_base else [],
                 version=get_enhancements_version(project, config_id),
+                referrer="project_rules",
             ).base64_string
         except InvalidEnhancerConfig:
             enhancements = get_default_enhancements()

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -822,7 +822,9 @@ def _load_configs() -> dict[str, Enhancements]:
                 # We cannot use `:` in filenames on Windows but we already have ids with
                 # `:` in their names hence this trickery.
                 filename = filename.replace("@", ":")
-                enhancements = Enhancements.from_rules_text(f.read(), id=filename, version=3)
+                enhancements = Enhancements.from_rules_text(
+                    f.read(), id=filename, version=3, referrer="default_rules"
+                )
                 enhancement_bases[filename] = enhancements
     return enhancement_bases
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -771,7 +771,11 @@ class Enhancements:
 
                 metrics_timer_tags.update(
                     # The first entry in the config structure is the enhancements version
-                    {"split": config_structure[0] == 3, "source": "base64_string"}
+                    {
+                        "split": config_structure[0] == 3,
+                        "source": "base64_string",
+                        "referrer": referrer,
+                    }
                 )
 
                 return cls._from_config_structure(config_structure, rust_enhancements)

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -785,6 +785,7 @@ class Enhancements:
         bases: list[str] | None = None,
         id: str | None = None,
         version: int | None = None,
+        referrer: str | None = None,
     ) -> Enhancements:
         """Create an `Enhancements` object from a text blob containing stacktrace rules"""
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -746,7 +746,9 @@ class Enhancements:
         )
 
     @classmethod
-    def from_base64_string(cls, base64_string: str | bytes) -> Enhancements:
+    def from_base64_string(
+        cls, base64_string: str | bytes, referrer: str | None = None
+    ) -> Enhancements:
         """Convert a base64 string into an `Enhancements` object"""
 
         with metrics.timer("grouping.enhancements.creation") as metrics_timer_tags:

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -790,7 +790,9 @@ class Enhancements:
         """Create an `Enhancements` object from a text blob containing stacktrace rules"""
 
         with metrics.timer("grouping.enhancements.creation") as metrics_timer_tags:
-            metrics_timer_tags.update({"split": version == 3, "source": "rules_text"})
+            metrics_timer_tags.update(
+                {"split": version == 3, "source": "rules_text", "referrer": referrer}
+            )
 
             rust_enhancements = get_rust_enhancements("config_string", rules_text)
             rules = parse_enhancements(rules_text)

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -303,9 +303,11 @@ class StrategyConfiguration:
 
     def __init__(self, enhancements: str | None = None, **extra: Any):
         if enhancements is None:
-            enhancements_instance = Enhancements.from_rules_text("")
+            enhancements_instance = Enhancements.from_rules_text("", referrer="strategy_config")
         else:
-            enhancements_instance = Enhancements.from_base64_string(enhancements)
+            enhancements_instance = Enhancements.from_base64_string(
+                enhancements, referrer="strategy_config"
+            )
         self.enhancements = enhancements_instance
 
     def __repr__(self) -> str:

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -176,7 +176,7 @@ def apply_stack_trace_rules_to_profile(profile: Profile, rules_config: str) -> N
     profiling_rules = keep_profiling_rules(rules_config)
     if profiling_rules == "":
         return
-    enhancements = Enhancements.from_rules_text(profiling_rules)
+    enhancements = Enhancements.from_rules_text(profiling_rules, referrer="profiling")
     if "version" in profile:
         enhancements.apply_category_and_updated_in_app_to_frames(
             profile["profile"]["frames"], profile["platform"], {}


### PR DESCRIPTION
In order to have a better sense of how the split enhancements will affect ingest time, this PR makes two changes:

- The amount of time it takes to parse the rules and do the splitting increases roughly linearly with the number of rules. Our base ruleset has more than 300 rules, and so, especially in a low-traffic situation like S4S, parsing the default rules can throw off the averages. (We don't much care how slow parsing the default rules is because it only happens once, at app startup.) Therefore, add a `referrer` tag to the timing metric measuring parsing time, so we can narrow it down to just parsing that happens during ingest. 

- Tag the overall error-save timer with whether or not split enhancements will be used. In order to do this, change the mechanism by which we decide if they should be used, so that it's based on project id. (This lets us get the same answer from anywhere in the ingest pipeline.)