### PR TITLE
chore(replays): Remove devtoolbar from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -368,8 +368,6 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/toolbar/                         @getsentry/replay-frontend @getsentry/replay-backend
 /tests/sentry/toolbar/                       @getsentry/replay-frontend @getsentry/replay-backend
 /static/app/components/devtoolbar/           @getsentry/replay-frontend
-/src/sentry/middleware/devtoolbar.py         @getsentry/replay-backend
-/tests/sentry/middleware/test_devtoolbar.py  @getsentry/replay-backend
 ## End of DevToolbar
 
 ## Codecov Merge UX


### PR DESCRIPTION
This is causing lots of unrelated issues to be auto-assigned to the replay team.