### PR TITLE
chore(perf-issues): Raise depth scan mn+1 experiment rollout

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1676,7 +1676,7 @@ register(
 )
 register(
     "performance.issues.experimental_m_n_plus_one_db_queries.problem-creation",
-    default=0.25,
+    default=1.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(


### PR DESCRIPTION
Increase rollout for MN+1, planning on merging tomorrow morning EST to monitor over the course of the day. Expecting acceptable latency increases