### PR TITLE
feat(explore): Better autocompletion of numeric attributes

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -36,6 +36,7 @@ interface SearchQueryBuilderContextData {
   filterKeys: TagCollection;
   focusOverride: FocusOverride | null;
   getFieldDefinition: (key: string, kind?: FieldKind) => FieldDefinition | null;
+  getSuggestedFilterKey: (key: string) => string | null;
   getTagValues: (tag: Tag, query: string) => Promise<string[]>;
   handleSearch: (query: string) => void;
   parseQuery: (query: string) => ParseResult | null;
@@ -78,6 +79,7 @@ export function SearchQueryBuilderProvider({
   filterKeys,
   filterKeyMenuWidth = 360,
   filterKeySections,
+  getSuggestedFilterKey,
   getTagValues,
   onSearch,
   placeholder,
@@ -139,6 +141,7 @@ export function SearchQueryBuilderProvider({
       filterKeySections: filterKeySections ?? [],
       filterKeyMenuWidth,
       filterKeys,
+      getSuggestedFilterKey: getSuggestedFilterKey ?? ((key: string) => key),
       getTagValues,
       getFieldDefinition: fieldDefinitionGetter,
       dispatch,
@@ -160,6 +163,7 @@ export function SearchQueryBuilderProvider({
     filterKeySections,
     filterKeyMenuWidth,
     filterKeys,
+    getSuggestedFilterKey,
     getTagValues,
     fieldDefinitionGetter,
     dispatch,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -90,8 +90,8 @@ const FILTER_KEYS: TagCollection = {
     key: 'tags[foo,string]',
     name: 'foo',
   },
-  'tags[bar,string]': {
-    key: 'tags[bar,string]',
+  'tags[bar,number]': {
+    key: 'tags[bar,number]',
     name: 'bar',
   },
 };
@@ -3456,6 +3456,92 @@ describe('SearchQueryBuilder', function () {
       const option = screen.getByRole('option', {name: 'bar'});
       expect(option).toBeInTheDocument();
       expect(option).toHaveTextContent('bar');
+    });
+  });
+
+  describe('autocomplete using suggestions', function () {
+    function getSuggestedFilterKey(key: string) {
+      if (key === 'foo') {
+        return 'tags[foo,string]';
+      }
+
+      if (key === 'bar') {
+        return 'tags[bar,number]';
+      }
+
+      return key;
+    }
+
+    it('replace string key with suggestion when autocompleting', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          getSuggestedFilterKey={getSuggestedFilterKey}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('foo:');
+      await userEvent.keyboard('{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit key for filter: tags[foo,string]'})
+      ).toHaveTextContent('foo');
+    });
+
+    it('replace number key with suggestion when autocompleting', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          getSuggestedFilterKey={getSuggestedFilterKey}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('bar:');
+      await userEvent.keyboard('{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit key for filter: tags[bar,number]'})
+      ).toHaveTextContent('bar');
+    });
+
+    it('replaces string key with suggestion on enter', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:firefox"
+          getSuggestedFilterKey={getSuggestedFilterKey}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit key for filter: browser.name'})
+      );
+      await userEvent.keyboard('foo{Enter}{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit key for filter: tags[foo,string]'})
+      ).toHaveTextContent('foo');
+    });
+
+    it('replaces number key with suggestion on enter', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:firefox"
+          getSuggestedFilterKey={getSuggestedFilterKey}
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit key for filter: browser.name'})
+      );
+      await userEvent.keyboard('bar{Enter}{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit key for filter: tags[bar,number]'})
+      ).toHaveTextContent('bar');
     });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -82,8 +82,10 @@ export interface SearchQueryBuilderProps {
    */
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   /**
-   * A function that maps user input to a suggested column. This is used
-   * to autocomplete user input if it's definitive what they're looking for.
+   * This is used when a user types in a search key and submits the token.
+   * The submission happens when the user types a colon or presses enter.
+   * When this happens, this function is used to map the user input to a
+   * known column.
    */
   getSuggestedFilterKey?: (key: string) => string | null;
   /**

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -82,6 +82,11 @@ export interface SearchQueryBuilderProps {
    */
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   /**
+   * A function that maps user input to a suggested column. This is used
+   * to autocomplete user input if it's definitive what they're looking for.
+   */
+  getSuggestedFilterKey?: (key: string) => string | null;
+  /**
    * Allows for customization of the invalid token messages.
    */
   invalidMessages?: SearchConfig['invalidMessages'];

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -33,7 +33,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     inputValue,
     includeSuggestions: false,
   });
