### PR TITLE
fix(2fa): require 2FA for auth token requests (dry run 2)

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -64,6 +64,9 @@ class OrganizationPermission(DemoSafePermission):
         if request.user.is_authenticated and request.user.is_sentry_app:
             return False
 
+        if request.user.is_anonymous:
+            return False
+
         if is_active_superuser(request):
             return False
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -243,6 +243,9 @@ class OrganizationMixin:
         if request.user.is_authenticated and request.user.is_sentry_app:
             return False
 
+        if request.user.is_anonymous:
+            return False
+
         if is_active_superuser(request):
             return False
 


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/VULN-727

Continuation of https://github.com/getsentry/sentry/pull/87077
Preparing to enable 2FA compliance check for token requests.

This PR:
* org auth token requests will ignore 2FA requirement since they're anonymous (no user to have 2FA attached)
* 2FA check will be done only after auth token permission check (to avoid disclosing information about org 2FA requirement)