### PR TITLE
fix: Add guards when enabling / disabling to keep detector and uptime in sync

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -346,7 +346,7 @@ def disable_uptime_detector(detector: Detector):
     uptime_monitor = get_project_subscription(detector)
     uptime_subscription: UptimeSubscription = uptime_monitor.uptime_subscription
 
-    if uptime_monitor.status == ObjectStatus.DISABLED:
+    if uptime_monitor.status == ObjectStatus.DISABLED and not detector.enabled:
         return
 
     if uptime_subscription.uptime_status == UptimeStatus.FAILED:
@@ -388,7 +388,12 @@ def enable_uptime_detector(detector: Detector, ensure_assignment: bool = False):
     no-op. Pass `ensure_assignment=True` to force seat assignment.
     """
     uptime_monitor = get_project_subscription(detector)
-    if not ensure_assignment and uptime_monitor.status != ObjectStatus.DISABLED:
+
+    if (
+        not ensure_assignment
+        and uptime_monitor.status != ObjectStatus.DISABLED
+        and detector.enabled
+    ):
         return
 
     seat_assignment = quotas.backend.check_assign_seat(DataCategory.UPTIME, uptime_monitor)


### PR DESCRIPTION
This PR aims to fix a hole where if the detector is enabled and project uptime sub is disabled we would be returning early on disable cases, and vice versa for enable cases.

We want to make sure that detectors and project uptime subs always have the same state, and this guard will help keep it that way. Also adds a couple tests.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
