### PR TITLE
feat(quick-start): Deprecate source maps task

### DIFF
--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -30,7 +30,8 @@ class OnboardingTask(enum.IntEnum):
     INVITE_MEMBER = 3
     SECOND_PLATFORM = 4
     RELEASE_TRACKING = 6
-    SOURCEMAPS = 7
+    # deprecated - no longer used
+    # SOURCEMAPS = 7
     ALERT_RULE = 10
     FIRST_TRANSACTION = 11
     SESSION_REPLAY = 14
@@ -118,7 +119,6 @@ class OrganizationOnboardingTask(AbstractOnboardingTask):
         (OnboardingTask.INVITE_MEMBER, "invite_member"),
         (OnboardingTask.SECOND_PLATFORM, "setup_second_platform"),
         (OnboardingTask.RELEASE_TRACKING, "setup_release_tracking"),
-        (OnboardingTask.SOURCEMAPS, "setup_sourcemaps"),
         (OnboardingTask.ALERT_RULE, "setup_alert_rules"),
         (OnboardingTask.FIRST_TRANSACTION, "setup_transactions"),
         (OnboardingTask.SESSION_REPLAY, "setup_session_replay"),
@@ -150,19 +150,11 @@ class OrganizationOnboardingTask(AbstractOnboardingTask):
         ]
     )
 
-    REQUIRED_ONBOARDING_TASKS_WITH_SOURCE_MAPS = frozenset(
-        [
-            *REQUIRED_ONBOARDING_TASKS,
-            OnboardingTask.SOURCEMAPS,
-        ]
-    )
-
     SKIPPABLE_TASKS = frozenset(
         [
             OnboardingTask.INVITE_MEMBER,
             OnboardingTask.SECOND_PLATFORM,
             OnboardingTask.RELEASE_TRACKING,
-            OnboardingTask.SOURCEMAPS,
             OnboardingTask.ALERT_RULE,
             OnboardingTask.FIRST_TRANSACTION,
             OnboardingTask.SESSION_REPLAY,
@@ -181,7 +173,6 @@ class OrganizationOnboardingTask(AbstractOnboardingTask):
             OnboardingTask.ALERT_RULE,
             OnboardingTask.FIRST_TRANSACTION,
             OnboardingTask.SESSION_REPLAY,
-            OnboardingTask.SOURCEMAPS,
         ]
     )
 

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -169,12 +169,3 @@ CATEGORY_LIST = [
     {id: "serverless", "name": _("Serverless"), "platforms": SERVERLESS},
     {id: "temporary", "name": _("Temporary"), "platforms": TEMPORARY},
 ]
-
-# Mirrors `const sourceMaps` in sentry/static/app/data/platformCategories.tsx
-# When changing this file, make sure to keep sentry/static/app/data/platformCategories.tsx in sync.
-SOURCE_MAPS = {
-    *FRONTEND,
-    "react-native",
-    "cordova",
-    "electron",
-}

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -108,13 +108,6 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert task is not None
 
-        task = OrganizationOnboardingTask.objects.get(
-            organization=project.organization,
-            task=OnboardingTask.SOURCEMAPS,
-            status=OnboardingTaskStatus.COMPLETE,
-        )
-        assert task is not None
-
     def test_project_created(self):
         now = timezone.now()
         project = self.create_project(first_event=now)
@@ -657,15 +650,11 @@ class OrganizationOnboardingTaskTest(TestCase):
                 }
             ]
         }
-
-        # Store first event
         event_1 = self.store_event(
             project_id=project.id,
             data=data,
         )
         event_processed.send(project=project, event=event_1, sender=None)
-
-        # Store second event
         event_2 = self.store_event(
             project_id=project.id,
             data=data,


### PR DESCRIPTION
Deprecating the SourceMaps onboarding task, as it will no longer be displayed in the UI (see base branch for reference).

Since task serialization uses `.get()` to map tasks ([source](https://github.com/getsentry/sentry/blob/95f92871535504446cc80513564d9382bc349237/src/sentry/api/serializers/models/organization.py#L499)), removing this task from the task map is safe and won’t cause errors, even if entries still exist in the database.

We may optionally run a cleanup job to remove existing SourceMaps task entries from the database, or simply leave them in place as we’ve done with deprecated tasks in the past.

contributes to TET-426 