### PR TITLE
fix(utils): return 0% for null and undefined values in formatpercentage

### DIFF
--- a/static/app/utils/number/formatPercentage.spec.tsx
+++ b/static/app/utils/number/formatPercentage.spec.tsx
@@ -16,4 +16,11 @@ describe('formatPercentage()', function () {
     expect(formatPercentage(-0.0001, 0, {minimumValue: 0.001})).toBe('<0.1%');
     expect(formatPercentage(0.00000234, 0, {minimumValue: 0.0001})).toBe('<0.01%');
   });
+
+  it('handles null and undefined inputs', function () {
+    // @ts-expect-error we are testing invalid inputs
+    expect(formatPercentage(null)).toBe('0%');
+    // @ts-expect-error we are testing invalid inputs
+    expect(formatPercentage(undefined)).toBe('0%');
+  });
 });

--- a/static/app/utils/number/formatPercentage.spec.tsx
+++ b/static/app/utils/number/formatPercentage.spec.tsx
@@ -23,4 +23,11 @@ describe('formatPercentage()', function () {
     // @ts-expect-error we are testing invalid inputs
     expect(formatPercentage(undefined)).toBe('0%');
   });
+
+  it('handles null and undefined inputs with a custom null value', function () {
+    // @ts-expect-error we are testing invalid inputs
+    expect(formatPercentage(null, 0, {nullValue: 'N/A'})).toBe('N/A');
+    // @ts-expect-error we are testing invalid inputs
+    expect(formatPercentage(undefined, 0, {nullValue: '-'})).toBe('-');
+  });
 });

--- a/static/app/utils/number/formatPercentage.tsx
+++ b/static/app/utils/number/formatPercentage.tsx
@@ -11,7 +11,7 @@ export function formatPercentage(
     minimumValue?: number;
   } = {}
 ) {
-  if (value === 0) {
+  if (value === 0 || value === undefined || value === null) {
     return '0%';
   }
 

--- a/static/app/utils/number/formatPercentage.tsx
+++ b/static/app/utils/number/formatPercentage.tsx
@@ -12,7 +12,11 @@ export function formatPercentage(
     nullValue?: string;
   } = {}
 ) {
-  if (value === 0 || value === undefined || value === null) {
+  if (value === 0) {
+    return '0%';
+  }
+
+  if (value === undefined || value === null) {
     return options.nullValue ?? '0%';
   }
 

--- a/static/app/utils/number/formatPercentage.tsx
+++ b/static/app/utils/number/formatPercentage.tsx
@@ -9,10 +9,11 @@ export function formatPercentage(
   places = 2,
   options: {
     minimumValue?: number;
+    nullValue?: string;
   } = {}
 ) {
   if (value === 0 || value === undefined || value === null) {
-    return '0%';
+    return options.nullValue ?? '0%';
   }
 
   const minimumValue = options.minimumValue ?? 0;


### PR DESCRIPTION
- So far, the formatPercentage function returns `<0%` for `null` and `undefined` values; which is not correct in any way.
- This PR explicitly returns 0% for those cases - this may not be semantically correct in some cases, so this PR also adds an option to define a null value.

Follow-up to https://github.com/getsentry/sentry/pull/91709