### PR TITLE
:bug: fix(vsts): catch org integration not found errors in outbound status sync

### DIFF
--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -11,6 +11,7 @@ from typing import Any, ClassVar
 
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.services.integration import integration_service
@@ -379,13 +380,18 @@ class IssueSyncIntegration(IssueBasicIntegration, ABC):
 
     def should_sync(self, attribute: str, sync_source: AssignmentSource | None = None) -> bool:
         key = getattr(self, f"{attribute}_key", None)
-        if key is None or self.org_integration is None:
+        try:
+            org_integration = self.org_integration
+        except OrganizationIntegrationNotFound:
+            return False
+
+        if key is None or org_integration is None:
             return False
 
         # Check that the assignment source isn't this same integration in order to
         # prevent sync-cycles from occurring. This should still allow other
         # integrations to propagate changes outward.
-        if sync_source and sync_source.integration_id == self.org_integration.integration_id:
+        if sync_source and sync_source.integration_id == org_integration.integration_id:
             return False
 
         value: bool = self.org_integration.config.get(key, False)

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -1,6 +1,7 @@
 from sentry import analytics, features
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.project_management.metrics import (
@@ -66,22 +67,23 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
         action_type=ProjectManagementActionType.OUTBOUND_STATUS_SYNC, integration=integration
     ).capture() as lifecycle:
         lifecycle.add_extra("sync_task", "sync_status_outbound")
-        if installation.should_sync("outbound_status"):
-            lifecycle.add_extras(
-                {
-                    "organization_id": external_issue.organization_id,
-                    "integration_id": integration.id,
-                    "external_issue": external_issue_id,
-                    "status": group.status,
-                }
-            )
-            try:
+        try:
+            if installation.should_sync("outbound_status"):
+                lifecycle.add_extras(
+                    {
+                        "organization_id": external_issue.organization_id,
+                        "integration_id": integration.id,
+                        "external_issue": external_issue_id,
+                        "status": group.status,
+                    }
+                )
+
                 installation.sync_status_outbound(
                     external_issue, group.status == GroupStatus.RESOLVED, group.project_id
                 )
-            except (IntegrationFormError, ApiUnauthorized) as e:
-                lifecycle.record_halt(halt_reason=e)
-                return None
+        except (IntegrationFormError, ApiUnauthorized, OrganizationIntegrationNotFound) as e:
+            lifecycle.record_halt(halt_reason=e)
+            return None
             analytics.record(
                 "integration.issue.status.synced",
                 provider=integration.provider,

--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -81,13 +81,14 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
                 installation.sync_status_outbound(
                     external_issue, group.status == GroupStatus.RESOLVED, group.project_id
                 )
+
+                analytics.record(
+                    "integration.issue.status.synced",
+                    provider=integration.provider,
+                    id=integration.id,
+                    organization_id=external_issue.organization_id,
+                )
         except (IntegrationFormError, ApiUnauthorized, OrganizationIntegrationNotFound) as e:
             lifecycle.record_halt(halt_reason=e)
             return None
-            analytics.record(
-                "integration.issue.status.synced",
-                provider=integration.provider,
-                id=integration.id,
-                organization_id=external_issue.organization_id,
-            )
     return None

--- a/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
@@ -7,7 +7,7 @@ from sentry.integrations.models import ExternalIssue, Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.tasks import sync_assignee_outbound
 from sentry.integrations.types import EventLifecycleOutcome
-from sentry.testutils.asserts import assert_halt_metric, assert_success_metric
+from sentry.testutils.asserts import assert_success_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.users.services.user import RpcUser
@@ -151,4 +151,4 @@ class TestSyncAssigneeOutbound(TestCase):
         mock_sync_assignee.assert_not_called()
 
         assert mock_record_event.call_count == 2
-        assert_halt_metric(mock_record_event, "organization_integration_not_found")
+        assert_success_metric(mock_record_event)


### PR DESCRIPTION
`self.org_integration` is a property that raises `OrganizationIntegrationNotFound` it doesn't exist.

we didn't catch this exception and recorded this as a failure, even though this should mean we _don't_ sync outbound.

lets catch this and mark as a halt

fixes RTC-918