### PR TITLE
fix(nextjs-insights): Display rage clicks

### DIFF
--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -32,7 +32,8 @@ export function DeadRageClicksWidget() {
     sort: '-count_dead_clicks',
     cursor: undefined,
     query: fullQuery,
-    isWidgetData: true,
+    // Setting this to true just strips rage clicks from the data
+    isWidgetData: false,
   });
 
   const isEmpty = !isLoading && data.length === 0;


### PR DESCRIPTION
- closes [TET-490: Rage Clicks are shown as 0 in widget, but API returns 2](https://linear.app/getsentry/issue/TET-490/rage-clicks-are-shown-as-0-in-widget-but-api-returns-2)