### PR TITLE
fix(eap-alerts): Use the correct entity key

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -415,7 +415,7 @@ def get_metric_issue_aggregates(
                 "incidents.get_incident_aggregates.snql.query.error",
                 tags={
                     "dataset": params.snuba_query.dataset,
-                    "entity": EntityKey.EAPSpans.value,
+                    "entity": EntityKey.EAPItemsSpan.value,
                 },
             )
             raise

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -79,7 +79,7 @@ from sentry.utils.validators import INVALID_ID_DETAILS, INVALID_SPAN_ID, WILDCAR
 DATASET_TO_ENTITY_MAP: Mapping[Dataset, EntityKey] = {
     Dataset.Events: EntityKey.Events,
     Dataset.Transactions: EntityKey.Transactions,
-    Dataset.EventsAnalyticsPlatform: EntityKey.EAPSpans,
+    Dataset.EventsAnalyticsPlatform: EntityKey.EAPItemsSpan,
 }
 
 

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -60,7 +60,6 @@ class EntityKey(Enum):
     Events = "events"
     Sessions = "sessions"
     Spans = "spans"
-    EAPSpans = "eap_spans"
     EAPItemsSpan = "eap_items_span"
     Transactions = "transactions"
     MetricsSets = "metrics_sets"

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -60,6 +60,7 @@ class EntityKey(Enum):
     Events = "events"
     Sessions = "sessions"
     Spans = "spans"
+    EAPSpans = "eap_spans"
     EAPItemsSpan = "eap_items_span"
     Transactions = "transactions"
     MetricsSets = "metrics_sets"

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -61,6 +61,7 @@ class EntityKey(Enum):
     Sessions = "sessions"
     Spans = "spans"
     EAPSpans = "eap_spans"
+    EAPItemsSpan = "eap_items_span"
     Transactions = "transactions"
     MetricsSets = "metrics_sets"
     MetricsCounters = "metrics_counters"

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -49,6 +49,7 @@ ENTITY_TIME_COLUMNS: Mapping[EntityKey, str] = {
     EntityKey.MetricsCounters: "timestamp",
     EntityKey.MetricsSets: "timestamp",
     EntityKey.EAPSpans: "timestamp",
+    EntityKey.EAPItemsSpan: "timestamp",
 }
 CRASH_RATE_ALERT_AGGREGATE_RE = (
     r"^percentage\([ ]*(sessions_crashed|users_crashed)[ ]*\,[ ]*(sessions|users)[ ]*\)"
@@ -621,7 +622,7 @@ def get_entity_key_from_snuba_query(
 ) -> EntityKey:
     query_dataset = Dataset(snuba_query.dataset)
     if query_dataset == Dataset.EventsAnalyticsPlatform:
-        return EntityKey.EAPSpans
+        return EntityKey.EAPItemsSpan
     entity_subscription = get_entity_subscription_from_snuba_query(
         snuba_query,
         organization_id,

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -48,7 +48,6 @@ ENTITY_TIME_COLUMNS: Mapping[EntityKey, str] = {
     EntityKey.GenericMetricsGauges: "timestamp",
     EntityKey.MetricsCounters: "timestamp",
     EntityKey.MetricsSets: "timestamp",
-    EntityKey.EAPSpans: "timestamp",
     EntityKey.EAPItemsSpan: "timestamp",
 }
 CRASH_RATE_ALERT_AGGREGATE_RE = (

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -148,7 +148,7 @@ def update_subscription_in_snuba(
             },
         )
         old_entity_key = (
-            EntityKey.EAPSpans
+            EntityKey.EAPItemsSpan
             if dataset == Dataset.EventsAnalyticsPlatform
             else get_entity_key_from_query_builder(
                 old_entity_subscription.build_query_builder(

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -370,15 +370,19 @@ class UpdateSubscriptionInSnubaTest(BaseSnubaTaskTest):
         assert sub.status == QuerySubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
 
-        sub.status = QuerySubscription.Status.UPDATING.value
         sub.update(
             status=QuerySubscription.Status.UPDATING.value,
-            subscription_id=sub.subscription_id,
         )
         update_subscription_in_snuba(sub.id)
         sub = QuerySubscription.objects.get(id=sub.id)
         assert sub.status == QuerySubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
+
+        sub.update(
+            status=QuerySubscription.Status.DELETING.value,
+        )
+        delete_subscription_from_snuba(sub.id)
+        assert not QuerySubscription.objects.filter(id=sub.id).exists()
 
 
 class DeleteSubscriptionFromSnubaTest(BaseSnubaTaskTest):

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -409,7 +409,7 @@ class DeleteSubscriptionFromSnubaTest(BaseSnubaTaskTest):
         delete_subscription_from_snuba(sub.id)
         assert not QuerySubscription.objects.filter(id=sub.id).exists()
 
-    def test_eap_rpc_query_count_delete(self):
+    def test_eap_rpc_query_count(self):
         subscription_id = f"1/{uuid4().hex}"
         sub = self.create_subscription(
             QuerySubscription.Status.DELETING,


### PR DESCRIPTION
Also updates all the integration tests to not mock snuba calls.
These tests should have caught that EntityKey.EAPSpans was
no longer an available option.
Also tests creating + updating + deleting a subscription in a
single tests since `create` uses a new RPC whereas `delete`
uses an older endpoint