### PR TITLE
ref(issue-stream): Update default query on BE w/ Taxonomy

### DIFF
--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -46,6 +46,7 @@ advanced_search_features: Sequence[tuple[Callable[[SearchFilter], Any], str]] = 
 ]
 
 DEFAULT_QUERY = "is:unresolved issue.priority:[high, medium]"
+TAXONOMY_DEFAULT_QUERY = "is:unresolved"
 
 
 def parse_and_convert_issue_search_query(
@@ -94,7 +95,11 @@ def build_query_params_from_request(
     has_query = request.GET.get("query")
     query = request.GET.get("query", None)
     if query is None:
-        query = DEFAULT_QUERY
+        query = (
+            DEFAULT_QUERY
+            if not features.has("organizations:issue-taxonomy", organization)
+            else TAXONOMY_DEFAULT_QUERY
+        )
 
     query = query.strip()
 

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -96,9 +96,9 @@ def build_query_params_from_request(
     query = request.GET.get("query", None)
     if query is None:
         query = (
-            DEFAULT_QUERY
-            if not features.has("organizations:issue-taxonomy", organization)
-            else TAXONOMY_DEFAULT_QUERY
+            TAXONOMY_DEFAULT_QUERY
+            if features.has("organizations:issue-taxonomy", organization)
+            else DEFAULT_QUERY
         )
 
     query = query.strip()


### PR DESCRIPTION
Changes the default query in the backend  from

`'is:unresolved issue.priority:[high, medium]`

to 

`'is:unresolved'`

