### PR TITLE
fix(ui): Hide timelineCursor when obscured by a overlay element

### DIFF
--- a/static/app/components/checkInTimeline/timelineCursor.spec.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.spec.tsx
@@ -24,6 +24,10 @@ function TestComponent() {
 }
 
 describe('TimelineCursor', function () {
+  beforeEach(() => {
+    document.elementsFromPoint = () => [];
+  });
+
   it('renders', async function () {
     render(<TestComponent />);
 

--- a/static/app/components/checkInTimeline/timelineCursor.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.tsx
@@ -65,11 +65,16 @@ function useTimelineCursor<E extends HTMLElement>({
       // within the containerRect. This proves to be less glitchy as some
       // elements within the container may trigger an onMouseLeave even when
       // the mouse is still "inside" of the container
+      //
+      // Also tests that the mouse is not obscured by a overlay element.
       const isInsideContainer =
         e.clientX > containerRect.left &&
         e.clientX < containerRect.right &&
         e.clientY > containerRect.top &&
-        e.clientY < containerRect.bottom;
+        e.clientY < containerRect.bottom &&
+        !document
+          .elementsFromPoint(e.clientX, e.clientY)
+          .some(el => el.hasAttribute('data-overlay'));
 
       if (isInsideContainer !== isVisible) {
         setIsVisible(isInsideContainer);


### PR DESCRIPTION
Fixes issues like this

<img alt="clipboard.png" width="459" src="https://i.imgur.com/70hcaeL.png" />

![clipboard.png](https://i.imgur.com/bWl5iq8.png)