### PR TITLE
fix(codeowners): move demomode upwards in codeowners to stop matching everything

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -145,6 +145,12 @@ yarn.lock                                                @getsentry/owners-js-de
 # Sentry product. These rules generally map to a signle team, but that may not
 # always be the case.
 
+# Demo Mode - moved upwards because it wraps other parts of the codebase
+# and was assigned many issues to telemetry-experience that should not have been
+/src/sentry/demo_mode/                                   @getsentry/telemetry-experience
+/tests/sentry/demo_mode/                                 @getsentry/telemetry-experience
+/static/app/utils/demoMode/                              @getsentry/telemetry-experience
+
 ## Crons
 /static/app/views/monitors                               @getsentry/crons
 /src/sentry/monitors                                     @getsentry/crons
@@ -506,8 +512,6 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/sentry_metrics/querying/                                           @getsentry/telemetry-experience
 /src/sentry/snuba/metrics/                                                       @getsentry/telemetry-experience
 /tests/sentry/snuba/metrics/                                                     @getsentry/telemetry-experience
-/src/sentry/demo_mode/                                                           @getsentry/telemetry-experience
-/tests/sentry/demo_mode/                                                         @getsentry/telemetry-experience
 
 /static/app/actionCreators/metrics.tsx                                           @getsentry/telemetry-experience
 /static/app/data/platformCategories.tsx                                          @getsentry/telemetry-experience
@@ -519,7 +523,6 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /static/app/views/settings/dynamicSampling/                                      @getsentry/telemetry-experience
 /static/app/views/onboarding*                                                    @getsentry/telemetry-experience
 /static/app/views/projectInstall/                                                @getsentry/telemetry-experience
-/static/app/utils/demoMode/                                                      @getsentry/telemetry-experience
 ## End of Telemetry Experience
 
 


### PR DESCRIPTION
- #telemetry-experience has been matching on different unrelated parts of the codebase. According to [our docs](https://docs.sentry.io/product/issues/ownership-rules/#evaluation-flow), the last matching rule should "win", therefore moving this to the top of product features, because demo-mode should only match when there is no other, more specific match for the file in question.
- Contributes to TET-461