### PR TITLE
fix(widget-library): Hide filters at top of panel if not small screen

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -225,9 +225,11 @@ function WidgetBuilderSlideout({
                 </Section>
               )}
             </div>
-            <Section>
-              <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
-            </Section>
+            {isSmallScreen && (
+              <Section>
+                <WidgetBuilderFilterBar releases={dashboard.filters?.release ?? []} />
+              </Section>
+            )}
             <WidgetTemplatesList
               onSave={onSave}
               setOpenWidgetTemplates={setOpenWidgetTemplates}


### PR DESCRIPTION
I missed a conditional here to hide the filters at the top of the panel for templates.