### PR TITLE
fix(crons): Floor seconds / microsecond on recorded dateClock

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -826,7 +826,7 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
                 #
                 # XXX: They are NOT timezone aware date times, set the timezone
                 # to UTC
-                clock_time = item.ts.replace(tzinfo=UTC)
+                clock_time = item.ts.replace(second=0, microsecond=0, tzinfo=UTC)
 
                 # Record the reported in_progress time when the check is in progress
                 date_in_progress = start_time if status == CheckInStatus.IN_PROGRESS else None

--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -357,7 +357,7 @@ class MonitorConsumerTest(TestCase):
         self.send_checkin(monitor.slug, ts=ts, item_ts=item_ts)
         checkin = MonitorCheckIn.objects.get(guid=self.guid)
         assert checkin.date_added == ts.replace(tzinfo=UTC)
-        assert checkin.date_clock == item_ts.replace(tzinfo=UTC)
+        assert checkin.date_clock == item_ts.replace(second=0, microsecond=0, tzinfo=UTC)
 
     def test_check_in_date_in_progress(self):
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
We record this value for check-ins, this is supposed to be trimmed of
it's seconds and microseconds, since we count clock ticks in minutes