### PR TITLE
chore(perf-issues): Add a flag and check it to allow customer to disable detectors

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -222,7 +222,15 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
             )
 
         body_has_admin_options = any([option in request.data for option in internal_only_settings])
-        if body_has_admin_options and not superuser_has_permission(request):
+        if (
+            body_has_admin_options
+            and not superuser_has_permission(request)
+            and not features.has(
+                "organizations:performance-manage-detectors",
+                project.organization,
+                actor=request.user,
+            )
+        ):
             return Response(
                 {
                     "detail": {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -198,14 +198,14 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit
     manager.add("organizations:ownership-size-limit-xlarge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable project admins to enable/disable performance detectors
+    manager.add("organizations:performance-manage-detectors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable mobile performance score calculation for transactions in relay
     manager.add("organizations:performance-calculate-mobile-perf-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable performance change explorer panel on trends page
     manager.add("organizations:performance-change-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     manager.add("organizations:performance-chart-interpolation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable consecutive http performance issue type
-    manager.add("organizations:performance-consecutive-http-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable Discover Saved Query dataset selector
     manager.add("organizations:performance-discover-dataset-selector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable deprecate discover widget type
@@ -222,8 +222,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-issues-search", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Detect performance issues in the new standalone spans pipeline instead of on transactions
     manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
-    # Enable consecutive http performance issue type
-    manager.add("organizations:performance-large-http-payload-detector", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable internal view for bannerless MEP view
     manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Re-enable histograms for Metrics Enhanced Performance Views


### PR DESCRIPTION
This will be overridden by detector work later on, but expose it now so customers can understand how it might work (and disable any detectors without support tickets)