### PR TITLE
feat(explore): Remove unnecessary prop

### DIFF
--- a/static/app/views/explore/hooks/useExploreSpansTable.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.tsx
@@ -45,7 +45,6 @@ export function useExploreSpansTable({
     queryHookImplementation: useExploreSpansTableImp,
     queryHookArgs: {enabled, limit, query},
     queryOptions: {
-      withholdBestEffort: true,
       canTriggerHighAccuracy,
     },
   });

--- a/static/app/views/explore/hooks/useProgressiveQuery.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.tsx
@@ -33,7 +33,6 @@ interface ProgressiveQueryOptions<TQueryFn extends (...args: any[]) => any> {
 
 interface QueryOptions<TQueryFn extends (...args: any[]) => any> {
   canTriggerHighAccuracy?: (data: ReturnType<TQueryFn>['result']) => boolean;
-  withholdBestEffort?: boolean;
 }
 
 /**

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
@@ -121,7 +121,6 @@ export function useMultiQueryTableSampleMode({query, yAxes, sortBys, enabled}: P
     queryHookImplementation: useMultiQueryTableSampleModeImpl,
     queryHookArgs: {query, yAxes, sortBys, enabled},
     queryOptions: {
-      withholdBestEffort: true,
       canTriggerHighAccuracy,
     },
   });


### PR DESCRIPTION
withholdBestEffort was a prop used in the old implementation of progressive loading, but that code has been removed
