### PR TITLE
fix(taskworker) Remove high-throughput setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1510,7 +1510,6 @@ TASKWORKER_SCHEDULES: ScheduleConfigMap = {
     },
 }
 
-TASKWORKER_ENABLE_HIGH_THROUGHPUT_NAMESPACES = False
 TASKWORKER_HIGH_THROUGHPUT_NAMESPACES = {
     "ingest.profiling",
     "ingest.transactions",

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -75,17 +75,12 @@ def taskworker_override(
     def override(*args: P.args, **kwargs: P.kwargs) -> R:
         rollout_rate = 0
         option_flag = f"taskworker.{namespace}.rollout"
-        check_option = True
-        if namespace in settings.TASKWORKER_HIGH_THROUGHPUT_NAMESPACES:
-            check_option = settings.TASKWORKER_ENABLE_HIGH_THROUGHPUT_NAMESPACES
-
-        if check_option:
-            rollout_map = options.get(option_flag)
-            if rollout_map:
-                if task_name in rollout_map:
-                    rollout_rate = rollout_map.get(task_name, 0)
-                elif "*" in rollout_map:
-                    rollout_rate = rollout_map.get("*", 0)
+        rollout_map = options.get(option_flag)
+        if rollout_map:
+            if task_name in rollout_map:
+                rollout_rate = rollout_map.get(task_name, 0)
+            elif "*" in rollout_map:
+                rollout_rate = rollout_map.get("*", 0)
 
         if rollout_rate > random.random():
             return taskworker_attr(*args, **kwargs)


### PR DESCRIPTION
We added this setting when options checks for taskworkers were expensive (because we used isset()), now that we've made option reads cheaper via get(), we shouldn't need this setting.
