### PR TITLE
feat(autofix): New onboarding/notice flow

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -64,7 +64,7 @@ export type Project = {
   team: Team;
   teams: Team[];
   verifySSL: boolean;
-  autofixAutomationTuning?: 'off' | 'low' | 'medium' | 'high';
+  autofixAutomationTuning?: 'off' | 'low' | 'medium' | 'high' | 'always';
   builtinSymbolSources?: string[];
   defaultEnvironment?: string;
   eventProcessing?: {

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -132,6 +132,10 @@ describe('SeerDrawer', () => {
         preference: null,
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${mockProject.organization.slug}/group-search-views/starred/`,
+      body: [],
+    });
   });
 
   it('renders consent state if not consented', async () => {
@@ -217,7 +221,7 @@ describe('SeerDrawer', () => {
     );
 
     expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
-    expect(screen.getByText('Set Up Now')).toBeInTheDocument();
+    expect(screen.getByText('Set Up Integration')).toBeInTheDocument();
 
     const startButton = screen.getByRole('button', {name: 'Start Seer'});
     expect(startButton).toBeInTheDocument();
@@ -486,7 +490,7 @@ describe('SeerDrawer', () => {
     // Since "Install the GitHub Integration" text isn't found, let's check for
     // the "Set Up the GitHub Integration" text which is what the component is actually showing
     expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
-    expect(screen.getByText('Set Up Now')).toBeInTheDocument();
+    expect(screen.getByText('Set Up Integration')).toBeInTheDocument();
   });
 
   it('does not render SeerNotices when all repositories are readable', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -79,7 +79,7 @@ describe('SeerNotices', function () {
   });
 
   it('shows fixability view step if automation is allowed and view not starred', () => {
-    const project = getProjectWithAutomation('on' as any);
+    const project = getProjectWithAutomation('high');
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization,
     });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -1,14 +1,12 @@
+import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
 import {SeerNotices} from 'sentry/views/issueDetails/streamline/sidebar/seerNotices';
 
-jest.mock('sentry/components/events/autofix/useAutofix');
-
 describe('SeerNotices', function () {
-  // Helper function to create repository objects
   const createRepository = (overrides = {}) => ({
     external_id: 'repo-123',
     name: 'org/repo',
@@ -20,251 +18,93 @@ describe('SeerNotices', function () {
     ...overrides,
   });
 
-  const project = ProjectFixture();
+  function getProjectWithAutomation(
+    automationTuning = 'off' as 'off' | 'low' | 'medium' | 'high' | 'always'
+  ) {
+    return {
+      ...ProjectFixture(),
+      autofixAutomationTuning: automationTuning,
+      organization: {
+        ...ProjectFixture().organization,
+        features: ['trigger-autofix-on-issue-summary'],
+      },
+    };
+  }
+
+  const organization = OrganizationFixture({
+    features: ['trigger-autofix-on-issue-summary'],
+  });
 
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/projects/${project.organization.slug}/${project.slug}/seer/preferences/`,
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/seer/preferences/`,
       body: {
         code_mapping_repos: [],
         preference: null,
       },
     });
-
-    // Reset mock before each test
-    jest.mocked(useAutofixRepos).mockReset();
-  });
-
-  it('renders nothing when all repositories are readable', function () {
-    const repositories = [createRepository(), createRepository({name: 'org/repo2'})];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    const {container} = render(
-      <SeerNotices groupId="123" hasGithubIntegration project={project} />
-    );
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('renders GitHub integration setup card when hasGithubIntegration is false', function () {
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: [createRepository()],
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration={false} project={project} />);
-
-    expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
-
-    // Test for text fragments with formatting
-    expect(screen.getByText(/Seer is/, {exact: false})).toBeInTheDocument();
-    expect(screen.getByText('a lot better')).toBeInTheDocument();
-    expect(
-      screen.getByText(/when it has your codebase as context/, {exact: false})
-    ).toBeInTheDocument();
-
-    // Test for text with links
-    expect(screen.getByText(/Set up the/, {exact: false})).toBeInTheDocument();
-    expect(screen.getByText('GitHub Integration', {selector: 'a'})).toBeInTheDocument();
-    expect(
-      screen.getByText(/to allow Seer to go deeper/, {exact: false})
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('Set Up Now')).toBeInTheDocument();
-    expect(screen.getByRole('img', {name: 'Install'})).toBeInTheDocument();
-  });
-
-  it('renders warning for a single unreadable GitHub repository', function () {
-    const repositories = [createRepository({is_readable: false})];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    expect(screen.getByText(/Seer can't access the/)).toBeInTheDocument();
-    expect(screen.getByText('org/repo')).toBeInTheDocument();
-    expect(screen.getByText(/GitHub integration/)).toBeInTheDocument();
-  });
-
-  it('renders warning for a single unreadable non-GitHub repository', function () {
-    const repositories = [
-      createRepository({is_readable: false, provider: 'gitlab', name: 'org/gitlab-repo'}),
-    ];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    expect(screen.getByText(/Seer can't access the/)).toBeInTheDocument();
-    expect(screen.getByText('org/gitlab-repo')).toBeInTheDocument();
-    expect(
-      screen.getByText(/It currently only supports GitHub repositories/)
-    ).toBeInTheDocument();
-  });
-
-  it('renders warning for multiple unreadable repositories (all GitHub)', function () {
-    const repositories = [
-      createRepository({is_readable: false, name: 'org/repo1'}),
-      createRepository({is_readable: false, name: 'org/repo2'}),
-    ];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    expect(screen.getByText(/Seer can't access these repositories:/)).toBeInTheDocument();
-    expect(screen.getByText('org/repo1, org/repo2')).toBeInTheDocument();
-    expect(screen.getByText(/For best performance, enable the/)).toBeInTheDocument();
-    expect(screen.getByText(/GitHub integration/)).toBeInTheDocument();
-  });
-
-  it('renders warning for multiple unreadable repositories (all non-GitHub)', function () {
-    const repositories = [
-      createRepository({
-        is_readable: false,
-        provider: 'gitlab',
-        name: 'org/gitlab-repo1',
-      }),
-      createRepository({
-        is_readable: false,
-        provider: 'bitbucket',
-        name: 'org/bitbucket-repo2',
-      }),
-    ];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    expect(screen.getByText(/Seer can't access these repositories:/)).toBeInTheDocument();
-    expect(screen.getByText('org/gitlab-repo1, org/bitbucket-repo2')).toBeInTheDocument();
-    expect(
-      screen.getByText(/Seer currently only supports GitHub repositories/)
-    ).toBeInTheDocument();
-  });
-
-  it('renders warning for multiple unreadable repositories (mixed GitHub and non-GitHub)', function () {
-    const repositories = [
-      createRepository({is_readable: false, name: 'org/github-repo'}),
-      createRepository({is_readable: false, provider: 'gitlab', name: 'org/gitlab-repo'}),
-    ];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    expect(screen.getByText(/Seer can't access these repositories:/)).toBeInTheDocument();
-    expect(screen.getByText('org/github-repo, org/gitlab-repo')).toBeInTheDocument();
-    expect(screen.getByText(/For best performance, enable the/)).toBeInTheDocument();
-    expect(screen.getByText(/GitHub integration/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Seer currently only supports GitHub repositories/)
-    ).toBeInTheDocument();
-  });
-
-  it('renders warning for unreadable repositories along with GitHub setup card when no GitHub integration', function () {
-    const repositories = [
-      createRepository({is_readable: false, name: 'org/repo1'}),
-      createRepository({is_readable: false, name: 'org/repo2'}),
-    ];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration={false} project={project} />);
-
-    // GitHub setup card
-    expect(screen.getByText('Set Up the GitHub Integration')).toBeInTheDocument();
-    expect(screen.getByText('Set Up Now')).toBeInTheDocument();
-
-    // Unreadable repos warning
-    expect(screen.getByText(/Seer can't access these repositories:/)).toBeInTheDocument();
-    expect(screen.getByText('org/repo1, org/repo2')).toBeInTheDocument();
-  });
-
-  it('renders GitHub integration link correctly', function () {
-    const repositories = [createRepository({is_readable: false, name: 'org/repo1'})];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    const integrationLink = screen.getByText('GitHub integration');
-    expect(integrationLink).toHaveAttribute(
-      'href',
-      '/settings/org-slug/integrations/github/'
-    );
-  });
-
-  it('combines multiple notices when necessary', function () {
-    const repositories = [
-      createRepository({is_readable: false, name: 'org/repo1'}),
-      createRepository({is_readable: false, name: 'org/repo2'}),
-    ];
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: repositories,
-      codebases: {},
-    });
-
-    render(<SeerNotices groupId="123" hasGithubIntegration={false} project={project} />);
-
-    // Should have both the GitHub setup card and the unreadable repos warning
-    const setupCard = screen.getByText('Set Up the GitHub Integration').closest('div');
-    const warningAlert = screen
-      .getByText(/Seer can't access these repositories:/)
-      .closest('div');
-
-    expect(setupCard).toBeInTheDocument();
-    expect(warningAlert).toBeInTheDocument();
-    expect(setupCard).not.toBe(warningAlert);
-  });
-
-  it('renders repository selection card when no repos are selected but GitHub integration is enabled', async function () {
-    jest.mocked(useAutofixRepos).mockReturnValue({
-      repos: [],
-      codebases: {},
-    });
-
     MockApiClient.addMockResponse({
-      url: `/projects/${project.organization.slug}/${project.slug}/seer/preferences/`,
-      body: {
-        code_mapping_repos: null,
-        preference: null,
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${ProjectFixture().slug}/autofix-repos/`,
+      body: [createRepository()],
+    });
+  });
+
+  it('shows automation step if automation is allowed and tuning is off', () => {
+    const project = getProjectWithAutomation('off');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization,
+    });
+    expect(screen.getByText('Unleash Automation')).toBeInTheDocument();
+    expect(screen.getByText('Enable Automation')).toBeInTheDocument();
+  });
+
+  it('does not show automation step if automation is not allowed', () => {
+    const project = {
+      ...ProjectFixture(),
+      autofixAutomationTuning: 'off' as const,
+      organization: {
+        ...ProjectFixture().organization,
+        features: [],
       },
+    };
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization: {...organization, features: []},
     });
