### PR TITLE
fix(uptime): Don't consume a seat or create audit log when onboarding an auto detected monitor

### DIFF
--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -7,7 +7,7 @@ from urllib.robotparser import RobotFileParser
 from dateutil.parser import parse as parse_datetime
 from django.utils import timezone
 
-from sentry import audit_log, features
+from sentry import features
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -34,7 +34,6 @@ from sentry.uptime.subscriptions.subscriptions import (
 )
 from sentry.uptime.types import ProjectUptimeSubscriptionMode
 from sentry.utils import metrics
-from sentry.utils.audit import create_system_audit_entry
 from sentry.utils.hashlib import md5_text
 from sentry.utils.locking import UnableToAcquireLock
 
@@ -240,16 +239,10 @@ def process_candidate_url(
         "organizations:uptime-automatic-subscription-creation", project.organization
     ) and features.has("organizations:uptime", project.organization):
         # If we hit this point, then the url looks worth monitoring. Create an uptime subscription in monitor mode.
-        uptime_monitor = monitor_url_for_project(project, url)
+        monitor_url_for_project(project, url)
         # Disable auto-detection on this project and organization now that we've successfully found a hostname
         project.update_option("sentry:uptime_autodetection", False)
         project.organization.update_option("sentry:uptime_autodetection", False)
-        create_system_audit_entry(
-            organization=project.organization,
-            target_object=uptime_monitor.id,
-            event=audit_log.get_event_id("UPTIME_MONITOR_ADD"),
-            data=uptime_monitor.get_audit_log_data(),
-        )
 
     metrics.incr("uptime.detectors.candidate_url.succeeded", sample_rate=1.0)
     return True

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -361,6 +361,19 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
         )
         mock_disable_uptime_detector.assert_called()
 
+    @mock.patch("sentry.uptime.subscriptions.subscriptions.disable_uptime_detector")
+    def test_status_disable_not_called_onboarding(self, mock_disable_uptime_detector):
+        create_project_uptime_subscription(
+            self.project,
+            self.environment,
+            url="https://sentry.io",
+            interval_seconds=3600,
+            timeout_ms=1000,
+            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            status=ObjectStatus.DISABLED,
+        )
+        mock_disable_uptime_detector.assert_not_called()
+
     @mock.patch("sentry.uptime.subscriptions.subscriptions.enable_uptime_detector")
     def test_status_enable(self, mock_enable_uptime_detector):
         with self.tasks():
@@ -376,6 +389,20 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             detector = get_detector(proj_sub.uptime_subscription)
             assert detector
             mock_enable_uptime_detector.assert_called_with(detector, ensure_assignment=True)
+
+    @mock.patch("sentry.uptime.subscriptions.subscriptions.enable_uptime_detector")
+    def test_status_enable_not_called_onboarding(self, mock_enable_uptime_detector):
+        with self.tasks():
+            create_project_uptime_subscription(
+                self.project,
+                self.environment,
+                url="https://sentry.io",
+                interval_seconds=3600,
+                timeout_ms=1000,
+                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+                status=ObjectStatus.ACTIVE,
+            )
+            mock_enable_uptime_detector.assert_not_called()
 
     @mock.patch(
         "sentry.quotas.backend.check_assign_seat",


### PR DESCRIPTION
Users don't see onboarding monitors, and so they shouldn't consume a quota seat or create an audit log. This pr moves this to the point where the monitor graduates from onboarding.