### PR TITLE
trace: fix buttons in chonk

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1156,7 +1156,7 @@ const ActionWrapper = styled('div')`
   overflow: visible;
   display: flex;
   align-items: center;
-  gap: ${space(0.25)};
+  gap: ${space(0.5)};
 `;
 
 function EventTags({projectSlug, event}: {event: Event; projectSlug: string}) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -701,24 +701,22 @@ function TabPinButton(props: {
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }) {
   return (
-    <PinButton
-      size="zero"
-      data-test-id="trace-drawer-tab-pin-button"
-      onClick={props.onClick}
-    >
+    <PinButton data-test-id="trace-drawer-tab-pin-button" onClick={props.onClick}>
       <StyledIconPin size="xs" isSolid={props.pinned} />
     </PinButton>
   );
 }
 
-const PinButton = styled(Button)`
+const PinButton = styled('button')`
   padding: ${space(0.5)};
   margin: 0;
   background-color: transparent;
   border: none;
+  color: ${p => p.theme.tokens.content.muted};
 
   &:hover {
     background-color: transparent;
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -704,10 +704,10 @@ function TabPinButton(props: {
   return (
     <StyledButton
       data-test-id="trace-drawer-tab-pin-button"
+      size="zero"
       onClick={props.onClick}
       // @ts-expect-error transparent is not supported in legacy button
       priority={theme.isChonk ? 'transparent' : 'default'}
-      size="zero"
       aria-label={props.pinned ? t('Unpin Tab') : t('Pin Tab')}
       icon={<StyledIconPin size="xs" isSolid={props.pinned} />}
     />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -700,24 +700,23 @@ function TabPinButton(props: {
   pinned: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }) {
+  const theme = useTheme();
   return (
-    <PinButton data-test-id="trace-drawer-tab-pin-button" onClick={props.onClick}>
-      <StyledIconPin size="xs" isSolid={props.pinned} />
-    </PinButton>
+    <StyledButton
+      data-test-id="trace-drawer-tab-pin-button"
+      onClick={props.onClick}
+      // @ts-expect-error transparent is not supported in legacy button
+      priority={theme.isChonk ? 'transparent' : 'default'}
+      size="zero"
+      aria-label={props.pinned ? t('Unpin Tab') : t('Pin Tab')}
+      icon={<StyledIconPin size="xs" isSolid={props.pinned} />}
+    />
   );
 }
 
-const PinButton = styled('button')`
-  padding: ${space(0.5)};
-  margin: 0;
-  background-color: transparent;
+const StyledButton = styled(Button)`
   border: none;
-  color: ${p => p.theme.tokens.content.muted};
-
-  &:hover {
-    background-color: transparent;
-    color: ${p => p.theme.tokens.content.primary};
-  }
+  box-shadow: none;
 `;
 
 const StyledIconPin = styled(IconPin)`


### PR DESCRIPTION
Fixes chonk buttons in trace view

Before
![CleanShot 2025-05-19 at 13 15 12@2x](https://github.com/user-attachments/assets/e0c424f8-db7b-4d42-975d-ff92df19aa0f)

After
![CleanShot 2025-05-19 at 13 15 38@2x](https://github.com/user-attachments/assets/2244f5f1-0cb4-45a3-adef-9a156bbee7dc)


Fixes DE-49