### PR TITLE
fix(ui): use a transparent priority for "See all selectors"

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -227,6 +227,7 @@ function SearchButton({
   return (
     <StyledLinkButton
       {...props}
+      priority="transparent"
       size="md"
       to={{
         pathname,
@@ -276,12 +277,8 @@ const CenteredContentContainer = styled(ContentContainer)`
 `;
 
 const StyledLinkButton = styled(LinkButton)`
-  width: 100%;
-  padding: ${space(1.5)};
-  border: none;
   border-top: 1px solid ${p => p.theme.border};
   border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
-  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const StyledAccordionHeader = styled('div')`


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-05-23 at 13 42 54](https://github.com/user-attachments/assets/346a963f-2d0b-495a-9056-8f3e8452b3d1) | ![Screenshot 2025-05-23 at 13 44 08](https://github.com/user-attachments/assets/7c649001-19cc-4d17-b907-1c662c962682) |
| ![Screenshot 2025-05-23 at 13 43 02](https://github.com/user-attachments/assets/12e0914c-7500-42af-b376-e42be1844f12) | ![Screenshot 2025-05-23 at 13 44 16](https://github.com/user-attachments/assets/f45e6cf1-5dba-4683-a893-c8bdbb1f7bac) | 