### PR TITLE
feat(nextjs-insights): add avg & p95 duration to navigations table

### DIFF
--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -36,11 +36,13 @@ type SortableField =
   | 'failure_rate()'
   | 'sum(span.duration)'
   | 'avg(span.duration)'
+  | 'p95(span.duration)'
   | 'performance_score(measurements.score.total)';
 
 interface TableData {
   avgDuration: number;
   errorRate: number;
+  p95: number;
   page: string;
   pageViews: number;
   projectID: number;
@@ -53,6 +55,13 @@ const errorRateColorThreshold = {
   error: 0.1,
   warning: 0.05,
 } as const;
+
+const getP95Threshold = (avg: number) => {
+  return {
+    error: avg * 3,
+    warning: avg * 2,
+  };
+};
 
 const getCellColor = (value: number, thresholds: Record<string, number>) => {
   return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0] as
@@ -80,6 +89,8 @@ const pageloadColumnOrder: Array<GridColumnOrder<SortableField>> = [
 const navigationColumnOrder: Array<GridColumnOrder<SortableField>> = [
   {key: 'transaction', name: t('Page'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Navigations'), width: 132},
+  {key: 'avg(span.duration)', name: t('Avg'), width: 90},
+  {key: 'p95(span.duration)', name: t('P95'), width: 90},
   {key: 'sum(span.duration)', name: t('Time Spent'), width: 110},
 ];
 
@@ -169,6 +180,7 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
         'count()',
         'sum(span.duration)',
         'avg(span.duration)',
+        'p95(span.duration)',
         'performance_score(measurements.score.total)',
         'project.id',
       ],
@@ -195,6 +207,7 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
       errorRate: span['failure_rate()'],
       totalTime: span['sum(span.duration)'],
       avgDuration: span['avg(span.duration)'],
+      p95: span['p95(span.duration)'],
       spanOp: span['span.op'],
       projectID: span['project.id'],
       'performance_score(measurements.score.total)':
@@ -368,6 +381,18 @@ const BodyCell = memo(function PagesBodyCell({
     }
     case 'sum(span.duration)':
       return <Duration>{getDuration(dataRow.totalTime / 1000, 2, true)}</Duration>;
+    case 'avg(span.duration)': {
+      return <Duration>{getDuration(dataRow.avgDuration / 1000, 2, true)}</Duration>;
+    }
+    case 'p95(span.duration)': {
+      const thresholds = getP95Threshold(dataRow.avgDuration);
+      const color = getCellColor(dataRow.p95, thresholds);
+      return (
+        <ColoredValue color={color}>
+          {getDuration(dataRow.p95 / 1000, 2, true)}
+        </ColoredValue>
+      );
+    }
     default:
       return <div />;
   }


### PR DESCRIPTION
- Add avg & p95 columns to Navigations table
- Color p95, but not avg in accordance with API table

Before:
<img width="1409" alt="Screenshot 2025-05-15 at 13 34 38" src="https://github.com/user-attachments/assets/01512e9a-e16a-4180-88bf-49c558692ca6" />

After:
<img width="1211" alt="Screenshot 2025-05-15 at 13 34 19" src="https://github.com/user-attachments/assets/660fdeed-aa07-44fa-bbfb-d999b19cdce0" />
