### PR TITLE
fix(symbolicator): check source credentials and not the credential token

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -616,7 +616,7 @@ def get_gcp_token(client_email):
     # Fetch the regular credentials for GCP
     source_credentials, _ = google.auth.default()
 
-    if source_credentials.token is None:
+    if source_credentials is None:
         return None
 
     # Impersonate the service account to give the token for symbolicator a proper scope


### PR DESCRIPTION
This PR fixes a bug where it would always report that no token can be obtained.
The reason is that no refresh is being performed on the `source_credentials`, so it does not have a `token` property yet and the check will always return `False`.