### PR TITLE
feat(taskworker) Collect task parameter distributions

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.safestring import SafeString
 
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 logger = logging.getLogger("celery.pickle")
 
@@ -114,6 +114,18 @@ class SentryTask(Task):
         )
         should_sample = random.random() <= settings.CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE
         if should_complain or should_sample:
+            try:
+                param_size = json.dumps({"args": args, "kwargs": kwargs})
+                metrics.distribution(
+                    "celery.task.parameter_bytes",
+                    len(param_size.encode("utf8")),
+                    tags={"taskname": self.name},
+                )
+            except Exception as e:
+                logger.warning(
+                    "task.payload.measure.failure", extra={"error": str(e), "task": self.name}
+                )
+
             try:
                 good_use_of_pickle_or_bad_use_of_pickle(self, args, kwargs)
             except TypeError:

--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -120,6 +120,7 @@ class SentryTask(Task):
                     "celery.task.parameter_bytes",
                     len(param_size.encode("utf8")),
                     tags={"taskname": self.name},
+                    sample_rate=1.0,
                 )
             except Exception as e:
                 logger.warning(

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -7,6 +7,7 @@ from sentry.silo.base import SiloLimit, SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import test_tasks
+from sentry.testutils.helpers.options import override_options
 
 
 @instrumented_task(
@@ -110,6 +111,25 @@ def test_exclude_exception_retry(capture_exception):
         exclude_on_exception_task("bruh")
 
     assert capture_exception.call_count == 0
+
+
+@override_settings(
+    CELERY_COMPLAIN_ABOUT_BAD_USE_OF_PICKLE=True,
+    CELERY_PICKLE_ERROR_REPORT_SAMPLE_RATE=1.0,
+)
+@override_options(
+    {
+        "taskworker.test.rollout": {"*": 0.0},
+        "taskworker.route.overrides": {},
+    }
+)
+@patch("sentry.tasks.base.metrics.distribution")
+def test_capture_payload_metrics(mock_distribution):
+    region_task.apply_async(args=("bruh",))
+
+    mock_distribution.assert_called_once_with(
+        "celery.task.parameter_bytes", 71, tags={"taskname": "test.tasks.test_base.region_task"}
+    )
 
 
 @patch("sentry.taskworker.retry.current_task")

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -128,7 +128,10 @@ def test_capture_payload_metrics(mock_distribution):
     region_task.apply_async(args=("bruh",))
 
     mock_distribution.assert_called_once_with(
-        "celery.task.parameter_bytes", 71, tags={"taskname": "test.tasks.test_base.region_task"}
+        "celery.task.parameter_bytes",
+        71,
+        tags={"taskname": "test.tasks.test_base.region_task"},
+        sample_rate=1.0,
     )
 
 


### PR DESCRIPTION
Start collecting distributions on task payloads. We want to validate assumptions about the distribution of task parameter sizes in production.

Include this in the other parameter verification sample rate logic we're running on tasks.