### PR TITLE
ref(crons): Share checks table with group details

### DIFF
--- a/static/app/views/insights/crons/components/monitorCheckIns.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckIns.tsx
@@ -1,19 +1,15 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
 import LoadingError from 'sentry/components/loadingError';
 import Pagination from 'sentry/components/pagination';
-import {PanelTable} from 'sentry/components/panels/panelTable';
-import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {Monitor, MonitorEnvironment} from 'sentry/views/insights/crons/types';
 import {useMonitorCheckIns} from 'sentry/views/insights/crons/utils/useMonitorCheckIns';
 
-import {CheckInRow} from './checkInRow';
+import {MonitorCheckInsGrid} from './monitorCheckInsGrid';
 
 type Props = {
   monitor: Monitor;
@@ -47,49 +43,16 @@ export function MonitorCheckIns({monitor, monitorEnvs}: Props) {
 
   const hasMultiEnv = monitorEnvs.length > 1;
 
-  const headers = [
-    t('Status'),
-    t('Started'),
-    t('Completed'),
-    t('Duration'),
-    t('Issues'),
-    ...(hasMultiEnv ? [t('Environment')] : []),
-    t('Expected At'),
-  ];
-
   return (
     <Fragment>
       <SectionHeading>{t('Recent Check-Ins')}</SectionHeading>
-      <PanelTable
-        headers={headers}
-        isEmpty={!isPending && checkInList.length === 0}
-        emptyMessage={t('No check-ins have been recorded for this time period.')}
-      >
-        {isPending
-          ? [...new Array(PER_PAGE)].map((_, i) => (
-              <RowPlaceholder key={i}>
-                <Placeholder height="2rem" />
-              </RowPlaceholder>
-            ))
-          : checkInList.map(checkIn => (
-              <CheckInRow
-                key={checkIn.id}
-                monitor={monitor}
-                checkIn={checkIn}
-                hasMultiEnv={hasMultiEnv}
-              />
-            ))}
-      </PanelTable>
+      <MonitorCheckInsGrid
+        checkIns={checkInList ?? []}
+        isLoading={isPending}
+        hasMultiEnv={hasMultiEnv}
+        project={monitor.project}
+      />
       <Pagination pageLinks={getResponseHeader?.('Link')} />
     </Fragment>
   );
 }
-
-const RowPlaceholder = styled('div')`
-  grid-column: 1 / -1;
-  padding: ${space(1)};
-
-  &:not(:last-child) {
-    border-bottom: solid 1px ${p => p.theme.innerBorder};
-  }
-`;

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.spec.tsx
@@ -1,15 +1,15 @@
 import {CheckInFixture} from 'sentry-fixture/checkIn';
-import {MonitorFixture} from 'sentry-fixture/monitor';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {CheckInStatus} from 'sentry/views/insights/crons/types';
 
-import {CheckInRow} from './checkInRow';
+import {MonitorCheckInsGrid} from './monitorCheckInsGrid';
 
 describe('CheckInRow', () => {
-  const monitor = MonitorFixture();
+  const project = ProjectFixture();
 
   it('represents a simple Missed check-in', function () {
     const checkIn = CheckInFixture({
@@ -17,7 +17,7 @@ describe('CheckInRow', () => {
       duration: null,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     expect(screen.getByText('Missed')).toBeInTheDocument();
     expect(screen.getByText('Jan 1, 2025 12:00:00 AM UTC')).toBeInTheDocument();
@@ -28,7 +28,7 @@ describe('CheckInRow', () => {
       status: CheckInStatus.OK,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     expect(screen.getByText('Okay')).toBeInTheDocument();
     expect(screen.getByText('Jan 1, 2025 12:00:01 AM UTC')).toBeInTheDocument();
@@ -49,7 +49,7 @@ describe('CheckInRow', () => {
       duration: null,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     expect(screen.getAllByText('In Progress')).toHaveLength(2);
   });
@@ -60,7 +60,7 @@ describe('CheckInRow', () => {
       environment: 'prod',
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} hasMultiEnv />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} hasMultiEnv />);
 
     expect(screen.getByText('prod')).toBeInTheDocument();
   });
@@ -72,7 +72,7 @@ describe('CheckInRow', () => {
       dateInProgress: null,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     const notSent = screen.getByText('Not Sent');
     expect(notSent).toBeInTheDocument();
@@ -92,7 +92,7 @@ describe('CheckInRow', () => {
       duration: null,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     const incomplete = screen.getByText('Incomplete');
     expect(incomplete).toBeInTheDocument();
@@ -113,7 +113,7 @@ describe('CheckInRow', () => {
       duration: 12 * 60 * 1000,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     const overrunBadge = screen.getByText(textWithMarkupMatcher('2min late'));
     expect(overrunBadge).toBeInTheDocument();
@@ -135,7 +135,7 @@ describe('CheckInRow', () => {
       expectedTime: '2025-01-02T00:00:00Z',
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     const earlyBadge = screen.getByText(textWithMarkupMatcher('Early'));
     expect(earlyBadge).toBeInTheDocument();
@@ -158,7 +158,7 @@ describe('CheckInRow', () => {
       duration: 12 * 60 * 1000,
     });
 
-    render(<CheckInRow monitor={monitor} checkIn={checkIn} />);
+    render(<MonitorCheckInsGrid project={project} checkIns={[checkIn]} />);
 
     const earlyBadge = screen.getByText(textWithMarkupMatcher('Early'));
     expect(earlyBadge).toBeInTheDocument();

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
@@ -1,0 +1,43 @@
+import type {GridColumnOrder} from 'sentry/components/gridEditable';
+import GridEditable from 'sentry/components/gridEditable';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import type {CheckIn, CheckInCellKey} from 'sentry/views/insights/crons/types';
+
+import {CheckInCell} from './checkInCell';
+
+type Props = {
+  checkIns: CheckIn[];
+  project: Project;
+  hasMultiEnv?: boolean;
+  isLoading?: boolean;
+};
+
+export function MonitorCheckInsGrid({checkIns, isLoading, project, hasMultiEnv}: Props) {
+  const envColumn: Array<GridColumnOrder<CheckInCellKey>> = hasMultiEnv
+    ? [{key: 'environment', width: 120, name: t('Environment')}]
+    : [];
+
+  return (
+    <GridEditable<CheckIn, CheckInCellKey>
+      isLoading={isLoading}
+      emptyMessage={t('No check-ins have been recorded for this time period.')}
+      data={checkIns}
+      columnOrder={[
+        {key: 'status', width: 120, name: t('Status')},
+        {key: 'started', width: 200, name: t('Started')},
+        {key: 'completed', width: 240, name: t('Completed')},
+        {key: 'duration', width: 150, name: t('Duration')},
+        {key: 'issues', width: 160, name: t('Issues')},
+        ...envColumn,
+        {key: 'expectedAt', width: 240, name: t('Expected At')},
+      ]}
+      columnSortBy={[]}
+      grid={{
+        renderBodyCell: (column, checkIn) => (
+          <CheckInCell cellKey={column.key} project={project} checkIn={checkIn} />
+        ),
+      }}
+    />
+  );
+}

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -176,9 +176,9 @@ export interface CheckIn {
   environment: string;
   /**
    * What was the monitors nextCheckIn value when this check-in occured, this
-   * is when we expected the check-in to happen.
+   * is when we expected the check-in to happen. May be null for the very first check-in.
    */
-  expectedTime: string;
+  expectedTime: string | null;
   /**
    * Check-in GUID
    */
@@ -322,3 +322,12 @@ export interface CheckinProcessingError {
   errors: ProcessingError[];
   id: string;
 }
+
+export type CheckInCellKey =
+  | 'status'
+  | 'started'
+  | 'completed'
+  | 'duration'
+  | 'issues'
+  | 'environment'
+  | 'expectedAt';

--- a/static/app/views/issueDetails/groupCheckIns.spec.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.spec.tsx
@@ -57,17 +57,9 @@ describe('GroupCheckIns', () => {
       deprecatedRouterMocks: true,
     });
     expect(await screen.findByText('All Check-Ins')).toBeInTheDocument();
-    for (const column of [
-      'Timestamp',
-      'Status',
-      'Duration',
-      'Environment',
-      'Monitor Config',
-      'ID',
-    ]) {
-      expect(screen.getByText(column)).toBeInTheDocument();
-    }
-    expect(screen.getByText('No matching check-ins found')).toBeInTheDocument();
+    expect(
+      screen.getByText('No check-ins have been recorded for this time period.')
+    ).toBeInTheDocument();
   });
 
   it('renders the check-in table with data', async () => {
@@ -88,10 +80,8 @@ describe('GroupCheckIns', () => {
     expect(screen.getByRole('button', {name: 'Previous Page'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Next Page'})).toBeInTheDocument();
 
-    expect(screen.getByRole('time')).toHaveTextContent(/Jan 1, 2025/);
     expect(screen.getByText(statusToText[check.status])).toBeInTheDocument();
-    expect(screen.getByText('9s 50ms')).toBeInTheDocument();
+    expect(screen.getByText('9 seconds')).toBeInTheDocument();
     expect(screen.getByText(check.environment)).toBeInTheDocument();
-    expect(screen.getByText(check.id)).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/groupCheckIns.tsx
+++ b/static/app/views/issueDetails/groupCheckIns.tsx
@@ -1,28 +1,14 @@
-import {Fragment} from 'react';
-import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
-import moment from 'moment-timezone';
+import uniq from 'lodash/uniq';
 
-import {Tooltip} from 'sentry/components/core/tooltip';
-import Duration from 'sentry/components/duration';
-import GridEditable, {type GridColumnOrder} from 'sentry/components/gridEditable';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconInfo} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import type {User} from 'sentry/types/user';
-import {defined} from 'sentry/utils';
-import {FIELD_FORMATTERS} from 'sentry/utils/discover/fieldRenderers';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {useUser} from 'sentry/utils/useUser';
-import {type CheckIn, CheckInStatus} from 'sentry/views/insights/crons/types';
-import {statusToText, tickStyle} from 'sentry/views/insights/crons/utils';
-import {scheduleAsText} from 'sentry/views/insights/crons/utils/scheduleAsText';
+import {MonitorCheckInsGrid} from 'sentry/views/insights/crons/components/monitorCheckInsGrid';
 import {useMonitorCheckIns} from 'sentry/views/insights/crons/utils/useMonitorCheckIns';
 import {EventListTable} from 'sentry/views/issueDetails/streamline/eventListTable';
 import {useCronIssueAlertId} from 'sentry/views/issueDetails/streamline/issueCronCheckTimeline';
@@ -32,7 +18,6 @@ export default function GroupCheckIns() {
   const organization = useOrganization();
   const {groupId} = useParams<{groupId: string}>();
   const location = useLocation();
-  const user = useUser();
   const cronAlertId = useCronIssueAlertId({groupId});
 
   const {
@@ -47,7 +32,7 @@ export default function GroupCheckIns() {
 
   const {cursor, ...locationQuery} = location.query;
   const {
-    data: cronData = [],
+    data: checkIns = [],
     isPending: isDataPending,
     getResponseHeader,
   } = useMonitorCheckIns(
@@ -73,7 +58,9 @@ export default function GroupCheckIns() {
   const links = parseLinkHeader(getResponseHeader?.('Link') ?? '');
   const previousDisabled = links?.previous?.results === false;
   const nextDisabled = links?.next?.results === false;
-  const pageCount = cronData.length;
+  const pageCount = checkIns.length;
+
+  const hasMultiEnv = uniq(checkIns.map(checkIn => checkIn.environment)).length > 0;
 
   return (
     <EventListTable
@@ -86,197 +73,12 @@ export default function GroupCheckIns() {
         previousDisabled,
       }}
     >
-      <GridEditable
+      <MonitorCheckInsGrid
         isLoading={isDataPending}
-        emptyMessage={t('No matching check-ins found')}
-        data={cronData}
-        columnOrder={[
-          {key: 'dateAdded', width: 225, name: t('Timestamp')},
-          {key: 'status', width: 100, name: t('Status')},
-          {key: 'duration', width: 130, name: t('Duration')},
-          {key: 'environment', width: 120, name: t('Environment')},
-          {key: 'monitorConfig', width: 145, name: t('Monitor Config')},
-          {key: 'id', width: 100, name: t('ID')},
-        ]}
-        columnSortBy={[]}
-        grid={{
-          renderHeadCell: (column: GridColumnOrder) => <CheckInHeader column={column} />,
-          renderBodyCell: (column, dataRow) => (
-            <CheckInCell column={column} dataRow={dataRow} userOptions={user.options} />
-          ),
-        }}
+        checkIns={checkIns}
+        hasMultiEnv={hasMultiEnv}
+        project={group.project}
       />
     </EventListTable>
   );
 }
-
-function CheckInHeader({column}: {column: GridColumnOrder}) {
-  if (column.key === 'monitorConfig') {
-    return (
-      <Cell>
-        {t('Monitor Config')}
-        <Tooltip
-          title={t(
-            'These are snapshots of the monitor configuration at the time of the check-in. They may differ from the current monitor config.'
-          )}
-          style={{lineHeight: 0}}
-        >
-          <IconInfo size="xs" />
-        </Tooltip>
-      </Cell>
-    );
-  }
-  return <Cell>{column.name}</Cell>;
-}
-
-function CheckInCell({
-  dataRow,
-  column,
-  userOptions,
-}: {
-  column: GridColumnOrder<string | number>;
-  dataRow: CheckIn;
-  userOptions: User['options'];
-}) {
-  const theme = useTheme();
-  const columnKey = column.key as keyof CheckIn;
-
-  if (!dataRow[columnKey]) {
-    return <Cell />;
-  }
-
-  switch (columnKey) {
-    case 'dateAdded': {
-      const format = userOptions.clock24Hours
-        ? 'MMM D, YYYY HH:mm:ss z'
-        : 'MMM D, YYYY h:mm:ss A z';
-      return (
-        <HoverableCell>
-          <Tooltip
-            maxWidth={300}
-            isHoverable
-            title={
-              <LabelledTooltip>
-                {dataRow.expectedTime && (
-                  <Fragment>
-                    <dt>{t('Expected at')}</dt>
-                    <dd>{moment(dataRow.expectedTime).format(format)}</dd>
-                  </Fragment>
-                )}
-                <dt>{t('Received at')}</dt>
-                <dd>{moment(dataRow[columnKey]).format(format)}</dd>
-              </LabelledTooltip>
-            }
-          >
-            {FIELD_FORMATTERS.date.renderFunc('dateAdded', dataRow)}
-          </Tooltip>
-        </HoverableCell>
-      );
-    }
-    case 'duration': {
-      const cellData = dataRow[columnKey];
-      if (typeof cellData === 'number') {
-        return (
-          <Cell>
-            <Duration seconds={cellData / 1000} abbreviation exact />
-          </Cell>
-        );
-      }
-      return <Cell>{cellData}</Cell>;
-    }
-    case 'status': {
-      const status = dataRow[columnKey];
-      let checkResult = <Cell>{status}</Cell>;
-      if (Object.values(CheckInStatus).includes(status)) {
-        const colorKey = tickStyle[status].labelColor ?? 'textColor';
-        checkResult = (
-          <Cell style={{color: theme[colorKey] as string}}>{statusToText[status]}</Cell>
-        );
-      }
-      return checkResult;
-    }
-    case 'monitorConfig': {
-      const config = dataRow[columnKey];
-
-      return (
-        <HoverableCell>
-          <Tooltip
-            maxWidth={400}
-            isHoverable
-            title={
-              <LabelledTooltip>
-                <dt>{t('Schedule')}</dt>
-                <dd>{scheduleAsText(config)}</dd>
-                {defined(config.schedule_type) && (
-                  <Fragment>
-                    <dt>{t('Schedule Type')}</dt>
-                    <dd>{config.schedule_type}</dd>
-                  </Fragment>
-                )}
-
-                {defined(config.checkin_margin) && (
-                  <Fragment>
-                    <dt>{t('Check-in Margin')}</dt>
-                    <dd>{config.checkin_margin}</dd>
-                  </Fragment>
-                )}
-                {defined(config.max_runtime) && (
-                  <Fragment>
-                    <dt>{t('Max Runtime')}</dt>
-                    <dd>{config.max_runtime}</dd>
-                  </Fragment>
-                )}
-                {defined(config.timezone) && (
-                  <Fragment>
-                    <dt>{t('Timezone')}</dt>
-                    <dd>{config.timezone}</dd>
-                  </Fragment>
-                )}
-                {defined(config.failure_issue_threshold) && (
-                  <Fragment>
-                    <dt>{t('Failure Threshold')}</dt>
-                    <dd>{config.failure_issue_threshold}</dd>
-                  </Fragment>
-                )}
-                {defined(config.recovery_threshold) && (
-                  <Fragment>
-                    <dt>{t('Recovery Threshold')}</dt>
-                    <dd>{config.recovery_threshold}</dd>
-                  </Fragment>
-                )}
-              </LabelledTooltip>
-            }
-          >
-            {t('View Config')}
-          </Tooltip>
-        </HoverableCell>
-      );
-    }
-    // We don't query groups for this table yet
-    case 'groups':
-      return <Cell />;
-    default:
-      return <Cell>{dataRow[columnKey]}</Cell>;
-  }
-}
-
-const Cell = styled('div')`
-  display: flex;
-  align-items: center;
-  text-align: left;
-  gap: ${space(1)};
-`;
-
-const HoverableCell = styled(Cell)`
-  color: ${p => p.theme.subText};
-  text-decoration: underline;
-  text-decoration-style: dotted;
-`;
-
-const LabelledTooltip = styled('div')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: ${space(0.5)} ${space(1)};
-  text-align: left;
-  margin: 0;
-`;


### PR DESCRIPTION
Prior to this change the checks table for cron issues was a totally separate implementation from the table in the cron details page.

This unifies the two tables

<img alt="clipboard.png" width="1815" src="https://i.imgur.com/2aPAb8w.png" />