### PR TITLE
fix: Wrap disable_uptime_monitor in a transaction for broken_monitor task

### DIFF
--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -4,7 +4,6 @@ import logging
 from datetime import timedelta
 from uuid import uuid4
 
-from django.db import router
 from django.utils import timezone
 
 from sentry.tasks.base import instrumented_task
@@ -13,7 +12,6 @@ from sentry.taskworker.namespaces import uptime_tasks
 from sentry.taskworker.retry import Retry
 from sentry.uptime.config_producer import produce_config, produce_config_removal
 from sentry.uptime.models import (
-    ProjectUptimeSubscription,
     UptimeRegionScheduleMode,
     UptimeStatus,
     UptimeSubscription,
@@ -22,9 +20,7 @@ from sentry.uptime.models import (
 )
 from sentry.uptime.types import CheckConfig, ProjectUptimeSubscriptionMode
 from sentry.utils import metrics
-from sentry.utils.db import atomic_transaction
 from sentry.utils.query import RangeQuerySetWrapper
-from sentry.workflow_engine.models.detector import Detector
 
 logger = logging.getLogger(__name__)
 
@@ -236,14 +232,7 @@ def broken_monitor_checker(**kwargs):
         detector = get_detector(uptime_subscription)
         assert detector
         if detector.config["mode"] == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE:
-            with atomic_transaction(
-                using=(
-                    router.db_for_write(UptimeSubscription),
-                    router.db_for_write(ProjectUptimeSubscription),
-                    router.db_for_write(Detector),
-                )
-            ):
-                disable_uptime_detector(detector)
-                count += 1
+            disable_uptime_detector(detector)
+            count += 1
 
     metrics.incr("uptime.subscriptions.disable_broken", amount=count, sample_rate=1.0)


### PR DESCRIPTION
This PR aims to fix instances where the broken monitor checker would leave uptimes in an inconsistent / broken state and then prevent them from being fixed / run again.

Within disable_uptime_monitor we are setting the uptime status to be "OK" in the middle of the disable function
https://github.com/getsentry/sentry/blob/eeff1fd5e915b314efceeaaf9e30010a1fe8bea9/src/sentry/uptime/subscriptions/subscriptions.py#L356-L358

The task relies on the UptimeSubscription have "failed" status here:
https://github.com/getsentry/sentry/blob/81a042a763b9374d9e9f9eb90636d72ee18c4787/src/sentry/uptime/subscriptions/tasks.py#L231-L234

If the disable job fails / exists early / etc. before actually running through everything, this would leave broken monitors in potentially a worse state than before. To prevent a similar situation from happening, I wrapped the disable_uptime_monitor job in a transaction outright.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
