### PR TITLE
feat(ACI): Use status column on Detector and Workflow

### DIFF
--- a/src/sentry/deletions/defaults/detector.py
+++ b/src/sentry/deletions/defaults/detector.py
@@ -3,6 +3,8 @@ from sentry.workflow_engine.models.detector import Detector
 
 
 class DetectorDeletionTask(ModelDeletionTask[Detector]):
+    manager_name = "objects_for_deletion"
+
     def get_child_relations(self, instance: Detector) -> list[BaseRelation]:
         from sentry.workflow_engine.models import DataConditionGroup, DataSource
 

--- a/src/sentry/deletions/defaults/detector.py
+++ b/src/sentry/deletions/defaults/detector.py
@@ -15,7 +15,11 @@ class DetectorDeletionTask(ModelDeletionTask[Detector]):
             "id", flat=True
         )
         if data_source_ids:
-            if Detector.objects.filter(data_sources__in=[data_source_ids[0]]).count() == 1:
+            # this ensures we're not deleting a data source that's connected to another detector
+            if (
+                Detector.objects_for_deletion.filter(data_sources__in=[data_source_ids[0]]).count()
+                == 1
+            ):
                 model_relations.append(ModelRelation(DataSource, {"detector": instance.id}))
 
         if instance.workflow_condition_group:

--- a/src/sentry/deletions/defaults/workflow.py
+++ b/src/sentry/deletions/defaults/workflow.py
@@ -3,6 +3,8 @@ from sentry.workflow_engine.models import Action, DataConditionGroup, Workflow
 
 
 class WorkflowDeletionTask(ModelDeletionTask[Workflow]):
+    manager_name = "objects_for_deletion"
+
     def get_child_relations(self, instance: Workflow) -> list[BaseRelation]:
         model_relations: list[BaseRelation] = []
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -19,6 +19,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import DetectorParams, GlobalParams
+from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues import grouptype
@@ -169,6 +170,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             return Response(status=403)
 
         RegionScheduledDeletion.schedule(detector, days=0, actor=request.user)
