### PR TITLE
feat(rules): Wrap IntegrationEventAction future callbacks in a span

### DIFF
--- a/src/sentry/rules/actions/integrations/base.py
+++ b/src/sentry/rules/actions/integrations/base.py
@@ -50,7 +50,7 @@ class IntegrationEventAction(EventAction, abc.ABC):
         def wrapped_callback(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             with sentry_sdk.start_span(
                 op="rule.action.integration",
-                description=f"{self.provider} integration action",
+                name=f"{self.provider} integration action",
             ):
                 callback(event, futures)
 

--- a/src/sentry/rules/actions/integrations/base.py
+++ b/src/sentry/rules/actions/integrations/base.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Callable, Sequence
+from typing import Any, override
+
+import sentry_sdk
 
 from sentry import analytics
 from sentry.eventstore.models import GroupEvent
@@ -12,6 +16,8 @@ from sentry.integrations.services.integration import (
 from sentry.models.organization import OrganizationStatus
 from sentry.models.rule import Rule
 from sentry.rules.actions import EventAction
+from sentry.rules.base import CallbackFuture
+from sentry.types.rules import RuleFuture
 
 INTEGRATION_KEY = "integration"
 
@@ -33,6 +39,22 @@ class IntegrationEventAction(EventAction, abc.ABC):
     @abc.abstractmethod
     def integration_key(self) -> str:
         pass
+
+    @override
+    def future(
+        self,
+        callback: Callable[[GroupEvent, Sequence[RuleFuture]], None],
+        key: str | None = None,
+        **kwargs: Any,
+    ) -> CallbackFuture:
+        def wrapped_callback(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
+            with sentry_sdk.start_span(
+                op="rule.action.integration",
+                description=f"{self.provider} integration action",
+            ):
+                callback(event, futures)
+
+        return super().future(wrapped_callback, key, **kwargs)
 
     def is_enabled(self) -> bool:
         enabled: bool = bool(self.get_integrations())

--- a/src/sentry/rules/actions/integrations/base.py
+++ b/src/sentry/rules/actions/integrations/base.py
@@ -49,8 +49,8 @@ class IntegrationEventAction(EventAction, abc.ABC):
     ) -> CallbackFuture:
         def wrapped_callback(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             with sentry_sdk.start_span(
-                op="rule.action.integration",
-                name=f"{self.provider} integration action",
+                op="IntegrationEventAction.future",
+                name=type(self).__name__,
             ):
                 callback(event, futures)
 


### PR DESCRIPTION
Add a wrapper span to our future callbacks to improve tracing of actions.
