### PR TITLE
feat(spans): Compue breakdowns on segment spans

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.21.0
-sentry-kafka-schemas>=1.3.2
+sentry-kafka-schemas>=1.3.6
 sentry-ophio>=1.1.3
 sentry-protos==0.2.0
 sentry-redis-tools>=0.5.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-devenv==1.21.0
 sentry-forked-django-stubs==5.2.0.post3
 sentry-forked-djangorestframework-stubs==3.16.0.post1
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.2
+sentry-kafka-schemas==1.3.6
 sentry-ophio==1.1.3
 sentry-protos==0.2.0
 sentry-redis-tools==0.5.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.21.0
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.2
+sentry-kafka-schemas==1.3.6
 sentry-ophio==1.1.3
 sentry-protos==0.2.0
 sentry-redis-tools==0.5.0

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -186,12 +186,12 @@ def compute_breakdowns(segment: Span, spans: list[Span], project: Project) -> No
         ty = breakdown_config.get("type")
 
         if ty == "spanOperations":
-            measurements = _compute_span_ops(spans, breakdown_config)
+            breakdowns = _compute_span_ops(spans, breakdown_config)
         else:
             continue
 
         measurements = segment.setdefault("measurements", {})
-        for key, value in measurements.items():
+        for key, value in breakdowns.items():
             measurements[f"{breakdown_name}.{key}"] = value
 
 
