### PR TITLE
ref(releases): Remove logs from `useReleaseDeploys`

### DIFF
--- a/static/app/views/releases/utils/useReleaseDeploys.tsx
+++ b/static/app/views/releases/utils/useReleaseDeploys.tsx
@@ -1,7 +1,3 @@
-import {useEffect, useRef} from 'react';
-import {logger} from '@sentry/react';
-
-import type {Project} from 'sentry/types/project';
 import type {Deploy} from 'sentry/types/release';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -16,17 +12,6 @@ export function useReleaseDeploys({
 }) {
   const organization = useOrganization();
   const project = useProjectFromSlug({organization, projectSlug});
-  const prevProject = useRef<Project | undefined>(undefined);
-
-  useEffect(() => {
-    if (!project) {
-      logger.warn('Release: project undefined in useReleaseDeploys', {projectSlug});
-    }
-    if (project && !prevProject.current) {
-      logger.warn('Release: project is now defined in useReleaseDeploys', {projectSlug});
-    }
-    prevProject.current = project;
-  }, [project, projectSlug]);
 
   return useApiQuery<Deploy[]>(
     [


### PR DESCRIPTION
Was added in #90829, wanted to confirm I was fixing the correct bug. Confirmed, now removing.
