### PR TITLE
fix(insights): issues widget not filtering in backend overview

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -38,6 +38,7 @@ import {
 import {EAPExperimentButton} from 'sentry/views/insights/pages/backend/eapExperimentButton';
 import {OldBackendOverviewPage} from 'sentry/views/insights/pages/backend/oldBackendOverviewPage';
 import {
+  BACKEND_ISSUES_WIDGET_DEFAULT_SEARCH,
   BACKEND_LANDING_TITLE,
   DEFAULT_SORT,
   OVERVIEW_PAGE_ALLOWED_OPS,
@@ -195,6 +196,11 @@ function EAPBackendOverviewPage() {
     project => project.id
   );
 
+  const issuesWidgetSearch = new MutableSearch([
+    ...BACKEND_ISSUES_WIDGET_DEFAULT_SEARCH,
+    searchBarQuery,
+  ]);
+
   return (
     <Feature
       features="performance-view"
@@ -247,7 +253,7 @@ function EAPBackendOverviewPage() {
                   </StackedWidgetWrapper>
                 </ModuleLayout.Third>
                 <ModuleLayout.TwoThirds>
-                  <IssuesWidget />
+                  <IssuesWidget search={issuesWidgetSearch} />
                 </ModuleLayout.TwoThirds>
                 <ModuleLayout.Full>
                   <TripleRowWidgetWrapper>

--- a/static/app/views/insights/pages/backend/settings.ts
+++ b/static/app/views/insights/pages/backend/settings.ts
@@ -26,4 +26,6 @@ export const DEFAULT_SORT: ValidSort = {
 
 export const BACKEND_PLATFORMS: PlatformKey[] = [...backend];
 
+export const BACKEND_ISSUES_WIDGET_DEFAULT_SEARCH = ['is:unresolved', 'event.type:error'];
+
 export const USE_NEW_BACKEND_EXPERIENCE = 'insights-backend-use-new-backend-experience';

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -320,7 +320,11 @@ const HeaderContainer = styled('div')`
   z-index: ${p => p.theme.zIndex.header};
 `;
 
-export function IssuesWidget() {
+type IssuesWidgetProps = {
+  search?: MutableSearch;
+};
+
+export function IssuesWidget({search}: IssuesWidgetProps) {
   const location = useLocation();
   const {query} = useTransactionNameQuery();
   const queryWithDefault = new MutableSearch(['is:unresolved', 'event.type:error']);
@@ -333,7 +337,7 @@ export function IssuesWidget() {
     ...normalizeDateTimeParams(
       pick(location.query, [...Object.values(URL_PARAM), 'cursor'])
     ),
-    query: queryWithDefault.formatString(),
+    query: search?.formatString() ?? queryWithDefault.formatString(),
     sort: 'freq',
   };
 


### PR DESCRIPTION
When you search for a transaction name in the backend overview page, you would expect the issues widget to show issues that contain that transaction name. However, this was not working. 

The `IssuesWidget` component assumed the `query` query param in the url contained the transaction name. This doesn't work with the backend overview page, resulting in a query string like `transaction:transaction:"mytransaction"`.

This Pr allows us to pass in a search string directly to solve this problem and make this component more generic.