### PR TITLE
chore(perf-issues): Remove fixed group creation limit

### DIFF
--- a/src/sentry/utils/performance_issues/README.md
+++ b/src/sentry/utils/performance_issues/README.md
@@ -21,7 +21,6 @@ Performance Issues are built on top of the [Issue Platform](https://develop.sent
   - After recording metrics about the results, two checks are run, dropping the `PerformanceProblem`s if either return `False`:
     - `PerformanceDetector.is_creation_allowed_for_organization()` - Pre-GA, check a feature flag; post-GA, just return `True`
     - `PerformanceDetector.is_creation_allowed_for_project()` - Usually checking project's detector settings
-  - Lastly, we trunacte any `PerformanceProblem`s in excess of `PERFORMANCE_GROUP_COUNT_LIMIT` from [performance_detection.py](./performance_detection.py)
 - We store the list of `PerformanceProblem`s from `_detect_performance_problems` on `job["performance_problems"]`
 - Then we run `_send_occurrence_to_platform` which reads `job["performance_problems"]`
   - It will map each `PerformanceProblem` into an `IssueOccurrence`

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -42,7 +42,6 @@ from .detectors.slow_db_query_detector import SlowDBQueryDetector
 from .detectors.uncompressed_asset_detector import UncompressedAssetSpanDetector
 from .performance_problem import PerformanceProblem
 
-PERFORMANCE_GROUP_COUNT_LIMIT = 10
 INTEGRATIONS_OF_INTEREST = [
     "django",
     "flask",
@@ -409,13 +408,7 @@ def _detect_performance_problems(
             else:
                 continue
 
-    truncated_problems = problems[:PERFORMANCE_GROUP_COUNT_LIMIT]
-
-    metrics.incr("performance.performance_issue.pretruncated", len(problems))
-    metrics.incr("performance.performance_issue.truncated", len(truncated_problems))
-
-    # Leans on Set to remove duplicate problems when extending a detector, since the new extended detector can overlap in terms of created issues.
-    unique_problems = set(truncated_problems)
+    unique_problems = set(problems)
 
     if len(unique_problems) > 0:
         metrics.incr(


### PR DESCRIPTION
We don't need a hard coded limit, especially as we add new detectors and experiments. Since the stats were also sampled, they weren't useful either to track exactly how many problems were being ignored.

Also because we trim from index 0 -> 10, we were inherently biasing towards the first detectors to run, meaning new detectors had a higher chance to have their problems dropped. 