### PR TITLE
fix(aci): fix `useAutomationBuilderReducer` to use id instead of list index

### DIFF
--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -1,5 +1,6 @@
-export interface NewAction {
+export interface Action {
   data: Record<string, unknown>;
+  id: string;
   type: ActionType;
   integrationId?: string;
 }

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -1,4 +1,4 @@
-import type {NewAction} from './actions';
+import type {Action} from './actions';
 
 interface SnubaQuery {
   aggregate: string;
@@ -68,19 +68,15 @@ export enum DataConditionGroupLogicType {
   NONE = 'none',
 }
 
-export interface NewDataCondition {
+export interface DataCondition {
   comparison: any;
   comparison_type: DataConditionType;
+  id: string;
   condition_result?: any;
 }
-
-export interface DataCondition extends Readonly<NewDataCondition> {
-  readonly id: string;
-}
-
 export interface DataConditionGroup {
-  conditions: NewDataCondition[];
+  conditions: DataCondition[];
   id: string;
   logicType: DataConditionGroupLogicType;
-  actions?: NewAction[];
+  actions?: Action[];
 }

--- a/static/app/views/automations/components/actionNodeList.tsx
+++ b/static/app/views/automations/components/actionNodeList.tsx
@@ -2,11 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Select} from 'sentry/components/core/select';
-import type {
-  ActionType,
-  Integration,
-  NewAction,
-} from 'sentry/types/workflowEngine/actions';
+import type {Action, ActionType, Integration} from 'sentry/types/workflowEngine/actions';
 import {
   ActionNodeContext,
   actionNodesMap,
@@ -15,13 +11,13 @@ import {
 import AutomationBuilderRow from 'sentry/views/automations/components/automationBuilderRow';
 
 interface ActionNodeListProps {
-  actions: NewAction[];
+  actions: Action[];
   availableActions: Array<{type: ActionType; integrations?: Integration[]}>;
   group: string;
   onAddRow: (type: ActionType) => void;
-  onDeleteRow: (id: number) => void;
+  onDeleteRow: (id: string) => void;
   placeholder: string;
-  updateAction: (index: number, data: Record<string, any>) => void;
+  updateAction: (id: string, data: Record<string, any>) => void;
 }
 
 export default function ActionNodeList({
@@ -39,18 +35,18 @@ export default function ActionNodeList({
 
   return (
     <Fragment>
-      {actions.map((action, i) => (
+      {actions.map(action => (
         <AutomationBuilderRow
-          key={`${group}.action.${i}`}
+          key={`${group}.action.${action.id}`}
           onDelete={() => {
-            onDeleteRow(i);
+            onDeleteRow(action.id);
           }}
         >
           <ActionNodeContext.Provider
             value={{
               action,
-              actionId: `${group}.action.${i}`,
-              onUpdate: newAction => updateAction(i, newAction),
+              actionId: `${group}.action.${action.id}`,
+              onUpdate: newAction => updateAction(action.id, newAction),
               integrations: availableActions.find(a => a.type === action.type)
                 ?.integrations,
             }}

--- a/static/app/views/automations/components/actionNodes.tsx
+++ b/static/app/views/automations/components/actionNodes.tsx
@@ -1,7 +1,7 @@
 import {createContext, useContext} from 'react';
 
 import {t} from 'sentry/locale';
-import type {Integration, NewAction} from 'sentry/types/workflowEngine/actions';
+import type {Action, Integration} from 'sentry/types/workflowEngine/actions';
 import {ActionType} from 'sentry/types/workflowEngine/actions';
 import {AzureDevOpsNode} from 'sentry/views/automations/components/actions/azureDevOps';
 import {DiscordNode} from 'sentry/views/automations/components/actions/discord';
@@ -16,7 +16,7 @@ import {PagerdutyNode} from 'sentry/views/automations/components/actions/pagerdu
 import {SlackNode} from 'sentry/views/automations/components/actions/slack';
 
 interface ActionNodeProps {
-  action: NewAction;
+  action: Action;
   actionId: string;
   onUpdate: (condition: Record<string, any>) => void;
   integrations?: Integration[];

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -10,6 +10,7 @@ import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextBu
 import {IconAdd, IconDelete, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -75,13 +76,14 @@ export default function AutomationBuilder() {
         group="triggers"
         onAddRow={type => actions.addWhenCondition(type)}
         onDeleteRow={index => actions.removeWhenCondition(index)}
-        updateCondition={(index, comparison) =>
-          actions.updateWhenCondition(index, comparison)
-        }
+        updateCondition={(id, comparison) => actions.updateWhenCondition(id, comparison)}
       />
 
-      {state.actionFilters.map((_, index) => (
-        <ActionFilterBlock key={index} groupIndex={index} />
+      {state.actionFilters.map(actionFilter => (
+        <ActionFilterBlock
+          key={`actionFilters.${actionFilter.id}`}
+          actionFilter={actionFilter}
+        />
       ))}
       <span>
         <PurpleTextButton
@@ -101,15 +103,14 @@ export default function AutomationBuilder() {
 }
 
 interface ActionFilterBlockProps {
-  groupIndex: number;
+  actionFilter: DataConditionGroup;
 }
 
-function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
-  const {state, actions} = useAutomationBuilderContext();
-  const actionFilterBlock = state.actionFilters[groupIndex];
+function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
+  const {actions} = useAutomationBuilderContext();
 
   return (
-    <IfThenWrapper key={`actionFilters.${groupIndex}`}>
+    <IfThenWrapper>
       <Step>
         <Flex column gap={space(0.75)}>
           <Flex justify="space-between">
@@ -129,13 +130,15 @@ function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
                       inline={false}
                       isSearchable={false}
                       isClearable={false}
-                      name={`actionFilters.${groupIndex}.logicType`}
+                      name={`actionFilters.${actionFilter.id}.logicType`}
                       required
                       flexibleControlStateSize
                       options={FILTER_MATCH_OPTIONS}
                       size="xs"
-                      value={actionFilterBlock?.logicType}
-                      onChange={value => actions.updateIfLogicType(groupIndex, value)}
+                      value={actionFilter.logicType}
+                      onChange={value =>
+                        actions.updateIfLogicType(actionFilter.id, value)
+                      }
                     />
                   </EmbeddedWrapper>
                 ),
@@ -146,7 +149,7 @@ function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
               size="sm"
               icon={<IconDelete />}
               borderless
-              onClick={() => actions.removeIf(groupIndex)}
+              onClick={() => actions.removeIf(actionFilter.id)}
               className="delete-condition-group"
             />
           </Flex>
@@ -154,15 +157,15 @@ function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
             // TODO: replace constant dataConditionTypes with DataConditions API response
             dataConditionTypes={FILTER_DATA_CONDITION_TYPES}
             placeholder={t('Filter by...')}
-            group={`actionFilters.${groupIndex}`}
-            conditions={actionFilterBlock?.conditions || []}
-            onAddRow={type => actions.addIfCondition(groupIndex, type)}
-            onDeleteRow={index => actions.removeIfCondition(groupIndex, index)}
-            updateCondition={(index, comparison) =>
-              actions.updateIfCondition(groupIndex, index, comparison)
+            group={`actionFilters.${actionFilter.id}`}
+            conditions={actionFilter?.conditions || []}
+            onAddRow={type => actions.addIfCondition(actionFilter.id, type)}
+            onDeleteRow={id => actions.removeIfCondition(actionFilter.id, id)}
+            updateCondition={(id, comparison) =>
+              actions.updateIfCondition(actionFilter.id, id, comparison)
             }
-            updateConditionType={(index, type) =>
-              actions.updateIfConditionType(groupIndex, index, type)
+            updateConditionType={(id, type) =>
+              actions.updateIfConditionType(actionFilter.id, id, type)
             }
           />
         </Flex>
@@ -178,11 +181,11 @@ function ActionFilterBlock({groupIndex}: ActionFilterBlockProps) {
           // TODO: replace constant availableActions with API response
           availableActions={[]}
           placeholder={t('Select an action')}
-          group={`actionFilters.${groupIndex}`}
-          actions={actionFilterBlock?.actions || []}
-          onAddRow={type => actions.addIfAction(groupIndex, type)}
-          onDeleteRow={index => actions.removeIfAction(groupIndex, index)}
-          updateAction={(index, data) => actions.updateIfAction(groupIndex, index, data)}
+          group={`actionFilters.${actionFilter.id}`}
+          actions={actionFilter?.actions || []}
+          onAddRow={type => actions.addIfAction(actionFilter.id, type)}
+          onDeleteRow={id => actions.removeIfAction(actionFilter.id, id)}
+          updateAction={(id, data) => actions.updateIfAction(actionFilter.id, id, data)}
         />
       </Step>
     </IfThenWrapper>

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -1,6 +1,6 @@
 import {createContext, type Reducer, useCallback, useContext, useReducer} from 'react';
+import {uuid4} from '@sentry/core';
 
-import type FormModel from 'sentry/components/forms/model';
 import type {ActionType} from 'sentry/types/workflowEngine/actions';
 import {
   type DataConditionGroup,
@@ -10,12 +10,12 @@ import {
 
 export function useAutomationBuilderReducer() {
   const reducer: Reducer<AutomationBuilderState, AutomationBuilderAction> = useCallback(
-    (state, action, formModel?: FormModel): AutomationBuilderState => {
+    (state, action): AutomationBuilderState => {
       switch (action.type) {
         case 'ADD_WHEN_CONDITION':
           return addWhenCondition(state, action);
         case 'REMOVE_WHEN_CONDITION':
-          return removeWhenCondition(state, action, formModel);
+          return removeWhenCondition(state, action);
         case 'UPDATE_WHEN_CONDITION':
           return updateWhenCondition(state, action);
         case 'UPDATE_WHEN_LOGIC_TYPE':
@@ -23,11 +23,11 @@ export function useAutomationBuilderReducer() {
         case 'ADD_IF':
           return addIf(state, action);
         case 'REMOVE_IF':
-          return removeIf(state, action, formModel);
+          return removeIf(state, action);
         case 'ADD_IF_CONDITION':
           return addIfCondition(state, action);
         case 'REMOVE_IF_CONDITION':
-          return removeIfCondition(state, action, formModel);
+          return removeIfCondition(state, action);
         case 'UPDATE_IF_CONDITION':
           return updateIfCondition(state, action);
         case 'UPDATE_IF_CONDITION_TYPE':
@@ -35,7 +35,7 @@ export function useAutomationBuilderReducer() {
         case 'ADD_IF_ACTION':
           return addIfAction(state, action);
         case 'REMOVE_IF_ACTION':
-          return removeIfAction(state, action, formModel);
+          return removeIfAction(state, action);
         case 'UPDATE_IF_ACTION':
           return updateIfAction(state, action);
         case 'UPDATE_IF_LOGIC_TYPE':
@@ -56,12 +56,12 @@ export function useAutomationBuilderReducer() {
       [dispatch]
     ),
     removeWhenCondition: useCallback(
-      (index: number) => dispatch({type: 'REMOVE_WHEN_CONDITION', index}),
+      (id: string) => dispatch({type: 'REMOVE_WHEN_CONDITION', id}),
       [dispatch]
     ),
     updateWhenCondition: useCallback(
-      (index: number, comparison: Record<string, any>) =>
-        dispatch({type: 'UPDATE_WHEN_CONDITION', index, comparison}),
+      (id: string, comparison: Record<string, any>) =>
+        dispatch({type: 'UPDATE_WHEN_CONDITION', id, comparison}),
       [dispatch]
     ),
     updateWhenLogicType: useCallback(
@@ -71,52 +71,52 @@ export function useAutomationBuilderReducer() {
     ),
     addIf: useCallback(() => dispatch({type: 'ADD_IF'}), [dispatch]),
     removeIf: useCallback(
-      (groupIndex: number) => dispatch({type: 'REMOVE_IF', groupIndex}),
+      (groupId: string) => dispatch({type: 'REMOVE_IF', groupId}),
       [dispatch]
     ),
     addIfCondition: useCallback(
-      (groupIndex: number, conditionType: DataConditionType) =>
-        dispatch({type: 'ADD_IF_CONDITION', groupIndex, conditionType}),
+      (groupId: string, conditionType: DataConditionType) =>
+        dispatch({type: 'ADD_IF_CONDITION', groupId, conditionType}),
       [dispatch]
     ),
     removeIfCondition: useCallback(
-      (groupIndex: number, conditionIndex: number) =>
-        dispatch({type: 'REMOVE_IF_CONDITION', groupIndex, conditionIndex}),
+      (groupId: string, conditionId: string) =>
+        dispatch({type: 'REMOVE_IF_CONDITION', groupId, conditionId}),
       [dispatch]
     ),
     updateIfConditionType: useCallback(
-      (groupIndex: number, conditionIndex: number, conditionType: DataConditionType) =>
+      (groupId: string, conditionId: string, conditionType: DataConditionType) =>
         dispatch({
           type: 'UPDATE_IF_CONDITION_TYPE',
-          groupIndex,
-          conditionIndex,
+          groupId,
+          conditionId,
           conditionType,
         }),
       [dispatch]
     ),
     updateIfCondition: useCallback(
-      (groupIndex: number, conditionIndex: number, comparison: Record<string, any>) =>
-        dispatch({type: 'UPDATE_IF_CONDITION', groupIndex, conditionIndex, comparison}),
+      (groupId: string, conditionId: string, comparison: Record<string, any>) =>
+        dispatch({type: 'UPDATE_IF_CONDITION', groupId, conditionId, comparison}),
       [dispatch]
     ),
     addIfAction: useCallback(
-      (groupIndex: number, actionType: ActionType) =>
-        dispatch({type: 'ADD_IF_ACTION', groupIndex, actionType}),
+      (groupId: string, actionType: ActionType) =>
+        dispatch({type: 'ADD_IF_ACTION', groupId, actionType}),
       [dispatch]
     ),
     removeIfAction: useCallback(
-      (groupIndex: number, actionIndex: number) =>
-        dispatch({type: 'REMOVE_IF_ACTION', groupIndex, actionIndex}),
+      (groupId: string, actionId: string) =>
+        dispatch({type: 'REMOVE_IF_ACTION', groupId, actionId}),
       [dispatch]
     ),
     updateIfAction: useCallback(
-      (groupIndex: number, actionIndex: number, data: Record<string, any>) =>
-        dispatch({type: 'UPDATE_IF_ACTION', groupIndex, actionIndex, data}),
+      (groupId: string, actionId: string, data: Record<string, any>) =>
+        dispatch({type: 'UPDATE_IF_ACTION', groupId, actionId, data}),
       [dispatch]
     ),
     updateIfLogicType: useCallback(
-      (groupIndex: number, logicType: DataConditionGroupLogicType) =>
-        dispatch({type: 'UPDATE_IF_LOGIC_TYPE', groupIndex, logicType}),
+      (groupId: string, logicType: DataConditionGroupLogicType) =>
+        dispatch({type: 'UPDATE_IF_LOGIC_TYPE', groupId, logicType}),
       [dispatch]
     ),
   };
@@ -135,30 +135,26 @@ interface AutomationBuilderState {
 // 2. The AutomationActions interface
 interface AutomationActions {
   addIf: () => void;
-  addIfAction: (groupIndex: number, actionType: ActionType) => void;
-  addIfCondition: (groupIndex: number, conditionType: DataConditionType) => void;
+  addIfAction: (groupId: string, actionType: ActionType) => void;
+  addIfCondition: (groupId: string, conditionType: DataConditionType) => void;
   addWhenCondition: (conditionType: DataConditionType) => void;
-  removeIf: (groupIndex: number) => void;
-  removeIfAction: (groupIndex: number, actionIndex: number) => void;
-  removeIfCondition: (groupIndex: number, conditionIndex: number) => void;
-  removeWhenCondition: (index: number) => void;
-  updateIfAction: (
-    groupIndex: number,
-    actionIndex: number,
-    data: Record<string, any>
-  ) => void;
+  removeIf: (groupId: string) => void;
+  removeIfAction: (groupId: string, actionId: string) => void;
+  removeIfCondition: (groupId: string, conditionId: string) => void;
+  removeWhenCondition: (id: string) => void;
+  updateIfAction: (groupId: string, actionId: string, data: Record<string, any>) => void;
   updateIfCondition: (
-    groupIndex: number,
-    conditionIndex: number,
+    groupId: string,
+    conditionId: string,
     comparison: Record<string, any>
   ) => void;
   updateIfConditionType: (
-    groupIndex: number,
-    conditionIndex: number,
+    groupId: string,
+    conditionId: string,
     conditionType: DataConditionType
   ) => void;
-  updateIfLogicType: (groupIndex: number, logicType: DataConditionGroupLogicType) => void;
-  updateWhenCondition: (index: number, comparison: Record<string, any>) => void;
+  updateIfLogicType: (groupId: string, logicType: DataConditionGroupLogicType) => void;
+  updateWhenCondition: (id: string, comparison: Record<string, any>) => void;
   updateWhenLogicType: (logicType: DataConditionGroupLogicType) => void;
 }
 
@@ -185,7 +181,7 @@ export const initialAutomationBuilderState: AutomationBuilderState = {
   },
   actionFilters: [
     {
-      id: 'if.0',
+      id: '0',
       logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
       conditions: [],
     },
@@ -198,13 +194,13 @@ type AddWhenConditionAction = {
 };
 
 type RemoveWhenConditionAction = {
-  index: number;
+  id: string;
   type: 'REMOVE_WHEN_CONDITION';
 };
 
 type UpdateWhenConditionAction = {
   comparison: Record<string, any>;
-  index: number;
+  id: string;
   type: 'UPDATE_WHEN_CONDITION';
 };
 
@@ -218,57 +214,57 @@ type AddIfAction = {
 };
 
 type RemoveIfAction = {
-  groupIndex: number;
+  groupId: string;
   type: 'REMOVE_IF';
 };
 
 type AddIfConditionAction = {
   conditionType: DataConditionType;
-  groupIndex: number;
+  groupId: string;
   type: 'ADD_IF_CONDITION';
 };
 
 type RemoveIfConditionAction = {
-  conditionIndex: number;
-  groupIndex: number;
+  conditionId: string;
+  groupId: string;
   type: 'REMOVE_IF_CONDITION';
 };
 
 type UpdateIfConditionTypeAction = {
-  conditionIndex: number;
+  conditionId: string;
   conditionType: DataConditionType;
-  groupIndex: number;
+  groupId: string;
   type: 'UPDATE_IF_CONDITION_TYPE';
 };
 
 type UpdateIfConditionAction = {
   comparison: Record<string, any>;
-  conditionIndex: number;
-  groupIndex: number;
+  conditionId: string;
+  groupId: string;
   type: 'UPDATE_IF_CONDITION';
 };
 
 type AddIfActionAction = {
   actionType: ActionType;
-  groupIndex: number;
+  groupId: string;
   type: 'ADD_IF_ACTION';
 };
 
 type RemoveIfActionAction = {
-  actionIndex: number;
-  groupIndex: number;
+  actionId: string;
+  groupId: string;
   type: 'REMOVE_IF_ACTION';
 };
 
 type UpdateIfActionAction = {
-  actionIndex: number;
+  actionId: string;
   data: Record<string, any>;
-  groupIndex: number;
+  groupId: string;
   type: 'UPDATE_IF_ACTION';
 };
 
 type UpdateIfLogicTypeAction = {
-  groupIndex: number;
+  groupId: string;
   logicType: DataConditionGroupLogicType;
   type: 'UPDATE_IF_LOGIC_TYPE';
 };
@@ -300,6 +296,7 @@ function addWhenCondition(
       conditions: [
         ...state.triggers.conditions,
         {
+          id: uuid4(),
           comparison_type: action.conditionType,
           comparison: {},
         },
@@ -310,23 +307,14 @@ function addWhenCondition(
 
 function removeWhenCondition(
   state: AutomationBuilderState,
-  action: RemoveWhenConditionAction,
-  formModel?: FormModel
+  action: RemoveWhenConditionAction
 ): AutomationBuilderState {
-  const {index} = action;
-  if (formModel) {
-    for (const key of formModel.fields.keys()) {
-      if (key.startsWith(`triggers.conditions.${index}.`)) {
-        formModel.removeField(key);
-      }
-    }
-  }
-
+  const {id} = action;
   return {
     ...state,
     triggers: {
       ...state.triggers,
-      conditions: [...state.triggers.conditions.filter((_, i) => i !== index)],
+      conditions: [...state.triggers.conditions.filter(c => c.id !== id)],
     },
   };
 }
@@ -335,14 +323,13 @@ function updateWhenCondition(
   state: AutomationBuilderState,
   action: UpdateWhenConditionAction
 ): AutomationBuilderState {
+  const {id, comparison} = action;
   return {
     ...state,
     triggers: {
       ...state.triggers,
-      conditions: state.triggers.conditions.map((c, i) =>
-        i === action.index
-          ? {...c, comparison: {...c.comparison, ...action.comparison}}
-          : c
+      conditions: state.triggers.conditions.map(c =>
+        c.id === id ? {...c, comparison: {...c.comparison, ...comparison}} : c
       ),
     },
   };
@@ -371,7 +358,7 @@ function addIf(
     actionFilters: [
       ...state.actionFilters,
       {
-        id: state.actionFilters.length.toString(),
+        id: uuid4(),
         conditions: [],
         logicType: DataConditionGroupLogicType.ANY,
       },
@@ -381,20 +368,12 @@ function addIf(
 
 function removeIf(
   state: AutomationBuilderState,
-  action: RemoveIfAction,
-  formModel?: FormModel
+  action: RemoveIfAction
 ): AutomationBuilderState {
-  const {groupIndex} = action;
-  if (formModel) {
-    for (const key of formModel.fields.keys()) {
-      if (key.startsWith(`actionFilters.${groupIndex}.`)) {
-        formModel.removeField(key);
-      }
-    }
-  }
+  const {groupId} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.filter((_, i) => i !== groupIndex),
+    actionFilters: state.actionFilters.filter(group => group.id !== groupId),
   };
 }
 
@@ -402,11 +381,11 @@ function addIfCondition(
   state: AutomationBuilderState,
   action: AddIfConditionAction
 ): AutomationBuilderState {
-  const {groupIndex, conditionType} = action;
+  const {groupId, conditionType} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
@@ -414,6 +393,7 @@ function addIfCondition(
         conditions: [
           ...group.conditions,
           {
+            id: uuid4(),
             comparison_type: conditionType,
             comparison: {},
           },
@@ -425,26 +405,18 @@ function addIfCondition(
 
 function removeIfCondition(
   state: AutomationBuilderState,
-  action: RemoveIfConditionAction,
-  formModel?: FormModel
+  action: RemoveIfConditionAction
 ): AutomationBuilderState {
-  const {groupIndex, conditionIndex} = action;
-  if (formModel) {
-    for (const key of formModel.fields.keys()) {
-      if (key.startsWith(`actionFilters.${groupIndex}.conditions.${conditionIndex}.`)) {
-        formModel.removeField(key);
-      }
-    }
-  }
+  const {groupId, conditionId} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
         ...group,
-        conditions: group.conditions.filter((_, j) => j !== conditionIndex),
+        conditions: group.conditions.filter(c => c.id !== conditionId),
       };
     }),
   };
@@ -454,17 +426,17 @@ function updateIfConditionType(
   state: AutomationBuilderState,
   action: UpdateIfConditionTypeAction
 ): AutomationBuilderState {
-  const {groupIndex, conditionIndex, conditionType} = action;
+  const {groupId, conditionId, conditionType} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
         ...group,
-        conditions: group.conditions.map((c, j) =>
-          j === conditionIndex ? {...c, comparison_type: conditionType} : c
+        conditions: group.conditions.map(c =>
+          c.id === conditionId ? {...c, comparison_type: conditionType} : c
         ),
       };
     }),
@@ -475,17 +447,17 @@ function updateIfCondition(
   state: AutomationBuilderState,
   action: UpdateIfConditionAction
 ): AutomationBuilderState {
-  const {groupIndex, conditionIndex, comparison} = action;
+  const {groupId, conditionId, comparison} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
         ...group,
-        conditions: group.conditions.map((c, j) =>
-          j === conditionIndex ? {...c, comparison: {...c.comparison, ...comparison}} : c
+        conditions: group.conditions.map(c =>
+          c.id === conditionId ? {...c, comparison: {...c.comparison, ...comparison}} : c
         ),
       };
     }),
@@ -496,11 +468,11 @@ function addIfAction(
   state: AutomationBuilderState,
   action: AddIfActionAction
 ): AutomationBuilderState {
-  const {groupIndex, actionType} = action;
+  const {groupId, actionType} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
@@ -508,6 +480,7 @@ function addIfAction(
         actions: [
           ...(group.actions ?? []),
           {
+            id: uuid4(),
             type: actionType,
             data: {},
           },
@@ -519,26 +492,18 @@ function addIfAction(
 
 function removeIfAction(
   state: AutomationBuilderState,
-  action: RemoveIfActionAction,
-  formModel?: FormModel
+  action: RemoveIfActionAction
 ): AutomationBuilderState {
-  const {groupIndex, actionIndex} = action;
-  if (formModel) {
-    for (const key of formModel.fields.keys()) {
-      if (key.startsWith(`actionFilters.${groupIndex}.actions.${actionIndex}.`)) {
-        formModel.removeField(key);
-      }
-    }
-  }
+  const {groupId, actionId} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
         ...group,
-        actions: group.actions?.filter((_, j) => j !== actionIndex),
+        actions: group.actions?.filter(a => a.id !== actionId),
       };
     }),
   };
@@ -548,19 +513,19 @@ function updateIfAction(
   state: AutomationBuilderState,
   action: UpdateIfActionAction
 ): AutomationBuilderState {
-  const {groupIndex, actionIndex, data} = action;
+  const {groupId, actionId, data} = action;
   // special case for integrationId which is outside of data
   if ('integrationId' in data) {
     return {
       ...state,
-      actionFilters: state.actionFilters.map((group, i) => {
-        if (i !== groupIndex) {
+      actionFilters: state.actionFilters.map(group => {
+        if (group.id !== groupId) {
           return group;
         }
         return {
           ...group,
-          actions: group.actions?.map((d, j) =>
-            j === actionIndex ? {...d, integrationId: data.integrationId} : d
+          actions: group.actions?.map(a =>
+            a.id === actionId ? {...a, integrationId: data.integrationId} : a
           ),
         };
       }),
@@ -568,14 +533,14 @@ function updateIfAction(
   }
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) => {
-      if (i !== groupIndex) {
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
         return group;
       }
       return {
         ...group,
-        actions: group.actions?.map((d, j) =>
-          j === actionIndex ? {...d, data: {...d.data, ...data}} : d
+        actions: group.actions?.map(a =>
+          a.id === actionId ? {...a, data: {...a.data, ...data}} : a
         ),
       };
     }),
@@ -586,11 +551,11 @@ function updateIfLogicType(
   state: AutomationBuilderState,
   action: UpdateIfLogicTypeAction
 ): AutomationBuilderState {
-  const {groupIndex, logicType} = action;
+  const {groupId, logicType} = action;
   return {
     ...state,
-    actionFilters: state.actionFilters.map((group, i) =>
-      i === groupIndex ? {...group, logicType} : group
+    actionFilters: state.actionFilters.map(group =>
+      group.id === groupId ? {...group, logicType} : group
     ),
   };
 }

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 
 import {Select} from 'sentry/components/core/select';
 import type {
+  DataCondition,
   DataConditionType,
-  NewDataCondition,
 } from 'sentry/types/workflowEngine/dataConditions';
 import AutomationBuilderRow from 'sentry/views/automations/components/automationBuilderRow';
 import {
@@ -14,14 +14,14 @@ import {
 } from 'sentry/views/automations/components/dataConditionNodes';
 
 interface DataConditionNodeListProps {
-  conditions: NewDataCondition[];
+  conditions: DataCondition[];
   dataConditionTypes: DataConditionType[];
   group: string;
   onAddRow: (type: DataConditionType) => void;
-  onDeleteRow: (id: number) => void;
+  onDeleteRow: (id: string) => void;
   placeholder: string;
-  updateCondition: (index: number, condition: Record<string, any>) => void;
-  updateConditionType?: (index: number, type: DataConditionType) => void;
+  updateCondition: (id: string, condition: Record<string, any>) => void;
+  updateConditionType?: (id: string, type: DataConditionType) => void;
 }
 
 export default function DataConditionNodeList({
@@ -40,17 +40,18 @@ export default function DataConditionNodeList({
 
   return (
     <Fragment>
-      {conditions.map((condition, i) => (
+      {conditions.map(condition => (
         <AutomationBuilderRow
-          key={`${group}.conditions.${i}`}
-          onDelete={() => onDeleteRow(i)}
+          key={`${group}.conditions.${condition.id}`}
+          onDelete={() => onDeleteRow(condition.id)}
         >
           <DataConditionNodeContext.Provider
             value={{
               condition,
-              condition_id: `${group}.conditions.${i}`,
-              onUpdate: newCondition => updateCondition(i, newCondition),
-              onUpdateType: type => updateConditionType && updateConditionType(i, type),
+              condition_id: `${group}.conditions.${condition.id}`,
+              onUpdate: newCondition => updateCondition(condition.id, newCondition),
+              onUpdateType: type =>
+                updateConditionType && updateConditionType(condition.id, type),
             }}
           >
             <Node />

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -2,8 +2,8 @@ import {createContext, useContext} from 'react';
 
 import {t} from 'sentry/locale';
 import {
+  type DataCondition,
   DataConditionType,
-  type NewDataCondition,
 } from 'sentry/types/workflowEngine/dataConditions';
 import AgeComparisonNode from 'sentry/views/automations/components/actionFilters/ageComparison';
 import EventAttributeNode from 'sentry/views/automations/components/actionFilters/eventAttribute';
@@ -17,7 +17,7 @@ import PercentSessionsNode from 'sentry/views/automations/components/actionFilte
 import TaggedEventNode from 'sentry/views/automations/components/actionFilters/taggedEvent';
 
 interface DataConditionNodeProps {
-  condition: NewDataCondition;
+  condition: DataCondition;
   condition_id: string;
   onUpdate: (comparison: Record<string, any>) => void;
   onUpdateType: (type: DataConditionType) => void;


### PR DESCRIPTION
we were previously relying on the list indexes to update/remove items, but this was actually causing a bug with the form field `names` when trying to delete rows, since every element would get shifted and take on new `names` that were dependent on the item index

this PR updates the automation builder reducer to give items unique ids to reference each item