+    expect(screen.queryByText('Unleash Automation')).not.toBeInTheDocument();
+  });
 
-    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Pick Repositories to Work In')).toBeInTheDocument();
+  it('shows fixability view step if automation is allowed and view not starred', () => {
+    const project = getProjectWithAutomation('on' as any);
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      organization,
     });
+    expect(screen.getByText('Get Some Quick Wins')).toBeInTheDocument();
+    expect(screen.getByText('Star Recommended View')).toBeInTheDocument();
+  });
 
-    const titleElement = screen.getByText('Pick Repositories to Work In');
-    const cardDescriptionElement = titleElement.nextElementSibling;
-    const firstSpanInDescription =
-      cardDescriptionElement?.querySelector('span:first-child');
-    expect(firstSpanInDescription?.textContent?.replace(/\s+/g, ' ').trim()).toBe(
-      'Seer is a lot better when it has your codebase as context.'
-    );
-
-    expect(
-      screen.getByText(/Open the Project Settings menu in the top right/)
-    ).toBeInTheDocument();
+  it('does not render guided steps if all onboarding steps are complete', () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [
+        GroupSearchViewFixture({
+          query: 'is:unresolved issue.seer_actionability:high',
+          starred: true,
+        }),
+      ],
+    });
+    const project = getProjectWithAutomation('medium');
+    render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
+      ...{organization: {...organization, features: []}},
+    });
+    // Should not find any step titles
+    expect(screen.queryByText('Set Up the GitHub Integration')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pick Repositories to Work In')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unleash Automation')).not.toBeInTheDocument();
+    expect(screen.queryByText('Get Some Quick Wins')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -1,106 +1,37 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import onboardingInstall from 'sentry-images/spot/onboarding-install.svg';
+import addIntegrationProvider from 'sentry-images/spot/add-integration-provider.svg';
+import feedbackOnboardingImg from 'sentry-images/spot/feedback-onboarding.svg';
+import onboardingCompass from 'sentry-images/spot/onboarding-compass.svg';
+import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
 import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
+import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
+import {FieldKey} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 
 interface SeerNoticesProps {
   groupId: string;
   project: Project;
   hasGithubIntegration?: boolean;
-}
-
-function GithubIntegrationSetupCard() {
-  const organization = useOrganization();
-
-  return (
-    <IntegrationCard key="no-readable-repos">
-      <CardContent>
-        <CardTitle>{t('Set Up the GitHub Integration')}</CardTitle>
-        <CardDescription>
-          <span>
-            {tct('Seer is [bold:a lot better] when it has your codebase as context.', {
-              bold: <b />,
-            })}
-          </span>
-          <span>
-            {tct(
-              'Set up the [integrationLink:GitHub Integration] to allow Seer to go deeper when troubleshooting and fixing your issues–including writing the code and opening PRs.',
-              {
-                integrationLink: (
-                  <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/`}
-                  />
-                ),
-              }
-            )}
-          </span>
-        </CardDescription>
-        <LinkButton
-          href={`/settings/${organization.slug}/integrations/github/`}
-          size="sm"
-          priority="primary"
-        >
-          {t('Set Up Now')}
-        </LinkButton>
-      </CardContent>
-      <CardIllustration src={onboardingInstall} alt="Install" />
-    </IntegrationCard>
-  );
-}
-
-function SelectReposCard() {
-  const organization = useOrganization();
-
-  return (
-    <IntegrationCard key="no-selected-repos">
-      <CardContent>
-        <CardTitle>{t('Pick Repositories to Work In')}</CardTitle>
-        <CardDescription>
-          <span>
-            {tct('Seer is [bold:a lot better] when it has your codebase as context.', {
-              bold: <b />,
-            })}
-          </span>
-          <span>
-            {tct(
-              'Select the repos Seer can explore in this project to allow it to go deeper when troubleshooting and fixing your issues–including writing the code and opening PRs.',
-              {
-                integrationLink: (
-                  <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/`}
-                  />
-                ),
-              }
-            )}
-          </span>
-          <span>
-            {t(
-              'You can also configure working branches and custom instructions so Seer acts just how you like.'
-            )}
-          </span>
-          <span>
-            {tct(
-              '[bold:Open the Project Settings menu in the top right] to get started.',
-              {
-                bold: <b />,
-              }
-            )}
-          </span>
-        </CardDescription>
-      </CardContent>
-      <CardIllustration src={onboardingInstall} alt="Install" />
-    </IntegrationCard>
-  );
 }
 
 export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNoticesProps) {
@@ -111,114 +42,289 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     codeMappingRepos,
     isLoading: isLoadingPreferences,
   } = useProjectSeerPreferences(project);
