### PR TITLE
feat(taxonomy): Add setup prompts to empty states

### DIFF
--- a/static/app/views/issueList/noGroupsHandler/noIssuesMatched.tsx
+++ b/static/app/views/issueList/noGroupsHandler/noIssuesMatched.tsx
@@ -57,10 +57,10 @@ function NoIssuesMatched() {
           </li>
           {(onBreachedMetricsView || onWarningsView) && (
             <li>
-              {tct('Make sure tracing is set up in your project. [link]', {
+              {tct('Make sure [link] is set up in your project.', {
                 link: (
                   <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=%2Ftracing%2F">
-                    {t('Learn more')}
+                    {t('tracing')}
                   </ExternalLink>
                 ),
               })}
@@ -68,13 +68,21 @@ function NoIssuesMatched() {
           )}
           {onErrorsAndOutagesView && (
             <li>
-              {tct('Make sure uptime monitoring is set up in your project. [link]', {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/">
-                    {t('Learn more')}
-                  </ExternalLink>
-                ),
-              })}
+              {tct(
+                'Make sure [uptimeLink] and [cronsLink] monitoring is set up in your project.',
+                {
+                  uptimeLink: (
+                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/">
+                      {t('uptime')}
+                    </ExternalLink>
+                  ),
+                  cronsLink: (
+                    <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=%2Fcrons%2F">
+                      {t('cron')}
+                    </ExternalLink>
+                  ),
+                }
+              )}
             </li>
           )}
         </Tips>

--- a/static/app/views/issueList/noGroupsHandler/noIssuesMatched.tsx
+++ b/static/app/views/issueList/noGroupsHandler/noIssuesMatched.tsx
@@ -6,12 +6,19 @@ import {navigateTo} from 'sentry/actionCreators/navigation';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 
 function NoIssuesMatched() {
   const organization = useOrganization();
   const router = useRouter();
+
+  const location = useLocation();
+  const onBreachedMetricsView = location.pathname.endsWith('/issues/breached-metrics/');
+  const onWarningsView = location.pathname.endsWith('/issues/warnings/');
+  const onErrorsAndOutagesView = location.pathname.endsWith('/issues/errors-outages/');
+
   return (
     <Wrapper data-test-id="empty-state" className="empty-state">
       <img src={campingImg} alt="Camping spot illustration" height={200} />
@@ -48,6 +55,28 @@ function NoIssuesMatched() {
               }
             )}
           </li>
+          {(onBreachedMetricsView || onWarningsView) && (
+            <li>
+              {tct('Make sure tracing is set up in your project. [link]', {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=%2Ftracing%2F">
+                    {t('Learn more')}
+                  </ExternalLink>
+                ),
+              })}
+            </li>
+          )}
+          {onErrorsAndOutagesView && (
+            <li>
+              {tct('Make sure uptime monitoring is set up in your project. [link]', {
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/">
+                    {t('Learn more')}
+                  </ExternalLink>
+                ),
+              })}
+            </li>
+          )}
         </Tips>
       </MessageContainer>
     </Wrapper>


### PR DESCRIPTION
Adds a bullet point to the taxonomy views (except user feedback) prompting users to setup telemetry that would populate those views: 

**Errors & Outages:**

![image](https://github.com/user-attachments/assets/d14e9a59-1e9e-42ca-a85c-c2a7f59a2127)

**Breached Metrics & Warnings:**

![image](https://github.com/user-attachments/assets/17a46c0a-e855-401d-bca1-b1f87306b2ee)
