### PR TITLE
feat(insights): make `failure_rate` generic to any span

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -172,7 +172,7 @@ def failure_rate_if(args: ResolvedArguments, settings: ResolverSettings) -> Colu
             conditional_aggregation=AttributeConditionalAggregation(
                 aggregate=Function.FUNCTION_COUNT,
                 key=AttributeKey(
-                    name="sentry.trace.status",
+                    name="sentry.status",
                     type=AttributeKey.TYPE_STRING,
                 ),
                 filter=TraceItemFilter(
@@ -181,7 +181,7 @@ def failure_rate_if(args: ResolvedArguments, settings: ResolverSettings) -> Colu
                             TraceItemFilter(
                                 comparison_filter=ComparisonFilter(
                                     key=AttributeKey(
-                                        name="sentry.trace.status",
+                                        name="sentry.status",
                                         type=AttributeKey.TYPE_STRING,
                                     ),
                                     op=ComparisonFilter.OP_NOT_IN,
@@ -219,13 +219,13 @@ def failure_rate(_: ResolvedArguments, settings: ResolverSettings) -> Column.Bin
             conditional_aggregation=AttributeConditionalAggregation(
                 aggregate=Function.FUNCTION_COUNT,
                 key=AttributeKey(
-                    name="sentry.trace.status",
+                    name="sentry.status",
                     type=AttributeKey.TYPE_STRING,
                 ),
                 filter=TraceItemFilter(
                     comparison_filter=ComparisonFilter(
                         key=AttributeKey(
-                            name="sentry.trace.status",
+                            name="sentry.status",
                             type=AttributeKey.TYPE_STRING,
                         ),
                         op=ComparisonFilter.OP_NOT_IN,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2826,7 +2826,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         self.store_spans(
             [
                 self.create_span(
-                    {"sentry_tags": {"trace.status": status}},
+                    {"sentry_tags": {"status": status}},
                     start_ts=self.ten_mins_ago,
                 )
                 for status in trace_statuses
@@ -2855,7 +2855,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         spans = [
             self.create_span(
                 {
-                    "sentry_tags": {"trace.status": status},
+                    "sentry_tags": {"status": status},
                     "is_segment": True,
                 },
                 start_ts=self.ten_mins_ago,
@@ -2866,7 +2866,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         spans.append(
             self.create_span(
                 {
-                    "sentry_tags": {"trace.status": "ok"},
+                    "sentry_tags": {"status": "ok"},
                     "is_segment": False,
                 },
                 start_ts=self.ten_mins_ago,


### PR DESCRIPTION
Previously `failure_rate` was specific to `trace.status` and it was used to show transaction failure_rate, however this doesn't work generically for any span type. This Pr updates `failure_rate` to be generic to any span type by using `span.status` instead. For transaction spans, `span.status` is `trace.status` anyways so it will still work as expected, this can be verified [in explore](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.status%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&aggregateField=%7B%22groupBy%22%3A%22trace.status%22%7D&field=span.description&field=span.status&field=trace.status&mode=aggregate&query=is_transaction%3ATrue&statsPeriod=7d)