### PR TITLE
feat(expore): Generalize drag n drop context for any type

### DIFF
--- a/static/app/views/explore/contexts/dragNDropContext.tsx
+++ b/static/app/views/explore/contexts/dragNDropContext.tsx
@@ -17,25 +17,35 @@ import {
   useDragNDropColumns,
 } from 'sentry/views/explore/hooks/useDragNDropColumns';
 
-interface DragNDropContextProps {
+interface DragNDropContextProps<T> {
   children: (props: {
     deleteColumnAtIndex: (i: number) => void;
-    editableColumns: Column[];
+    editableColumns: Array<Column<T>>;
     insertColumn: () => void;
-    updateColumnAtIndex: (i: number, column: string) => void;
+    updateColumnAtIndex: (i: number, column: T) => void;
   }) => React.ReactNode;
-  columns: string[];
-  setColumns: (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
+  columns: T[];
+  defaultColumn: () => T;
+  setColumns: (columns: T[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
 }
 
-export function DragNDropContext({columns, setColumns, children}: DragNDropContextProps) {
+export function DragNDropContext<T>({
+  columns,
+  defaultColumn,
+  setColumns,
+  children,
+}: DragNDropContextProps<T>) {
   const {
     editableColumns,
     insertColumn,
     updateColumnAtIndex,
     deleteColumnAtIndex,
     onDragEnd,
-  } = useDragNDropColumns({columns, setColumns});
+  } = useDragNDropColumns({
+    columns,
+    defaultColumn,
+    setColumns,
+  });
 
   const sensors = useSensors(
     useSensor(PointerSensor),

--- a/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
@@ -7,6 +7,10 @@ import {useDragNDropColumns} from './useDragNDropColumns';
 describe('useDragNDropColumns', () => {
   const initialColumns = ['span.op', 'span_id', 'timestamp'];
 
+  function defaultColumn(): string {
+    return '';
+  }
+
   it('should insert a column', () => {
     let columns!: string[];
     let setColumns: (columns: string[]) => void;
@@ -14,7 +18,7 @@ describe('useDragNDropColumns', () => {
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({insertColumn} = useDragNDropColumns({columns, setColumns}));
+      ({insertColumn} = useDragNDropColumns({columns, defaultColumn, setColumns}));
       return null;
     }
 
@@ -30,13 +34,11 @@ describe('useDragNDropColumns', () => {
   it('should update a column at a specific index', () => {
     let columns!: string[];
     let setColumns: (columns: string[]) => void;
-    let updateColumnAtIndex: ReturnType<
-      typeof useDragNDropColumns
-    >['updateColumnAtIndex'];
+    let updateColumnAtIndex: (i: number, column: string) => void;
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({updateColumnAtIndex} = useDragNDropColumns({columns, setColumns}));
+      ({updateColumnAtIndex} = useDragNDropColumns({columns, defaultColumn, setColumns}));
       return null;
     }
 
@@ -56,7 +58,7 @@ describe('useDragNDropColumns', () => {
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({deleteColumnAtIndex} = useDragNDropColumns({columns, setColumns}));
+      ({deleteColumnAtIndex} = useDragNDropColumns({columns, defaultColumn, setColumns}));
       return null;
     }
 
@@ -76,7 +78,7 @@ describe('useDragNDropColumns', () => {
 
     function TestPage() {
       [columns, setColumns] = useState(initialColumns);
-      ({onDragEnd} = useDragNDropColumns({columns, setColumns}));
+      ({onDragEnd} = useDragNDropColumns({columns, defaultColumn, setColumns}));
       return null;
     }
 

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -131,7 +131,11 @@ export function ColumnEditorModal({
   }
 
   return (
-    <DragNDropContext columns={tempColumns} setColumns={setTempColumns}>
+    <DragNDropContext
+      columns={tempColumns}
+      setColumns={setTempColumns}
+      defaultColumn={() => ''}
+    >
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => (
         <Fragment>
           <Header closeButton data-test-id="editor-header">
@@ -194,7 +198,7 @@ export function ColumnEditorModal({
 
 interface ColumnEditorRowProps {
   canDelete: boolean;
-  column: Column;
+  column: Column<string>;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -91,7 +91,7 @@ export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
   }, [groupBys, tags]);
 
   return (
-    <DragNDropContext columns={groupBys} setColumns={setColumns}>
+    <DragNDropContext columns={groupBys} setColumns={setColumns} defaultColumn={() => ''}>
       {({editableColumns, insertColumn, updateColumnAtIndex, deleteColumnAtIndex}) => {
         return (
           <ToolbarSection data-test-id="section-group-by">
@@ -136,7 +136,7 @@ export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
 
 interface ColumnEditorRowProps {
   canDelete: boolean;
-  column: Column;
+  column: Column<string>;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;


### PR DESCRIPTION
For use with the aggregate fields column editor. Allow not just list of strings.