### PR TITLE
ref(issue-stream): Change feed's default query

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -234,7 +234,7 @@ export const MAX_PICKABLE_DAYS = 90;
 
 export const DEFAULT_STATS_PERIOD = '14d';
 
-export const DEFAULT_QUERY = 'is:unresolved issue.priority:[high, medium]';
+export const DEFAULT_QUERY = 'is:unresolved';
 
 export const DEFAULT_USE_UTC = true;
 

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -234,7 +234,8 @@ export const MAX_PICKABLE_DAYS = 90;
 
 export const DEFAULT_STATS_PERIOD = '14d';
 
-export const DEFAULT_QUERY = 'is:unresolved';
+export const DEFAULT_QUERY = 'is:unresolved issue.priority:[high, medium]';
+export const TAXONOMY_DEFAULT_QUERY = 'is:unresolved';
 
 export const DEFAULT_USE_UTC = true;
 

--- a/static/app/views/issueList/overviewWrapper.tsx
+++ b/static/app/views/issueList/overviewWrapper.tsx
@@ -1,6 +1,8 @@
+import {DEFAULT_QUERY, TAXONOMY_DEFAULT_QUERY} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
 import IssueListContainer from 'sentry/views/issueList';
 import IssueListOverview from 'sentry/views/issueList/overview';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
@@ -13,8 +15,13 @@ type OverviewWrapperProps = RouteComponentProps<
 export function OverviewWrapper(props: OverviewWrapperProps) {
   const shouldFetchOnMount = !defined(props.location.query.new);
   const prefersStackedNav = usePrefersStackedNav();
+  const organization = useOrganization();
 
   const title = prefersStackedNav ? t('Feed') : t('Issues');
+
+  const defaultQuery = organization.features.includes('issue-taxonomy')
+    ? TAXONOMY_DEFAULT_QUERY
+    : DEFAULT_QUERY;
 
   return (
     <IssueListContainer title={title}>
@@ -22,6 +29,7 @@ export function OverviewWrapper(props: OverviewWrapperProps) {
         {...props}
         shouldFetchOnMount={shouldFetchOnMount}
         title={title}
+        initialQuery={defaultQuery}
       />
     </IssueListContainer>
   );


### PR DESCRIPTION
Changes the default query of the feed from 

`'is:unresolved issue.priority:[high, medium]`

to 

`'is:unresolved'`