### PR TITLE
fix(aci): default Workflow frequency to 0 if not in config

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -49,7 +49,7 @@ def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action
                     "action__dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow__config"
                 ),
             ),
-            Value("30"),  # default 30
+            Value("0"),  # default 0
         ),
         output_field=IntegerField(),
     )


### PR DESCRIPTION
This may be affecting metric alert dual processing, as there is no `frequency` set in workflows connected to metric detectors. Thus it's possible these workflows are triggering less often than expected.