### PR TITLE
feat(insights): use eap search bar insight sample panels

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -23,6 +23,7 @@ import {
   TraceItemSearchQueryBuilder,
   useSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 import {
@@ -39,6 +40,7 @@ interface SpanSearchQueryBuilderProps {
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
   projects?: PageFilters['projects'];
+  useEap?: boolean;
 }
 
 export const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
@@ -155,7 +157,17 @@ function useSpanSearchQueryBuilderProps({
   };
 }
 
-export function SpanSearchQueryBuilder({
+export function SpanSearchQueryBuilder(props: SpanSearchQueryBuilderProps) {
+  const {useEap} = props;
+
+  if (useEap) {
+    return <EapSpanSearchQueryBuilder {...props} />;
+  }
+
+  return <IndexedSpanSearchQueryBuilder {...props} />;
+}
+
+export function IndexedSpanSearchQueryBuilder({
   initialQuery,
   searchSource,
   datetime,
@@ -175,6 +187,29 @@ export function SpanSearchQueryBuilder({
   });
 
   return <SearchQueryBuilder {...searchQueryBuilderProps} />;
+}
+
+export function EapSpanSearchQueryBuilder({
+  initialQuery,
+  searchSource,
+  datetime,
+  onSearch,
+  onBlur,
+}: SpanSearchQueryBuilderProps) {
+  const {tags: numberTags} = useSpanTags('number');
+  const {tags: stringTags} = useSpanTags('string');
+
+  const eapSearchQueryBuilderProps = useEAPSpanSearchQueryBuilderProps({
+    initialQuery,
+    searchSource,
+    datetime,
+    onSearch,
+    onBlur,
+    numberTags,
+    stringTags,
+  });
+
+  return <SearchQueryBuilder {...eapSearchQueryBuilderProps} />;
 }
 
 export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -42,6 +42,7 @@ import {
   DataTitles,
   getThroughputTitle,
 } from 'sentry/views/insights/common/views/spans/types';
+import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import type {
   MetricsQueryFilters,
   SpanIndexedQueryFilters,
@@ -288,128 +289,133 @@ export function CacheSamplePanel() {
 
   return (
     <PageAlertProvider>
-      <EventDrawerHeader>
-        <SampleDrawerHeaderTransaction
-          project={project}
-          transaction={query.transaction}
-        />
-      </EventDrawerHeader>
+      <InsightsSpanTagProvider>
+        <EventDrawerHeader>
+          <SampleDrawerHeaderTransaction
+            project={project}
+            transaction={query.transaction}
+          />
+        </EventDrawerHeader>
 
-      <SampleDrawerBody>
-        <ModuleLayout.Layout>
-          <ModuleLayout.Full>
-            <ReadoutRibbon>
-              <MetricReadout
-                title={DataTitles[`avg(${SpanMetricsField.CACHE_ITEM_SIZE})`]}
-                value={
-                  cacheTransactionMetrics?.[0]?.[
-                    `avg(${SpanMetricsField.CACHE_ITEM_SIZE})`
-                  ]
-                }
-                unit={SizeUnit.BYTE}
-                isLoading={areCacheTransactionMetricsFetching}
-              />
-              <MetricReadout
-                title={getThroughputTitle('cache')}
-                value={cacheTransactionMetrics?.[0]?.[`${SpanFunction.EPM}()`]}
-                unit={RateUnit.PER_MINUTE}
-                isLoading={areCacheTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={DataTitles[`avg(${MetricsFields.TRANSACTION_DURATION})`]}
-                value={transactionDurationData?.[0]?.[`avg(${SpanFields.SPAN_DURATION})`]}
-                unit={DurationUnit.MILLISECOND}
-                isLoading={isTransactionDurationLoading}
-              />
-
-              <MetricReadout
-                title={DataTitles[`${SpanFunction.CACHE_MISS_RATE}()`]}
-                value={
-                  cacheTransactionMetrics?.[0]?.[`${SpanFunction.CACHE_MISS_RATE}()`]
-                }
-                unit="percentage"
-                isLoading={areCacheTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={DataTitles.timeSpent}
-                value={cacheTransactionMetrics?.[0]?.['sum(span.self_time)']}
-                unit={DurationUnit.MILLISECOND}
-                isLoading={areCacheTransactionMetricsFetching}
-              />
-            </ReadoutRibbon>
-          </ModuleLayout.Full>
-          <ModuleLayout.Full>
-            <CompactSelect
-              value={query.statusClass}
-              options={CACHE_STATUS_OPTIONS}
-              onChange={handleStatusClassChange}
-              triggerProps={{
-                prefix: t('Status'),
-              }}
-            />
-          </ModuleLayout.Full>
-          <ModuleLayout.Half>
-            <CacheHitMissChart
-              isLoading={isCacheHitRateLoading}
-              series={cacheHitRateData[`cache_miss_rate()`]}
-            />
-          </ModuleLayout.Half>
-          <ModuleLayout.Half>
-            <TransactionDurationChartWithSamples samples={samplesPlottable} />
-          </ModuleLayout.Half>
-
-          <ModuleLayout.Full>
-            <SpanSearchQueryBuilder
-              searchSource={`${ModuleName.CACHE}-sample-panel`}
-              initialQuery={query.spanSearchQuery}
-              onSearch={handleSearch}
-              placeholder={t('Search for span attributes')}
-              projects={selection.projects}
-            />
-          </ModuleLayout.Full>
-
-          <Fragment>
+        <SampleDrawerBody>
+          <ModuleLayout.Layout>
             <ModuleLayout.Full>
-              <SpanSamplesTable
-                data={spansWithDuration ?? []}
-                meta={{
-                  // TODO: combine meta between samples and transactions response instead
-                  fields: {
-                    'transaction.duration': 'duration',
-                    [SpanIndexedField.CACHE_ITEM_SIZE]: 'size',
-                  },
-                  units: {[SpanIndexedField.CACHE_ITEM_SIZE]: 'byte'},
+              <ReadoutRibbon>
+                <MetricReadout
+                  title={DataTitles[`avg(${SpanMetricsField.CACHE_ITEM_SIZE})`]}
+                  value={
+                    cacheTransactionMetrics?.[0]?.[
+                      `avg(${SpanMetricsField.CACHE_ITEM_SIZE})`
+                    ]
+                  }
+                  unit={SizeUnit.BYTE}
+                  isLoading={areCacheTransactionMetricsFetching}
+                />
+                <MetricReadout
+                  title={getThroughputTitle('cache')}
+                  value={cacheTransactionMetrics?.[0]?.[`${SpanFunction.EPM}()`]}
+                  unit={RateUnit.PER_MINUTE}
+                  isLoading={areCacheTransactionMetricsFetching}
+                />
+
+                <MetricReadout
+                  title={DataTitles[`avg(${MetricsFields.TRANSACTION_DURATION})`]}
+                  value={
+                    transactionDurationData?.[0]?.[`avg(${SpanFields.SPAN_DURATION})`]
+                  }
+                  unit={DurationUnit.MILLISECOND}
+                  isLoading={isTransactionDurationLoading}
+                />
+
+                <MetricReadout
+                  title={DataTitles[`${SpanFunction.CACHE_MISS_RATE}()`]}
+                  value={
+                    cacheTransactionMetrics?.[0]?.[`${SpanFunction.CACHE_MISS_RATE}()`]
+                  }
+                  unit="percentage"
+                  isLoading={areCacheTransactionMetricsFetching}
+                />
+
+                <MetricReadout
+                  title={DataTitles.timeSpent}
+                  value={cacheTransactionMetrics?.[0]?.['sum(span.self_time)']}
+                  unit={DurationUnit.MILLISECOND}
+                  isLoading={areCacheTransactionMetricsFetching}
+                />
+              </ReadoutRibbon>
+            </ModuleLayout.Full>
+            <ModuleLayout.Full>
+              <CompactSelect
+                value={query.statusClass}
+                options={CACHE_STATUS_OPTIONS}
+                onChange={handleStatusClassChange}
+                triggerProps={{
+                  prefix: t('Status'),
                 }}
-                isLoading={
-                  isCacheHitsFetching || isCacheMissesFetching || isFetchingTransactions
-                }
-                highlightedSpanId={highlightedSpanId}
-                onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
-                onSampleMouseOut={() => setHighlightedSpanId(undefined)}
-                error={transactionError}
               />
             </ModuleLayout.Full>
-          </Fragment>
+            <ModuleLayout.Half>
+              <CacheHitMissChart
+                isLoading={isCacheHitRateLoading}
+                series={cacheHitRateData[`cache_miss_rate()`]}
+              />
+            </ModuleLayout.Half>
+            <ModuleLayout.Half>
+              <TransactionDurationChartWithSamples samples={samplesPlottable} />
+            </ModuleLayout.Half>
 
-          <Fragment>
             <ModuleLayout.Full>
-              <Button
-                onClick={() => {
-                  trackAnalytics(
-                    'performance_views.sample_spans.try_different_samples_clicked',
-                    {organization, source: ModuleName.CACHE}
-                  );
-                  handleRefetch();
-                }}
-              >
-                {t('Try Different Samples')}
-              </Button>
+              <SpanSearchQueryBuilder
+                searchSource={`${ModuleName.CACHE}-sample-panel`}
+                initialQuery={query.spanSearchQuery}
+                onSearch={handleSearch}
+                placeholder={t('Search for span attributes')}
+                projects={selection.projects}
+                useEap={useEap}
+              />
             </ModuleLayout.Full>
-          </Fragment>
-        </ModuleLayout.Layout>
-      </SampleDrawerBody>
+
+            <Fragment>
+              <ModuleLayout.Full>
+                <SpanSamplesTable
+                  data={spansWithDuration ?? []}
+                  meta={{
+                    // TODO: combine meta between samples and transactions response instead
+                    fields: {
+                      'transaction.duration': 'duration',
+                      [SpanIndexedField.CACHE_ITEM_SIZE]: 'size',
+                    },
+                    units: {[SpanIndexedField.CACHE_ITEM_SIZE]: 'byte'},
+                  }}
+                  isLoading={
+                    isCacheHitsFetching || isCacheMissesFetching || isFetchingTransactions
+                  }
+                  highlightedSpanId={highlightedSpanId}
+                  onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
+                  onSampleMouseOut={() => setHighlightedSpanId(undefined)}
+                  error={transactionError}
+                />
+              </ModuleLayout.Full>
+            </Fragment>
+
+            <Fragment>
+              <ModuleLayout.Full>
+                <Button
+                  onClick={() => {
+                    trackAnalytics(
+                      'performance_views.sample_spans.try_different_samples_clicked',
+                      {organization, source: ModuleName.CACHE}
+                    );
+                    handleRefetch();
+                  }}
+                >
+                  {t('Try Different Samples')}
+                </Button>
+              </ModuleLayout.Full>
+            </Fragment>
+          </ModuleLayout.Layout>
+        </SampleDrawerBody>
+      </InsightsSpanTagProvider>
     </PageAlertProvider>
   );
 }

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -25,9 +25,11 @@ import type {
   NonDefaultSpanSampleFields,
   SpanSample,
 } from 'sentry/views/insights/common/queries/useSpanSamples';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import DurationChart from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/durationChart';
 import SampleInfo from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/sampleInfo';
 import SampleTable from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
+import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   ModuleName,
@@ -48,6 +50,7 @@ type Props = {
 export function SampleList({groupId, moduleName, transactionRoute, referrer}: Props) {
   const organization = useOrganization();
   const {view} = useDomainViewFilters();
+  const useEap = useInsightsEap();
 
   const {
     transaction: transactionName,
@@ -149,62 +152,65 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
 
   return (
     <PageAlertProvider>
-      <EventDrawerHeader>
-        <SampleDrawerHeaderTransaction
-          project={project}
-          transaction={transactionName}
-          transactionMethod={transactionMethod}
-        />
-      </EventDrawerHeader>
-
-      <SampleDrawerBody>
-        <PageAlert />
-
-        <SampleInfo
-          groupId={groupId}
-          transactionName={transactionName}
-          transactionMethod={transactionMethod}
-          subregions={subregions}
-        />
-
-        <DurationChart
-          groupId={groupId}
-          transactionName={transactionName}
-          transactionMethod={transactionMethod}
-          subregions={subregions}
-          additionalFields={additionalFields}
-          onClickSample={handleClickSample}
-          onMouseOverSample={handleMouseOverSample}
-          onMouseLeaveSample={handleMouseLeaveSample}
-          spanSearch={spanSearch}
-          highlightedSpanId={highlightedSpanId}
-        />
-
-        <StyledSearchBar>
-          <SpanSearchQueryBuilder
-            projects={selection.projects}
-            initialQuery={spanSearchQuery ?? ''}
-            onSearch={handleSearch}
-            placeholder={t('Search for span attributes')}
-            searchSource={`${moduleName}-sample-panel`}
+      <InsightsSpanTagProvider>
+        <EventDrawerHeader>
+          <SampleDrawerHeaderTransaction
+            project={project}
+            transaction={transactionName}
+            transactionMethod={transactionMethod}
           />
-        </StyledSearchBar>
+        </EventDrawerHeader>
 
-        <SampleTable
-          highlightedSpanId={highlightedSpanId}
-          transactionMethod={transactionMethod}
-          onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
-          onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
-          groupId={groupId}
-          moduleName={moduleName}
-          transactionName={transactionName}
-          subregions={subregions}
-          spanSearch={spanSearch}
-          columnOrder={columnOrder}
-          additionalFields={additionalFields}
-          referrer={referrer}
-        />
-      </SampleDrawerBody>
+        <SampleDrawerBody>
+          <PageAlert />
+
+          <SampleInfo
+            groupId={groupId}
+            transactionName={transactionName}
+            transactionMethod={transactionMethod}
+            subregions={subregions}
+          />
+
+          <DurationChart
+            groupId={groupId}
+            transactionName={transactionName}
+            transactionMethod={transactionMethod}
+            subregions={subregions}
+            additionalFields={additionalFields}
+            onClickSample={handleClickSample}
+            onMouseOverSample={handleMouseOverSample}
+            onMouseLeaveSample={handleMouseLeaveSample}
+            spanSearch={spanSearch}
+            highlightedSpanId={highlightedSpanId}
+          />
+
+          <StyledSearchBar>
+            <SpanSearchQueryBuilder
+              projects={selection.projects}
+              initialQuery={spanSearchQuery ?? ''}
+              onSearch={handleSearch}
+              placeholder={t('Search for span attributes')}
+              searchSource={`${moduleName}-sample-panel`}
+              useEap={useEap}
+            />
+          </StyledSearchBar>
+
+          <SampleTable
+            highlightedSpanId={highlightedSpanId}
+            transactionMethod={transactionMethod}
+            onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
+            onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
+            groupId={groupId}
+            moduleName={moduleName}
+            transactionName={transactionName}
+            subregions={subregions}
+            spanSearch={spanSearch}
+            columnOrder={columnOrder}
+            additionalFields={additionalFields}
+            referrer={referrer}
+          />
+        </SampleDrawerBody>
+      </InsightsSpanTagProvider>
     </PageAlertProvider>
   );
 }

--- a/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.spec.tsx
@@ -54,6 +54,11 @@ describe('HTTPSamplesPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+
     eventsRequestMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -41,6 +41,7 @@ import {
 } from 'sentry/views/insights/common/queries/useDiscover';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {
   DataTitles,
   getDurationChartTitle,
@@ -54,6 +55,7 @@ import {Referrer} from 'sentry/views/insights/http/referrers';
 import {BASE_FILTERS} from 'sentry/views/insights/http/settings';
 import decodePanel from 'sentry/views/insights/http/utils/queryParameterDecoders/panel';
 import decodeResponseCodeClass from 'sentry/views/insights/http/utils/queryParameterDecoders/responseCodeClass';
+import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {
   ModuleName,
   SpanFunction,
@@ -66,6 +68,7 @@ import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHe
 export function HTTPSamplesPanel() {
   const navigate = useNavigate();
   const location = useLocation();
+  const useEap = useInsightsEap();
 
   const query = useLocationQuery({
     fields: {
@@ -323,200 +326,203 @@ export function HTTPSamplesPanel() {
 
   return (
     <PageAlertProvider>
-      <EventDrawerHeader>
-        <SampleDrawerHeaderTransaction
-          project={project}
-          transaction={query.transaction}
-          transactionMethod={query.transactionMethod}
-        />
-      </EventDrawerHeader>
+      <InsightsSpanTagProvider>
+        <EventDrawerHeader>
+          <SampleDrawerHeaderTransaction
+            project={project}
+            transaction={query.transaction}
+            transactionMethod={query.transactionMethod}
+          />
+        </EventDrawerHeader>
 
-      <SampleDrawerBody>
-        <ModuleLayout.Layout>
-          <ModuleLayout.Full>
-            <ReadoutRibbon>
-              <MetricReadout
-                title={getThroughputTitle('http')}
-                value={domainTransactionMetrics?.[0]?.[`${SpanFunction.EPM}()`]}
-                unit={RateUnit.PER_MINUTE}
-                isLoading={areDomainTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={DataTitles.avg}
-                value={
-                  domainTransactionMetrics?.[0]?.[
-                    `avg(${SpanMetricsField.SPAN_SELF_TIME})`
-                  ]
-                }
-                unit={DurationUnit.MILLISECOND}
-                isLoading={areDomainTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={t('3XXs')}
-                value={domainTransactionMetrics?.[0]?.[`http_response_rate(3)`]}
-                unit="percentage"
-                isLoading={areDomainTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={t('4XXs')}
-                value={domainTransactionMetrics?.[0]?.[`http_response_rate(4)`]}
-                unit="percentage"
-                isLoading={areDomainTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={t('5XXs')}
-                value={domainTransactionMetrics?.[0]?.[`http_response_rate(5)`]}
-                unit="percentage"
-                isLoading={areDomainTransactionMetricsFetching}
-              />
-
-              <MetricReadout
-                title={DataTitles.timeSpent}
-                value={domainTransactionMetrics?.[0]?.['sum(span.self_time)']}
-                unit={DurationUnit.MILLISECOND}
-                isLoading={areDomainTransactionMetricsFetching}
-              />
-            </ReadoutRibbon>
-          </ModuleLayout.Full>
-
-          <ModuleLayout.Full>
-            <PanelControls>
-              <SegmentedControl
-                value={query.panel}
-                onChange={handlePanelChange}
-                aria-label={t('Choose breakdown type')}
-              >
-                <SegmentedControl.Item key="duration">
-                  {t('By Duration')}
-                </SegmentedControl.Item>
-                <SegmentedControl.Item key="status">
-                  {t('By Response Code')}
-                </SegmentedControl.Item>
-              </SegmentedControl>
-
-              <CompactSelect
-                value={query.responseCodeClass}
-                options={HTTP_RESPONSE_CODE_CLASS_OPTIONS}
-                onChange={handleResponseCodeClassChange}
-                triggerProps={{
-                  prefix: t('Response Code'),
-                }}
-              />
-            </PanelControls>
-          </ModuleLayout.Full>
-
-          {query.panel === 'duration' && (
-            <Fragment>
-              <ModuleLayout.Full>
-                <InsightsLineChartWidget
-                  showLegend="never"
-                  title={getDurationChartTitle('http')}
-                  isLoading={isDurationDataFetching}
-                  error={durationError}
-                  series={[durationData[`avg(span.self_time)`]]}
-                  samples={samplesPlottable}
+        <SampleDrawerBody>
+          <ModuleLayout.Layout>
+            <ModuleLayout.Full>
+              <ReadoutRibbon>
+                <MetricReadout
+                  title={getThroughputTitle('http')}
+                  value={domainTransactionMetrics?.[0]?.[`${SpanFunction.EPM}()`]}
+                  unit={RateUnit.PER_MINUTE}
+                  isLoading={areDomainTransactionMetricsFetching}
                 />
-              </ModuleLayout.Full>
-            </Fragment>
-          )}
 
-          {query.panel === 'status' && (
-            <Fragment>
-              <ModuleLayout.Full>
-                <ResponseCodeCountChart
-                  series={Object.values(responseCodeData).filter(Boolean)}
-                  isLoading={isResponseCodeDataLoading}
-                  error={responseCodeError}
+                <MetricReadout
+                  title={DataTitles.avg}
+                  value={
+                    domainTransactionMetrics?.[0]?.[
+                      `avg(${SpanMetricsField.SPAN_SELF_TIME})`
+                    ]
+                  }
+                  unit={DurationUnit.MILLISECOND}
+                  isLoading={areDomainTransactionMetricsFetching}
                 />
-              </ModuleLayout.Full>
-            </Fragment>
-          )}
 
-          <ModuleLayout.Full>
-            <SpanSearchQueryBuilder
-              projects={selection.projects}
-              initialQuery={query.spanSearchQuery}
-              onSearch={handleSearch}
-              placeholder={t('Search for span attributes')}
-              searchSource={`${ModuleName.HTTP}-sample-panel`}
-            />
-          </ModuleLayout.Full>
-
-          {query.panel === 'duration' && (
-            <Fragment>
-              <ModuleLayout.Full>
-                <SpanSamplesTable
-                  data={spanSamplesData?.data ?? []}
-                  isLoading={isDurationDataFetching || isDurationSamplesDataFetching}
-                  highlightedSpanId={highlightedSpanId}
-                  onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
-                  onSampleMouseOut={() => setHighlightedSpanId(undefined)}
-                  error={durationSamplesDataError}
-                  // TODO: The samples endpoint doesn't provide its own meta, so we need to create it manually
-                  meta={{
-                    fields: {
-                      'span.response_code': 'number',
-                    },
-                    units: {},
-                  }}
-                  referrer={TraceViewSources.REQUESTS_MODULE}
+                <MetricReadout
+                  title={t('3XXs')}
+                  value={domainTransactionMetrics?.[0]?.[`http_response_rate(3)`]}
+                  unit="percentage"
+                  isLoading={areDomainTransactionMetricsFetching}
                 />
-              </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                <Button
-                  onClick={() => {
-                    trackAnalytics(
-                      'performance_views.sample_spans.try_different_samples_clicked',
-                      {organization, source: ModuleName.HTTP}
-                    );
-                    refetchDurationSpanSamples();
-                  }}
+                <MetricReadout
+                  title={t('4XXs')}
+                  value={domainTransactionMetrics?.[0]?.[`http_response_rate(4)`]}
+                  unit="percentage"
+                  isLoading={areDomainTransactionMetricsFetching}
+                />
+
+                <MetricReadout
+                  title={t('5XXs')}
+                  value={domainTransactionMetrics?.[0]?.[`http_response_rate(5)`]}
+                  unit="percentage"
+                  isLoading={areDomainTransactionMetricsFetching}
+                />
+
+                <MetricReadout
+                  title={DataTitles.timeSpent}
+                  value={domainTransactionMetrics?.[0]?.['sum(span.self_time)']}
+                  unit={DurationUnit.MILLISECOND}
+                  isLoading={areDomainTransactionMetricsFetching}
+                />
+              </ReadoutRibbon>
+            </ModuleLayout.Full>
+
+            <ModuleLayout.Full>
+              <PanelControls>
+                <SegmentedControl
+                  value={query.panel}
+                  onChange={handlePanelChange}
+                  aria-label={t('Choose breakdown type')}
                 >
-                  {t('Try Different Samples')}
-                </Button>
-              </ModuleLayout.Full>
-            </Fragment>
-          )}
+                  <SegmentedControl.Item key="duration">
+                    {t('By Duration')}
+                  </SegmentedControl.Item>
+                  <SegmentedControl.Item key="status">
+                    {t('By Response Code')}
+                  </SegmentedControl.Item>
+                </SegmentedControl>
 
-          {query.panel === 'status' && (
-            <Fragment>
-              <ModuleLayout.Full>
-                <SpanSamplesTable
-                  data={responseCodeSamplesData ?? []}
-                  isLoading={isResponseCodeSamplesDataFetching}
-                  error={responseCodeSamplesDataError}
-                  // TODO: The samples endpoint doesn't provide its own meta, so we need to create it manually
-                  meta={{
-                    fields: {
-                      'span.response_code': 'number',
-                    },
-                    units: {},
+                <CompactSelect
+                  value={query.responseCodeClass}
+                  options={HTTP_RESPONSE_CODE_CLASS_OPTIONS}
+                  onChange={handleResponseCodeClassChange}
+                  triggerProps={{
+                    prefix: t('Response Code'),
                   }}
                 />
-              </ModuleLayout.Full>
+              </PanelControls>
+            </ModuleLayout.Full>
 
-              <ModuleLayout.Full>
-                <Button
-                  onClick={() => {
-                    trackAnalytics(
-                      'performance_views.sample_spans.try_different_samples_clicked',
-                      {organization, source: ModuleName.HTTP}
-                    );
-                    refetchResponseCodeSpanSamples();
-                  }}
-                >
-                  {t('Try Different Samples')}
-                </Button>
-              </ModuleLayout.Full>
-            </Fragment>
-          )}
-        </ModuleLayout.Layout>
-      </SampleDrawerBody>
+            {query.panel === 'duration' && (
+              <Fragment>
+                <ModuleLayout.Full>
+                  <InsightsLineChartWidget
+                    showLegend="never"
+                    title={getDurationChartTitle('http')}
+                    isLoading={isDurationDataFetching}
+                    error={durationError}
+                    series={[durationData[`avg(span.self_time)`]]}
+                    samples={samplesPlottable}
+                  />
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+
+            {query.panel === 'status' && (
+              <Fragment>
+                <ModuleLayout.Full>
+                  <ResponseCodeCountChart
+                    series={Object.values(responseCodeData).filter(Boolean)}
+                    isLoading={isResponseCodeDataLoading}
+                    error={responseCodeError}
+                  />
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+
+            <ModuleLayout.Full>
+              <SpanSearchQueryBuilder
+                projects={selection.projects}
+                initialQuery={query.spanSearchQuery}
+                onSearch={handleSearch}
+                placeholder={t('Search for span attributes')}
+                searchSource={`${ModuleName.HTTP}-sample-panel`}
+                useEap={useEap}
+              />
+            </ModuleLayout.Full>
+
+            {query.panel === 'duration' && (
+              <Fragment>
+                <ModuleLayout.Full>
+                  <SpanSamplesTable
+                    data={spanSamplesData?.data ?? []}
+                    isLoading={isDurationDataFetching || isDurationSamplesDataFetching}
+                    highlightedSpanId={highlightedSpanId}
+                    onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
+                    onSampleMouseOut={() => setHighlightedSpanId(undefined)}
+                    error={durationSamplesDataError}
+                    // TODO: The samples endpoint doesn't provide its own meta, so we need to create it manually
+                    meta={{
+                      fields: {
+                        'span.response_code': 'number',
+                      },
+                      units: {},
+                    }}
+                    referrer={TraceViewSources.REQUESTS_MODULE}
+                  />
+                </ModuleLayout.Full>
+
+                <ModuleLayout.Full>
+                  <Button
+                    onClick={() => {
+                      trackAnalytics(
+                        'performance_views.sample_spans.try_different_samples_clicked',
+                        {organization, source: ModuleName.HTTP}
+                      );
+                      refetchDurationSpanSamples();
+                    }}
+                  >
+                    {t('Try Different Samples')}
+                  </Button>
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+
+            {query.panel === 'status' && (
+              <Fragment>
+                <ModuleLayout.Full>
+                  <SpanSamplesTable
+                    data={responseCodeSamplesData ?? []}
+                    isLoading={isResponseCodeSamplesDataFetching}
+                    error={responseCodeSamplesDataError}
+                    // TODO: The samples endpoint doesn't provide its own meta, so we need to create it manually
+                    meta={{
+                      fields: {
+                        'span.response_code': 'number',
+                      },
+                      units: {},
+                    }}
+                  />
+                </ModuleLayout.Full>
+
+                <ModuleLayout.Full>
+                  <Button
+                    onClick={() => {
+                      trackAnalytics(
+                        'performance_views.sample_spans.try_different_samples_clicked',
+                        {organization, source: ModuleName.HTTP}
+                      );
+                      refetchResponseCodeSpanSamples();
+                    }}
+                  >
+                    {t('Try Different Samples')}
+                  </Button>
+                </ModuleLayout.Full>
+              </Fragment>
+            )}
+          </ModuleLayout.Layout>
+        </SampleDrawerBody>
+      </InsightsSpanTagProvider>
     </PageAlertProvider>
   );
 }

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -21,10 +21,12 @@ import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
 import type {SpanSample} from 'sentry/views/insights/common/queries/useSpanSamples';
 import {formatVersionAndCenterTruncate} from 'sentry/views/insights/common/utils/centerTruncate';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import DurationChart from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/durationChart';
 import SampleTable from 'sentry/views/insights/common/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
+import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   type ModuleName,
@@ -61,6 +63,7 @@ export function SpanSamplesContainer({
   const location = useLocation();
   const navigate = useNavigate();
   const {view} = useDomainViewFilters();
+  const useEap = useInsightsEap();
   const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
     undefined
   );
@@ -154,97 +157,100 @@ export function SpanSamplesContainer({
 
   return (
     <Fragment>
-      <PaddedTitle>
-        {release && (
-          <SectionTitle>
-            <Tooltip title={release}>
-              <Link
-                to={{
-                  pathname: normalizeUrl(
-                    `/organizations/${organization?.slug}/releases/${encodeURIComponent(
-                      release
-                    )}/`
-                  ),
-                }}
-              >
-                {formatVersionAndCenterTruncate(release)}
-              </Link>
-            </Tooltip>
-          </SectionTitle>
-        )}
-      </PaddedTitle>
+      <InsightsSpanTagProvider>
+        <PaddedTitle>
+          {release && (
+            <SectionTitle>
+              <Tooltip title={release}>
+                <Link
+                  to={{
+                    pathname: normalizeUrl(
+                      `/organizations/${organization?.slug}/releases/${encodeURIComponent(
+                        release
+                      )}/`
+                    ),
+                  }}
+                >
+                  {formatVersionAndCenterTruncate(release)}
+                </Link>
+              </Tooltip>
+            </SectionTitle>
+          )}
+        </PaddedTitle>
 
-      <StyledReadoutRibbon>
-        <MetricReadout
-          title={DataTitles.avg}
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          value={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
-          unit={DurationUnit.MILLISECOND}
-          isLoading={isPending}
+        <StyledReadoutRibbon>
+          <MetricReadout
+            title={DataTitles.avg}
+            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+            value={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
+            unit={DurationUnit.MILLISECOND}
+            isLoading={isPending}
+          />
+          <MetricReadout
+            title={DataTitles.count}
+            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+            value={spanMetrics?.['count()'] ?? 0}
+            unit="count"
+            isLoading={isPending}
+          />
+        </StyledReadoutRibbon>
+
+        <DurationChart
+          spanSearch={spanSearch}
+          additionalFilters={additionalFilters}
+          groupId={groupId}
+          transactionName={transactionName}
+          transactionMethod={transactionMethod}
+          onClickSample={handleClickSample}
+          onMouseOverSample={handleMouseOverSample}
+          onMouseLeaveSample={handleMouseLeaveSample}
+          highlightedSpanId={highlightedSpanId}
+          release={release}
+          platform={isProjectCrossPlatform ? selectedPlatform : undefined}
         />
-        <MetricReadout
-          title={DataTitles.count}
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          value={spanMetrics?.['count()'] ?? 0}
-          unit="count"
-          isLoading={isPending}
+
+        <StyledSearchBar>
+          <SpanSearchQueryBuilder
+            searchSource={`${moduleName}-sample-panel`}
+            initialQuery={searchQuery ?? ''}
+            onSearch={handleSearch}
+            placeholder={t('Search for span attributes')}
+            projects={selection.projects}
+            useEap={useEap}
+          />
+        </StyledSearchBar>
+
+        <SampleTable
+          referrer={TraceViewSources.APP_STARTS_MODULE}
+          spanSearch={spanSearch}
+          additionalFilters={additionalFilters}
+          highlightedSpanId={highlightedSpanId}
+          transactionMethod={transactionMethod}
+          onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
+          onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
+          groupId={groupId}
+          transactionName={transactionName}
+          moduleName={moduleName}
+          release={release}
+          columnOrder={[
+            {
+              key: 'span_id',
+              name: t('Span ID'),
+              width: COL_WIDTH_UNDEFINED,
+            },
+            {
+              key: 'profile_id',
+              name: t('Profile'),
+              width: COL_WIDTH_UNDEFINED,
+            },
+            {
+              key: 'avg_comparison',
+              name: t('Compared to Average'),
+              width: COL_WIDTH_UNDEFINED,
+            },
+          ]}
         />
-      </StyledReadoutRibbon>
-
-      <DurationChart
-        spanSearch={spanSearch}
-        additionalFilters={additionalFilters}
-        groupId={groupId}
-        transactionName={transactionName}
-        transactionMethod={transactionMethod}
-        onClickSample={handleClickSample}
-        onMouseOverSample={handleMouseOverSample}
-        onMouseLeaveSample={handleMouseLeaveSample}
-        highlightedSpanId={highlightedSpanId}
-        release={release}
-        platform={isProjectCrossPlatform ? selectedPlatform : undefined}
-      />
-
-      <StyledSearchBar>
-        <SpanSearchQueryBuilder
-          searchSource={`${moduleName}-sample-panel`}
-          initialQuery={searchQuery ?? ''}
-          onSearch={handleSearch}
-          placeholder={t('Search for span attributes')}
-          projects={selection.projects}
-        />
-      </StyledSearchBar>
-
-      <SampleTable
-        referrer={TraceViewSources.APP_STARTS_MODULE}
-        spanSearch={spanSearch}
-        additionalFilters={additionalFilters}
-        highlightedSpanId={highlightedSpanId}
-        transactionMethod={transactionMethod}
-        onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
-        onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
-        groupId={groupId}
-        transactionName={transactionName}
-        moduleName={moduleName}
-        release={release}
-        columnOrder={[
-          {
-            key: 'span_id',
-            name: t('Span ID'),
-            width: COL_WIDTH_UNDEFINED,
-          },
-          {
-            key: 'profile_id',
-            name: t('Profile'),
-            width: COL_WIDTH_UNDEFINED,
-          },
-          {
-            key: 'avg_comparison',
-            name: t('Compared to Average'),
-            width: COL_WIDTH_UNDEFINED,
-          },
-        ]}
-      />
+      </InsightsSpanTagProvider>
     </Fragment>
   );
 }

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -140,6 +140,11 @@ describe('messageSpanSamplesPanel', () => {
     });
 
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/recent-searches/`,
       body: [],
     });

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -31,8 +31,10 @@ import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDrawerBody';
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {getDurationChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {useSpanSamples} from 'sentry/views/insights/http/queries/useSpanSamples';
+import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {MessageSpanSamplesTable} from 'sentry/views/insights/queues/components/tables/messageSpanSamplesTable';
 import {useQueuesMetricsQuery} from 'sentry/views/insights/queues/queries/useQueuesMetricsQuery';
 import {Referrer} from 'sentry/views/insights/queues/referrers';
@@ -67,6 +69,7 @@ export function MessageSpanSamplesPanel() {
   });
   const {projects} = useProjects();
   const {selection} = usePageFilters();
+  const useEap = useInsightsEap();
 
   const project = projects.find(p => query.project === p.id);
 
@@ -252,118 +255,123 @@ export function MessageSpanSamplesPanel() {
 
   return (
     <PageAlertProvider>
-      <EventDrawerHeader>
-        <SampleDrawerHeaderTransaction
-          project={project}
-          transaction={query.transaction}
-          subtitle={
-            messageActorType === MessageActorType.PRODUCER ? t('Producer') : t('Consumer')
-          }
-        />
-      </EventDrawerHeader>
+      <InsightsSpanTagProvider>
+        <EventDrawerHeader>
+          <SampleDrawerHeaderTransaction
+            project={project}
+            transaction={query.transaction}
+            subtitle={
+              messageActorType === MessageActorType.PRODUCER
+                ? t('Producer')
+                : t('Consumer')
+            }
+          />
+        </EventDrawerHeader>
 
-      <SampleDrawerBody>
-        <ModuleLayout.Layout>
-          <ModuleLayout.Full>
-            <MetricsRibbonContainer>
-              {messageActorType === MessageActorType.PRODUCER ? (
-                <ProducerMetricsRibbon
-                  metrics={transactionMetrics}
-                  isLoading={aretransactionMetricsFetching}
-                />
-              ) : (
-                <ConsumerMetricsRibbon
-                  metrics={transactionMetrics}
-                  isLoading={aretransactionMetricsFetching}
-                />
-              )}
-            </MetricsRibbonContainer>
-          </ModuleLayout.Full>
+        <SampleDrawerBody>
+          <ModuleLayout.Layout>
+            <ModuleLayout.Full>
+              <MetricsRibbonContainer>
+                {messageActorType === MessageActorType.PRODUCER ? (
+                  <ProducerMetricsRibbon
+                    metrics={transactionMetrics}
+                    isLoading={aretransactionMetricsFetching}
+                  />
+                ) : (
+                  <ConsumerMetricsRibbon
+                    metrics={transactionMetrics}
+                    isLoading={aretransactionMetricsFetching}
+                  />
+                )}
+              </MetricsRibbonContainer>
+            </ModuleLayout.Full>
 
-          <ModuleLayout.Full>
-            <PanelControls>
-              <CompactSelect
-                searchable
-                value={query.traceStatus}
-                options={TRACE_STATUS_SELECT_OPTIONS}
-                onChange={handleTraceStatusChange}
-                triggerProps={{
-                  prefix: t('Status'),
-                }}
-              />
-              {messageActorType === MessageActorType.CONSUMER && (
+            <ModuleLayout.Full>
+              <PanelControls>
                 <CompactSelect
-                  value={query.retryCount}
-                  options={RETRY_COUNT_SELECT_OPTIONS}
-                  onChange={handleRetryCountChange}
+                  searchable
+                  value={query.traceStatus}
+                  options={TRACE_STATUS_SELECT_OPTIONS}
+                  onChange={handleTraceStatusChange}
                   triggerProps={{
-                    prefix: t('Retries'),
+                    prefix: t('Status'),
                   }}
                 />
-              )}
-            </PanelControls>
-          </ModuleLayout.Full>
+                {messageActorType === MessageActorType.CONSUMER && (
+                  <CompactSelect
+                    value={query.retryCount}
+                    options={RETRY_COUNT_SELECT_OPTIONS}
+                    onChange={handleRetryCountChange}
+                    triggerProps={{
+                      prefix: t('Retries'),
+                    }}
+                  />
+                )}
+              </PanelControls>
+            </ModuleLayout.Full>
 
-          <ModuleLayout.Full>
-            <InsightsLineChartWidget
-              showLegend="never"
-              title={getDurationChartTitle('queue')}
-              isLoading={isDurationDataFetching}
-              error={durationError}
-              series={[durationData[`avg(span.duration)`]]}
-              samples={samplesPlottable}
-            />
-          </ModuleLayout.Full>
+            <ModuleLayout.Full>
+              <InsightsLineChartWidget
+                showLegend="never"
+                title={getDurationChartTitle('queue')}
+                isLoading={isDurationDataFetching}
+                error={durationError}
+                series={[durationData[`avg(span.duration)`]]}
+                samples={samplesPlottable}
+              />
+            </ModuleLayout.Full>
 
-          <ModuleLayout.Full>
-            <SpanSearchQueryBuilder
-              searchSource={`${ModuleName.QUEUE}-sample-panel`}
-              initialQuery={query.spanSearchQuery}
-              onSearch={handleSearch}
-              placeholder={t('Search for span attributes')}
-              projects={selection.projects}
-            />
-          </ModuleLayout.Full>
+            <ModuleLayout.Full>
+              <SpanSearchQueryBuilder
+                searchSource={`${ModuleName.QUEUE}-sample-panel`}
+                initialQuery={query.spanSearchQuery}
+                onSearch={handleSearch}
+                placeholder={t('Search for span attributes')}
+                projects={selection.projects}
+                useEap={useEap}
+              />
+            </ModuleLayout.Full>
 
-          <ModuleLayout.Full>
-            <MessageSpanSamplesTable
-              data={spanSamplesData?.data ?? []}
-              isLoading={isDurationDataFetching || isDurationSamplesDataFetching}
-              highlightedSpanId={highlightedSpanId}
-              onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
-              onSampleMouseOut={() => setHighlightedSpanId(undefined)}
-              error={durationSamplesDataError}
-              // Samples endpoint doesn't provide meta data, so we need to provide it here
-              meta={{
-                fields: {
-                  [SpanIndexedField.SPAN_DURATION]: 'duration',
-                  [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: 'size',
-                  [SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT]: 'number',
-                },
-                units: {
-                  [SpanIndexedField.SPAN_DURATION]: DurationUnit.MILLISECOND,
-                  [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: SizeUnit.BYTE,
-                },
-              }}
-              type={messageActorType}
-            />
-          </ModuleLayout.Full>
+            <ModuleLayout.Full>
+              <MessageSpanSamplesTable
+                data={spanSamplesData?.data ?? []}
+                isLoading={isDurationDataFetching || isDurationSamplesDataFetching}
+                highlightedSpanId={highlightedSpanId}
+                onSampleMouseOver={sample => setHighlightedSpanId(sample.span_id)}
+                onSampleMouseOut={() => setHighlightedSpanId(undefined)}
+                error={durationSamplesDataError}
+                // Samples endpoint doesn't provide meta data, so we need to provide it here
+                meta={{
+                  fields: {
+                    [SpanIndexedField.SPAN_DURATION]: 'duration',
+                    [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: 'size',
+                    [SpanIndexedField.MESSAGING_MESSAGE_RETRY_COUNT]: 'number',
+                  },
+                  units: {
+                    [SpanIndexedField.SPAN_DURATION]: DurationUnit.MILLISECOND,
+                    [SpanIndexedField.MESSAGING_MESSAGE_BODY_SIZE]: SizeUnit.BYTE,
+                  },
+                }}
+                type={messageActorType}
+              />
+            </ModuleLayout.Full>
 
-          <ModuleLayout.Full>
-            <Button
-              onClick={() => {
-                trackAnalytics(
-                  'performance_views.sample_spans.try_different_samples_clicked',
-                  {organization, source: ModuleName.QUEUE}
-                );
-                refetchDurationSpanSamples();
-              }}
-            >
-              {t('Try Different Samples')}
-            </Button>
-          </ModuleLayout.Full>
-        </ModuleLayout.Layout>
-      </SampleDrawerBody>
+            <ModuleLayout.Full>
+              <Button
+                onClick={() => {
+                  trackAnalytics(
+                    'performance_views.sample_spans.try_different_samples_clicked',
+                    {organization, source: ModuleName.QUEUE}
+                  );
+                  refetchDurationSpanSamples();
+                }}
+              >
+                {t('Try Different Samples')}
+              </Button>
+            </ModuleLayout.Full>
+          </ModuleLayout.Layout>
+        </SampleDrawerBody>
+      </InsightsSpanTagProvider>
     </PageAlertProvider>
   );
 }


### PR DESCRIPTION
1. Update span search to use eap search in insights sample panels
2. wrap panels in `InsightsSpanTagProvider` which is required for the eap search bar