### PR TITLE
fix(spend-allocations): normalize singular billingMetric values for c…

### DIFF
--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -22,7 +22,7 @@ import type {Organization} from 'sentry/types/organization';
 import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
 
-import {AllocationTargetTypes} from 'getsentry/constants';
+import {AllocationTargetTypes, BILLED_DATA_CATEGORY_INFO} from 'getsentry/constants';
 import type {Subscription} from 'getsentry/types';
 import {
   getCategoryInfoFromPlural,
@@ -545,15 +545,11 @@ const Select = styled(SelectField)`
   }
 `;
 
-// Normalizes singular billingMetric values to match DataCategory enum
+// Normalizes singular billingMetric values to match DataCategory enum using BILLED_DATA_CATEGORY_INFO
 function normalizeBillingMetric(metric: string): DataCategory {
-  switch (metric) {
-    case 'error':
-      return DataCategory.ERRORS;
-    case 'attachment':
-      return DataCategory.ATTACHMENTS;
-    // Add more mappings as needed
-    default:
-      return metric as DataCategory;
-  }
+  return (
+    Object.values(BILLED_DATA_CATEGORY_INFO)
+      .filter(info => info.canAllocate)
+      .find(c => c.name === metric)?.plural ?? (metric as DataCategory)
+  );
 }

--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -64,7 +64,7 @@ function AllocationForm({
   const [showPrice, setShowPrice] = useState<boolean>(false);
   const [selectedMetric, setSelectedMetric] = useState<DataCategory>(
     initializedData
-      ? (initializedData.billingMetric as DataCategory)
+      ? normalizeBillingMetric(initializedData.billingMetric)
       : initialMetric && getCategoryInfoFromPlural(initialMetric)?.canAllocate
         ? initialMetric
         : DataCategory.ERRORS // default to errors
@@ -544,3 +544,16 @@ const Select = styled(SelectField)`
     padding-left: 0;
   }
 `;
+
+// Normalizes singular billingMetric values to match DataCategory enum
+function normalizeBillingMetric(metric: string): DataCategory {
+  switch (metric) {
+    case 'error':
+      return DataCategory.ERRORS;
+    case 'attachment':
+      return DataCategory.ATTACHMENTS;
+    // Add more mappings as needed
+    default:
+      return metric as DataCategory;
+  }
+}


### PR DESCRIPTION
This PR addresses an issue where the Spend Allocation edit modal would not correctly pre-select the category if the backend provided a singular billingMetric value (e.g., "error" or "attachment") instead of the plural form expected by the frontend (e.g., "errors", "attachments").

What was changed:
- Added a normalizeBillingMetric function to map singular billingMetric values to their correct plural DataCategory enum equivalents.
- Updated the initialization of the selectedMetric state to use this normalization function, ensuring the correct default value is selected in the modal.

Why:
Without this normalization, users would see the category select default to an incorrect or empty value when editing allocations for certain categories, leading to confusion and escalation

Fixes: https://github.com/getsentry/sentry/issues/91213