### PR TITLE
feat(quick-start): Remove source maps task

### DIFF
--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -40,7 +40,6 @@ const orderedGettingStartedTasks = [
   OnboardingTaskKey.FIRST_EVENT,
   OnboardingTaskKey.INVITE_MEMBER,
   OnboardingTaskKey.ALERT_RULE,
-  OnboardingTaskKey.SOURCEMAPS,
   OnboardingTaskKey.LINK_SENTRY_TO_SOURCE_CODE,
   OnboardingTaskKey.RELEASE_TRACKING,
 ];

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -3,7 +3,6 @@ import {navigateTo} from 'sentry/actionCreators/navigation';
 import {filterSupportedTasks} from 'sentry/components/onboardingWizard/filterSupportedTasks';
 import {filterProjects} from 'sentry/components/performanceOnboarding/utils';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {sourceMaps} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import type {OnboardingTask, OnboardingTaskDescriptor} from 'sentry/types/onboarding';
@@ -17,12 +16,6 @@ import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
-
-function hasPlatformWithSourceMaps(projects: Project[] | undefined) {
-  return projects === undefined
-    ? false
-    : projects.some(({platform}) => platform && sourceMaps.includes(platform));
-}
 
 type Options = {
   /**
@@ -302,17 +295,6 @@ export function getOnboardingTasks({
       }),
       display: true,
       group: OnboardingTaskGroup.GETTING_STARTED,
-    },
-    {
-      task: OnboardingTaskKey.SOURCEMAPS,
-      title: t('Unminify your code'),
-      description: t(
-        'Enable readable stack traces in Sentry errors by uploading your source maps.'
-      ),
-      skippable: true,
-      actionType: 'external',
-      location: 'https://docs.sentry.io/platforms/javascript/sourcemaps/',
-      display: hasPlatformWithSourceMaps(projects),
     },
     {
       task: OnboardingTaskKey.ALERT_RULE,

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -16,7 +16,6 @@ export enum OnboardingTaskKey {
   INVITE_MEMBER = 'invite_member',
   SECOND_PLATFORM = 'setup_second_platform',
   RELEASE_TRACKING = 'setup_release_tracking',
-  SOURCEMAPS = 'setup_sourcemaps',
   ALERT_RULE = 'setup_alert_rules',
   FIRST_TRANSACTION = 'setup_transactions',
   REAL_TIME_NOTIFICATIONS = 'setup_real_time_notifications',

--- a/tests/js/getsentry-test/fixtures/onboardingTasks.ts
+++ b/tests/js/getsentry-test/fixtures/onboardingTasks.ts
@@ -22,7 +22,6 @@ export function OnboardingTasksFixture(
     },
     {status: 'skipped', task: OnboardingTaskKey.FIRST_PROJECT},
     {status: 'skipped', task: OnboardingTaskKey.PERFORMANCE_GUIDE},
-    {status: 'skipped', task: OnboardingTaskKey.SOURCEMAPS},
     ...params,
   ];
 }


### PR DESCRIPTION
We’re removing the “Unminify your code” task from the Quick Start due to low user engagement. We will continue guiding users to upload source maps on the issue details page.

![image](https://github.com/user-attachments/assets/d8935ac2-f1f2-465f-8d16-d68e032206f9)


Contributes to TET-426 