### PR TITLE
fix(jira): Makes field checks case insensitive

### DIFF
--- a/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
+++ b/src/sentry/integrations/jira/utils/create_issue_schema_transformers.py
@@ -98,8 +98,10 @@ def transform_fields(
     type_transformers = get_type_transformer_mappings(user_id_field)
     custom_field_transformers = get_custom_field_transformer_mappings()
 
+    lowercased_data = {k.lower(): v for k, v in data.items()}
+
     for field in jira_fields:
-        field_data = data.get(field.key)
+        field_data = lowercased_data.get(field.key.lower())
 
         # Skip any values that indicate no value should be provided.
         # We have some older alert templates with "" values, which will raise

--- a/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
+++ b/tests/sentry/integrations/jira/utils/test_create_issue_schema_transformers.py
@@ -206,3 +206,10 @@ class TestDataTransformer(TestCase):
             self.client.user_id_field(), jira_fields=[field], **{"title": "Test Title"}
         )
         assert transformed_data == {"summary": "Test Title"}
+
+    def test_field_capitalization(self):
+        field = self.create_standard_field(name="issuetype", schema_type=JiraSchemaTypes.issue_type)
+        transformed_data = transform_fields(
+            self.client.user_id_field(), jira_fields=[field], **{"issueType": "1122"}
+        )
+        assert transformed_data == {"issuetype": {"id": "1122"}}


### PR DESCRIPTION
Fixes #91632

Makes field name checks case-insensitive for Jira data transformations. This can result in failed ticket creation in a small number of cases when the saved alert config differs from our typical casing.

