### PR TITLE
feat(releases): Add separate y-axis for release bubbles

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -938,6 +938,19 @@ export default storyBook('TimeSeriesWidgetVisualization', (story, APIReference) 
             />
           </MediumWidget>
         </SideBySide>
+        <SideBySide>
+          <MediumWidget>
+            <TimeSeriesWidgetVisualization
+              plottables={[
+                new Line(sampleThroughputTimeSeries),
+                new Line(sampleDurationTimeSeries),
+                new Line(sampleDurationTimeSeriesP50),
+              ]}
+              releases={releases}
+              showReleaseAs="bubble"
+            />
+          </MediumWidget>
+        </SideBySide>
       </Fragment>
     );
   });

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -69,6 +69,7 @@ interface ReleaseBubbleSeriesProps {
   };
   releases: ReleaseMetaBasic[];
   theme: Theme;
+  yAxisIndex?: number;
 }
 
 /**
@@ -82,6 +83,7 @@ function ReleaseBubbleSeries({
   bubblePadding,
   dateFormatOptions,
   alignInMiddle,
+  yAxisIndex,
 }: ReleaseBubbleSeriesProps): CustomSeriesOption | null {
   const totalReleases = buckets.reduce((acc, {releases}) => acc + releases.length, 0);
   const avgReleases = totalReleases / buckets.length;
@@ -190,6 +192,7 @@ function ReleaseBubbleSeries({
   return {
     id: BUBBLE_SERIES_ID,
     type: 'custom',
+    yAxisIndex,
     renderItem: renderReleaseBubble,
     name: t('Releases'),
     data,
@@ -286,6 +289,10 @@ interface UseReleaseBubblesParams {
    * List of releases that will be grouped
    */
   releases?: ReleaseMetaBasic[];
+  /**
+   * The index of the y-axis to use for the release bubbles
+   */
+  yAxisIndex?: number;
 }
 
 export function useReleaseBubbles({
@@ -297,6 +304,7 @@ export function useReleaseBubbles({
   environments,
   projects,
   legendSelected,
+  yAxisIndex,
   alignInMiddle = false,
   bubbleSize = 4,
   bubblePadding = 2,
@@ -342,6 +350,17 @@ export function useReleaseBubbles({
     }),
     [bubbleSize, totalBubblePaddingY]
   );
+
+  const releaseBubbleYAxis = useMemo(
+    () => ({
+      type: 'value' as const,
+      min: 0,
+      max: 100,
+      show: false,
+    }),
+    []
+  );
+
   const releaseBubbleGrid = useMemo(
     () => ({
       // Moves bottom of grid "up" `bubbleSize` pixels so that bubbles are
@@ -600,6 +619,7 @@ export function useReleaseBubbles({
       ReleaseBubbleSeries: null,
       releaseBubbleXAxis: {},
       releaseBubbleGrid: {},
+      releaseBubbleYAxis: null,
     };
   }
 
@@ -610,6 +630,7 @@ export function useReleaseBubbles({
      * Series to append to a chart's existing `series`
      */
     releaseBubbleSeries: ReleaseBubbleSeries({
+      yAxisIndex,
       alignInMiddle,
       buckets,
       bubbleSize,
@@ -621,6 +642,8 @@ export function useReleaseBubbles({
         timezone: options.timezone,
       },
     }),
+
+    releaseBubbleYAxis,
 
     /**
      * ECharts xAxis configuration. Spread/override charts `xAxis` prop.


### PR DESCRIPTION
By default, release bubbles will use the default y-axis. This generally works except when the chart does not start at "y=0" as the bubbles are hard-coded to show below "y=0". With this change, the `useReleaseBubbles` hook returns a yaxis object that the hook consumer can use to pass to echarts -- you will also need to configure `yaxisIndex` to tell the release bubbles series which yaxis to use. This works by adding a new yaxis to decouple release bubbles series from the default yaxis. This new yaxis is configured to be hidden.

This also works if you ignore the returned y-axis object and don't specify a `yaxisIndex` since it will use the default yaxis (assuming it starts at 0).

Unblocks https://github.com/getsentry/sentry/pull/90247