### PR TITLE
chore(aci): remove uses of WorkflowFireHistory rollout columns

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -422,7 +422,7 @@ class WorkflowEngineRuleSerializer(Serializer):
         result_qs = reduce(
             lambda q1, q2: q1.union(q2),
             [
-                WorkflowFireHistory.objects.filter(workflow=item, has_fired_actions=True)
+                WorkflowFireHistory.objects.filter(workflow=item)
                 .order_by("-date_added")
                 .values("workflow_id", "date_added")[:1]
                 for item in item_list

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -83,8 +83,6 @@ def create_workflow_fire_histories(
             workflow_id=workflow_id,
             group=event_data.event.group,
             event_id=event_data.event.event_id,
-            has_passed_filters=True,
-            has_fired_actions=True,
         )
         for workflow_id in workflow_ids
     ]

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -56,7 +56,6 @@ class WorkflowRuleSerializerTest(TestCase):
         WorkflowFireHistory.objects.create(
             workflow=workflow,
             group=self.group,
-            has_fired_actions=True,
             event_id="fc6d8c0c43fc4630ad850ee518f1b9d0",
         )
 
@@ -213,15 +212,13 @@ class WorkflowRuleSerializerTest(TestCase):
         workflow_2 = self.create_workflow()
 
         WorkflowFireHistory.objects.create(workflow=workflow, group=self.group, event_id="asdf")
-        WorkflowFireHistory.objects.create(
-            workflow=workflow, group=self.group, event_id="jklm", has_fired_actions=True
-        )
+        WorkflowFireHistory.objects.create(workflow=workflow, group=self.group, event_id="jklm")
         wfh = WorkflowFireHistory.objects.create(
-            workflow=workflow_2, group=self.group, event_id="qwer", has_fired_actions=True
+            workflow=workflow_2, group=self.group, event_id="qwer"
         )
         wfh.update(date_added=before_now(days=1))
         wfh_2 = WorkflowFireHistory.objects.create(
-            workflow=workflow_2, group=self.group, event_id="fdsa", has_fired_actions=True
+            workflow=workflow_2, group=self.group, event_id="fdsa"
         )
         wfh_2.update(date_added=before_now(hours=1))
 

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -93,8 +93,6 @@ class TestWorkflowFireHistory(BaseWorkflowTest):
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,
-                has_passed_filters=True,
-                has_fired_actions=True,
             ).count()
             == 1
         )

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -828,16 +828,12 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             workflow=self.workflow2,
             group_id=self.group2.id,
             event_id=self.event2.event_id,
-            has_passed_filters=True,
-            has_fired_actions=True,
         ).exists()
 
         assert WorkflowFireHistory.objects.filter(
             workflow=self.workflow1,
             group_id=self.group1.id,
             event_id=self.event1.event_id,
-            has_passed_filters=True,
-            has_fired_actions=True,
         ).exists()
 
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -628,7 +628,6 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
                 workflow=self.workflow,
                 group=self.group,
                 event_id=self.group_event.event_id,
-                has_fired_actions=True,
             ).count()
             == 1
         )


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/91600 refactored `WorkflowFireHistory` to only be created when trigger + filters conditions are met for a workflow and we fire actions for the `Workflow`. Thus we will no longer need the columns `has_passed_filters` and `has_fired_actions` as they are automatically true.

Remove the uses of these columns in preparation for dropping them.