### PR TITLE
chore(ACI): Add metric for dual processing in metric alerts

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -467,7 +467,10 @@ class SubscriptionProcessor:
                     ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                         # If the value has breached our threshold (above/below)
                         # And the trigger is not yet active
-                        metrics.incr("incidents.alert_rules.threshold.alert")
+                        metrics.incr(
+                            "incidents.alert_rules.threshold.alert",
+                            tags={"detection_type": self.alert_rule.detection_type},
+                        )
                         if features.has(
                             "organizations:workflow-engine-metric-alert-dual-processing-logs",
                             self.subscription.project.organization,
@@ -495,10 +498,7 @@ class SubscriptionProcessor:
                             "organizations:workflow-engine-metric-alert-dual-processing-logs",
                             self.subscription.project.organization,
                         ):
-                            metrics.incr(
-                                "dual_processing.alert_rules.fire",
-                                tags={"detection_type": self.alert_rule.detection_type},
-                            )
+                            metrics.incr("dual_processing.alert_rules.fire")
                         incident_trigger = self.trigger_resolve_threshold(
                             trigger, aggregation_value
                         )

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -368,16 +368,6 @@ class SubscriptionProcessor:
             "organizations:anomaly-detection-alerts", organization
         ) and features.has("organizations:anomaly-detection-rollout", organization)
 
-        alert_triggered_tags = {
-            "detection_type": self.alert_rule.detection_type,
-            "organization_id": None,
-        }
-        if features.has(
-            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-            self.subscription.project.organization,
-        ):
-            alert_triggered_tags["organization_id"] = self.alert_rule.organization_id
-
         potential_anomalies = None
         if (
             has_anomaly_detection
@@ -440,7 +430,7 @@ class SubscriptionProcessor:
                         ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.alert",
-                                tags=alert_triggered_tags,
+                                tags={"detection_type": self.alert_rule.detection_type},
                             )
                             incident_trigger = self.trigger_alert_threshold(
                                 trigger, aggregation_value
@@ -457,7 +447,7 @@ class SubscriptionProcessor:
                         ):
                             metrics.incr(
                                 "incidents.alert_rules.threshold.resolve",
-                                tags=alert_triggered_tags,
+                                tags={"detection_type": self.alert_rule.detection_type},
                             )
                             incident_trigger = self.trigger_resolve_threshold(
                                 trigger, aggregation_value
@@ -479,8 +469,16 @@ class SubscriptionProcessor:
                         # And the trigger is not yet active
                         metrics.incr(
                             "incidents.alert_rules.threshold.alert",
-                            tags=alert_triggered_tags,
+                            tags={"detection_type": self.alert_rule.detection_type},
                         )
+                        if features.has(
+                            "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                            self.subscription.project.organization,
+                        ):
+                            metrics.incr(
+                                "dual_processing.alert_rules.fire",
+                                tags={"detection_type": self.alert_rule.detection_type},
+                            )
                         # triggering a threshold will create an incident and set the status to active
                         incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
                         if incident_trigger is not None:
@@ -497,8 +495,16 @@ class SubscriptionProcessor:
                     ):
                         metrics.incr(
                             "incidents.alert_rules.threshold.resolve",
-                            tags=alert_triggered_tags,
+                            tags={"detection_type": self.alert_rule.detection_type},
                         )
+                        if features.has(
+                            "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                            self.subscription.project.organization,
+                        ):
+                            metrics.incr(
+                                "dual_processing.alert_rules.fire",
+                                tags={"detection_type": self.alert_rule.detection_type},
+                            )
                         incident_trigger = self.trigger_resolve_threshold(
                             trigger, aggregation_value
                         )

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -467,18 +467,12 @@ class SubscriptionProcessor:
                     ) and not self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE):
                         # If the value has breached our threshold (above/below)
                         # And the trigger is not yet active
-                        metrics.incr(
-                            "incidents.alert_rules.threshold.alert",
-                            tags={"detection_type": self.alert_rule.detection_type},
-                        )
+                        metrics.incr("incidents.alert_rules.threshold.alert")
                         if features.has(
                             "organizations:workflow-engine-metric-alert-dual-processing-logs",
                             self.subscription.project.organization,
                         ):
-                            metrics.incr(
-                                "dual_processing.alert_rules.fire",
-                                tags={"detection_type": self.alert_rule.detection_type},
-                            )
+                            metrics.incr("dual_processing.alert_rules.fire")
                         # triggering a threshold will create an incident and set the status to active
                         incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
                         if incident_trigger is not None:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,7 +1,6 @@
 import logging
 from dataclasses import asdict, replace
 from enum import StrEnum
-from typing import Any
 
 import sentry_sdk
 from django.db import router, transaction
@@ -218,14 +217,6 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
 
     # TODO: remove fetching org, only used for feature flag checks
     organization = detector.project.organization
