### PR TITLE
feat(trace-items): Allow dashes in trace item attribute names

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -189,13 +189,18 @@ describe('useTraceItemAttributeKeys', () => {
         kind: FieldKind.TAG,
       },
       {
-        key: 'invalid-attribute',
-        name: 'Invalid Attribute',
+        key: 'valid-attribute-with-dash',
+        name: 'Valid Attribute With Dash',
         kind: FieldKind.TAG,
       },
       {
         key: 'another_valid.attribute',
         name: 'Another Valid Attribute',
+        kind: FieldKind.TAG,
+      },
+      {
+        key: 'invalid attribute',
+        name: 'Invalid Attribute',
         kind: FieldKind.TAG,
       },
     ];
@@ -223,6 +228,11 @@ describe('useTraceItemAttributeKeys', () => {
       'valid.attribute': {
         key: 'valid.attribute',
         name: 'Valid Attribute',
+        kind: FieldKind.TAG,
+      },
+      'valid-attribute-with-dash': {
+        key: 'valid-attribute-with-dash',
+        name: 'Valid Attribute With Dash',
         kind: FieldKind.TAG,
       },
       'another_valid.attribute': {

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -61,8 +61,8 @@ export function useTraceItemAttributeKeys({
       // EAP spans contain tags with illegal characters
       // SnQL forbids `-` but is allowed in RPC. So add it back later
       if (
-        !/^[a-zA-Z0-9_.:]+$/.test(attribute.key) &&
-        !/^tags\[[a-zA-Z0-9_.:]+,number\]$/.test(attribute.key)
+        !/^[a-zA-Z0-9_.:-]+$/.test(attribute.key) &&
+        !/^tags\[[a-zA-Z0-9_.:-]+,number\]$/.test(attribute.key)
       ) {
         continue;
       }


### PR DESCRIPTION
Dashes are permitted in the trace item attribute names so add it into the list.

Backend test in #92048

Fixes LOGS-138