### PR TITLE
ref(notifications): remove "powered by seer" at end of slack summary

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -580,13 +580,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             else:
                 footer_text = footer_text[:-4]  # chop off the empty space
 
-            if self.issue_summary:
-                footer_text += "    Powered by Seer"
-
             return self.get_context_block(text=footer_text)
         else:
-            if self.issue_summary:
-                footer += " | Powered by Seer"
             return self.get_context_block(text=footer, timestamp=timestamp)
 
     def build(self, notification_uuid: str | None = None) -> SlackBlock:


### PR DESCRIPTION
removes "Powered by Seer" at end of slack issue summary messages. it comes across as noisy at the moment.

https://sentry.slack.com/archives/CQDHVRS2W/p1747766428181659