### PR TITLE
fix(dashboards): Remove 30d query warning for spans widgets

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -17,13 +17,11 @@ import type {Confidence, Organization} from 'sentry/types/organization';
 import {getFormattedDate} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
-import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import {useExtractionStatus} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -31,12 +29,8 @@ import withPageFilters from 'sentry/utils/withPageFilters';
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {DASHBOARD_CHART_GROUP} from 'sentry/views/dashboards/dashboard';
 import {useDiscoverSplitAlert} from 'sentry/views/dashboards/discoverSplitAlert';
-import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
-import {
-  DisplayType,
-  OnDemandExtractionState,
-  WidgetType,
-} from 'sentry/views/dashboards/types';
+import type {DashboardFilters, Widget, WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType, OnDemandExtractionState} from 'sentry/views/dashboards/types';
 import {DEFAULT_RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
@@ -167,7 +161,6 @@ function WidgetCard(props: Props) {
   const onDemandWarning = useOnDemandWarning({widget});
   const discoverSplitAlert = useDiscoverSplitAlert({widget, onSetTransactionsDataset});
   const sessionDurationWarning = hasSessionDuration ? SESSION_DURATION_ALERT_TEXT : null;
-  const spanTimeRangeWarning = useTimeRangeWarning({widget});
 
   const onFullScreenViewClick = () => {
     if (!isWidgetViewerPath(location.pathname)) {
@@ -207,12 +200,9 @@ function WidgetCard(props: Props) {
 
   const badges = [indexedDataBadge, onDemandExtractionBadge].filter(n => n !== undefined);
 
-  const warnings = [
-    onDemandWarning,
-    discoverSplitAlert,
-    sessionDurationWarning,
-    spanTimeRangeWarning,
-  ].filter(Boolean) as string[];
+  const warnings = [onDemandWarning, discoverSplitAlert, sessionDurationWarning].filter(
+    Boolean
+  ) as string[];
 
   const actionsDisabled = Boolean(props.isPreview);
   const actionsMessage = actionsDisabled
@@ -323,26 +313,6 @@ function useOnDemandWarning(props: {widget: Widget}): string | null {
   if (widgetReachedSpecLimit) {
     return t(
       "This widget is using indexed data because you've reached your organization limit for dynamically extracted metrics."
-    );
-  }
-
-  return null;
-}
-
-function useTimeRangeWarning(props: {widget: Widget}) {
-  const {
-    selection: {datetime},
-  } = usePageFilters();
-
-  if (props.widget.widgetType !== WidgetType.SPANS) {
-    return null;
-  }
-
-  if (statsPeriodToDays(datetime.period, datetime.start, datetime.end) > 30) {
-    // This message applies if the user has selected a time range >30d because we truncate the
-    // snuba response to 30 days to reduce load on the system.
-    return t(
-      "Spans-based widgets have been truncated to 30 days of data. We're working on ramping this up."
     );
   }
 


### PR DESCRIPTION
We support 90d queries now. Remove this warning