+  const {starredViews: views} = useStarredIssueViews();
+  const {mutate: createIssueView} = useCreateGroupSearchView({
+    onMutate: () => {
+      addLoadingMessage(t('Creating view...'));
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('View starred successfully'));
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to create view'));
+    },
+  });
+
+  const isAutomationAllowed = organization.features.includes(
+    'trigger-autofix-on-issue-summary'
+  );
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
-  const notices: React.JSX.Element[] = [];
+  const githubRepos = unreadableRepos.filter(repo => repo.provider.includes('github'));
+  const nonGithubRepos = unreadableRepos.filter(
+    repo => !repo.provider.includes('github')
+  );
 
-  if (!hasGithubIntegration) {
-    notices.push(<GithubIntegrationSetupCard key="github-setup" />);
-  } else if (
+  // Onboarding conditions
+  const needsGithubIntegration = !hasGithubIntegration;
+  const needsRepoSelection =
+    hasGithubIntegration &&
     repos.length === 0 &&
     !preference?.repositories?.length &&
     !codeMappingRepos?.length &&
-    !isLoadingPreferences
-  ) {
-    notices.push(<SelectReposCard key="repo-selection" />);
-  }
+    !isLoadingPreferences;
+  const needsAutomation =
+    project.autofixAutomationTuning === 'off' && isAutomationAllowed;
+  const needsFixabilityView =
+    !views.some(view => view.query.includes(FieldKey.ISSUE_SEER_ACTIONABILITY)) &&
+    isAutomationAllowed;
 
