### PR TITLE
fix(grouping): Fix enhancement caching bugs

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -16,7 +16,7 @@ from sentry.grouping.component import (
     DefaultGroupingComponent,
     SystemGroupingComponent,
 )
-from sentry.grouping.enhancer import LATEST_VERSION, Enhancements, get_enhancements_version
+from sentry.grouping.enhancer import Enhancements, get_enhancements_version
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.strategies.base import DEFAULT_GROUPING_ENHANCEMENTS_BASE, GroupingContext
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
@@ -93,6 +93,7 @@ class GroupingConfigLoader:
 
         config_id = self._get_config_id(project)
         enhancements_base = CONFIGURATIONS[config_id].enhancements_base
+        enhancements_version = get_enhancements_version(project, config_id)
 
         # Instead of parsing and dumping out config here, we can make a
         # shortcut
@@ -100,7 +101,7 @@ class GroupingConfigLoader:
         from sentry.utils.hashlib import md5_text
 
         cache_prefix = self.cache_prefix
-        cache_prefix += f"{LATEST_VERSION}:"
+        cache_prefix += f"{enhancements_version}:"
         cache_key = (
             cache_prefix
             + md5_text(
@@ -124,7 +125,7 @@ class GroupingConfigLoader:
             enhancements = Enhancements.from_rules_text(
                 enhancements_string,
                 bases=[enhancements_base] if enhancements_base else [],
-                version=get_enhancements_version(project, config_id),
+                version=enhancements_version,
                 referrer="project_rules",
             ).base64_string
         except InvalidEnhancerConfig:


### PR DESCRIPTION
This fixes two bugs with our system for caching grouping enhancements:

- The cache key includes the enhancements version, but it's hardcoded to be the default version, rather than the version of the enhancements being cached.
- If we try to load enhancements from the cache (or from an event, as we do when getting grouping info) that have an invalid version, currently the whole process crashes. This is most likely to happen if we store enhancements with a certain version in an event, we then created a new version and remove the old one, and then try to load the stored enhancements. We already fall back to the defaults if the grouping config version is invalid, and we should do the same if the enhancement version is invalid.

This also adds a few tests testing caching behavior.