### PR TITLE
Reapply "buttonbar: support dropdowns (#91886)"

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -320,7 +320,7 @@ function ArchiveActions({
         className={className}
         minMenuWidth={270}
         trigger={(triggerProps, isOpen) => (
-          <DropdownTrigger
+          <Button
             {...triggerProps}
             aria-label={t('Archive options')}
             size={size}
@@ -350,12 +350,6 @@ export default ArchiveActions;
 const ArchiveButton = styled(Button)`
   box-shadow: none;
   border-radius: ${p => p.theme.borderRadius} 0 0 ${p => p.theme.borderRadius};
-`;
-
-const DropdownTrigger = styled(Button)`
-  box-shadow: none;
-  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
-  border-left: none;
 `;
 
 const MenuWrapper = styled('div')`

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -269,7 +269,7 @@ function ResolveActions({
         itemsHidden={shouldDisplayCta}
         items={items}
         trigger={(triggerProps, isOpen) => (
-          <DropdownTrigger
+          <Button
             {...triggerProps}
             size={size}
             priority={priority}
@@ -381,12 +381,6 @@ const ResolveButton = withChonk(
     box-shadow: none;
 `
 );
-
-const DropdownTrigger = styled(Button)`
-  box-shadow: none;
-  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
-  border-left: none;
-`;
 
 /**
  * Used to hide the list items when prompting to set up releases

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -92,8 +92,6 @@ export default storyBook('ButtonBar', (story, APIReference) => {
         </p>
         <ButtonBar merged>
           <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
           <DropdownMenu
             items={[
               {
@@ -111,16 +109,6 @@ export default storyBook('ButtonBar', (story, APIReference) => {
               />
             )}
           />
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
-          <Button>One</Button>
         </ButtonBar>
       </Fragment>
     );

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -2,7 +2,9 @@ import {Fragment, useState} from 'react';
 
 import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import JSXNode from 'sentry/components/stories/jsxNode';
+import {IconChevron} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -82,6 +84,43 @@ export default storyBook('ButtonBar', (story, APIReference) => {
         </p>
         <ButtonBar>
           <Button>One Lonely Button</Button>
+        </ButtonBar>
+
+        <p>
+          You can also use a <JSXNode name="DropdownMenu" /> inside a{' '}
+          <JSXNode name="ButtonBar" /> to create a button with secondary actions.
+        </p>
+        <ButtonBar merged>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <DropdownMenu
+            items={[
+              {
+                key: 'click-me',
+                label: 'Click me',
+                // eslint-disable-next-line no-alert
+                onAction: () => alert('clicked'),
+              },
+            ]}
+            trigger={(triggerProps, isOpen) => (
+              <Button
+                {...triggerProps}
+                aria-label="options"
+                icon={<IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
+              />
+            )}
+          />
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
+          <Button>One</Button>
         </ButtonBar>
       </Fragment>
     );

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -28,6 +28,8 @@ export function ButtonBar({children, merged = false, gap = 0, ...props}: ButtonB
 const getChildTransforms = (count: number) => {
   return Array.from(
     {length: count},
+    // Do not use translate, as it will create a new stacking context which might break
+    // focus styles for dropdowns, causing them to fall under other elements positioned on the page.
     (_, index) => css`
       > *:nth-child(${index + 1}),
       > *:nth-child(${index + 1}) > button {
@@ -54,7 +56,7 @@ const StyledButtonBar = styled('div')<{
     css`
       /* Raised buttons show borders on both sides. Useful to create pill bars */
       & > .active,
-      & > *:focus-within {
+      & *:focus-visible {
         z-index: 2;
       }
 

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,85 +14,87 @@ interface ButtonBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'cla
 
 export function ButtonBar({children, merged = false, gap = 0, ...props}: ButtonBarProps) {
   return (
-    <StyledButtonBar merged={merged} gap={gap} {...props}>
+    <StyledButtonBar
+      merged={merged}
+      gap={gap}
+      {...props}
+      listSize={React.Children.count(children)}
+    >
       {children}
     </StyledButtonBar>
   );
 }
 
-const StyledButtonBar = styled('div')<{gap: ValidSize | 0; merged: boolean}>`
+const getChildTransforms = (count: number) => {
+  return Array.from(
+    {length: count},
+    (_, index) => css`
+      > *:nth-child(${index + 1}),
+      > *:nth-child(${index + 1}) > button {
+        transform: translateX(-${index}px);
+      }
+    `
+  );
+};
+
+const StyledButtonBar = styled('div')<{
+  gap: ValidSize | 0;
+  listSize: number;
+  merged: boolean;
+}>`
   display: grid;
   grid-auto-flow: column;
   grid-column-gap: ${p => (p.gap === 0 ? '0' : space(p.gap))};
   align-items: center;
 
-  ${p => p.merged && MergedButtonBarStyles}
-`;
+  ${p => getChildTransforms(p.listSize)}
 
-const MergedButtonBarStyles = () => css`
-  /* Raised buttons show borders on both sides. Useful to create pill bars */
-  & > .active {
-    z-index: 2;
-  }
-
-  & > .dropdown,
-  & > button,
-  & > input,
-  & > a {
-    position: relative;
-
-    /* First button is square on the right side */
-    &:first-child:not(:last-child) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-
-      & > .dropdown-actor > ${StyledButton} {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+  ${p =>
+    p.merged &&
+    css`
+      /* Raised buttons show borders on both sides. Useful to create pill bars */
+      & > .active,
+      & > *:focus-within,
+      & > *:focus-within > * {
+        z-index: 2;
       }
-    }
 
-    /* Middle buttons are square */
-    &:not(:last-child):not(:first-child) {
-      border-radius: 0;
+      & > * {
+        position: relative;
 
-      & > .dropdown-actor > ${StyledButton} {
-        border-radius: 0;
+        /* First button is square on the right side */
+        &:first-child:not(:last-child),
+        &:first-child:not(:last-child) > button {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+
+          & > .dropdown-actor > ${StyledButton} {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+        }
+
+        /* Middle buttons are square */
+        &:not(:last-child):not(:first-child),
+        &:not(:last-child):not(:first-child) > button {
+          border-radius: 0;
+
+          & > .dropdown-actor > ${StyledButton} {
+            border-radius: 0;
+          }
+        }
+
+        /* Last button is square on the left side */
+        &:last-child:not(:first-child) {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+
+          & > button,
+          & > .dropdown-actor > ${StyledButton} {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+          }
+        }
       }
-    }
-
-    /* Middle buttons only need one border so we don't get a double line */
-    &:first-child {
-      & + .dropdown:not(:last-child),
-      & + a:not(:last-child),
-      & + input:not(:last-child),
-      & + button:not(:last-child) {
-        margin-left: -1px;
-      }
-    }
-
-    /* Middle buttons only need one border so we don't get a double line */
-    /* stylelint-disable-next-line no-duplicate-selectors */
-    &:not(:last-child):not(:first-child) {
-      & + .dropdown,
-      & + button,
-      & + input,
-      & + a {
-        margin-left: -1px;
-      }
-    }
-
-    /* Last button is square on the left side */
-    &:last-child:not(:first-child) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-      margin-left: -1px;
-
-      & > .dropdown-actor > ${StyledButton} {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        margin-left: -1px;
-      }
-    }
-  }
+    `}
 `;

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -31,7 +31,7 @@ const getChildTransforms = (count: number) => {
     (_, index) => css`
       > *:nth-child(${index + 1}),
       > *:nth-child(${index + 1}) > button {
-        transform: translateX(-${index}px);
+        margin-left: -${index}px;
       }
     `
   );
@@ -54,8 +54,7 @@ const StyledButtonBar = styled('div')<{
     css`
       /* Raised buttons show borders on both sides. Useful to create pill bars */
       & > .active,
-      & > *:focus-within,
-      & > *:focus-within > * {
+      & > *:focus-within {
         z-index: 2;
       }
 


### PR DESCRIPTION
Fixes the previously faulty implementation by removing the translate approach in favor of margin, and sets is so that only elements that are focused receive the z-index propagation, which omits any containers that might be holding the elements