### PR TITLE
:mag: nit(integrations): use IntegrationProviderSlug.Gitlab instead of magic str

### DIFF
--- a/fixtures/gitlab.py
+++ b/fixtures/gitlab.py
@@ -2,6 +2,7 @@ from time import time
 
 from sentry.integrations.gitlab.integration import GitlabIntegration
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
@@ -15,7 +16,7 @@ WEBHOOK_TOKEN = f"{EXTERNAL_ID}:{WEBHOOK_SECRET}"
 
 
 class GitLabTestCase(APITestCase):
-    provider = "gitlab"
+    provider = IntegrationProviderSlug.GITLAB.value
 
     def setUp(self):
         self.login_as(self.user)

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -11,6 +11,7 @@ from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.identity.services.identity import identity_service
 from sentry.identity.services.identity.model import RpcIdentity
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
 
@@ -63,7 +64,7 @@ def get_user_info(access_token, installation_data):
 
 
 class GitlabIdentityProvider(OAuth2Provider):
-    key = "gitlab"
+    key = IntegrationProviderSlug.GITLAB.value
     name = "Gitlab"
 
     oauth_scopes = ("api",)
@@ -72,7 +73,7 @@ class GitlabIdentityProvider(OAuth2Provider):
         data = data["data"]
 
         return {
-            "type": "gitlab",
+            "type": IntegrationProviderSlug.GITLAB.value,
             "id": data["user"]["id"],
             "email": data["user"]["email"],
             "scopes": sorted(data["scope"].split(",")),

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -575,11 +575,14 @@ def disable_integration(
         return None
 
     if org and (
-        (rpc_integration.provider == "slack" and buffer.is_integration_fatal_broken())
-        or (rpc_integration.provider == "github")
+        (
+            rpc_integration.provider == IntegrationProviderSlug.SLACK
+            and buffer.is_integration_fatal_broken()
+        )
+        or (rpc_integration.provider == IntegrationProviderSlug.GITHUB)
         or (
             features.has("organizations:gitlab-disable-on-broken", org)
-            and rpc_integration.provider == "gitlab"
+            and rpc_integration.provider == IntegrationProviderSlug.GITLAB.value
         )
     ):
         integration_service.update_integration(

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -17,6 +17,7 @@ from sentry.integrations.source_code_management.commit_context import (
     SourceLineInfo,
 )
 from sentry.integrations.source_code_management.repository import RepositoryClient
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
@@ -75,7 +76,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         self.refreshed_identity: RpcIdentity | None = None
         self.base_url = self.metadata["base_url"]
         org_integration_id = installation.org_integration.id
-        self.integration_name = "gitlab"
+        self.integration_name = IntegrationProviderSlug.GITLAB
 
         super().__init__(
             integration_id=installation.model.id,
@@ -408,7 +409,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
             files,
             extra={
                 **extra,
-                "provider": "gitlab",
+                "provider": IntegrationProviderSlug.GITLAB.value,
                 "org_integration_id": self.org_integration_id,
             },
         )

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -25,6 +25,7 @@ from sentry.integrations.source_code_management.commit_context import (
     PRCommentWorkflow,
 )
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest
@@ -109,7 +110,7 @@ class GitlabIntegration(RepositoryIntegration, GitlabIssuesSpec, CommitContextIn
 
     @property
     def integration_name(self) -> str:
-        return "gitlab"
+        return IntegrationProviderSlug.GITLAB
 
     def get_client(self) -> GitLabApiClient:
         try:
@@ -386,7 +387,7 @@ class InstallationGuideView(PipelineView):
 
 
 class GitlabIntegrationProvider(IntegrationProvider):
-    key = "gitlab"
+    key = IntegrationProviderSlug.GITLAB.value
     name = "GitLab"
     metadata = metadata
     integration_cls = GitlabIntegration
@@ -423,7 +424,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
 
         return NestedPipelineView(
             bind_key="identity",
-            provider_key="gitlab",
+            provider_key=IntegrationProviderSlug.GITLAB.value,
             pipeline_cls=IdentityProviderPipeline,
             config=identity_pipeline_config,
         )
@@ -514,7 +515,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                 "include_subgroups": include_subgroups,
             },
             "user_identity": {
-                "type": "gitlab",
+                "type": IntegrationProviderSlug.GITLAB.value,
                 "external_id": "{}:{}".format(hostname, user["id"]),
                 "scopes": scopes,
                 "data": oauth_data,

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,3 +1,4 @@
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.shared_integrations.exceptions import ApiError
@@ -5,7 +6,7 @@ from sentry.shared_integrations.exceptions import ApiError
 
 class GitlabRepositoryProvider(IntegrationRepositoryProvider):
     name = "Gitlab"
-    repo_provider = "gitlab"
+    repo_provider = IntegrationProviderSlug.GITLAB.value
 
     def get_repository_data(self, organization, config):
         installation = self.get_installation(config.get("installation"), organization.id)

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -8,6 +8,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.shared_integrations.exceptions import ApiError
 
 T = TypeVar("T", bound=SourceCodeIssueIntegration)
@@ -21,7 +22,7 @@ class GitlabIssueSearchEndpoint(SourceCodeSearchEndpoint):
 
     @property
     def integration_provider(self):
-        return "gitlab"
+        return IntegrationProviderSlug.GITLAB.value
 
     @property
     def installation_class(self):

--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -21,6 +21,7 @@ from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.webhook import SCMWebhook
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models.commit import Commit
@@ -68,7 +69,7 @@ def get_gitlab_external_id(request, extra) -> tuple[str, str] | HttpResponse:
 class GitlabWebhook(SCMWebhook, ABC):
     @property
     def provider(self) -> str:
-        return "gitlab"
+        return IntegrationProviderSlug.GITLAB.value
 
     def get_repo(
         self, integration: RpcIntegration, organization: RpcOrganization, event: Mapping[str, Any]
@@ -260,7 +261,7 @@ class GitlabWebhookEndpoint(Endpoint):
     }
     authentication_classes = ()
     permission_classes = ()
-    provider = "gitlab"
+    provider = IntegrationProviderSlug.GITLAB
 
     _handlers: dict[str, type[GitlabWebhook]] = {
         "Push Hook": PushEventWebhook,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -15,6 +15,7 @@ from google.api_core.exceptions import ServiceUnavailable
 
 from sentry import features, options, projectoptions
 from sentry.exceptions import PluginError
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.killswitches import killswitch_matches_context
@@ -1121,7 +1122,11 @@ def process_commits(job: PostProcessJob) -> None:
 
                     org_integrations = integration_service.get_organization_integrations(
                         organization_id=event.project.organization_id,
-                        providers=["github", "gitlab", "github_enterprise"],
+                        providers=[
+                            IntegrationProviderSlug.GITHUB.value,
+                            IntegrationProviderSlug.GITLAB.value,
+                            IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+                        ],
                     )
                     has_integrations = len(org_integrations) > 0
                     # Cache the integrations check for 4 hours

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -7,14 +7,14 @@ from django.urls import reverse
 
 from fixtures.gitlab import GitLabTestCase
 from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.integrations.types import EventLifecycleOutcome
+from sentry.integrations.types import EventLifecycleOutcome, IntegrationProviderSlug
 from sentry.testutils.asserts import assert_middleware_metrics
 from sentry.testutils.silo import control_silo_test
 
 
 @control_silo_test
 class GitlabSearchTest(GitLabTestCase):
-    provider = "gitlab"
+    provider = IntegrationProviderSlug.GITLAB.value
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
working on standardizing references to integration slugs

contributes to ECO-541