### PR TITLE
ref(platform-insights): Make traffic charts loadable

### DIFF
--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -155,8 +155,12 @@ jest.mock(
 jest.mock('sentry/views/insights/common/queries/useDiscoverSeries', () => ({
   useEAPSeries: jest.fn(() => ({
     data: {
+      'count(span.duration)': mockDiscoverSeries('count(span.duration)'),
       'avg(span.duration)': mockDiscoverSeries('avg(span.duration)'),
       'p95(span.duration)': mockDiscoverSeries('p95(span.duration)'),
+      'trace_status_rate(internal_error)': mockDiscoverSeries(
+        'trace_status_rate(internal_error)'
+      ),
     },
     isPending: false,
     error: null,

--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -159,6 +159,12 @@ const CHART_MAP = {
     import(
       'sentry/views/insights/common/components/widgets/overviewApiLatencyChartWidget'
     ),
+  overviewPageloadsChartWidget: () =>
+    import(
+      'sentry/views/insights/common/components/widgets/overviewPageloadsChartWidget'
+    ),
+  overviewRequestsChartWidget: () =>
+    import('sentry/views/insights/common/components/widgets/overviewRequestsChartWidget'),
 } satisfies Record<string, () => Promise<{default: React.FC<LoadableChartWidgetProps>}>>;
 
 /**

--- a/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
@@ -58,6 +58,7 @@ export default function OverviewApiLatencyChartWidget(props: LoadableChartWidget
       visualizationProps={{
         id: 'overviewApiLatencyChartWidget',
         plottables,
+        ...props,
         ...releaseBubbleProps,
       }}
     />
@@ -82,6 +83,7 @@ export default function OverviewApiLatencyChartWidget(props: LoadableChartWidget
               query: fullQuery,
               interval: pageFilterChartParams.interval,
             }}
+            loaderSource={props.loaderSource}
             onOpenFullScreen={() => {
               openInsightChartModal({
                 title: t('API Latency'),

--- a/static/app/views/insights/common/components/widgets/overviewPageloadsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewPageloadsChartWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
+
+export default function OverviewPageloadsChartWidget(props: LoadableChartWidgetProps) {
+  return (
+    <BaseTrafficWidget
+      id="overviewPageloadsChartWidget"
+      title={t('Pageloads')}
+      trafficSeriesName={t('Pageloads')}
+      baseQuery={'span.op:[pageload]'}
+      {...props}
+    />
+  );
+}

--- a/static/app/views/insights/common/components/widgets/overviewRequestsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewRequestsChartWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
+
+export default function OverviewRequestsChartWidget(props: LoadableChartWidgetProps) {
+  return (
+    <BaseTrafficWidget
+      id="overviewRequestsChartWidget"
+      title={t('Requests')}
+      trafficSeriesName={t('Requests')}
+      baseQuery={'span.op:http.server'}
+      {...props}
+    />
+  );
+}

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -8,7 +8,6 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {PageAlert} from 'sentry/utils/performance/contexts/pageAlert';
@@ -26,6 +25,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import OverviewApiLatencyChartWidget from 'sentry/views/insights/common/components/widgets/overviewApiLatencyChartWidget';
+import OverviewRequestsChartWidget from 'sentry/views/insights/common/components/widgets/overviewRequestsChartWidget';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
@@ -58,7 +58,6 @@ import {
 } from 'sentry/views/insights/pages/platform/nextjs/features';
 import {NewNextJsExperienceButton} from 'sentry/views/insights/pages/platform/nextjs/newNextjsExperienceToggle';
 import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWidget';
-import {TrafficWidget} from 'sentry/views/insights/pages/platform/shared/trafficWidget';
 import {TransactionNameSearchBar} from 'sentry/views/insights/pages/transactionNameSearchBar';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 import {categorizeProjects} from 'sentry/views/insights/pages/utils';
@@ -238,11 +237,7 @@ function EAPBackendOverviewPage() {
               <Fragment>
                 <ModuleLayout.Third>
                   <StackedWidgetWrapper>
-                    <TrafficWidget
-                      title={t('Requests')}
-                      trafficSeriesName={t('Requests')}
-                      baseQuery={'span.op:http.server'}
-                    />
+                    <OverviewRequestsChartWidget />
                     <OverviewApiLatencyChartWidget />
                   </StackedWidgetWrapper>
                 </ModuleLayout.Third>

--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -1,9 +1,9 @@
 import {useEffect} from 'react';
 
-import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import OverviewApiLatencyChartWidget from 'sentry/views/insights/common/components/widgets/overviewApiLatencyChartWidget';
+import OverviewRequestsChartWidget from 'sentry/views/insights/common/components/widgets/overviewRequestsChartWidget';
 import {CachesWidget} from 'sentry/views/insights/pages/platform/laravel/cachesWidget';
 import {JobsWidget} from 'sentry/views/insights/pages/platform/laravel/jobsWidget';
 import {QueriesWidget} from 'sentry/views/insights/pages/platform/laravel/queriesWidget';
@@ -11,7 +11,6 @@ import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWi
 import {PlatformLandingPageLayout} from 'sentry/views/insights/pages/platform/shared/layout';
 import {PathsTable} from 'sentry/views/insights/pages/platform/shared/pathsTable';
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
-import {TrafficWidget} from 'sentry/views/insights/pages/platform/shared/trafficWidget';
 
 export function LaravelOverviewPage() {
   const organization = useOrganization();
@@ -27,11 +26,7 @@ export function LaravelOverviewPage() {
     <PlatformLandingPageLayout performanceType={'backend'}>
       <WidgetGrid>
         <WidgetGrid.Position1>
-          <TrafficWidget
-            title={t('Requests')}
-            trafficSeriesName={t('Requests')}
-            baseQuery={'span.op:http.server'}
-          />
+          <OverviewRequestsChartWidget />
         </WidgetGrid.Position1>
         <WidgetGrid.Position2>
           <OverviewApiLatencyChartWidget />

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -9,6 +9,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import OverviewApiLatencyChartWidget from 'sentry/views/insights/common/components/widgets/overviewApiLatencyChartWidget';
+import OverviewPageloadsChartWidget from 'sentry/views/insights/common/components/widgets/overviewPageloadsChartWidget';
 import {DeadRageClicksWidget} from 'sentry/views/insights/pages/platform/nextjs/deadRageClickWidget';
 import SSRTreeWidget from 'sentry/views/insights/pages/platform/nextjs/ssrTreeWidget';
 import {WebVitalsWidget} from 'sentry/views/insights/pages/platform/nextjs/webVitalsWidget';
@@ -17,7 +18,6 @@ import {PlatformLandingPageLayout} from 'sentry/views/insights/pages/platform/sh
 import {PagesTable} from 'sentry/views/insights/pages/platform/shared/pagesTable';
 import {PathsTable} from 'sentry/views/insights/pages/platform/shared/pathsTable';
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
-import {TrafficWidget} from 'sentry/views/insights/pages/platform/shared/trafficWidget';
 
 enum TableType {
   API = 'api',
@@ -90,11 +90,7 @@ export function NextJsOverviewPage({
     <PlatformLandingPageLayout performanceType={performanceType}>
       <WidgetGrid>
         <WidgetGrid.Position1>
-          <TrafficWidget
-            title={t('Pageloads')}
-            trafficSeriesName={t('Pageloads')}
-            baseQuery={'span.op:[pageload]'}
-          />
+          <OverviewPageloadsChartWidget />
         </WidgetGrid.Position1>
         <WidgetGrid.Position2>
           <OverviewApiLatencyChartWidget />

--- a/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
@@ -10,6 +10,7 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
@@ -20,18 +21,24 @@ import {ModalChartContainer} from 'sentry/views/insights/pages/platform/shared/s
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
-export function TrafficWidget({
-  title,
-  trafficSeriesName,
-  baseQuery,
-}: {
+interface TrafficWidgetProps extends LoadableChartWidgetProps {
   title: string;
   trafficSeriesName: string;
   baseQuery?: string;
-}) {
+}
+
+export function BaseTrafficWidget({
+  title,
+  trafficSeriesName,
+  baseQuery,
+  ...props
+}: TrafficWidgetProps) {
   const organization = useOrganization();
-  const releaseBubbleProps = useReleaseBubbleProps();
-  const pageFilterChartParams = usePageFilterChartParams({granularity: 'spans-low'});
+  const releaseBubbleProps = useReleaseBubbleProps(props);
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+    pageFilters: props.pageFilters,
+  });
   const {query} = useTransactionNameQuery();
   const theme = useTheme();
 
@@ -44,7 +51,8 @@ export function TrafficWidget({
       yAxis: ['trace_status_rate(internal_error)', 'count(span.duration)'],
       referrer: Referrer.REQUESTS_CHART,
     },
-    Referrer.REQUESTS_CHART
+    Referrer.REQUESTS_CHART,
+    props.pageFilters
   );
 
   const plottables = useMemo(() => {
@@ -76,7 +84,9 @@ export function TrafficWidget({
       isEmpty={isEmpty}
       VisualizationType={TimeSeriesWidgetVisualization}
       visualizationProps={{
+        id: props.id,
         plottables,
+        ...props,
         ...releaseBubbleProps,
       }}
     />
@@ -103,6 +113,7 @@ export function TrafficWidget({
               query: fullQuery,
               interval: pageFilterChartParams.interval,
             }}
+            loaderSource={props.loaderSource}
             onOpenFullScreen={() => {
               openInsightChartModal({
                 title,

--- a/static/app/views/insights/pages/platform/shared/toolbar.tsx
+++ b/static/app/views/insights/pages/platform/shared/toolbar.tsx
@@ -6,15 +6,17 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 
 type ExploreParams = Parameters<typeof getExploreUrl>[0];
 
 interface ToolbarProps {
   onOpenFullScreen: () => void;
   exploreParams?: Omit<ExploreParams, 'organization' | 'selection'>;
+  loaderSource?: LoadableChartWidgetProps['loaderSource'];
 }
 
-export function Toolbar({exploreParams, onOpenFullScreen}: ToolbarProps) {
+export function Toolbar({exploreParams, onOpenFullScreen, loaderSource}: ToolbarProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const exploreUrl =
@@ -44,13 +46,15 @@ export function Toolbar({exploreParams, onOpenFullScreen}: ToolbarProps) {
           ]}
         />
       ) : null}
-      <Button
-        size="xs"
-        aria-label={t('Open Full-Screen View')}
-        borderless
-        icon={<IconExpand />}
-        onClick={onOpenFullScreen}
-      />
+      {loaderSource !== 'releases-drawer' && (
+        <Button
+          size="xs"
+          aria-label={t('Open Full-Screen View')}
+          borderless
+          icon={<IconExpand />}
+          onClick={onOpenFullScreen}
+        />
+      )}
     </Widget.WidgetToolbar>
   );
 }


### PR DESCRIPTION
Make traffic charts loadable in the releases drawer.
Hide fullscreen button when rendered in drawer.
<img width="1417" alt="Screenshot 2025-05-22 at 14 06 38" src="https://github.com/user-attachments/assets/eeceb73d-2b00-43d4-b824-72dd7b84ff6b" />

- part of [TET-379: Make widgets re-usable in releases drawer](https://linear.app/getsentry/issue/TET-379/make-widgets-re-usable-in-releases-drawer)