### PR TITLE
ref(grouping): Cache enhancements in split form

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -860,13 +860,19 @@ class Enhancements:
                 else base64_string
             )
 
-            # For now, only one encoded config structure is included in the base64 string, and since
-            # the delimiter consists of characters which can't appear in a base64 string, splitting
-            # like this has the same effect as just putting `raw_bytes_str` into a one-item list
+            # Split the string to get encoded data for each set of rules: unsplit rules (i.e., rules
+            # the way they're stored in project config), classifier rules, and contributes rules.
+            # Older base64 strings - such as those stored in events created before rule-splitting was
+            # introduced - will only have one part and thus will end up unchanged. (The delimiter is
+            # chosen specifically to be a character which can't appear in base64.)
             bytes_strs = raw_bytes_str.split(BASE64_ENHANCEMENTS_DELIMITER)
             configs = [cls._get_config_from_base64_bytes(bytes_str) for bytes_str in bytes_strs]
 
             unsplit_config = configs[0]
+            split_configs = None
+
+            if len(configs) == 3:
+                split_configs = (configs[1], configs[2])
 
             version = unsplit_config.version
             bases = unsplit_config.bases
@@ -876,6 +882,7 @@ class Enhancements:
             return cls(
                 rules=unsplit_config.rules,
                 rust_enhancements=unsplit_config.rust_enhancements,
+                split_enhancement_configs=split_configs,
                 version=version,
                 bases=bases,
             )

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -845,13 +845,16 @@ class Enhancements:
         with metrics.timer("grouping.enhancements.creation") as metrics_timer_tags:
             metrics_timer_tags.update({"source": "base64_string", "referrer": referrer})
 
-            bytes_str = (
+            raw_bytes_str = (
                 base64_string.encode("ascii", "ignore")
                 if isinstance(base64_string, str)
                 else base64_string
             )
 
-            unsplit_config = cls._get_config_from_base64_bytes(bytes_str)
+            bytes_strs = [raw_bytes_str]
+            configs = [cls._get_config_from_base64_bytes(bytes_str) for bytes_str in bytes_strs]
+
+            unsplit_config = configs[0]
 
             version = unsplit_config.version
             bases = unsplit_config.bases

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -811,7 +811,12 @@ class Enhancements:
     @cached_property
     def base64_string(self) -> str:
         """A base64 string representation of the enhancements object"""
-        base64_bytes = self._get_base64_bytes_from_rules(self.rules)
+        rulesets = [self.rules]
+
+        # For now, since there's only one item being joined, the join is a no-op
+        base64_bytes = BASE64_ENHANCEMENTS_DELIMITER.join(
+            self._get_base64_bytes_from_rules(ruleset) for ruleset in rulesets
+        )
         base64_str = base64_bytes.decode("ascii")
         return base64_str
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -813,7 +813,14 @@ class Enhancements:
         """A base64 string representation of the enhancements object"""
         rulesets = [self.rules]
 
-        # For now, since there's only one item being joined, the join is a no-op
+        if self.run_split_enhancements:
+            rulesets.extend([self.classifier_rules, self.contributes_rules])
+
+        # Create a base64 bytestring for each set of rules, and join them with a character we know
+        # can never appear in base64. We do it this way rather than combining all three sets of
+        # rules into a single bytestring because the rust enhancer only knows how to deal with
+        # bytestrings encoding data of the form `[version, bases, rules]` (not
+        # `[version, bases, rules, rules, rules]`).
         base64_bytes = BASE64_ENHANCEMENTS_DELIMITER.join(
             self._get_base64_bytes_from_rules(ruleset) for ruleset in rulesets
         )

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -44,6 +44,10 @@ VERSIONS = [
 ]
 LATEST_VERSION = VERSIONS[-1]
 
+# A delimiter to insert between rulesets in the base64 represenation of enhancements (by spec,
+# base64 strings never contain '#')
+BASE64_ENHANCEMENTS_DELIMITER = b"#"
+
 VALID_PROFILING_MATCHER_PREFIXES = (
     "stack.abs_path",
     "path",  # stack.abs_path alias
@@ -851,7 +855,10 @@ class Enhancements:
                 else base64_string
             )
 
-            bytes_strs = [raw_bytes_str]
+            # For now, only one encoded config structure is included in the base64 string, and since
+            # the delimiter consists of characters which can't appear in a base64 string, splitting
+            # like this has the same effect as just putting `raw_bytes_str` into a one-item list
+            bytes_strs = raw_bytes_str.split(BASE64_ENHANCEMENTS_DELIMITER)
             configs = [cls._get_config_from_base64_bytes(bytes_str) for bytes_str in bytes_strs]
 
             unsplit_config = configs[0]

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -700,8 +700,8 @@ class EnhancementsTest(TestCase):
             == "<EnhancementRule function:playFetch +group>"
         )
         assert strategy_config.enhancements.id is None
-        # Currently we re-split the rules when translating from base64 back to object
-        assert split_rules_spy.call_count == 2
+        # Rules didn't have to be split again because they were cached in split form
+        assert split_rules_spy.call_count == 1
 
     def test_uses_default_enhancements_when_loading_string_with_invalid_version(self):
         enhancements = Enhancements.from_rules_text("function:playFetch +app")


### PR DESCRIPTION
Right now, even when we're using split enhancements, the version we cache isn't split, which means that every time we pull them out of the cache, the work to split the rules has to be done all over again. This is obviously not ideal, so this PR changes the way we compute (and parse) the cached string so that it now includes the split rules.

Since the rust enhancer can only parse base64 strings including one set of rules, this is done by computing a separate string for each of the three kinds of rules - rules in their original/pre-split form, classifier rules, and contributes rules - and then concatenating them, separated by a character which can't ever appear in base64. Older base64 strings containing only the original rules and no delimiter can still be parsed, because for them, splitting on the delimiter will be a no-op.