### PR TITLE
fix(symbolicator): add `Bearer` to the obtained gcp token before pass…

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -584,7 +584,7 @@ def get_sources_for_project(project):
                 # if target_credentials.token is None it means that the
                 # token could not be fetched successfully
                 if token is not None:
-                    source["bearer_token"] = token
+                    source["bearer_token"] = "Bearer " + token
 
                     # Remove other credentials if we have a token
                     if "client_email" in source:

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -57,7 +57,7 @@ class TestGcpBearerAuthentication:
         for i in (1, 2):
             assert "client_email" not in sources[i]
             assert "private_key" not in sources[i]
-            assert sources[i]["bearer_token"] == "ya29.TOKEN"
+            assert sources[i]["bearer_token"] == "Bearer ya29.TOKEN"
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
     @patch("sentry.lang.native.sources.get_gcp_token")
@@ -84,7 +84,7 @@ class TestGcpBearerAuthentication:
         for i in (1, 2):
             assert "client_email" not in sources[i]
             assert "private_key" not in sources[i]
-            assert sources[i]["bearer_token"] == "ya29.TOKEN"
+            assert sources[i]["bearer_token"] == "Bearer ya29.TOKEN"
 
 
 class TestIgnoredSourcesFiltering:


### PR DESCRIPTION
This PR adds `Bearer ` in front of the Token so that it can be used in authorization headers