### PR TITLE
fix(taskworker) Don't send project to find_channel_id_for_rule

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -244,7 +244,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             kwargs = {
                 "name": data["name"],
                 "environment": data.get("environment"),
-                "project": project,
+                "project": None,
                 "project_id": project.id,
                 "action_match": data["actionMatch"],
                 "filter_match": data.get("filterMatch"),

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -799,7 +799,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         kwargs = {
             "name": data["name"],
             "environment": data.get("environment"),
-            "project": project,
+            "project": None,
             "project_id": project.id,
             "action_match": data["actionMatch"],
             "filter_match": data.get("filterMatch"),

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -727,6 +727,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         payload["actions"][0].pop("name")
         kwargs = {
             "name": payload["name"],
+            "project": None,
             "project_id": self.project.id,
             "environment": payload.get("environment"),
             "action_match": payload["actionMatch"],
@@ -739,7 +740,6 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             "uuid": "abc123",
         }
         call_args = mock_find_channel_id_for_alert_rule.call_args[1]["kwargs"]
-        assert call_args.pop("project").id == self.project.id
         assert call_args == kwargs
 
     def test_comparison_condition(self):


### PR DESCRIPTION
Continues #91810 by changing the call sites to not pass `project` anymore.