### PR TITLE
Add directory for preprod

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -681,6 +681,9 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /src/sentry/migrations/                                  @getsentry/owners-migrations
 /src/sentry/*/migrations/                                @getsentry/owners-migrations
 
+# Preprod build artifact analysis
+/src/sentry/preprod                                   @getsentry/emerge-tool
+# End of preprod
 
 ## Frontend Platform (keep last as we want highest specificity)
 /static/app/utils/theme/                              @getsentry/design-engineering


### PR DESCRIPTION
We're investigating analyzing and distributing pre-production artifacts
(e.g. .apk, .ipa, .aab, .xcframework, etc). This adds a directory for that code
to live in so it is not spread across the codebase as well as matching CODEOWNERS
entry for the team investigating this.