### PR TITLE
feat(source-maps): Do not render source maps wizard if platform is react native

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -260,7 +260,7 @@ function SentryWizardCallout({
     <Fragment>
       <WizardInstructionParagraph>
         {t(
-          'Firstly, have you already run the Sentry Wizard with `sourcemaps` in your project’s terminal? It’s the easiest way to get source maps set up:'
+          "Firstly, have you already run the Sentry Wizard with `sourcemaps` in your project's terminal? It's the easiest way to get source maps set up:"
         )}
       </WizardInstructionParagraph>
       <InstructionCodeSnippet
@@ -539,7 +539,7 @@ export function SourceMapsDebuggerModal({
       <Body>
         <p>
           {t(
-            "It looks like the original source code for this stack frame couldn't be determined when this error was captured. To get the original code for this stack frame, Sentry needs source maps to be configured."
+            "It looks like the original source code for this stack frame couldn't be determined when this error was captured. To get the original code for this stack frame, Sentry needs source maps to be uploaded."
           )}
         </p>
         <DebuggerSection title={t('Why Configure Source Maps?')}>
@@ -570,7 +570,20 @@ export function SourceMapsDebuggerModal({
           </div>
         </DebuggerSection>
         <DebuggerSection title={t('Troubleshooting Your Source Maps')}>
-          {metaFrameworksWithSentryWizardInOnboarding.includes(platform) ? (
+          {isReactNativeSDK({
+            sdkName: sourceResolutionResults.sdkName,
+          }) ? (
+            <WizardInstructionParagraph>
+              {tct(
+                "For React Native projects, source maps should be generated and uploaded automatically during the build process. If they're not showing up, chances are something's off in your setup. [link:Our docs] can help you double-check.",
+                {
+                  link: (
+                    <ExternalLinkWithIcon href="https://docs.sentry.io/platforms/react-native/sourcemaps/" />
+                  ),
+                }
+              )}
+            </WizardInstructionParagraph>
+          ) : metaFrameworksWithSentryWizardInOnboarding.includes(platform) ? (
             <MetaFrameworkConfigInfo
               framework={platform}
               orgSlug={orgSlug}
@@ -585,9 +598,15 @@ export function SourceMapsDebuggerModal({
           )}
           {!hideAllTabs && (
             <p>
-              {t(
-                "Secondly, let's go through a checklist to help you troubleshoot why source maps aren't showing up. There are a few ways to configure them:"
-              )}
+              {isReactNativeSDK({
+                sdkName: sourceResolutionResults.sdkName,
+              })
+                ? t(
+                    "After confirming your setup is correct, let's go through a quick checklist to help you troubleshoot your source maps further. There are a few ways to configure them:"
+                  )
+                : t(
+                    "Secondly, let's go through a checklist to help you troubleshoot why source maps aren't showing up. There are a few ways to configure them:"
+                  )}
             </p>
           )}
           <Tabs<'debug-ids' | 'release' | 'fetching'>
@@ -658,14 +677,23 @@ export function SourceMapsDebuggerModal({
               <TabPanels.Item key="debug-ids">
                 {hideAllTabs ? (
                   <p>
-                    {tct(
-                      "Secondly, let's go through a checklist to troubleshoot why your source maps aren't showing up. We rely on [link:Debug IDs] to link your source files to the maps, so let's make sure they're set up correctly:",
-                      {
-                        link: sourceMapsDocLinks.debugIds ? (
-                          <ExternalLink href={sourceMapsDocLinks.debugIds} />
-                        ) : undefined,
-                      }
-                    )}
+                    {isReactNativeSDK({sdkName: sourceResolutionResults.sdkName})
+                      ? tct(
+                          "After confirming your setup is correct, the next step is verifying your Debug IDs, which link your source files to the source maps. Let's make sure they're set up properly by running through this quick checklist:",
+                          {
+                            link: sourceMapsDocLinks.debugIds ? (
+                              <ExternalLink href={sourceMapsDocLinks.debugIds} />
+                            ) : undefined,
+                          }
+                        )
+                      : tct(
+                          "Secondly, let's go through a checklist to troubleshoot why your source maps aren't showing up. We rely on [link:Debug IDs] to link your source files to the maps, so let's make sure they're set up correctly:",
+                          {
+                            link: sourceMapsDocLinks.debugIds ? (
+                              <ExternalLink href={sourceMapsDocLinks.debugIds} />
+                            ) : undefined,
+                          }
+                        )}
                   </p>
                 ) : (
                   <p>
@@ -714,14 +742,25 @@ export function SourceMapsDebuggerModal({
               <TabPanels.Item key="release">
                 {hideAllTabs ? (
                   <p>
-                    {tct(
-                      "Secondly, let's go through a checklist to troubleshoot why your source maps aren't showing up. Your stack trace is matched to your source code using [link:Releases] and artifact names, so let's ensure that's set up correctly:",
-                      {
-                        link: (
-                          <ExternalLinkWithIcon href="https://docs.sentry.io/product/releases/" />
-                        ),
-                      }
-                    )}
+                    {isReactNativeSDK({
+                      sdkName: sourceResolutionResults.sdkName,
+                    })
+                      ? tct(
+                          "After confirming your setup is correct, the next step is to check whether your source maps are properly linked to your stack traces. This happens through [link:Releases] and artifact names, so let's make sure those are configured correctly:",
+                          {
+                            link: (
+                              <ExternalLinkWithIcon href="https://docs.sentry.io/product/releases/" />
+                            ),
+                          }
+                        )
+                      : t(
+                          "Secondly, let's go through a checklist to troubleshoot why your source maps aren't showing up. Your stack trace is matched to your source code using [link:Releases] and artifact names, so let's ensure that's set up correctly:",
+                          {
+                            link: (
+                              <ExternalLinkWithIcon href="https://docs.sentry.io/product/releases/" />
+                            ),
+                          }
+                        )}
                   </p>
                 ) : (
                   <p>
@@ -1008,7 +1047,7 @@ function SentryPluginMessage({
     return (
       <p>
         {tct(
-          'For your Sentry [pluginNameAndLink] Plugin, check your [configFile] and ensure the plugin is active when building your production app. You cannot do two separate builds—one for uploading to Sentry with the plugin active, and one for deploying without it. The plugin needs to be active for every build.',
+          'For your Sentry [pluginNameAndLink] Plugin, check your [configFile] and ensure the plugin is active when building your production app. You cannot do two separate builds—one for uploading to Sentry with the plugin active, and one for deploying without it.',
           {
             pluginNameAndLink: (
               <ExternalLinkWithIcon href={plugin.link}>
@@ -1025,7 +1064,7 @@ function SentryPluginMessage({
   return (
     <p>
       {tct(
-        'If you are using a [bundlerPluginRepoLink:Sentry Plugin for your Bundler], the plugin needs to be active when building your production app. You cannot do two separate builds, for example, one for uploading to Sentry with the plugin being active and one for deploying without the plugin. The plugin needs to be active for every build.',
+        'If you are using a [bundlerPluginRepoLink:Sentry Plugin for your Bundler], the plugin needs to be active when building your production app. You cannot do two separate builds, for example, one for uploading to Sentry with the plugin being active and one for deploying without the plugin.',
         {
           bundlerPluginRepoLink: (
             <ExternalLinkWithIcon href={sourceMapsDocLinks.bundlerPluginRepoLink} />
@@ -1147,7 +1186,7 @@ function HasDebugIdChecklistItem({
               </p>
               <p>
                 {tct(
-                  'The [bundlerPluginRepoLink:Sentry Metro Plugin] needs to be active when building your production app. You cannot do two separate builds, for example, one for uploading to Sentry with the plugin being active and one for deploying without the plugin. The plugin needs to be active for every build.',
+                  'The [bundlerPluginRepoLink:Sentry Metro Plugin] needs to be active when building your production app. You cannot do two separate builds, for example, one for uploading to Sentry with the plugin being active and one for deploying without the plugin.',
                   {
                     bundlerPluginRepoLink: (
                       <ExternalLinkWithIcon
@@ -1181,14 +1220,6 @@ function HasDebugIdChecklistItem({
               toolUsedToUploadSourceMaps={toolUsedToUploadSourceMaps}
             />
           )}
-          <p>
-            {tct(
-              'Read the [link:Sentry Source Maps Documentation] to learn how to inject Debug IDs into your build artifacts and how to upload them to Sentry.',
-              {
-                link: <ExternalLinkWithIcon href={sourceMapsDocLinks.sourcemaps} />,
-              }
-            )}
-          </p>
         </CheckListInstruction>
       </CheckListItem>
     );


### PR DESCRIPTION
If the platform is React Native, we shouldn’t guide users to run the Sentry Wizard with the sourcemaps option, as that workflow doesn’t apply to React Native. Source maps are generated and uploaded differently during the app’s build process. This PR updates the messaging to reflect that and instead directs users to the appropriate documentation.

_when we show multiple tabs_
<img width="763" alt="Screenshot 2025-05-19 at 11 43 47" src="https://github.com/user-attachments/assets/1b577c7b-2605-4801-803a-cfd9219a40f4" />

_when we show only releases:_
<img width="775" alt="Screenshot 2025-05-19 at 11 38 23" src="https://github.com/user-attachments/assets/135c715f-6881-4af9-b642-6ec240ce089e" />

_when we show only debug ids_
<img width="761" alt="Screenshot 2025-05-19 at 11 41 52" src="https://github.com/user-attachments/assets/50466b79-be6f-4b88-b569-90c85850c78b" />


This is a follow-up of https://github.com/getsentry/sentry/pull/87702
contributes to TET-363


