### PR TITLE
fix(issue-details): Avoid persisting stacktrace folding behaviour

### DIFF
--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -407,6 +407,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
       <InterimSection
         title={tn('Stack Trace', 'Stack Traces', threads.length)}
         type={SectionKey.STACKTRACE}
+        disableCollapsePersistence
       >
         <Flex column gap={space(2)}>
           {threadComponent}

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -349,6 +349,7 @@ export function TraceEventDataSection({
       type={type}
       showPermalink={!hasStreamlinedUI}
       title={title}
+      disableCollapsePersistence
       actions={
         !stackTraceNotFound && (
           <ButtonBar gap={1}>


### PR DESCRIPTION
People have been closing them, coming back later and having trouble finding the stack trace. It's usually the most critical part of the debugging flow, so lets just always have it visible at the start.

For some platforms though, they get long, so it can still be closed, but a refresh/page navigation will bring it back.