### PR TITLE
fix(stats): use data category title name

### DIFF
--- a/static/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx
+++ b/static/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx
@@ -226,6 +226,7 @@ function EnhancedUsageStatsOrganization({
   projectIds,
   dataDatetime,
   dataCategory,
+  dataCategoryName,
   dataCategoryApiName,
   setRouteAnalyticsParams,
   isSingleProject,
@@ -335,7 +336,7 @@ function EnhancedUsageStatsOrganization({
       organization={organization}
       dataCategory={dataCategory}
       dataCategoryApiName={dataCategoryApiName}
-      dataCategoryName={dataCategoryInfo.name}
+      dataCategoryName={dataCategoryName}
       dataDatetime={dataDatetime}
       projectIds={projectIds}
       endpointQuery={newEndpointQuery}


### PR DESCRIPTION
use `dataCategoryName` in stats page

old
<img width="559" alt="Screenshot 2025-05-19 at 3 53 43 PM" src="https://github.com/user-attachments/assets/ff32dbad-0ce2-4205-8c17-c47d978fde83" />

new
<img width="554" alt="Screenshot 2025-05-19 at 3 57 25 PM" src="https://github.com/user-attachments/assets/9998458f-91d1-4224-8021-38fe3e18410b" />