-  const {dispatch, getFieldDefinition} = useSearchQueryBuilder();
+  const {dispatch, getFieldDefinition, getSuggestedFilterKey} = useSearchQueryBuilder();
 
   const currentFilterValueType = getFilterValueType(
     token,
@@ -88,6 +88,13 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
     [handleSelectKey]
   );
 
+  const onValueCommited = useCallback(
+    (keyName: string) => {
+      handleSelectKey(getSuggestedFilterKey(keyName) ?? keyName);
+    },
+    [handleSelectKey, getSuggestedFilterKey]
+  );
+
   const onCustomValueBlurred = useCallback(() => {
     onCommit();
   }, [onCommit]);
@@ -103,7 +110,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
         items={sortedFilterKeys}
         placeholder={getKeyLabel(token.key)}
         onOptionSelected={onOptionSelected}
-        onCustomValueCommitted={handleSelectKey}
+        onCustomValueCommitted={onValueCommited}
         onCustomValueBlurred={onCustomValueBlurred}
         onExit={onExit}
         inputValue={inputValue}

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -254,6 +254,7 @@ function SearchQueryBuilderInputInternal({
     filterKeys,
     dispatch,
     getFieldDefinition,
+    getSuggestedFilterKey,
     handleSearch,
     placeholder,
     searchSource,
@@ -516,7 +517,7 @@ function SearchQueryBuilderInputInternal({
                 textToken.type === Token.FILTER && textToken.key.text === filterValue
             )
           ) {
-            const filterKey = filterValue;
+            const filterKey = getSuggestedFilterKey(filterValue) ?? filterValue;
             const key = filterKeys[filterKey];
             dispatch({
               type: 'UPDATE_FREE_TEXT',

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {getHasTag} from 'sentry/components/events/searchBar';
 import type {EAPSpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
@@ -76,6 +76,25 @@ export function useSearchQueryBuilderProps({
     projectIds: projects,
   });
 
+  const getSuggestedFilterKey = useCallback(
+    (key: string) => {
+      // prioritize exact matches first
+      if (filterTags.hasOwnProperty(key)) {
+        return key;
+      }
+
+      // try to see if there's numeric attribute by the same name
+      const explicitNumberTag = `tags[${key},number]`;
+      if (filterTags.hasOwnProperty(explicitNumberTag)) {
+        return explicitNumberTag;
+      }
+
+      // give up, and fall back to the default behaviour
+      return null;
+    },
+    [filterTags]
+  );
+
   return {
     searchOnChange: organization.features.includes('ui-search-on-change'),
     placeholder: placeholderText,
@@ -88,6 +107,7 @@ export function useSearchQueryBuilderProps({
     getFilterTokenWarning,
     searchSource,
     filterKeySections,
+    getSuggestedFilterKey,
     getTagValues: getTraceItemAttributeValues,
     disallowUnsupportedFilters: true,
     recentSearches: itemTypeToRecentSearches(itemType),


### PR DESCRIPTION
It's quite tedious to have to type in `tags[...,number]` for the search bar to pick up it's a numeric attribute. This introduces a shortcut via suggested filter keys that let's users type in `<key name>:` and tries to pick a known key name that "matches" the user input. In explore spans + logs, the heuristic is simply try the name as the numeric attribute, and use it if it exists.

Complementary to #91986 to improve the autocomplete experience while typing.

Closes EXP-294