### PR TITLE
feat(nextjs-insights): fixed thresholds for p95 durations

### DIFF
--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -56,10 +56,10 @@ const errorRateColorThreshold = {
   warning: 0.05,
 } as const;
 
-const getP95Threshold = (avg: number) => {
+const getP95Threshold = (_avg: number) => {
   return {
-    error: avg * 3,
-    warning: avg * 2,
+    error: 4000,
+    warning: 2500,
   };
 };
 


### PR DESCRIPTION
- Frontend data is more diverse than API responses and has more outliers, therefore there are many more cases where P95>2 x avg
- Use fixed threshold to color the P95 in the PagesTable component
- Thresholds are inspired by Web Vitals - 2500 and 4000 milliseconds for yellow & red

Before:
![Screenshot 2025-05-23 at 11 12 08](https://github.com/user-attachments/assets/e44e0831-e5eb-4383-87b6-5f0c4216fee9)

After:
![Screenshot 2025-05-23 at 11 11 49](https://github.com/user-attachments/assets/39644b83-cae2-4c88-a3fc-f33d57130e2b)
