### PR TITLE
feat(ourlogs): Make log bytes visible to all user in open beta

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -507,7 +507,7 @@ export const DATA_CATEGORY_INFO = {
     apiName: 'log_item',
     plural: DataCategory.LOG_ITEM,
     displayName: 'log',
-    titleName: t('Logs'),
+    titleName: t('Log Counts'), // Only currently visible internally, this name should change if we expose this to users.
     productName: t('Logging'),
     uid: 23,
     isBilledCategory: false,
@@ -521,7 +521,7 @@ export const DATA_CATEGORY_INFO = {
     apiName: 'log_byte',
     plural: DataCategory.LOG_BYTE,
     displayName: 'log byte',
-    titleName: t('Logs Storage'),
+    titleName: t('Logs'),
     productName: t('Logging'),
     uid: 24,
     isBilledCategory: false,

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -276,7 +276,10 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
       if ([DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER].includes(opt.value)) {
         return organization.features.includes('seer-billing');
       }
-      if ([DataCategory.LOG_BYTE, DataCategory.LOG_ITEM].includes(opt.value)) {
+      if ([DataCategory.LOG_BYTE].includes(opt.value)) {
+        return organization.features.includes('ourlogs-enabled');
+      }
+      if ([DataCategory.LOG_ITEM].includes(opt.value)) {
         return organization.features.includes('ourlogs-stats');
       }
       if (


### PR DESCRIPTION
### Summary
This renames 'log storage' to 'logs', exposing it to users, and leaves logs count as an internal feature.


