### PR TITLE
ref(js): No need to pass timezone to moment

### DIFF
--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -164,7 +164,7 @@ function TimeSince({
     fixed: options?.clock24Hours
       ? 'November 3, 2020 08:57 UTC'
       : 'November 3, 2020 8:58 AM UTC',
-    value: moment.tz(dateObj, options?.timezone ?? '').format(format),
+    value: moment(dateObj).format(format),
   });
 
   return (

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -35,7 +35,6 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import Placeholder from 'sentry/components/placeholder';
 import {IconCheckmark, IconClock, IconFire, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {DateString} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
@@ -93,10 +92,7 @@ interface MetricChartProps {
 }
 
 function formatTooltipDate(date: moment.MomentInput, format: string): string {
-  const {
-    options: {timezone},
-  } = ConfigStore.get('user');
-  return moment.tz(date, timezone).format(format);
+  return moment(date).format(format);
 }
 
 export function getRuleChangeSeries(

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -7,7 +7,6 @@ import type {AreaChartProps, AreaChartSeries} from 'sentry/components/charts/are
 import MarkArea from 'sentry/components/charts/components/markArea';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {Series} from 'sentry/types/echarts';
 import type {SessionApiResponse} from 'sentry/types/organization';
@@ -29,10 +28,7 @@ import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 function formatTooltipDate(date: moment.MomentInput, format: string): string {
-  const {
-    options: {timezone},
-  } = ConfigStore.get('user');
-  return moment.tz(date, timezone).format(format);
+  return moment(date).format(format);
 }
 
 function createStatusAreaSeries(

--- a/static/app/views/alerts/rules/metric/utils/anomalyChart.tsx
+++ b/static/app/views/alerts/rules/metric/utils/anomalyChart.tsx
@@ -4,7 +4,6 @@ import moment from 'moment-timezone';
 
 import type {AreaChartSeries} from 'sentry/components/charts/areaChart';
 import MarkLine from 'sentry/components/charts/components/markLine';
-import ConfigStore from 'sentry/stores/configStore';
 import type {Anomaly} from 'sentry/views/alerts/types';
 import {AnomalyType} from 'sentry/views/alerts/types';
 
@@ -156,8 +155,5 @@ function getDateForTimestamp(timestamp: string | number): Date {
 }
 
 function formatTooltipDate(date: moment.MomentInput, format: string): string {
-  const {
-    options: {timezone},
-  } = ConfigStore.get('user');
-  return moment.tz(date, timezone).format(format);
+  return moment(date).format(format);
 }

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -2,9 +2,9 @@ import moment from 'moment-timezone';
 
 import {DateTime} from 'sentry/components/dateTime';
 import Link from 'sentry/components/links/link';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import {t, tct} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 
 interface AutomationHistoryData {
   dateSent: Date;
@@ -37,10 +37,7 @@ const getColumns = (timezone: string) =>
   });
 
 export default function AutomationHistoryList({history}: Props) {
-  const {
-    options: {timezone},
-  } = ConfigStore.get('user');
-
+  const timezone = useTimezone();
   const columns = getColumns(timezone);
 
   return <SimpleTable columns={columns} data={history} />;

--- a/static/app/views/issueDetails/groupCheckIns.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.tsx
@@ -160,19 +160,11 @@ function CheckInCell({
                 {dataRow.expectedTime && (
                   <Fragment>
                     <dt>{t('Expected at')}</dt>
-                    <dd>
-                      {moment
-                        .tz(dataRow.expectedTime, userOptions?.timezone ?? '')
-                        .format(format)}
-                    </dd>
+                    <dd>{moment(dataRow.expectedTime).format(format)}</dd>
                   </Fragment>
                 )}
                 <dt>{t('Received at')}</dt>
-                <dd>
-                  {moment
-                    .tz(dataRow[columnKey], userOptions?.timezone ?? '')
-                    .format(format)}
-                </dd>
+                <dd>{moment(dataRow[columnKey]).format(format)}</dd>
               </LabelledTooltip>
             }
           >

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -166,13 +166,11 @@ function ReleaseCard({
                 <Tooltip
                   isHoverable
                   title={tct('This release was finalized on [date]. [docs:Read More].', {
-                    date: moment
-                      .tz(release.dateReleased, options?.timezone ?? '')
-                      .format(
-                        options?.clock24Hours
-                          ? 'MMMM D, YYYY HH:mm z'
-                          : 'MMMM D, YYYY h:mm A z'
-                      ),
+                    date: moment(release.dateReleased).format(
+                      options?.clock24Hours
+                        ? 'MMMM D, YYYY HH:mm z'
+                        : 'MMMM D, YYYY h:mm A z'
+                    ),
                     docs: (
                       <ExternalLink href="https://docs.sentry.io/cli/releases/#finalizing-releases" />
                     ),
@@ -186,16 +184,11 @@ function ReleaseCard({
                   title={tct(
                     'Set release date to [date].[br]Finalizing a release means that we populate a second timestamp on the release record, which is prioritized over [code:date_created] when sorting releases. [docs:Read more].',
                     {
-                      date: moment
-                        .tz(
-                          release.firstEvent ?? release.dateCreated,
-                          options?.timezone ?? ''
-                        )
-                        .format(
-                          options?.clock24Hours
-                            ? 'MMMM D, YYYY HH:mm z'
-                            : 'MMMM D, YYYY h:mm A z'
-                        ),
+                      date: moment(release.firstEvent ?? release.dateCreated).format(
+                        options?.clock24Hours
+                          ? 'MMMM D, YYYY HH:mm z'
+                          : 'MMMM D, YYYY h:mm A z'
+                      ),
                       br: <br />,
                       code: <code />,
                       docs: (

--- a/static/gsApp/hooks/firstPartyIntegrationAlertHook.tsx
+++ b/static/gsApp/hooks/firstPartyIntegrationAlertHook.tsx
@@ -4,7 +4,6 @@ import moment from 'moment-timezone';
 import {Alert} from 'sentry/components/core/alert';
 import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
-import {getUserTimezone} from 'sentry/utils/dates';
 import AlertContainer from 'sentry/views/settings/organizationIntegrations/integrationAlertContainer';
 
 import UpsellButton from 'getsentry/components/upsellButton';
@@ -39,9 +38,7 @@ function FirstPartyIntegrationAlertHook({
         t(
           'Your %s integration will be disabled after %s',
           integration.provider.name,
-          moment(integration.gracePeriodEnd)
-            .tz(getUserTimezone())
-            .format('MMMM Do, YYYY h:mm A z')
+          moment(integration.gracePeriodEnd).format('MMMM Do, YYYY h:mm A z')
         ),
         'grace-period',
         integration.provider.key,


### PR DESCRIPTION
We already set the default timezone in moment.tz to the user's configured timezone.

This is done here https://github.com/getsentry/sentry/blob/20b05fc91a4ad6783bff1875327f4570bcfb5d00/static/app/stores/configStore.tsx#L47

We had two types of moment invocations that did not require us to pass the users timezone:

- `moment.tz(myDate, userTimezone)`
- `moment(myDate).tz(userTimezone)`

Here are some examples showing that these work fine WITHOUT providing the timezone and letting moment fall back to it's default

```tsx
// Set timezone to America/New_York. We ALWAYS were doing this
const userTz = 'America/New_York';
moment.tz.setDefault(userTz);

// A few Example timestamps. All of our server response timestamps will
// be at UTC, but for illustration purposes we can also look at dates
// specified in other timezones
const dateUTC = '2014-06-01T12:00:00-00:00';
const dateNY = '2014-06-01T12:00:00-04:00';

// Calling moment.tz with or without the timezone always localizes to
// America/New_York because of the default
moment.tz(dateUTC, userTz).format(); // '2014-06-01T08:00:00-04:00'
moment(dateUTC).tz(userTz).format(); // '2014-06-01T08:00:00-04:00'
moment(dateUTC).format();            // '2014-06-01T08:00:00-04:00'

// Passing a date as a different timezone
moment.tz(dateLA, userTz).format();  // '2014-06-01T15:00:00-04:00'
moment(dateLA).format();             // '2014-06-01T15:00:00-04:00'
```