### PR TITLE
fix(insights): backend cache widget errors out

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -51,7 +51,7 @@ export function CachesWidget() {
   const search = new MutableSearch('');
   search.addDisjunctionFilterValues(
     'transaction',
-    cachesRequest.data.map(item => item.transaction)
+    cachesRequest.data.map(item => `"${item.transaction}"`)
   );
 
   const timeSeriesRequest = useTopNSpanEAPSeries(

--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -6,6 +6,7 @@ import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
@@ -47,14 +48,16 @@ export function CachesWidget() {
     Referrer.CACHE_CHART
   );
 
+  const search = new MutableSearch('');
+  search.addDisjunctionFilterValues(
+    'transaction',
+    cachesRequest.data.map(item => item.transaction)
+  );
+
   const timeSeriesRequest = useTopNSpanEAPSeries(
     {
       ...pageFilterChartParams,
-      search:
-        cachesRequest.data &&
-        `transaction:[${cachesRequest.data
-          .map(item => `"${item.transaction}"`)
-          .join(', ')}]`,
+      search,
       fields: ['transaction', 'cache_miss_rate()'],
       yAxis: ['cache_miss_rate()'],
       sort: {field: 'cache_miss_rate()', kind: 'desc'},


### PR DESCRIPTION
When we have weird transaction names in the cache modules widget, the ```transaction:[${cachesRequest.data.map(item => `"${item.transaction}"`).join(', ')}]``` filter fails because it doesn't escape things properly.
<img width="416" alt="image" src="https://github.com/user-attachments/assets/3afdf625-a39f-4247-9836-1cde4e13c8c2" />


This PR changes this to use `addDisjunctionFilterValues` which handles this properly.

Previously the cache widget would fail to load with 30days of data on sentry project in sentry, now it loads
<img width="305" alt="image" src="https://github.com/user-attachments/assets/3028aa19-c1d1-4890-80f4-b348b0887e7d" />
