### PR TITLE
Skip test_queries_profile_candidates_from_spans

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
 from django.http import HttpResponse
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
@@ -810,6 +811,7 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase, SpanTestCase):
 
     @patch("sentry.profiles.flamegraph.bulk_snuba_queries")
     @patch("sentry.api.endpoints.organization_profiling_profiles.proxy_profiling_service")
+    @pytest.mark.skip(reason="Intermittent failure")
     def test_queries_profile_candidates_from_spans(
         self,
         mock_proxy_profiling_service,

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -809,9 +809,9 @@ class OrganizationProfilingFlamegraphTest(ProfilesSnubaTestCase, SpanTestCase):
                 },
             )
 
+    @pytest.mark.skip(reason="See https://github.com/getsentry/sentry/issues/91731")
     @patch("sentry.profiles.flamegraph.bulk_snuba_queries")
     @patch("sentry.api.endpoints.organization_profiling_profiles.proxy_profiling_service")
-    @pytest.mark.skip(reason="Intermittent failure")
     def test_queries_profile_candidates_from_spans(
         self,
         mock_proxy_profiling_service,


### PR DESCRIPTION
It's happening on master, preventing deployments: https://github.com/getsentry/sentry/actions/runs/15048003009/job/42295408496

See https://github.com/getsentry/sentry/issues/91731 to re-enable it.