### PR TITLE
chore(issue-views): Create new style option for PowerFeatureHovercard

### DIFF
--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import {Hovercard} from 'sentry/components/hovercard';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -46,6 +47,12 @@ type Props = {
   partial?: boolean;
 
   upsellDefaultSelection?: string;
+
+  /**
+   * Replaces the default learn more button with a more subtle link text that
+   * opens the upsell modal.
+   */
+  useLearnMoreLink?: boolean;
 };
 
 class PowerFeatureHovercard extends Component<Props> {
@@ -79,6 +86,7 @@ class PowerFeatureHovercard extends Component<Props> {
       partial,
       features,
       children,
+      useLearnMoreLink,
     } = this.props;
 
     const hoverBody = (
@@ -90,7 +98,18 @@ class PowerFeatureHovercard extends Component<Props> {
             planName = `Performance ${planName}`;
           }
 
-          return (
+          return useLearnMoreLink ? (
+            <LearnMoreTextBody data-test-id="power-hovercard">
+              <div>
+                {partial
+                  ? t('Better With %s Plan', planName)
+                  : t('Requires %s Plan', planName)}
+              </div>
+              <LearnMoreLink onClick={this.handleClick} data-test-id="power-learn-more">
+                {t('Learn More')}
+              </LearnMoreLink>
+            </LearnMoreTextBody>
+          ) : (
             <HovercardBody data-test-id="power-hovercard">
               <Text>
                 {partial
@@ -126,6 +145,20 @@ class PowerFeatureHovercard extends Component<Props> {
   }
 }
 
+const LearnMoreLink = styled('a')`
+  color: ${p => p.theme.subText};
+  text-decoration: underline;
+
+  &:hover {
+    color: ${p => p.theme.subText};
+    text-decoration: none;
+  }
+`;
+
+const LearnMoreTextBody = styled('div')`
+  padding: ${space(1)};
+`;
+
 const UpsellModalButton = styled(Button)`
   height: auto;
   border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
@@ -150,7 +183,7 @@ const StyledHovercard = styled(Hovercard)`
   }
 `;
 
-const Text = styled('span')`
+const Text = styled('div')`
   margin: 10px;
   font-size: 14px;
   white-space: pre;

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
 import {Hovercard} from 'sentry/components/hovercard';
+import {linkStyles} from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -145,7 +146,9 @@ class PowerFeatureHovercard extends Component<Props> {
   }
 }
 
-const LearnMoreLink = styled('a')`
+const LearnMoreLink = styled('div')`
+  ${p => linkStyles({theme: p.theme})}
+
   color: ${p => p.theme.subText};
   text-decoration: underline;
 

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/core/button';
 import {Hovercard} from 'sentry/components/hovercard';
 import {linkStyles} from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
@@ -87,7 +86,6 @@ class PowerFeatureHovercard extends Component<Props> {
       partial,
       features,
       children,
-      useLearnMoreLink,
     } = this.props;
 
     const hoverBody = (
@@ -99,7 +97,7 @@ class PowerFeatureHovercard extends Component<Props> {
             planName = `Performance ${planName}`;
           }
 
-          return useLearnMoreLink ? (
+          return (
             <LearnMoreTextBody data-test-id="power-hovercard">
               <div>
                 {partial
@@ -110,22 +108,6 @@ class PowerFeatureHovercard extends Component<Props> {
                 {t('Learn More')}
               </LearnMoreLink>
             </LearnMoreTextBody>
-          ) : (
-            <HovercardBody data-test-id="power-hovercard">
-              <Text>
-                {partial
-                  ? t('Better With %s Plan', planName)
-                  : t('Requires %s Plan', planName)}
-              </Text>
-              <UpsellModalButton
-                priority="primary"
-                size="sm"
-                onClick={this.handleClick}
-                data-test-id="power-learn-more"
-              >
-                {t('Learn More')}
-              </UpsellModalButton>
-            </HovercardBody>
           );
         }}
       </PlanFeature>
@@ -162,21 +144,6 @@ const LearnMoreTextBody = styled('div')`
   padding: ${space(1)};
 `;
 
-const UpsellModalButton = styled(Button)`
-  height: auto;
-  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
-  white-space: pre;
-  margin-top: -1px;
-  margin-bottom: -1px;
-  margin-right: -1px;
-  box-shadow: none;
-`;
-
-const HovercardBody = styled('div')`
-  display: flex;
-  justify-content: space-between;
-`;
-
 const StyledHovercard = styled(Hovercard)`
   width: auto;
   border-radius: ${p => p.theme.borderRadius};
@@ -184,12 +151,6 @@ const StyledHovercard = styled(Hovercard)`
     padding: 0;
     align-items: center;
   }
-`;
-
-const Text = styled('div')`
-  margin: 10px;
-  font-size: 14px;
-  white-space: pre;
 `;
 
 export default withOrganization(

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -128,8 +128,11 @@ class PowerFeatureHovercard extends Component<Props> {
   }
 }
 
-const LearnMoreLink = styled('div')`
+const LearnMoreLink = styled('button')`
   ${p => linkStyles({theme: p.theme})}
+  background: none;
+  border: none;
+  padding: 0;
 
   color: ${p => p.theme.subText};
   text-decoration: underline;

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -351,7 +351,11 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   ),
   'feature-disabled:open-in-discover': p => <OpenInDiscoverBtn {...p} />,
   'feature-disabled:issue-views': p => (
-    <PowerFeatureHovercard features={['organizations:issue-views']} id="issue-views">
+    <PowerFeatureHovercard
+      features={['organizations:issue-views']}
+      id="issue-views"
+      useLearnMoreLink
+    >
       {typeof p.children === 'function' ? p.children(p) : p.children}
     </PowerFeatureHovercard>
   ),


### PR DESCRIPTION
Gives the option in powerfeaturehovercard to replace this: 
![image](https://github.com/user-attachments/assets/61a97c27-734b-4b64-9390-72ad1229755c)
with this: 

![image](https://github.com/user-attachments/assets/1b5f7c50-64df-4354-801d-90081d9b62ac)


I think it's saying [unavailable] instead of Team because my [PR](https://github.com/getsentry/getsentry/pull/17524) adding the feature to billing logic has not been deployed yet. 