### PR TITLE
fix(insights): domain selector not working in eap

### DIFF
--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -91,14 +91,14 @@ export function DomainSelector({
   const incomingDomains: Array<{label: string; value: string}> = [
     ...uniq(
       domainData?.flatMap(row => {
-        const spanDomain = row[SpanMetricsField.SPAN_DOMAIN];
-        if (useEap) {
-          return spanDomain?.split(',').map(domain => ({
+        const spanDomain: string | string[] = row[SpanMetricsField.SPAN_DOMAIN];
+        if (typeof spanDomain === 'string') {
+          return spanDomain.split(',').map(domain => ({
             label: domain,
             value: `*${domain}*`,
           }));
         }
-        return spanDomain?.map(domain => ({
+        return spanDomain.map(domain => ({
           label: domain,
           value: domain,
         }));

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -92,6 +92,7 @@ export function DomainSelector({
     ...uniq(
       domainData?.flatMap(row => {
         const spanDomain: string | string[] = row[SpanMetricsField.SPAN_DOMAIN];
+        // `useInsightsEap` returns a string, but `metrics` returns an array
         if (typeof spanDomain === 'string') {
           return spanDomain.split(',').map(domain => ({
             label: domain,

--- a/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/domainSelector.tsx
@@ -88,31 +88,30 @@ export function DomainSelector({
     pageLinks,
   });
 
-  const incomingDomains: Array<{label: string; value: string}> = [
+  const incomingDomains = [
     ...uniq(
       domainData?.flatMap(row => {
         const spanDomain: string | string[] = row[SpanMetricsField.SPAN_DOMAIN];
         // `useInsightsEap` returns a string, but `metrics` returns an array
         if (typeof spanDomain === 'string') {
-          return spanDomain.split(',').map(domain => ({
-            label: domain,
-            value: `*${domain}*`,
-          }));
+          return spanDomain.split(',');
         }
-        return spanDomain.map(domain => ({
-          label: domain,
-          value: domain,
-        }));
+        return spanDomain;
       })
-    ),
+    ).filter(Boolean),
   ];
+
+  const domainList = incomingDomains.map(domain => ({
+    label: domain,
+    value: useEap ? `*${domain}*` : domain,
+  }));
 
   if (value) {
     const scrubbedValue = useEap
       ? value.replace(/^\*(.*)\*$/, '$1') // removes wildcards, only if they are at the beginning and end of the string
       : value;
 
-    incomingDomains.push({
+    domainList.push({
       label: scrubbedValue,
       value,
     });
@@ -120,7 +119,7 @@ export function DomainSelector({
 
   const {options: domainOptions, clear: clearDomainOptionsCache} =
     useCompactSelectOptionsCache(
-      incomingDomains
+      domainList
         .filter(domain => Boolean(domain?.label))
         .filter(domain => domain.value !== EMPTY_OPTION_VALUE)
     );

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -169,7 +169,8 @@ type SpanStringFields =
   | 'replayId'
   | 'profile.id'
   | 'profiler.id'
-  | 'thread.id';
+  | 'thread.id'
+  | 'span.domain'; // TODO: With `useInsightsEap` we get a string, without it we get an array
 
 export type SpanMetricsQueryFilters = Partial<Record<SpanStringFields, string>> & {
   [SpanMetricsField.PROJECT_ID]?: string;


### PR DESCRIPTION
Fixes several issues with the domain selector in eap

In eap, the `span.domain` field comes back as a string, whereas in the metrics it would come back as an array because the backend would split by `','` in the database. The eap rpc does not support splitting by `,`, therefore for now we have to do this in the frontend. To make the span.domain filter work, we wrap the domain value with wildcards.

For example:
1. span.domain for the db module comes back as `',table1,table2,'`
2. The frontend splits this result to produce `[table1, table2]` to populate the domain selector
3. when you select `table1` in the selector, the query gets populated with `span.domain:*table1*`

This fixes another issue where comma's would appear in the domain selector
Before
![image](https://github.com/user-attachments/assets/b9269dd8-2fb3-4220-bb2c-68424ee5c1d0)

After
![image](https://github.com/user-attachments/assets/60da37d9-63be-4ff0-ada1-587591c6813c)
