### PR TITLE
fix(ourlogs): Improve the drawer navigation, search, and scrolling

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -6,6 +6,7 @@ import {
   EventDrawerBody,
   EventDrawerContainer,
   EventDrawerHeader,
+  EventNavigator,
   NavigationCrumbs,
   ShortId,
 } from 'sentry/components/events/eventDrawer';
@@ -56,32 +57,34 @@ export function OurlogsDrawer({event, project, group}: LogIssueDrawerProps) {
   );
 
   return (
-    <EventDrawerContainer>
-      <EventDrawerHeader>
-        <NavigationCrumbs
-          crumbs={[
-            {
-              label: (
-                <CrumbContainer>
-                  <ProjectAvatar project={project} />
-                  <ShortId>{group.shortId}</ShortId>
-                </CrumbContainer>
-              ),
-            },
-            {label: getShortEventId(event.id)},
-            {label: t('Logs')},
-          ]}
-        />
-      </EventDrawerHeader>
-      <EventDrawerBody>
-        <SearchQueryBuilderProvider {...searchQueryBuilderProps}>
+    <SearchQueryBuilderProvider {...searchQueryBuilderProps}>
+      <EventDrawerContainer>
+        <EventDrawerHeader>
+          <NavigationCrumbs
+            crumbs={[
+              {
+                label: (
+                  <CrumbContainer>
+                    <ProjectAvatar project={project} />
+                    <ShortId>{group.shortId}</ShortId>
+                  </CrumbContainer>
+                ),
+              },
+              {label: getShortEventId(event.id)},
+              {label: t('Logs')},
+            ]}
+          />
+        </EventDrawerHeader>
+        <EventNavigator>
+          <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+        </EventNavigator>
+        <EventDrawerBody>
           <LogsTableContainer>
-            <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
             <LogsTable showHeader={false} allowPagination tableData={tableData} />
           </LogsTableContainer>
-        </SearchQueryBuilderProvider>
-      </EventDrawerBody>
-    </EventDrawerContainer>
+        </EventDrawerBody>
+      </EventDrawerContainer>
+    </SearchQueryBuilderProvider>
   );
 }
 

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -50,6 +50,7 @@ export const HeaderButtonContainer = styled('div')`
 export const Body = styled(
   ({
     children,
+    showVerticalScrollbar: _,
     ...props
   }: React.ComponentProps<typeof Panel> & {
     children?: React.ReactNode;

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -53,7 +53,7 @@ export const Body = styled(({children, ...props}: any) => (
   </Panel>
 ))`
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: ${props => (props?.showVerticalScrollbar ? 'auto' : 'hidden')};
   z-index: ${Z_INDEX_PANEL};
 `;
 

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -47,13 +47,21 @@ export const HeaderButtonContainer = styled('div')`
   }
 `;
 
-export const Body = styled(({children, ...props}: any) => (
-  <Panel {...props}>
-    <PanelBody>{children}</PanelBody>
-  </Panel>
-))`
+export const Body = styled(
+  ({
+    children,
+    ...props
+  }: React.ComponentProps<typeof Panel> & {
+    children?: React.ReactNode;
+    showVerticalScrollbar?: boolean;
+  }) => (
+    <Panel {...props}>
+      <PanelBody>{children}</PanelBody>
+    </Panel>
+  )
+)`
   overflow-x: auto;
-  overflow-y: ${props => (props?.showVerticalScrollbar ? 'auto' : 'hidden')};
+  overflow-y: ${({showVerticalScrollbar}) => (showVerticalScrollbar ? 'auto' : 'hidden')};
   z-index: ${Z_INDEX_PANEL};
 `;
 

