### PR TITLE
fix(issues): Make sure there is a gap between controls when drawer is narrow

### DIFF
--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -67,6 +67,7 @@ export const EventNavigator = styled('div')`
 export const EventStickyControls = styled('div')`
   display: flex;
   justify-content: space-between;
+  gap: ${space(1)};
   position: sticky;
   top: -${space(2)};
   margin-block: -${space(2)};


### PR DESCRIPTION
**Before**
<img width="382" alt="before" src="https://github.com/user-attachments/assets/7449494d-684a-43f0-98c2-58d725b2f88d" />

**After**
<img width="373" alt="after" src="https://github.com/user-attachments/assets/6683b097-5e08-4df3-ab16-0294b9a4735d" />
