### PR TITLE
feat(insights): add series to meta fields/units in top N hook

### DIFF
--- a/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useTopNDiscoverSeries.ts
@@ -136,6 +136,7 @@ const useTopNDiscoverSeries = <T extends string[]>(
   });
 
   const parsedData: DiscoverSeries[] = [];
+  const parsedMeta: EventsMetaType = {fields: {}, units: {}};
 
   const seriesData = result.data ?? {};
 
@@ -144,14 +145,36 @@ const useTopNDiscoverSeries = <T extends string[]>(
   if (!seriesData?.data) {
     Object.keys(seriesData).forEach(seriesName => {
       const data = seriesData[seriesName]?.data ?? [];
-      const meta = (seriesData[seriesName]?.meta ?? {}) as EventsMetaType;
       parsedData.push({
         seriesName,
         data: convertDiscoverTimeseriesResponse(data),
-        meta,
+        meta: parsedMeta,
       });
+
+      const meta = (seriesData[seriesName]?.meta ?? {}) as EventsMetaType;
+      const yAxisField = yAxis[0];
+
+      if (meta) {
+        parsedMeta.fields = {
+          ...parsedMeta.fields,
+          ...meta.fields,
+        };
+        parsedMeta.units = {
+          ...parsedMeta.units,
+          ...meta.units,
+        };
+      }
+
+      if (yAxisField) {
+        if (meta.fields[yAxisField]) {
+          parsedMeta.fields[seriesName] = meta.fields[yAxisField];
+        }
+        if (meta.units[yAxisField]) {
+          parsedMeta.units[seriesName] = meta.units[yAxisField];
+        }
+      }
     });
   }
 
-  return {...result, data: parsedData};
+  return {...result, data: parsedData, meta: parsedMeta};
 };

--- a/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/cachesWidget.tsx
@@ -95,21 +95,7 @@ export function CachesWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Line(
-              convertSeriesToTimeseries({
-                ...ts,
-                // TODO: Remove this once the correct meta is returned from useTopNSpanEAPSeries
-                meta: {
-                  fields: {
-                    [ts.seriesName]: ts.meta.fields['cache_miss_rate()']!,
-                  },
-                  units: {
-                    [ts.seriesName]: ts.meta.units['cache_miss_rate()']!,
-                  },
-                },
-              }),
-              {color: colorPalette[index]}
-            )
+            new Line(convertSeriesToTimeseries(ts), {color: colorPalette[index]})
         ),
         ...releaseBubbleProps,
       }}

--- a/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
+++ b/static/app/views/insights/pages/platform/laravel/queriesWidget.tsx
@@ -101,24 +101,10 @@ export function QueriesWidget() {
         showLegend: 'never',
         plottables: timeSeries.map(
           (ts, index) =>
-            new Line(
-              convertSeriesToTimeseries({
-                ...ts,
-                // TODO: Remove this once the correct meta is returned from useTopNSpanEAPSeries
-                meta: {
-                  fields: {
-                    [ts.seriesName]: ts.meta.fields['avg(span.duration)']!,
-                  },
-                  units: {
-                    [ts.seriesName]: ts.meta.units['avg(span.duration)']!,
-                  },
-                },
-              }),
-              {
-                color: colorPalette[index],
-                alias: aliases[ts.seriesName],
-              }
-            )
+            new Line(convertSeriesToTimeseries(ts), {
+              color: colorPalette[index],
+              alias: aliases[ts.seriesName],
+            })
         ),
         ...releaseBubbleProps,
       }}


### PR DESCRIPTION
The widgets need to be able to lookup up the series meta by series name, however when making topN requests, the keys in the meta object are the yAxis names, but the seriesName are the name of the groups. 

In this Pr we add a new key in the meta for each seriesName. 

Note: this is mostly temporary until we have the new backend return type