### PR TITLE
ref(feedback): validate associated event_id for events

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -341,6 +341,16 @@ def create_feedback_issue(
             sample_rate=1.0,
         )
 
+    # Removes associated_event_id from event if it is invalid
+    associated_event_id = get_path(event, "contexts", "feedback", "associated_event_id")
+
+    if associated_event_id:
+        try:
+            UUID(str(associated_event_id))
+        except ValueError:
+            associated_event_id = None
+            event["contexts"]["feedback"]["associated_event_id"] = None
+
     # Note that some of the fields below like title and subtitle
     # are not used by the feedback UI, but are required.
     event["event_id"] = event.get("event_id") or uuid4().hex
@@ -379,14 +389,6 @@ def create_feedback_issue(
     user_email = get_path(event_fixed, "user", "email")
     if user_email and "user.email" not in event_fixed["tags"]:
         event_fixed["tags"]["user.email"] = user_email
-
-    # add the associated_event_id and has_linked_error to tags
-    associated_event_id = get_path(event_data, "contexts", "feedback", "associated_event_id")
-
-    try:
-        UUID(str(associated_event_id), version=4)
-    except ValueError:
-        associated_event_id = None
 
     if associated_event_id:
         event_fixed["tags"]["associated_event_id"] = associated_event_id

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -390,6 +390,7 @@ def create_feedback_issue(
     if user_email and "user.email" not in event_fixed["tags"]:
         event_fixed["tags"]["user.email"] = user_email
 
+    # add the associated_event_id and has_linked_error to tags
     if associated_event_id:
         event_fixed["tags"]["associated_event_id"] = associated_event_id
         event_fixed["tags"]["has_linked_error"] = "true"

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -513,7 +513,7 @@ def shim_to_feedback(
                 org_id=project.organization_id,
                 project_id=project.id,
                 key_id=None,
-                outcome=Outcome.RATE_LIMITED,
+                outcome=Outcome.INVALID,
                 reason="invalid_event_id",
                 timestamp=datetime.fromisoformat(event.timestamp),
                 event_id=event.event_id,

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -507,23 +507,7 @@ def shim_to_feedback(
             },
         }
 
-        # An invalid event_id leads to tracking the outcome and dropping the feedback
-        try:
-            UUID(event.event_id, version=4)
-            feedback_event["contexts"]["feedback"]["associated_event_id"] = event.event_id
-        except ValueError:
-            track_outcome(
-                org_id=project.organization_id,
-                project_id=project.id,
-                key_id=None,
-                outcome=Outcome.INVALID,
-                reason="invalid_event_id",
-                timestamp=datetime.fromisoformat(event.timestamp),
-                event_id=event.event_id,
-                category=DataCategory.USER_REPORT_V2,
-                quantity=1,
-            )
-            return
+        feedback_event["contexts"]["feedback"]["associated_event_id"] = event.event_id
 
         if get_path(event.data, "contexts", "replay", "replay_id"):
             feedback_event["contexts"]["replay"] = event.data["contexts"]["replay"]

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -349,7 +349,7 @@ def create_feedback_issue(
             UUID(str(associated_event_id))
         except ValueError:
             associated_event_id = None
-            event["contexts"]["feedback"]["associated_event_id"] = None
+            event["contexts"]["feedback"].pop("associated_event_id", "")
 
     # Note that some of the fields below like title and subtitle
     # are not used by the feedback UI, but are required.

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -789,6 +789,58 @@ def test_create_feedback_adds_associated_event_id(
 
 
 @django_db_all
+def test_create_feedback_adds_invalid_associated_event_id(
+    default_project, mock_produce_occurrence_to_kafka
+):
+    event = {
+        "project_id": default_project.id,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "message": "great website",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+                "associated_event_id": "abcdefg",
+            },
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+    create_feedback_issue(event, default_project.id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+
+    assert mock_produce_occurrence_to_kafka.call_count == 1
+
+    associated_event_id_evidence = [
+        evidence.value
+        for evidence in mock_produce_occurrence_to_kafka.call_args.kwargs[
+            "occurrence"
+        ].evidence_display
+        if evidence.name == "associated_event_id"
+    ]
+    associated_event_id = associated_event_id_evidence[0] if associated_event_id_evidence else None
+    assert associated_event_id is None
+
+
+@django_db_all
 def test_create_feedback_tags(default_project, mock_produce_occurrence_to_kafka):
     """We want to surface these tags in the UI. We also use user.email for alert conditions."""
     event = mock_feedback_event(default_project.id)

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -841,6 +841,7 @@ def test_create_feedback_excludes_invalid_associated_event_id(
 
     produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
     assert produced_event["tags"]["has_linked_error"] == "false"
+    assert not produced_event["tags"].get("associated_event_id")
     assert not produced_event["contexts"]["feedback"].get("associated_event_id")
 
 

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -789,7 +789,7 @@ def test_create_feedback_adds_associated_event_id(
 
 
 @django_db_all
-def test_create_feedback_adds_invalid_associated_event_id(
+def test_create_feedback_excludes_invalid_associated_event_id(
     default_project, mock_produce_occurrence_to_kafka
 ):
     event = {
@@ -838,6 +838,10 @@ def test_create_feedback_adds_invalid_associated_event_id(
     ]
     associated_event_id = associated_event_id_evidence[0] if associated_event_id_evidence else None
     assert associated_event_id is None
+
+    produced_event = mock_produce_occurrence_to_kafka.call_args.kwargs["event_data"]
+    assert produced_event["tags"]["has_linked_error"] == "false"
+    assert not produced_event["contexts"]["feedback"].get("associated_event_id")
 
 
 @django_db_all


### PR DESCRIPTION
Adds UUID validation for the associated event ID for user feedback events as mentioned in https://github.com/getsentry/sentry/issues/89919#top