### PR TITLE
:wrench: chore(slack): add `integration_id` to slack alert notif slo context

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -148,6 +148,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 "error": str(e),
                 "project_id": event.project_id,
                 "event_id": event.event_id,
+                "integration_id": client.integration_id,
             }
 
             lifecycle.add_extras(log_params)

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -276,6 +276,7 @@ def _send_notification(
                 "error": str(e),
                 "incident_id": metric_issue_context.id,
                 "incident_status": str(metric_issue_context.new_status),
+                "integration_id": integration.id,
             }
             if channel:
                 log_params["channel_id"] = channel


### PR DESCRIPTION
adding `integration_id` so we can figure out problems like workspace rate limiting faster through our logs