### PR TITLE
chore(sdk): Use add_full_stack by default

### DIFF
--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -16,6 +16,7 @@ class SdkConfig(TypedDict):
     auto_enabling_integrations: bool
     keep_alive: NotRequired[bool]
     spotlight: NotRequired[str | bool | None]
+    add_full_stack: NotRequired[bool]
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     before_send: NotRequired[Callable[[Event, Hint], Event | None]]

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -16,7 +16,6 @@ class SdkConfig(TypedDict):
     auto_enabling_integrations: bool
     keep_alive: NotRequired[bool]
     spotlight: NotRequired[str | bool | None]
-    add_full_stack: NotRequired[bool]
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     before_send: NotRequired[Callable[[Event, Hint], Event | None]]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2367,13 +2367,6 @@ register(
 
 # END: SDK Crash Detection
 
-# Whether to add the full stack trace to Python errors.
-register(
-    "sentry_sdk.add_full_stack",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     # Lists the shared resource ids we want to account usage for.
     "shared_resources_accounting_enabled",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -285,6 +285,7 @@ class Dsns(NamedTuple):
 def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options = settings.SENTRY_SDK_CONFIG.copy()
     sdk_options["send_client_reports"] = True
+    sdk_options["add_full_stack"] = True
     sdk_options["traces_sampler"] = traces_sampler
     sdk_options["before_send_transaction"] = before_send_transaction
     sdk_options["before_send"] = before_send
@@ -296,8 +297,6 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
         before_send_log=before_send_log,
         enable_logs=True,
     )
-    # Captured errors will include the full stack trace.
-    sdk_options["add_full_stack"] = True
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     dsns = Dsns(

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -296,7 +296,8 @@ def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
         before_send_log=before_send_log,
         enable_logs=True,
     )
-    sdk_options["add_full_stack"] = options.get("sentry_sdk.add_full_stack", False)
+    # Captured errors will include the full stack trace.
+    sdk_options["add_full_stack"] = True
 
     # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     dsns = Dsns(


### PR DESCRIPTION
The option has been enabled since the weekend (https://github.com/getsentry/sentry-options-automator/pull/3902).

This undoes some of what was added [here](https://github.com/getsentry/sentry/pull/91062).