### PR TITLE
feat(aci): add eventUniqueUserFrequency and percentSessions data condition nodes

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -57,6 +57,8 @@ export enum DataConditionType {
 
   // frequency types for UI only
   EVENT_FREQUENCY = 'event_frequency',
+  EVENT_UNIQUE_USER_FREQUENCY = 'event_unique_user_frequency',
+  PERCENT_SESSIONS = 'percent_sessions',
 }
 
 export enum DataConditionGroupLogicType {

--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -1,0 +1,72 @@
+import AutomationBuilderNumberField from 'sentry/components/workflowEngine/form/automationBuilderNumberField';
+import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
+import {tct} from 'sentry/locale';
+import {
+  COMPARISON_INTERVAL_CHOICES,
+  INTERVAL_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function CountBranch() {
+  return tct('more than [value] [interval]', {
+    value: <ValueField />,
+    interval: <IntervalField />,
+  });
+}
+
+export function PercentBranch() {
+  return tct('[value] higher [interval] compared to [comparison_interval]', {
+    value: <ValueField />,
+    interval: <IntervalField />,
+    comparison_interval: <ComparisonIntervalField />,
+  });
+}
+
+function ValueField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <AutomationBuilderNumberField
+      name={`${condition_id}.comparison.value`}
+      value={condition.comparison.value}
+      min={1}
+      step={1}
+      onChange={(value: string) => {
+        onUpdate({
+          value,
+        });
+      }}
+    />
+  );
+}
+
+function IntervalField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <AutomationBuilderSelectField
+      name={`${condition_id}.comparison.interval`}
+      value={condition.comparison.interval}
+      options={INTERVAL_CHOICES}
+      onChange={(value: string) => {
+        onUpdate({
+          interval: value,
+        });
+      }}
+    />
+  );
+}
+
+function ComparisonIntervalField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  return (
+    <AutomationBuilderSelectField
+      name={`${condition_id}.comparison.comparison_interval`}
+      value={condition.comparison.comparison_interval}
+      options={COMPARISON_INTERVAL_CHOICES}
+      onChange={(value: string) => {
+        onUpdate({
+          comparison_interval: value,
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -22,6 +22,8 @@ export const FILTER_DATA_CONDITION_TYPES = [
   DataConditionType.TAGGED_EVENT,
   DataConditionType.LEVEL,
   DataConditionType.EVENT_FREQUENCY,
+  DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
+  DataConditionType.PERCENT_SESSIONS,
 ];
 
 export enum MatchType {

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -7,8 +7,8 @@ import {
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
-export default function EventFrequencyNode() {
-  return tct('Number of events in an issue is [select]', {
+export default function EventUniqueUserFrequencyNode() {
+  return tct('Number of users affected by an issue is [select]', {
     select: <ComparisonTypeField />,
   });
 }
@@ -16,10 +16,12 @@ export default function EventFrequencyNode() {
 function ComparisonTypeField() {
   const {condition, condition_id, onUpdateType} = useDataConditionNodeContext();
 
-  if (condition.comparison_type === DataConditionType.EVENT_FREQUENCY_COUNT) {
+  if (condition.comparison_type === DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT) {
     return <CountBranch />;
   }
-  if (condition.comparison_type === DataConditionType.EVENT_FREQUENCY_PERCENT) {
+  if (
+    condition.comparison_type === DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT
+  ) {
     return <PercentBranch />;
   }
 
@@ -30,11 +32,11 @@ function ComparisonTypeField() {
       options={[
         {
           label: 'more than...',
-          value: DataConditionType.EVENT_FREQUENCY_COUNT,
+          value: DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
         },
         {
           label: 'relatively higher than...',
-          value: DataConditionType.EVENT_FREQUENCY_PERCENT,
+          value: DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
         },
       ]}
       onChange={(value: DataConditionType) => {

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -7,8 +7,8 @@ import {
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
-export default function EventFrequencyNode() {
-  return tct('Number of events in an issue is [select]', {
+export default function PercentSessionsNode() {
+  return tct('Percentage of sessions affected by an issue is [select]', {
     select: <ComparisonTypeField />,
   });
 }
@@ -16,10 +16,10 @@ export default function EventFrequencyNode() {
 function ComparisonTypeField() {
   const {condition, condition_id, onUpdateType} = useDataConditionNodeContext();
 
-  if (condition.comparison_type === DataConditionType.EVENT_FREQUENCY_COUNT) {
+  if (condition.comparison_type === DataConditionType.PERCENT_SESSIONS_COUNT) {
     return <CountBranch />;
   }
-  if (condition.comparison_type === DataConditionType.EVENT_FREQUENCY_PERCENT) {
+  if (condition.comparison_type === DataConditionType.PERCENT_SESSIONS_PERCENT) {
     return <PercentBranch />;
   }
 
@@ -30,11 +30,11 @@ function ComparisonTypeField() {
       options={[
         {
           label: 'more than...',
-          value: DataConditionType.EVENT_FREQUENCY_COUNT,
+          value: DataConditionType.PERCENT_SESSIONS_COUNT,
         },
         {
           label: 'relatively higher than...',
-          value: DataConditionType.EVENT_FREQUENCY_PERCENT,
+          value: DataConditionType.PERCENT_SESSIONS_PERCENT,
         },
       ]}
       onChange={(value: DataConditionType) => {

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -8,10 +8,12 @@ import {
 import AgeComparisonNode from 'sentry/views/automations/components/actionFilters/ageComparison';
 import EventAttributeNode from 'sentry/views/automations/components/actionFilters/eventAttribute';
 import EventFrequencyNode from 'sentry/views/automations/components/actionFilters/eventFrequency';
+import EventUniqueUserFrequencyNode from 'sentry/views/automations/components/actionFilters/eventUniqueUserFrequency';
 import IssueOccurrencesNode from 'sentry/views/automations/components/actionFilters/issueOccurrences';
 import IssuePriorityNode from 'sentry/views/automations/components/actionFilters/issuePriority';
 import LatestAdoptedReleaseNode from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
 import LevelNode from 'sentry/views/automations/components/actionFilters/level';
+import PercentSessionsNode from 'sentry/views/automations/components/actionFilters/percentSessions';
 import TaggedEventNode from 'sentry/views/automations/components/actionFilters/taggedEvent';
 
 interface DataConditionNodeProps {
@@ -134,6 +136,48 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Number of events'),
       dataCondition: <EventFrequencyNode />,
+    },
+  ],
+  [
+    DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
+    {
+      label: t('Number of users affected'),
+      dataCondition: <EventUniqueUserFrequencyNode />,
+    },
+  ],
+  [
+    DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+    {
+      label: t('Number of users affected'),
+      dataCondition: <EventUniqueUserFrequencyNode />,
+    },
+  ],
+  [
+    DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+    {
+      label: t('Number of users affected'),
+      dataCondition: <EventUniqueUserFrequencyNode />,
+    },
+  ],
+  [
+    DataConditionType.PERCENT_SESSIONS,
+    {
+      label: t('Percentage of sessions affected'),
+      dataCondition: <PercentSessionsNode />,
+    },
+  ],
+  [
+    DataConditionType.PERCENT_SESSIONS_COUNT,
+    {
+      label: t('Percentage of sessions affected'),
+      dataCondition: <PercentSessionsNode />,
+    },
+  ],
+  [
+    DataConditionType.PERCENT_SESSIONS_PERCENT,
+    {
+      label: t('Percentage of sessions affected'),
+      dataCondition: <PercentSessionsNode />,
     },
   ],
 ]);


### PR DESCRIPTION
uses the same logic as the eventFrequency data condition node (https://github.com/getsentry/sentry/pull/91786) to implement branching


https://github.com/user-attachments/assets/e336ac2c-228a-4020-88a2-e7c6a9e17ebb

