### PR TITLE
feat(workflow_engine): Add state tracking for priority levels for stateful detectors

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/index.md
+++ b/src/sentry/workflow_engine/handlers/detector/index.md
@@ -2,7 +2,19 @@
 
 ## DetectorHandler
 
-## StatefulDetector
+The Base `DetectorHandler` abstraction can be used to evaluate DataPackets that can be evaluated by a Detector, and don't require any stateful tracking.
+
+Some examples of these detectors are:
+
+- N+1 Query Detector: It can evaluate the number of queries in a span, and determine that it needs to create an issue.
+
+## StatefulDetectorHandler
+
+The `StatefulDetectorHandler` is used when you need to have knowledge of a previous state to have the detector update correctly.
+
+Examples of stateful detectors are:
+
+- Metric Issues: These issues are based on a metric in time, if the metric breaches a threshold, the detector will create or resolve an issue correspondingly.
 
 ### Evaluations (`.evaluate`)
 

--- a/src/sentry/workflow_engine/handlers/detector/index.md
+++ b/src/sentry/workflow_engine/handlers/detector/index.md
@@ -1,0 +1,29 @@
+# Detectors
+
+## DetectorHandler
+
+## StatefulDetector
+
+### Evaluations (`.evaluate`)
+
+This method will be called for each data packet that is processed by the detector.
+
+The detector will extract the data from each packet, evaluate the conditions, and return a DetectorEvaluationResult or a group of them.
+
+### Thresholds (`.thresholds`)
+
+StatefulDetectorHandlers will track each time the detector reaches a PriorityLevel.
+
+If a PriorityLevel's threshold is reached, the detector will create an issue occurrence. By default, each PriorityLevel's threshold value is set to 1, so the detector will create an issue occurrence each time it reaches that PriorityLevel.
+
+To override these thresholds use the `counters` property in the constructor.
+
+For example:
+
+```python
+class ExampleDetectorHandler(StatefulDetectorHandler):
+    thresholds: DetectorThresholds = {
+        DetectorPriorityLevel.LOW: 10,
+        DetectorPriorityLevel.HIGH: 5,
+    }
+```

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -271,31 +271,6 @@ class StatefulDetectorHandler(
 ):
     """
     Stateful Detectors are provided as a base class for new detectors that need to track state.
-
-    See below for helpful hooks and methods to override.
-    # TODO @saponifi3d - turn this into a markdown file
-    ``````````````````
-    ## Detector Evaluations (`StatefulDetectorHandler.evaluate`)
-    This method will be called for each data packet that is processed by the detector.
-
-    The detector will extract the data from each packet, evaluate the conditions, and return a
-    DetectorEvaluationResult or a group of them.
-
-    ## Detector Counters
-    StatefulDetectorHandlers will track each time the detector reaches a PriorityLevel.
-
-    If a PriorityLevel's threshold is reached, the detector will create an issue occurrence.  By default,
-    each PriorityLevel's threshold value is set to 1, so the detector will create an issue
-    occurrence each time it reaches that PriorityLevel.
-
-    To override these thresholds use the `counters` property in the constructor. For example:
-    ```python
-    class ExampleDetectorHandler(StatefulDetectorHandler):
-        thresholds: DetectorThresholds = {
-            DetectorPriorityLevel.LOW: 10,
-            DetectorPriorityLevel.HIGH: 5,
-        }
-    ```
     """
 
     thresholds: DetectorThresholds = {}

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -80,6 +80,14 @@ class DetectorStateManager:
     def enqueue_dedupe_update(self, group_key: DetectorGroupKey, dedupe_value: int):
         self.dedupe_updates[group_key] = dedupe_value
 
+    def enqueue_counter_reset(self, group_key: DetectorGroupKey = None) -> None:
+        """
+        Resets the counter values for the detector.
+        This method is to reset the counters when the detector is resolved.
+        """
+        for counter in self.counter_names:
+            self.counter_updates[group_key][counter] = None
+
     def enqueue_counter_update(
         self, group_key: DetectorGroupKey, counter_updates: DetectorCounters
     ):
