### PR TITLE
feat(issue-views): Add empty state for no personal views

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -337,6 +337,7 @@ export type IssueEventParameters = {
     surface: 'issue-views-list' | 'issue-view-details';
   };
   'issue_views.switched_views': Record<string, unknown>;
+  'issue_views.table.banner_create_view_clicked': Record<string, unknown>;
   'issue_views.table.create_view_clicked': Record<string, unknown>;
   'issue_views.table.search': {
     query: string;
@@ -525,6 +526,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue_views.page_filters_logged': 'Issue Views: Page Filters Logged',
   'issue_views.table.sort_changed': 'Issue Views: Changed Sort',
   'issue_views.table.create_view_clicked': 'Issue Views: Create View Clicked',
+  'issue_views.table.banner_create_view_clicked':
+    'Issue Views: Create View Clicked from No Views Banner',
   'issue_views.new_view.suggested_query_clicked': 'Issue Views: Suggested Query Clicked',
   'issue_views.edit_name': 'Issue Views: Edit Name',
   'issue_views.star_view': 'Issue Views: Star View',

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -48,6 +48,7 @@ type IssueViewSectionProps = {
   createdBy: GroupSearchViewCreatedBy;
   cursorQueryParam: string;
   limit: number;
+  emptyState?: React.ReactNode;
 };
 
 // We expose a few simplified sort options which are mapped to multiple
@@ -81,7 +82,12 @@ function useIssueViewSort(): GroupSearchViewSort {
   return sort as GroupSearchViewSort;
 }
 
-function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSectionProps) {
+function IssueViewSection({
+  createdBy,
+  limit,
+  cursorQueryParam,
+  emptyState,
+}: IssueViewSectionProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
@@ -162,6 +168,10 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
 
   const pageLinks = getResponseHeader?.('Link');
 
+  if (emptyState && !isPending && views.length === 0) {
+    return emptyState;
+  }
+
   return (
     <Fragment>
       <IssueViewsTable
@@ -198,6 +208,34 @@ function IssueViewSection({createdBy, limit, cursorQueryParam}: IssueViewSection
         }}
       />
     </Fragment>
+  );
+}
+
+function NoViewsBanner({handleCreateView}: {handleCreateView: () => void}) {
+  const organization = useOrganization();
+
+  return (
+    <Banner>
+      <BannerTitle>{t('Create your first view')}</BannerTitle>
+      <BannerText>
+        {t(
+          'Your haven’t saved any issue views yet — saving views makes it easier to return to your most frequent search queries, like high priority, assigned to you, or most recent.'
+        )}
+      </BannerText>
+      <BannerAddViewButton
+        priority="primary"
+        icon={<IconAdd />}
+        size="sm"
+        onClick={() => {
+          trackAnalytics('issue_views.table.banner_create_view_clicked', {
+            organization,
+          });
+          handleCreateView();
+        }}
+      >
+        {t('Create View')}
+      </BannerAddViewButton>
+    </Banner>
   );
 }
 
@@ -267,6 +305,33 @@ export default function IssueViewsList() {
     return <Redirect to={`/organizations/${organization.slug}/issues/`} />;
   }
 
+  const handleCreateView = () => {
+    createGroupSearchView(
+      {
+        name: t('New View'),
+        query: 'is:unresolved',
+        projects: defaultProject,
+        environments: DEFAULT_ENVIRONMENTS,
+        timeFilters: DEFAULT_TIME_FILTERS,
+        querySort: IssueSortOptions.DATE,
+        starred: true,
+      },
+      {
+        onSuccess: data => {
+          navigate({
+            pathname: normalizeUrl(
+              `/organizations/${organization.slug}/issues/views/${data.id}/`
+            ),
+            query: {
+              ...getIssueViewQueryParams({view: data}),
+              new: 'true',
+            },
+          });
+        },
+      }
+    );
+  };
+
   return (
     <SentryDocumentTitle title={t('All Views')} orgSlug={organization.slug}>
       <Layout.Page>
@@ -306,30 +371,7 @@ export default function IssueViewsList() {
                   trackAnalytics('issue_views.table.create_view_clicked', {
                     organization,
                   });
-                  createGroupSearchView(
-                    {
-                      name: t('New View'),
-                      query: 'is:unresolved',
-                      projects: defaultProject,
-                      environments: DEFAULT_ENVIRONMENTS,
-                      timeFilters: DEFAULT_TIME_FILTERS,
-                      querySort: IssueSortOptions.DATE,
-                      starred: true,
-                    },
-                    {
-                      onSuccess: data => {
-                        navigate({
-                          pathname: normalizeUrl(
-                            `/organizations/${organization.slug}/issues/views/${data.id}/`
-                          ),
-                          query: {
-                            ...getIssueViewQueryParams({view: data}),
-                            new: 'true',
-                          },
-                        });
-                      },
-                    }
-                  );
+                  handleCreateView();
                 }}
               >
                 {t('Create View')}
@@ -362,6 +404,16 @@ export default function IssueViewsList() {
               createdBy={GroupSearchViewCreatedBy.ME}
               limit={20}
               cursorQueryParam="mc"
+              emptyState={
+                <NoViewsBanner
+                  handleCreateView={() => {
+                    trackAnalytics('issue_views.table.banner_create_view_clicked', {
+                      organization,
+                    });
+                    handleCreateView();
+                  }}
+                />
+              }
             />
             <TableHeading>{t('Created by Others')}</TableHeading>
             <IssueViewSection
@@ -375,6 +427,51 @@ export default function IssueViewsList() {
     </SentryDocumentTitle>
   );
 }
+
+const Banner = styled('div')`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  margin-top: ${space(2)};
+  margin-bottom: 0;
+  padding: 12px;
+  gap: ${space(1)};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+
+  background: linear-gradient(
+    269.35deg,
+    ${p => p.theme.backgroundTertiary} 0.32%,
+    rgba(245, 243, 247, 0) 99.69%
+  );
+`;
+
+const BannerTitle = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightBold};
+`;
+
+const BannerText = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: ${p => p.theme.fontWeightNormal};
+  flex-shrink: 0;
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    max-width: 75%;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    max-width: 60%;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    max-width: 50%;
+  }
+`;
+
+const BannerAddViewButton = styled(Button)`
+  align-self: flex-start;
+`;
 
 const FilterSortBar = styled('div')`
   display: grid;

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -211,7 +211,13 @@ function IssueViewSection({
   );
 }
 
-function NoViewsBanner({handleCreateView}: {handleCreateView: () => void}) {
+function NoViewsBanner({
+  handleCreateView,
+  isCreatingView,
+}: {
+  handleCreateView: () => void;
+  isCreatingView: boolean;
+}) {
   const organization = useOrganization();
 
   return (
@@ -232,6 +238,7 @@ function NoViewsBanner({handleCreateView}: {handleCreateView: () => void}) {
           });
           handleCreateView();
         }}
+        disabled={isCreatingView}
       >
         {t('Create View')}
       </BannerAddViewButton>
@@ -412,6 +419,7 @@ export default function IssueViewsList() {
                     });
                     handleCreateView();
                   }}
+                  isCreatingView={isCreatingView}
                 />
               }
             />


### PR DESCRIPTION
Adds this banner when the user has no personal issue views

![image](https://github.com/user-attachments/assets/68b042ed-5fd2-45fd-8a14-506a927431b9)

The text dynamically consumes less width for better readability as the window screen gets larger. 