### PR TITLE
ref(shared-views):  Delete BE default views

### DIFF
--- a/src/sentry/models/groupsearchview.py
+++ b/src/sentry/models/groupsearchview.py
@@ -14,21 +14,6 @@ from sentry.models.savedsearch import SortOptions
 
 DEFAULT_TIME_FILTER = {"period": "14d"}
 
-DEFAULT_VIEWS = [
-    {
-        "name": "Prioritized",
-        "query": "is:unresolved issue.priority:[high, medium]",
-        "querySort": SortOptions.DATE.value,
-        "position": 0,
-        "isAllProjects": False,
-        "environments": [],
-        "projects": [],
-        "timeFilters": DEFAULT_TIME_FILTER,
-        "dateCreated": None,
-        "dateUpdated": None,
-    }
-]
-
 
 @region_silo_model
 class GroupSearchViewProject(DefaultFieldsModel):


### PR DESCRIPTION
Deletes the default groupsearchviews. This was previously returned by the `GET /group-search-views/` when the user had no views, but we have now abandoned returning defaults as part of the new views. 

This variable was not used anywhere. 