-    workflow_metric_tags: dict[str, Any] = {
-        "detector_type": detector.type,
-        "organization_id": None,
-    }
-    if features.has(
-        "organizations:workflow-engine-metric-alert-dual-processing-logs", organization
-    ):
-        workflow_metric_tags["organization_id"] = organization.id
 
     # Get the workflows, evaluate the when_condition_group, finally evaluate the actions for workflows that are triggered
     workflows = set(
@@ -240,7 +231,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
         metrics.incr(
             "workflow_engine.process_workflows",
             len(workflows),
-            tags=workflow_metric_tags,
+            tags={"detector_type": detector.type},
         )
 
         logger.info(
@@ -263,7 +254,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
             metrics.incr(
                 "workflow_engine.process_workflows.triggered_workflows",
                 len(triggered_workflows),
-                tags=workflow_metric_tags,
+                tags={"detector_type": detector.type},
             )
 
             logger.info(
@@ -284,7 +275,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
         metrics.incr(
             "workflow_engine.process_workflows.actions",
             amount=len(actions),
-            tags=workflow_metric_tags,
+            tags={"detector_type": detector.type},
         )
 
         logger.info(
@@ -309,7 +300,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
         metrics.incr(
             "workflow_engine.process_workflows.triggered_actions",
             amount=len(actions),
-            tags=workflow_metric_tags,
+            tags={"detector_type": detector.type},
         )
         logger.info(
             "workflow_engine.process_workflows.triggered_actions (batch)",
@@ -324,7 +315,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
     # in order to check if workflow engine is firing 1:1 with the old system, we must only count once rather than each action
     metrics.incr(
         "workflow_engine.process_workflows.fired_actions",
-        tags=workflow_metric_tags,
+        tags={"detector_type": detector.type},
     )
 
     return triggered_workflows

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1059,7 +1059,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [
                 call(
                     "incidents.alert_rules.threshold.alert",
-                    tags={"detection_type": "static", "organization_id": None},
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
             ],
@@ -1252,12 +1252,12 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [
                 call(
                     "incidents.alert_rules.threshold.alert",
-                    tags={"detection_type": "static", "organization_id": None},
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
                     "incidents.alert_rules.threshold.resolve",
-                    tags={"detection_type": "static", "organization_id": None},
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1079,7 +1079,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 ),
                 call(
                     "dual_processing.alert_rules.fire",
-                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
             ],
@@ -1279,7 +1278,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 ),
                 call(
                     "dual_processing.alert_rules.fire",
-                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
@@ -1288,7 +1286,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 ),
                 call(
                     "dual_processing.alert_rules.fire",
-                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1075,7 +1075,11 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [
                 call(
                     "incidents.alert_rules.threshold.alert",
-                    tags={"detection_type": "static", "organization_id": rule.organization_id},
+                    tags={"detection_type": "static"},
+                ),
+                call(
+                    "dual_processing.alert_rules.fire",
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
             ],
@@ -1271,12 +1275,20 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             [
                 call(
                     "incidents.alert_rules.threshold.alert",
-                    tags={"detection_type": "static", "organization_id": rule.organization_id},
+                    tags={"detection_type": "static"},
+                ),
+                call(
+                    "dual_processing.alert_rules.fire",
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
                 call(
                     "incidents.alert_rules.threshold.resolve",
-                    tags={"detection_type": "static", "organization_id": rule.organization_id},
+                    tags={"detection_type": "static"},
+                ),
+                call(
+                    "dual_processing.alert_rules.fire",
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -310,7 +310,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
             "workflow_engine.process_workflows.fired_actions",
             tags={
                 "detector_type": self.error_detector.type,
-                "organization_id": self.error_detector.project.organization_id,
             },
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -62,10 +62,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
                 id=1, is_new=False, is_regression=True, is_new_group_environment=False
             ),
         )
-        self.workflow_metric_tags = {
-            "detector_type": self.error_detector.type,
-            "organization_id": None,
-        }
 
     def test_skips_disabled_workflows(self):
         workflow_triggers = self.create_data_condition_group()
@@ -280,7 +276,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_incr.assert_any_call(
             "workflow_engine.process_workflows",
             1,
-            tags=self.workflow_metric_tags,
+            tags={"detector_type": self.error_detector.type},
         )
 
     @patch("sentry.utils.metrics.incr")
@@ -290,7 +286,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_incr.assert_any_call(
             "workflow_engine.process_workflows.triggered_workflows",
             1,
-            tags=self.workflow_metric_tags,
+            tags={"detector_type": self.error_detector.type},
         )
 
     @with_feature("organizations:workflow-engine-process-workflows")
@@ -302,7 +298,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_incr.assert_any_call(
             "workflow_engine.process_workflows.triggered_actions",
             amount=0,
-            tags=self.workflow_metric_tags,
+            tags={"detector_type": self.error_detector.type},
         )
 
     @with_feature("organizations:workflow-engine-process-workflows")


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/91840

The `organization_id` tag is not showing up in Datadog despite manually allowing it for these metrics (I suspect something higher up is blocking it) so this PR removes that tag and adds a metric behind the logging flag for metric alerts firing so that we can see if they are firing at the same rate as in workflow engine.