### PR TITLE
ref(js): Factor button functionality

### DIFF
--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -1,102 +1,23 @@
 import isPropValid from '@emotion/is-prop-valid';
-import type {SerializedStyles, Theme} from '@emotion/react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {type LinkButtonProps} from 'sentry/components/core/button/linkButton';
-import {Tooltip, type TooltipProps} from 'sentry/components/core/tooltip';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
-import HookStore from 'sentry/stores/hookStore';
 import {space} from 'sentry/styles/space';
 
-import {getChonkButtonStyles} from './index.chonk';
+import {
+  DO_NOT_USE_BUTTON_ICON_SIZES as BUTTON_ICON_SIZES,
+  DO_NOT_USE_getButtonStyles as getButtonStyles,
+} from './styles';
+import {DO_NOT_USE_getChonkButtonStyles as getChonkButtonStyles} from './styles.chonk';
+import type {
+  DO_NOT_USE_ButtonProps as ButtonProps,
+  DO_NOT_USE_CommonButtonProps as CommonButtonProps,
+} from './types';
+import {useButtonFunctionality} from './useButtonFunctionality';
 
-// We do not want people using this type as it should only be used
-// internally by the different button implementations
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export interface DO_NOT_USE_CommonButtonProps {
-  /**
-   * Used when you want to overwrite the default Reload event key for analytics
-   */
-  analyticsEventKey?: string;
-  /**
-   * Used when you want to send an Amplitude Event. By default, Amplitude events are not sent so
-   * you must pass in a eventName to send an Amplitude event.
-   */
-  analyticsEventName?: string;
-  /**
-   * Adds extra parameters to the analytics tracking
-   */
-  analyticsParams?: Record<string, any>;
-  /**
-   * Removes borders from the button.
-   */
-  borderless?: boolean;
-  /**
-   * Indicates that the button is "doing" something.
-   */
-  busy?: boolean;
-  /**
-   * The icon to render inside of the button. The size will be set
-   * appropriately based on the size of the button.
-   */
-  icon?: React.ReactNode;
-  /**
-   * The semantic "priority" of the button. Use `primary` when the action is
-   * contextually the primary action, `danger` if the button will do something
-   * destructive, `link` for visual similarity to a link.
-   */
-  priority?: 'default' | 'primary' | 'danger' | 'link';
-  /**
-   * The size of the button
-   */
-  size?: 'zero' | 'xs' | 'sm' | 'md';
-  /**
-   * Display a tooltip for the button.
-   */
-  title?: TooltipProps['title'];
-  /**
-   * Additional properites for the Tooltip when `title` is set.
-   */
-  tooltipProps?: Omit<TooltipProps, 'children' | 'title' | 'skipWrapper'>;
-  /**
-   * Userful in scenarios where the border of the button should blend with the
-   * background behind the button.
-   */
-  translucentBorder?: boolean;
-}
-
-/**
- * Helper type to extraxct the HTML element props for use in button prop
- * interfaces.
- *
- * XXX(epurkhiser): Right now all usages of this use ButtonElement, but in the
- * future ButtonElement should go away and be replaced with HTMLButtonElement
- * and HTMLAnchorElement respectively
- */
-type ButtonElementProps = Omit<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  'label' | 'size' | 'title'
->;
-
-interface BaseButtonProps extends DO_NOT_USE_CommonButtonProps, ButtonElementProps {
-  href?: never;
-  ref?: React.Ref<HTMLButtonElement>;
-  to?: never;
-}
-
-interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
-  children: React.ReactNode;
-}
-
-interface ButtonPropsWithAriaLabel extends BaseButtonProps {
-  'aria-label': string;
-  children?: never;
-}
-
-export type ButtonProps = ButtonPropsWithoutAriaLabel | ButtonPropsWithAriaLabel;
+export type {ButtonProps};
 
 export function Button({
   size = 'md',
@@ -134,7 +55,7 @@ export function Button({
         <ButtonLabel size={size} borderless={props.borderless}>
           {props.icon && (
             <Icon size={size} hasChildren={hasChildren}>
-              <IconDefaultsProvider size={DO_NOT_USE_BUTTON_ICON_SIZES[size]}>
+              <IconDefaultsProvider size={BUTTON_ICON_SIZES[size]}>
                 {props.icon}
               </IconDefaultsProvider>
             </Icon>
@@ -147,266 +68,15 @@ export function Button({
 }
 
 export const StyledButton = styled('button')<ButtonProps>`
-  ${p =>
-    p.theme.isChonk
-      ? getChonkButtonStyles(p as any)
-      : DO_NOT_USE_getButtonStyles(p as any)}
+  ${p => (p.theme.isChonk ? getChonkButtonStyles(p as any) : getButtonStyles(p as any))}
 `;
-
-export const useButtonFunctionality = (props: ButtonProps | LinkButtonProps) => {
-  // Fallbacking aria-label to string children is not necessary as screen
-  // readers natively understand that scenario. Leaving it here for a bunch of
-  // our tests that query by aria-label.
-  const accessibleLabel =
-    props['aria-label'] ??
-    (typeof props.children === 'string' ? props.children : undefined);
-
-  const useButtonTrackingLogger = () => {
-    const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
-    const hasCustomAnalytics =
-      props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
-    if (!hasCustomAnalytics || !hasAnalyticsDebug) {
-      return () => {};
-    }
-
-    return () => {
-      // eslint-disable-next-line no-console
-      console.log('buttonAnalyticsEvent', {
-        eventKey: props.analyticsEventKey,
-        eventName: props.analyticsEventName,
-        priority: props.priority,
-        href: 'href' in props ? props.href : undefined,
-        ...props.analyticsParams,
-      });
-    };
-  };
-
-  const useButtonTracking =
-    HookStore.get('react-hook:use-button-tracking')[0] ?? useButtonTrackingLogger;
-
-  const buttonTracking = useButtonTracking({
-    analyticsEventName: props.analyticsEventName,
-    analyticsEventKey: props.analyticsEventKey,
-    analyticsParams: {
-      priority: props.priority,
-      href: 'href' in props ? props.href : undefined,
-      ...props.analyticsParams,
-    },
-    'aria-label': accessibleLabel || '',
-  });
-
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
-    // Don't allow clicks when disabled or busy
-    if (props.disabled || props.busy) {
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
-
-    buttonTracking();
-    // @ts-expect-error at this point, we don't know if the button is a button or a link
-    props.onClick?.(e);
-  };
-
-  const hasChildren = Array.isArray(props.children)
-    ? props.children.some(child => !!child || String(child) === '0')
-    : !!props.children || String(props.children) === '0';
-
-  // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.
-  // Let's use props to determine which to serve up, so we don't have to think about it.
-  // *Note* you must still handle tabindex manually.
-
-  return {
-    handleClick,
-    hasChildren,
-    accessibleLabel,
-  };
-};
-
-const getBoxShadow = ({
-  priority,
-  borderless,
-  translucentBorder,
-  disabled,
-  size,
-  theme,
-}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
-  if (disabled || borderless || priority === 'link') {
-    return css`
-      box-shadow: none;
-    `;
-  }
-
-  const themeName = disabled ? 'disabled' : priority || 'default';
-  const {borderTranslucent} = theme.button[themeName];
-  const translucentBorderString = translucentBorder
-    ? `0 0 0 1px ${borderTranslucent},`
-    : '';
-  const dropShadow = size === 'xs' ? theme.dropShadowLight : theme.dropShadowMedium;
-
-  return css`
-    box-shadow: ${translucentBorderString} ${dropShadow};
-    &:active {
-      box-shadow: ${translucentBorderString} inset ${dropShadow};
-    }
-  `;
-};
-
-const getColors = ({
-  size,
-  priority,
-  disabled,
-  borderless,
-  translucentBorder,
-  theme,
-}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
-  const themeName = disabled ? 'disabled' : priority || 'default';
-  const {color, colorActive, background, border, borderActive, focusBorder, focusShadow} =
-    theme.button[themeName];
-
-  const getFocusState = (): SerializedStyles => {
-    switch (priority) {
-      case 'primary':
-      case 'danger':
-        return css`
-          border-color: ${focusBorder};
-          box-shadow:
-            ${focusBorder} 0 0 0 1px,
-            ${focusShadow} 0 0 0 4px;
-        `;
-      default:
-        if (translucentBorder) {
-          return css`
-            border-color: ${focusBorder};
-            box-shadow: ${focusBorder} 0 0 0 2px;
-          `;
-        }
-        return css`
-          border-color: ${focusBorder};
-          box-shadow: ${focusBorder} 0 0 0 1px;
-        `;
-    }
-  };
-
-  return css`
-    color: ${color};
-    background-color: ${priority === 'primary' || priority === 'danger'
-      ? background
-      : borderless
-        ? 'transparent'
-        : background};
-
-    border: 1px solid ${borderless || priority === 'link' ? 'transparent' : border};
-
-    ${translucentBorder &&
-    css`
-      border-width: 0;
-    `}
-
-    &:hover {
-      color: ${color};
-    }
-
-    ${size !== 'zero' &&
-    css`
-      &:hover,
-      &:active,
-      &[aria-expanded='true'] {
-        color: ${colorActive || color};
-        border-color: ${borderless || priority === 'link' ? 'transparent' : borderActive};
-      }
-
-      &:focus-visible {
-        color: ${colorActive || color};
-        border-color: ${borderActive};
-      }
-    `}
-
-    &:focus-visible {
-      ${getFocusState()}
-      z-index: 1;
-    }
-  `;
-};
-
-const getSizeStyles = ({
-  size = 'md',
-  translucentBorder,
-  theme,
-}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
-  const buttonSize = size === 'zero' ? 'md' : size;
-  const formStyles = theme.form[buttonSize];
-  const buttonPadding = theme.buttonPadding[buttonSize];
-
-  // If using translucent borders, rewrite size styles to
-  // prevent layout shifts
-  const borderStyles = translucentBorder
-    ? {
-        height: `calc(${formStyles.height} - 2px)`,
-        minHeight: `calc(${formStyles.minHeight} - 2px)`,
-        paddingTop: buttonPadding.paddingTop - 1,
-        paddingBottom: buttonPadding.paddingBottom - 1,
-        margin: 1,
-      }
-    : {};
-
-  return css`
-    ${formStyles}
-    ${buttonPadding}
-    ${borderStyles}
-  `;
-};
-
-// This should only be used by the different underlying button implementations
-// and not directly by consumers of the button component.
-export function DO_NOT_USE_getButtonStyles(
-  p: (ButtonProps | LinkButtonProps) & {theme: Theme}
-): SerializedStyles {
-  return css`
-    position: relative;
-    display: inline-block;
-    border-radius: ${p.theme.borderRadius};
-    text-transform: none;
-    font-weight: ${p.theme.fontWeightBold};
-    cursor: ${p.disabled ? 'not-allowed' : 'pointer'};
-    opacity: ${(p.busy || p.disabled) && '0.65'};
-
-    ${getColors(p)}
-    ${getSizeStyles(p)}
-    ${getBoxShadow(p)}
-
-    transition:
-      background 0.1s,
-      border 0.1s,
-      box-shadow 0.1s;
-
-    ${p.priority === 'link' &&
-    css`
-      font-size: inherit;
-      font-weight: inherit;
-      padding: 0;
-      height: auto;
-      min-height: auto;
-    `}
-    ${p.size === 'zero' &&
-    css`
-      height: auto;
-      min-height: auto;
-      padding: ${space(0.25)};
-    `}
-
-  &:focus {
-      outline: none;
-    }
-  `;
-}
 
 const ButtonLabel = styled('span', {
   shouldForwardProp: prop =>
     typeof prop === 'string' &&
     isPropValid(prop) &&
     !['size', 'borderless'].includes(prop),
-})<Pick<ButtonProps, 'size' | 'borderless'>>`
+})<Pick<CommonButtonProps, 'size' | 'borderless'>>`
   height: 100%;
   display: flex;
   align-items: center;
@@ -414,7 +84,10 @@ const ButtonLabel = styled('span', {
   white-space: nowrap;
 `;
 
-const Icon = styled('span')<{hasChildren?: boolean; size?: ButtonProps['size']}>`
+const Icon = styled('span')<{
+  hasChildren?: boolean;
+  size?: CommonButtonProps['size'];
+}>`
   display: flex;
   align-items: center;
   margin-right: ${p =>
@@ -425,13 +98,3 @@ const Icon = styled('span')<{hasChildren?: boolean; size?: ButtonProps['size']}>
       : '0'};
   flex-shrink: 0;
 `;
-
-export const DO_NOT_USE_BUTTON_ICON_SIZES: Record<
-  NonNullable<BaseButtonProps['size']>,
-  SVGIconProps['size']
-> = {
-  zero: undefined,
-  xs: 'xs',
-  sm: 'sm',
-  md: 'sm',
-};

--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -1,54 +1,24 @@
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
-import type {LocationDescriptor} from 'history';
 
-import type {DO_NOT_USE_CommonButtonProps} from 'sentry/components/core/button';
-import {
-  DO_NOT_USE_BUTTON_ICON_SIZES,
-  DO_NOT_USE_getButtonStyles,
-  useButtonFunctionality,
-} from 'sentry/components/core/button';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link from 'sentry/components/links/link';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {space} from 'sentry/styles/space';
 
-import {getChonkButtonStyles} from './index.chonk';
+import {
+  DO_NOT_USE_BUTTON_ICON_SIZES as BUTTON_ICON_SIZES,
+  DO_NOT_USE_getButtonStyles as getButtonStyles,
+} from './styles';
+import {DO_NOT_USE_getChonkButtonStyles as getChonkButtonStyles} from './styles.chonk';
+import type {
+  DO_NOT_USE_CommonButtonProps as CommonButtonProps,
+  DO_NOT_USE_LinkButtonProps as LinkButtonProps,
+} from './types';
+import {useButtonFunctionality} from './useButtonFunctionality';
 
-type LinkElementProps = Omit<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
-  'label' | 'size' | 'title' | 'href'
->;
-
-interface BaseLinkButtonProps extends DO_NOT_USE_CommonButtonProps, LinkElementProps {
-  /**
-   * Determines if the link is disabled.
-   */
-  disabled?: boolean;
-}
-
-interface LinkButtonPropsWithHref extends BaseLinkButtonProps {
-  href: string;
-  /**
-   * Determines if the link is external and should open in a new tab.
-   */
-  external?: boolean;
-}
-
-interface LinkButtonPropsWithTo extends BaseLinkButtonProps {
-  to: string | LocationDescriptor;
-  /**
-   * If true, the link will not reset the scroll position of the page when clicked.
-   */
-  preventScrollReset?: boolean;
-  /**
-   * Determines if the link should replace the current history entry.
-   */
-  replace?: boolean;
-}
-
-export type LinkButtonProps = LinkButtonPropsWithHref | LinkButtonPropsWithTo;
+export type {LinkButtonProps};
 
 export function LinkButton({
   size = 'md',
@@ -84,7 +54,7 @@ export function LinkButton({
         <ButtonLabel size={size} borderless={props.borderless}>
           {props.icon && (
             <Icon size={size} hasChildren={hasChildren}>
-              <IconDefaultsProvider size={DO_NOT_USE_BUTTON_ICON_SIZES[size]}>
+              <IconDefaultsProvider size={BUTTON_ICON_SIZES[size]}>
                 {props.icon}
               </IconDefaultsProvider>
             </Icon>
@@ -125,10 +95,7 @@ const StyledLinkButton = styled(
       (typeof prop === 'string' && isPropValid(prop)),
   }
 )<LinkButtonProps>`
-  ${p =>
-    p.theme.isChonk
-      ? getChonkButtonStyles(p as any)
-      : DO_NOT_USE_getButtonStyles(p as any)}
+  ${p => (p.theme.isChonk ? getChonkButtonStyles(p as any) : getButtonStyles(p as any))}
 `;
 
 const ButtonLabel = styled('span', {
@@ -136,7 +103,7 @@ const ButtonLabel = styled('span', {
     typeof prop === 'string' &&
     isPropValid(prop) &&
     !['size', 'borderless'].includes(prop),
-})<Pick<LinkButtonProps, 'size' | 'borderless'>>`
+})<Pick<CommonButtonProps, 'size' | 'borderless'>>`
   height: 100%;
   display: flex;
   align-items: center;
@@ -144,7 +111,10 @@ const ButtonLabel = styled('span', {
   white-space: nowrap;
 `;
 
-const Icon = styled('span')<{hasChildren?: boolean; size?: LinkButtonProps['size']}>`
+const Icon = styled('span')<{
+  hasChildren?: boolean;
+  size?: CommonButtonProps['size'];
+}>`
   display: flex;
   align-items: center;
   margin-right: ${p =>

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -1,6 +1,6 @@
 import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
 
-import type {ButtonProps} from 'sentry/components/core/button';
+import type {DO_NOT_USE_ButtonProps as ButtonProps} from 'sentry/components/core/button/types';
 import type {StrictCSSObject} from 'sentry/utils/theme';
 
 // @TODO: remove Link type in the future
@@ -33,7 +33,7 @@ function chonkPriorityToType(priority: ButtonProps['priority']): ChonkButtonType
   }
 }
 
-export function getChonkButtonStyles(
+export function DO_NOT_USE_getChonkButtonStyles(
   p: Pick<ButtonProps, 'size' | 'priority' | 'busy' | 'disabled' | 'borderless'> & {
     theme: DO_NOT_USE_ChonkTheme;
   }

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -1,0 +1,199 @@
+import type {SerializedStyles, Theme} from '@emotion/react';
+import {css} from '@emotion/react';
+
+import {type SVGIconProps} from 'sentry/icons/svgIcon';
+import {space} from 'sentry/styles/space';
+
+import type {
+  DO_NOT_USE_ButtonProps as ButtonProps,
+  DO_NOT_USE_CommonButtonProps as CommonButtonProps,
+  DO_NOT_USE_LinkButtonProps as LinkButtonProps,
+} from './types';
+
+const getBoxShadow = ({
+  priority,
+  borderless,
+  translucentBorder,
+  disabled,
+  size,
+  theme,
+}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
+  if (disabled || borderless || priority === 'link') {
+    return css`
+      box-shadow: none;
+    `;
+  }
+
+  const themeName = disabled ? 'disabled' : priority || 'default';
+  const {borderTranslucent} = theme.button[themeName];
+  const translucentBorderString = translucentBorder
+    ? `0 0 0 1px ${borderTranslucent},`
+    : '';
+  const dropShadow = size === 'xs' ? theme.dropShadowLight : theme.dropShadowMedium;
+
+  return css`
+    box-shadow: ${translucentBorderString} ${dropShadow};
+    &:active {
+      box-shadow: ${translucentBorderString} inset ${dropShadow};
+    }
+  `;
+};
+
+const getColors = ({
+  size,
+  priority,
+  disabled,
+  borderless,
+  translucentBorder,
+  theme,
+}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
+  const themeName = disabled ? 'disabled' : priority || 'default';
+  const {color, colorActive, background, border, borderActive, focusBorder, focusShadow} =
+    theme.button[themeName];
+
+  const getFocusState = (): SerializedStyles => {
+    switch (priority) {
+      case 'primary':
+      case 'danger':
+        return css`
+          border-color: ${focusBorder};
+          box-shadow:
+            ${focusBorder} 0 0 0 1px,
+            ${focusShadow} 0 0 0 4px;
+        `;
+      default:
+        if (translucentBorder) {
+          return css`
+            border-color: ${focusBorder};
+            box-shadow: ${focusBorder} 0 0 0 2px;
+          `;
+        }
+        return css`
+          border-color: ${focusBorder};
+          box-shadow: ${focusBorder} 0 0 0 1px;
+        `;
+    }
+  };
+
+  return css`
+    color: ${color};
+    background-color: ${priority === 'primary' || priority === 'danger'
+      ? background
+      : borderless
+        ? 'transparent'
+        : background};
+
+    border: 1px solid ${borderless || priority === 'link' ? 'transparent' : border};
+
+    ${translucentBorder &&
+    css`
+      border-width: 0;
+    `}
+
+    &:hover {
+      color: ${color};
+    }
+
+    ${size !== 'zero' &&
+    css`
+      &:hover,
+      &:active,
+      &[aria-expanded='true'] {
+        color: ${colorActive || color};
+        border-color: ${borderless || priority === 'link' ? 'transparent' : borderActive};
+      }
+
+      &:focus-visible {
+        color: ${colorActive || color};
+        border-color: ${borderActive};
+      }
+    `}
+
+    &:focus-visible {
+      ${getFocusState()}
+      z-index: 1;
+    }
+  `;
+};
+
+const getSizeStyles = ({
+  size = 'md',
+  translucentBorder,
+  theme,
+}: (ButtonProps | LinkButtonProps) & {theme: Theme}): SerializedStyles => {
+  const buttonSize = size === 'zero' ? 'md' : size;
+  const formStyles = theme.form[buttonSize];
+  const buttonPadding = theme.buttonPadding[buttonSize];
+
+  // If using translucent borders, rewrite size styles to
+  // prevent layout shifts
+  const borderStyles = translucentBorder
+    ? {
+        height: `calc(${formStyles.height} - 2px)`,
+        minHeight: `calc(${formStyles.minHeight} - 2px)`,
+        paddingTop: buttonPadding.paddingTop - 1,
+        paddingBottom: buttonPadding.paddingBottom - 1,
+        margin: 1,
+      }
+    : {};
+
+  return css`
+    ${formStyles}
+    ${buttonPadding}
+    ${borderStyles}
+  `;
+};
+
+// This should only be used by the different underlying button implementations
+// and not directly by consumers of the button component.
+export function DO_NOT_USE_getButtonStyles(
+  p: (ButtonProps | LinkButtonProps) & {theme: Theme}
+): SerializedStyles {
+  return css`
+    position: relative;
+    display: inline-block;
+    border-radius: ${p.theme.borderRadius};
+    text-transform: none;
+    font-weight: ${p.theme.fontWeightBold};
+    cursor: ${p.disabled ? 'not-allowed' : 'pointer'};
+    opacity: ${(p.busy || p.disabled) && '0.65'};
+
+    ${getColors(p)}
+    ${getSizeStyles(p)}
+    ${getBoxShadow(p)}
+
+    transition:
+      background 0.1s,
+      border 0.1s,
+      box-shadow 0.1s;
+
+    ${p.priority === 'link' &&
+    css`
+      font-size: inherit;
+      font-weight: inherit;
+      padding: 0;
+      height: auto;
+      min-height: auto;
+    `}
+    ${p.size === 'zero' &&
+    css`
+      height: auto;
+      min-height: auto;
+      padding: ${space(0.25)};
+    `}
+
+  &:focus {
+      outline: none;
+    }
+  `;
+}
+
+export const DO_NOT_USE_BUTTON_ICON_SIZES: Record<
+  NonNullable<CommonButtonProps['size']>,
+  SVGIconProps['size']
+> = {
+  zero: undefined,
+  xs: 'xs',
+  sm: 'sm',
+  md: 'sm',
+};

--- a/static/app/components/core/button/types.tsx
+++ b/static/app/components/core/button/types.tsx
@@ -1,0 +1,119 @@
+import type {LocationDescriptor} from 'history';
+
+import type {TooltipProps} from 'sentry/components/core/tooltip';
+
+// We do not want people using this type as it should only be used
+// internally by the different button implementations
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface DO_NOT_USE_CommonButtonProps {
+  /**
+   * Used when you want to overwrite the default Reload event key for analytics
+   */
+  analyticsEventKey?: string;
+  /**
+   * Used when you want to send an Amplitude Event. By default, Amplitude events are not sent so
+   * you must pass in a eventName to send an Amplitude event.
+   */
+  analyticsEventName?: string;
+  /**
+   * Adds extra parameters to the analytics tracking
+   */
+  analyticsParams?: Record<string, any>;
+  /**
+   * Removes borders from the button.
+   */
+  borderless?: boolean;
+  /**
+   * Indicates that the button is "doing" something.
+   */
+  busy?: boolean;
+  /**
+   * The icon to render inside of the button. The size will be set
+   * appropriately based on the size of the button.
+   */
+  icon?: React.ReactNode;
+  /**
+   * The semantic "priority" of the button. Use `primary` when the action is
+   * contextually the primary action, `danger` if the button will do something
+   * destructive, `link` for visual similarity to a link.
+   */
+  priority?: 'default' | 'primary' | 'danger' | 'link';
+  /**
+   * The size of the button
+   */
+  size?: 'zero' | 'xs' | 'sm' | 'md';
+  /**
+   * Display a tooltip for the button.
+   */
+  title?: TooltipProps['title'];
+  /**
+   * Additional properties for the Tooltip when `title` is set.
+   */
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title' | 'skipWrapper'>;
+  /**
+   * Userful in scenarios where the border of the button should blend with the
+   * background behind the button.
+   */
+  translucentBorder?: boolean;
+}
+
+type ButtonElementProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'label' | 'size' | 'title'
+>;
+
+interface BaseButtonProps extends DO_NOT_USE_CommonButtonProps, ButtonElementProps {
+  href?: never;
+  ref?: React.Ref<HTMLButtonElement>;
+  to?: never;
+}
+
+interface ButtonPropsWithoutAriaLabel extends BaseButtonProps {
+  children: React.ReactNode;
+}
+
+interface ButtonPropsWithAriaLabel extends BaseButtonProps {
+  'aria-label': string;
+  children?: never;
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type DO_NOT_USE_ButtonProps =
+  | ButtonPropsWithoutAriaLabel
+  | ButtonPropsWithAriaLabel;
+
+type LinkElementProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  'label' | 'size' | 'title' | 'href'
+>;
+
+interface BaseLinkButtonProps extends DO_NOT_USE_CommonButtonProps, LinkElementProps {
+  /**
+   * Determines if the link is disabled.
+   */
+  disabled?: boolean;
+}
+
+interface LinkButtonPropsWithHref extends BaseLinkButtonProps {
+  href: string;
+  /**
+   * Determines if the link is external and should open in a new tab.
+   */
+  external?: boolean;
+}
+
+interface LinkButtonPropsWithTo extends BaseLinkButtonProps {
+  to: string | LocationDescriptor;
+  /**
+   * If true, the link will not reset the scroll position of the page when clicked.
+   */
+  preventScrollReset?: boolean;
+  /**
+   * Determines if the link should replace the current history entry.
+   */
+  replace?: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type DO_NOT_USE_LinkButtonProps = LinkButtonPropsWithHref | LinkButtonPropsWithTo;

--- a/static/app/components/core/button/useButtonFunctionality.tsx
+++ b/static/app/components/core/button/useButtonFunctionality.tsx
@@ -1,0 +1,76 @@
+import HookStore from 'sentry/stores/hookStore';
+
+import type {
+  DO_NOT_USE_ButtonProps as ButtonProps,
+  DO_NOT_USE_LinkButtonProps as LinkButtonProps,
+} from './types';
+
+export function useButtonFunctionality(props: ButtonProps | LinkButtonProps) {
+  // Fallbacking aria-label to string children is not necessary as screen
+  // readers natively understand that scenario. Leaving it here for a bunch of
+  // our tests that query by aria-label.
+  const accessibleLabel =
+    props['aria-label'] ??
+    (typeof props.children === 'string' ? props.children : undefined);
+
+  const useButtonTrackingLogger = () => {
+    const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
+    const hasCustomAnalytics =
+      props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;
+    if (!hasCustomAnalytics || !hasAnalyticsDebug) {
+      return () => {};
+    }
+
+    return () => {
+      // eslint-disable-next-line no-console
+      console.log('buttonAnalyticsEvent', {
+        eventKey: props.analyticsEventKey,
+        eventName: props.analyticsEventName,
+        priority: props.priority,
+        href: 'href' in props ? props.href : undefined,
+        ...props.analyticsParams,
+      });
+    };
+  };
+
+  const useButtonTracking =
+    HookStore.get('react-hook:use-button-tracking')[0] ?? useButtonTrackingLogger;
+
+  const buttonTracking = useButtonTracking({
+    analyticsEventName: props.analyticsEventName,
+    analyticsEventKey: props.analyticsEventKey,
+    analyticsParams: {
+      priority: props.priority,
+      href: 'href' in props ? props.href : undefined,
+      ...props.analyticsParams,
+    },
+    'aria-label': accessibleLabel || '',
+  });
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+    // Don't allow clicks when disabled or busy
+    if (props.disabled || props.busy) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    buttonTracking();
+    // @ts-expect-error at this point, we don't know if the button is a button or a link
+    props.onClick?.(e);
+  };
+
+  const hasChildren = Array.isArray(props.children)
+    ? props.children.some(child => !!child || String(child) === '0')
+    : !!props.children || String(props.children) === '0';
+
+  // Buttons come in 4 flavors: <Link>, <ExternalLink>, <a>, and <button>.
+  // Let's use props to determine which to serve up, so we don't have to think about it.
+  // *Note* you must still handle tabindex manually.
+
+  return {
+    handleClick,
+    hasChildren,
+    accessibleLabel,
+  };
+}

--- a/static/app/components/core/segmentedControl/index.chonk.tsx
+++ b/static/app/components/core/segmentedControl/index.chonk.tsx
@@ -1,7 +1,7 @@
 import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
 import {css} from '@emotion/react';
 
-import {getChonkButtonStyles} from 'sentry/components/core/button/index.chonk';
+import {DO_NOT_USE_getChonkButtonStyles} from 'sentry/components/core/button/styles.chonk';
 import type {FormSize} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 
@@ -65,7 +65,7 @@ export const ChonkStyledSegmentWrap = chonkStyled('label')<{
   ${p => p.theme.buttonPadding[p.size]}
   font-weight: ${p => p.theme.fontWeightNormal};
 
-  ${p => ({...getChonkButtonStyles({...p, disabled: p.isDisabled, priority: p.isSelected && p.priority === 'primary' ? 'primary' : 'default'})})}
+  ${p => ({...DO_NOT_USE_getChonkButtonStyles({...p, disabled: p.isDisabled, priority: p.isSelected && p.priority === 'primary' ? 'primary' : 'default'})})}
 
   &:has(input:focus-visible) {
     ${p => p.theme.focusRing};


### PR DESCRIPTION
- Move `useButtonFunctionality` into it's own module, keeping index.tsx
  specifc to JUST what is required to render the Button, and not sharing
  anything with linkButton

- Move common styles out of the index module into styles.tsx, renames
  index.chonk to styles.chonk as well.

- Move common types into types.tsx

- Renames `getChonkButtonStyles` to `DO_NOT_USE_getChonkButtonStyles` to
  match the `DO_NOT_USE_getButtonStyles`