-  if (unreadableRepos.length > 1) {
-    const githubRepos = unreadableRepos.filter(repo => repo.provider.includes('github'));
-    const nonGithubRepos = unreadableRepos.filter(
-      repo => !repo.provider.includes('github')
-    );
+  // Warning conditions
+  const hasMultipleUnreadableRepos = unreadableRepos.length > 1;
+  const hasSingleUnreadableRepo = unreadableRepos.length === 1;
 
-    notices.push(
-      <Alert type="warning" showIcon key="multiple-repos">
-        {tct("Seer can't access these repositories: [repoList].", {
-          repoList: <b>{unreadableRepos.map(repo => repo.name).join(', ')}</b>,
-        })}
-        {githubRepos.length > 0 && (
-          <Fragment>
-            {' '}
-            {tct(
-              'For best performance, enable the [integrationLink:GitHub integration].',
-              {
-                integrationLink: (
-                  <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/`}
-                  />
-                ),
-              }
+  const anyStepIncomplete =
+    needsGithubIntegration ||
+    needsRepoSelection ||
+    needsAutomation ||
+    needsFixabilityView;
+
+  const handleStarFixabilityView = () => {
+    createIssueView({
+      name: 'Easy Fixes 🤖',
+      query: 'is:unresolved issue.seer_actionability:high',
+      querySort: IssueSortOptions.DATE,
+      projects: [],
+      environments: [],
+      timeFilters: {
+        start: null,
+        end: null,
+        period: '7d',
+        utc: null,
+      },
+      starred: true,
+    });
+  };
+
+  return (
+    <NoticesContainer>
+      {anyStepIncomplete && (
+        <Fragment>
+          <StepsHeader>
+            <SeerWaitingIcon size="xl" />
+            Debug Faster with Seer
+          </StepsHeader>
+          <GuidedSteps>
+            {/* Step 1: GitHub Integration */}
+            <GuidedSteps.Step
+              key="github-setup"
+              stepKey="github-setup"
+              title={t('Set Up the GitHub Integration')}
+              isCompleted={!needsGithubIntegration}
+            >
+              <StepContentRow>
+                <StepTextCol>
+                  <CardDescription>
+                    <span>
+                      {tct(
+                        'Seer is [bold:a lot better] when it has your codebase as context.',
+                        {
+                          bold: <b />,
+                        }
+                      )}
+                    </span>
+                    <span>
+                      {tct(
+                        'Set up the [integrationLink:GitHub Integration] to allow Seer to find the most accurate root causes, solutions, and code changes for your issues.',
+                        {
+                          integrationLink: (
+                            <ExternalLink
+                              href={`/settings/${organization.slug}/integrations/github/`}
+                            />
+                          ),
+                        }
+                      )}
+                    </span>
+                  </CardDescription>
+                </StepTextCol>
+                <StepImageCol>
+                  <CardIllustration src={addIntegrationProvider} alt="Add Integration" />
+                </StepImageCol>
+              </StepContentRow>
+              <GuidedSteps.StepButtons>
+                <LinkButton
+                  href={`/settings/${organization.slug}/integrations/github/`}
+                  size="sm"
+                  priority="primary"
+                >
+                  {t('Set Up Integration')}
+                </LinkButton>
+              </GuidedSteps.StepButtons>
+            </GuidedSteps.Step>
+
+            {/* Step 2: Repo Selection */}
+            <GuidedSteps.Step
+              key="repo-selection"
+              stepKey="repo-selection"
+              title={t('Pick Repositories to Work In')}
+              isCompleted={!needsRepoSelection}
+            >
+              <StepContentRow>
+                <StepTextCol>
+                  <CardDescription>
+                    <span>{t('Select the repos Seer can explore in this project.')}</span>
+                    <span>
+                      {t(
+                        'You can also configure working branches and custom instructions so Seer fits your unique workflow.'
+                      )}
+                    </span>
+                  </CardDescription>
+                </StepTextCol>
+                <StepImageCol>
+                  <CardIllustration src={onboardingCompass} alt="Compass" />
+                </StepImageCol>
+              </StepContentRow>
+              <GuidedSteps.StepButtons>
+                <LinkButton
+                  to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+                  size="sm"
+                  priority="primary"
+                >
+                  {t('Configure Repos')}
+                </LinkButton>
+              </GuidedSteps.StepButtons>
+            </GuidedSteps.Step>
+
+            {/* Step 3: Unleash Automation */}
+            {isAutomationAllowed && (
+              <GuidedSteps.Step
+                key="unleash-automation"
+                stepKey="unleash-automation"
+                title={t('Unleash Automation')}
+                isCompleted={!needsAutomation}
+              >
+                <StepContentRow>
+                  <StepTextCol>
+                    <CardDescription>
+                      <span>
+                        {t(
+                          'Let Seer automatically deep dive into incoming issues, so you wake up to solutions, not headaches.'
+                        )}
+                      </span>
+                    </CardDescription>
+                  </StepTextCol>
+                  <StepImageCol>
+                    <CardIllustration src={waitingForEventImg} alt="Waiting for Event" />
+                  </StepImageCol>
+                </StepContentRow>
+                <GuidedSteps.StepButtons>
+                  <LinkButton
+                    to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+                    size="sm"
+                    priority="primary"
+                  >
+                    {t('Enable Automation')}
+                  </LinkButton>
+                </GuidedSteps.StepButtons>
+              </GuidedSteps.Step>
             )}
-          </Fragment>
-        )}
-        {nonGithubRepos.length > 0 && (
-          <Fragment> {t('Seer currently only supports GitHub repositories.')}</Fragment>
-        )}
-      </Alert>
-    );
-  } else if (unreadableRepos.length === 1) {
-    const unreadableRepo = unreadableRepos[0]!;
-    notices.push(
-      <Alert type="warning" showIcon key="single-repo">
-        {unreadableRepo.provider.includes('github')
-          ? tct(
-              "Seer can't access the [repo] repository, make sure the [integrationLink:GitHub integration] is correctly set up.",
-              {
-                repo: <b>{unreadableRepo.name}</b>,
-                integrationLink: (
-                  <ExternalLink
-                    href={`/settings/${organization.slug}/integrations/github/`}
-                  />
-                ),
-              }
-            )
-          : tct(
-              "Seer can't access the [repo] repository. It currently only supports GitHub repositories.",
-              {repo: <b>{unreadableRepo.name}</b>}
+
+            {/* Step 4: Fixability View */}
+            {isAutomationAllowed && (
+              <GuidedSteps.Step
+                key="fixability-view"
+                stepKey="fixability-view"
+                title={t('Get Some Quick Wins')}
+                isCompleted={!needsFixabilityView}
+              >
+                <StepContentRow>
+                  <StepTextCol>
+                    <CardDescription>
+                      <span>
+                        {t(
+                          'Seer scans all your issues and highlights the ones that are likely quick to fix.'
+                        )}
+                      </span>
+                      <span>
+                        {t(
+                          'Star the recommended issue view to keep an eye on quick debugging opportunities. You can customize the view later.'
+                        )}
+                      </span>
+                    </CardDescription>
+                  </StepTextCol>
+                  <StepImageCol>
+                    <CardIllustration src={feedbackOnboardingImg} alt="Feedback" />
+                  </StepImageCol>
+                </StepContentRow>
+                <GuidedSteps.StepButtons>
+                  <Button onClick={handleStarFixabilityView} size="sm" priority="primary">
+                    {t('Star Recommended View')}
+                  </Button>
+                </GuidedSteps.StepButtons>
+              </GuidedSteps.Step>
             )}
-      </Alert>
-    );
-  }
-
-  if (notices.length === 0) {
-    return null;
-  }
-
-  return <NoticesContainer>{notices}</NoticesContainer>;
+          </GuidedSteps>
+          <StepsDivider />
+        </Fragment>
+      )}
+      {/* Banners for unreadable repos */}
+      {hasMultipleUnreadableRepos && (
+        <StyledAlert type="warning" showIcon key="multiple-repos">
+          {tct("Seer can't access these repositories: [repoList].", {
+            repoList: <b>{unreadableRepos.map(repo => repo.name).join(', ')}</b>,
+          })}
+          {githubRepos.length > 0 && (
+            <Fragment>
+              {' '}
+              {tct(
+                'For best performance, enable the [integrationLink:GitHub integration].',
+                {
+                  integrationLink: (
+                    <ExternalLink
+                      href={`/settings/${organization.slug}/integrations/github/`}
+                    />
+                  ),
+                }
+              )}
+            </Fragment>
+          )}
+          {nonGithubRepos.length > 0 && (
+            <Fragment> {t('Seer currently only supports GitHub repositories.')}</Fragment>
+          )}
+        </StyledAlert>
+      )}
+      {hasSingleUnreadableRepo && (
+        <StyledAlert type="warning" showIcon key="single-repo">
+          {unreadableRepos[0]?.provider.includes('github')
+            ? tct(
+                "Seer can't access the [repo] repository, make sure the [integrationLink:GitHub integration] is correctly set up.",
+                {
+                  repo: <b>{unreadableRepos[0]?.name}</b>,
+                  integrationLink: (
+                    <ExternalLink
+                      href={`/settings/${organization.slug}/integrations/github/`}
+                    />
+                  ),
+                }
+              )
+            : tct(
+                "Seer can't access the [repo] repository. It currently only supports GitHub repositories.",
+                {repo: <b>{unreadableRepos[0]?.name}</b>}
+              )}
+        </StyledAlert>
+      )}
+    </NoticesContainer>
+  );
 }
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(1)};
+`;
 
 const NoticesContainer = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(2)};
   align-items: stretch;
-  margin-bottom: ${space(2)};
-`;
-
-const IntegrationCard = styled('div')`
-  position: relative;
-  overflow: hidden;
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-  gap: ${space(1)};
-  background: linear-gradient(
-    90deg,
-    ${p => p.theme.backgroundSecondary}00 0%,
-    ${p => p.theme.backgroundSecondary}FF 70%,
-    ${p => p.theme.backgroundSecondary}FF 100%
-  );
-`;
-
-const CardContent = styled('div')`
-  padding: ${space(2)};
-  display: flex;
-  flex-direction: column;
-  gap: ${space(2)};
-  align-items: flex-start;
 `;
 
 const CardDescription = styled('div')`
@@ -227,16 +333,50 @@ const CardDescription = styled('div')`
   gap: ${space(1)};
 `;
 
-const CardTitle = styled('h3')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  font-weight: 600;
-  margin-bottom: 0;
-`;
-
 const CardIllustration = styled('img')`
-  height: 100%;
+  width: 100%;
+  max-width: 200px;
+  min-width: 100px;
+  height: auto;
   object-fit: contain;
-  max-width: 30%;
   margin-bottom: -6px;
   margin-right: 10px;
+`;
+
+const StepContentRow = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: ${space(3)};
+`;
+
+const StepTextCol = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+  flex: 0 0 75%;
+  min-width: 0;
+`;
+
+const StepImageCol = styled('div')`
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  flex-grow: 1;
+`;
+
+const StepsHeader = styled('h3')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  margin-bottom: ${space(0.5)};
+`;
+
+const StepsDivider = styled('hr')`
+  border: none;
+  border-top: 1px solid ${p => p.theme.border};
+  margin: ${space(3)} 0;
 `;

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -5,18 +5,21 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Flex} from 'sentry/components/container/flex';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {useOrganizationRepositories} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import type {RepoSettings} from 'sentry/components/events/autofix/types';
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconAdd} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {AddAutofixRepoModalContent} from './addAutofixRepoModal';
 import {AutofixRepoItem} from './autofixRepoItem';
@@ -27,6 +30,7 @@ interface ProjectSeerProps {
 }
 
 export function AutofixRepositories({project}: ProjectSeerProps) {
+  const organization = useOrganization();
   const {data: repositories, isFetching: isFetchingRepositories} =
     useOrganizationRepositories();
   const {
@@ -195,7 +199,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
     <Panel>
       <PanelHeader hasButtons>
         <Flex align="center" gap={space(0.5)}>
-          {t('Autofix Repositories')}
+          {t('Seer Repositories')}
           <QuestionTooltip
             title={t(
               'Below are the repositories that Seer will work on. Seer will only be able to see code from and make PRs to the repositories that you select here.'
@@ -204,28 +208,39 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
           />
         </Flex>
         <div>
-          <Button
-            size="xs"
-            icon={<IconAdd />}
+          <Tooltip
+            isHoverable
             title={
               isRepoLimitReached
-                ? t('Max repositories reached')
+                ? 'Max repositories reached'
                 : unselectedRepositories?.length === 0
-                  ? t('No repositories to add')
-                  : ''
+                  ? tct(
+                      'No repositories to add. [manageRepositoriesLink:Manage repositories in Organization Settings.]',
+                      {
+                        manageRepositoriesLink: (
+                          <Link to={`/settings/${organization.slug}/repos/`} />
+                        ),
+                      }
+                    )
+                  : null
             }
-            disabled={isRepoLimitReached || unselectedRepositories?.length === 0}
-            onClick={openAddRepoModal}
           >
-            {t('Add Repos')}
-          </Button>
+            <Button
+              size="xs"
+              icon={<IconAdd />}
+              disabled={isRepoLimitReached || unselectedRepositories?.length === 0}
+              onClick={openAddRepoModal}
+            >
+              {t('Add Repos')}
+            </Button>
+          </Tooltip>
         </div>
       </PanelHeader>
 
       {showSaveNotice && (
         <Alert type="info" showIcon system>
           {t(
-            'Changes will apply on the next Seer run or hit "Start Over" in the Seer panel to start a new run and use your changes.'
+            'Changes will apply on future Seer runs. Hit "Start Over" in the Seer panel to start a new run and use your new selected repositories.'
           )}
         </Alert>
       )}


### PR DESCRIPTION
Instead of a bunch of banners at the top, creates a nice set of guided steps. Also adds steps for enabling automation in settings and for creating the recommended fixability-score-based view. (title says "Debug Faster with Seer," some screenshots are outdated)



<img width="796" alt="Screenshot 2025-05-17 at 9 36 47 AM" src="https://github.com/user-attachments/assets/07baf09b-51cd-44cf-91e9-ee1d73161385" />
<img width="790" alt="Screenshot 2025-05-17 at 9 36 49 AM" src="https://github.com/user-attachments/assets/c2d7fa6f-acdc-4b3d-b5c4-1088474b8c83" />
<img width="768" alt="Screenshot 2025-05-17 at 9 36 53 AM" src="https://github.com/user-attachments/assets/59df2406-6fa0-4175-af02-a1d31dc9c8f2" />
<img width="784" alt="Screenshot 2025-05-17 at 11 24 17 AM" src="https://github.com/user-attachments/assets/0939a0ed-bddd-4172-a515-b9202d311c53" />


Also in repo settings, add a link to manage organization repos if there are no repos to add.

<img width="292" alt="Screenshot 2025-05-17 at 9 52 38 AM" src="https://github.com/user-attachments/assets/751cfa52-8f96-4076-8ba9-e8bb2f73e98c" />
