### PR TITLE
fix(aci): 404 for non-digit IDs in endpoints

### DIFF
--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -28,7 +28,7 @@ from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
 
 organization_urlpatterns = [
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/detectors/(?P<detector_id>[^\/]+)/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/detectors/(?P<detector_id>\d+)/$",
         OrganizationDetectorDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-detector-details",
     ),
@@ -43,12 +43,12 @@ organization_urlpatterns = [
         name="sentry-api-0-organization-detector-index",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>\d+)/$",
         OrganizationWorkflowDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-details",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>[^\/]+)/group-history$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/workflows/(?P<workflow_id>\d+)/group-history$",
         OrganizationWorkflowGroupHistoryEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-group-history",
     ),
@@ -68,7 +68,7 @@ organization_urlpatterns = [
         name="sentry-api-0-organization-detector-workflow-index",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/detector-workflow/(?P<detector_workflow_id>[^\/]+)/$",
+        r"^(?P<organization_id_or_slug>[^\/]+)/detector-workflow/(?P<detector_workflow_id>\d+)/$",
         OrganizationDetectorWorkflowDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-detector-workflow-details",
     ),

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -14,6 +14,7 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
+from sentry.testutils.asserts import assert_status_code
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -90,6 +91,15 @@ class OrganizationDetectorDetailsGetTest(OrganizationDetectorDetailsBaseTest):
 
     def test_does_not_exist(self):
         self.get_error_response(self.organization.slug, 3, status_code=404)
+
+    def test_malformed_id(self):
+        from django.urls import reverse
+
+        # get_error_response can't generate an invalid URL, so we have to
+        # generate a correct one and replace the valid ID with an invalid one.
+        good_url = reverse(self.endpoint, args=[self.organization.slug, 7654])
+        bad_url = good_url.replace("7654", "not-an-id")
+        assert_status_code(self.client.get(bad_url), 404)
 
 
 @region_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -96,7 +96,7 @@ class OrganizationDeleteWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
     def test_does_not_exist(self):
         with outbox_runner():
-            response = self.get_error_response(self.organization.slug, -1)
+            response = self.get_error_response(self.organization.slug, 999999999)
             assert response.status_code == 404
 
         # Ensure it wasn't deleted


### PR DESCRIPTION
Change our URL regexes to only recognize numeric IDs.

This doesn't avoid issues from  >2**64 numbers, but we can come back with a Model.id-bounds-aware ID parser on all endpoints if that ends up mattering. 

Fixes #92083 
