### PR TITLE
chore(sentryapps): update email address

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_publish_request.py
@@ -117,7 +117,7 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
         )
 
         # Must send to user & partners so that the reply-to email will be each other
-        recipients = ["partners@sentry.io", request.user.email]
+        recipients = ["integrations-platform@sentry.io", request.user.email]
         sent_messages = new_message.send(
             to=recipients,
         )

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_publish_request.py
@@ -45,7 +45,7 @@ class SentryAppPublishRequestTest(APITestCase):
             },
         )
         assert response.status_code == 201
-        send.assert_called_with(to=["partners@sentry.io", self.user.email])
+        send.assert_called_with(to=["integrations-platform@sentry.io", self.user.email])
 
     @mock.patch("sentry.utils.email.message_builder.MessageBuilder.send")
     def test_publish_request_email_fails(self, send):
@@ -66,7 +66,7 @@ class SentryAppPublishRequestTest(APITestCase):
         assert response.data == {
             "detail": "Something went wrong trying to send publish confirmation email"
         }
-        send.assert_called_with(to=["partners@sentry.io", self.user.email])
+        send.assert_called_with(to=["integrations-platform@sentry.io", self.user.email])
 
     @mock.patch("sentry.utils.email.message_builder.MessageBuilder.send")
     def test_publish_already_published(self, send_mail):


### PR DESCRIPTION
Sentry app requests goes to partners@sentry.io today but the word partners is very loaded. For example for provisioning requests we're also thinking partners 🤷‍♀️ 

Renaming it to integrations-platform@sentry.io