### PR TITLE
fix(widget-viewer): Inject table columns if there are no group bys

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1260,24 +1260,25 @@ describe('Modals -> WidgetViewerModal', function () {
 
   describe('Release Health Widgets', function () {
     let metricsMock!: jest.Mock;
-    const mockQuery = {
-      conditions: '',
-      fields: [`sum(session)`],
-      columns: [],
-      aggregates: ['sum(session)'],
-      id: '1',
-      name: 'Query Name',
-      orderby: '',
-    };
-    const mockWidget = {
-      id: '1',
-      title: 'Release Widget',
-      displayType: DisplayType.LINE,
-      interval: '5m',
-      queries: [mockQuery],
-      widgetType: WidgetType.RELEASE,
-    };
+    let mockQuery: WidgetQuery;
+    let mockWidget: Widget;
     beforeEach(function () {
+      mockQuery = {
+        conditions: '',
+        fields: [`sum(session)`],
+        columns: [],
+        aggregates: ['sum(session)'],
+        name: 'Query Name',
+        orderby: '',
+      };
+      mockWidget = {
+        id: '1',
+        title: 'Release Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [mockQuery],
+        widgetType: WidgetType.RELEASE,
+      };
       setMockDate(new Date('2022-08-02'));
       metricsMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/metrics/data/',
@@ -1389,6 +1390,64 @@ describe('Modals -> WidgetViewerModal', function () {
       await waitFor(() => {
         expect(metricsMock).toHaveBeenCalledTimes(2);
       });
+    });
+
+    it('adds the release column to the table if no group by is set', async function () {
+      mockQuery = {
+        conditions: '',
+        fields: [`sum(session)`],
+        columns: [],
+        aggregates: ['sum(session)'],
+        name: 'Query Name',
+        orderby: '',
+      };
+      mockWidget = {
+        id: '1',
+        title: 'Release Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [mockQuery],
+        widgetType: WidgetType.RELEASE,
+      };
+      await renderModal({initialData, widget: mockWidget});
+      expect(await screen.findByText('release')).toBeInTheDocument();
+      expect(metricsMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/metrics/data/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            groupBy: ['release'],
+          }),
+        })
+      );
+    });
+
+    it('does not add a release grouping to the table if a group by is set', async function () {
+      mockQuery = {
+        conditions: '',
+        fields: [],
+        columns: ['environment'],
+        aggregates: ['sum(session)'],
+        name: 'Query Name',
+        orderby: '',
+      };
+      mockWidget = {
+        id: '1',
+        title: 'Release Widget',
+        displayType: DisplayType.LINE,
+        interval: '5m',
+        queries: [mockQuery],
+        widgetType: WidgetType.RELEASE,
+      };
+      await renderModal({initialData, widget: mockWidget});
+      expect(await screen.findByText('environment')).toBeInTheDocument();
+      expect(metricsMock).toHaveBeenCalledWith(
+        '/organizations/org-slug/metrics/data/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            groupBy: ['environment'],
+          }),
+        })
+      );
     });
   });
 

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -320,7 +320,8 @@ function WidgetViewerModal(props: Props) {
     }]`;
   }
 
-  // Default table columns for visualizations that don't have a column setting
+  // Default table columns for visualizations that don't have a group by set
+  const hasGroupBy = (widget.queries[0]?.columns.length ?? 0) > 0;
   const shouldReplaceTableColumns =
     [
       DisplayType.AREA,
@@ -330,7 +331,7 @@ function WidgetViewerModal(props: Props) {
     ].includes(widget.displayType) &&
     widget.widgetType &&
     [WidgetType.DISCOVER, WidgetType.RELEASE].includes(widget.widgetType) &&
-    !defined(widget.limit);
+    !hasGroupBy;
 
   // Updates fields by adding any individual terms from equation fields as a column
   if (!isTableWidget) {


### PR DESCRIPTION
Otherwise the widget viewer table just shows the aggregate and it's pointless.

Closes https://github.com/getsentry/sentry/issues/91922