### PR TITLE
chore(issue-views): Register permanent issue-views flag

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -124,6 +124,8 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:seer-based-priority": False,
         # Enable Vercel integration - there is a custom handler in getsentry
         "organizations:integrations-vercel": True,
+        # Enable issue view endpoints and UI
+        "organizations:issue-views": False,
     }
 
     permanent_project_features = {


### PR DESCRIPTION
Register the permanent "organizations:issue-views" flag to be used to gate issue views features on certain plans. 

getSentry PR coming soon 