### PR TITLE
fix(whats-new): No box-shadow when title is focused

### DIFF
--- a/static/app/components/sidebar/broadcastPanelItem.tsx
+++ b/static/app/components/sidebar/broadcastPanelItem.tsx
@@ -65,6 +65,9 @@ const Title = styled(ExternalLink)<Pick<BroadcastPanelItemProps, 'hasSeen'>>`
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.blue400};
   ${p => !p.hasSeen && `font-weight: ${p.theme.fontWeightBold}`};
+  &:focus-visible {
+    box-shadow: none;
+  }
 `;
 
 const Message = styled('div')`


### PR DESCRIPTION
**Before**

https://github.com/user-attachments/assets/002db439-4771-49fd-a83f-56f5f32009b0


**After**


https://github.com/user-attachments/assets/23f9eb4a-1dcc-4f67-a830-fc017cceed54

