### PR TITLE
fix(aci): Add an initial UptimeSubscription serializer

### DIFF
--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableMapping, Sequence
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast, override
 
 from django.db.models import prefetch_related_objects
 from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import (
@@ -10,7 +10,7 @@ from sentry_kafka_schemas.schema_types.snuba_uptime_results_v1 import (
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.types.actor import Actor
-from sentry.uptime.models import ProjectUptimeSubscription
+from sentry.uptime.models import ProjectUptimeSubscription, UptimeSubscription
 from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.uptime.types import EapCheckEntry, IncidentStatus
 
@@ -133,4 +133,34 @@ class EapCheckEntrySerializer(Serializer):
             "environment": obj.environment,
             "region": obj.region,
             "regionName": region_name,
+        }
+
+
+class UptimeSubscriptionSerializerResponse(TypedDict):
+    timeoutMs: int
+    intervalSeconds: int
+    method: str
+    url: str
+    urlDomain: str
+    urlDomainSuffix: str
+    traceSampling: bool
+    hostProviderId: str
+    hostProviderName: str
+
+
+@register(UptimeSubscription)
+class UptimeSubscriptionSerializer(Serializer):
+
+    @override
+    def serialize(self, obj: UptimeSubscription, attrs, user, **kwargs) -> dict[str, Any]:
+        return {
+            "timeoutMs": obj.timeout_ms,
+            "intervalSeconds": obj.interval_seconds,
+            "method": obj.method,
+            "url": obj.url,
+            "urlDomain": obj.url_domain,
+            "urlDomainSuffix": obj.url_domain_suffix,
+            "traceSampling": obj.trace_sampling,
+            "hostProviderId": obj.host_provider_id,
+            "hostProviderName": obj.host_provider_name,
         }


### PR DESCRIPTION
Add UptimeSubscriptionSerializer to allow Detector endpoints to return successfully.
Detector data source subscription types need to be serializable for the detectors APIs.
Add a test to verify that we can return a serialized uptime detector; the specifics of the fields serialized are more a question for uptime folks and not yet relevant, so the serialization result contents are left untested.