### PR TITLE
fix(task) Cleanup deprecated & unused parameters from reprocessing

### DIFF
--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -1,6 +1,4 @@
 import time
-from collections.abc import Sequence
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sentry_sdk
@@ -161,13 +159,8 @@ def handle_remaining_events(
     project_id: int,
     new_group_id: int,
     remaining_events: str,
-    # TODO(markus): Should be mandatory arguments.
-    event_ids_redis_key: str | None = None,
-    old_group_id: int | None = None,
-    # TODO(markus): Deprecated arguments, can remove in next version.
-    event_ids: Sequence[str] | None = None,
-    from_timestamp: datetime | None = None,
-    to_timestamp: datetime | None = None,
+    event_ids_redis_key: str,
+    old_group_id: int,
 ) -> None:
     """
     Delete or merge/move associated per-event data: nodestore, event


### PR DESCRIPTION
These parameters haven't been used for a long time and are being found by static analysis on task parameters.