### PR TITLE
feat(taskworker) Add taskname dimension to execute_task metric

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -341,6 +341,7 @@ def child_process(
             "taskworker.worker.execute_task",
             tags={
                 "namespace": activation.namespace,
+                "taskname": activation.taskname,
                 "status": status,
                 "processing_pool": processing_pool_name,
             },


### PR DESCRIPTION
Having a taskname tag on this metric will let folks do throughput breakdowns per task.
