### PR TITLE
fix(issues): Temporarily remove LLM insights from issue details

### DIFF
--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, lazy, useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -55,13 +55,12 @@ import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import {DataSection} from 'sentry/components/events/styles';
 import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
-import LazyLoad from 'sentry/components/lazyLoad';
 import Placeholder from 'sentry/components/placeholder';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Entry, EntryException, Event, EventTransaction} from 'sentry/types/event';
-import {EntryType, EventOrGroupType} from 'sentry/types/event';
+import type {Entry, Event, EventTransaction} from 'sentry/types/event';
+import {EntryType} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {IssueType} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
@@ -79,10 +78,6 @@ import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/us
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
-
-const LLMMonitoringSection = lazy(
-  () => import('sentry/components/events/interfaces/llm-monitoring/llmMonitoringSection')
-);
 
 export interface EventDetailsContentProps {
   group: Group;
@@ -199,24 +194,6 @@ export function EventDetailsContent({
           ) : null}
         </InterimSection>
       )}
-      {event.type === EventOrGroupType.ERROR &&
-      organization.features.includes('insights-addon-modules') &&
-      event?.entries
-        ?.filter((x): x is EntryException => x.type === EntryType.EXCEPTION)
-        .flatMap(x => x.data.values ?? [])
-        .some(({value}) => {
-          const lowerText = value?.toLowerCase();
-          return (
-            lowerText &&
-            (lowerText.includes('api key') || lowerText.includes('429')) &&
-            (lowerText.includes('openai') ||
-              lowerText.includes('anthropic') ||
-              lowerText.includes('cohere') ||
-              lowerText.includes('langchain'))
-          );
-        }) ? (
-        <LazyLoad LazyComponent={LLMMonitoringSection} />
-      ) : null}
       {!hasStreamlinedUI && group.issueType === IssueType.UPTIME_DOMAIN_FAILURE && (
         <UptimeDataSection event={event} project={project} group={group} />
       )}


### PR DESCRIPTION
This is currently positioned in a promenent place and also seems to not ever be able to load data correctly. Removing it for now as a quick fix.

Example issue: https://sentry.sentry.io/issues/6582590183/?project=6178942