### PR TITLE
feat(crons): Add various check-ins status's to check-in table

### DIFF
--- a/static/app/views/insights/crons/components/checkInRow.spec.tsx
+++ b/static/app/views/insights/crons/components/checkInRow.spec.tsx
@@ -1,0 +1,173 @@
+import {CheckInFixture} from 'sentry-fixture/checkIn';
+import {MonitorFixture} from 'sentry-fixture/monitor';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import {CheckInStatus} from 'sentry/views/insights/crons/types';
+
+import {CheckInRow} from './checkInRow';
+
+describe('CheckInRow', () => {
+  const monitor = MonitorFixture();
+
+  it('represents a simple Missed check-in', function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.MISSED,
+      duration: null,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    expect(screen.getByText('Missed')).toBeInTheDocument();
+    expect(screen.getByText('Jan 1, 2025 12:00:00 AM UTC')).toBeInTheDocument();
+  });
+
+  it('represents a simple Okay check-in', async function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.OK,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    expect(screen.getByText('Okay')).toBeInTheDocument();
+    expect(screen.getByText('Jan 1, 2025 12:00:01 AM UTC')).toBeInTheDocument();
+    expect(screen.getByText('Jan 1, 2025 12:00:10 AM UTC')).toBeInTheDocument();
+    expect(screen.getByText('9 seconds')).toBeInTheDocument();
+    expect(screen.getByText('Jan 1, 2025 12:00:00 AM UTC')).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('9 seconds'));
+    expect(await screen.findByText('9 seconds 50 milliseconds')).toBeInTheDocument();
+  });
+
+  it('represents an In Progress check-in', function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.IN_PROGRESS,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateUpdated: '2025-01-01T00:00:01Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: null,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    expect(screen.getAllByText('In Progress')).toHaveLength(2);
+  });
+
+  it('shows environments when hasMultiEnv', function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.OK,
+      environment: 'prod',
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} hasMultiEnv />);
+
+    expect(screen.getByText('prod')).toBeInTheDocument();
+  });
+
+  it('represents a check-in without a in-progress', async function () {
+    const checkIn = CheckInFixture({
+      dateAdded: '2025-01-01T00:00:10Z',
+      dateUpdated: '2025-01-01T00:00:10Z',
+      dateInProgress: null,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    const notSent = screen.getByText('Not Sent');
+    expect(notSent).toBeInTheDocument();
+    await userEvent.hover(notSent);
+
+    const expectedTooltip = /No in-progress check-in was received/;
+
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('represents a timed-out incomplete check-in', async function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.TIMEOUT,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateUpdated: '2025-01-01T00:00:01Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: null,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    const incomplete = screen.getByText('Incomplete');
+    expect(incomplete).toBeInTheDocument();
+    await userEvent.hover(incomplete);
+
+    const expectedTooltip =
+      /An in-progress check-in was received, but no closing check-in followed/;
+
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('represents a timed-out check-in with a late terminal check-in', async function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.TIMEOUT,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateUpdated: '2025-01-01T00:12:00Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      duration: 12 * 60 * 1000,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    const overrunBadge = screen.getByText(textWithMarkupMatcher('2min late'));
+    expect(overrunBadge).toBeInTheDocument();
+    await userEvent.hover(overrunBadge);
+
+    const expectedTooltip = textWithMarkupMatcher(
+      'The closing check-in occurred 2 minutes after this check-in was marked as timed out. The configured maximum allowed runtime is 10 minutes.'
+    );
+
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('represents a early check-in', async function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.OK,
+      dateAdded: '2025-01-01T00:00:01Z',
+      dateUpdated: '2025-01-01T00:00:10Z',
+      dateInProgress: '2025-01-01T00:00:01Z',
+      expectedTime: '2025-01-02T00:00:00Z',
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    const earlyBadge = screen.getByText(textWithMarkupMatcher('Early'));
+    expect(earlyBadge).toBeInTheDocument();
+    await userEvent.hover(earlyBadge);
+
+    const expectedTooltip = textWithMarkupMatcher(
+      'This check-in was Received 24 hours before it was expected. This is likely due to a misconfiguration.'
+    );
+
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+
+  it('represents a early check-in that is likely due to a missing in-progress', async function () {
+    const checkIn = CheckInFixture({
+      status: CheckInStatus.OK,
+      dateAdded: '2025-01-01T00:12:00Z',
+      dateUpdated: '2025-01-01T00:12:00',
+      dateInProgress: null,
+      expectedTime: '2025-01-02T00:00:00Z',
+      duration: 12 * 60 * 1000,
+    });
+
+    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+
+    const earlyBadge = screen.getByText(textWithMarkupMatcher('Early'));
+    expect(earlyBadge).toBeInTheDocument();
+    await userEvent.hover(earlyBadge);
+
+    const expectedTooltip = textWithMarkupMatcher(
+      'This check-in was received 24 hours before it was expected. This may be due to the missing in-progress check-in, as your job reported a duration of 12 minutes without sending an in-progress. Your grace period for the first check-in is 5 minutes.'
+    );
+
+    expect(await screen.findByText(expectedTooltip)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/crons/components/checkInRow.tsx
+++ b/static/app/views/insights/crons/components/checkInRow.tsx
@@ -1,0 +1,394 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment-timezone';
+
+import {Tag} from 'sentry/components/core/badge/tag';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {DateTime} from 'sentry/components/dateTime';
+import Duration from 'sentry/components/duration';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import ShortId from 'sentry/components/shortId';
+import {
+  StatusIndicator,
+  type StatusIndicatorProps,
+} from 'sentry/components/statusIndicator';
+import Text from 'sentry/components/text';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
+import {QuickContextHovercard} from 'sentry/views/discover/table/quickContext/quickContextHovercard';
+import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
+import type {CheckIn, Monitor} from 'sentry/views/insights/crons/types';
+import {CheckInStatus} from 'sentry/views/insights/crons/types';
+import {statusToText} from 'sentry/views/insights/crons/utils';
+
+import {DEFAULT_CHECKIN_MARGIN, DEFAULT_MAX_RUNTIME} from './monitorForm';
+
+interface CheckInRowProps {
+  checkIn: CheckIn;
+  monitor: Monitor;
+  hasMultiEnv?: boolean;
+}
+
+const checkStatusToIndicatorStatus: Record<
+  CheckInStatus,
+  StatusIndicatorProps['status']
+> = {
+  [CheckInStatus.OK]: 'success',
+  [CheckInStatus.ERROR]: 'error',
+  [CheckInStatus.IN_PROGRESS]: 'muted',
+  [CheckInStatus.MISSED]: 'warning',
+  [CheckInStatus.TIMEOUT]: 'error',
+  [CheckInStatus.UNKNOWN]: 'muted',
+};
+
+const emptyCell = <Text>{'\u2014'}</Text>;
+
+/**
+ * Represents the 'completion' of a check-in.
+ */
+enum CompletionStatus {
+  /**
+   * Check-in has not finished yet (an in-progress was received).
+   */
+  INCOMPLETE = 'incomplete',
+  /**
+   * Check-in was marked as timed out and never received a completing check-in.
+   */
+  INCOMPLETE_TIMEOUT = 'incomplete_timeout',
+  /**
+   * Check-in was marked as timed out and later received a user completing check-in.
+   */
+  COMPLETE_TIMEOUT = 'complete_timeout',
+  /**
+   * Check-in received a user terminal completion.
+   */
+  COMPLETE = 'complete',
+}
+
+function getCompletionStatus({status, duration}: CheckIn) {
+  const isUserComplete = [CheckInStatus.OK, CheckInStatus.ERROR].includes(status);
+  const isTimeout = status === CheckInStatus.TIMEOUT;
+
+  // If we have a user sent terminal status we're definitely complete. We also
+  // know we are complete if we have a timeout with a duration.
+  if (isUserComplete) {
+    return CompletionStatus.COMPLETE;
+  }
+
+  // Check-ins that are timed out but have a duration indicate that we did
+  // receive a closing check-in, but it was too late.
+  if (isTimeout && duration !== null) {
+    return CompletionStatus.COMPLETE_TIMEOUT;
+  }
+
+  // A timeout without a duration means we never sent a closing check-in
+  if (isTimeout) {
+    return CompletionStatus.INCOMPLETE_TIMEOUT;
+  }
+
+  // Otherwise we have not sent a closing check-in yet
+  return CompletionStatus.INCOMPLETE;
+}
+
+export function CheckInRow({monitor, checkIn, hasMultiEnv}: CheckInRowProps) {
+  const organization = useOrganization();
+  const {
+    status,
+    dateAdded,
+    dateUpdated,
+    dateInProgress,
+    expectedTime,
+    environment,
+    duration,
+    groups,
+  } = checkIn;
+
+  const statusText = statusToText[status];
+
+  const statusColumn = (
+    <Status>
+      <StatusIndicator
+        status={checkStatusToIndicatorStatus[status]}
+        tooltipTitle={tct('Check-in Status: [statusText]', {statusText})}
+      />
+      <Text>{statusText}</Text>
+    </Status>
+  );
+
+  const expectedTimeColum = expectedTime ? (
+    <TimestampContainer>
+      <ExpectedDateTime date={expectedTime} timeZone seconds />
+      <OffScheduleIndicator checkIn={checkIn} />
+    </TimestampContainer>
+  ) : (
+    emptyCell
+  );
+
+  // Missed rows are mostly empty
+  if (status === CheckInStatus.MISSED) {
+    return (
+      <Fragment>
+        {statusColumn}
+        {emptyCell}
+        {emptyCell}
+        {emptyCell}
+        {emptyCell}
+        {hasMultiEnv ? emptyCell : null}
+        {expectedTimeColum}
+      </Fragment>
+    );
+  }
+
+  const hadInProgress = !!dateInProgress;
+  const completionStatus = getCompletionStatus(checkIn);
+
+  const startedColumn = (
+    <TimestampContainer>
+      {hadInProgress ? (
+        <DateTime date={dateAdded} timeZone seconds />
+      ) : (
+        <NotSentIndicator />
+      )}
+    </TimestampContainer>
+  );
+
+  const completedColumn = (
+    <TimestampContainer>
+      {completionStatus === CompletionStatus.COMPLETE ? (
+        <DateTime date={dateUpdated} timeZone seconds />
+      ) : completionStatus === CompletionStatus.COMPLETE_TIMEOUT && defined(duration) ? (
+        <Fragment>
+          <DateTime date={dateUpdated} timeZone seconds />
+          <CompletedLateIndicator checkIn={checkIn} />
+        </Fragment>
+      ) : completionStatus === CompletionStatus.INCOMPLETE_TIMEOUT ? (
+        <IncompleteTimeoutIndicator />
+      ) : completionStatus === CompletionStatus.INCOMPLETE ? (
+        <Tag type="default">{t('In Progress')}</Tag>
+      ) : (
+        emptyCell
+      )}
+    </TimestampContainer>
+  );
+
+  const durationColumn = defined(duration) ? (
+    <DurationContainer>
+      <Tooltip skipWrapper title={<Duration exact seconds={duration / 1000} />}>
+        <Duration seconds={duration / 1000} />
+      </Tooltip>
+    </DurationContainer>
+  ) : (
+    emptyCell
+  );
+
+  const groupsColumn =
+    groups && groups.length > 0 ? (
+      <IssuesContainer>
+        {groups.map(({id, shortId}) => (
+          <QuickContextHovercard
+            dataRow={{
+              ['issue.id']: id,
+              issue: shortId,
+            }}
+            contextType={ContextType.ISSUE}
+            organization={organization}
+            key={id}
+          >
+            <StyledShortId
+              shortId={shortId}
+              avatar={<ProjectBadge project={monitor.project} hideName avatarSize={12} />}
+              to={`/organizations/${organization.slug}/issues/${id}/`}
+            />
+          </QuickContextHovercard>
+        ))}
+      </IssuesContainer>
+    ) : (
+      emptyCell
+    );
+
+  return (
+    <Fragment>
+      {statusColumn}
+      {startedColumn}
+      {completedColumn}
+      {durationColumn}
+      {groupsColumn}
+      {hasMultiEnv ? <div>{environment}</div> : null}
+      {expectedTimeColum}
+    </Fragment>
+  );
+}
+
+interface OffScheduleIndicatorProps {
+  checkIn: CheckIn;
+}
+
+/**
+ * Renders a "Early" tag when the check-in occurred before it was expected.
+ *
+ * In scenarios where there is no in-progress and we know the duration of the
+ * job, we can suggest the problem is the missing in-progress
+ */
+function OffScheduleIndicator({checkIn}: OffScheduleIndicatorProps) {
+  const {duration, dateAdded, dateInProgress, expectedTime, monitorConfig} = checkIn;
+
+  const durationSeconds = duration && duration / 1000;
+  const marginSeconds = (monitorConfig.checkin_margin ?? DEFAULT_CHECKIN_MARGIN) * 60;
+
+  const beforeExpected = moment(dateAdded).isBefore(expectedTime);
+
+  // The check-in is on time if we're not checking-in before the expected
+  // check-in time. If we are after the expected check-in time this means the
+  // check-in happened before a miss was marked, and we are in the grace window.
+  if (!beforeExpected) {
+    return null;
+  }
+
+  const earlyBy = (
+    <strong>
+      <Duration seconds={moment(expectedTime).diff(dateAdded, 'seconds')} />
+    </strong>
+  );
+
+  const checkInMargin = (
+    <strong>
+      <Duration seconds={marginSeconds} />
+    </strong>
+  );
+
+  const jobDuration = durationSeconds && (
+    <strong>
+      <Duration seconds={durationSeconds} />
+    </strong>
+  );
+
+  // If the check-in ran longer than the configured margin and we're missing an
+  // in-progress check-in, it's very likely this check-in is off-schedule
+  // because of the missing in-progress.
+  const dueToMissingInProgress =
+    durationSeconds && durationSeconds > marginSeconds && !dateInProgress;
+
+  const title = dueToMissingInProgress
+    ? tct(
+        'This check-in was received [earlyBy] before it was expected. This may be due to the missing in-progress check-in, as your job reported a duration of [jobDuration] without sending an in-progress. Your grace period for the first check-in is [checkInMargin].',
+        {earlyBy, jobDuration, checkInMargin}
+      )
+    : tct(
+        'This check-in was Received [earlyBy] before it was expected. This is likely due to a misconfiguration.',
+        {earlyBy}
+      );
+
+  return (
+    <Tooltip skipWrapper title={title}>
+      <Tag type="error">{t('Early')}</Tag>
+    </Tooltip>
+  );
+}
+
+interface TimeoutLateByProps {
+  checkIn: CheckIn;
+}
+
+/**
+ * Renders a tag indicating how late the completing check-in was when a
+ * check-in timed out but still has a duration (indicating we have a closing
+ * check-in)
+ */
+function CompletedLateIndicator({checkIn}: TimeoutLateByProps) {
+  const {duration, monitorConfig} = checkIn;
+
+  if (duration === null) {
+    return null;
+  }
+
+  const maxRuntimeSeconds = (monitorConfig.max_runtime ?? DEFAULT_MAX_RUNTIME) * 60;
+  const lateBySecond = duration / 1000 - maxRuntimeSeconds;
+
+  const maxRuntime = (
+    <strong>
+      <Duration seconds={maxRuntimeSeconds} />
+    </strong>
+  );
+
+  const lateBy = (
+    <strong>
+      <Duration seconds={lateBySecond} />
+    </strong>
+  );
+
+  const title = tct(
+    'The closing check-in occurred [lateBy] after this check-in was marked as timed out. The configured maximum allowed runtime is [maxRuntime].',
+    {lateBy, maxRuntime}
+  );
+
+  return (
+    <Tooltip skipWrapper title={title}>
+      <Tag type="error">
+        {t('%s late', <Duration abbreviation seconds={lateBySecond} />)}
+      </Tag>
+    </Tooltip>
+  );
+}
+
+/**
+ * Renders an "Incomplete" badge, indicating the check-in never reported a
+ * terminal completion status.
+ */
+function IncompleteTimeoutIndicator() {
+  const title = t(
+    'An in-progress check-in was received, but no closing check-in followed. Your job may be terminating before it reports to Sentry.'
+  );
+
+  return (
+    <Tooltip skipWrapper title={title}>
+      <Tag type="error">{t('Incomplete')}</Tag>
+    </Tooltip>
+  );
+}
+
+/**
+ * Renders a "Not Sent" badge, indicating no in-progress check-in was sent.
+ */
+function NotSentIndicator() {
+  const title = t(
+    "No in-progress check-in was received. These are optional, but without them, timeouts can't be enforced, and long-running jobs may be marked as missed."
+  );
+
+  return (
+    <Tooltip skipWrapper title={title}>
+      <Tag type="warning">{t('Not Sent')}</Tag>
+    </Tooltip>
+  );
+}
+
+const Status = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const TimestampContainer = styled('div')`
+  display: flex;
+  gap: ${space(0.5)};
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+`;
+
+const DurationContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const IssuesContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ExpectedDateTime = styled(DateTime)`
+  color: ${p => p.theme.subText};
+`;
+
+const StyledShortId = styled(ShortId)`
+  justify-content: flex-start;
+`;

--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -2,51 +2,22 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
-import {Tag} from 'sentry/components/core/badge/tag';
-import {Tooltip} from 'sentry/components/core/tooltip';
-import {DateTime} from 'sentry/components/dateTime';
-import Duration from 'sentry/components/duration';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import Placeholder from 'sentry/components/placeholder';
-import QuestionTooltip from 'sentry/components/questionTooltip';
-import ShortId from 'sentry/components/shortId';
-import {
-  StatusIndicator,
-  type StatusIndicatorProps,
-} from 'sentry/components/statusIndicator';
-import Text from 'sentry/components/text';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {QuickContextHovercard} from 'sentry/views/discover/table/quickContext/quickContextHovercard';
-import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
 import type {Monitor, MonitorEnvironment} from 'sentry/views/insights/crons/types';
-import {CheckInStatus} from 'sentry/views/insights/crons/types';
-import {statusToText} from 'sentry/views/insights/crons/utils';
 import {useMonitorCheckIns} from 'sentry/views/insights/crons/utils/useMonitorCheckIns';
 
-import {DEFAULT_MAX_RUNTIME} from './monitorForm';
+import {CheckInRow} from './checkInRow';
 
 type Props = {
   monitor: Monitor;
   monitorEnvs: MonitorEnvironment[];
-};
-
-const checkStatusToIndicatorStatus: Record<
-  CheckInStatus,
-  StatusIndicatorProps['status']
-> = {
-  [CheckInStatus.OK]: 'success',
-  [CheckInStatus.ERROR]: 'error',
-  [CheckInStatus.IN_PROGRESS]: 'muted',
-  [CheckInStatus.MISSED]: 'warning',
-  [CheckInStatus.TIMEOUT]: 'error',
-  [CheckInStatus.UNKNOWN]: 'muted',
 };
 
 const PER_PAGE = 10;
@@ -74,19 +45,12 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
     return <LoadingError />;
   }
 
-  const emptyCell = <Text>{'\u2014'}</Text>;
-
   const hasMultiEnv = monitorEnvs.length > 1;
 
   const headers = [
     t('Status'),
-    <RecordedHeader key="recorded-header">
-      {t('Recorded')}
-      <QuestionTooltip
-        size="sm"
-        title={t('The time when Sentry received the first check-in for this job.')}
-      />
-    </RecordedHeader>,
+    t('Started'),
+    t('Completed'),
     t('Duration'),
     t('Issues'),
     ...(hasMultiEnv ? [t('Environment')] : []),
@@ -108,153 +72,18 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
               </RowPlaceholder>
             ))
           : checkInList.map(checkIn => (
-              <Fragment key={checkIn.id}>
-                <Status>
-                  <StatusIndicator
-                    status={checkStatusToIndicatorStatus[checkIn.status]}
-                    tooltipTitle={tct('Check-in Status: [status]', {
-                      status: statusToText[checkIn.status],
-                    })}
-                  />
-                  <Text>{statusToText[checkIn.status]}</Text>
-                </Status>
-                {checkIn.status === CheckInStatus.MISSED ? (
-                  emptyCell
-                ) : (
-                  <div>
-                    <DateTime date={checkIn.dateAdded} timeZone seconds />
-                  </div>
-                )}
-                {defined(checkIn.duration) ? (
-                  <DurationContainer>
-                    <Tooltip title={<Duration exact seconds={checkIn.duration / 1000} />}>
-                      <Duration seconds={checkIn.duration / 1000} />
-                    </Tooltip>
-                    {checkIn.status === CheckInStatus.TIMEOUT && (
-                      <TimeoutLateBy monitor={monitor} duration={checkIn.duration} />
-                    )}
-                  </DurationContainer>
-                ) : checkIn.status === CheckInStatus.TIMEOUT ? (
-                  <div>
-                    <Tooltip
-                      title={t(
-                        'An in-progress check-in was received, but no closing check-in followed. Your job may be terminating before it reports to Sentry.'
-                      )}
-                    >
-                      <Tag type="error">{t('Incomplete')}</Tag>
-                    </Tooltip>
-                  </div>
-                ) : (
-                  emptyCell
-                )}
-                {checkIn.groups && checkIn.groups.length > 0 ? (
-                  <IssuesContainer>
-                    {checkIn.groups.map(({id, shortId}) => (
-                      <QuickContextHovercard
-                        dataRow={{
-                          ['issue.id']: id,
-                          issue: shortId,
-                        }}
-                        contextType={ContextType.ISSUE}
-                        organization={organization}
-                        key={id}
-                      >
-                        <StyledShortId
-                          shortId={shortId}
-                          avatar={
-                            <ProjectBadge
-                              project={monitor.project}
-                              hideName
-                              avatarSize={12}
-                            />
-                          }
-                          to={`/organizations/${organization.slug}/issues/${id}/`}
-                        />
-                      </QuickContextHovercard>
-                    ))}
-                  </IssuesContainer>
-                ) : (
-                  emptyCell
-                )}
-                {hasMultiEnv ? <div>{checkIn.environment}</div> : null}
-                <div>
-                  {checkIn.expectedTime ? (
-                    <Timestamp date={checkIn.expectedTime} timeZone seconds />
-                  ) : (
-                    emptyCell
-                  )}
-                </div>
-              </Fragment>
+              <CheckInRow
+                key={checkIn.id}
+                monitor={monitor}
+                checkIn={checkIn}
+                hasMultiEnv={hasMultiEnv}
+              />
             ))}
       </PanelTable>
       <Pagination pageLinks={getResponseHeader?.('Link')} />
     </Fragment>
   );
 }
-
-interface TimeoutLateByProps {
-  duration: number;
-  monitor: Monitor;
-}
-
-function TimeoutLateBy({monitor, duration}: TimeoutLateByProps) {
-  const maxRuntimeSeconds = (monitor.config.max_runtime ?? DEFAULT_MAX_RUNTIME) * 60;
-  const lateBySecond = duration / 1000 - maxRuntimeSeconds;
-
-  const maxRuntime = (
-    <strong>
-      <Duration seconds={(monitor.config.max_runtime ?? DEFAULT_MAX_RUNTIME) * 60} />
-    </strong>
-  );
-
-  const lateBy = (
-    <strong>
-      <Duration seconds={lateBySecond} />
-    </strong>
-  );
-
-  return (
-    <Tooltip
-      title={tct(
-        'The closing check-in occurred [lateBy] after this check-in was marked as timed out. The configured maximum allowed runtime is [maxRuntime].',
-        {lateBy, maxRuntime}
-      )}
-    >
-      <Tag type="error">
-        {t('%s late', <Duration abbreviation seconds={lateBySecond} />)}
-      </Tag>
-    </Tooltip>
-  );
-}
-
-const RecordedHeader = styled('div')`
-  display: flex;
-  gap: ${space(0.5)};
-  align-items: center;
-`;
-
-const Status = styled('div')`
-  line-height: 1.1;
-`;
-
-const DurationContainer = styled('div')`
-  display: flex;
-  gap: ${space(0.5)};
-  align-items: center;
-`;
-
-const IssuesContainer = styled('div')`
-  display: flex;
-  flex-direction: column;
-`;
-
-const Timestamp = styled(DateTime)`
-  color: ${p => p.theme.subText};
-`;
-
-const StyledShortId = styled(ShortId)`
-  justify-content: flex-start;
-`;
 
 const RowPlaceholder = styled('div')`
   grid-column: 1 / -1;

--- a/static/app/views/issueDetails/groupCheckIns.spec.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.spec.tsx
@@ -90,7 +90,7 @@ describe('GroupCheckIns', () => {
 
     expect(screen.getByRole('time')).toHaveTextContent(/Jan 1, 2025/);
     expect(screen.getByText(statusToText[check.status])).toBeInTheDocument();
-    expect(screen.getByText(`${check.duration}ms`)).toBeInTheDocument();
+    expect(screen.getByText('9s 50ms')).toBeInTheDocument();
     expect(screen.getByText(check.environment)).toBeInTheDocument();
     expect(screen.getByText(check.id)).toBeInTheDocument();
   });

--- a/tests/js/fixtures/checkIn.ts
+++ b/tests/js/fixtures/checkIn.ts
@@ -4,13 +4,13 @@ import {CheckInStatus, ScheduleType} from 'sentry/views/insights/crons/types';
 export function CheckInFixture(params: Partial<CheckIn> = {}): CheckIn {
   return {
     status: CheckInStatus.ERROR,
-    duration: 767,
+    duration: 9050,
     environment: 'production',
-    dateAdded: '2025-01-01T00:00:00Z',
-    dateCreated: '2025-01-01T00:00:00Z',
-    dateUpdated: '2025-01-01T00:00:00Z',
+    dateAdded: '2025-01-01T00:00:01Z',
+    dateCreated: '2025-01-01T00:00:05Z',
+    dateUpdated: '2025-01-01T00:00:10Z',
     dateClock: '2025-01-01T00:00:00Z',
-    dateInProgress: null,
+    dateInProgress: '2025-01-01T00:00:00Z',
     expectedTime: '2025-01-01T00:00:00Z',
     id: '97f0e440-317c-5bb5-b5e0-024ca202a61d',
     monitorConfig: {


### PR DESCRIPTION
- The Started column now represents when no "in progress" check-in was received with a "Not Sent" badge.

   <img alt="clipboard.png" width="1022" src="https://i.imgur.com/wUNfXvw.png" />

 - Adds a new "Completed" column that now represents the "completion" time of a check-in. This is determined by

   - Check-in's that are in-progress will have a "In Progress" badge in the completed column.

	 <img width="1250" alt="image" src="https://github.com/user-attachments/assets/64dc1613-6c56-4659-bdfc-e8116423a1bf" />

   - Check-ins that timed out and do not have a duration will have a "Incomplete" badge, indicating to the user that a closing check-in was never sent.

     <img alt="clipboard.png" width="1254" src="https://i.imgur.com/WGJ1taO.png" />

   - Check-ins that timed out but had a closing check-in (as determined by the fact that we have a duration) will have a completed timestamp and a "Late By" badge indicating that the closing check-in was past the max run-time.

     <img alt="clipboard.png" width="1244" src="https://i.imgur.com/jXMiTh4.png" />

 - The expected time will render a "Early" badge when the check-in started before the expected time.

   - If there was a in-progress check-in we will simply indicate how early the check-in was in the tooltip.

     <img alt="clipboard.png" width="1102" src="https://i.imgur.com/6VMCKrW.png" />

   - If no in-progress check-in was sent, and the duration of the check-in indicates that if a in-progress check-in had been sent the check-in would have been on-time, we will indicate to the user.

     <img alt="clipboard.png" width="1106" src="https://i.imgur.com/bOksgln.png" />

Fixes [NEW-341: Indicate in the crons check-in table when a check-in is off-schedule](https://linear.app/getsentry/issue/NEW-341/indicate-in-the-crons-check-in-table-when-a-check-in-is-off-schedule)
Fixes [NEW-226: Display more timing details for cron monitor check-ins](https://linear.app/getsentry/issue/NEW-226/display-more-timing-details-for-cron-monitor-check-ins)