### PR TITLE
fix(autofix): Stricter manual autofix rate limits

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -35,9 +35,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
     enforce_rate_limit = True
     rate_limits = {
         "POST": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=60),
-            RateLimitCategory.USER: RateLimit(limit=10, window=60),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60),
+            RateLimitCategory.IP: RateLimit(limit=5, window=60),
+            RateLimitCategory.USER: RateLimit(limit=5, window=60),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=60 * 60),  # 1 hour
         },
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=256, window=60),


### PR DESCRIPTION
Implements stricter rate limits for manually triggered Autofixes. Does not affect Automation-ran runs.

Max 20 runs per hour per org, and max 5 runs per minute per user.