@@ -202,7 +202,7 @@ def _compute_span_ops(spans: list[Span], config: Any) -> dict[str, _MeasurementV
 
     intervals_by_op = defaultdict(list)
     for span in spans:
-        op = span["op"]
+        op = span.get("sentry_tags", {}).get("op", "")
         if operation_name := next(filter(lambda m: op.startswith(m), matches), None):
             intervals_by_op[operation_name].append(_span_interval(span))
 

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -1,5 +1,10 @@
+from collections import defaultdict
 from typing import Any, cast
 
+# TODO(ja): Fix and update the schema
+from sentry_kafka_schemas.schema_types.buffered_segments_v1 import _MeasurementValue
+
+from sentry.models.project import Project
 from sentry.spans.consumers.process_segments.types import Span
 
 # Keys in `sentry_tags` that are shared across all spans in a segment. This list
@@ -127,7 +132,7 @@ def set_exclusive_time(spans: list[Span]) -> None:
     span_map: dict[str, list[tuple[int, int]]] = {}
     for span in spans:
         if parent_span_id := span.get("parent_span_id"):
-            interval = (_us(span["start_timestamp_precise"]), _us(span["end_timestamp_precise"]))
+            interval = _span_interval(span)
             span_map.setdefault(parent_span_id, []).append(interval)
 
     for span in spans:
@@ -136,7 +141,7 @@ def set_exclusive_time(spans: list[Span]) -> None:
         intervals.sort(key=lambda x: (x[0], -x[1]))
 
         exclusive_time_us: int = 0  # microseconds to prevent rounding issues
-        start, end = _us(span["start_timestamp_precise"]), _us(span["end_timestamp_precise"])
+        start, end = _span_interval(span)
 
         # Progressively add time gaps before the next span and then skip to its end.
         for child_start, child_end in intervals:
@@ -155,7 +160,95 @@ def set_exclusive_time(spans: list[Span]) -> None:
         span["exclusive_time_ms"] = exclusive_time_us / 1_000
 
 
+def _span_interval(span: Span) -> tuple[int, int]:
+    """Get the start and end timestamps of a span in microseconds."""
+    return _us(span["start_timestamp_precise"]), _us(span["end_timestamp_precise"])
+
+
 def _us(timestamp: float) -> int:
     """Convert the floating point duration or timestamp to integer microsecond
     precision."""
     return int(timestamp * 1_000_000)
+
+
+def compute_breakdowns(segment: Span, spans: list[Span], project: Project) -> None:
+    """
+    Computes breakdowns from all spans and writes them to the segment span.
+
+    Breakdowns are measurements that are derived from the spans in the segment.
+    By convention, their unit is in milliseconds. In the end, these measurements
+    are converted into attributes on the span trace item.
+    """
+
+    config = project.get_option("sentry:breakdowns")
+
+    for breakdown_name, breakdown_config in config.items():
+        ty = breakdown_config.get("type")
+
+        if ty == "spanOperations":
+            measurements = _compute_span_ops(spans, breakdown_config)
+        else:
+            continue
+
+        measurements = segment.setdefault("measurements", {})
+        for key, value in measurements.items():
+            measurements[f"{breakdown_name}.{key}"] = value
+
+
+def _compute_span_ops(spans: list[Span], config: Any) -> dict[str, _MeasurementValue]:
+    matches = config.get("matches")
+    if not matches:
+        return {}
+
+    emit_intervals = defaultdict(list)
+    other_intervals = defaultdict(list)
+    for span in spans:
+        # If the span operation matches one of the prefixes, emit a breakdown
+        # for this interval. Otherwise, only count it for total_time.
+        op = span["op"]
+        if operation_name := next(filter(lambda m: op.startswith(m), matches), None):
+            emit_intervals[operation_name].append(_span_interval(span))
+        else:
+            other_intervals[op].append(_span_interval(span))
+
+    total_time = 0
+    measurements = {}
+
+    for _, intervals in other_intervals.items():
+        total_time += _get_duration_us(intervals)
+
+    for operation_name, intervals in emit_intervals.items():
+        total_time += _get_duration_us(intervals)
+        measurements[f"ops.{operation_name}"] = _measurement_us(_get_duration_us(intervals))
+
+    measurements["total.time"] = _measurement_us(total_time)
+    return measurements
+
+
+def _get_duration_us(intervals: list[tuple[int, int]]) -> int:
+    """
+    Get the wall clock time duration covered by the intervals in microseconds.
+
+    Overlapping intervals are merged so that they are not counted twice. For
+    example, the intervals [(1, 3), (2, 4)] would yield a duration of 3, not 4.
+    """
+
+    duration = 0
+    last_end = 0
+
+    intervals.sort(key=lambda x: (x[0], -x[1]))
+    for start, end in intervals:
+        # Ensure the current interval doesn't overlap with the last one
+        start = max(start, last_end)
+        duration += max(end - start, 0)
+        last_end = end
+
+    return duration
+
+
+def _measurement_us(value_us: int) -> _MeasurementValue:
+    """
+    Create a measurement value from the provided value in microseconds
+    """
+
+    return {"value": value_us / 1000, "unit": "millisecond"}

--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -1,11 +1,8 @@
 from collections import defaultdict
 from typing import Any, cast
 
-# TODO(ja): Fix and update the schema
-from sentry_kafka_schemas.schema_types.buffered_segments_v1 import _MeasurementValue
-
 from sentry.models.project import Project
-from sentry.spans.consumers.process_segments.types import Span
+from sentry.spans.consumers.process_segments.types import MeasurementValue, Span
 
 # Keys in `sentry_tags` that are shared across all spans in a segment. This list
 # is taken from `extract_shared_tags` in Relay.
@@ -195,7 +192,7 @@ def compute_breakdowns(segment: Span, spans: list[Span], project: Project) -> No
             measurements[f"{breakdown_name}.{key}"] = value
 
 
-def _compute_span_ops(spans: list[Span], config: Any) -> dict[str, _MeasurementValue]:
+def _compute_span_ops(spans: list[Span], config: Any) -> dict[str, MeasurementValue]:
     matches = config.get("matches")
     if not matches:
         return {}
@@ -206,7 +203,7 @@ def _compute_span_ops(spans: list[Span], config: Any) -> dict[str, _MeasurementV
         if operation_name := next(filter(lambda m: op.startswith(m), matches), None):
             intervals_by_op[operation_name].append(_span_interval(span))
 
-    measurements: dict[str, _MeasurementValue] = {}
+    measurements: dict[str, MeasurementValue] = {}
     for operation_name, intervals in intervals_by_op.items():
         duration = _get_duration_us(intervals)
         measurements[f"ops.{operation_name}"] = {"value": duration / 1000, "unit": "millisecond"}

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -24,6 +24,7 @@ from sentry.receivers.onboarding import (
     record_release_received,
 )
 from sentry.spans.consumers.process_segments.enrichment import (
+    compute_breakdowns,
     match_schemas,
     set_exclusive_time,
     set_shared_tags,
@@ -50,6 +51,7 @@ def process_segment(unprocessed_spans: list[UnprocessedSpan]) -> list[Span]:
         # If the project does not exist then it might have been deleted during ingestion.
         return []
 
+    compute_breakdowns(segment_span, spans, project)
     _create_models(segment_span, project)
     _detect_performance_problems(segment_span, spans, project)
     _record_signals(segment_span, spans, project)

--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -1,8 +1,10 @@
-from typing import Any, NotRequired
+from typing import NotRequired
 
+from sentry_kafka_schemas.schema_types.buffered_segments_v1 import MeasurementValue
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan as UnprocessedSpan
 
 __all__ = (
+    "MeasurementValue",
     "Span",
     "UnprocessedSpan",
 )
@@ -13,11 +15,6 @@ class Span(UnprocessedSpan, total=True):
     Enriched version of the incoming span payload that has additional attributes
     extracted.
     """
-
-    # Missing in schema
-    start_timestamp_precise: float
-    end_timestamp_precise: float
-    data: NotRequired[dict[str, Any]]  # currently unused
 
     # Added in enrichment
     exclusive_time: float


### PR DESCRIPTION
Computes breakdowns as measurements that ultimately get converted to span
attributes. Once we have a specification for span breakdowns in span data, this
implementation can be updated.

Follows the implementation in Relay from getsentry/relay#1260 and
getsentry/relay#4600.

Closes VIEPF-5
Requires https://github.com/getsentry/sentry-kafka-schemas/pull/411