+        detector.update(status=ObjectStatus.PENDING_DELETION)
         create_audit_entry(
             request=request,
             organization=detector.project.organization,

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_details.py
@@ -14,6 +14,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.parameters import GlobalParams, WorkflowParams
+from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.models.organization import Organization
 from sentry.utils.audit import create_audit_entry
@@ -107,6 +108,7 @@ class OrganizationWorkflowDetailsEndpoint(OrganizationWorkflowEndpoint):
         Delete a workflow
         """
         RegionScheduledDeletion.schedule(workflow, days=0, actor=request.user)
+        workflow.update(status=ObjectStatus.PENDING_DELETION)
         create_audit_entry(
             request=request,
             organization=organization,

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -17,7 +17,6 @@ from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.db.models.manager.types import M
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.models.owner_base import OwnerModel
@@ -31,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class DetectorManager(BaseManager["Detector"]):
-    def get_queryset(self) -> BaseQuerySet[M]:
+    def get_queryset(self) -> BaseQuerySet[Detector]:
         return (
             super()
             .get_queryset()

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.conf import settings
 from django.db import models
@@ -15,6 +15,9 @@ from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
 from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+from sentry.db.models.manager.base import BaseManager
+from sentry.db.models.manager.base_query_set import BaseQuerySet
+from sentry.db.models.manager.types import M
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.models.owner_base import OwnerModel
@@ -27,9 +30,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class DetectorManager(BaseManager["Detector"]):
+    def get_queryset(self) -> BaseQuerySet[M]:
+        return (
+            super()
+            .get_queryset()
+            .exclude(status__in=(ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS))
+        )
+
+
 @region_silo_model
 class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
     __relocation_scope__ = RelocationScope.Organization
+
+    objects: ClassVar[DetectorManager] = DetectorManager()
+    objects_for_deletion: ClassVar[BaseManager] = BaseManager()
 
     project = FlexibleForeignKey("sentry.Project", on_delete=models.CASCADE)
     name = models.CharField(max_length=200)

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import replace
 from typing import Any, ClassVar
 
@@ -12,7 +14,6 @@ from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey, region_silo
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.db.models.manager.types import M
 from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
 from sentry.workflow_engine.types import WorkflowEventData
@@ -21,7 +22,7 @@ from .json_config import JSONConfigBase
 
 
 class WorkflowManager(BaseManager["Workflow"]):
-    def get_queryset(self) -> BaseQuerySet[M]:
+    def get_queryset(self) -> BaseQuerySet[Workflow]:
         return (
             super()
             .get_queryset()

--- a/tests/sentry/deletions/test_detector.py
+++ b/tests/sentry/deletions/test_detector.py
@@ -1,3 +1,4 @@
+from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.grouptype import MetricIssue
 from sentry.snuba.models import QuerySubscription, SnubaQuery
@@ -40,6 +41,8 @@ class DeleteDetectorTest(BaseWorkflowTest, HybridCloudTestMixin):
         self.detector_workflow = DetectorWorkflow.objects.create(
             detector=self.detector, workflow=self.workflow
         )
+        self.detector.status = ObjectStatus.PENDING_DELETION
+        self.detector.save()
 
     def test_simple(self):
         self.ScheduledDeletion.schedule(instance=self.detector, days=0)

--- a/tests/sentry/deletions/test_workflow.py
+++ b/tests/sentry/deletions/test_workflow.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import TaskRunner
@@ -53,6 +54,8 @@ class TestDeleteWorkflow(HybridCloudTestMixin):
             comparison=1,
             condition_result=True,
         )
+        self.workflow.status = ObjectStatus.PENDING_DELETION
+        self.workflow.save()
 
     @pytest.mark.parametrize(
         "instance_attr",

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -1,5 +1,6 @@
 from sentry import audit_log
 from sentry.api.serializers import serialize
+from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.models.auditlogentry import AuditLogEntry
@@ -30,6 +31,12 @@ class OrganizationWorkflowIndexGetTest(OrganizationWorkflowDetailsBaseTest):
 
     def test_does_not_exist(self):
         self.get_error_response(self.organization.slug, 3, status_code=404)
+
+    def test_pending_deletion(self):
+        workflow = self.create_workflow(organization_id=self.organization.id)
+        workflow.status = ObjectStatus.PENDING_DELETION
+        workflow.save()
+        self.get_error_response(self.organization.slug, workflow.id, status_code=404)
 
 
 @region_silo_test
@@ -82,6 +89,8 @@ class OrganizationDeleteWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             model_name="Workflow",
             object_id=self.workflow.id,
         ).exists()
+        self.workflow.refresh_from_db()
+        assert self.workflow.status == ObjectStatus.PENDING_DELETION
 
     def test_audit_entry(self):
         with outbox_runner():

--- a/tests/sentry/workflow_engine/models/test_detector.py
+++ b/tests/sentry/workflow_engine/models/test_detector.py
@@ -1,0 +1,21 @@
+from sentry.constants import ObjectStatus
+from sentry.workflow_engine.models import Detector
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class DetectorTest(BaseWorkflowTest):
+    def setUp(self):
+        self.detector = self.create_detector()
+
+    def test_queryset(self):
+        """
+        Test that we filter out objects with statuses other than 'active'
+        """
+        assert Detector.objects.filter(id=self.detector.id).exists()
+        self.detector.status = ObjectStatus.PENDING_DELETION
+        self.detector.save()
+        assert not Detector.objects.filter(id=self.detector.id).exists()
+
+        self.detector.status = ObjectStatus.DELETION_IN_PROGRESS
+        self.detector.save()
+        assert not Detector.objects.filter(id=self.detector.id).exists()

--- a/tests/sentry/workflow_engine/models/test_workflow.py
+++ b/tests/sentry/workflow_engine/models/test_workflow.py
@@ -1,6 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
+from sentry.constants import ObjectStatus
 from sentry.workflow_engine.models import Workflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowEventData
@@ -15,6 +16,19 @@ class WorkflowTest(BaseWorkflowTest):
         self.data_condition = self.data_condition_group.conditions.first()
         self.group, self.event, self.group_event = self.create_group_event()
         self.event_data = WorkflowEventData(event=self.group_event)
+
+    def test_queryset(self):
+        """
+        Test that we filter out objects with statuses other than 'active'
+        """
+        assert Workflow.objects.filter(id=self.workflow.id).exists()
+        self.workflow.status = ObjectStatus.PENDING_DELETION
+        self.workflow.save()
+        assert not Workflow.objects.filter(id=self.workflow.id).exists()
+
+        self.workflow.status = ObjectStatus.DELETION_IN_PROGRESS
+        self.workflow.save()
+        assert not Workflow.objects.filter(id=self.workflow.id).exists()
 
     def test_evaluate_trigger_conditions__condition_new_event__True(self):
         evaluation, _ = self.workflow.evaluate_trigger_conditions(self.event_data)


### PR DESCRIPTION
Redo of https://github.com/getsentry/sentry/pull/91994 because git ate everything to use the `status` column on the `Detector` and `Workflow` models.