### PR TITLE
feat(insights): query for trace id with cache span samples

### DIFF
--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -56,6 +56,7 @@ const useTransactionDurationSeries = ({transaction}: {transaction: string}) => {
         transaction,
       } satisfies MetricsQueryFilters),
       transformAliasToInputFormat: true,
+      enabled: !useEap,
     },
     Referrer.SAMPLES_CACHE_TRANSACTION_DURATION_CHART
   );
@@ -67,6 +68,7 @@ const useTransactionDurationSeries = ({transaction}: {transaction: string}) => {
         is_transaction: 'true',
       } satisfies SpanQueryFilters),
       yAxis: [`avg(${SpanFields.SPAN_DURATION})`],
+      enabled: useEap,
     },
     Referrer.SAMPLES_CACHE_TRANSACTION_DURATION
   );

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -160,6 +160,7 @@ export function CacheSamplePanel() {
           SpanIndexedField.CACHE_HIT,
           SpanIndexedField.SPAN_OP,
           SpanIndexedField.CACHE_ITEM_SIZE,
+          SpanIndexedField.TRACE,
           ...(useEap ? [] : ([SpanIndexedField.TRANSACTION_ID] as const)),
         ],
         sorts: [SPAN_SAMPLES_SORT],
@@ -197,8 +198,9 @@ export function CacheSamplePanel() {
   }, [cacheHitSamples, cacheMissSamples]);
 
   const transactionIds = cacheSamples?.map(span => span[transactionIdField]) || [];
+  const traceIds = cacheSamples?.map(span => span.trace) || [];
   const search = useEap
-    ? `${SpanIndexedField.TRANSACTION_SPAN_ID}:[${transactionIds.join(',')}] is_transaction:true`
+    ? `${SpanIndexedField.TRANSACTION_SPAN_ID}:[${transactionIds.join(',')}] trace:[${traceIds.join(',')}] is_transaction:true`
     : `id:[${transactionIds.join(',')}]`;
 
   const {


### PR DESCRIPTION
This PR adds `trace` to the cache samples search query.
Anytime we are looking up an item id we should also include the trace id so that we hit the bloomfilter index.

Also disabled a query that isn't used when eap is on