### PR TITLE
ref(alerts): fetch group_to_groupevent once per delayed processing task

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -526,8 +526,8 @@ def fire_rules(
                 for group_id in group_ids:
                     group = group_id_to_group.get(group_id)
                     if not group:
-                        logger.info(
-                            "delayed_processing.group_not_found",
+                        logger.error(
+                            "delayed_processing.missing_group_to_fire",
                             extra={
                                 "rule_id": rule.id,
                                 "group_id": group_id,

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -500,7 +500,7 @@ def fire_rules(
     ) as tracker:
         groups_to_fire = set().union(*rules_to_fire.values())
         group_to_groupevent = get_group_to_groupevent(
-            parsed_rulegroup_to_event_data, project_id, groups_to_fire
+            log_config, parsed_rulegroup_to_event_data, project_id, groups_to_fire
         )
         group_id_to_group = {group.id: group for group in group_to_groupevent.keys()}
         for rule, group_ids in rules_to_fire.items():

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -526,6 +526,7 @@ def fire_rules(
                 for group_id in group_ids:
                     group = group_id_to_group.get(group_id)
                     if not group:
+                        # we need to fire the rule for this group, but we don't have the group
                         logger.error(
                             "delayed_processing.missing_group_to_fire",
                             extra={


### PR DESCRIPTION
Because we fetch `group_to_groupevent` for every rule that we need to fire groups for, this quickly takes up space in the span tree when we are trying to debug why `fire_rules` is taking so long. Fetching it once should also improve performance a little.

Rules can also fire for the same groups so this reduces some redundancy.