### PR TITLE
fix(replay): Look at issue.project.platform instead of pageFilters for Issue>Replays table

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/core/button';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Placeholder from 'sentry/components/placeholder';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
+import {replayMobilePlatforms} from 'sentry/data/platformCategories';
 import {IconPlay, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -78,7 +79,10 @@ export default function GroupReplays({group}: Props) {
     location,
     organization,
   });
-  const {allMobileProj} = useAllMobileProj({});
+
+  const isMobilePlatform = replayMobilePlatforms.includes(
+    group.project.platform ?? 'other'
+  );
 
   useEffect(() => {
     trackAnalytics('replay.render-issues-group-list', {
@@ -110,7 +114,7 @@ export default function GroupReplays({group}: Props) {
           isFetching={isFetching}
           replays={[]}
           sort={undefined}
-          visibleColumns={visibleColumns(allMobileProj)}
+          visibleColumns={visibleColumns(isMobilePlatform)}
           showDropdownFilters={false}
         />
       </StyledLayoutPage>


### PR DESCRIPTION
The problem is that global page filters are affecting the table display inside the Issue Details > Replay view.

You can repro the problem by doing something like:
- go to issue list page
- select multiple projects from the dropdown
- open a mobile issue with replays & go to the replay list within that issue (this page we're fixing)
- notice that the extra browser column is visible

Fixes REPLAY-218