### PR TITLE
build(ui): Only annotate react components in production

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -784,7 +784,8 @@ appConfig.plugins?.push(
       create: false,
     },
     reactComponentAnnotation: {
-      enabled: true,
+      // Enabled only in production because annotating is slow
+      enabled: IS_PRODUCTION,
     },
     bundleSizeOptimizations: {
       // This is enabled so that our SDKs send exceptions to Sentry

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -823,7 +823,8 @@ appConfig.plugins?.push(
       create: false,
     },
     reactComponentAnnotation: {
-      enabled: true,
+      // Enabled only in production because annotating is slow
+      enabled: IS_PRODUCTION,
     },
     bundleSizeOptimizations: {
       // This is enabled so that our SDKs send exceptions to Sentry


### PR DESCRIPTION
Removes 20 seconds from rspack dev startup time. Unknown on webpack.

before - measured via `yarn dev-ui` with rsdoctor enabled

![image](https://github.com/user-attachments/assets/02edd223-18e1-451f-9968-271e31a63517)

after

![image](https://github.com/user-attachments/assets/12f446eb-a2be-4851-be35-2c6eb9ef2fae)
