### PR TITLE
feat(perf-issues): Expose management settings to users

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -526,6 +526,7 @@ describe('projectPerformance', function () {
       render(<ProjectPerformance />, {
         organization: OrganizationFixture({
           features: ['performance-view', 'performance-manage-detectors'],
+          access: ['project:read'],
         }),
         initialRouterConfig,
       });

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -170,7 +170,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedDurationValues,
       defaultValue: 100,
       newValue: 500,
-      sliderIndex: 1,
+      sliderIdentifier: {
+        label: 'Minimum Total Duration',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
@@ -178,7 +181,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedCountValues,
       defaultValue: 5,
       newValue: 10,
-      sliderIndex: 2,
+      sliderIdentifier: {
+        label: 'Minimum Query Count',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_SLOW_DB_QUERY,
@@ -186,7 +192,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedDurationValues.slice(5),
       defaultValue: 1000,
       newValue: 3000,
-      sliderIndex: 3,
+      sliderIdentifier: {
+        label: 'Minimum Duration',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_N_PLUS_ONE_API_CALLS,
@@ -194,7 +203,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedDurationValues.slice(5),
       defaultValue: 300,
       newValue: 500,
-      sliderIndex: 4,
+      sliderIdentifier: {
+        label: 'Minimum Total Duration',
+        index: 1,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_RENDER_BLOCKING_ASSET,
@@ -202,7 +214,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedPercentageValues,
       defaultValue: 0.33,
       newValue: 0.5,
-      sliderIndex: 5,
+      sliderIdentifier: {
+        label: 'Minimum FCP Ratio',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_LARGE_HTTP_PAYLOAD,
@@ -210,7 +225,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedSizeValues.slice(1),
       defaultValue: 1000000,
       newValue: 5000000,
-      sliderIndex: 6,
+      sliderIdentifier: {
+        label: 'Minimum Size',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_DB_MAIN_THREAD,
@@ -218,7 +236,10 @@ describe('projectPerformance', function () {
       allowedValues: [10, 16, 33, 50],
       defaultValue: 16,
       newValue: 33,
-      sliderIndex: 7,
+      sliderIdentifier: {
+        label: 'Frame Rate Drop',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_FILE_IO_MAIN_THREAD,
@@ -226,7 +247,10 @@ describe('projectPerformance', function () {
       allowedValues: [10, 16, 33, 50],
       defaultValue: 16,
       newValue: 50,
-      sliderIndex: 8,
+      sliderIdentifier: {
+        label: 'Frame Rate Drop',
+        index: 1,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_CONSECUTIVE_DB_QUERIES,
@@ -234,7 +258,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedDurationValues.slice(0, 23),
       defaultValue: 100,
       newValue: 5000,
-      sliderIndex: 9,
+      sliderIdentifier: {
+        label: 'Minimum Time Saved',
+        index: 0,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET,
@@ -242,7 +269,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedSizeValues.slice(1),
       defaultValue: 512000,
       newValue: 700000,
-      sliderIndex: 10,
+      sliderIdentifier: {
+        label: 'Minimum Size',
+        index: 1,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET,
@@ -250,7 +280,10 @@ describe('projectPerformance', function () {
       allowedValues: allowedDurationValues.slice(5),
       defaultValue: 500,
       newValue: 400,
-      sliderIndex: 11,
+      sliderIdentifier: {
+        label: 'Minimum Duration',
+        index: 1,
+      },
     },
     {
       title: IssueTitle.PERFORMANCE_CONSECUTIVE_HTTP,
@@ -258,11 +291,21 @@ describe('projectPerformance', function () {
       allowedValues: allowedDurationValues.slice(14),
       defaultValue: 2000,
       newValue: 4000,
-      sliderIndex: 12,
+      sliderIdentifier: {
+        label: 'Minimum Time Saved',
+        index: 1,
+      },
     },
   ])(
     'renders detector thresholds settings for $title issue',
-    async ({title, threshold, allowedValues, defaultValue, newValue, sliderIndex}) => {
+    async ({
+      title,
+      threshold,
+      allowedValues,
+      defaultValue,
+      newValue,
+      sliderIdentifier,
+    }) => {
       // Mock endpoints
       const mockGETBody = {
         [threshold]: defaultValue,
@@ -305,7 +348,10 @@ describe('projectPerformance', function () {
         await userEvent.click(chevron);
       }
 
-      const slider = screen.getAllByRole('slider')[sliderIndex]!;
+      // Some of the sliders have the same label, so use an index as well
+      const slider = screen.getAllByRole('slider', {name: sliderIdentifier.label})[
+        sliderIdentifier.index
+      ]!;
       const indexOfValue = allowedValues.indexOf(defaultValue);
       const newValueIndex = allowedValues.indexOf(newValue);
 

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -909,8 +909,8 @@ function ProjectPerformance() {
                     help: t(
                       'Controls whether or not Sentry should detect this type of issue.'
                     ),
-                    disabled: !project.access.includes('project:admin'),
-                    disabledReason: t('This action requires project admin access.'),
+                    disabled: !hasAccess,
+                    disabledReason: t('You do not have permission to manage detectors.'),
                   },
                   ...fieldGroup.fields,
                 ],

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -340,7 +340,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_N_PLUS_ONE_DB_QUERIES]: {
       name: DetectorConfigAdmin.N_PLUS_DB_ENABLED,
       type: 'boolean',
-      label: t('N+1 DB Queries Detection Enabled'),
+      label: t('N+1 DB Queries Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -356,7 +356,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_SLOW_DB_QUERY]: {
       name: DetectorConfigAdmin.SLOW_DB_ENABLED,
       type: 'boolean',
-      label: t('Slow DB Queries Detection Enabled'),
+      label: t('Slow DB Queries Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -372,7 +372,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_N_PLUS_ONE_API_CALLS]: {
       name: DetectorConfigAdmin.N_PLUS_ONE_API_CALLS_ENABLED,
       type: 'boolean',
-      label: t('N+1 API Calls Detection Enabled'),
+      label: t('N+1 API Calls Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -388,7 +388,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_RENDER_BLOCKING_ASSET]: {
       name: DetectorConfigAdmin.RENDER_BLOCK_ASSET_ENABLED,
       type: 'boolean',
-      label: t('Large Render Blocking Asset Detection Enabled'),
+      label: t('Large Render Blocking Asset Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -404,7 +404,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_CONSECUTIVE_DB_QUERIES]: {
       name: DetectorConfigAdmin.CONSECUTIVE_DB_ENABLED,
       type: 'boolean',
-      label: t('Consecutive DB Queries Detection Enabled'),
+      label: t('Consecutive DB Queries Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -420,7 +420,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_LARGE_HTTP_PAYLOAD]: {
       name: DetectorConfigAdmin.LARGE_HTTP_PAYLOAD_ENABLED,
       type: 'boolean',
-      label: t('Large HTTP Payload Detection Enabled'),
+      label: t('Large HTTP Payload Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -436,7 +436,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_DB_MAIN_THREAD]: {
       name: DetectorConfigAdmin.DB_MAIN_THREAD_ENABLED,
       type: 'boolean',
-      label: t('DB On Main Thread Detection Enabled'),
+      label: t('DB on Main Thread Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -452,7 +452,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_FILE_IO_MAIN_THREAD]: {
       name: DetectorConfigAdmin.FILE_IO_ENABLED,
       type: 'boolean',
-      label: t('File I/O on Main Thread Detection Enabled'),
+      label: t('File I/O on Main Thread Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -468,7 +468,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_UNCOMPRESSED_ASSET]: {
       name: DetectorConfigAdmin.UNCOMPRESSED_ASSET_ENABLED,
       type: 'boolean',
-      label: t('Uncompressed Assets Detection Enabled'),
+      label: t('Uncompressed Assets Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -484,7 +484,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_CONSECUTIVE_HTTP]: {
       name: DetectorConfigAdmin.CONSECUTIVE_HTTP_ENABLED,
       type: 'boolean',
-      label: t('Consecutive HTTP Detection Enabled'),
+      label: t('Consecutive HTTP Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -500,7 +500,7 @@ function ProjectPerformance() {
     [IssueTitle.PERFORMANCE_HTTP_OVERHEAD]: {
       name: DetectorConfigAdmin.HTTP_OVERHEAD_ENABLED,
       type: 'boolean',
-      label: t('HTTP/1.1 Overhead Enabled'),
+      label: t('HTTP/1.1 Overhead Detection'),
       defaultValue: true,
       onChange: value => {
         setApiQueryData<ProjectPerformanceSettings>(
@@ -906,7 +906,6 @@ function ProjectPerformance() {
                 fields: [
                   {
                     ...manageField,
-                    label: t('Enable Issue Detection'),
                     help: t(
                       'Controls whether or not Sentry should detect this type of issue.'
                     ),


### PR DESCRIPTION
This PR will enable flagged organizations to modify the detection settings manually rather than having to go through support.



Keeping the regression issue fields, but everything else has been moved into the section for the detector.

<img width="635" alt="image" src="https://github.com/user-attachments/assets/76bdf93c-0544-434f-a8f1-1dd1c8ed2620" />


**todo**
- [x] Add some tests 
- [x] Add screenshots/videos to the PR