### PR TITLE
ref(nextjs-insights): Remove time spent from pageloads table

### DIFF
--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -78,7 +78,6 @@ const pageloadColumnOrder: Array<GridColumnOrder<SortableField>> = [
   {key: 'transaction', name: t('Page'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Pageloads'), width: 122},
   {key: 'failure_rate()', name: t('Error Rate'), width: 122},
-  {key: 'sum(span.duration)', name: t('Time Spent'), width: 110},
   {
     key: 'performance_score(measurements.score.total)',
     name: t('Perf Score'),


### PR DESCRIPTION
Duration metrics on pageloads are not useful as there is no clearly defined end of them.
We already have the performance score which is calculated from web vitals to detect slow pageloads.

- closes [TET-456: We are missing avg/p95 here](https://linear.app/getsentry/issue/TET-456/we-are-missing-avgp95-here)