### PR TITLE
ref(grouping): Enhancements refactors to prepare for caching split rules

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -779,6 +779,8 @@ class Enhancements:
         """Convert a base64 string into an `Enhancements` object"""
 
         with metrics.timer("grouping.enhancements.creation") as metrics_timer_tags:
+            metrics_timer_tags.update({"source": "base64_string", "referrer": referrer})
+
             bytes_str = (
                 base64_string.encode("ascii", "ignore")
                 if isinstance(base64_string, str)
@@ -798,9 +800,7 @@ class Enhancements:
                 if version not in VERSIONS:
                     raise InvalidEnhancerConfig(f"Unknown enhancements version: {version}")
 
-                metrics_timer_tags.update(
-                    {"split": version == 3, "source": "base64_string", "referrer": referrer}
-                )
+                metrics_timer_tags.update({"split": version == 3})
 
                 rules = [EnhancementRule._from_config_structure(rule, version) for rule in rules]
                 rust_enhancements = get_rust_enhancements("config_structure", pickled)

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -6,6 +6,7 @@ import os
 import zlib
 from collections import Counter
 from collections.abc import Sequence
+from dataclasses import dataclass
 from functools import cached_property
 from random import random
 from typing import Any, Literal
@@ -54,6 +55,14 @@ VALID_PROFILING_MATCHER_PREFIXES = (
     "package",  # stack.package
 )
 VALID_PROFILING_ACTIONS_SET = frozenset(["+app", "-app"])
+
+
+@dataclass
+class EnhancementsConfig:
+    rules: list[EnhancementRule]
+    rust_enhancements: RustEnhancements
+    version: int | None = None
+    bases: list[str] | None = None
 
 
 # Hack to fake a subclass of `RustFrame` (which can't be directly subclassed because it's a

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -224,7 +224,7 @@ def get_hint_for_frame(
 
 def _split_rules(
     rules: list[EnhancementRule],
-) -> tuple[list[EnhancementRule], list[EnhancementRule], RustEnhancements, RustEnhancements]:
+) -> tuple[EnhancementsConfig, EnhancementsConfig]:
     """
     Given a list of EnhancementRules, each of which may have both classifier and contributes
     actions, split the rules into separate classifier and contributes rule lists, and return them
@@ -259,10 +259,8 @@ def _split_rules(
     contributes_rust_enhancements = get_rust_enhancements("config_string", contributes_rules_text)
 
     return (
-        classifier_rules,
-        contributes_rules,
-        classifier_rust_enhancements,
-        contributes_rust_enhancements,
+        EnhancementsConfig(classifier_rules, classifier_rust_enhancements),
+        EnhancementsConfig(contributes_rules, contributes_rust_enhancements),
     )
 
 
@@ -451,21 +449,15 @@ class Enhancements:
 
         self.run_split_enhancements = version == 3
         if self.run_split_enhancements:
-            (
-                classifier_rules,
-                contributes_rules,
-                classifier_rust_enhancements,
-                contributes_rust_enhancements,
-            ) = _split_rules(rules)
+            classifier_config, contributes_config = _split_rules(rules)
 
-            self.classifier_rules = classifier_rules
-            self.contributes_rules = contributes_rules
+            self.classifier_rules = classifier_config.rules
+            self.contributes_rules = contributes_config.rules
             self.classifier_rust_enhancements = merge_rust_enhancements(
-                self.bases, classifier_rust_enhancements, type="classifier"
+                self.bases, classifier_config.rust_enhancements, type="classifier"
             )
-
             self.contributes_rust_enhancements = merge_rust_enhancements(
-                self.bases, contributes_rust_enhancements, type="contributes"
+                self.bases, contributes_config.rust_enhancements, type="contributes"
             )
 
     def apply_category_and_updated_in_app_to_frames(

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -805,15 +805,15 @@ class Enhancements:
                 rules = [EnhancementRule._from_config_structure(rule, version) for rule in rules]
                 rust_enhancements = get_rust_enhancements("config_structure", pickled)
 
-                return cls(
-                    rules=rules,
-                    rust_enhancements=rust_enhancements,
-                    version=version,
-                    bases=bases,
-                )
-
             except (LookupError, AttributeError, TypeError, ValueError) as e:
                 raise ValueError("invalid stack trace rule config: %s" % e)
+
+            return cls(
+                rules=rules,
+                rust_enhancements=rust_enhancements,
+                version=version,
+                bases=bases,
+            )
 
     @classmethod
     @sentry_sdk.tracing.trace

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -755,18 +755,17 @@ class Enhancements:
 
         return stacktrace_component
 
+    def _get_base64_bytes_from_rules(self, rules: list[EnhancementRule]) -> bytes:
+        pickled = msgpack.dumps(
+            [self.version, self.bases, [rule._to_config_structure(self.version) for rule in rules]]
+        )
+        compressed_pickle = zstandard.compress(pickled)
+        return base64.urlsafe_b64encode(compressed_pickle).strip(b"=")
+
     @cached_property
     def base64_string(self) -> str:
         """A base64 string representation of the enhancements object"""
-        pickled = msgpack.dumps(
-            [
-                self.version,
-                self.bases,
-                [rule._to_config_structure(self.version) for rule in self.rules],
-            ]
-        )
-        compressed_pickle = zstandard.compress(pickled)
-        base64_bytes = base64.urlsafe_b64encode(compressed_pickle).strip(b"=")
+        base64_bytes = self._get_base64_bytes_from_rules(self.rules)
         base64_str = base64_bytes.decode("ascii")
         return base64_str
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -436,6 +436,7 @@ class Enhancements:
         self,
         rules: list[EnhancementRule],
         rust_enhancements: RustEnhancements,
+        split_enhancement_configs: tuple[EnhancementsConfig, EnhancementsConfig] | None = None,
         version: int | None = None,
         bases: list[str] | None = None,
         id: str | None = None,
@@ -449,7 +450,7 @@ class Enhancements:
 
         self.run_split_enhancements = version == 3
         if self.run_split_enhancements:
-            classifier_config, contributes_config = _split_rules(rules)
+            classifier_config, contributes_config = split_enhancement_configs or _split_rules(rules)
 
             self.classifier_rules = classifier_config.rules
             self.contributes_rules = contributes_config.rules

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -809,8 +809,8 @@ class Enhancements:
                 else:
                     pickled = zlib.decompress(compressed_pickle)
 
-                rust_enhancements = get_rust_enhancements("config_structure", pickled)
                 config_structure = msgpack.loads(pickled, raw=False)
+                rust_enhancements = get_rust_enhancements("config_structure", pickled)
 
                 metrics_timer_tags.update(
                     # The first entry in the config structure is the enhancements version

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -755,18 +755,16 @@ class Enhancements:
 
         return stacktrace_component
 
-    def _to_config_structure(self) -> list[Any]:
-        # TODO: Can we switch this to a tuple so we can type it more exactly?
-        return [
-            self.version,
-            self.bases,
-            [rule._to_config_structure(self.version) for rule in self.rules],
-        ]
-
     @cached_property
     def base64_string(self) -> str:
         """A base64 string representation of the enhancements object"""
-        pickled = msgpack.dumps(self._to_config_structure())
+        pickled = msgpack.dumps(
+            [
+                self.version,
+                self.bases,
+                [rule._to_config_structure(self.version) for rule in self.rules],
+            ]
+        )
         compressed_pickle = zstandard.compress(pickled)
         base64_bytes = base64.urlsafe_b64encode(compressed_pickle).strip(b"=")
         base64_str = base64_bytes.decode("ascii")

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -128,10 +128,9 @@ def test_basic_parsing(insta_snapshot, version):
 
     enhancements_str = enhancements.base64_string
     assert Enhancements.from_base64_string(enhancements_str).base64_string == enhancements_str
-    assert (
-        Enhancements.from_base64_string(enhancements_str)._to_config_structure()
-        == enhancements._to_config_structure()
-    )
+    assert Enhancements.from_base64_string(enhancements_str)._get_base64_bytes_from_rules(
+        enhancements.rules
+    ) == enhancements._get_base64_bytes_from_rules(enhancements.rules)
     assert isinstance(enhancements_str, str)
 
 

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -13,6 +13,7 @@ from sentry.grouping.component import FrameGroupingComponent, StacktraceGrouping
 from sentry.grouping.enhancer import (
     ENHANCEMENT_BASES,
     Enhancements,
+    _split_rules,
     is_valid_profiling_action,
     is_valid_profiling_matcher,
     keep_profiling_rules,
@@ -664,6 +665,44 @@ class EnhancementsTest(TestCase):
         assert len(strategy_config.enhancements.rules) == 1
         assert str(enhancements.rules[0]) == "<EnhancementRule function:playFetch +app>"
         assert strategy_config.enhancements.id is None
+
+    @patch("sentry.grouping.enhancer._split_rules", wraps=_split_rules)
+    def test_loads_split_enhancements_from_base64_string(self, split_rules_spy: MagicMock):
+        # Using version 3 forces the enhancements to be split, and we know a split will happen
+        # because the rule below has both an in-app and a contributes action
+        enhancements = Enhancements.from_rules_text("function:playFetch +app +group", version=3)
+        assert len(enhancements.rules) == 1
+        assert len(enhancements.classifier_rules) == 1
+        assert len(enhancements.contributes_rules) == 1
+        assert str(enhancements.rules[0]) == "<EnhancementRule function:playFetch +app +group>"
+        assert str(enhancements.classifier_rules[0]) == "<EnhancementRule function:playFetch +app>"
+        assert (
+            str(enhancements.contributes_rules[0]) == "<EnhancementRule function:playFetch +group>"
+        )
+        assert enhancements.id is None
+        assert split_rules_spy.call_count == 1
+
+        strategy_config = load_grouping_config(
+            {"id": DEFAULT_GROUPING_CONFIG, "enhancements": enhancements.base64_string}
+        )
+        assert len(strategy_config.enhancements.rules) == 1
+        assert len(strategy_config.enhancements.classifier_rules) == 1
+        assert len(strategy_config.enhancements.contributes_rules) == 1
+        assert (
+            str(strategy_config.enhancements.rules[0])
+            == "<EnhancementRule function:playFetch +app +group>"
+        )
+        assert (
+            str(strategy_config.enhancements.classifier_rules[0])
+            == "<EnhancementRule function:playFetch +app>"
+        )
+        assert (
+            str(strategy_config.enhancements.contributes_rules[0])
+            == "<EnhancementRule function:playFetch +group>"
+        )
+        assert strategy_config.enhancements.id is None
+        # Currently we re-split the rules when translating from base64 back to object
+        assert split_rules_spy.call_count == 2
 
     def test_uses_default_enhancements_when_loading_string_with_invalid_version(self):
         enhancements = Enhancements.from_rules_text("function:playFetch +app")


### PR DESCRIPTION
This PR includes refactors of a few enhancements helpers, as a first step towards being able to cache split enhancements in their split form. It also adds tests for caching split enhancements and loading them from a base64 string. No behavior changes.

- Create a new `EnhancementsConfig` type to wrap rules and rust enhancements, since we now have three sets (unsplit, classifier, and contributes) we're passing around, and refactor `_split_rules` and `Enhancements.__init__` to use it.
- Allow `Enhancements.__init__` to take in pre-split rules and rust enhancements.
- Currently the logic in `base64_string` and `from_base64_string` is split between the main method and helper (`_to_config_structure` and `_from_config_structure`, respectively). Preserve that, but change how the logic is split between method and helper, and in the process replace `_to_config_structure` with `_get_base64_bytes_from_rules` and `_from_config_structure` with `_get_config_from_base64_bytes`.