### PR TITLE
fix(releases): Fix unwanted whitespace on y-axis w/ bubbles

### DIFF
--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -357,6 +357,11 @@ export function useReleaseBubbles({
       min: 0,
       max: 100,
       show: false,
+      // `axisLabel` causes an unwanted whitespace/width on the y-axis
+      axisLabel: {show: false},
+      // Hides an axis line + tooltip when hovering on chart
+      // This is default `false`, but the main y-axis has
+      // `tooltip.trigger=axis` which will cause this to be enabled.
       axisPointer: {show: false},
     }),
     []


### PR DESCRIPTION
This fixes an unwanted whitespace due to the release bubbles y-axis.

old:
![image](https://github.com/user-attachments/assets/c22a1cd9-92f4-4b44-b966-e743ef1d3cc7)


new:
![image](https://github.com/user-attachments/assets/2c864f8e-dd89-43a0-9ebd-430a4a4647b0)
