### PR TITLE
feat(aci): add event frequency data condition node

### DIFF
--- a/static/app/components/workflowEngine/form/automationBuilderRowLine.tsx
+++ b/static/app/components/workflowEngine/form/automationBuilderRowLine.tsx
@@ -3,7 +3,7 @@ import {space} from 'sentry/styles/space';
 
 export function RowLine({children}: {children: React.ReactNode}) {
   return (
-    <Flex align="center" gap={space(1)}>
+    <Flex align="center" gap={space(1)} wrap="wrap">
       {children}
     </Flex>
   );

--- a/static/app/components/workflowEngine/form/automationBuilderSelectField.tsx
+++ b/static/app/components/workflowEngine/form/automationBuilderSelectField.tsx
@@ -23,6 +23,7 @@ const StyledSelectField = styled(SelectField)`
   > div {
     padding-left: 0;
   }
+  border: none;
 `;
 
 export const selectControlStyles = {

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -54,6 +54,9 @@ export enum DataConditionType {
   PERCENT_SESSIONS_PERCENT = 'percent_sessions_percent',
   EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT = 'event_unique_user_frequency_with_conditions_count',
   EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT = 'event_unique_user_frequency_with_conditions_percent',
+
+  // frequency types for UI only
+  EVENT_FREQUENCY = 'event_frequency',
 }
 
 export enum DataConditionGroupLogicType {

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -21,6 +21,7 @@ export const FILTER_DATA_CONDITION_TYPES = [
   DataConditionType.EVENT_ATTRIBUTE,
   DataConditionType.TAGGED_EVENT,
   DataConditionType.LEVEL,
+  DataConditionType.EVENT_FREQUENCY,
 ];
 
 export enum MatchType {
@@ -96,6 +97,16 @@ export enum Level {
   SAMPLING = 0,
 }
 
+export enum Interval {
+  ONE_MINUTE = '1m',
+  FIVE_MINUTES = '5m',
+  FIFTEEN_MINUTES = '15m',
+  ONE_HOUR = '1h',
+  ONE_DAY = '1d',
+  ONE_WEEK = '1w',
+  THIRTY_DAYS = '30d',
+}
+
 export const MATCH_CHOICES = [
   {value: MatchType.CONTAINS, label: 'contains'},
   {value: MatchType.EQUAL, label: 'equals'},
@@ -151,4 +162,23 @@ export const LEVEL_CHOICES = [
   {value: Level.INFO, label: t('info')},
   {value: Level.DEBUG, label: t('debug')},
   {value: Level.SAMPLING, label: t('sampling')},
+];
+
+export const INTERVAL_CHOICES = [
+  {value: Interval.ONE_MINUTE, label: t('in one minute')},
+  {value: Interval.FIVE_MINUTES, label: t('in 5 minutes')},
+  {value: Interval.FIFTEEN_MINUTES, label: t('in 15 minutes')},
+  {value: Interval.ONE_HOUR, label: t('in one hour')},
+  {value: Interval.ONE_DAY, label: t('in one day')},
+  {value: Interval.ONE_WEEK, label: t('in one week')},
+  {value: Interval.THIRTY_DAYS, label: t('in 30 days')},
+];
+
+export const COMPARISON_INTERVAL_CHOICES = [
+  {value: Interval.FIVE_MINUTES, label: t('5 minutes ago')},
+  {value: Interval.FIFTEEN_MINUTES, label: t('15 minutes ago')},
+  {value: Interval.ONE_HOUR, label: t('one hour ago')},
+  {value: Interval.ONE_DAY, label: t('one day ago')},
+  {value: Interval.ONE_WEEK, label: t('one week ago')},
+  {value: Interval.THIRTY_DAYS, label: t('30 days ago')},
 ];

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -1,0 +1,110 @@
+import AutomationBuilderNumberField from 'sentry/components/workflowEngine/form/automationBuilderNumberField';
+import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
+import {tct} from 'sentry/locale';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  COMPARISON_INTERVAL_CHOICES,
+  INTERVAL_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export default function EventFrequencyNode() {
+  return tct('Number of events in an issue is [select]', {
+    select: <ComparisonTypeField />,
+  });
+}
+
+function ComparisonTypeField() {
+  const {condition, condition_id, onUpdateType} = useDataConditionNodeContext();
+
+  if (condition.comparison_type === DataConditionType.EVENT_FREQUENCY_COUNT) {
+    return <CountBranch />;
+  }
+  if (condition.comparison_type === DataConditionType.EVENT_FREQUENCY_PERCENT) {
+    return <PercentBranch />;
+  }
+
+  return (
+    <AutomationBuilderSelectField
+      name={`${condition_id}.comparison_type`}
+      value={condition.comparison_type}
+      options={[
+        {
+          label: 'more than...',
+          value: DataConditionType.EVENT_FREQUENCY_COUNT,
+        },
+        {
+          label: 'relatively higher than...',
+          value: DataConditionType.EVENT_FREQUENCY_PERCENT,
+        },
+      ]}
+      onChange={(value: DataConditionType) => {
+        onUpdateType(value);
+      }}
+    />
+  );
+}
+
+function CountBranch() {
+  return tct('more than [value] [interval]', {
+    value: <ValueField />,
+    interval: <IntervalField />,
+  });
+}
+
+function PercentBranch() {
+  return tct('[value] higher [interval] compared to [comparison_interval]', {
+    value: <ValueField />,
+    interval: <IntervalField />,
+    comparison_interval: <ComparisonIntervalField />,
+  });
+}
+
+function ValueField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <AutomationBuilderNumberField
+      name={`${condition_id}.comparison.value`}
+      value={condition.comparison.value}
+      min={1}
+      step={1}
+      onChange={(value: string) => {
+        onUpdate({
+          value,
+        });
+      }}
+    />
+  );
+}
+
+function IntervalField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <AutomationBuilderSelectField
+      name={`${condition_id}.comparison.interval`}
+      value={condition.comparison.interval}
+      options={INTERVAL_CHOICES}
+      onChange={(value: string) => {
+        onUpdate({
+          interval: value,
+        });
+      }}
+    />
+  );
+}
+
+function ComparisonIntervalField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <AutomationBuilderSelectField
+      name={`${condition_id}.comparison.comparison_interval`}
+      value={condition.comparison.comparison_interval}
+      options={COMPARISON_INTERVAL_CHOICES}
+      onChange={(value: string) => {
+        onUpdate({
+          comparison_interval: value,
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -158,6 +158,9 @@ function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
             updateCondition={(index, comparison) =>
               actions.updateIfCondition(groupIndex, index, comparison)
             }
+            updateConditionType={(index, type) =>
+              actions.updateIfConditionType(groupIndex, index, type)
+            }
           />
         </Flex>
       </Step>

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -30,6 +30,8 @@ export function useAutomationBuilderReducer() {
           return removeIfCondition(state, action, formModel);
         case 'UPDATE_IF_CONDITION':
           return updateIfCondition(state, action);
+        case 'UPDATE_IF_CONDITION_TYPE':
+          return updateIfConditionType(state, action);
         case 'ADD_IF_ACTION':
           return addIfAction(state, action);
         case 'REMOVE_IF_ACTION':
@@ -80,6 +82,16 @@ export function useAutomationBuilderReducer() {
     removeIfCondition: useCallback(
       (groupIndex: number, conditionIndex: number) =>
         dispatch({type: 'REMOVE_IF_CONDITION', groupIndex, conditionIndex}),
+      [dispatch]
+    ),
+    updateIfConditionType: useCallback(
+      (groupIndex: number, conditionIndex: number, conditionType: DataConditionType) =>
+        dispatch({
+          type: 'UPDATE_IF_CONDITION_TYPE',
+          groupIndex,
+          conditionIndex,
+          conditionType,
+        }),
       [dispatch]
     ),
     updateIfCondition: useCallback(
@@ -139,6 +151,11 @@ interface AutomationActions {
     groupIndex: number,
     conditionIndex: number,
     comparison: Record<string, any>
+  ) => void;
+  updateIfConditionType: (
+    groupIndex: number,
+    conditionIndex: number,
+    conditionType: DataConditionType
   ) => void;
   updateIfLogicType: (groupIndex: number, logicType: DataConditionGroupLogicType) => void;
   updateWhenCondition: (index: number, comparison: Record<string, any>) => void;
@@ -217,6 +234,13 @@ type RemoveIfConditionAction = {
   type: 'REMOVE_IF_CONDITION';
 };
 
+type UpdateIfConditionTypeAction = {
+  conditionIndex: number;
+  conditionType: DataConditionType;
+  groupIndex: number;
+  type: 'UPDATE_IF_CONDITION_TYPE';
+};
+
 type UpdateIfConditionAction = {
   comparison: Record<string, any>;
   conditionIndex: number;
@@ -258,6 +282,7 @@ type AutomationBuilderAction =
   | RemoveIfAction
   | AddIfConditionAction
   | RemoveIfConditionAction
+  | UpdateIfConditionTypeAction
   | UpdateIfConditionAction
   | AddIfActionAction
   | RemoveIfActionAction
@@ -420,6 +445,27 @@ function removeIfCondition(
       return {
         ...group,
         conditions: group.conditions.filter((_, j) => j !== conditionIndex),
+      };
+    }),
+  };
+}
+
+function updateIfConditionType(
+  state: AutomationBuilderState,
+  action: UpdateIfConditionTypeAction
+): AutomationBuilderState {
+  const {groupIndex, conditionIndex, conditionType} = action;
+  return {
+    ...state,
+    actionFilters: state.actionFilters.map((group, i) => {
+      if (i !== groupIndex) {
+        return group;
+      }
+      return {
+        ...group,
+        conditions: group.conditions.map((c, j) =>
+          j === conditionIndex ? {...c, comparison_type: conditionType} : c
+        ),
       };
     }),
   };

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -27,12 +27,15 @@ export default function AutomationBuilderRow({onDelete, children}: RowProps) {
 }
 
 const RowContainer = styled('div')<{incompatible?: boolean}>`
+  display: flex;
   background-color: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px ${p => p.theme.innerBorder} solid;
   border-color: ${p => (p.incompatible ? p.theme.red200 : 'none')};
   position: relative;
   padding: ${space(0.75)} ${space(1.5)};
+  min-height: 46px;
+  align-items: center;
 `;
 
 const DeleteButton = styled(Button)`

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -21,6 +21,7 @@ interface DataConditionNodeListProps {
   onDeleteRow: (id: number) => void;
   placeholder: string;
   updateCondition: (index: number, condition: Record<string, any>) => void;
+  updateConditionType?: (index: number, type: DataConditionType) => void;
 }
 
 export default function DataConditionNodeList({
@@ -31,6 +32,7 @@ export default function DataConditionNodeList({
   onAddRow,
   onDeleteRow,
   updateCondition,
+  updateConditionType,
 }: DataConditionNodeListProps) {
   const options = Array.from(dataConditionNodesMap.entries())
     .map(([value, {label}]) => ({value, label}))
@@ -48,6 +50,7 @@ export default function DataConditionNodeList({
               condition,
               condition_id: `${group}.conditions.${i}`,
               onUpdate: newCondition => updateCondition(i, newCondition),
+              onUpdateType: type => updateConditionType && updateConditionType(i, type),
             }}
           >
             <Node />

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -7,6 +7,7 @@ import {
 } from 'sentry/types/workflowEngine/dataConditions';
 import AgeComparisonNode from 'sentry/views/automations/components/actionFilters/ageComparison';
 import EventAttributeNode from 'sentry/views/automations/components/actionFilters/eventAttribute';
+import EventFrequencyNode from 'sentry/views/automations/components/actionFilters/eventFrequency';
 import IssueOccurrencesNode from 'sentry/views/automations/components/actionFilters/issueOccurrences';
 import IssuePriorityNode from 'sentry/views/automations/components/actionFilters/issuePriority';
 import LatestAdoptedReleaseNode from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
@@ -16,7 +17,8 @@ import TaggedEventNode from 'sentry/views/automations/components/actionFilters/t
 interface DataConditionNodeProps {
   condition: NewDataCondition;
   condition_id: string;
-  onUpdate: (condition: Record<string, any>) => void;
+  onUpdate: (comparison: Record<string, any>) => void;
+  onUpdateType: (type: DataConditionType) => void;
 }
 
 export const DataConditionNodeContext = createContext<DataConditionNodeProps | null>(
@@ -111,6 +113,27 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Event level'),
       dataCondition: <LevelNode />,
+    },
+  ],
+  [
+    DataConditionType.EVENT_FREQUENCY,
+    {
+      label: t('Number of events'),
+      dataCondition: <EventFrequencyNode />,
+    },
+  ],
+  [
+    DataConditionType.EVENT_FREQUENCY_COUNT,
+    {
+      label: t('Number of events'),
+      dataCondition: <EventFrequencyNode />,
+    },
+  ],
+  [
+    DataConditionType.EVENT_FREQUENCY_PERCENT,
+    {
+      label: t('Number of events'),
+      dataCondition: <EventFrequencyNode />,
     },
   ],
 ]);


### PR DESCRIPTION
adding the event frequency data condition node which has special branching. other special branching data condition nodes (unique user and percent sessions) will come in the next PR.

this required adding another `updateIfConditionType` action to the automation builder reducer in order to update the data condition's `comparison_type` depending on which option was selected (count/frequency)

https://github.com/user-attachments/assets/ef2df300-1b53-4a5e-929c-5291adbdc598

