### PR TITLE
fix(nodestore): Avoid full bigtable scans in get_multi

### DIFF
--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -180,6 +180,8 @@ class NodeStorage(local, Service):
         }
         """
         with sentry_sdk.start_span(op="nodestore.get_multi") as span:
+            # Deduplicate ids, preserving order
+            id_list = list(dict.fromkeys(id_list))
             span.set_tag("subkey", str(subkey))
             span.set_tag("num_ids", len(id_list))
 

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -127,6 +127,11 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         return self.__decode_row(row)
 
     def get_many(self, keys: Sequence[str]) -> Iterator[tuple[str, bytes]]:
+        if not keys:
+            # This is probably unintentional, and the behavior isn't specified.
+            logging.warning("get_many called with empty keys sequence")
+            return
+
         rows = RowSet()
         for key in keys:
             rows.add_row_key(key)

--- a/tests/sentry/nodestore/test_common.py
+++ b/tests/sentry/nodestore/test_common.py
@@ -44,6 +44,20 @@ def test_get_multi(ns):
 
 
 @override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+def test_get_multi_with_duplicates(ns):
+    key = "a" * 32
+    value = {"foo": "a"}
+
+    ns.set(key, value)
+    ns.set("unrelated", {"notfoo": "nota"})
+
+    assert ns.get_multi([key, key]) == {key: value}
+    # When the result is cached, improper duplicate handling can result in a full
+    # bigtable scan. Check that we only get the intended result.
+    assert ns.get_multi([key, key]) == {key: value}
+
+
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
 def test_set(ns):
     node_id = "d2502ebbd7df41ceba8d3275595cac33"
     data = {"foo": "bar"}


### PR DESCRIPTION
Add an id_list deduplication so that we can correctly recognize cache hits and avoid full table scans in bigtable.
Add a test that demonstrates the fix.

We observed some timeouts in nodestore.get_multi calls, with lookups for a small number of IDs taking 40s+.
One commonality was that they were lookups that included duplicated IDs and cache hits; this is because we
recognize full cache hits by comparing cached records to len(id_list), return if they are equal, and otherwise
pass on id_list with cached IDs removed to bigtable get_bytes_multi. With dupes removed, id_list is empty,
and the resulting row_scan to bigtable is unconstrained, meaning it either won't finish, or will return irrelevant data.
Duplicates aren't visible in the result, so deduping early avoid this issue and any others that might result from repeated keys.
