### PR TITLE
fix(issues): Remove xAxis ticks on events chart

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -560,6 +560,12 @@ export function EventGraph({
             },
           }}
           xAxis={{
+            axisTick: {
+              show: false,
+            },
+            axisLabel: {
+              margin: 8,
+            },
             ...releaseBubbleXAxis,
           }}
           {...(disableZoomNavigation


### PR DESCRIPTION
because the bar graph buckets events, the ticks can sometimes appear off center compared to the position of the bucket. There's also sometimes random ticks with no labels.

before
![image](https://github.com/user-attachments/assets/0efb9395-2bd4-4012-93ae-d9ff01f5296d)

after
![image](https://github.com/user-attachments/assets/59c59cae-85cb-499d-8b69-a2cc17069768)
