### PR TITLE
ref(grouping): Various small simplifications

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -228,16 +228,17 @@ class Strategy(Generic[ConcreteInterface]):
         self, event: Event, context: GroupingContext, variant: str | None = None
     ) -> None | BaseGroupingComponent[Any] | ReturnedVariants:
         """Given a specific variant this calculates the grouping component."""
-        args = []
         iface = event.interfaces.get(self.interface_name)
+
         if iface is None:
             return None
-        args.append(iface)
+
         with context:
             # If a variant is passed put it into the context
             if variant is not None:
                 context["variant"] = variant
-            return self(event=event, context=context, *args)
+
+            return self(iface, event=event, context=context)
 
     def get_grouping_components(self, event: Event, context: GroupingContext) -> ReturnedVariants:
         """This returns a dictionary of all components by variant that this

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -325,7 +325,7 @@ class StrategyConfiguration:
 
     def iter_strategies(self) -> Iterator[Strategy[Any]]:
         """Iterates over all strategies by highest score to lowest."""
-        return iter(sorted(self.strategies.values(), key=lambda x: x.score and -x.score or 0))
+        return iter(sorted(self.strategies.values(), key=lambda x: -x.score if x.score else 0))
 
     @classmethod
     def as_dict(cls) -> dict[str, Any]:

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -20,6 +20,41 @@ from sentry.utils.settings import is_self_hosted
 if TYPE_CHECKING:
     from sentry.eventstore.models import Event
 
+REGEX_PATTERN_KEYS = (
+    "email",
+    "url",
+    "hostname",
+    "ip",
+    "uuid",
+    "sha1",
+    "md5",
+    "date",
+    "duration",
+    "hex",
+    "float",
+    "int",
+    "quoted_str",
+    "bool",
+)
+
+EXPERIMENT_PROJECTS = [  # Active internal Sentry projects
+    1,
+    11276,
+    54785,
+    155735,
+    162676,
+    221969,
+    300688,
+    1267915,
+    1269704,
+    1492057,
+    6424467,
+    6690737,
+    4503972821204992,
+    4505469596663808,
+    4506400311934976,
+]
+
 
 @metrics.wraps("grouping.normalize_message_for_grouping")
 def normalize_message_for_grouping(message: str, event: Event, share_analytics: bool = True) -> str:
@@ -37,23 +72,7 @@ def normalize_message_for_grouping(message: str, event: Event, share_analytics: 
         trimmed += "..."
 
     parameterizer = Parameterizer(
-        regex_pattern_keys=(
-            "email",
-            "url",
-            "hostname",
-            "ip",
-            "uuid",
-            "sha1",
-            "md5",
-            "date",
-            "duration",
-            "hex",
-            "float",
-            "int",
-            "quoted_str",
-            "bool",
-        ),
-        experiments=(UniqueIdExperiment,),
+        regex_pattern_keys=REGEX_PATTERN_KEYS, experiments=(UniqueIdExperiment,)
     )
 
     def _shoudl_run_experiment(experiment_name: str) -> bool:
@@ -64,24 +83,7 @@ def normalize_message_for_grouping(message: str, event: Event, share_analytics: 
                 in_rollout_group(
                     f"grouping.experiments.parameterization.{experiment_name}", event.project_id
                 )
-                or event.project_id
-                in [  # Active internal Sentry projects
-                    155735,
-                    4503972821204992,
-                    1267915,
-                    221969,
-                    11276,
-                    1269704,
-                    4505469596663808,
-                    1,
-                    54785,
-                    1492057,
-                    162676,
-                    6690737,
-                    300688,
-                    4506400311934976,
-                    6424467,
-                ]
+                or event.project_id in EXPERIMENT_PROJECTS
             )
         )
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -861,10 +861,12 @@ def react_error_with_cause(exceptions: list[SingleException]) -> int | None:
     return main_exception_id
 
 
+MAIN_EXCEPTION_ID_FUNCS = [
+    react_error_with_cause,
+]
+
+
 def determine_main_exception_id(exceptions: list[SingleException]) -> int | None:
-    MAIN_EXCEPTION_ID_FUNCS = [
-        react_error_with_cause,
-    ]
     main_exception_id = None
     for func in MAIN_EXCEPTION_ID_FUNCS:
         main_exception_id = func(exceptions)

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -685,7 +685,7 @@ def filter_exceptions_for_exception_groups(
             children: list[SingleException] | None = None,
         ):
             self.exception = exception
-            self.children = children if children else []
+            self.children = children or []
 
     exception_tree: dict[int, ExceptionTreeNode] = {}
     for exception in reversed(exceptions):

--- a/src/sentry/grouping/variants.py
+++ b/src/sentry/grouping/variants.py
@@ -91,7 +91,6 @@ class HashedChecksumVariant(ChecksumVariant):
 
 class FallbackVariant(BaseVariant):
     type = "fallback"
-    contributes = True
 
     def get_hash(self) -> str | None:
         return hash_from_values([])
@@ -110,7 +109,6 @@ class PerformanceProblemVariant(BaseVariant):
 
     type = "performance_problem"
     description = "performance problem"
-    contributes = True
 
     def __init__(self, event_performance_problem: Any):
         self.event_performance_problem = event_performance_problem

--- a/tests/sentry/grouping/test_builtin_fingerprinting.py
+++ b/tests/sentry/grouping/test_builtin_fingerprinting.py
@@ -559,15 +559,10 @@ class BuiltInFingerprintingTest(TestCase):
 
     def test_built_in_chunkload_rules_variants(self):
         event = self._get_event_for_trace(stacktrace=self.chunkload_error_trace)
-        variants = {
-            variant_name: variant.as_dict()
-            for variant_name, variant in event.get_grouping_variants(
-                force_config=GROUPING_CONFIG
-            ).items()
-        }
+        variants = event.get_grouping_variants(GROUPING_CONFIG)
         assert "built_in_fingerprint" in variants
 
-        assert variants["built_in_fingerprint"] == {
+        assert variants["built_in_fingerprint"].as_dict() == {
             "hash": mock.ANY,  # ignore hash as it can change for unrelated reasons
             "type": "built_in_fingerprint",
             "description": "Sentry defined fingerprint",


### PR DESCRIPTION
This is a collection of tiny grouping refactors I've had hanging around, all with the goal of making the code a little easier to read and/or keeping the linter happy. The only one which isn't fairly self-explanatory is the change to remove the default `contributes` value from two of the `Variant` subclasses. In that case, the parent class has the same value as its default, so there's no need for the subclasses to redefine it.

