### PR TITLE
Pin `pytest-sentry`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest-django>=4.9.0
 pytest-fail-slow>=0.3.0
 pytest-json-report>=1.5.0
 pytest-rerunfailures>=15
-pytest-sentry>=0.3.0
+pytest-sentry>=0.3.0,<0.4.0
 pytest-workaround-12888
 pytest-xdist>=3
 responses>=0.23.1


### PR DESCRIPTION
Do not install `pytest-sentry` 0.4 because it is only compatible with python sdk 3.0.