@@ -265,6 +273,7 @@ class StatefulDetectorHandler(
     Stateful Detectors are provided as a base class for new detectors that need to track state.
 
     See below for helpful hooks and methods to override.
+    # TODO @saponifi3d - turn this into a markdown file
     ``````````````````
     ## Detector Evaluations (`StatefulDetectorHandler.evaluate`)
     This method will be called for each data packet that is processed by the detector.
@@ -521,6 +530,9 @@ class StatefulGroupingDetectorHandler(
                 new_status=GroupStatus.RESOLVED,
                 new_substatus=None,
             )
+
+            # Now that we've resolved the issue, we can reset the counters
+            self.state_manager.enqueue_counter_reset(group_key)
         else:
             detector_occurrence, event_data = self.create_occurrence(
                 processed_data_condition, data_packet, new_status

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -379,6 +379,9 @@ class StatefulDetectorHandler(
         self,
         updated_threshold_counts: DetectorCounters,
     ) -> DetectorPriorityLevel | None:
+        # TODO @saponifi3d - Should this only be for thresholds configured on the detector?
+        # If so, gather the self.detector.when_condition_group.conditions()
+        # and see which ones are configured.
         threshold_keys: list[DetectorPriorityLevel] = list(self._thresholds.keys())
         threshold_keys.sort(reverse=True)
         for level in threshold_keys:

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -284,12 +284,7 @@ class StatefulDetectorHandler(
             **(thresholds or {}),  # Allow each instance to override
         }
 
-        # Merge all kinds of counters together for the state manager
-        counters = {
-            **self._thresholds,
-        }
-
-        self.state_manager = DetectorStateManager(detector, list(counters.keys()))
+        self.state_manager = DetectorStateManager(detector, list(self._thresholds.keys()))
 
     def build_issue_fingerprint(self, group_key: DetectorGroupKey = None) -> list[str]:
         return []

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -372,9 +372,8 @@ class StatefulDetectorHandler(
         condition_evaluation, new_priority = self._evaluation_detector_conditions(value)
         state = self.state_manager.get_state_data([None])[None]
 
-        if (state.status == new_priority) or (  # The status hasn't changed
-            not condition_evaluation
-        ):  # If the condition is not met
+        if not condition_evaluation or state.status == new_priority:
+            # If the condition is not met or the status is not the same, nothing to do
             return None
 
         updated_status_count = (state.counter_updates.get(new_priority) or 0) + 1

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -54,11 +54,6 @@ def status_change_comparator(self: StatusChangeMessage, other: StatusChangeMessa
 
 
 class MockDetectorStateHandler(StatefulGroupingDetectorHandler[dict, int | None]):
-    counter_names = ["test1", "test2"]
-
-    def test_get_empty_counter_state(self):
-        return {name: None for name in self.counter_names}
-
     def extract_dedupe_value(self, data_packet: DataPacket[dict]) -> int:
         return data_packet.packet.get("dedupe", 0)
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -13,6 +13,7 @@ from sentry.workflow_engine.handlers.detector import (
     DetectorOccurrence,
     StatefulGroupingDetectorHandler,
 )
+from sentry.workflow_engine.handlers.detector.stateful import DetectorCounters
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
@@ -54,6 +55,9 @@ def status_change_comparator(self: StatusChangeMessage, other: StatusChangeMessa
 
 
 class MockDetectorStateHandler(StatefulGroupingDetectorHandler[dict, int | None]):
+    def test_get_empty_counter_state(self):
+        return {name: None for name in self.state_manager.counter_names}
+
     def extract_dedupe_value(self, data_packet: DataPacket[dict]) -> int:
         return data_packet.packet.get("dedupe", 0)
 
@@ -211,7 +215,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         handler: StatefulGroupingDetectorHandler,
         group_key: DetectorGroupKey | None,
         dedupe_value: int | None,
-        counter_updates: dict[str, Any] | None,
+        counter_updates: DetectorCounters | None,
         is_triggered: bool | None,
         priority: DetectorPriorityLevel | None,
     ):

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -144,7 +144,13 @@ class TestStatefulDetectorHandlerEvaluate(TestCase):
 
     def test_evaualte__override_threshold(self):
         result = self.handler.evaluate(self.data_packet)
-        assert result == {}
+        evaluation_result = result[self.group_key]
+
+        # Check that the detector is triggered in a medium priority.
+        assert evaluation_result
+        assert evaluation_result.priority == DetectorPriorityLevel.MEDIUM
+        assert evaluation_result.is_triggered is True
+        assert isinstance(evaluation_result.result, IssueOccurrence)
 
     def test_evaluate__override_threshold__triggered(self):
         self.handler.evaluate(self.data_packet)

--- a/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_stateful.py
@@ -1,0 +1,83 @@
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.models import DataPacket
+from sentry.workflow_engine.types import DetectorPriorityLevel
+from tests.sentry.workflow_engine.handlers.detector.test_base import MockDetectorStateHandler
+
+
+class TestStatefulDetectorHandler(TestCase):
+    def setUp(self):
+        self.detector = self.create_detector(
+            name="Stateful Detector",
+            project=self.project,
+        )
+
+    def test__init_creates_default_thresholds(self):
+        handler = MockDetectorStateHandler(detector=self.detector)
+        assert handler._thresholds == {
+            DetectorPriorityLevel.HIGH: 1,
+            DetectorPriorityLevel.MEDIUM: 1,
+            DetectorPriorityLevel.LOW: 1,
+            DetectorPriorityLevel.OK: 1,
+        }
+
+    def test_init__override_thresholds(self):
+        handler = MockDetectorStateHandler(
+            detector=self.detector,
+            thresholds={
+                DetectorPriorityLevel.HIGH: 1,
+                DetectorPriorityLevel.LOW: 2,
+                DetectorPriorityLevel.OK: 1,
+            },
+        )
+
+        assert handler._thresholds == {
+            DetectorPriorityLevel.HIGH: 1,
+            DetectorPriorityLevel.MEDIUM: 1,
+            DetectorPriorityLevel.LOW: 2,
+            DetectorPriorityLevel.OK: 1,
+        }
+
+    def test_init__creates_correct_state_counters(self):
+        handler = MockDetectorStateHandler(detector=self.detector)
+        assert handler.state_manager.counter_names == [
+            DetectorPriorityLevel.OK,
+            DetectorPriorityLevel.LOW,
+            DetectorPriorityLevel.MEDIUM,
+            DetectorPriorityLevel.HIGH,
+        ]
+
+    def test_evaluate__counters_increment(self):
+        self.detector.workflow_condition_group = self.create_data_condition_group()
+        self.create_data_condition(
+            type="gte",
+            comparison=0,
+            condition_group=self.detector.workflow_condition_group,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        handler = MockDetectorStateHandler(
+            detector=self.detector, thresholds={DetectorPriorityLevel.HIGH: 2}
+        )
+        data_packet = DataPacket(
+            source_id="1",
+            packet={
+                "id": "1",
+                "group_vals": {None: 1},
+                "dedupe": 1,
+            },
+        )
+        result = handler.evaluate(data_packet)
+        assert result == {}
+
+        data_packet_two = DataPacket(
+            source_id="2",
+            packet={
+                "id": "2",
+                "group_vals": {None: 1},
+                "dedupe": 2,
+            },
+        )
+        result = handler.evaluate(data_packet_two)
+        import pdb
+
+        pdb.set_trace()
+        assert result == {}  # TODO this should be a detector result

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -269,7 +269,11 @@ class TestGetStateData(BaseDetectorHandlerTest):
         key = "test_key"
         assert handler.state_manager.get_state_data([key]) == {
             key: DetectorStateData(
-                key, False, DetectorPriorityLevel.OK, 0, {"test1": None, "test2": None}
+                group_key=key,
+                is_triggered=False,
+                status=DetectorPriorityLevel.OK,
+                dedupe_value=0,
+                counter_updates={level: None for level in handler._thresholds},
             )
         }
 
@@ -277,7 +281,14 @@ class TestGetStateData(BaseDetectorHandlerTest):
         handler = self.build_handler()
         key = "test_key"
         state_data = DetectorStateData(
-            key, True, DetectorPriorityLevel.OK, 10, {"test1": 5, "test2": 200}
+            group_key=key,
+            is_triggered=True,
+            status=DetectorPriorityLevel.OK,
+            dedupe_value=10,
+            counter_updates={
+                **{level: None for level in handler._thresholds},
+                DetectorPriorityLevel.HIGH: 1,
+            },
         )
         handler.state_manager.enqueue_dedupe_update(state_data.group_key, state_data.dedupe_value)
         handler.state_manager.enqueue_counter_update(
@@ -293,7 +304,15 @@ class TestGetStateData(BaseDetectorHandlerTest):
         handler = self.build_handler()
         key_1 = "test_key_1"
         state_data_1 = DetectorStateData(
-            key_1, True, DetectorPriorityLevel.OK, 100, {"test1": 50, "test2": 300}
+            group_key=key_1,
+            is_triggered=True,
+            status=DetectorPriorityLevel.OK,
+            dedupe_value=100,
+            counter_updates={
+                **{level: None for level in handler._thresholds},
+                DetectorPriorityLevel.OK: 5,
+                DetectorPriorityLevel.MEDIUM: 1,
+            },
         )
         handler.state_manager.enqueue_dedupe_update(key_1, state_data_1.dedupe_value)
         handler.state_manager.enqueue_counter_update(key_1, state_data_1.counter_updates)
@@ -303,7 +322,14 @@ class TestGetStateData(BaseDetectorHandlerTest):
 
         key_2 = "test_key_2"
         state_data_2 = DetectorStateData(
-            key_2, True, DetectorPriorityLevel.OK, 10, {"test1": 55, "test2": 12}
+            group_key=key_2,
+            is_triggered=True,
+            status=DetectorPriorityLevel.OK,
+            dedupe_value=10,
+            counter_updates={
+                **{level: None for level in handler._thresholds},
+                DetectorPriorityLevel.HIGH: 5,
+            },
         )
         handler.state_manager.enqueue_dedupe_update(key_2, state_data_2.dedupe_value)
         handler.state_manager.enqueue_counter_update(key_2, state_data_2.counter_updates)
@@ -313,7 +339,11 @@ class TestGetStateData(BaseDetectorHandlerTest):
 
         key_uncommitted = "test_key_uncommitted"
         state_data_uncommitted = DetectorStateData(
-            key_uncommitted, False, DetectorPriorityLevel.OK, 0, {"test1": None, "test2": None}
+            group_key=key_uncommitted,
+            is_triggered=False,
+            status=DetectorPriorityLevel.OK,
+            dedupe_value=0,
+            counter_updates={level: None for level in handler._thresholds},
         )
         handler.state_manager.commit_state_updates()
         assert handler.state_manager.get_state_data([key_1, key_2, key_uncommitted]) == {
@@ -406,7 +436,10 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler,
             "val1",
             2,
-            handler.test_get_empty_counter_state(),
+            {
+                **handler.test_get_empty_counter_state(),
+                DetectorPriorityLevel.HIGH: 1,
+            },
             True,
             DetectorPriorityLevel.HIGH,
         )
@@ -502,7 +535,10 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler,
             "val1",
             2,
-            handler.test_get_empty_counter_state(),
+            {
+                **handler.test_get_empty_counter_state(),
+                DetectorPriorityLevel.HIGH: 1,
+            },
             True,
             DetectorPriorityLevel.HIGH,
         )
@@ -542,7 +578,10 @@ class TestEvaluate(BaseDetectorHandlerTest):
             handler,
             "val1",
             2,
-            handler.test_get_empty_counter_state(),
+            {
+                **handler.test_get_empty_counter_state(),
+                DetectorPriorityLevel.HIGH: 1,
+            },
             True,
             DetectorPriorityLevel.HIGH,
         )
@@ -554,7 +593,15 @@ class TestEvaluate(BaseDetectorHandlerTest):
                 "workflow_engine.detector.skipping_already_processed_update"
             )
         self.assert_updates(
-            handler, "val1", None, handler.test_get_empty_counter_state(), None, None
+            handler,
+            "val1",
+            None,
+            {
+                **handler.test_get_empty_counter_state(),
+                DetectorPriorityLevel.HIGH: 1,
+            },
+            None,
+            None,
         )
 
 

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -311,7 +311,6 @@ class TestGetStateData(BaseDetectorHandlerTest):
             counter_updates={
                 **{level: None for level in handler._thresholds},
                 DetectorPriorityLevel.OK: 5,
-                DetectorPriorityLevel.MEDIUM: 1,
             },
         )
         handler.state_manager.enqueue_dedupe_update(key_1, state_data_1.dedupe_value)


### PR DESCRIPTION
## Description
Implement state tracking for threshold changes on detectors.

This is pt 4 of the great stateful detector refactoring. Taking a moment to also document these changes. For now, adding these as inline markdown. (Not sure if we have a way to do docgen from comment headers or not)

_Up next,_ - the final refactoring - make the `Stateful` handler easier to reckon with grouping.