### PR TITLE
fix(assignee): Fix assignee text alignment

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -589,6 +589,7 @@ export default function AssigneeSelectorDropdown({
 export const AssigneeWrapper = styled('div')`
   display: flex;
   justify-content: flex-end;
+  text-align: left;
 `;
 
 const AssigneeDropdownButton = styled(DropdownButton)`


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/45581dac-36fe-4c3a-9f3e-4d4e1772ea2c)

After:
![image](https://github.com/user-attachments/assets/2a26f37c-736b-4f39-9573-96776c77b419)

The assignee dropdown was inheriting the `text-align: right` property from the issue stream cell wrapper. I have no idea why it seemed to only apply to the suggested assignee. 