### PR TITLE
fix(weekly-report): filter to active teams for user projects

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -19,6 +19,7 @@ from sentry.models.grouphistory import GroupHistory
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
+from sentry.models.team import TeamStatus
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.types.group import GroupSubStatus
@@ -145,7 +146,9 @@ def user_project_ownership(ctx: OrganizationReportContext) -> None:
     Populates context.project_ownership which is { user_id: set<project_id> }
     """
     for project_id, user_id in OrganizationMember.objects.filter(
-        organization_id=ctx.organization.id, teams__projectteam__project__isnull=False
+        organization_id=ctx.organization.id,
+        teams__projectteam__project__isnull=False,
+        teams__status=TeamStatus.ACTIVE,
     ).values_list("teams__projectteam__project_id", "user_id"):
         if user_id is not None:
             ctx.project_ownership.setdefault(user_id, set()).add(project_id)

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1198,7 +1198,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             )
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
-    def test_user_does_not_see_deleted_team_data(self, message_builder, record):
+    def test_user_does_not_see_deleted_team_data(self, message_builder):
         user = self.create_user(email="test@example.com")
         self.create_member(teams=[self.team], user=user, organization=self.organization)
 

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -15,6 +15,7 @@ from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistoryStatus
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
+from sentry.models.team import TeamStatus
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
@@ -1195,3 +1196,30 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             mock_prepare_organization_report.delay.assert_any_call(
                 timestamp, ONE_DAY * 7, org.id, mock.ANY, dry_run=False
             )
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
+    def test_user_does_not_see_deleted_team_data(self, message_builder, record):
+        user = self.create_user(email="test@example.com")
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+
+        self.team.status = TeamStatus.PENDING_DELETION
+        self.team.save()
+
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.two_days_ago, num_times=2
+        )
+
+        prepare_organization_report(
+            self.timestamp,
+            ONE_DAY * 7,
+            self.organization.id,
+            self._dummy_batch_id,
+            dry_run=False,
+            target_user=user.id,
+        )
+
+        # Verify the report is empty as the user's team is pending deletion
+        for call_args in message_builder.call_args_list:
+            message_params = call_args.kwargs
+            context = message_params["context"]
+            assert len(context["trends"]["legend"]) == 0


### PR DESCRIPTION
I'm investigating https://github.com/getsentry/sentry/issues/73594 and as part of that, we should filter out pending deletion team relations from the projects included in the email.