### PR TITLE
chore(autofix): Remove auto closing behavior

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -42,6 +42,7 @@ interface Props {
   stepIndex: number;
   blockName?: string;
   isAgentComment?: boolean;
+  onShouldPersistChange?: (shouldPersist: boolean) => void;
 }
 
 interface OptimisticMessage extends CommentThreadMessage {
@@ -137,10 +138,12 @@ function AutofixHighlightPopupContent({
   isAgentComment,
   blockName,
   isFocused,
+  onShouldPersistChange,
 }: Props & {isFocused?: boolean}) {
   const {mutate: submitComment} = useCommentThread({groupId, runId});
   const {mutate: closeCommentThread} = useCloseCommentThread({groupId, runId});
 
+  const [hidden, setHidden] = useState(false);
   const [comment, setComment] = useState('');
   const [threadId] = useState(() => {
     const timestamp = Date.now();
@@ -261,12 +264,23 @@ function AutofixHighlightPopupContent({
 
   const handleResolve = (e: React.MouseEvent) => {
     e.stopPropagation();
+    setHidden(true);
     closeCommentThread({
       thread_id: threadId,
       step_index: stepIndex,
       is_agent_comment: isAgentComment ?? false,
     });
   };
+
+  useEffect(() => {
+    if (onShouldPersistChange) {
+      onShouldPersistChange(!!commentThread && commentThread.is_completed !== true);
+    }
+  }, [commentThread, onShouldPersistChange]);
+
+  if (hidden) {
+    return null;
+  }
 
   return (
     <Container onClick={handleContainerClick} isFocused={isFocused}>
@@ -656,8 +670,8 @@ const CircularSeerIcon = styled('div')`
   flex-shrink: 0;
 
   > svg {
-    width: 14px;
-    height: 14px;
+    width: 18px;
+    height: 18px;
     color: ${p => p.theme.white};
   }
 `;

--- a/static/app/components/events/autofix/autofixHighlightWrapper.tsx
+++ b/static/app/components/events/autofix/autofixHighlightWrapper.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence} from 'framer-motion';
@@ -34,6 +34,17 @@ export function AutofixHighlightWrapper({
   const containerRef = useRef<HTMLDivElement>(null);
   const selection = useTextSelection(containerRef);
 
+  const [shouldPersist, setShouldPersist] = useState(false);
+  const lastSelectedText = useRef<string | null>(null);
+  const lastReferenceElement = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (selection) {
+      lastSelectedText.current = selection.selectedText;
+      lastReferenceElement.current = selection.referenceElement;
+    }
+  }, [selection]);
+
   return (
     <React.Fragment>
       <Wrapper ref={containerRef} className={className} isSelected={!!selection}>
@@ -41,16 +52,17 @@ export function AutofixHighlightWrapper({
       </Wrapper>
 
       <AnimatePresence>
-        {selection && (
+        {(selection || shouldPersist) && (
           <AutofixHighlightPopup
-            selectedText={selection.selectedText}
-            referenceElement={selection.referenceElement}
+            selectedText={selection?.selectedText ?? lastSelectedText.current ?? ''}
+            referenceElement={selection?.referenceElement ?? lastReferenceElement.current}
             groupId={groupId}
             runId={runId}
             stepIndex={stepIndex}
             retainInsightCardIndex={retainInsightCardIndex}
             isAgentComment={isAgentComment}
             blockName={displayName}
+            onShouldPersistChange={setShouldPersist}
           />
         )}
       </AnimatePresence>

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -305,7 +305,6 @@ export const useOpenSeerDrawer = ({
   group,
   project,
   event,
-  buttonRef,
 }: {
   event: Event | null;
   group: Group;
@@ -333,46 +332,8 @@ export const useOpenSeerDrawer = ({
         height: fit-content;
         max-height: 100%;
       `,
-      shouldCloseOnInteractOutside: element => {
-        const viewAllButton = buttonRef?.current;
-
-        // Check if the element is inside any autofix input element
-        const isInsideAutofixInput = () => {
-          const rethinkInputs = document.querySelectorAll(
-            '[data-autofix-input-type="rethink"]'
-          );
-          const agentCommentInputs = document.querySelectorAll(
-            '[data-autofix-input-type="agent-comment"]'
-          );
-
-          // Check if element is inside any rethink input
-          for (const input of rethinkInputs) {
-            if (input.contains(element)) {
-              return true;
-            }
-          }
-
-          // Check if element is inside any agent comment input
-          for (const input of agentCommentInputs) {
-            if (input.contains(element)) {
-              return true;
-            }
-          }
-
-          return false;
-        };
-
-        if (
-          viewAllButton?.contains(element) ||
-          document.getElementById('sentry-feedback')?.contains(element) ||
-          isInsideAutofixInput() ||
-          document.getElementById('autofix-output-stream')?.contains(element) ||
-          document.getElementById('autofix-write-access-modal')?.contains(element) ||
-          element.closest('[data-overlay="true"]')
-        ) {
-          return false;
-        }
-        return true;
+      shouldCloseOnInteractOutside: () => {
+        return false;
       },
       onClose: () => {
         navigate({
@@ -384,7 +345,7 @@ export const useOpenSeerDrawer = ({
         });
       },
     });
-  }, [openDrawer, buttonRef, event, group, project, location, navigate, organization]);
+  }, [openDrawer, event, group, project, location, navigate, organization]);
 
   return {openSeerDrawer};
 };


### PR DESCRIPTION
- Only close the seer drawer if the user presses "close", so it doesn't disappear while interacting with issue details
- Don't auto-close comment thread popups if they have an active conversation. Only close when starting a new thread somewhere else or when clicking the X button.
- Makes the X button feel more responsive.