### PR TITLE
feat(ui): Use pathname as the ScrollRestoration key

### DIFF
--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -64,7 +64,7 @@ function OrganizationLayout({children}: Props) {
           <App organization={organization}>{children}</App>
         </GlobalDrawer>
       </OrganizationContainer>
-      <ScrollRestoration />
+      <ScrollRestoration getKey={location => location.pathname} />
     </SentryDocumentTitle>
   );
 }


### PR DESCRIPTION
Prevents URL changes such as query params from changing the scroll unexpectedly.