### PR TITLE
ref(span-buffer): Move max-memory-percentage to right CLI

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -424,6 +424,11 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
                 default=100,
                 help="The number of segments to download from redis at once. Defaults to 100.",
             ),
+            click.Option(
+                ["--max-memory-percentage", "max_memory_percentage"],
+                default=1.0,
+                help="Maximum memory usage of the Redis cluster in % (0.0-1.0) before the consumer backpressures.",
+            ),
             *multiprocessing_options(default_max_batch_size=100),
         ],
     },
@@ -435,11 +440,6 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
                 ["--skip-produce", "skip_produce"],
                 is_flag=True,
                 default=False,
-            ),
-            click.Option(
-                ["--max-memory-percentage", "max_memory_percentage"],
-                default=1.0,
-                help="Maximum memory usage of the Redis cluster in % (0.0-1.0) before the consumer backpressures.",
             ),
             *multiprocessing_options(default_max_batch_size=100),
         ],


### PR DESCRIPTION
This was added to the wrong CLI, and because it's an optional argument
in the factory this wasn't noticed during manual testing.
