### PR TITLE
fix(symbolicator): use `requests` implementation instead of abstract class

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -15,7 +15,7 @@ from cachetools.func import ttl_cache
 from django.conf import settings
 from django.urls import reverse
 from google.auth import impersonated_credentials
-from google.auth.transport import Request
+from google.auth.transport.requests import Request
 from rediscluster import RedisCluster
 
 from sentry import features, options


### PR DESCRIPTION
Fixes this issue:
```
>>> from sentry.lang.native.sources import get_gcp_token
>>> t = get_gcp_token(client_email)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/.venv/lib/python3.13/site-packages/cachetools/__init__.py", line 702, in wrapper
    v = func(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/lang/native/sources.py", line 630, in get_gcp_token
    target_credentials.refresh(Request())
                               ~~~~~~~^^
TypeError: Can't instantiate abstract class Request without an implementation for abstract method '__call__'
```

We need to use `requests` implementation instead of abstract class