### PR TITLE
fix(insights): span samples panel should pass fix(insights): sample queries should pass dataset param

### DIFF
--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -1,4 +1,5 @@
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -7,6 +8,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {computeAxisMax} from 'sentry/views/insights/common/components/chart';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import type {
   SpanIndexedFieldTypes,
   SpanIndexedProperty,
@@ -141,6 +143,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
             SpanIndexedField.TRANSACTION_SPAN_ID, // TODO: transaction.span_id should be a default from the backend
             ...additionalFields,
           ],
+          dataset: useInsightsEap() ? DiscoverDatasets.SPANS_EAP : undefined,
           sort: `-${SPAN_SELF_TIME}`,
         },
       },

--- a/static/app/views/insights/http/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/http/queries/useSpanSamples.tsx
@@ -2,6 +2,7 @@
 
 import {defined} from 'sentry/utils';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -11,6 +12,7 @@ import type {
   NonDefaultSpanSampleFields,
 } from 'sentry/views/insights/common/queries/useSpanSamples';
 import {getDateConditions} from 'sentry/views/insights/common/utils/getDateConditions';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {SpanIndexedField, type SpanIndexedResponse} from 'sentry/views/insights/types';
 
 interface UseSpanSamplesOptions<Fields> {
@@ -67,6 +69,7 @@ export const useSpanSamples = <Fields extends NonDefaultSpanSampleFields[]>(
           // TODO: transaction.span_id should be a default from the backend
           additionalFields: [...fields, SpanIndexedField.TRANSACTION_SPAN_ID],
           sort: '-timestamp',
+          dataset: useInsightsEap() ? DiscoverDatasets.SPANS_EAP : undefined,
           referrer,
         },
       },


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/90698/ the `useRpc` param was removed, but was not replaced with `dataset=spans` 