### PR TITLE
ref(js): Prefer testing in UTC

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -1,11 +1,9 @@
-import {ConfigFixture} from 'sentry-fixture/config';
 import {ThemeFixture} from 'sentry-fixture/theme';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -148,26 +146,13 @@ describe('getFieldRenderer', function () {
   });
 
   describe('date', function () {
-    beforeEach(function () {
-      ConfigStore.loadInitialData(
-        ConfigFixture({
-          user: UserFixture({
-            options: {
-              ...UserFixture().options,
-              timezone: 'America/Los_Angeles',
-            },
-          }),
-        })
-      );
-    });
-
     it('can render date fields', async function () {
       const renderer = getFieldRenderer('createdAt', {createdAt: 'date'});
       render(
         renderer(data, {location, organization, theme}) as React.ReactElement<any, any>
       );
 
-      await screen.findByText('Oct 3, 2019 9:13:14 AM PDT');
+      await screen.findByText('Oct 3, 2019 4:13:14 PM UTC');
     });
 
     it('can render date fields using utc when query string has utc set to true', async function () {
@@ -194,18 +179,6 @@ describe('getFieldRenderer', function () {
   });
 
   it('can render timestamp.to_day', function () {
-    // Set timezone
-    ConfigStore.loadInitialData(
-      ConfigFixture({
-        user: UserFixture({
-          options: {
-            ...UserFixture().options,
-            timezone: 'America/Los_Angeles',
-          },
-        }),
-      })
-    );
-
     const renderer = getFieldRenderer('timestamp.to_day', {'timestamp.to_day': 'date'});
     render(
       renderer(data, {location, organization, theme}) as React.ReactElement<any, any>

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -5,28 +5,10 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import type {Config} from 'sentry/types/system';
-import type {User} from 'sentry/types/user';
 import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 
 describe('OrganizationAuditLog', function () {
-  const user: User = {
-    ...UserFixture(),
-    options: {
-      ...UserFixture().options,
-      clock24Hours: true,
-      timezone: 'America/Los_Angeles',
-    },
-  };
-
-  const config: Config = {...ConfigStore.getState(), user};
-
-  beforeEach(() => {
-    ConfigStore.loadInitialData(config);
-  });
-
   it('renders', async function () {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/audit-logs/`,
@@ -72,7 +54,7 @@ describe('OrganizationAuditLog', function () {
     expect(await screen.findByText('project.remove')).toBeInTheDocument();
     expect(screen.getByText('org.create')).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
-    expect(screen.getByText('17:29 PDT')).toBeInTheDocument();
+    expect(screen.getByText('12:29 AM UTC')).toBeInTheDocument();
   });
 
   it('Displays pretty dynamic sampling logs', async function () {


### PR DESCRIPTION
These two tests where just testing that DateTime does what is supposed
to, but we can leave that testing up to the DateTime tests themselves.