### PR TITLE
storybook: smaller last edited

### DIFF
--- a/static/app/views/stories/storySourceLinks.tsx
+++ b/static/app/views/stories/storySourceLinks.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {DateTime} from 'sentry/components/dateTime';
@@ -24,15 +25,15 @@ export function StorySourceLinks(props: {story: StoryDescriptor}) {
       return response.json();
     },
   });
+
   const committerDate = data?.[0]?.commit.committer.date;
 
   return (
     <Fragment>
       {committerDate ? (
-        <Fragment>
-          Story Last Edited:
-          <DateTime date={committerDate} />
-        </Fragment>
+        <LastEdited>
+          Last Edited: <DateTime date={committerDate} />
+        </LastEdited>
       ) : null}
       <LinkButton
         href={`https://github.com/getsentry/sentry/blob/master/static/${props.story.filename}`}
@@ -55,3 +56,8 @@ export function StorySourceLinks(props: {story: StoryDescriptor}) {
     </Fragment>
   );
 }
+
+const LastEdited = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/views/stories/storySourceLinks.tsx
+++ b/static/app/views/stories/storySourceLinks.tsx
@@ -59,5 +59,5 @@ export function StorySourceLinks(props: {story: StoryDescriptor}) {
 
 const LastEdited = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.tokens.content.muted};
 `;


### PR DESCRIPTION
Visually update the last edited label to be smaller and visually prioritize the component title and the buttons

Before
![CleanShot 2025-05-19 at 12 50 52@2x](https://github.com/user-attachments/assets/8c4712fa-8c16-4472-897e-5aea5a5c38b0)
After
![CleanShot 2025-05-19 at 12 49 17@2x](https://github.com/user-attachments/assets/9788f7b0-ae00-4b2d-ab74-f4364cb42088)

