### PR TITLE
perf(aci): Track batch performance in fire_action_for_groups/fire_rules

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -52,6 +52,7 @@ from sentry.utils import json, metrics
 from sentry.utils.iterators import chunked
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.safe import safe_execute
+from sentry.workflow_engine.processors.log_util import track_batch_performance
 
 logger = logging.getLogger("sentry.rules.delayed_processing")
 EVENT_LIMIT = 100
@@ -458,92 +459,107 @@ def fire_rules(
 ) -> None:
     now = datetime.now(tz=timezone.utc)
     project_id = project.id
-    for rule, group_ids in rules_to_fire.items():
-        frequency = rule.data.get("frequency") or Rule.DEFAULT_FREQUENCY
-        freq_offset = now - timedelta(minutes=frequency)
-        group_to_groupevent = get_group_to_groupevent(
-            parsed_rulegroup_to_event_data, project.id, group_ids
-        )
-        if features.has(
-            "organizations:workflow-engine-process-workflows", project.organization
-        ) or features.has("projects:num-events-issue-debugging", project):
-            serialized_groups = {
-                group.id: group_event.event_id for group, group_event in group_to_groupevent.items()
-            }
-            logger.info(
-                "delayed_processing.group_to_groupevent",
-                extra={
-                    "group_to_groupevent": serialized_groups,
-                    "project_id": project_id,
-                    "rule_id": rule.id,
-                },
-            )
-        for group, groupevent in group_to_groupevent.items():
-            rule_statuses = bulk_get_rule_status(alert_rules, group, project)
-            status = rule_statuses[rule.id]
-            if status.last_active and status.last_active > freq_offset:
-                logger.info(
-                    "delayed_processing.last_active",
-                    extra={
-                        "last_active": status.last_active,
-                        "freq_offset": freq_offset,
-                        "project_id": project_id,
-                        "group_id": group.id,
-                    },
+    with track_batch_performance(
+        "delayed_processing.fire_rules.loop", logger, timedelta(seconds=40)
+    ) as tracker:
+        for rule, group_ids in rules_to_fire.items():
+            with tracker.track(f"rule_{rule.id}"):
+                frequency = rule.data.get("frequency") or Rule.DEFAULT_FREQUENCY
+                freq_offset = now - timedelta(minutes=frequency)
+                group_to_groupevent = get_group_to_groupevent(
+                    parsed_rulegroup_to_event_data, project.id, group_ids
                 )
-                break
+                if features.has(
+                    "organizations:workflow-engine-process-workflows", project.organization
+                ) or features.has("projects:num-events-issue-debugging", project):
+                    serialized_groups = {
+                        group.id: group_event.event_id
+                        for group, group_event in group_to_groupevent.items()
+                    }
+                    logger.info(
+                        "delayed_processing.group_to_groupevent",
+                        extra={
+                            "group_to_groupevent": serialized_groups,
+                            "project_id": project_id,
+                            "rule_id": rule.id,
+                        },
+                    )
+                for group, groupevent in group_to_groupevent.items():
+                    rule_statuses = bulk_get_rule_status(alert_rules, group, project)
+                    status = rule_statuses[rule.id]
+                    if status.last_active and status.last_active > freq_offset:
+                        logger.info(
+                            "delayed_processing.last_active",
+                            extra={
+                                "last_active": status.last_active,
+                                "freq_offset": freq_offset,
+                                "project_id": project_id,
+                                "group_id": group.id,
+                            },
+                        )
+                        break
 
-            updated = (
-                GroupRuleStatus.objects.filter(id=status.id)
-                .exclude(last_active__gt=freq_offset)
-                .update(last_active=now)
-            )
+                    updated = (
+                        GroupRuleStatus.objects.filter(id=status.id)
+                        .exclude(last_active__gt=freq_offset)
+                        .update(last_active=now)
+                    )
 
-            if not updated:
-                logger.info(
-                    "delayed_processing.not_updated",
-                    extra={"status_id": status.id, "project_id": project_id, "group_id": group.id},
-                )
-                break
+                    if not updated:
+                        logger.info(
+                            "delayed_processing.not_updated",
+                            extra={
+                                "status_id": status.id,
+                                "project_id": project_id,
+                                "group_id": group.id,
+                            },
+                        )
+                        break
 
-            notification_uuid = str(uuid.uuid4())
-            groupevent = group_to_groupevent[group]
-            rule_fire_history = history.record(rule, group, groupevent.event_id, notification_uuid)
+                    notification_uuid = str(uuid.uuid4())
+                    groupevent = group_to_groupevent[group]
+                    rule_fire_history = history.record(
+                        rule, group, groupevent.event_id, notification_uuid
+                    )
 
-            if features.has(
-                "organizations:workflow-engine-process-workflows-logs",
-                project.organization,
-            ) or features.has("projects:num-events-issue-debugging", project):
-                logger.info(
-                    "post_process.delayed_processing.triggered_rule",
-                    extra={
-                        "rule_id": rule.id,
-                        "group_id": group.id,
-                        "event_id": groupevent.event_id,
-                    },
-                )
+                    if features.has(
+                        "organizations:workflow-engine-process-workflows-logs",
+                        project.organization,
+                    ) or features.has("projects:num-events-issue-debugging", project):
+                        logger.info(
+                            "post_process.delayed_processing.triggered_rule",
+                            extra={
+                                "rule_id": rule.id,
+                                "group_id": group.id,
+                                "event_id": groupevent.event_id,
+                            },
+                        )
 
-            callback_and_futures = activate_downstream_actions(
-                rule, groupevent, notification_uuid, rule_fire_history, is_post_process=False
-            ).values()
+                    callback_and_futures = activate_downstream_actions(
+                        rule,
+                        groupevent,
+                        notification_uuid,
+                        rule_fire_history,
+                        is_post_process=False,
+                    ).values()
 
-            # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
-            not_sent = 0
-            for callback, futures in callback_and_futures:
-                results = safe_execute(callback, groupevent, futures)
-                if results is None:
-                    not_sent += 1
+                    # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
+                    not_sent = 0
+                    for callback, futures in callback_and_futures:
+                        results = safe_execute(callback, groupevent, futures)
+                        if results is None:
+                            not_sent += 1
 
-            if features.has("projects:num-events-issue-debugging", project):
-                logger.info(
-                    "delayed_processing.rules_fired",
-                    extra={
-                        "total": len(callback_and_futures),
-                        "not_sent": not_sent,
-                        "project_id": project_id,
-                        "rule_id": rule.id,
-                    },
-                )
+                    if features.has("projects:num-events-issue-debugging", project):
+                        logger.info(
+                            "delayed_processing.rules_fired",
+                            extra={
+                                "total": len(callback_and_futures),
+                                "not_sent": not_sent,
+                                "project_id": project_id,
+                                "rule_id": rule.id,
+                            },
+                        )
 
 
 def cleanup_redis_buffer(

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -460,7 +460,10 @@ def fire_rules(
     now = datetime.now(tz=timezone.utc)
     project_id = project.id
     with track_batch_performance(
-        "delayed_processing.fire_rules.loop", logger, timedelta(seconds=40)
+        "delayed_processing.fire_rules.loop",
+        logger,
+        timedelta(seconds=40),
+        extra={"project_id": project_id},
     ) as tracker:
         for rule, group_ids in rules_to_fire.items():
             with tracker.track(f"rule_{rule.id}"):

--- a/src/sentry/workflow_engine/processors/log_util.py
+++ b/src/sentry/workflow_engine/processors/log_util.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from datetime import timedelta
+from typing import Any
 
 
 def top_n_slowest(durations: dict[str, float], n: int) -> dict[str, float]:
@@ -56,7 +57,7 @@ class BatchPerformanceTracker:
         # even if keys are duplicated, we want to track total duration accurately.
         self.iteration_durations: defaultdict[str, float] = defaultdict(float)
 
-    def _generate_extra(self) -> dict[str, object]:
+    def _generate_extra(self) -> dict[str, Any]:
         """
         Generate the extra data to log from iteration durations.
         """

--- a/src/sentry/workflow_engine/processors/log_util.py
+++ b/src/sentry/workflow_engine/processors/log_util.py
@@ -1,0 +1,132 @@
+import logging
+import time
+from collections import defaultdict
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from datetime import timedelta
+
+
+def top_n_slowest(durations: dict[str, float], n: int) -> dict[str, float]:
+    if len(durations) <= n:
+        return durations
+    return dict(sorted(durations.items(), key=lambda x: x[1], reverse=True)[:n])
+
+
+# To keep logs reasonable, we only report up to this many individual iteration times.
+_MAX_ITERATIONS_LOGGED = 200
+
+
+# NOTE: You should be using Sentry's built-in performance tracking instead of this.
+# This is a manual fallback for when that isn't working for us.
+class BatchPerformanceTracker:
+    """
+    A utility class for monitoring and logging the performance of batch processing operations to better
+    understand where time is spent among the iterations when a batch takes too long.
+    If an exception is raised, it will be logged if the total processing time exceeds the threshold
+    even if finalize is not called.
+
+    Example:
+        tracker = BatchPerformanceTracker("my_package.process_items", logger, threshold=timedelta(seconds=10))
+        for item in items:
+            with tracker.track("process_single_item"):
+                process_item(item)
+        tracker.finalize()  # Logs if total time exceeds threshold
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: logging.Logger,
+        threshold: timedelta,
+        time_func: Callable[[], float] = time.time,
+    ) -> None:
+        """
+        Initialize the tracker.
+
+        Args:
+            name: A descriptive name for the batch operation being tracked
+            logger: The logger to use for performance reporting
+            total_threshold: The time threshold that triggers detailed logging
+            time_func: The function to use for timing. Defaults to time.time.
+        """
+        self.name = name
+        self.logger = logger
+        self.threshold = threshold
+        self.time_func = time_func
+        # even if keys are duplicated, we want to track total duration accurately.
+        self.iteration_durations: defaultdict[str, float] = defaultdict(float)
+
+    def _generate_extra(self) -> dict[str, object]:
+        """
+        Generate the extra data to log from iteration durations.
+        """
+        extra = {
+            "name": self.name,
+            "total_duration": sum(self.iteration_durations.values()),
+            "durations": top_n_slowest(self.iteration_durations, _MAX_ITERATIONS_LOGGED),
+        }
+        if len(self.iteration_durations) > _MAX_ITERATIONS_LOGGED:
+            extra["durations_truncated"] = True
+        return extra
+
+    @contextmanager
+    def track(self, key: str) -> Generator[None]:
+        """
+        Context manager to track the duration of a single iteration.
+        If an exception is raised, it will be logged if the total processing time exceeds the threshold
+        and the exception will be re-raised.
+
+        Args:
+            key: A unique identifier for this iteration (e.g., item ID or operation name)
+        """
+        start_time = self.time_func()
+        stored = False
+        try:
+            yield
+        except Exception as e:
+            duration = self.time_func() - start_time
+            self.iteration_durations[key] += duration
+            stored = True
+            if duration >= self.threshold.total_seconds():
+                self.logger.exception(
+                    e,
+                    extra=self._generate_extra(),
+                )
+            raise
+        finally:
+            if not stored:
+                duration = self.time_func() - start_time
+                self.iteration_durations[key] += duration
+
+    def finalize(self) -> None:
+        """
+        Log detailed performance metrics if the total processing time exceeds the threshold.
+        This helps identify if performance issues are caused by a few slow items or
+        consistent slowness across all items.
+        """
+        if not self.iteration_durations:
+            return
+        cumulative_duration = sum(self.iteration_durations.values())
+        if cumulative_duration >= self.threshold.total_seconds():
+            self.logger.info(
+                f"{self.name} took {cumulative_duration} seconds to complete",
+                extra=self._generate_extra(),
+            )
+
+
+@contextmanager
+def track_batch_performance(
+    name: str, logger: logging.Logger, threshold: timedelta
+) -> Generator[BatchPerformanceTracker]:
+    """Context manager that yields a BatchPerformanceTracker for monitoring batch operation performance.
+
+    Args:
+        name: Log event name, eg "my_package.my_function.process_batch_loop".
+        logger: Logger for performance reporting
+        total_threshold: Time threshold where per iteration performance is logged.
+    """
+    tracker = BatchPerformanceTracker(name, logger, threshold)
+    try:
+        yield tracker
+    finally:
+        tracker.finalize()

--- a/tests/sentry/workflow_engine/processors/test_log_util.py
+++ b/tests/sentry/workflow_engine/processors/test_log_util.py
@@ -1,0 +1,104 @@
+import logging
+import unittest
+from datetime import timedelta
+from unittest.mock import Mock, patch
+
+from sentry.workflow_engine.processors.log_util import BatchPerformanceTracker, top_n_slowest
+
+
+class TestBatchPerformanceTracker(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.logger = Mock(spec=logging.Logger)
+        self.time_func = Mock(return_value=0)
+        self.tracker = BatchPerformanceTracker(
+            "test_operation", self.logger, timedelta(seconds=100), time_func=self.time_func
+        )
+
+    def test_basic_tracking(self):
+        """Test basic tracking functionality without exceeding threshold."""
+        with self.tracker.track("item1"):
+            self.time_func.return_value = 1  # Fast enough.
+
+        self.tracker.finalize()
+        self.logger.info.assert_not_called()
+
+    def test_exceeds_threshold(self):
+        """Test that logging occurs when total time exceeds threshold."""
+        with self.tracker.track("item1"):
+            self.time_func.return_value = 200  # Slow operation.
+
+        self.tracker.finalize()
+        self.logger.info.assert_called_once()
+        call_args = self.logger.info.call_args[1]
+        assert call_args["extra"]["name"] == "test_operation"
+        assert call_args["extra"]["total_duration"] == 200
+        assert call_args["extra"]["durations"]["item1"] == 200
+
+    def test_multiple_items(self):
+        """Test tracking multiple items and their cumulative duration."""
+        with self.tracker.track("item1"):
+            self.time_func.return_value = 50  # First item takes half the threshold.
+
+        with self.tracker.track("item2"):
+            self.time_func.return_value = (
+                100  # Second item takes the other half, hitting threshold exactly.
+            )
+
+        self.tracker.finalize()
+        self.logger.info.assert_called_once()
+        call_args = self.logger.info.call_args[1]
+        assert call_args["extra"]["durations"]["item1"] == 50
+        assert call_args["extra"]["durations"]["item2"] == 50
+        assert call_args["extra"]["total_duration"] == 100
+
+    def test_key_collisions(self):
+        """Test that durations are summed when the same key is used multiple times."""
+        # First operation with key "item1"
+        with self.tracker.track("item1"):
+            self.time_func.return_value = 30
+
+        # Second operation with same key
+        with self.tracker.track("item1"):
+            self.time_func.return_value = 70
+
+        # Third operation with same key
+        with self.tracker.track("item1"):
+            self.time_func.return_value = 100
+
+        self.tracker.finalize()
+        self.logger.info.assert_called_once()
+        call_args = self.logger.info.call_args[1]
+        assert call_args["extra"]["durations"]["item1"] == 100  # 30 + 40 + 30
+        assert call_args["extra"]["total_duration"] == 100
+
+    def test_exception_handling(self):
+        """Test that exceptions are logged if duration exceeds threshold."""
+        with patch.object(self.logger, "exception") as mock_exception:
+            # First do a fast operation
+            with self.tracker.track("item1"):
+                self.time_func.return_value = 1  # Fast operation.
+
+            try:
+                with self.tracker.track("item2"):
+                    self.time_func.return_value = 200  # Slow enough to exceed threshold.
+                    raise ValueError("Test exception")
+            except ValueError:
+                pass
+
+            mock_exception.assert_called_once()
+            call_args = mock_exception.call_args[1]
+            assert call_args["extra"]["name"] == "test_operation"
+            assert call_args["extra"]["total_duration"] == 200
+            assert call_args["extra"]["durations"]["item1"] == 1
+            assert call_args["extra"]["durations"]["item2"] == 199
+
+
+def test_top_n_slowest():
+    durations = {"item1": 100, "item2": 50, "item3": 200, "item4": 150}
+    assert top_n_slowest(durations, 0) == {}
+    assert top_n_slowest(durations, 1) == {"item3": 200}
+    assert top_n_slowest(durations, 2) == {"item3": 200, "item4": 150}
+    assert top_n_slowest(durations, 3) == {"item1": 100, "item3": 200, "item4": 150}
+    # n > len(durations)
+    assert top_n_slowest(durations, 5) == durations

--- a/tests/sentry/workflow_engine/processors/test_log_util.py
+++ b/tests/sentry/workflow_engine/processors/test_log_util.py
@@ -95,7 +95,7 @@ class TestBatchPerformanceTracker(unittest.TestCase):
 
 
 def test_top_n_slowest():
-    durations = {"item1": 100, "item2": 50, "item3": 200, "item4": 150}
+    durations: dict[str, float] = {"item1": 100, "item2": 50, "item3": 200, "item4": 150}
     assert top_n_slowest(durations, 0) == {}
     assert top_n_slowest(durations, 1) == {"item3": 200}
     assert top_n_slowest(durations, 2) == {"item3": 200, "item4": 150}


### PR DESCRIPTION
Introduces a BatchPerformanceTracker logging helper that makes it easy to track slow loops and know where the slow items are.

We're seeing regular soft timeouts in our delayed rule/workflow processing, and with existing Sentry instrumentation it's not clear where the time is distributed; awareness of if it is a few outliers or a general perf issue will aide debugging.

