### PR TITLE
feat(nextjs-insights): Move dropdown options into segmented control

### DIFF
--- a/static/app/utils/analytics/nextJsInsightsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/nextJsInsightsAnalyticsEvents.tsx
@@ -1,5 +1,10 @@
 type NextJsInsightsEventParameters = {
-  'nextjs-insights.page-view': Record<string, unknown>;
+  'nextjs-insights.page-view': {
+    view: string;
+  };
+  'nextjs-insights.table_view_change': {
+    view: string;
+  };
   'nextjs-insights.ui_toggle': {
     isEnabled: boolean;
   };
@@ -8,5 +13,6 @@ type NextJsInsightsEventParameters = {
 export const nextJsInsightsEventMap: Record<keyof NextJsInsightsEventParameters, string> =
   {
     'nextjs-insights.page-view': 'NextJS Insights: Page View',
+    'nextjs-insights.table_view_change': 'NextJS Insights: Table View Change',
     'nextjs-insights.ui_toggle': 'NextJS Insights: UI Toggle',
   };

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -43,7 +43,7 @@ export function NextJsOverviewPage({
 
   const activeTable: TableType = isTableType(location.query.view)
     ? location.query.view
-    : TableType.API;
+    : TableType.PAGELOAD;
 
   const updateQuery = useCallback(
     (newParams: Record<string, string | string[] | null | undefined>) => {

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -1,7 +1,6 @@
-import {useEffect} from 'react';
+import {useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {SegmentedControl} from 'sentry/components/core/segmentedControl';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -20,18 +19,18 @@ import {PathsTable} from 'sentry/views/insights/pages/platform/shared/pathsTable
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
 import {TrafficWidget} from 'sentry/views/insights/pages/platform/shared/trafficWidget';
 
-type View = 'api' | 'pages';
-type SpanOperation = 'pageload' | 'navigation';
+enum TableType {
+  API = 'api',
+  PAGELOAD = 'pageload',
+  NAVIGATION = 'navigation',
+}
 
-// Define cursor parameter names based on span operation
-const CURSOR_PARAM_NAMES: Record<SpanOperation, string> = {
-  pageload: 'pageCursor',
-  navigation: 'navCursor',
-};
-const spanOperationOptions: Array<SelectOption<SpanOperation>> = [
-  {value: 'pageload', label: t('Pageloads')},
-  {value: 'navigation', label: t('Navigations')},
-];
+function isTableType(value: any): value is TableType {
+  return Object.values(TableType).includes(value as TableType);
+}
+
+const TableControl = SegmentedControl<TableType>;
+const TableControlItem = SegmentedControl.Item<TableType>;
 
 export function NextJsOverviewPage({
   performanceType,
@@ -42,36 +41,50 @@ export function NextJsOverviewPage({
   const location = useLocation();
   const navigate = useNavigate();
 
-  const activeView: View = (location.query.view as View) ?? 'api';
-  const spanOperationFilter: SpanOperation =
-    (location.query.spanOp as SpanOperation) ?? 'pageload';
+  const activeTable: TableType = isTableType(location.query.view)
+    ? location.query.view
+    : TableType.API;
 
-  const updateQuery = (newParams: Record<string, string>) => {
-    const newQuery = {
-      ...location.query,
-      ...newParams,
-    };
-    if ('spanOp' in newParams && newParams.spanOp !== spanOperationFilter) {
-      const oldCursorParamName = CURSOR_PARAM_NAMES[spanOperationFilter];
-      delete newQuery[oldCursorParamName];
-    }
+  const updateQuery = useCallback(
+    (newParams: Record<string, string | string[] | null | undefined>) => {
+      const newQuery = {
+        ...location.query,
+        ...newParams,
+      };
 
-    navigate(
-      {
-        pathname: location.pathname,
-        query: newQuery,
-      },
-      {replace: true}
-    );
-  };
+      navigate(
+        {
+          pathname: location.pathname,
+          query: newQuery,
+        },
+        {replace: true, preventScrollReset: true}
+      );
+    },
+    [location.query, location.pathname, navigate]
+  );
 
   useEffect(() => {
     trackAnalytics('nextjs-insights.page-view', {
       organization,
-      view: activeView,
-      spanOp: spanOperationFilter,
+      view: activeTable,
     });
-  }, [organization, activeView, spanOperationFilter]);
+  }, [organization, activeTable]);
+
+  const handleTableViewChange = useCallback(
+    (view: TableType) => {
+      trackAnalytics('nextjs-insights.table_view_change', {
+        organization,
+        view,
+      });
+      updateQuery({
+        view,
+        pathsCursor: undefined,
+        navigationCursor: undefined,
+        pageloadCursor: undefined,
+      });
+    },
+    [organization, updateQuery]
+  );
 
   return (
     <PlatformLandingPageLayout performanceType={performanceType}>
@@ -100,35 +113,27 @@ export function NextJsOverviewPage({
         </WidgetGrid.Position6>
       </WidgetGrid>
       <ControlsWrapper>
-        <SegmentedControl
-          value={activeView}
-          onChange={value => updateQuery({view: value})}
-          size="sm"
-        >
-          <SegmentedControl.Item key="api">{t('API')}</SegmentedControl.Item>
-          <SegmentedControl.Item key="pages">{t('Pages')}</SegmentedControl.Item>
-        </SegmentedControl>
-        {activeView === 'pages' && (
-          <CompactSelect<SpanOperation>
-            size="sm"
-            triggerProps={{prefix: t('Display')}}
-            options={spanOperationOptions}
-            value={spanOperationFilter}
-            onChange={(option: SelectOption<SpanOperation>) =>
-              updateQuery({spanOp: option.value})
-            }
-          />
-        )}
+        <TableControl value={activeTable} onChange={handleTableViewChange} size="sm">
+          <TableControlItem key={TableType.PAGELOAD}>{t('Pageloads')}</TableControlItem>
+          <TableControlItem key={TableType.NAVIGATION}>
+            {t('Navigations')}
+          </TableControlItem>
+          <TableControlItem key={TableType.API}>{t('API')}</TableControlItem>
+        </TableControl>
       </ControlsWrapper>
 
-      {activeView === 'api' && (
-        <PathsTable showHttpMethodColumn={false} showUsersColumn={false} />
+      {activeTable === TableType.API && (
+        <PathsTable
+          showHttpMethodColumn={false}
+          showUsersColumn={false}
+          showRouteController={false}
+        />
       )}
-
-      {activeView === 'pages' && (
-        // Set key to force the PagesTable component to rerender the table & column order
-        // when the user switches between navigations and pageloads
-        <PagesTable key={spanOperationFilter} spanOperationFilter={spanOperationFilter} />
+      {activeTable === TableType.PAGELOAD && (
+        <PagesTable spanOperationFilter={TableType.PAGELOAD} />
+      )}
+      {activeTable === TableType.NAVIGATION && (
+        <PagesTable spanOperationFilter={TableType.NAVIGATION} />
       )}
     </PlatformLandingPageLayout>
   );

--- a/static/app/views/insights/pages/platform/shared/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pathsTable.tsx
@@ -109,12 +109,14 @@ function useTableSortParams() {
 
 interface PathsTableProps {
   showHttpMethodColumn?: boolean;
+  showRouteController?: boolean;
   showUsersColumn?: boolean;
 }
 
 export function PathsTable({
   showHttpMethodColumn = true,
   showUsersColumn = true,
+  showRouteController = true,
 }: PathsTableProps) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -150,6 +152,7 @@ export function PathsTable({
         ...(showUsersColumn ? ['count_unique(user)' as const] : []),
       ],
       limit: PER_PAGE,
+      keepPreviousData: true,
       cursor:
         typeof location.query.pathsCursor === 'string'
           ? location.query.pathsCursor
@@ -177,7 +180,8 @@ export function PathsTable({
         'count()',
       ],
       limit: PER_PAGE,
-      enabled: !!transactionsRequest.data && transactionPaths.length > 0,
+      enabled:
+        showRouteController && !!transactionsRequest.data && transactionPaths.length > 0,
     },
     Referrer.PATHS_TABLE
   );
@@ -247,26 +251,32 @@ export function PathsTable({
 
   return (
     <Fragment>
-      <GridEditable
-        isLoading={transactionsRequest.isLoading}
-        error={transactionsRequest.error}
-        data={tableData}
-        columnOrder={columnOrder}
-        columnSortBy={EMPTY_ARRAY}
-        stickyHeader
-        grid={{
-          renderBodyCell,
-          renderHeadCell,
-          onResizeColumn: handleResizeColumn,
-        }}
-      />
+      <GridEditableContainer>
+        <GridEditable
+          isLoading={transactionsRequest.isPending}
+          error={transactionsRequest.error}
+          data={tableData}
+          columnOrder={columnOrder}
+          columnSortBy={EMPTY_ARRAY}
+          stickyHeader
+          grid={{
+            renderBodyCell,
+            renderHeadCell,
+            onResizeColumn: handleResizeColumn,
+          }}
+        />
+        {transactionsRequest.isPlaceholderData && <LoadingOverlay />}
+      </GridEditableContainer>
       <Pagination
         pageLinks={transactionsRequest.pageLinks}
         onCursor={(cursor, path, currentQuery) => {
-          navigate({
-            pathname: path,
-            query: {...currentQuery, pathsCursor: cursor},
-          });
+          navigate(
+            {
+              pathname: path,
+              query: {...currentQuery, pathsCursor: cursor},
+            },
+            {replace: true, preventScrollReset: true}
+          );
         }}
       />
     </Fragment>
@@ -281,6 +291,7 @@ const HeadCell = memo(function HeadCell({column}: {column: GridColumnHeader<stri
       align={column.key === 'count_unique(user)' ? 'right' : 'left'}
       direction={sortField === column.key ? sortOrder : undefined}
       canSort
+      preventScrollReset
       generateSortLink={() => ({
         ...location,
         query: {
@@ -433,4 +444,20 @@ const ControllerText = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   min-width: 0px;
+`;
+
+const GridEditableContainer = styled('div')`
+  position: relative;
+  margin-bottom: ${space(1)};
+`;
+
+const LoadingOverlay = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${p => p.theme.background};
+  opacity: 0.5;
+  z-index: 1;
 `;


### PR DESCRIPTION
Move the table's dropdown options into the segmented control.
Prevent the API table from collapsing as in https://github.com/getsentry/sentry/pull/91671
Add analytics event for switching tables.
Prevent URL param changes from resetting the scroll position.

https://github.com/user-attachments/assets/95704e13-1518-4786-8ff2-85a14c0ce77b


- closes [TET-418: Pages Table: Scroll to top when switching](https://linear.app/getsentry/issue/TET-418/pages-table-scroll-to-top-when-switching)
- closes [TET-417: Pages Table: Visibility of display dropdown](https://linear.app/getsentry/issue/TET-417/pages-table-visibility-of-display-dropdown)
