### PR TITLE
fix(nextjs-insights): Remove url decoding

### DIFF
--- a/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.spec.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.spec.tsx
@@ -129,7 +129,7 @@ describe('mapResponseToTree', () => {
     });
   });
 
-  it('handles URL encoded path segments', () => {
+  it('does not decode URL encoded path segments', () => {
     const response = [
       {
         'avg(span.duration)': 100,
@@ -158,7 +158,7 @@ describe('mapResponseToTree', () => {
                   type: 'file',
                 },
               ],
-              name: 'user profile',
+              name: 'user%20profile',
               type: 'folder',
             },
           ],

--- a/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/ssrTreeWidget.tsx
@@ -110,14 +110,13 @@ export function mapResponseToTree(response: TreeResponseItem[]): TreeContainer {
 
     // Iterate over the path segments and create folders if they don't exist yet
     for (const segment of fullPath) {
-      const decodedSegment = decodeURIComponent(segment);
-      const child = currentFolder.children.find(c => c.name === decodedSegment);
+      const child = currentFolder.children.find(c => c.name === segment);
       if (child) {
         currentFolder = child as TreeContainer;
       } else {
         const newFolder: TreeContainer = {
           children: [],
-          name: decodedSegment,
+          name: segment,
           type: file === segment ? 'file' : 'folder',
         };
         currentFolder.children.push(newFolder);


### PR DESCRIPTION
Remove URL decoding from SSR Tree widget.

- closes [TET-477: Fix the tree encoding/decoding](https://linear.app/getsentry/issue/TET-477/fix-the-tree-encodingdecoding)