### PR TITLE
feat(perf-issues): Improve experiment N+1 API/DB, MN+1 UI

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -7,7 +7,7 @@ import {
 } from 'sentry-test/performance/utils';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {EventTransaction} from 'sentry/types/event';
+import type {EventTransaction} from 'sentry/types/event';
 import {IssueType} from 'sentry/types/group';
 
 import {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -7,6 +7,7 @@ import {
 } from 'sentry-test/performance/utils';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {EventTransaction} from 'sentry/types/event';
 import {IssueType} from 'sentry/types/group';
 
 import {
@@ -198,6 +199,16 @@ describe('SpanEvidenceKeyValueList', () => {
     builder.addSpan(parentSpan);
 
     it('Renders relevant fields', () => {
+      const event = builder.getEventFixture();
+      event.occurrence = {
+        ...event.occurrence,
+        evidenceData: {
+          pattern_size: 2,
+          pattern_span_ids: ['aaa', 'bbb'],
+          num_pattern_repetitions: 4,
+        },
+      } as EventTransaction['occurrence'];
+
       render(
         <SpanEvidenceKeyValueList
           event={builder.getEventFixture()}
@@ -237,6 +248,21 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(
         screen.queryByTestId('span-evidence-key-value-list.problem-parameters')
       ).not.toBeInTheDocument();
+
+      expect(screen.getByRole('cell', {name: 'Pattern Size'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.pattern-size')
+      ).toHaveTextContent('2');
+      expect(screen.getByRole('cell', {name: 'Pattern Span IDs'})).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.pattern-span-i-ds')
+      ).toHaveTextContent('aaabbb');
+      expect(
+        screen.getByRole('cell', {name: 'Number of Repetitions'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('span-evidence-key-value-list.number-of-repetitions')
+      ).toHaveTextContent('4');
     });
   });
 
@@ -409,7 +435,7 @@ describe('SpanEvidenceKeyValueList', () => {
       startTimestamp: 10,
       endTimestamp: 2100,
       op: 'http.client',
-      description: 'GET /book/?book_id=8&sort=down',
+      description: 'GET /user/123/book/?book_id=8&sort=down',
       problemSpan: ProblemSpan.OFFENDER,
     });
 
@@ -425,6 +451,15 @@ describe('SpanEvidenceKeyValueList', () => {
     );
 
     it('Renders relevant fields', () => {
+      const event = builder.getEventFixture();
+      event.occurrence = {
+        ...event.occurrence,
+        subtitle: '/user/*/book/?book_id=*',
+        evidenceData: {
+          pathParameters: ['123'],
+        },
+      } as EventTransaction['occurrence'];
+
       render(
         <SpanEvidenceKeyValueList
           event={builder.getEventFixture()}
@@ -450,16 +485,23 @@ describe('SpanEvidenceKeyValueList', () => {
       expect(screen.getByRole('cell', {name: 'Repeating Spans (2)'})).toBeInTheDocument();
       expect(
         screen.getByTestId(/span-evidence-key-value-list.repeating-spans/)
-      ).toHaveTextContent('/book/[Parameters]');
+      ).toHaveTextContent('/user/*/book/?book_id=*');
 
-      expect(screen.getByRole('cell', {name: 'Parameters'})).toBeInTheDocument();
+      expect(screen.getByRole('cell', {name: 'Query Parameters'})).toBeInTheDocument();
 
-      const parametersKeyValue = screen.getByTestId(
-        'span-evidence-key-value-list.parameters'
+      const queryParamsKeyValue = screen.getByTestId(
+        'span-evidence-key-value-list.query-parameters'
       );
 
-      expect(parametersKeyValue).toHaveTextContent('book_id:{7,8}');
-      expect(parametersKeyValue).toHaveTextContent('sort:{up,down}');
+      expect(queryParamsKeyValue).toHaveTextContent('book_id:{7,8}');
+      expect(queryParamsKeyValue).toHaveTextContent('sort:{up,down}');
+
+      expect(screen.getByRole('cell', {name: 'Path Parameters'})).toBeInTheDocument();
+      const pathParamsKeyValue = screen.getByTestId(
+        'span-evidence-key-value-list.path-parameters'
+      );
+
+      expect(pathParamsKeyValue).toHaveTextContent('123');
     });
 
     describe('extractSpanURLString', () => {

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -182,6 +182,10 @@ function NPlusOneDBQueriesSpanEvidence({
         getSpanEvidenceValue(span)
       )
     );
+  const evidenceData = event?.occurrence?.evidenceData ?? {};
+  const patternSize = evidenceData.pattern_size ?? 0;
+  const patternSpanIds = evidenceData.pattern_span_ids ?? [];
+  const numPatternRepetitions = evidenceData.num_pattern_repetitions ?? 0;
 
   return (
     <PresortedKeyValueList
@@ -193,6 +197,13 @@ function NPlusOneDBQueriesSpanEvidence({
             ? makeRow(t('Preceding Span'), getSpanEvidenceValue(causeSpans[0]!))
             : null,
           ...repeatingSpanRows,
+          patternSize > 0 ? makeRow(t('Pattern Size'), patternSize) : null,
+          patternSpanIds.length > 0
+            ? makeRow(t('Pattern Span IDs'), patternSpanIds)
+            : null,
+          numPatternRepetitions > 0
+            ? makeRow(t('Number of Repetitions'), numPatternRepetitions)
+            : null,
         ].filter(Boolean) as KeyValueListData
       }
     />
@@ -207,10 +218,14 @@ function NPlusOneAPICallsSpanEvidence({
   location,
 }: SpanEvidenceKeyValueListProps) {
   const requestEntry = event?.entries?.find(isRequestEntry);
+  const occurrence = event?.occurrence;
+  const evidenceData = occurrence?.evidenceData ?? {};
   const baseURL = requestEntry?.data?.url;
 
-  const problemParameters = formatChangingQueryParameters(offendingSpans, baseURL);
-  const commonPathPrefix = formatBasePath(offendingSpans[0]!, baseURL);
+  const queryParameters = formatChangingQueryParameters(offendingSpans, baseURL);
+  const pathParameters = evidenceData.pathParameters ?? [];
+  const commonPathPrefix =
+    occurrence?.subtitle ?? formatBasePath(offendingSpans[0]!, baseURL);
 
   return (
     <PresortedKeyValueList
@@ -224,16 +239,24 @@ function NPlusOneAPICallsSpanEvidence({
                   <AnnotatedText
                     value={
                       <Fragment>
-                        {commonPathPrefix}
-                        <HighlightedEvidence>[Parameters]</HighlightedEvidence>
+                        {commonPathPrefix.split('').map((char, i) => {
+                          return char === '*' ? (
+                            <HighlightedEvidence key={i}>{char}</HighlightedEvidence>
+                          ) : (
+                            char
+                          );
+                        })}
                       </Fragment>
                     }
                   />
                 </pre>
               )
             : null,
-          problemParameters.length > 0
-            ? makeRow(t('Parameters'), problemParameters)
+          queryParameters.length > 0
+            ? makeRow(t('Query Parameters'), queryParameters)
+            : null,
+          pathParameters.length > 0
+            ? makeRow(t('Path Parameters'), pathParameters)
             : null,
         ].filter(Boolean) as KeyValueListData
       }


### PR DESCRIPTION
Display some new fields for the experimental detectors if present on the payload. Existing UI won't be seriously affected, other than the `[Parameter]` label being reformatted for N+1 API calls