### PR TITLE
fix(ui): adjust tooltip positioning to fix overflow bug

### DIFF
--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -104,7 +104,13 @@ export function ModulePageFilterBar({
       >
         {/* TODO: Placing a DIV here is a hack, it allows the tooltip to close and the ProjectPageFilter to close at the same time,
           otherwise two clicks are required because of some rerendering/event propogation issues into the children */}
-        <div style={{position: 'absolute', width: '100px', height: '36px'}} />
+        <div
+          style={{
+            position: 'absolute',
+            width: '100px',
+            height: '36px' /* default button height */,
+          }}
+        />
       </Tooltip>
       {/* Requires an extra div, else the pagefilterbar will grow to fill the height
       of the readout ribbon which results in buttons being very large. */}

--- a/static/app/views/insights/common/components/modulePageFilterBar.tsx
+++ b/static/app/views/insights/common/components/modulePageFilterBar.tsx
@@ -104,7 +104,7 @@ export function ModulePageFilterBar({
       >
         {/* TODO: Placing a DIV here is a hack, it allows the tooltip to close and the ProjectPageFilter to close at the same time,
           otherwise two clicks are required because of some rerendering/event propogation issues into the children */}
-        <div style={{width: '100px', position: 'absolute', height: '100%'}} />
+        <div style={{position: 'absolute', width: '100px', height: '36px'}} />
       </Tooltip>
       {/* Requires an extra div, else the pagefilterbar will grow to fill the height
       of the readout ribbon which results in buttons being very large. */}


### PR DESCRIPTION
@billyvg reported a [strange overflow issue](https://sentry.slack.com/archives/C592MC8TF/p1747763541976859) which I was able to trace to this `<div>`. Because the `position: absolute` here created a new stacking context, `height: 100%` was using the full height of the `html` element (`100vh`). Since there was no `top` value set, the div was being rendered starting at the edge of the containing element, leading to an overflow.

The quick fix here is to hardcode a reasonable button height!

**Before**

https://github.com/user-attachments/assets/31ab7ac9-4d42-492f-88b3-8cd06e593b86

**After**

https://github.com/user-attachments/assets/3ed38f59-86b2-4b48-aa6c-e6ba274d1d4c

Digging a bit more, #75741 properly flagged the existence of this `<div />` as a hack—I did attempt to remove this hack entirely, but concluded that changing event propagation behavior in this component tree was too risky. The quickfix here is the best option for now.