### PR TITLE
fix(replay): Stringify any tags so we can see the value of objects instead of erroring

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -43,6 +43,21 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...user,
   };
 
+  // Stringify everything, so we don't try to render objects or something strange
+  // an error boundary will save us, but that's not useful to see
+  const stringifiedTags = Object.fromEntries(
+    Object.entries(unorderedTags).map(([key, value]) => [
+      key,
+      value.map((v: unknown) => {
+        try {
+          return v instanceof Object ? JSON.stringify(v) : v;
+        } catch (e) {
+          return v;
+        }
+      }),
+    ])
+  );
+
   const startedAt = new Date(apiResponse.started_at);
   invariant(isValidDate(startedAt), 'replay.started_at is invalid');
   const finishedAt = new Date(apiResponse.finished_at);
@@ -55,7 +70,7 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...(apiResponse.duration === undefined
       ? {}
       : {duration: duration(apiResponse.duration * 1000)}),
-    tags: unorderedTags,
+    tags: stringifiedTags,
   };
 }
 


### PR DESCRIPTION
This iterates on https://github.com/getsentry/sentry/pull/91854 to fix [JAVASCRIPT-30NR](https://sentry.io/organizations/sentry/issues/?project=11276&query=JAVASCRIPT-30NR)

**Before**
With the first iteration we started showing an error boundary if we get an object to render:
<img width="598" alt="SCR-20250519-ipoh" src="https://github.com/user-attachments/assets/8f810891-6988-498a-910a-e2d0ad4c2d5b" />

**After**
Now we're going to try and stringify objects so they render with some kind of useful info:
<img width="598" alt="SCR-20250519-ijjc" src="https://github.com/user-attachments/assets/a0d083e6-c753-4d44-9b18-11fc22b8ee82" />


Fixes JAVASCRIPT-30P3