### PR TITLE
enh(breadcrumbs): Add Timber to the known breadcrumb categories

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/utils.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/utils.tsx
@@ -25,6 +25,7 @@ export function convertCrumbType(breadcrumb: RawCrumb): RawCrumb {
     switch (category) {
       case 'console':
       case 'Logcat':
+      case 'Timber':
         return {...breadcrumb, type: BreadcrumbType.DEBUG};
       case 'session':
         return {...breadcrumb, type: BreadcrumbType.NAVIGATION};


### PR DESCRIPTION
[Timber](https://docs.sentry.io/platforms/android/integrations/timber/) is a popular logging library for Android that is widely used as a replacement of the standard Logcat

### Before

![Google Chrome 2025-05-15 12 27 05](https://github.com/user-attachments/assets/95001734-17a7-4890-8f6b-35f97fd182a8)


### After

![image](https://github.com/user-attachments/assets/a38b2a64-4bb9-45d8-9303-dba599693613)

