### PR TITLE
ref(explore): Consolidate visualize arguments helper

### DIFF
--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -5,11 +5,15 @@ import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
+import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {
+  SpanTagsProvider,
+  useSpanTags,
+} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
@@ -32,6 +36,17 @@ function createWrapper(organization: Organization) {
   };
 }
 
+function useWrapper(yAxis: string) {
+  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useSpanTags('number');
+  return useVisualizeFields({
+    numberTags,
+    stringTags,
+    yAxes: [yAxis],
+    parsedFunction: parseFunction(yAxis) ?? undefined,
+  });
+}
+
 describe('useVisualizeFields', () => {
   const organization = OrganizationFixture();
 
@@ -46,21 +61,41 @@ describe('useVisualizeFields', () => {
     mockedUsedLocation.mockReturnValue(LocationFixture());
   });
 
-  it('returns a valid list of field options', () => {
-    const {result} = renderHook(
-      () =>
-        useVisualizeFields({
-          yAxes: ['avg(span.duration)', 'avg(score.ttfb)'],
-        }),
-      {
-        wrapper: createWrapper(organization),
-      }
-    );
+  it('returns numeric fields', () => {
+    const {result} = renderHook(() => useWrapper('avg(score.ttfb)'), {
+      wrapper: createWrapper(organization),
+    });
 
     expect(result.current.map(field => field.value)).toEqual([
       'score.ttfb',
       'span.duration',
       'span.self_time',
     ]);
+  });
+
+  it('returns numeric fields for count', () => {
+    const {result} = renderHook(() => useWrapper('count(span.duration)'), {
+      wrapper: createWrapper(organization),
+    });
+
+    expect(result.current.map(field => field.value)).toEqual(['span.duration']);
+  });
+
+  it('returns string fields for count_unique', () => {
+    const {result} = renderHook(() => useWrapper('count_unique(foobar)'), {
+      wrapper: createWrapper(organization),
+    });
+
+    expect(result.current.map(field => field.value)).toEqual(
+      expect.arrayContaining([
+        'foobar',
+        'project',
+        'span.description',
+        'span.op',
+        'timestamp',
+        'trace',
+        'transaction',
+      ])
+    );
   });
 });

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -1,46 +1,56 @@
 import {useMemo} from 'react';
 
 import type {SelectOption} from 'sentry/components/core/compactSelect';
+import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 
-interface Props {
+interface UseVisualizeFieldsProps {
+  numberTags: TagCollection;
+  stringTags: TagCollection;
   /**
    * All the aggregates that are in use. The arguments will be extracted
    * and injected as options if they are compatible.
    */
   yAxes: string[];
-  /**
-   * The current aggregate in use. Used to determine what the argument
-   * types will be compatible.
-   */
-  yAxis?: string;
+  parsedFunction?: ParsedFunction | null;
 }
 
-export function useVisualizeFields({yAxis, yAxes}: Props) {
-  const {tags: stringTags} = useSpanTags('string');
-  const {tags: numberTags} = useSpanTags('number');
+export function useVisualizeFields({
+  parsedFunction,
+  numberTags,
+  stringTags,
+  yAxes,
+}: UseVisualizeFieldsProps) {
+  const [kind, tags]: [FieldKind, TagCollection] = useMemo(() => {
+    if (parsedFunction?.name === AggregationKey.COUNT) {
+      const countTags: TagCollection = {
+        [SpanIndexedField.SPAN_DURATION]: {
+          name: t('spans'),
+          key: SpanIndexedField.SPAN_DURATION,
+        },
+      };
+      return [FieldKind.MEASUREMENT, countTags];
+    }
 
-  const parsedYAxis = useMemo(() => (yAxis ? parseFunction(yAxis) : undefined), [yAxis]);
+    if (parsedFunction?.name === AggregationKey.COUNT_UNIQUE) {
+      return [FieldKind.TAG, stringTags];
+    }
 
-  const tags =
-    parsedYAxis?.name === AggregationKey.COUNT_UNIQUE ? stringTags : numberTags;
+    return [FieldKind.MEASUREMENT, numberTags];
+  }, [parsedFunction?.name, numberTags, stringTags]);
 
   const parsedYAxes: ParsedFunction[] = useMemo(() => {
     return yAxes.map(parseFunction).filter(defined);
   }, [yAxes]);
 
   const fieldOptions: Array<SelectOption<string>> = useMemo(() => {
-    const kind =
-      parsedYAxis?.name === AggregationKey.COUNT_UNIQUE
-        ? FieldKind.TAG
-        : FieldKind.MEASUREMENT;
-
     const unknownOptions = parsedYAxes
       .flatMap(entry => {
         return entry.arguments;
@@ -90,7 +100,7 @@ export function useVisualizeFields({yAxis, yAxes}: Props) {
     });
 
     return options;
-  }, [tags, parsedYAxes, parsedYAxis?.name]);
+  }, [kind, tags, parsedYAxes]);
 
   return fieldOptions;
 }

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -9,11 +9,8 @@ import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
-import {
-  DEFAULT_VISUALIZATION_AGGREGATE,
-  DEFAULT_VISUALIZATION_FIELD,
-  updateVisualizeAggregate,
-} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {updateVisualizeAggregate} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {
   type ReadableExploreQueryParts,
@@ -31,32 +28,17 @@ type Props = {
 };
 
 export function VisualizeSection({query, index}: Props) {
-  const [yAxis, parsedFunction] = findFirstFunction(query.yAxes);
+  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useSpanTags('number');
 
-  // We want to lock down the fields dropdown when using count so that we can
-  // render `count(spans)` for better legibility. However, for backwards
-  // compatibility, we don't want to lock down all `count` queries immediately.
-  const lockOptions =
-    defined(parsedFunction) &&
-    parsedFunction.name === DEFAULT_VISUALIZATION_AGGREGATE &&
-    parsedFunction.arguments.length === 1 &&
-    parsedFunction.arguments[0] === DEFAULT_VISUALIZATION_FIELD;
+  const parsedFunction = findFirstFunction(query.yAxes);
 
-  const countFieldOptions: Array<SelectOption<string>> = useMemo(
-    () => [
-      {
-        label: t('spans'),
-        value: DEFAULT_VISUALIZATION_FIELD,
-        textValue: DEFAULT_VISUALIZATION_FIELD,
-      },
-    ],
-    []
-  );
-  const defaultFieldOptions: Array<SelectOption<string>> = useVisualizeFields({
+  const options: Array<SelectOption<string>> = useVisualizeFields({
+    numberTags,
+    stringTags,
     yAxes: query.yAxes,
-    yAxis,
+    parsedFunction,
   });
-  const fieldOptions = lockOptions ? countFieldOptions : defaultFieldOptions;
 
   const updateYAxis = useUpdateQueryAtIndex(index);
 
@@ -97,13 +79,13 @@ export function VisualizeSection({query, index}: Props) {
           />
           <CompactSelect
             searchable
-            options={fieldOptions}
+            options={options}
             value={parsedFunction?.arguments?.[0]}
             onChange={newField => {
               const newYAxis = `${parsedFunction!.name}(${newField.value})`;
               updateYAxis({yAxes: [newYAxis]});
             }}
-            disabled={lockOptions}
+            disabled={options.length === 1}
           />
         </StyledPageFilterBar>
       </Fragment>
@@ -113,15 +95,15 @@ export function VisualizeSection({query, index}: Props) {
 
 function findFirstFunction(
   yAxes: ReadableExploreQueryParts['yAxes']
-): [string | undefined, ParsedFunction | undefined] {
+): ParsedFunction | undefined {
   for (const yAxis of yAxes) {
     const parsed = parseFunction(yAxis);
     if (defined(parsed)) {
-      return [yAxis, parsed];
+      return parsed;
     }
   }
 
-  return [undefined, undefined];
+  return undefined;
 }
 
 const StyledPageFilterBar = styled(PageFilterBar)`


### PR DESCRIPTION
This consolidates all the places the visualize arguments are generated into the `useVisualizeFields` helper.