### PR TITLE
chore(issue summary): More obvious re-summarize button on summary in drawer

### DIFF
--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -2,6 +2,7 @@ import {isValidElement, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Placeholder from 'sentry/components/placeholder';
 import {IconDocs, IconFatal, IconFocus, IconRefresh, IconSpan} from 'sentry/icons';
@@ -247,8 +248,15 @@ export function GroupSummary({
               size="xs"
               icon={<IconRefresh />}
             >
-              {t('Re-summarize this event')}
+              {t('Summarize current event')}
             </Button>
+            <OriginalEventLink
+              to={`/organizations/${organization.slug}/projects/${project.slug}/issues/${group.id}/events/${data.eventId}/`}
+              size="xs"
+              borderless
+            >
+              {t('View original event')}
+            </OriginalEventLink>
           </ResummarizeWrapper>
         )}
       </Content>
@@ -342,4 +350,8 @@ const ResummarizeWrapper = styled('div')`
   align-items: center;
   margin-top: ${space(1)};
   flex-shrink: 0;
+`;
+
+const OriginalEventLink = styled(LinkButton)`
+  margin-left: ${space(1)};
 `;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -2,7 +2,6 @@ import {isValidElement, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Placeholder from 'sentry/components/placeholder';
 import {IconDocs, IconFatal, IconFocus, IconRefresh, IconSpan} from 'sentry/icons';
@@ -250,13 +249,6 @@ export function GroupSummary({
             >
               {t('Summarize current event')}
             </Button>
-            <OriginalEventLink
-              to={`/organizations/${organization.slug}/projects/${project.slug}/issues/${group.id}/events/${data.eventId}/`}
-              size="xs"
-              borderless
-            >
-              {t('View original event')}
-            </OriginalEventLink>
           </ResummarizeWrapper>
         )}
       </Content>
@@ -350,8 +342,4 @@ const ResummarizeWrapper = styled('div')`
   align-items: center;
   margin-top: ${space(1)};
   flex-shrink: 0;
-`;
-
-const OriginalEventLink = styled(LinkButton)`
-  margin-left: ${space(1)};
 `;

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -1,10 +1,10 @@
 import {isValidElement, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {Button} from 'sentry/components/core/button';
 import {makeAutofixQueryKey} from 'sentry/components/events/autofix/useAutofix';
 import Placeholder from 'sentry/components/placeholder';
-import {IconDocs, IconEllipsis, IconFatal, IconFocus, IconSpan} from 'sentry/icons';
+import {IconDocs, IconFatal, IconFocus, IconRefresh, IconSpan} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -13,8 +13,6 @@ import type {Project} from 'sentry/types/project';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {type ApiQueryKey, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
@@ -119,7 +117,6 @@ export function GroupSummary({
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const [forceEvent, setForceEvent] = useState(false);
-  const openFeedbackForm = useFeedbackForm();
   const aiConfig = useAiConfig(group, project);
   const {data, isPending, isError, refresh} = useGroupSummary(
     group,
@@ -152,53 +149,6 @@ export function GroupSummary({
     queryClient,
     organization.slug,
   ]);
-
-  const eventDetailsItems = [
-    {
-      key: 'event-info',
-      label:
-        event?.id === data?.eventId ? (
-          t('Based on this event')
-        ) : (
-          <span>{t('See original event (%s)', data?.eventId?.substring(0, 8))}</span>
-        ),
-      to:
-        event?.id === data?.eventId
-          ? undefined
-          : window.location.origin +
-            normalizeUrl(
-              `/organizations/${organization.slug}/issues/${data?.groupId}/events/${data?.eventId}/`
-            ),
-      disabled: event?.id === data?.eventId,
-    },
-    ...(event?.id === data?.eventId
-      ? []
-      : [
-          {
-            key: 'refresh',
-            label: t('Summarize this event instead'),
-            onAction: () => setForceEvent(true),
-            disabled: isPending,
-          },
-        ]),
-    ...(openFeedbackForm
-      ? [
-          {
-            key: 'feedback',
-            label: t('Give feedback'),
-            onAction: () => {
-              openFeedbackForm({
-                messagePlaceholder: t('How can we make Issue Summary better for you?'),
-                tags: {
-                  ['feedback.source']: 'issue_details_ai_autofix',
-                  ['feedback.owner']: 'ml-ai',
-                },
-              });
-            },
-          },
-        ]
-      : []),
-  ];
 
   const shouldShowPossibleCause =
     !data?.scores ||
@@ -254,26 +204,6 @@ export function GroupSummary({
     <div data-testid="group-summary">
       {isError ? <div>{t('Error loading summary')}</div> : null}
       <Content>
-        {data?.eventId && !isPending && !preview && (
-          <TooltipWrapper id="group-summary-tooltip-wrapper">
-            <DropdownMenu
-              items={eventDetailsItems}
-              triggerProps={{
-                icon: <StyledIconEllipsis size="xs" />,
-                'aria-label': t('Event details'),
-                size: 'xs',
-                borderless: true,
-                showChevron: false,
-                style: {
-                  zIndex: 0,
-                },
-              }}
-              isDisabled={isPending}
-              position="bottom-end"
-              offset={4}
-            />
-          </TooltipWrapper>
-        )}
         <InsightGrid>
           {insightCards.map(card => {
             if ((!isPending && !card.insight) || (isPending && !card.showWhenLoading)) {
@@ -309,6 +239,18 @@ export function GroupSummary({
             );
           })}
         </InsightGrid>
+        {data?.eventId && !isPending && !preview && event?.id !== data?.eventId && (
+          <ResummarizeWrapper>
+            <Button
+              onClick={() => setForceEvent(true)}
+              disabled={isPending}
+              size="xs"
+              icon={<IconRefresh />}
+            >
+              {t('Re-summarize this event')}
+            </Button>
+          </ResummarizeWrapper>
+        )}
       </Content>
     </div>
   );
@@ -395,17 +337,9 @@ const CardContent = styled('div')`
   flex: 1;
 `;
 
-const TooltipWrapper = styled('div')`
-  position: absolute;
-  top: -${space(1)};
-  right: 0;
-
-  ul {
-    max-height: none !important;
-    overflow: visible !important;
-  }
-`;
-
-const StyledIconEllipsis = styled(IconEllipsis)`
-  color: ${p => p.theme.subText};
+const ResummarizeWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  margin-top: ${space(1)};
+  flex-shrink: 0;
 `;


### PR DESCRIPTION
Removes the ellipsis menu and puts a more obvious button to re-generate the summary when in the drawer and the event id doesn't match.
<img width="726" alt="Screenshot 2025-05-16 at 2 52 17 PM" src="https://github.com/user-attachments/assets/33a0655d-6928-4922-8801-41bfdfa4c25b" />
