### PR TITLE
ref(aci): prefetch to reduce queries in process_workflows

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -133,7 +133,11 @@ def evaluate_workflows_action_filters(
         workflow_event_data = event_data
 
         # each DataConditionGroup here has 1 WorkflowDataConditionGroup
-        workflow_data_condition_group = action_condition.workflowdataconditiongroup_set.first()
+        workflow_data_condition_group = (
+            list(action_condition.workflowdataconditiongroup_set.all())[0]
+            if action_condition.workflowdataconditiongroup_set.exists()
+            else None
+        )
 
         # Populate the workflow_env in the event_data for the action_condition evaluation
         if workflow_data_condition_group:
@@ -228,7 +232,6 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
             enabled=True,
         )
         .select_related("when_condition_group")
-        .prefetch_related("when_condition_group__conditions")
         .distinct()
     )
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -95,7 +95,7 @@ def enqueue_workflow(
 
 
 def evaluate_workflow_triggers(
-    workflows: BaseQuerySet[Workflow], event_data: WorkflowEventData
+    workflows: set[Workflow], event_data: WorkflowEventData
 ) -> set[Workflow]:
     triggered_workflows: set[Workflow] = set()
 
@@ -221,7 +221,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
     organization = detector.project.organization
 
     # Get the workflows, evaluate the when_condition_group, finally evaluate the actions for workflows that are triggered
-    workflows = (
+    workflows = set(
         Workflow.objects.filter(
             (Q(environment_id=None) | Q(environment_id=environment.id)),
             detectorworkflow__detector_id=detector.id,


### PR DESCRIPTION
1. For all workflows that will process an event (trigger conditions), prefetch the `when_condition_group` and `when_condition_group__conditions`
2. For evaluating workflow action filters, prefetch fetching the workflow environment for each DCG (this will remove 1-2 extra queries per workflow)