### PR TITLE
fix(releases): Fix additional y-axis line appearing w/ bubbles

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -357,6 +357,7 @@ export function useReleaseBubbles({
       min: 0,
       max: 100,
       show: false,
+      axisPointer: {show: false},
     }),
     []
   );


### PR DESCRIPTION
This fixes an issue on our charts w/ releases bubbles where the new additional y-axis (#91813) is showing a new pop-up when hovering over a chart. This is due to the `axisPointer` configuration which defaults to `false` unless `tooltip.trigger==axis`. It seems like the other y-axis having this tooltip enables it for this y-axis.

Removes the `60` tooltip thing and the additional dashed horizontal line.
<img width="546" alt="image" src="https://github.com/user-attachments/assets/3b32ba37-2339-48a1-adf8-0d92c3bec21c" />

