### PR TITLE
fix(dashboards): Alert the user when there are unsaved changes 

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -49,6 +49,7 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
+import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -259,13 +260,17 @@ class DashboardDetail extends Component<Props, State> {
       navigate: this.props.navigate,
     }),
     isSavingDashboardFilters: false,
-    isWidgetBuilderOpen: this.isRedesignedWidgetBuilder,
+    isWidgetBuilderOpen: false,
     openWidgetTemplates: undefined,
     newlyAddedWidget: undefined,
   };
 
   componentDidMount() {
     this.checkIfShouldMountWidgetViewerModal();
+    if (this.isWidgetBuilder()) {
+      this.setState({isWidgetBuilderOpen: true});
+    }
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -291,6 +296,10 @@ class DashboardDetail extends Component<Props, State> {
         }),
       });
     }
+  }
+
+  componentWillUnmount(): void {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   checkIfShouldMountWidgetViewerModal() {
@@ -415,33 +424,22 @@ class DashboardDetail extends Component<Props, State> {
     ].includes(dashboardState);
   }
 
-  get isWidgetBuilderRouter() {
-    const {location, params, organization} = this.props;
-    const {dashboardId, widgetIndex} = params;
-
-    const widgetBuilderRoutes = [
-      `/organizations/${organization.slug}/dashboards/new/widget/new/`,
-      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/new/`,
-      `/organizations/${organization.slug}/dashboards/new/widget/${widgetIndex}/edit/`,
-      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
-    ];
-
-    if (USING_CUSTOMER_DOMAIN) {
-      // TODO: replace with url generation later on.
-      widgetBuilderRoutes.push(
-        ...[
-          `/dashboards/new/widget/new/`,
-          `/dashboard/${dashboardId}/widget/new/`,
-          `/dashboards/new/widget/${widgetIndex}/edit/`,
-          `/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
-        ]
-      );
-    }
-
-    return widgetBuilderRoutes.includes(location.pathname);
+  get dashboardTitle() {
+    const {dashboard} = this.props;
+    const {modifiedDashboard} = this.state;
+    return modifiedDashboard ? modifiedDashboard.title : dashboard.title;
   }
 
-  get isRedesignedWidgetBuilder() {
+  handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    const {dashboard} = this.props;
+    const {modifiedDashboard} = this.state;
+    if (defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard)) {
+      event.preventDefault();
+      event.returnValue = '';
+    }
+  };
+
+  isWidgetBuilder = (path?: string) => {
     const {organization, location, params} = this.props;
     const {dashboardId, widgetIndex} = params;
 
@@ -463,14 +461,8 @@ class DashboardDetail extends Component<Props, State> {
       );
     }
 
-    return widgetBuilderRoutes.includes(location.pathname);
-  }
-
-  get dashboardTitle() {
-    const {dashboard} = this.props;
-    const {modifiedDashboard} = this.state;
-    return modifiedDashboard ? modifiedDashboard.title : dashboard.title;
-  }
+    return widgetBuilderRoutes.includes(path ?? location.pathname);
+  };
 
   onEdit = () => {
     const {dashboard, organization} = this.props;
@@ -1118,6 +1110,28 @@ class DashboardDetail extends Component<Props, State> {
 
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={organization.slug}>
+        <OnRouteLeave
+          message={UNSAVED_MESSAGE}
+          when={locationChange => {
+            // The widget builder uses its own pathname at the moment, so check if we're navigating
+            // between the dashboard and the widget builder
+            const navigatingWithinDashboards =
+              this.isWidgetBuilder(locationChange.nextLocation.pathname) ||
+              (this.isWidgetBuilder(locationChange.currentLocation.pathname) &&
+                [`/dashboard/${dashboard.id}`, `/dashboards/new/`].includes(
+                  locationChange.nextLocation.pathname
+                ));
+            const hasUnsavedChanges =
+              (defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard)) ||
+              hasUnsavedFilters;
+            return (
+              locationChange.currentLocation.pathname !==
+                locationChange.nextLocation.pathname &&
+              !navigatingWithinDashboards &&
+              hasUnsavedChanges
+            );
+          }}
+        />
         <PageFiltersContainer
           disablePersistence
           skipLoadLastUsed
@@ -1344,10 +1358,6 @@ class DashboardDetail extends Component<Props, State> {
   render() {
     const {organization} = this.props;
 
-    if (this.isWidgetBuilderRouter) {
-      return this.renderWidgetBuilder();
-    }
-
     if (organization.features.includes('dashboards-edit')) {
       return this.renderDashboardDetail();
     }
@@ -1375,6 +1385,7 @@ function DashboardDetailWithThemeAndNavigate(props: Omit<Props, 'theme' | 'navig
   const navigate = useNavigate();
   return <DashboardDetail {...props} theme={theme} navigate={navigate} />;
 }
+
 export default withPageFilters(
   withProjects(withApi(withOrganization(DashboardDetailWithThemeAndNavigate)))
 );

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1122,8 +1122,7 @@ class DashboardDetail extends Component<Props, State> {
                   locationChange.nextLocation.pathname
                 ));
             const hasUnsavedChanges =
-              (defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard)) ||
-              hasUnsavedFilters;
+              defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard);
             return (
               locationChange.currentLocation.pathname !==
                 locationChange.nextLocation.pathname &&

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1118,7 +1118,7 @@ class DashboardDetail extends Component<Props, State> {
             const navigatingWithinDashboards =
               this.isWidgetBuilder(locationChange.nextLocation.pathname) ||
               (this.isWidgetBuilder(locationChange.currentLocation.pathname) &&
-                [`/dashboard/${dashboard.id}`, `/dashboards/new/`].includes(
+                [`/dashboard/${dashboard.id}/`, `/dashboards/new/`].includes(
                   locationChange.nextLocation.pathname
                 ));
             const hasUnsavedChanges =


### PR DESCRIPTION
When users navigate away from the page or close the tab, if there are
unsaved changes we should trigger an alert to let them know they need to
save.

With these changes, a confirmation modal should pop up when the dashboard (excluding the dashboard filters) has changes and:
- A user clicks away to a different part of the app (e.g. issues)
- A user clicks Cancel in the edit state
- A user attempts to close the tab
- A user attempts to navigate to another dashboard

Closes DAIN-202