### PR TITLE
feat(crons): Always update date_updated when updating a check-in

### DIFF
--- a/src/sentry/monitors/clock_tasks/check_missed.py
+++ b/src/sentry/monitors/clock_tasks/check_missed.py
@@ -118,6 +118,7 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime):
         monitor_environment=monitor_environment,
         status=CheckInStatus.MISSED,
         date_added=expected_time,
+        date_updated=expected_time,
         date_clock=ts,
         expected_time=expected_time,
         monitor_config=monitor.get_validated_config(),

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -381,6 +381,7 @@ def update_existing_check_in(
     updated_checkin: _CheckinUpdateKwargs = {
         "status": updated_status,
         "duration": updated_duration,
+        "date_updated": start_time,
     }
 
     # XXX(epurkhiser): We currently allow a existing timed-out check-in to
@@ -394,7 +395,7 @@ def update_existing_check_in(
     if updated_duration_only:
         del updated_checkin["status"]
 
-    # IN_PROGRESS heartbeats bump the timeout
+    # IN_PROGRESS heartbeats bump the timeout, terminal staus's set None
     updated_checkin["timeout_at"] = get_new_timeout_at(
         existing_check_in,
         updated_status,
@@ -405,12 +406,10 @@ def update_existing_check_in(
         tags={**metric_kwargs, "status": "updated_existing_checkin"},
     )
 
-    # IN_PROGRESS heartbeats bump the date_updated
+    # XXX(epurkhiser): Tracking metrics on updating the date_updated since
+    # we may want to remove this 'heart-beat' feature at some point.
     if updated_status == CheckInStatus.IN_PROGRESS:
-        # XXX(epurkhiser): Tracking metrics on updating the date_updated since
-        # we may weant to remove this 'heart-beat' feature.
         metrics.incr("monitors.in_progress_heart_beat", tags=metric_kwargs)
-        updated_checkin["date_updated"] = start_time
 
     existing_check_in.update(**updated_checkin)
 

--- a/tests/sentry/monitors/clock_tasks/test_check_missed.py
+++ b/tests/sentry/monitors/clock_tasks/test_check_missed.py
@@ -95,6 +95,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
         next_checkin = next_checkin.replace(second=0, microsecond=0)
 
         assert missed_checkin.date_added == next_checkin
+        assert missed_checkin.date_updated == next_checkin
         assert missed_checkin.expected_time == next_checkin
         assert missed_checkin.monitor_config == monitor.config
 
@@ -255,6 +256,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
         checkin_date = checkin_date.replace(second=0, microsecond=0)
 
         assert missed_checkin.date_added == checkin_date
+        assert missed_checkin.date_updated == checkin_date
         assert missed_checkin.expected_time == checkin_date
         assert missed_checkin.monitor_config == monitor.config
 
@@ -347,6 +349,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
             status=CheckInStatus.MISSED,
         )
         assert missed_checkin.date_added == ts
+        assert missed_checkin.date_updated == ts
         assert missed_checkin.expected_time == ts
 
         monitor_env = MonitorEnvironment.objects.get(
@@ -694,6 +697,7 @@ class MonitorClockTasksCheckMissingTest(TestCase):
             monitor_environment=monitor_environment.id, status=CheckInStatus.MISSED
         )
         assert missed_checkin.date_added == ts
+        assert missed_checkin.date_updated == ts
         assert missed_checkin.expected_time == ts
 
         # Execute the second task. This should detect that we've already moved

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -320,6 +320,34 @@ class MonitorConsumerTest(TestCase):
         assert checkin.status == CheckInStatus.OK
         assert checkin.date_added == now.replace(tzinfo=UTC)
 
+    def test_check_date_updated(self):
+        now = datetime.now()
+        guid = uuid.uuid4().hex
+
+        monitor = self._create_monitor(slug="my-monitor")
+        self.send_checkin(monitor.slug, guid=guid, ts=now, status="in_progress")
+
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.status == CheckInStatus.IN_PROGRESS
+        assert checkin.date_added == now.replace(tzinfo=UTC)
+        assert checkin.date_updated == now.replace(tzinfo=UTC)
+
+        # Another in_progress moves the date_updated forward
+        self.send_checkin(
+            monitor.slug, guid=guid, ts=now + timedelta(seconds=10), status="in_progress"
+        )
+        checkin.refresh_from_db()
+        assert checkin.status == CheckInStatus.IN_PROGRESS
+        assert checkin.date_added == now.replace(tzinfo=UTC)
+        assert checkin.date_updated == now.replace(tzinfo=UTC) + timedelta(seconds=10)
+
+        # Closing check in moves the date_updated forward
+        self.send_checkin(monitor.slug, guid=guid, ts=now + timedelta(seconds=20), status="ok")
+        checkin.refresh_from_db()
+        assert checkin.status == CheckInStatus.OK
+        assert checkin.date_added == now.replace(tzinfo=UTC)
+        assert checkin.date_updated == now.replace(tzinfo=UTC) + timedelta(seconds=20)
+
     def test_check_in_date_clock(self):
         monitor = self._create_monitor(slug="my-monitor")
         now = datetime.now()


### PR DESCRIPTION
Prior to this change, the date_updated would ONLY be changed when a
in_progress heart-beat was sent. This is rather confusing since this
column is named in such a way that you would expect the date to reflect
the last time the check-in was modified.

Any time we update a check-in we will now modify the date_updated. This
can be helpful to understand the last time a check-in was sent for this
job.

Fixes [NEW-321: Always set `date_updated`, not just when sending a `in_progress` heart beat](https://linear.app/getsentry/issue/NEW-321/always-set-date-updated-not-just-when-sending-a-in-progress-heart-beat)