### PR TITLE
feat(ourlogs): Add new widget type for logs

### DIFF
--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -63,6 +63,10 @@ class DashboardWidgetTypes(TypesClass):
     This targets transaction-like data from the split from discover. Itt may either use 'Transactions' events or 'PerformanceMetrics' depending on on-demand, MEP metrics, etc.
     """
     SPANS = 102
+    """
+    These represent the logs trace item type on the EAP dataset.
+    """
+    LOGS = 103
 
     TYPES = [
         (DISCOVER, "discover"),
@@ -74,6 +78,7 @@ class DashboardWidgetTypes(TypesClass):
         (ERROR_EVENTS, "error-events"),
         (TRANSACTION_LIKE, "transaction-like"),
         (SPANS, "spans"),
+        (LOGS, "logs"),
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1106,6 +1106,29 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
+    def test_widget_type_logs(self):
+        data = {
+            "title": "Test Logs Query",
+            "widgetType": "logs",
+            "displayType": "table",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": ["log.message", "count()"],
+                    "columns": ["log.message"],
+                    "aggregates": ["count()"],
+                },
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data
+
     def test_has_group_by_and_no_limit_on_creation(self):
         data = {
             "title": "Test Query",


### PR DESCRIPTION
### Summary
This adds a dashboard widget type for logs, needed before UX work.

Refs LOGS-50