--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -142,7 +142,7 @@ export function SuspectFunctionsTable({
           />
         </ButtonBar>
       </TableHeader>
-      <Table ref={tableRef} styles={initialTableStyles}>
+      <Table ref={tableRef} style={initialTableStyles}>
         <TableHead>
           <TableRow>
             {COLUMNS.map((column, i) => {

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -20,6 +20,7 @@ import {Actions} from 'sentry/views/discover/table/cellAction';
 
 interface TableProps extends React.ComponentProps<typeof _TableWrapper> {
   ref?: React.Ref<HTMLTableElement>;
+  showVerticalScrollbar?: boolean;
 }
 
 export function Table({ref, children, styles, ...props}: TableProps) {

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -23,10 +23,10 @@ interface TableProps extends React.ComponentProps<typeof _TableWrapper> {
   showVerticalScrollbar?: boolean;
 }
 
-export function Table({ref, children, styles, ...props}: TableProps) {
+export function Table({ref, children, style, ...props}: TableProps) {
   return (
     <_TableWrapper {...props}>
-      <_Table ref={ref} style={styles}>
+      <_Table ref={ref} style={style}>
         {children}
       </_Table>
     </_TableWrapper>

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -82,7 +82,7 @@ export function LogsTable({
     <Fragment>
       <Table
         ref={tableRef}
-        styles={initialTableStyles}
+        style={initialTableStyles}
         data-test-id="logs-table"
         hideBorder={isTableFrozen}
         showVerticalScrollbar={isTableFrozen}

--- a/static/app/views/explore/logs/logsTable.tsx
+++ b/static/app/views/explore/logs/logsTable.tsx
@@ -85,6 +85,7 @@ export function LogsTable({
         styles={initialTableStyles}
         data-test-id="logs-table"
         hideBorder={isTableFrozen}
+        showVerticalScrollbar={isTableFrozen}
       >
         {showHeader ? (
           <TableHead>

--- a/static/app/views/explore/multiQueryMode/components/miniTable.tsx
+++ b/static/app/views/explore/multiQueryMode/components/miniTable.tsx
@@ -5,18 +5,15 @@ import styled from '@emotion/styled';
 import {Body, Grid} from 'sentry/components/gridEditable/styles';
 
 interface TableProps extends React.ComponentProps<typeof _TableWrapper> {
+  height?: string | number;
   ref?: React.Ref<HTMLTableElement>;
+  scrollable?: boolean;
 }
 
-export function Table({ref, children, styles, ...props}: TableProps) {
+export function Table({ref, children, style, height, scrollable, ...props}: TableProps) {
   return (
     <_TableWrapper {...props}>
-      <_Table
-        ref={ref}
-        style={styles}
-        scrollable={props.scrollable}
-        height={props.height}
-      >
+      <_Table ref={ref} style={style} scrollable={scrollable} height={height}>
         {children}
       </_Table>
     </_TableWrapper>

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -110,7 +110,7 @@ function AggregatesTable({
 
   return (
     <Fragment>
-      <Table ref={tableRef} styles={initialTableStyles} scrollable height={TABLE_HEIGHT}>
+      <Table ref={tableRef} style={initialTableStyles} scrollable height={TABLE_HEIGHT}>
         <TableHead>
           <TableRow>
             <TableHeadCell isFirst={false}>
@@ -241,7 +241,7 @@ function SpansTable({spansTableResult, query: queryParts, index}: SampleTablePro
 
   return (
     <Fragment>
-      <Table ref={tableRef} styles={initialTableStyles} scrollable height={TABLE_HEIGHT}>
+      <Table ref={tableRef} style={initialTableStyles} scrollable height={TABLE_HEIGHT}>
         <TableHead>
           <TableRow>
             {visibleFields.map((field, i) => {

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -88,7 +88,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
   return (
     <Fragment>
-      <Table ref={tableRef} styles={initialTableStyles}>
+      <Table ref={tableRef} style={initialTableStyles}>
         <TableHead>
           <TableRow>
             <TableHeadCell isFirst={false}>

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -69,7 +69,7 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
 
   return (
     <Fragment>
-      <Table ref={tableRef} styles={initialTableStyles}>
+      <Table ref={tableRef} style={initialTableStyles}>
         <TableHead>
           <TableRow>
             {visibleFields.map((field, i) => {


### PR DESCRIPTION
- Pins the searchbar at the top of the drawer
- Makes the pagination cursor stored in `useState` in embedded views
- Makes the overflow in the table be scrollable in embedded views