### PR TITLE
fix(symbolicator): fetch gcp token for alias sources

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -567,22 +567,16 @@ def get_sources_for_project(project):
             # processing at this point.
             logger.exception("Invalid symbolicator source config")
 
-    def resolve_alias(source):
+    def resolve_alias(source, organization):
         for key in source.get("sources") or ():
             other_source = settings.SENTRY_BUILTIN_SOURCES.get(key)
             if other_source:
                 if other_source.get("type") == "alias":
-                    yield from resolve_alias(other_source)
+                    yield from resolve_alias(other_source, organization)
                 else:
-                    yield other_source
+                    yield fetch_token_for_gcp_source(other_source, organization)
 
-    # Add builtin sources last to ensure that custom sources have precedence
-    # over our defaults.
-    builtin_sources = project.get_option("sentry:builtin_symbol_sources")
-    for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
-        if key not in builtin_sources:
-            continue
-
+    def fetch_token_for_gcp_source(source, organization):
         if features.has("organizations:gcp-bearer-token-authentication", organization):
             if source.get("type") == "gcs":
                 client_email = source.get("client_email")
@@ -598,13 +592,22 @@ def get_sources_for_project(project):
                     if "private_key" in source:
                         del source["private_key"]
 
+        return source
+
+    # Add builtin sources last to ensure that custom sources have precedence
+    # over our defaults.
+    builtin_sources = project.get_option("sentry:builtin_symbol_sources")
+    for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
+        if key not in builtin_sources:
+            continue
+
         # special internal alias type expands to more than one item.  This
         # is used to make `apple` expand to `ios`/`macos` and other
         # sources if configured as such.
         if source.get("type") == "alias":
-            sources.extend(resolve_alias(source))
+            sources.extend(resolve_alias(source, organization))
         else:
-            sources.append(source)
+            sources.append(fetch_token_for_gcp_source(source, organization))
 
     return sources
 

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -1,9 +1,16 @@
+from unittest.mock import patch
+
 import jsonschema
 import pytest
 from django.conf import settings
+from django.test import override_settings
 
-from sentry.lang.native.sources import BUILTIN_SOURCE_SCHEMA, filter_ignored_sources
-from sentry.testutils.helpers import override_options
+from sentry.lang.native.sources import (
+    BUILTIN_SOURCE_SCHEMA,
+    filter_ignored_sources,
+    get_sources_for_project,
+)
+from sentry.testutils.helpers import Feature, override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -11,6 +18,73 @@ from sentry.testutils.pytest.fixtures import django_db_all
 def test_validate_builtin_sources():
     for source in settings.SENTRY_BUILTIN_SOURCES.values():
         jsonschema.validate(source, BUILTIN_SOURCE_SCHEMA)
+
+
+SENTRY_BUILTIN_SOURCES_TEST = {
+    "aaa": {
+        "id": "sentry:builtin-aaa",
+        "name": "aaa",
+        "type": "gcs",
+        "client_email": "application@project-id.iam.gserviceaccount.com",
+        "private_key": "FAKE_PRIVATE_KEY_STRING",
+    },
+    "bbb": {
+        "id": "sentry:builtin-bbb",
+        "name": "bbb",
+        "type": "gcs",
+        "client_email": "application@project-id.iam.gserviceaccount.com",
+        "private_key": "FAKE_PRIVATE_KEY_STRING",
+    },
+    "ccc": {"id": "sentry:builtin-ccc", "name": "ccc", "type": "alias", "sources": ["aaa", "bbb"]},
+}
+
+
+class TestGcpBearerAuthentication:
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    @patch("sentry.lang.native.sources.get_gcp_token")
+    @django_db_all
+    def test_sources_gcp_bearer_authentication(self, mock_get_gcp_token, default_project):
+        mock_get_gcp_token.return_value = "ya29.TOKEN"
+        features = {
+            "organizations:symbol-sources": True,
+            "organizations:gcp-bearer-token-authentication": True,
+        }
+        default_project.update_option("sentry:builtin_symbol_sources", ["aaa", "bbb"])
+
+        with Feature(features):
+            sources = get_sources_for_project(default_project)
+
+        for i in (1, 2):
+            assert "client_email" not in sources[i]
+            assert "private_key" not in sources[i]
+            assert sources[i]["bearer_token"] == "ya29.TOKEN"
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    @patch("sentry.lang.native.sources.get_gcp_token")
+    @django_db_all
+    def test_source_alias(self, mock_get_gcp_token, default_project):
+        mock_get_gcp_token.return_value = "ya29.TOKEN"
+        features = {
+            "organizations:symbol-sources": True,
+            "organizations:gcp-bearer-token-authentication": True,
+        }
+        default_project.update_option("sentry:builtin_symbol_sources", ["ccc"])
+
+        with Feature(features):
+            sources = get_sources_for_project(default_project)
+
+        # Make sure that we expanded successfully here
+        # Source 1 will be sentry, the following 2 will be the expanded gcs sources
+        assert len(sources) == 3
+        assert sources[0]["type"] == "sentry"
+        assert sources[1]["type"] == "gcs"
+        assert sources[1]["name"] == "aaa"
+        assert sources[2]["type"] == "gcs"
+        assert sources[2]["name"] == "bbb"
+        for i in (1, 2):
+            assert "client_email" not in sources[i]
+            assert "private_key" not in sources[i]
+            assert sources[i]["bearer_token"] == "ya29.TOKEN"
 
 
 class TestIgnoredSourcesFiltering:


### PR DESCRIPTION
This PR enables the fetching of GCP tokens for sources referenced in `alias` type sources.
It also adds mocked tests