### PR TITLE
feat(crons): Indicate when a timeout is incomplete

### DIFF
--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -144,6 +144,16 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
                       <TimeoutLateBy monitor={monitor} duration={checkIn.duration} />
                     )}
                   </DurationContainer>
+                ) : checkIn.status === CheckInStatus.TIMEOUT ? (
+                  <div>
+                    <Tooltip
+                      title={t(
+                        'An in-progress check-in was received, but no closing check-in followed. Your job may be terminating before it reports to Sentry.'
+                      )}
+                    >
+                      <Tag type="error">{t('Incomplete')}</Tag>
+                    </Tooltip>
+                  </div>
                 ) : (
                   emptyCell
                 )}


### PR DESCRIPTION
This looks like this when no terminating check-in was sent.

<img alt="clipboard.png" width="1051" src="https://i.imgur.com/JLOpGtB.png" />k

Fixes [NEW-332: If a timeout does NOT have a duration indicate `incomplete`](https://linear.app/getsentry/issue/NEW-332/if-a-timeout-does-not-have-a-duration-indicate-incomplete)