### PR TITLE
ref(issue-views): Update backend endpoints with new packaging logic

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_view_details.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details.py
@@ -46,11 +46,6 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         """
         Get an issue view for the current organization member.
         """
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
         try:
             view = GroupSearchView.objects.get(id=view_id, organization=organization)
         except GroupSearchView.DoesNotExist:
@@ -73,9 +68,7 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         """
         Update an issue view for the current organization member.
         """
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
+        if not features.has("organizations:issue-views", organization, actor=request.user):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         try:
@@ -127,11 +120,6 @@ class OrganizationGroupSearchViewDetailsEndpoint(OrganizationEndpoint):
         """
         Delete an issue view for the current organization member.
         """
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
         try:
             view = GroupSearchView.objects.get(id=view_id, organization=organization)
         except GroupSearchView.DoesNotExist:

--- a/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
@@ -2,7 +2,6 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -42,11 +41,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpoint(OrganizationEndpoint):
         """
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
-
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
 
         serializer = StarViewSerializer(data=request.data)
         if not serializer.is_valid():

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
@@ -38,9 +38,7 @@ class OrganizationGroupSearchViewStarredOrderEndpoint(OrganizationEndpoint):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
+        if not features.has("organizations:issue-views", organization):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         serializer = GroupSearchViewStarredOrderSerializer(

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
@@ -3,7 +3,6 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -36,9 +35,6 @@ class OrganizationGroupSearchViewStarredOrderEndpoint(OrganizationEndpoint):
 
     def put(self, request: Request, organization: Organization) -> Response:
         if not request.user.is_authenticated:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
-        if not features.has("organizations:issue-views", organization):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         serializer = GroupSearchViewStarredOrderSerializer(

--- a/src/sentry/issues/endpoints/organization_group_search_view_visit.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_visit.py
@@ -3,7 +3,6 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -31,11 +30,6 @@ class OrganizationGroupSearchViewVisitEndpoint(OrganizationEndpoint):
         """
         Update the last_visited timestamp for a GroupSearchView for the current organization member.
         """
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
         try:
             view = GroupSearchView.objects.get(id=view_id, organization=organization)
         except GroupSearchView.DoesNotExist:

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -76,11 +76,6 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
         has_global_views = features.has("organizations:global-views", organization)
 
         serializer = OrganizationGroupSearchViewGetSerializer(data=request.GET)
@@ -184,9 +179,7 @@ class OrganizationGroupSearchViewsEndpoint(OrganizationEndpoint):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
+        if not features.has("organizations:issue-views", organization, actor=request.user):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         serializer = GroupSearchViewPostValidator(

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -35,11 +35,6 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         """
         Retrieve a list of starred views for the current organization member.
         """
-        if not features.has(
-            "organizations:issue-stream-custom-views", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
         has_global_views = features.has("organizations:global-views", organization)
 
         default_project = None

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details.py
@@ -114,7 +114,6 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
             kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
         )
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_get_view_success(self) -> None:
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -125,7 +124,6 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
         assert response.data["name"] == view.name
         assert response.data["query"] == view.query
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_get_nonexistent_view(self) -> None:
         nonexistent_id = "37373"
         url = reverse(
@@ -136,7 +134,6 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
         response = self.client.get(url)
         assert response.status_code == 404
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_get_view_from_another_user(self) -> None:
         # Get a view ID from user_two
         view_id = str(self.base_data["user_two_views"][0].id)
@@ -151,10 +148,6 @@ class OrganizationGroupSearchViewsGetTest(BaseGSVTestCase):
         assert response.data["id"] == view_id
         assert response.data["name"] == view.name
         assert response.data["query"] == view.query
-
-    def test_get_without_feature_flag(self) -> None:
-        response = self.client.get(self.url)
-        assert response.status_code == 404
 
 
 class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
@@ -185,7 +178,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
             },
         )
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_view_success(self) -> None:
         response = self.client.delete(self.user_2_view_url)
         assert response.status_code == 204
@@ -199,7 +191,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         )
         assert remaining_views.count() == 1
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_nonexistent_view(self) -> None:
         """Test that attempting to delete a nonexistent view returns 404."""
         nonexistent_id = "99999"
@@ -211,7 +202,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         response = self.client.delete(url)
         assert response.status_code == 404
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_view_from_another_user(self) -> None:
         view_id = str(self.base_data["user_one_views"][0].id)
         url = reverse(
@@ -225,7 +215,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
         # Verify the view still exists (this will error out if not)
         GroupSearchView.objects.get(id=view_id)
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_superuser_can_delete_view_from_another_user(self) -> None:
         # User 1 is a superuser
         self.login_as(user=self.user)
@@ -242,7 +231,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
 
         assert not GroupSearchView.objects.filter(id=self.user_2_view_id).exists()
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_org_write_can_delete_view_from_another_user(self) -> None:
         self.admin_user = self.create_user()
         self.create_member(
@@ -257,7 +245,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
 
         assert not GroupSearchView.objects.filter(id=self.user_1_view_id).exists()
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_first_starred_view_decrements_succeeding_positions(self) -> None:
         # Delete the first view
         self.login_as(user=self.user)
@@ -287,7 +274,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
             assert self.base_data["user_one_views"][idx + 1].id == gsv.group_search_view.id
             assert gsv.position == idx
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     def test_delete_last_starred_view_does_not_decrement_positions(self) -> None:
         # Delete the last view
         self.login_as(user=self.user)
@@ -315,12 +301,6 @@ class OrganizationGroupSearchViewsDeleteTest(BaseGSVTestCase):
             )
         ):
             assert self.base_data["user_one_views"][idx].id == gsv.group_search_view.id
-
-    def test_delete_without_feature_flag(self) -> None:
-        response = self.client.delete(self.user_1_view_url)
-        assert response.status_code == 404
-
-        GroupSearchView.objects.get(id=self.user_2_view_id)
 
 
 class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
@@ -381,7 +361,7 @@ class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
             last_visited=timezone.now(),
         )
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_cannot_delete_other_users_view(self) -> None:
         self.login_as(user=self.user_2)
 
@@ -397,7 +377,7 @@ class OrganizationGroupSearchViewsDeleteStarredAndLastVisitedTest(APITestCase):
 
         assert response.status_code == 403
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_deleting_my_view_deletes_from_others_starred_views(self) -> None:
         self.login_as(user=self.user_1)
 
@@ -447,9 +427,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
             kwargs={"organization_id_or_slug": self.organization.slug, "view_id": self.view_id},
         )
 
-    @with_feature(
-        {"organizations:issue-stream-custom-views": True, "organizations:global-views": True}
-    )
+    @with_feature({"organizations:issue-views": True, "organizations:global-views": True})
     def test_put_view_success(self) -> None:
         data = {
             "name": "Updated View Name",
@@ -474,7 +452,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         assert updated_view.environments == ["production"]
         assert updated_view.time_filters == {"period": "14d"}
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_put_update_projects(self) -> None:
         second_project = self.create_project(organization=self.organization)
@@ -498,7 +476,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
             second_project.id,
         }
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_put_all_projects(self) -> None:
         data = {
@@ -518,7 +496,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         assert updated_view.is_all_projects is True
         assert updated_view.projects.count() == 0
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_put_nonexistent_view(self) -> None:
         nonexistent_id = "99999"
         url = reverse(
@@ -537,7 +515,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         response = self.client.put(url, data=data)
         assert response.status_code == 404
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_put_view_from_another_user(self) -> None:
         # Log in as user 3 (no access to user_two's views)
         self.login_as(user=self.user_3)
@@ -559,7 +537,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         response = self.client.put(url, data=data)
         assert response.status_code == 403
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_put_view_from_another_user_superuser(self) -> None:
         # User 1 is a superuser
         self.login_as(user=self.user)
@@ -585,7 +563,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         updated_view = GroupSearchView.objects.get(id=self.view_id)
         assert updated_view.name == "Updated View"
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_put_invalid_data(self) -> None:
         # Missing required timeFilters
         data = {
@@ -598,7 +576,7 @@ class OrganizationGroupSearchViewsPutTest(BaseGSVTestCase):
         response = self.client.put(self.url, data=data)
         assert response.status_code == 400
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     def test_put_multi_project_without_global_views(self) -> None:
         second_project = self.create_project(organization=self.organization)
 

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_details_starred.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_details_starred.py
@@ -3,7 +3,6 @@ from django.urls import reverse
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 
 
 class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
@@ -46,13 +45,11 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
             )
         return view
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_view_not_found(self) -> None:
         response = self.client.post(self.get_url(737373), data={"starred": True})
 
         assert response.status_code == 404
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_organization_view_accessible(self) -> None:
         other_user = self.create_user()
         view = self.create_view(
@@ -68,7 +65,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
             group_search_view=view,
         ).exists()
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_invalid_request_data(self) -> None:
         view = self.create_view()
 
@@ -80,7 +76,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
         response = self.client.post(self.get_url(view.id), data={"starred": False, "position": 0})
         assert response.status_code == 400
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_star_view_with_position(self) -> None:
         view1 = self.create_view(starred=True)
         view2 = self.create_view(starred=True)
@@ -112,7 +107,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
             position=2,
         ).exists()
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_star_view_without_position(self) -> None:
         view = self.create_view()
 
@@ -128,7 +122,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
 
         assert starred_view.position == 0
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_unstar_view(self) -> None:
         starred_view = self.create_view(starred=True)
         view_to_be_unstarred = self.create_view(starred=True)
@@ -147,7 +140,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
             group_search_view=starred_view,
         ).exists()
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_star_already_starred_view(self) -> None:
         view = self.create_view(starred=True)
 
@@ -155,7 +147,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
 
         assert response.status_code == 204
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_unstar_not_starred_view(self) -> None:
         view = self.create_view()
 
@@ -163,7 +154,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
 
         assert response.status_code == 204
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_multiple_starred_views_order(self) -> None:
         view1 = self.create_view()
         view2 = self.create_view()
@@ -206,7 +196,6 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
             == 1
         )
 
-    @with_feature("organizations:issue-stream-custom-views")
     def test_unstar_adjust_positions(self) -> None:
         view1 = self.create_view(starred=True)
         view2 = self.create_view(starred=True)
@@ -234,15 +223,3 @@ class OrganizationGroupSearchViewDetailsStarredEndpointTest(APITestCase):
             ).position
             == 0
         )
-
-    def test_error_when_feature_flag_disabled(self) -> None:
-        view = self.create_view()
-
-        response = self.client.post(self.get_url(view.id), data={"starred": True})
-
-        assert response.status_code == 404
-        assert not GroupSearchViewStarred.objects.filter(
-            organization=self.org,
-            user_id=self.user.id,
-            group_search_view=view,
-        ).exists()

--- a/tests/sentry/issues/endpoints/test_organization_group_search_views.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_views.py
@@ -119,7 +119,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         # User 1 stars User 2's view
         self.star_view(self.user, self.other_view_2)
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_get_views_created_by_me(self) -> None:
         self.login_as(user=self.user)
@@ -144,7 +143,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.data[2]["createdBy"]["id"] == str(self.user.id)
         assert not response.data[2]["starred"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_get_views_created_by_others(self) -> None:
         self.login_as(user=self.user)
@@ -165,7 +163,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.data[1]["createdBy"]["id"] == str(self.user_2.id)
         assert not response.data[1]["starred"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_invalid_created_by_value(self) -> None:
         self.login_as(user=self.user)
@@ -175,7 +172,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.status_code == 400
         assert "createdBy" in response.data
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_invalid_sort_value(self) -> None:
         self.login_as(user=self.user)
@@ -185,7 +181,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.status_code == 400
         assert "sort" in response.data
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_query_filter_by_name(self) -> None:
         self.login_as(user=self.user)
@@ -203,7 +198,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.data[0]["id"] == str(self.other_view_2.id)
         assert response.data[0]["name"] == "Other View 2"
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_query_filter_by_query(self) -> None:
         self.login_as(user=self.user)
@@ -215,7 +209,6 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert response.data[1]["id"] == str(self.my_view_1.id)
         assert "assigned:me" in response.data[0]["query"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_query_filter_case_insensitive(self) -> None:
         self.login_as(user=self.user)
@@ -227,19 +220,12 @@ class OrganizationGroupSearchViewsGetTest(GroupSearchViewAPITestCase):
         assert "My View" in response.data[1]["name"]
         assert "My View" in response.data[2]["name"]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
     @with_feature({"organizations:global-views": True})
     def test_query_filter_no_matches(self) -> None:
         self.login_as(user=self.user)
         response = self.get_success_response(self.organization.slug, query="capybara")
 
         assert len(response.data) == 0
-
-    @with_feature({"organizations:issue-stream-custom-views": False})
-    def test_feature_flag_disabled(self) -> None:
-        self.login_as(user=self.user)
-        response = self.get_response(self.organization.slug, createdBy="me")
-        assert response.status_code == 404
 
 
 class OrganizationGroupSearchViewsPostTest(APITestCase):
@@ -255,7 +241,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_create_basic_view(self) -> None:
         data = {
@@ -287,7 +273,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
             group_search_view=view,
         ).exists()
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_create_view_with_projects(self) -> None:
         """Test creating a view with specific projects"""
@@ -311,7 +297,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
             self.project2.id,
         }
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_create_view_all_projects(self) -> None:
         """Test creating a view for all projects"""
@@ -333,7 +319,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
         assert view.is_all_projects is True
         assert list(view.projects.all()) == []  # No projects should be associated
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_create_view_with_environments(self) -> None:
         """Test creating a view with specific environments"""
@@ -354,7 +340,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
         view = GroupSearchView.objects.get(id=response.data["id"])
         assert set(view.environments) == {"production", "staging"}
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_create_view_with_time_filters(self) -> None:
         """Test creating a view with custom time filters"""
@@ -375,7 +361,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
         view = GroupSearchView.objects.get(id=response.data["id"])
         assert view.time_filters == {"period": "90d"}
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_create_view_with_starred(self) -> None:
         data = {
@@ -397,7 +383,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
             group_search_view_id=view_id,
         ).exists()
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": False})
     def test_create_view_without_global_views(self) -> None:
         data = {
@@ -413,7 +399,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
 
         assert response.data["projects"] == [self.project1.id]
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": False})
     def test_invalid_multiple_projects_without_global_views(self) -> None:
         data = {
@@ -429,7 +415,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
 
         assert "You do not have the multi project stream feature enabled" in str(response.data)
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": False})
     def test_invalid_all_projects_without_global_views(self) -> None:
         data = {
@@ -445,7 +431,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
 
         assert "You do not have the multi project stream feature enabled" in str(response.data)
 
-    @with_feature({"organizations:issue-stream-custom-views": False})
+    @with_feature({"organizations:issue-views": False})
     def test_feature_flag_disabled(self) -> None:
         data = {
             "name": "Custom View",
@@ -459,7 +445,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
         response = self.get_response(self.organization.slug, **data)
         assert response.status_code == 404
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_invalid_sort_option(self) -> None:
         data = {
@@ -474,7 +460,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
         response = self.get_error_response(self.organization.slug, **data)
         assert "querySort" in response.data
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_invalid_time_filters(self) -> None:
         data = {
@@ -489,7 +475,7 @@ class OrganizationGroupSearchViewsPostTest(APITestCase):
         response = self.get_error_response(self.organization.slug, **data)
         assert "timeFilters" in response.data
 
-    @with_feature({"organizations:issue-stream-custom-views": True})
+    @with_feature({"organizations:issue-views": True})
     @with_feature({"organizations:global-views": True})
     def test_nonexistent_project(self) -> None:
         data = {


### PR DESCRIPTION
Updates the gating logic in certain groupsearchview's backend endpoints to reflect new packaging logic. 

At a high level, the new logic is that free users keep any existing views, but they cannot edit them or create new ones (with the exception of deleting and unstarring). 


This PR will not be merged until the frontend has been updated with new disabled states to reflect the same packaging logic. 