### PR TITLE
feat(widget-builder): Cache builder state between dataset changes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.spec.tsx
@@ -97,6 +97,7 @@ describe('useCacheBuilderState', () => {
 
   it('restores builder state from localStorage when available', () => {
     const cachedWidget: WidgetBuilderState = {
+      title: 'error widget title',
       dataset: WidgetType.ERRORS,
       displayType: DisplayType.LINE,
       yAxis: [
@@ -108,6 +109,7 @@ describe('useCacheBuilderState', () => {
       query: ['this is a test query'],
     };
     const currentWidget: WidgetBuilderState = {
+      title: 'issue widget title',
       dataset: WidgetType.ISSUE,
       displayType: DisplayType.TABLE,
       query: ['issue.id:123'],
@@ -140,7 +142,11 @@ describe('useCacheBuilderState', () => {
       type: BuilderStateAction.SET_STATE,
 
       // the yAxis gets converted to a string when used with this payload
-      payload: expect.objectContaining({...cachedWidget, yAxis: ['count()']}),
+      payload: expect.objectContaining({
+        ...cachedWidget,
+        yAxis: ['count()'],
+        title: 'issue widget title', // The title was not overridden
+      }),
     });
   });
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.spec.tsx
@@ -98,6 +98,7 @@ describe('useCacheBuilderState', () => {
   it('restores builder state from localStorage when available', () => {
     const cachedWidget: WidgetBuilderState = {
       title: 'error widget title',
+      description: 'error widget description',
       dataset: WidgetType.ERRORS,
       displayType: DisplayType.LINE,
       yAxis: [
@@ -110,6 +111,7 @@ describe('useCacheBuilderState', () => {
     };
     const currentWidget: WidgetBuilderState = {
       title: 'issue widget title',
+      description: 'issue widget description',
       dataset: WidgetType.ISSUE,
       displayType: DisplayType.TABLE,
       query: ['issue.id:123'],
@@ -146,6 +148,7 @@ describe('useCacheBuilderState', () => {
         ...cachedWidget,
         yAxis: ['count()'],
         title: 'issue widget title', // The title was not overridden
+        description: 'issue widget description', // The description was not overridden
       }),
     });
   });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.spec.tsx
@@ -1,0 +1,195 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  useWidgetBuilderContext,
+  WidgetBuilderProvider,
+} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {
+  BuilderStateAction,
+  type WidgetBuilderState,
+} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+
+import {useCacheBuilderState} from './useCacheBuilderState';
+
+jest.mock('sentry/utils/useNavigate', () => ({
+  useNavigate: jest.fn(),
+}));
+jest.mock('sentry/utils/useLocation');
+
+jest.mock('sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext', () => ({
+  useWidgetBuilderContext: jest.fn(),
+  WidgetBuilderProvider: jest.requireActual(
+    'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext'
+  ).WidgetBuilderProvider,
+}));
+
+const mockUseWidgetBuilderContext = jest.mocked(useWidgetBuilderContext);
+const mockUseLocation = jest.mocked(useLocation);
+
+function Wrapper({children}: {children: React.ReactNode}) {
+  return <WidgetBuilderProvider>{children}</WidgetBuilderProvider>;
+}
+
+describe('useCacheBuilderState', () => {
+  let mockLocalStorage: Record<string, string>;
+
+  beforeEach(() => {
+    mockLocalStorage = {};
+    mockUseWidgetBuilderContext.mockReturnValue({
+      state: {},
+      dispatch: jest.fn(),
+    });
+    mockUseLocation.mockReturnValue(LocationFixture());
+
+    Storage.prototype.getItem = jest.fn(key => mockLocalStorage[key] ?? null);
+    Storage.prototype.setItem = jest.fn((key, value) => {
+      mockLocalStorage[key] = value;
+    });
+    Storage.prototype.removeItem = jest.fn(key => {
+      delete mockLocalStorage[key];
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('caches builder state to localStorage', () => {
+    const cachedWidget: WidgetBuilderState = {
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      yAxis: [
+        {
+          function: ['count', '', undefined, undefined],
+          kind: 'function',
+        },
+      ],
+      query: ['this is a test query'],
+    };
+    mockUseWidgetBuilderContext.mockReturnValue({
+      state: cachedWidget,
+      dispatch: jest.fn(),
+    });
+
+    const {result} = renderHook(() => useCacheBuilderState(), {
+      wrapper: Wrapper,
+    });
+
+    result.current.cacheBuilderState(WidgetType.ERRORS);
+
+    // Verify state was saved to localStorage
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'dashboards:widget-builder:dataset:error-events',
+      JSON.stringify(convertBuilderStateToWidget(cachedWidget))
+    );
+
+    result.current.restoreOrSetBuilderState(WidgetType.ERRORS);
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(
+      'dashboards:widget-builder:dataset:error-events'
+    );
+  });
+
+  it('restores builder state from localStorage when available', () => {
+    const cachedWidget: WidgetBuilderState = {
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      yAxis: [
+        {
+          function: ['count', '', undefined, undefined],
+          kind: 'function',
+        },
+      ],
+      query: ['this is a test query'],
+    };
+    const currentWidget: WidgetBuilderState = {
+      dataset: WidgetType.ISSUE,
+      displayType: DisplayType.TABLE,
+      query: ['issue.id:123'],
+      fields: [
+        {
+          field: 'issue',
+          kind: 'field',
+        },
+      ],
+    };
+    const mockDispatch = jest.fn();
+    mockUseWidgetBuilderContext.mockReturnValue({
+      state: currentWidget,
+      dispatch: mockDispatch,
+    });
+    // Add cached widget to the localStorage
+    localStorage.setItem(
+      'dashboards:widget-builder:dataset:error-events',
+      JSON.stringify(convertBuilderStateToWidget(cachedWidget))
+    );
+
+    const {result} = renderHook(() => useCacheBuilderState(), {
+      wrapper: Wrapper,
+    });
+
+    // Call the restore helper on the cached dataset
+    result.current.restoreOrSetBuilderState(WidgetType.ERRORS);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BuilderStateAction.SET_STATE,
+
+      // the yAxis gets converted to a string when used with this payload
+      payload: expect.objectContaining({...cachedWidget, yAxis: ['count()']}),
+    });
+  });
+
+  it('plainly sets the new dataset when no cached state exists', () => {
+    const cachedWidget: WidgetBuilderState = {
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      yAxis: [
+        {
+          function: ['count', '', undefined, undefined],
+          kind: 'function',
+        },
+      ],
+      query: ['this is a test query'],
+    };
+    const currentWidget: WidgetBuilderState = {
+      dataset: WidgetType.ISSUE,
+      displayType: DisplayType.TABLE,
+      query: ['issue.id:123'],
+      fields: [
+        {
+          field: 'issue',
+          kind: 'field',
+        },
+      ],
+    };
+    const mockDispatch = jest.fn();
+    mockUseWidgetBuilderContext.mockReturnValue({
+      state: currentWidget,
+      dispatch: mockDispatch,
+    });
+    // Add cached widget to the localStorage, this will not be the one
+    // used in the test to test that a cache miss falls back to the plain
+    // dataset change
+    localStorage.setItem(
+      'dashboards:widget-builder:dataset:error-events',
+      JSON.stringify(convertBuilderStateToWidget(cachedWidget))
+    );
+
+    const {result} = renderHook(() => useCacheBuilderState(), {
+      wrapper: Wrapper,
+    });
+
+    // Call the restore helper on the cached dataset
+    result.current.restoreOrSetBuilderState(WidgetType.TRANSACTIONS);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: BuilderStateAction.SET_DATASET,
+      payload: WidgetType.TRANSACTIONS,
+    });
+  });
+});

--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
@@ -51,7 +51,7 @@ export function useCacheBuilderState() {
         );
         dispatch({
           type: BuilderStateAction.SET_STATE,
-          payload: builderState,
+          payload: {...builderState, title: state.title},
         });
       } else {
         dispatch({
@@ -60,7 +60,7 @@ export function useCacheBuilderState() {
         });
       }
     },
-    [dispatch]
+    [dispatch, state.title]
   );
 
   return {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
@@ -1,0 +1,70 @@
+import {useCallback, useEffect} from 'react';
+
+import type {WidgetType} from 'sentry/views/dashboards/types';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+
+const WIDGET_BUILDER_DATASET_STATE_KEY = 'dashboards:widget-builder:dataset';
+
+function cleanUpDatasetState() {
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(WIDGET_BUILDER_DATASET_STATE_KEY)) {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+/**
+ * This hook is used to cache the builder state for the given dataset
+ * and restore it when the user navigates back to the same dataset.
+ */
+export function useCacheBuilderState() {
+  const {state, dispatch} = useWidgetBuilderContext();
+
+  useEffect(() => {
+    return cleanUpDatasetState;
+  }, []);
+
+  const cacheBuilderState = useCallback(
+    (dataset: WidgetType) => {
+      localStorage.setItem(
+        `${WIDGET_BUILDER_DATASET_STATE_KEY}:${dataset}`,
+        JSON.stringify(convertBuilderStateToWidget(state))
+      );
+    },
+    [state]
+  );
+
+  // Checks if there is a cached builder state for the given dataset
+  // and restores it if it exists. Otherwise, it sets the dataset.
+  const restoreOrSetBuilderState = useCallback(
+    (nextDataset: WidgetType) => {
+      const previousDatasetState = localStorage.getItem(
+        `${WIDGET_BUILDER_DATASET_STATE_KEY}:${nextDataset}`
+      );
+      if (previousDatasetState) {
+        const builderState = convertWidgetToBuilderStateParams(
+          JSON.parse(previousDatasetState)
+        );
+        dispatch({
+          type: BuilderStateAction.SET_STATE,
+          payload: builderState,
+        });
+      } else {
+        dispatch({
+          type: BuilderStateAction.SET_DATASET,
+          payload: nextDataset,
+        });
+      }
+    },
+    [dispatch]
+  );
+
+  return {
+    cacheBuilderState,
+    restoreOrSetBuilderState,
+  };
+}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
@@ -51,7 +51,7 @@ export function useCacheBuilderState() {
         );
         dispatch({
           type: BuilderStateAction.SET_STATE,
-          payload: {...builderState, title: state.title},
+          payload: {...builderState, title: state.title, description: state.description},
         });
       } else {
         dispatch({
@@ -60,7 +60,7 @@ export function useCacheBuilderState() {
         });
       }
     },
-    [dispatch, state.title]
+    [dispatch, state.title, state.description]
   );
 
   return {


### PR DESCRIPTION
Either restore the old state if it exists, or push the dataset change through the original way the widget builder hook works.

Note: We have to purposely ignore the `title` and `description` fields because a user should not have those values change if they return to a cached state with a different title/description.