### PR TITLE
:bug: fix(azure): update metdata migration version logic

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -531,10 +531,6 @@ class VstsIntegrationProvider(IntegrationProvider):
                     "secret": subscription_secret,
                 }
 
-                integration["metadata"][
-                    "integration_migration_version"
-                ] = VstsIntegrationProvider.CURRENT_MIGRATION_VERSION
-
                 logger.info(
                     "vsts.build_integration.migrated",
                     extra={
@@ -572,13 +568,6 @@ class VstsIntegrationProvider(IntegrationProvider):
         # Assertion error happens when org_integration does not exist
         # KeyError happens when subscription is not found
         except (IntegrationModel.DoesNotExist, AssertionError, KeyError):
-            if features.has(
-                "organizations:migrate-azure-devops-integration", self.pipeline.organization
-            ):
-                # If there is a new integration, we need to set the migration version to 1
-                integration["metadata"][
-                    "integration_migration_version"
-                ] = VstsIntegrationProvider.CURRENT_MIGRATION_VERSION
 
             logger.warning(
                 "vsts.build_integration.error",
@@ -599,6 +588,17 @@ class VstsIntegrationProvider(IntegrationProvider):
                 "id": subscription_id,
                 "secret": subscription_secret,
             }
+
+        # Ensure integration_migration_version is set if the feature flag is active.
+        # This guarantees that if the new scopes are in use (due to the flag),
+        # the metadata correctly reflects the current migration version, even if
+        # the integration was already considered "up-to-date" based on DB records.
+        if features.has(
+            "organizations:migrate-azure-devops-integration", self.pipeline.organization
+        ):
+            integration["metadata"][
+                "integration_migration_version"
+            ] = VstsIntegrationProvider.CURRENT_MIGRATION_VERSION
 
         return integration
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -115,6 +115,82 @@ class VstsIntegrationMigrationTest(VstsIntegrationTestCase):
             VstsIntegrationProvider.NEW_SCOPES
         )
 
+    # Test that on reinstall of new migration, we keep the migration version
+    @with_feature("organizations:migrate-azure-devops-integration")
+    @patch(
+        "sentry.integrations.vsts.VstsIntegrationProvider.get_scopes",
+        return_value=VstsIntegrationProvider.NEW_SCOPES,
+    )
+    def test_migration_after_reinstall(self, mock_get_scopes):
+        state = {
+            "account": {"accountName": self.vsts_account_name, "accountId": self.vsts_account_id},
+            "base_url": self.vsts_base_url,
+            "identity": {
+                "data": {
+                    "access_token": self.access_token,
+                    "expires_in": "3600",
+                    "refresh_token": self.refresh_token,
+                    "token_type": "jwt-bearer",
+                }
+            },
+            "integration_migration_version": 1,
+            "subscription": {
+                "id": "123",
+                "secret": "456",
+            },
+        }
+
+        external_id = self.vsts_account_id
+
+        # Create the integration with old integration metadata
+        integration = self.create_provider_integration(
+            metadata=state, provider="vsts", external_id=external_id
+        )
+        self.create_organization_integration(
+            integration_id=integration.id,
+            organization_id=self.organization.id,
+        )
+
+        provider = VstsIntegrationProvider()
+        pipeline = Mock()
+        pipeline.organization = self.organization
+        provider.set_pipeline(pipeline)
+
+        data = provider.build_integration(
+            {
+                "account": {"accountName": self.vsts_account_name, "accountId": external_id},
+                "base_url": self.vsts_base_url,
+                "identity": {
+                    "data": {
+                        "access_token": "new_access_token",
+                        "expires_in": "3600",
+                        "refresh_token": "new_refresh_token",
+                        "token_type": "bearer",
+                    }
+                },
+                "subscription": {
+                    "id": "123",
+                    "secret": "456",
+                },
+                "integration_migration_version": 1,
+            }
+        )
+        assert external_id == data["external_id"]
+        subscription = data["metadata"]["subscription"]
+        assert subscription["id"] is not None and subscription["secret"] is not None
+        metadata = data.get("metadata")
+        assert metadata is not None
+        assert set(metadata["scopes"]) == set(VstsIntegrationProvider.NEW_SCOPES)
+        assert metadata["integration_migration_version"] == 1
+
+        # Make sure the integration object is updated
+        # ensure_integration will be called in _finish_pipeline
+        new_integration_obj = ensure_integration("vsts", data)
+        assert new_integration_obj.metadata["integration_migration_version"] == 1
+        assert set(new_integration_obj.metadata["scopes"]) == set(
+            VstsIntegrationProvider.NEW_SCOPES
+        )
+
 
 @control_silo_test
 class VstsIntegrationProviderTest(VstsIntegrationTestCase):


### PR DESCRIPTION
## Problem:
In the VSTS integration's `build_integration` method, there was a scenario where the returned `IntegrationData` could include the new Azure DevOps OAuth scopes (NEW_SCOPES) in its metadata but omit the `integration_migration_version` field.

## This could happen if:
An existing `IntegrationModel` was found for the VSTS account.
The `organizations:migrate-azure-devops-integration` feature flag was enabled for the organization.

The `integration_migration_version` stored in the existing `IntegrationModel`'s metadata was already at or above `VstsIntegrationProvider.CURRENT_MIGRATION_VERSION` (which is true if under the FF).

In this case, the logic would use the NEW_SCOPES (because the feature flag was active) but would not explicitly add or update the `integration_migration_version` in the `IntegrationData` being constructed for the current operation. 

## Solution:
This change modifies the method in to ensure that if the `organizations:migrate-azure-devops-integration` ff is active for the organization, the `integration["metadata"]["integration_migration_version"]` is explicitly set to `VstsIntegrationProvider.CURRENT_MIGRATION_VERSION` before returning the `IntegrationData`.

I verified my test fails before the fix
