### PR TITLE
fix(platform-insights): Filter spans without descriptions

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -42,7 +42,7 @@ export function CachesWidget() {
     {
       fields: ['transaction', 'project.id', 'cache_miss_rate()', 'count()'],
       sorts: [{field: 'cache_miss_rate()', kind: 'desc'}],
-      search: `span.op:[cache.get_item,cache.get] ${query}`,
+      search: `span.op:[cache.get_item,cache.get] has:span.group ${query}`,
       limit: 4,
     },
     Referrer.CACHE_CHART
@@ -95,7 +95,21 @@ export function CachesWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Line(convertSeriesToTimeseries(ts), {color: colorPalette[index]})
+            new Line(
+              convertSeriesToTimeseries({
+                ...ts,
+                // TODO: Remove this once the correct meta is returned from useTopNSpanEAPSeries
+                meta: {
+                  fields: {
+                    [ts.seriesName]: ts.meta.fields['cache_miss_rate()']!,
+                  },
+                  units: {
+                    [ts.seriesName]: ts.meta.units['cache_miss_rate()']!,
+                  },
+                },
+              }),
+              {color: colorPalette[index]}
+            )
         ),
         ...releaseBubbleProps,
       }}

--- a/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
@@ -41,7 +41,7 @@ export function QueriesWidget() {
   const releaseBubbleProps = useReleaseBubbleProps();
   const pageFilterChartParams = usePageFilterChartParams();
 
-  const fullQuery = `has:db.system ${query}`;
+  const fullQuery = `has:db.system has:span.group ${query}`;
 
   const queriesRequest = useEAPSpans(
     {
@@ -101,10 +101,24 @@ export function QueriesWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Line(convertSeriesToTimeseries(ts), {
-              color: colorPalette[index],
-              alias: aliases[ts.seriesName],
-            })
+            new Line(
+              convertSeriesToTimeseries({
+                ...ts,
+                // TODO: Remove this once the correct meta is returned from useTopNSpanEAPSeries
+                meta: {
+                  fields: {
+                    [ts.seriesName]: ts.meta.fields['avg(span.duration)']!,
+                  },
+                  units: {
+                    [ts.seriesName]: ts.meta.units['avg(span.duration)']!,
+                  },
+                },
+              }),
+              {
+                color: colorPalette[index],
+                alias: aliases[ts.seriesName],
+              }
+            )
         ),
         ...releaseBubbleProps,
       }}


### PR DESCRIPTION
### Problem
We received some spans without description (no SQL query) which broke the data matching and made the summary below the chart go out of sync.

![Screenshot 2025-05-22 at 16 24 56](https://github.com/user-attachments/assets/f91de8a2-864a-4081-ac24-e3f172bc4db6)

### Solution
Filter for spans that have a description.