### PR TITLE
feat(explore): Merge group bys and visualizes

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
@@ -1,0 +1,149 @@
+import type {Location} from 'history';
+
+import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {decodeList} from 'sentry/utils/queryString';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+import {defaultGroupBys, getGroupBysFromLocation} from './groupBys';
+import type {BaseVisualize} from './visualizes';
+import {
+  defaultVisualizes,
+  getVisualizesFromLocation,
+  parseBaseVisualize,
+  Visualize,
+} from './visualizes';
+
+export interface GroupBy {
+  groupBy: string;
+}
+
+function _isGroupBy(value: any): value is GroupBy {
+  return typeof value === 'object' && typeof value.groupBy === 'string';
+}
+
+function _isBaseVisualize(value: any): value is BaseVisualize {
+  return (
+    typeof value === 'object' &&
+    Array.isArray(value.yAxes) &&
+    value.yAxes.every((v: any) => typeof v === 'string') &&
+    (!defined(value.chartType) || Object.values(ChartType).includes(value.chartType))
+  );
+}
+
+export function isGroupBy(value: GroupBy | Visualize): value is GroupBy {
+  return _isGroupBy(value);
+}
+
+export function isVisualize(value: GroupBy | Visualize): value is Visualize {
+  return 'yAxes' in value && Array.isArray(value.yAxes);
+}
+
+export type AggregateField = GroupBy | Visualize;
+
+export function defaultAggregateFields(): AggregateField[] {
+  return [
+    ...defaultGroupBys().map(groupBy => ({
+      groupBy,
+    })),
+    ...defaultVisualizes(),
+  ];
+}
+
+export function getAggregateFieldsFromLocation(
+  location: Location,
+  organization: Organization
+): AggregateField[] {
+  const rawAggregateFields = decodeList(location.query.aggregateField);
+
+  if (!rawAggregateFields.length) {
+    return [
+      ...getGroupBysFromLocation(location).map(groupBy => ({
+        groupBy,
+      })),
+      ...getVisualizesFromLocation(location, organization),
+    ];
+  }
+
+  const parsed: Array<GroupBy | BaseVisualize | null> = rawAggregateFields.map(raw =>
+    parseGroupByOrBaseVisualize(raw, organization)
+  );
+
+  let i = 0;
+
+  const aggregateFields: AggregateField[] = [];
+
+  let hasGroupBys = false;
+  let hasVisualizes = false;
+
+  for (const groupByOrBaseVisualize of parsed) {
+    if (_isGroupBy(groupByOrBaseVisualize)) {
+      aggregateFields.push(groupByOrBaseVisualize);
+      hasGroupBys = true;
+    } else if (_isBaseVisualize(groupByOrBaseVisualize)) {
+      for (const yAxis of groupByOrBaseVisualize.yAxes) {
+        aggregateFields.push(
+          new Visualize([yAxis], {
+            label: String.fromCharCode(65 + i), // starts from 'A',
+            chartType: groupByOrBaseVisualize.chartType,
+          })
+        );
+        i++;
+        hasVisualizes = true;
+      }
+    }
+  }
+
+  if (!hasGroupBys) {
+    aggregateFields.push(
+      ...defaultGroupBys().map(groupBy => ({
+        groupBy,
+      }))
+    );
+  }
+
+  if (!hasVisualizes) {
+    aggregateFields.push(...defaultVisualizes());
+  }
+
+  return aggregateFields;
+}
+
+export function updateLocationWithAggregateFields(
+  location: Location,
+  aggregateFields: Array<GroupBy | BaseVisualize> | null | undefined
+) {
+  if (defined(aggregateFields)) {
+    location.query.aggregateField = aggregateFields.map(aggregateField => {
+      if (_isBaseVisualize(aggregateField)) {
+        return JSON.stringify(Visualize.fromJSON(aggregateField).toJSON());
+      }
+      return JSON.stringify(aggregateField);
+    });
+  } else if (aggregateFields === null) {
+    delete location.query.aggregateField;
+  }
+}
+
+function parseGroupByOrBaseVisualize(
+  raw: string,
+  organization: Organization
+): GroupBy | BaseVisualize | null {
+  const groupBy = parseGroupBy(raw);
+  if (defined(groupBy)) {
+    return groupBy;
+  }
+  return parseBaseVisualize(raw, organization);
+}
+
+function parseGroupBy(raw: string): GroupBy | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!defined(parsed) || typeof parsed.groupBy !== 'string') {
+      return null;
+    }
+    return {groupBy: parsed.groupBy};
+  } catch (error) {
+    return null;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/groupBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/groupBys.tsx
@@ -25,17 +25,3 @@ export function getGroupBysFromLocation(location: Location): string[] {
 
   return defaultGroupBys();
 }
-
-export function updateLocationWithGroupBys(
-  location: Location,
-  groupBys: string[] | null | undefined
-) {
-  if (defined(groupBys)) {
-    location.query.groupBy = groupBys;
-
-    // make sure to clear the cursor every time the query is updated
-    delete location.query.cursor;
-  } else if (groupBys === null) {
-    delete location.query.groupBy;
-  }
-}

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -74,11 +74,11 @@ describe('PageParamsProvider', function () {
       setPageParams({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
         fields: ['id', 'timestamp'],
-        groupBys: ['span.op'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-        visualizes: [
+        aggregateFields: [
+          {groupBy: 'span.op'},
           {
             chartType: ChartType.AREA,
             label: 'A',
@@ -97,22 +97,26 @@ describe('PageParamsProvider', function () {
       </PageParamsProvider>
     );
 
-    expect(pageParams).toEqual({
-      dataset: undefined,
-      fields: [
-        'id',
-        'span.op',
-        'span.description',
-        'span.duration',
-        'transaction',
-        'timestamp',
-      ],
-      groupBys: [''],
-      mode: Mode.SAMPLES,
-      query: '',
-      sortBys: [{field: 'timestamp', kind: 'desc'}],
-      visualizes: [new Visualize(['count(span.duration)'], {label: 'A'})],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: undefined,
+        fields: [
+          'id',
+          'span.op',
+          'span.description',
+          'span.duration',
+          'transaction',
+          'timestamp',
+        ],
+        mode: Mode.SAMPLES,
+        query: '',
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: ''},
+          new Visualize(['count(span.duration)'], {label: 'A'}),
+        ],
+      })
+    );
   });
 
   it('correctly updates fields', function () {
@@ -120,17 +124,22 @@ describe('PageParamsProvider', function () {
 
     act(() => setFields(['id', 'span.op', 'timestamp']));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'span.op', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'span.op', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates groupBys', function () {
@@ -138,17 +147,23 @@ describe('PageParamsProvider', function () {
 
     act(() => setGroupBys(['browser.name', 'sdk.name']));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['browser.name', 'sdk.name'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          {groupBy: 'browser.name'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+          {groupBy: 'sdk.name'},
+        ],
+      })
+    );
   });
 
   it('correctly gives default for empty groupBys', function () {
@@ -156,17 +171,22 @@ describe('PageParamsProvider', function () {
 
     act(() => setGroupBys([]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: [''],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+          {groupBy: ''},
+        ],
+      })
+    );
   });
 
   it('permits ungrouped', function () {
@@ -174,17 +194,22 @@ describe('PageParamsProvider', function () {
 
     act(() => setGroupBys(['']));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: [''],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          {groupBy: ''},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates mode from samples to aggregates', function () {
@@ -192,35 +217,56 @@ describe('PageParamsProvider', function () {
 
     act(() => setMode(Mode.AGGREGATE));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates mode from aggregates to sample without group bys', function () {
-    renderTestComponent({mode: Mode.AGGREGATE, groupBys: [''], sortBys: null});
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      aggregateFields: [
+        {groupBy: ''},
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+      sortBys: null,
+    });
 
     act(() => setMode(Mode.SAMPLES));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: [''],
-      mode: Mode.SAMPLES,
-      query: '',
-      sortBys: [{field: 'timestamp', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.SAMPLES,
+        query: '',
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: ''},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates mode from aggregates to sample with group bys', function () {
@@ -228,22 +274,40 @@ describe('PageParamsProvider', function () {
       mode: Mode.AGGREGATE,
       sortBys: null,
       fields: ['id', 'sdk.name', 'sdk.version', 'timestamp'],
-      groupBys: ['sdk.name', 'sdk.version', 'span.op', ''],
+      aggregateFields: [
+        {groupBy: 'sdk.name'},
+        {groupBy: 'sdk.version'},
+        {groupBy: 'span.op'},
+        {groupBy: ''},
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
     });
 
     act(() => setMode(Mode.SAMPLES));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'sdk.name', 'sdk.version', 'timestamp', 'span.op'],
-      groupBys: ['sdk.name', 'sdk.version', 'span.op', ''],
-      mode: Mode.SAMPLES,
-      query: '',
-      sortBys: [{field: 'timestamp', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'sdk.name', 'sdk.version', 'timestamp', 'span.op'],
+        mode: Mode.SAMPLES,
+        query: '',
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'sdk.name'},
+          {groupBy: 'sdk.version'},
+          {groupBy: 'span.op'},
+          {groupBy: ''},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates query', function () {
@@ -251,17 +315,22 @@ describe('PageParamsProvider', function () {
 
     act(() => setQuery('foo:bar'));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.AGGREGATE,
-      query: 'foo:bar',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: 'foo:bar',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates sort bys in samples mode with known field', function () {
@@ -269,17 +338,22 @@ describe('PageParamsProvider', function () {
 
     act(() => setSortBys([{field: 'id', kind: 'desc'}]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.SAMPLES,
-      query: '',
-      sortBys: [{field: 'id', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.SAMPLES,
+        query: '',
+        sortBys: [{field: 'id', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates sort bys in samples mode with unknown field', function () {
@@ -287,23 +361,29 @@ describe('PageParamsProvider', function () {
 
     act(() => setSortBys([{field: 'span.op', kind: 'desc'}]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.SAMPLES,
-      query: '',
-      sortBys: [{field: 'timestamp', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.SAMPLES,
+        query: '',
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates sort bys in aggregates mode with known y axis', function () {
     renderTestComponent({
       mode: Mode.AGGREGATE,
-      visualizes: [
+      aggregateFields: [
+        {groupBy: 'span.op'},
         {
           chartType: ChartType.AREA,
           label: 'A',
@@ -314,30 +394,33 @@ describe('PageParamsProvider', function () {
 
     act(() => setSortBys([{field: 'max(span.duration)', kind: 'desc'}]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'max(span.duration)', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['min(span.self_time)'], {
-          label: 'A',
-          chartType: ChartType.AREA,
-        }),
-        new Visualize(['max(span.duration)'], {
-          label: 'B',
-          chartType: ChartType.AREA,
-        }),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'max(span.duration)', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['min(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+          new Visualize(['max(span.duration)'], {
+            label: 'B',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates sort bys in aggregates mode with unknown y axis', function () {
     renderTestComponent({
       mode: Mode.AGGREGATE,
-      visualizes: [
+      aggregateFields: [
+        {groupBy: 'span.op'},
         {
           chartType: ChartType.AREA,
           label: 'A',
@@ -348,60 +431,112 @@ describe('PageParamsProvider', function () {
 
     act(() => setSortBys([{field: 'avg(span.duration)', kind: 'desc'}]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['min(span.self_time)'], {
-          label: 'A',
-          chartType: ChartType.AREA,
-        }),
-        new Visualize(['max(span.duration)'], {
-          label: 'B',
-          chartType: ChartType.AREA,
-        }),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['min(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+          new Visualize(['max(span.duration)'], {
+            label: 'B',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates sort bys in aggregates mode with known group by', function () {
-    renderTestComponent({mode: Mode.AGGREGATE, groupBys: ['sdk.name']});
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      aggregateFields: [
+        {groupBy: 'sdk.name'},
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
 
     act(() => setSortBys([{field: 'sdk.name', kind: 'desc'}]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['sdk.name'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'sdk.name', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'sdk.name', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'sdk.name'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates sort bys in aggregates mode with unknown group by', function () {
-    renderTestComponent({mode: Mode.AGGREGATE, groupBys: ['sdk.name']});
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      aggregateFields: [
+        {groupBy: 'sdk.name'},
+        {
+          chartType: ChartType.AREA,
+          label: 'A',
+          yAxes: ['count(span.self_time)'],
+        },
+      ],
+    });
 
     act(() => setSortBys([{field: 'sdk.version', kind: 'desc'}]));
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['sdk.name'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'sdk.name'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
+  });
+
+  it('correctly gives default for empty visualizes', function () {
+    renderTestComponent();
+
+    act(() => setVisualizes([]));
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.duration)', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.duration)'], {label: 'A'}),
+        ],
+      })
+    );
   });
 
   it('correctly updates visualizes with labels', function () {
@@ -420,25 +555,30 @@ describe('PageParamsProvider', function () {
       ])
     );
 
-    expect(pageParams).toEqual({
-      dataset: DiscoverDatasets.SPANS_EAP_RPC,
-      fields: ['id', 'timestamp'],
-      groupBys: ['span.op'],
-      mode: Mode.AGGREGATE,
-      query: '',
-      sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
-      visualizes: [
-        new Visualize(['count(span.self_time)'], {label: 'A', chartType: ChartType.AREA}),
-        new Visualize(['avg(span.duration)'], {
-          label: 'B',
-          chartType: ChartType.LINE,
-        }),
-        new Visualize(['avg(span.self_time)'], {
-          label: 'C',
-          chartType: ChartType.LINE,
-        }),
-      ],
-    });
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        dataset: DiscoverDatasets.SPANS_EAP_RPC,
+        fields: ['id', 'timestamp'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new Visualize(['count(span.self_time)'], {
+            label: 'A',
+            chartType: ChartType.AREA,
+          }),
+          new Visualize(['avg(span.duration)'], {
+            label: 'B',
+            chartType: ChartType.LINE,
+          }),
+          new Visualize(['avg(span.self_time)'], {
+            label: 'C',
+            chartType: ChartType.LINE,
+          }),
+        ],
+      })
+    );
   });
 
   it('correctly updates id', function () {

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -13,17 +13,20 @@ import {
   updateLocationWithId,
 } from 'sentry/views/explore/contexts/pageParamsContext/id';
 
+import type {AggregateField, GroupBy} from './aggregateFields';
+import {
+  defaultAggregateFields,
+  getAggregateFieldsFromLocation,
+  isGroupBy,
+  isVisualize,
+  updateLocationWithAggregateFields,
+} from './aggregateFields';
 import {
   defaultDataset,
   getDatasetFromLocation,
   updateLocationWithDataset,
 } from './dataset';
 import {defaultFields, getFieldsFromLocation, updateLocationWithFields} from './fields';
-import {
-  defaultGroupBys,
-  getGroupBysFromLocation,
-  updateLocationWithGroupBys,
-} from './groupBys';
 import {defaultMode, getModeFromLocation, Mode, updateLocationWithMode} from './mode';
 import {defaultQuery, getQueryFromLocation, updateLocationWithQuery} from './query';
 import {
@@ -33,34 +36,64 @@ import {
 } from './sortBys';
 import {defaultTitle, getTitleFromLocation, updateLocationWithTitle} from './title';
 import type {BaseVisualize, Visualize} from './visualizes';
-import {
-  defaultVisualizes,
-  getVisualizesFromLocation,
-  updateLocationWithVisualizes,
-} from './visualizes';
 
-interface ReadablePageParams {
+interface ReadablePageParamsOptions {
+  aggregateFields: AggregateField[];
   dataset: DiscoverDatasets | undefined;
   fields: string[];
-  groupBys: string[];
   mode: Mode;
   query: string;
   sortBys: Sort[];
-  visualizes: Visualize[];
   id?: string;
   title?: string;
 }
 
+class ReadablePageParams {
+  aggregateFields: AggregateField[];
+  dataset: DiscoverDatasets | undefined;
+  fields: string[];
+  mode: Mode;
+  query: string;
+  sortBys: Sort[];
+  id?: string;
+  title?: string;
+  private _groupBys: string[];
+  private _visualizes: Visualize[];
+
+  constructor(options: ReadablePageParamsOptions) {
+    this.aggregateFields = options.aggregateFields;
+    this.dataset = options.dataset;
+    this.fields = options.fields;
+    this.mode = options.mode;
+    this.query = options.query;
+    this.sortBys = options.sortBys;
+    this.id = options.id;
+    this.title = options.title;
+
+    this._groupBys = this.aggregateFields
+      .filter(isGroupBy)
+      .map(groupBy => groupBy.groupBy);
+    this._visualizes = this.aggregateFields.filter(isVisualize);
+  }
+
+  get groupBys(): string[] {
+    return this._groupBys;
+  }
+
+  get visualizes(): Visualize[] {
+    return this._visualizes;
+  }
+}
+
 interface WritablePageParams {
+  aggregateFields?: Array<GroupBy | BaseVisualize> | null;
   dataset?: DiscoverDatasets | null;
   fields?: string[] | null;
-  groupBys?: string[] | null;
   id?: string | null;
   mode?: Mode | null;
   query?: string | null;
   sortBys?: Sort[] | null;
   title?: string | null;
-  visualizes?: BaseVisualize[] | null;
 }
 
 export interface SuggestedQuery {
@@ -74,31 +107,29 @@ export interface SuggestedQuery {
 }
 
 function defaultPageParams(): ReadablePageParams {
+  const aggregateFields = defaultAggregateFields();
   const dataset = defaultDataset();
   const fields = defaultFields();
-  const groupBys = defaultGroupBys();
   const mode = defaultMode();
   const query = defaultQuery();
-  const visualizes = defaultVisualizes();
   const title = defaultTitle();
   const id = defaultId();
   const sortBys = defaultSortBys(
     mode,
     fields,
-    visualizes.flatMap(visualize => visualize.yAxes)
+    aggregateFields.filter(isVisualize).flatMap(visualize => visualize.yAxes)
   );
 
-  return {
+  return new ReadablePageParams({
+    aggregateFields,
     dataset,
     fields,
-    groupBys,
     mode,
     query,
     sortBys,
     title,
     id,
-    visualizes,
-  };
+  });
 }
 
 const PageParamsContext = createContext<ReadablePageParams>(defaultPageParams());
@@ -112,27 +143,27 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
   const organization = useOrganization();
 
   const pageParams: ReadablePageParams = useMemo(() => {
+    const aggregateFields = getAggregateFieldsFromLocation(location, organization);
     const dataset = getDatasetFromLocation(location);
     const fields = getFieldsFromLocation(location);
-    const groupBys = getGroupBysFromLocation(location);
     const mode = getModeFromLocation(location);
     const query = getQueryFromLocation(location);
-    const visualizes = getVisualizesFromLocation(location, organization);
+    const groupBys = aggregateFields.filter(isGroupBy).map(groupBy => groupBy.groupBy);
+    const visualizes = aggregateFields.filter(isVisualize);
     const sortBys = getSortBysFromLocation(location, mode, fields, groupBys, visualizes);
     const title = getTitleFromLocation(location);
     const id = getIdFromLocation(location);
 
-    return {
+    return new ReadablePageParams({
+      aggregateFields,
       dataset,
       fields,
-      groupBys,
       mode,
       query,
       sortBys,
       title,
       id,
-      visualizes,
-    };
+    });
   }, [location, organization]);
 
   return <PageParamsContext value={pageParams}>{children}</PageParamsContext>;
@@ -191,19 +222,18 @@ export function newExploreTarget(
   pageParams: WritablePageParams
 ): Location {
   const target = {...location, query: {...location.query}};
+  updateLocationWithAggregateFields(target, pageParams.aggregateFields);
   updateLocationWithDataset(target, pageParams.dataset);
   updateLocationWithFields(target, pageParams.fields);
-  updateLocationWithGroupBys(target, pageParams.groupBys);
   updateLocationWithMode(target, pageParams.mode);
   updateLocationWithQuery(target, pageParams.query);
   updateLocationWithSortBys(target, pageParams.sortBys);
-  updateLocationWithVisualizes(target, pageParams.visualizes);
   updateLocationWithTitle(target, pageParams.title);
   updateLocationWithId(target, pageParams.id);
   return target;
 }
 
-export function useSetExplorePageParams() {
+export function useSetExplorePageParams(): (pageParams: WritablePageParams) => void {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -227,16 +257,34 @@ export function useSetExploreFields() {
 }
 
 export function useSetExploreGroupBys() {
+  const pageParams = useExplorePageParams();
   const setPageParams = useSetExplorePageParams();
   return useCallback(
     (groupBys: string[], mode?: Mode) => {
+      const aggregateFields = [];
+      let i = 0;
+      for (const aggregateField of pageParams.aggregateFields) {
+        if (isGroupBy(aggregateField)) {
+          if (i < groupBys.length) {
+            const groupBy: GroupBy = {groupBy: groupBys[i++]!};
+            aggregateFields.push(groupBy);
+          }
+        } else {
+          aggregateFields.push(aggregateField.toJSON());
+        }
+      }
+      for (; i < groupBys.length; i++) {
+        const groupBy = {groupBy: groupBys[i]!};
+        aggregateFields.push(groupBy);
+      }
+
       if (mode) {
-        setPageParams({groupBys, mode});
+        setPageParams({aggregateFields, mode});
       } else {
-        setPageParams({groupBys});
+        setPageParams({aggregateFields});
       }
     },
-    [setPageParams]
+    [pageParams, setPageParams]
   );
 }
 
@@ -294,11 +342,28 @@ export function useSetExploreVisualizes() {
   const setPageParams = useSetExplorePageParams();
   return useCallback(
     (visualizes: BaseVisualize[], fields?: string[]) => {
-      const writablePageParams: WritablePageParams = {visualizes};
+      const aggregateFields: WritablePageParams['aggregateFields'] = [];
+      let i = 0;
+      for (const aggregateField of pageParams.aggregateFields) {
+        if (isVisualize(aggregateField)) {
+          if (i < visualizes.length) {
+            aggregateFields.push(visualizes[i++]!);
+          }
+        } else {
+          aggregateFields.push(aggregateField);
+        }
+      }
+      for (; i < visualizes.length; i++) {
+        aggregateFields.push(visualizes[i]!);
+      }
+
+      const writablePageParams: WritablePageParams = {aggregateFields};
+
       const newFields = fields?.filter(field => !pageParams.fields.includes(field)) || [];
       if (newFields.length > 0) {
         writablePageParams.fields = [...pageParams.fields, ...newFields];
       }
+
       setPageParams(writablePageParams);
     },
     [pageParams, setPageParams]

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -89,7 +89,7 @@ export function getVisualizesFromLocation(
   const visualizes: Visualize[] = [];
 
   const baseVisualizes: BaseVisualize[] = rawVisualizes
-    .map(raw => parseVisualizes(raw, organization))
+    .map(raw => parseBaseVisualize(raw, organization))
     .filter(defined);
 
   let i = 0;
@@ -108,7 +108,10 @@ export function getVisualizesFromLocation(
   return visualizes.length ? visualizes : defaultVisualizes();
 }
 
-function parseVisualizes(raw: string, organization: Organization): BaseVisualize | null {
+export function parseBaseVisualize(
+  raw: string,
+  organization: Organization
+): BaseVisualize | null {
   try {
     const parsed = JSON.parse(raw);
     if (!defined(parsed) || !Array.isArray(parsed.yAxes)) {
@@ -135,19 +138,6 @@ function parseVisualizes(raw: string, organization: Organization): BaseVisualize
     return visualize;
   } catch (error) {
     return null;
-  }
-}
-
-export function updateLocationWithVisualizes(
-  location: Location,
-  visualizes: BaseVisualize[] | null | undefined
-) {
-  if (defined(visualizes)) {
-    location.query.visualize = visualizes.map(visualize => {
-      return JSON.stringify(Visualize.fromJSON(visualize).toJSON());
-    });
-  } else if (visualizes === null) {
-    delete location.query.visualize;
   }
 }
 


### PR DESCRIPTION
In preparation for allowing re-ordering of the aggregates table, this merges group bys and visualizes into a single aggregateFields that is managed together and split as needed.