### PR TITLE
feat(agents-insights): LLM Generations and Tool Usage widgets

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -1,0 +1,171 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {
+  AI_MODEL_ID_ATTRIBUTE,
+  getLLMGenerationsFilter,
+} from 'sentry/views/insights/agentMonitoring/utils/query';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+export default function LLMGenerationsWidget() {
+  const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+  });
+
+  const theme = useTheme();
+
+  const fullQuery = `${getLLMGenerationsFilter()} ${query}`.trim();
+
+  const generationsRequest = useEAPSpans(
+    {
+      // @ts-expect-error TODO(telex): Add model id attribute to Fields
+      fields: [AI_MODEL_ID_ATTRIBUTE, 'count(span.duration)'],
+      sorts: [{field: 'count(span.duration)', kind: 'desc'}],
+      search: fullQuery,
+      limit: 3,
+    },
+    Referrer.QUERIES_CHART // TODO
+  );
+
+  const timeSeriesRequest = useTopNSpanEAPSeries(
+    {
+      ...pageFilterChartParams,
+      search: fullQuery,
+      fields: [AI_MODEL_ID_ATTRIBUTE, 'count(span.duration)'],
+      yAxis: ['count(span.duration)'],
+      sort: {field: 'count(span.duration)', kind: 'desc'},
+      topN: 3,
+      enabled: !!generationsRequest.data,
+    },
+    Referrer.QUERIES_CHART // TODO
+  );
+
+  const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');
+
+  const isLoading = timeSeriesRequest.isLoading || generationsRequest.isLoading;
+  const error = timeSeriesRequest.error || generationsRequest.error;
+
+  // TODO(telex): Add model id attribute to Fields and get rid of this cast
+  const models = generationsRequest.data as unknown as
+    | Array<{
+        [AI_MODEL_ID_ATTRIBUTE]: string;
+        'count(span.duration)': number;
+      }>
+    | undefined;
+
+  const hasData = models && models.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 2);
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={<TimeSpentInDatabaseWidgetEmptyStateWarning />}
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        showLegend: 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Bars(convertSeriesToTimeseries(ts), {
+              color: colorPalette[index],
+              alias: ts.seriesName,
+              stack: 'stack',
+            })
+        ),
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {models?.map((item, index) => (
+        <Fragment key={item[AI_MODEL_ID_ATTRIBUTE]}>
+          <div>
+            <SeriesColorIndicator
+              style={{
+                backgroundColor: colorPalette[index],
+              }}
+            />
+          </div>
+          <div>
+            <ModelText>{item[AI_MODEL_ID_ATTRIBUTE]}</ModelText>
+          </div>
+          <span>{item['count(span.duration)']}</span>
+        </Fragment>
+      ))}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={t('LLM Generations')} />}
+      Visualization={visualization}
+      Actions={
+        organization.features.includes('visibility-explore-view') &&
+        hasData && (
+          <Toolbar
+            exploreParams={{
+              mode: Mode.SAMPLES,
+              visualize: [
+                {
+                  chartType: ChartType.BAR,
+                  yAxes: ['count(span.duration)'],
+                },
+              ],
+              query: fullQuery,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: t('LLM Generations'),
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
+        )
+      }
+      noFooterPadding
+      Footer={footer}
+    />
+  );
+}
+
+const ModelText = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1.2;
+  min-width: 0px;
+`;

--- a/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
@@ -1,0 +1,171 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {
+  AI_TOOL_NAME_ATTRIBUTE,
+  getAIToolCallsFilter,
+} from 'sentry/views/insights/agentMonitoring/utils/query';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {TimeSpentInDatabaseWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+export default function ToolUsageWidget() {
+  const organization = useOrganization();
+  const {query} = useTransactionNameQuery();
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+  });
+
+  const theme = useTheme();
+
+  const fullQuery = `${getAIToolCallsFilter()} ${query}`.trim();
+
+  const toolsRequest = useEAPSpans(
+    {
+      // @ts-expect-error TODO(telex): Add tool name attribute to Fields
+      fields: [AI_TOOL_NAME_ATTRIBUTE, 'count(span.duration)'],
+      sorts: [{field: 'count(span.duration)', kind: 'desc'}],
+      search: fullQuery,
+      limit: 3,
+    },
+    Referrer.QUERIES_CHART // TODO
+  );
+
+  const timeSeriesRequest = useTopNSpanEAPSeries(
+    {
+      ...pageFilterChartParams,
+      search: fullQuery,
+      fields: [AI_TOOL_NAME_ATTRIBUTE, 'count(span.duration)'],
+      yAxis: ['count(span.duration)'],
+      sort: {field: 'count(span.duration)', kind: 'desc'},
+      topN: 3,
+      enabled: !!toolsRequest.data,
+    },
+    Referrer.QUERIES_CHART // TODO
+  );
+
+  const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');
+
+  const isLoading = timeSeriesRequest.isLoading || toolsRequest.isLoading;
+  const error = timeSeriesRequest.error || toolsRequest.error;
+
+  // TODO(telex): Add tool name attribute to Fields and get rid of this cast
+  const tools = toolsRequest.data as unknown as
+    | Array<{
+        [AI_TOOL_NAME_ATTRIBUTE]: string;
+        'count(span.duration)': number;
+      }>
+    | undefined;
+
+  const hasData = tools && tools.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 2);
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={<TimeSpentInDatabaseWidgetEmptyStateWarning />}
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        showLegend: 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Bars(convertSeriesToTimeseries(ts), {
+              color: colorPalette[index],
+              alias: ts.seriesName,
+              stack: 'stack',
+            })
+        ),
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {tools.map((item, index) => (
+        <Fragment key={item[AI_TOOL_NAME_ATTRIBUTE]}>
+          <div>
+            <SeriesColorIndicator
+              style={{
+                backgroundColor: colorPalette[index],
+              }}
+            />
+          </div>
+          <div>
+            <ModelText>{item[AI_TOOL_NAME_ATTRIBUTE]}</ModelText>
+          </div>
+          <span>{item['count(span.duration)']}</span>
+        </Fragment>
+      ))}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={t('Tool Usage')} />}
+      Visualization={visualization}
+      Actions={
+        organization.features.includes('visibility-explore-view') &&
+        hasData && (
+          <Toolbar
+            exploreParams={{
+              mode: Mode.SAMPLES,
+              visualize: [
+                {
+                  chartType: ChartType.BAR,
+                  yAxes: ['count(span.duration)'],
+                },
+              ],
+              query: fullQuery,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: t('Tool Usage'),
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
+        )
+      }
+      noFooterPadding
+      Footer={footer}
+    />
+  );
+}
+
+const ModelText = styled('div')`
+  ${p => p.theme.overflowEllipsis};
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1.2;
+  min-width: 0px;
+`;

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -1,7 +1,20 @@
 // These are the span op we are currently ingesting.
-// They will probably change.
+// They will probably change and maybe it will be enough to inline them in the widgets.
 const AI_PIPELINE_OPS = ['ai.pipeline.generateText', 'ai.pipeline.generateObject'];
+const AI_GENERATION_OPS = ['ai.run.doGenerate'];
+const AI_TOOL_CALL_OPS = ['ai.toolCall'];
+
+export const AI_MODEL_ID_ATTRIBUTE = 'ai.model_id';
+export const AI_TOOL_NAME_ATTRIBUTE = 'ai.toolCall.name';
 
 export const getAgentRunsFilter = () => {
   return `span.op:[${AI_PIPELINE_OPS.join(',')}]`;
+};
+
+export const getLLMGenerationsFilter = () => {
+  return `span.op:[${AI_GENERATION_OPS.join(',')}]`;
+};
+
+export const getAIToolCallsFilter = () => {
+  return `span.description:[${AI_TOOL_CALL_OPS.join(',')}]`;
 };

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -14,8 +14,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
+import LLMGenerationsWidget from 'sentry/views/insights/agentMonitoring/components/llmGenerationsWidget';
 import {ModelsTable} from 'sentry/views/insights/agentMonitoring/components/modelsTable';
 import {ToolsTable} from 'sentry/views/insights/agentMonitoring/components/toolsTable';
+import ToolUsageWidget from 'sentry/views/insights/agentMonitoring/components/toolUsageWidget';
 import {TracesTable} from 'sentry/views/insights/agentMonitoring/components/tracesTable';
 import {
   TableType,
@@ -88,10 +90,10 @@ function AgentsMonitoringPage() {
                     <IssuesWidget />
                   </WidgetGrid.Position3>
                   <WidgetGrid.Position4>
-                    <PlaceholderWidget title="LLM Generations" />
+                    <LLMGenerationsWidget />
                   </WidgetGrid.Position4>
                   <WidgetGrid.Position5>
-                    <PlaceholderWidget title="Tool Usage" />
+                    <ToolUsageWidget />
                   </WidgetGrid.Position5>
                   <WidgetGrid.Position6>
                     <PlaceholderWidget title="Token Usage" />


### PR DESCRIPTION
Closes [TET-500: Dashboard - Generations widget](https://linear.app/getsentry/issue/TET-500/dashboard-generations-widget)
Closes [TET-501: Dashboard - Tool usage widget](https://linear.app/getsentry/issue/TET-501/dashboard-tool-usage-widget)

<img width="946" alt="image" src="https://github.com/user-attachments/assets/fc5bb326-bd13-4b5c-8ee5-de9db0352fe6" />