### PR TITLE
feat(source-maps): Hide loaded source maps on issue details if js platform

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -6,6 +6,7 @@ import type {Group} from 'sentry/types/group';
 import type {Organization, SharedViewOrganization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
+import {isJavascriptPlatform} from 'sentry/utils/platform';
 import type {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
@@ -108,7 +109,7 @@ function EventEntryContent({
       );
 
     case EntryType.DEBUGMETA:
-      if (isShare) {
+      if (isShare || isJavascriptPlatform(event.platform)) {
         return null;
       }
 

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -138,8 +138,6 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
   const [isOpen, setIsOpen] = useState(false);
   const hasStreamlinedUI = useHasStreamlinedUI();
 
-  const isJSPlatform = event.platform?.includes('javascript');
-
   const getRelevantImages = useCallback(() => {
     // There are a bunch of images in debug_meta that are not relevant to this
     // component. Filter those out to reduce the noise. Most importantly, this
@@ -168,9 +166,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
         return {
           ...releventImage,
           // 'debug_status' and 'unwind_status' are only used by native platforms
-          status: isJSPlatform
-            ? ImageStatus.FOUND
-            : combineStatus(releventImage.debug_status, releventImage.unwind_status),
+          status: combineStatus(releventImage.debug_status, releventImage.unwind_status),
         };
       }
     );
@@ -214,7 +210,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       filterOptions,
       filterSelections: defaultFilterSelections,
     });
-  }, [data, isJSPlatform]);
+  }, [data]);
 
   const handleReprocessEvent = useCallback(
     (id: Group['id']) => {
@@ -257,9 +253,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
         const hasActiveFilter = filterSelections.length > 0;
 
         return {
-          emptyMessage: isJSPlatform
-            ? t('No source maps match your search query')
-            : t('No images match your search query'),
+          emptyMessage: t('No images match your search query'),
           emptyAction: hasActiveFilter ? (
             <Button
               onClick={() => setFilterState(fs => ({...fs, filterSelections: []}))}
@@ -276,12 +270,10 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       }
 
       return {
-        emptyMessage: isJSPlatform
-          ? t('There are no source maps to be displayed')
-          : t('There are no images to be displayed'),
+        emptyMessage: t('There are no images to be displayed'),
       };
     },
-    [filterState, searchTerm, isJSPlatform]
+    [filterState, searchTerm]
   );
 
   const handleOpenImageDetailsModal = useCallback(
@@ -397,7 +389,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
   return (
     <InterimSection
       type={SectionKey.DEBUGMETA}
-      title={isJSPlatform ? t('Source Maps Loaded') : t('Images Loaded')}
+      title={t('Images Loaded')}
       help={t(
         'A list of dynamic libraries, shared objects or source maps loaded into process memory at the time of the crash. Images contribute to the application code that is referenced in stack traces.'
       )}
@@ -407,7 +399,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
       {isOpen || hasStreamlinedUI ? (
         <Fragment>
           <StyledSearchBarAction
-            placeholder={isJSPlatform ? t('Search source maps') : t('Search images')}
+            placeholder={t('Search images')}
             onChange={value => DebugMetaStore.updateFilter(value)}
             query={searchTerm}
             filterOptions={showFilters ? filterOptions : undefined}

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -49,6 +49,10 @@ export function isNativePlatform(platform: string | undefined) {
   }
 }
 
+export function isJavascriptPlatform(platform: string | undefined) {
+  return platform?.includes('javascript');
+}
+
 export function isMobilePlatform(platform: string | undefined) {
   if (!platform) {
     return false;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -69,6 +69,7 @@ import {defined} from 'sentry/utils';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
+import {isJavascriptPlatform} from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -441,16 +442,17 @@ export function EventDetailsContent({
       {hasStreamlinedUI && (
         <EventProcessingErrors event={event} project={project} isShare={false} />
       )}
-      {defined(eventEntries[EntryType.DEBUGMETA]) && (
-        <EntryErrorBoundary type={EntryType.DEBUGMETA}>
-          <DebugMeta
-            event={event}
-            projectSlug={projectSlug}
-            groupId={group?.id}
-            data={eventEntries[EntryType.DEBUGMETA].data}
-          />
-        </EntryErrorBoundary>
-      )}
+      {defined(eventEntries[EntryType.DEBUGMETA]) &&
+        !isJavascriptPlatform(event.platform) && (
+          <EntryErrorBoundary type={EntryType.DEBUGMETA}>
+            <DebugMeta
+              event={event}
+              projectSlug={projectSlug}
+              groupId={group?.id}
+              data={eventEntries[EntryType.DEBUGMETA].data}
+            />
+          </EntryErrorBoundary>
+        )}
       {event.groupID && (
         <EventGroupingInfoSection
           projectSlug={project.slug}


### PR DESCRIPTION
We currently show "Source Maps Loaded" in the issue details because the backend returns data in the _debug_images_ field. In my opinion, if we don’t plan to display the debug images component for JavaScript platforms, we shouldn’t return `debug_images` entry at all. However, @lforst mentioned it’s useful for debugging, but we shouldn't display the "Source Maps Loaded" table (but...if it helps us, it might help users too...or?)

For now, I’ve hidden the debug images component (aka "Source Maps Loaded") for JavaScript platforms, since it was originally designed for native platforms. We can revisit this later and decide if we want to bring it back, possibly in a new component.

closes TET-438