### PR TITLE
fix(aci milestone 3): fix failing data condition tests

### DIFF
--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -76,7 +76,7 @@ class ProjectAlertRuleTaskDetailsTest(APITestCase):
             alert_rule_trigger=self.critical_trigger
         )
         _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.rule)
-        self.critical_detector_trigger, _ = migrate_metric_data_conditions(self.critical_trigger)
+        self.critical_detector_trigger, _, _ = migrate_metric_data_conditions(self.critical_trigger)
 
         self.critical_action, _, _ = migrate_metric_action(self.critical_trigger_action)
         self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(self.rule)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -236,7 +236,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
             alert_rule_trigger=critical_trigger
         )
         _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        self.critical_detector_trigger, _ = migrate_metric_data_conditions(critical_trigger)
+        self.critical_detector_trigger, _, _ = migrate_metric_data_conditions(critical_trigger)
 
         self.critical_action, _, _ = migrate_metric_action(critical_trigger_action)
         self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(
@@ -719,7 +719,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             alert_rule_trigger=critical_trigger
         )
         _, _, _, self.detector, _, _, _, _ = migrate_alert_rule(self.alert_rule)
-        self.critical_detector_trigger, _ = migrate_metric_data_conditions(critical_trigger)
+        self.critical_detector_trigger, _, _ = migrate_metric_data_conditions(critical_trigger)
 
         self.critical_action, _, _ = migrate_metric_action(critical_trigger_action)
         self.resolve_trigger_data_condition = migrate_resolve_threshold_data_condition(


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/90898 changes what is returned by `migrate_metric_data_conditions`. The return value is primarily used by tests, and a few more tests using the function were added after the last time we merged latest master into the branch.