### PR TITLE
chore(aci milestone 3): temporarily skip dual processing anomaly detection alerts

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -422,20 +422,24 @@ class SubscriptionProcessor:
                 data_packet = DataPacket[MetricDetectorUpdate](
                     source_id=str(self.subscription.id), packet=packet
                 )
-                results = process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
-                if features.has(
-                    "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                    self.alert_rule.organization,
-                ):
-                    logger.info(
-                        "dual processing results for alert rule",
-                        extra={
-                            "results": results,
-                            "num_results": len(results),
-                            "value": aggregation_value,
-                            "rule_id": self.alert_rule.id,
-                        },
+                # temporarily skip processing any anomaly detection alerts
+                if self.alert_rule.detection_type != AlertRuleDetectionType.DYNAMIC:
+                    results = process_data_packets(
+                        [data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
                     )
+                    if features.has(
+                        "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                        self.alert_rule.organization,
+                    ):
+                        logger.info(
+                            "dual processing results for alert rule",
+                            extra={
+                                "results": results,
+                                "num_results": len(results),
+                                "value": aggregation_value,
+                                "rule_id": self.alert_rule.id,
+                            },
+                        )
 
         has_anomaly_detection = features.has(
             "organizations:anomaly-detection-alerts", self.subscription.project.organization

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -3919,6 +3919,36 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         assert data_packet_list[0].packet["values"] == {"value": 10}
 
     @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:anomaly-detection-rollout")
+    @mock.patch(
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
+    )
+    @mock.patch("sentry.incidents.subscription_processor.process_data_packets")
+    def test_process_data_packets_not_called_dynamic_rule(
+        self, mock_process_data_packets, mock_seer_request
+    ):
+        # TODO: remove once we migrate dynamic metric alerts
+        rule = self.dynamic_rule
+        seer_return_value: DetectAnomaliesResponse = {
+            "success": True,
+            "timeseries": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.2,
+                        "anomaly_type": AnomalyType.NONE.value,
+                    },
+                    "timestamp": 1,
+                    "value": 5,
+                }
+            ],
+        }
+
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        self.send_update(rule, 10)
+        assert mock_process_data_packets.call_count == 0
+
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @mock.patch("sentry.incidents.subscription_processor.process_data_packets")
     @mock.patch(
         "sentry.incidents.subscription_processor.SubscriptionProcessor.get_comparison_aggregation_value"


### PR DESCRIPTION
Either they don't have detectors written, or the processing results will be incorrect because the data conditions aren't correctly set up yet.