### PR TITLE
fix(ourlogs): Add hardcoded timestamp to filter

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -65,6 +65,7 @@ export const SENTRY_LOG_STRING_TAGS: string[] = [
   OurLogKnownFieldKey.ID,
   OurLogKnownFieldKey.MESSAGE,
   OurLogKnownFieldKey.SEVERITY,
+  OurLogKnownFieldKey.TIMESTAMP,
 ];
 
 export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NUMBER];


### PR DESCRIPTION
### Summary
It's not an attribute but is always present in EAP, this permanently adds it to the filter.


