### PR TITLE
chore(seer): Update gen AI toggle copy

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -14,12 +14,15 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
   return {
     name: 'hideAiFeatures',
     type: 'boolean',
-    label: t('Enable Generative AI features'),
-    help: tct('Enables [docs:features] powered by Generative AI', {
-      docs: (
-        <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/" />
-      ),
-    }),
+    label: t('Show Generative AI Features'),
+    help: tct(
+      'Allows organization members to use [docs:features] powered by generative AI',
+      {
+        docs: (
+          <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/" />
+        ),
+      }
+    ),
     defaultValue: defaultEnableSeerFeaturesValue(organization),
     disabled: ({access}) => !access.has('org:write'),
     getValue: value => {

--- a/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/aiFeatureSettings.tsx
@@ -16,7 +16,7 @@ export const makeHideAiFeaturesField = (organization: Organization): FieldObject
     type: 'boolean',
     label: t('Show Generative AI Features'),
     help: tct(
-      'Allows organization members to use [docs:features] powered by generative AI',
+      'Allows organization members to access [docs:features] powered by generative AI',
       {
         docs: (
           <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/" />

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -175,7 +175,7 @@ describe('OrganizationSettingsForm', function () {
     );
   });
 
-  it('can toggle "Enable Seer Features"', async function () {
+  it('can toggle "Show Generative AI Features"', async function () {
     // Default org fixture has hideAiFeatures: false, so Seer is enabled by default
     const hiddenAiOrg = OrganizationFixture({hideAiFeatures: true});
     render(
@@ -192,7 +192,7 @@ describe('OrganizationSettingsForm', function () {
     });
 
     const checkbox = screen.getByRole('checkbox', {
-      name: 'Enable Generative AI features',
+      name: 'Show Generative AI Features',
     });
 
     // Inverted from hideAiFeatures
@@ -245,7 +245,7 @@ describe('OrganizationSettingsForm', function () {
       }
     );
 
-    const toggle = screen.getByRole('checkbox', {name: 'Enable Generative AI features'});
+    const toggle = screen.getByRole('checkbox', {name: 'Show Generative AI Features'});
     expect(toggle).toBeEnabled();
   });
 });


### PR DESCRIPTION
Updates copy of gen AI settings toggle for clarity so it reads more as a kill switch than part of the consent flow