### PR TITLE
ref(feedback): create a new spam FF to consolidate old flag and misnamed blocklist

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -422,7 +422,9 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:user-feedback-spam-filter-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Block User Feedback spam auto filtering feature ingest
     manager.add("organizations:user-feedback-spam-ingest-blocklist", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable User Feedback spam auto filtering feature actions
+    # Enable auto spam classification at User Feedback ingest time (TODO: use this to replace the two flags above)
+    manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable auto spam filtering at User Feedback ingest time, if spam-ingest is also enabled
     manager.add("organizations:user-feedback-spam-filter-actions", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable User Feedback v2 UI
     manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)


### PR DESCRIPTION
See https://github.com/getsentry/team-replay/issues/582 for plan on how to use this

> these [2 flags](https://github.com/getsentry/sentry/blob/14f67d0690c83424f1d86af64732b968181ce02a/src/sentry/features/temporary.py#L417-L420) should be merged into 1 flagpole flag. The first uses the old INTERNAL feature manager and the second is named in a confusing way (see https://github.com/getsentry/sentry-options-automator/pull/3812 - "allowlist" is more intuitive).