### PR TITLE
fix(ourlogs): Allow multiple traces

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -10,7 +10,7 @@ from sentry.search.eap.columns import (
     simple_sentry_field,
 )
 from sentry.search.eap.common_columns import COMMON_COLUMNS
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import is_event_id_or_list
 
 OURLOG_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
@@ -35,7 +35,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             public_alias="trace",
             internal_name="sentry.trace_id",
             search_type="string",
-            validator=is_event_id,
+            validator=is_event_id_or_list,
         ),
         ResolvedAttribute(
             public_alias="timestamp",

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -21,15 +21,7 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.types import SnubaParams
 from sentry.search.utils import DEVICE_CLASS
-from sentry.utils.validators import is_empty_string, is_event_id, is_span_id
-
-
-def validate_event_id(value: str | list[str]) -> bool:
-    if isinstance(value, list):
-        return all([is_event_id(item) for item in value])
-    else:
-        return is_event_id(value)
-
+from sentry.utils.validators import is_empty_string, is_event_id_or_list, is_span_id
 
 SPAN_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
@@ -125,7 +117,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="trace",
             internal_name="sentry.trace_id",
             search_type="string",
-            validator=validate_event_id,
+            validator=is_event_id_or_list,
         ),
         ResolvedAttribute(
             public_alias="transaction",

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -25,6 +25,13 @@ def is_event_id(value):
     return normalize_event_id(value) is not None
 
 
+def is_event_id_or_list(value):
+    if isinstance(value, list):
+        return all(is_event_id(item) for item in value)
+    else:
+        return is_event_id(value)
+
+
 def is_span_id(value):
     return bool(HEXADECIMAL_16_DIGITS.search(force_str(value)))
 


### PR DESCRIPTION
### Summary
Span attribute definitions were updated but not logs, this allows multiple event ids to be sent in a list form as a generic validator. Adds a test.

