### PR TITLE
fix(previews): Fix missing user in useIsSentryEmployee

### DIFF
--- a/static/app/utils/useIsSentryEmployee.ts
+++ b/static/app/utils/useIsSentryEmployee.ts
@@ -8,9 +8,9 @@ import {useUser} from 'sentry/utils/useUser';
  * @return {boolean} - Returns true if the user is a Sentry employee, otherwise false.
  */
 export function useIsSentryEmployee(): boolean {
-  const {emails} = useUser();
+  const user = useUser();
 
-  return emails.some(
+  return user?.emails.some(
     // TODO: In the near future isStaff should actually mean is a Sentry employee, right now it doesn't.
     ({email, is_verified}) => email.endsWith('@sentry.io') && is_verified
   );


### PR DESCRIPTION
I am not sure what changed, or why user is not in the config store on initial load, but in vercel previews I am getting this error: 

![CleanShot 2025-05-21 at 13 20 25](https://github.com/user-attachments/assets/fac2f2e1-bf3b-41bd-876f-5ef9872db0fa)

This fixes it for now, but we may want to change `useUser()` to `User | undefined` if this is a possibility, or prevent it from being so.
