### PR TITLE
feat(ourlogs): Add feature flag splitting log stats

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -488,6 +488,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable our logs stats to be displayed in the UI, includes stats not meant to be displayed to users. Will be removed in the future.
+    manager.add("organizations:ourlogs-stats-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs stats to be displayed in the UI.
     manager.add("organizations:ourlogs-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the visualize sidebar in the logs UI.


### PR DESCRIPTION
### Summary
We want to keep count visible for devs for now, and bytes will be displayed to our users.


