### PR TITLE
fix(dashboards): Use regexes for change alerts

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1118,12 +1118,12 @@ class DashboardDetail extends Component<Props, State> {
             const checkDashboardRoute = (path: string) => {
               const widgetBuilderRoutes = [
                 // Legacy routes
-                /^\/organizations\/.+\/dashboards\/new\/widget-builder\/widget\//,
-                /^\/organizations\/.+\/dashboard\/\d+\/widget-builder\/widget\//,
+                /^\/organizations\/.+\/dashboards\//,
+                /^\/organizations\/.+\/dashboard\//,
 
                 // Customer domain routes
-                /^\/dashboards\/new\/widget-builder\/widget\//,
-                /^\/dashboard\/\d+\/widget-builder\/widget\//,
+                /^\/dashboards\//,
+                /^\/dashboard\//,
               ];
 
               return widgetBuilderRoutes.some(route =>
@@ -1133,9 +1133,7 @@ class DashboardDetail extends Component<Props, State> {
             const navigatingWithinDashboards =
               checkDashboardRoute(locationChange.nextLocation.pathname) ||
               (checkDashboardRoute(locationChange.currentLocation.pathname) &&
-                [`/dashboard/${dashboard.id}/`, `/dashboards/new/`].includes(
-                  locationChange.nextLocation.pathname
-                ));
+                checkDashboardRoute(locationChange.nextLocation.pathname));
             const hasUnsavedChanges =
               defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard);
             return (

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1118,12 +1118,12 @@ class DashboardDetail extends Component<Props, State> {
             const checkDashboardRoute = (path: string) => {
               const dashboardRoutes = [
                 // Legacy routes
-                /^\/organizations\/.+\/dashboards\//,
-                /^\/organizations\/.+\/dashboard\//,
+                new RegExp('^\/organizations\/.+\/dashboards\/new\/'),
+                new RegExp(`^\/organizations\/.+\/dashboard\/${dashboard.id}\/`),
 
                 // Customer domain routes
-                /^\/dashboards\//,
-                /^\/dashboard\//,
+                new RegExp('^\/dashboards\/new\/'),
+                new RegExp(`^\/dashboard\/${dashboard.id}\/`),
               ];
 
               return dashboardRoutes.some(route => route.test(path ?? location.pathname));

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1116,7 +1116,7 @@ class DashboardDetail extends Component<Props, State> {
             // The widget builder uses its own pathname at the moment, so check if we're navigating
             // between the dashboard and the widget builder
             const checkDashboardRoute = (path: string) => {
-              const widgetBuilderRoutes = [
+              const dashboardRoutes = [
                 // Legacy routes
                 /^\/organizations\/.+\/dashboards\//,
                 /^\/organizations\/.+\/dashboard\//,
@@ -1126,9 +1126,7 @@ class DashboardDetail extends Component<Props, State> {
                 /^\/dashboard\//,
               ];
 
-              return widgetBuilderRoutes.some(route =>
-                route.test(path ?? location.pathname)
-              );
+              return dashboardRoutes.some(route => route.test(path ?? location.pathname));
             };
             const navigatingWithinDashboards =
               checkDashboardRoute(locationChange.nextLocation.pathname) ||

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -440,21 +440,28 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   isWidgetBuilder = (path?: string) => {
-    const {location} = this.props;
+    const {organization, location, params} = this.props;
+    const {dashboardId, widgetIndex} = params;
 
     const widgetBuilderRoutes = [
-      /^\/organizations\/.+\/dashboards\/new\/widget-builder\/widget\//,
-      /^\/organizations\/.+\/dashboard\/\d+\/widget-builder\/widget\//,
+      `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/new/`,
+      `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/${widgetIndex}/edit/`,
+      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget-builder/widget/new/`,
+      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget-builder/widget/${widgetIndex}/edit/`,
     ];
 
     if (USING_CUSTOMER_DOMAIN) {
       widgetBuilderRoutes.push(
-        /^\/dashboards\/new\/widget-builder\/widget\//,
-        /^\/dashboard\/\d+\/widget-builder\/widget\//
+        ...[
+          `/dashboards/new/widget-builder/widget/new/`,
+          `/dashboards/new/widget-builder/widget/${widgetIndex}/edit/`,
+          `/dashboard/${dashboardId}/widget-builder/widget/new/`,
+          `/dashboard/${dashboardId}/widget-builder/widget/${widgetIndex}/edit/`,
+        ]
       );
     }
 
-    return widgetBuilderRoutes.some(route => route.test(path ?? location.pathname));
+    return widgetBuilderRoutes.includes(path ?? location.pathname);
   };
 
   onEdit = () => {
@@ -1108,9 +1115,24 @@ class DashboardDetail extends Component<Props, State> {
           when={locationChange => {
             // The widget builder uses its own pathname at the moment, so check if we're navigating
             // between the dashboard and the widget builder
+            const checkDashboardRoute = (path: string) => {
+              const widgetBuilderRoutes = [
+                // Legacy routes
+                /^\/organizations\/.+\/dashboards\/new\/widget-builder\/widget\//,
+                /^\/organizations\/.+\/dashboard\/\d+\/widget-builder\/widget\//,
+
+                // Customer domain routes
+                /^\/dashboards\/new\/widget-builder\/widget\//,
+                /^\/dashboard\/\d+\/widget-builder\/widget\//,
+              ];
+
+              return widgetBuilderRoutes.some(route =>
+                route.test(path ?? location.pathname)
+              );
+            };
             const navigatingWithinDashboards =
-              this.isWidgetBuilder(locationChange.nextLocation.pathname) ||
-              (this.isWidgetBuilder(locationChange.currentLocation.pathname) &&
+              checkDashboardRoute(locationChange.nextLocation.pathname) ||
+              (checkDashboardRoute(locationChange.currentLocation.pathname) &&
                 [`/dashboard/${dashboard.id}/`, `/dashboards/new/`].includes(
                   locationChange.nextLocation.pathname
                 ));

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -440,28 +440,21 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   isWidgetBuilder = (path?: string) => {
-    const {organization, location, params} = this.props;
-    const {dashboardId, widgetIndex} = params;
+    const {location} = this.props;
 
     const widgetBuilderRoutes = [
-      `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/new/`,
-      `/organizations/${organization.slug}/dashboards/new/widget-builder/widget/${widgetIndex}/edit/`,
-      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget-builder/widget/new/`,
-      `/organizations/${organization.slug}/dashboard/${dashboardId}/widget-builder/widget/${widgetIndex}/edit/`,
+      /^\/organizations\/.+\/dashboards\/new\/widget-builder\/widget\//,
+      /^\/organizations\/.+\/dashboard\/\d+\/widget-builder\/widget\//,
     ];
 
     if (USING_CUSTOMER_DOMAIN) {
       widgetBuilderRoutes.push(
-        ...[
-          `/dashboards/new/widget-builder/widget/new/`,
-          `/dashboards/new/widget-builder/widget/${widgetIndex}/edit/`,
-          `/dashboard/${dashboardId}/widget-builder/widget/new/`,
-          `/dashboard/${dashboardId}/widget-builder/widget/${widgetIndex}/edit/`,
-        ]
+        /^\/dashboards\/new\/widget-builder\/widget\//,
+        /^\/dashboard\/\d+\/widget-builder\/widget\//
       );
     }
 
-    return widgetBuilderRoutes.includes(path ?? location.pathname);
+    return widgetBuilderRoutes.some(route => route.test(path ?? location.pathname));
   };
 
   onEdit = () => {


### PR DESCRIPTION
We can't depend on the `widgetIndex` being part of the query params anymore. Also, we just need to check a certain amount of the URL pathname, so we just use regexes.