### PR TITLE
fix(nextjs-insights): show 0% for failure_rate()==0 instead of <0%

### DIFF
--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -363,7 +363,9 @@ const BodyCell = memo(function PagesBodyCell({
       const thresholds = errorRateColorThreshold;
       const color = getCellColor(dataRow.errorRate, thresholds);
       return (
-        <ColoredValue color={color}>{formatPercentage(dataRow.errorRate)}</ColoredValue>
+        <ColoredValue color={color}>
+          {formatPercentage(dataRow.errorRate ?? 0)}
+        </ColoredValue>
       );
     }
     case 'sum(span.duration)':


### PR DESCRIPTION
- API returns null when there are no errors - render this as 0% instead of <0%
Before:
<img width="297" alt="Screenshot 2025-05-15 at 13 44 28" src="https://github.com/user-attachments/assets/19f6dd19-6f64-4da4-8a05-3d324e176821" />

After:
<img width="268" alt="Screenshot 2025-05-15 at 13 44 19" src="https://github.com/user-attachments/assets/1fa53095-65e1-4565-999f-37e0ee915776" />

