### PR TITLE
chore(ACI): Update metric issue dual processing metrics

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -498,7 +498,7 @@ class SubscriptionProcessor:
                             "organizations:workflow-engine-metric-alert-dual-processing-logs",
                             self.subscription.project.organization,
                         ):
-                            metrics.incr("dual_processing.alert_rules.fire")
+                            metrics.incr("dual_processing.alert_rules.resolve")
                         incident_trigger = self.trigger_resolve_threshold(
                             trigger, aggregation_value
                         )

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -313,9 +313,10 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
             },
         )
     # in order to check if workflow engine is firing 1:1 with the old system, we must only count once rather than each action
-    metrics.incr(
-        "workflow_engine.process_workflows.fired_actions",
-        tags={"detector_type": detector.type},
-    )
+    if len(actions) > 0:
+        metrics.incr(
+            "workflow_engine.process_workflows.fired_actions",
+            tags={"detector_type": detector.type},
+        )
 
     return triggered_workflows

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1285,7 +1285,7 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                     tags={"detection_type": "static"},
                 ),
                 call(
-                    "dual_processing.alert_rules.fire",
+                    "dual_processing.alert_rules.resolve",
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "resolve"}),
             ]

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -301,18 +301,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
             tags={"detector_type": self.error_detector.type},
         )
 
-    @with_feature("organizations:workflow-engine-process-workflows")
-    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
-    @patch("sentry.utils.metrics.incr")
-    def test_metrics_issue_dual_processing_metrics(self, mock_incr):
-        process_workflows(self.event_data)
-        mock_incr.assert_any_call(
-            "workflow_engine.process_workflows.fired_actions",
-            tags={
-                "detector_type": self.error_detector.type,
-            },
-        )
-
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     def setUp(self):
@@ -542,6 +530,18 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
         )
         self.event_data = WorkflowEventData(event=self.group_event)
+
+    @with_feature("organizations:workflow-engine-process-workflows")
+    @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @patch("sentry.utils.metrics.incr")
+    def test_metrics_issue_dual_processing_metrics(self, mock_incr):
+        process_workflows(self.event_data)
+        mock_incr.assert_any_call(
+            "workflow_engine.process_workflows.fired_actions",
+            tags={
+                "detector_type": self.detector.type,
+            },
+        )
 
     def test_basic__no_filter(self):
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/91979 to only track when there is at least one action in `process_workflows` and differentiate between fires and resolves in the subscription processor. Previously I wanted them added together but now that we've realized we're not reaching `process_workflows` for resolutions I want to be able to determine if the number of fires is accurate.