### PR TITLE
fix(aci): return sentry app component title in available action endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -52,6 +52,7 @@ class SentryAppContext(TypedDict):
     installationId: str
     status: int
     settings: NotRequired[dict[str, Any]]
+    title: NotRequired[str]
 
 
 class ActionHandlerSerializerResponse(TypedDict):

--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -102,14 +102,17 @@ class ActionHandlerSerializer(Serializer):
         sentry_app_context = kwargs.get("sentry_app_context")
         if sentry_app_context:
             installation = sentry_app_context.installation
+            component = sentry_app_context.component
             sentry_app: SentryAppContext = {
                 "id": str(installation.sentry_app.id),
                 "name": installation.sentry_app.name,
                 "installationId": str(installation.id),
                 "status": installation.sentry_app.status,
             }
-            if sentry_app_context.component:
-                sentry_app["settings"] = sentry_app_context.component.app_schema.get("settings", {})
+            if component:
+                sentry_app["settings"] = component.app_schema.get("settings", {})
+                if component.app_schema.get("title"):
+                    sentry_app["title"] = component.app_schema.get("title")
             result["sentryApp"] = sentry_app
 
         services = kwargs.get("services")

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -355,6 +355,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                     "installationId": str(self.sentry_app_installation.id),
                     "status": SentryAppStatus.as_str(self.sentry_app.status),
                     "settings": ANY,
+                    "title": ANY,
                 },
             },
             {
@@ -458,6 +459,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                     "installationId": str(self.sentry_app_installation.id),
                     "status": SentryAppStatus.as_str(self.sentry_app.status),
                     "settings": ANY,
+                    "title": ANY,
                 },
             },
             {


### PR DESCRIPTION
If available, we need to return the sentry app component's title to display in the frontend

In this example, the title is `Create a Linear issue`

<img width="383" alt="Screenshot 2025-05-22 at 10 52 57 AM" src="https://github.com/user-attachments/assets/b07dcb35-91a9-40ad-aff3-0a7be95381fb" />