### PR TITLE
tag: fix bad tag change and flickering text

### DIFF
--- a/static/app/components/core/avatar/avatarList.tsx
+++ b/static/app/components/core/avatar/avatarList.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 
 import {TeamAvatar} from 'sentry/components/core/avatar/teamAvatar';
 import {UserAvatar, type UserAvatarProps} from 'sentry/components/core/avatar/userAvatar';
+import {Tag} from 'sentry/components/core/badge/tag';
 import {Tooltip} from 'sentry/components/core/tooltip';
-import {space} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
 import type {Team} from 'sentry/types/organization';
 import type {AvatarUser} from 'sentry/types/user';
@@ -39,9 +39,9 @@ export function CollapsedAvatars({
 
   if (hasStreamlinedUI) {
     return (
-      <CollapsedAvatarPill ref={ref} data-test-id="avatarList-collapsedavatars">
+      <Tag ref={ref} data-test-id="avatarList-collapsedavatars">
         {children}
-      </CollapsedAvatarPill>
+      </Tag>
     );
   }
   return (
@@ -102,7 +102,7 @@ function AvatarList({
               size={avatarSize}
               data-test-id="avatarList-collapsedavatars"
             >
-              {numCollapsedAvatars < 99 && <Plus>+</Plus>}
+              {numCollapsedAvatars < 99 && '+'}
               {numCollapsedAvatars}
             </CollapsedAvatars>
           </Tooltip>
@@ -202,30 +202,4 @@ const CollapsedAvatarsCicle = styled('div')<{size: number}>`
   height: ${p => p.size}px;
   border-radius: 50%;
   ${AvatarStyle};
-`;
-
-const CollapsedAvatarPill = styled('div')`
-  ${AvatarStyle};
-
-  display: flex;
-  align-items: center;
-  gap: ${space(0.25)};
-  font-weight: ${p => p.theme.fontWeightNormal};
-  color: ${p => p.theme.subText};
-  height: 24px;
-  padding: 0 ${space(1)};
-  background-color: ${p => p.theme.surface400};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: 24px;
-
-  ${AvatarListWrapper}:hover & {
-    background-color: ${p => p.theme.surface100};
-    cursor: pointer;
-  }
-`;
-
-const Plus = styled('span')`
-  font-size: 10px;
-  margin-left: 1px;
-  margin-right: -1px;
 `;

--- a/static/app/components/core/avatar/baseAvatar.tsx
+++ b/static/app/components/core/avatar/baseAvatar.tsx
@@ -106,7 +106,7 @@ export function BaseAvatar({
     );
 
   return (
-    <Tooltip title={tooltip} disabled={!hasTooltip} {...tooltipOptions}>
+    <Tooltip title={tooltip} disabled={!hasTooltip} {...tooltipOptions} skipWrapper>
       <AvatarContainer
         ref={ref as React.Ref<HTMLSpanElement>}
         data-test-id={`${type}-avatar`}
@@ -115,7 +115,6 @@ export function BaseAvatar({
         suggested={!!suggested}
         style={{...(size ? {height: size, width: size} : {}), ...style}}
         title={title}
-        hasTooltip={hasTooltip}
         {...props}
       >
         {hasError
@@ -137,7 +136,6 @@ export function BaseAvatar({
 // Note: Avatar will not always be a child of a flex layout, but this seems like a
 // sensible default.
 const AvatarContainer = styled('span')<{
-  hasTooltip: boolean;
   round: boolean;
   suggested: boolean;
 }>`
@@ -145,9 +143,6 @@ const AvatarContainer = styled('span')<{
   border-radius: ${p => (p.round ? '50%' : '3px')};
   border: ${p => (p.suggested ? `1px dashed ${p.theme.subText}` : 'none')};
   background-color: ${p => (p.suggested ? p.theme.background : 'none')};
-  :hover {
-    pointer-events: ${p => (p.hasTooltip ? 'none' : 'auto')};
-  }
 `;
 
 interface BackgroundAvatarProps extends React.HTMLAttributes<SVGSVGElement> {

--- a/static/app/components/core/badge/index.tsx
+++ b/static/app/components/core/badge/index.tsx
@@ -77,7 +77,7 @@ const StyledBadge = styled('span')<BadgeProps>`
   min-width: 20px;
   line-height: 20px;
   border-radius: 20px;
-  font-weight: ${p => p.theme.fontWeightBold};
+  font-weight: ${p => p.theme.fontWeightNormal};
 
   /* @TODO(jonasbadalic) can we standardize this transition? */
   transition: background 100ms linear;

--- a/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
@@ -42,14 +42,17 @@ function ReleaseCardCommits({release, withHeading = true}: Props) {
   ].join(' ');
 
   return (
-    <div className="release-stats">
+    <ReleaseStatsContainer className="release-stats">
       {withHeading && <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>}
-      <span style={{display: 'inline-block'}}>
-        <AvatarList users={authors} avatarSize={25} typeAvatars="authors" />
-      </span>
-    </div>
+      <AvatarList users={authors} avatarSize={25} typeAvatars="authors" />
+    </ReleaseStatsContainer>
   );
 }
+
+const ReleaseStatsContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
 
 const ReleaseSummaryHeading = styled('div')`
   color: ${p => p.theme.subText};

--- a/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardCommits.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/container/flex';
 import AvatarList from 'sentry/components/core/avatar/avatarList';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -42,17 +43,12 @@ function ReleaseCardCommits({release, withHeading = true}: Props) {
   ].join(' ');
 
   return (
-    <ReleaseStatsContainer className="release-stats">
+    <Flex className="release-stats" align="center">
       {withHeading && <ReleaseSummaryHeading>{releaseSummary}</ReleaseSummaryHeading>}
       <AvatarList users={authors} avatarSize={25} typeAvatars="authors" />
-    </ReleaseStatsContainer>
+    </Flex>
   );
 }
-
-const ReleaseStatsContainer = styled('div')`
-  display: flex;
-  align-items: center;
-`;
 
 const ReleaseSummaryHeading = styled('div')`
   color: ${p => p.theme.subText};


### PR DESCRIPTION
Fixes a bad tag change where the text became bolded (I must have modified the wrong tag and not noticed it)

Also removes a custom component for the tag pill (this must have been like this before), which makes this look better aligned and with a more appropriate font size

Before
![CleanShot 2025-05-20 at 10 12 07@2x](https://github.com/user-attachments/assets/6f27d0fc-aa32-4ba1-8248-601f6da9fa68)

After
![CleanShot 2025-05-20 at 10 11 55@2x](https://github.com/user-attachments/assets/dfbe3aec-10c9-4645-a633-654ee828f765)

Also fixed this awkward flickering caused by the tooltip on the avatar (first interaction is fixed state, second one is from prod)

https://github.com/user-attachments/assets/dd604408-3185-4243-9d0e-25e63326b9c2

