### PR TITLE
fix: ip addresses in ps onboarding

### DIFF
--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -58,7 +58,7 @@ export default function EmptyState() {
                   'Allow list our Outbound IP addresses as they will be the once used for making the requests using the provided credentials'
                 )}
                 <CodeSnippetWrapper>
-                  <OnboardingCodeSnippet language="javascript">
+                  <OnboardingCodeSnippet>
                     {`
 35.184.238.160/32
 104.155.159.182/32


### PR DESCRIPTION
- IP addresses were not copy-able without weird spaces, remove the prettify that happens because it's tagged as javascript

Before: 
![Screenshot 2025-05-23 at 12 21 53](https://github.com/user-attachments/assets/92c243ab-4d49-4c03-92a1-dcf1364c3ad4)

After:
![Screenshot 2025-05-23 at 12 23 39](https://github.com/user-attachments/assets/83d9c479-2c6d-45b0-805f-704c5c5fae4e)
