### PR TITLE
ci: Make fail-slow 120s instead of 60

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -50,7 +50,12 @@ runs:
 
         ### pytest configuration ###
         echo "PY_COLORS=1" >> "$GITHUB_ENV"
-        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10 --fail-slow=60s" >> $GITHUB_ENV
+        # XXX(epurkihser): We've raised fail-slow from 60s to 120s since
+        # 2025-05, our migration dependency tree has grown too large and it
+        # takes these tests longer than 60 seconds to run. Once we've flattened
+        # our migrations we can bring this back down (asottile is working on
+        # this)
+        echo "PYTEST_ADDOPTS=--reruns=5 --durations=10 --fail-slow=120s" >> $GITHUB_ENV
         echo "COVERAGE_CORE=sysmon" >> "$GITHUB_ENV"
 
         ### pytest-sentry configuration ###


### PR DESCRIPTION
We've raised fail-slow from 60s to 120s since 2025-05, our migration dependency tree has grown too large and it takes these tests longer than 60 seconds to run. Once we've flattened our migrations we can bring this back down (@asottile is working on this)