### PR TITLE
chore(perf-issues): Dedupe the evidence from URL parameters in experiment

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -218,11 +218,21 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
                 query_dict[key] += value
 
         path_params_list = [f"{', '.join(param_group)}" for param_group in path_params]
+        path_seen_set = set()
         query_params_list = [f"{key}: {', '.join(values)}" for key, values in query_dict.items()]
+        query_param_set = set()
         return {
-            # Use sets to deduplicate the lists.
-            "path_params": list(set(path_params_list)),
-            "query_params": list(set(query_params_list)),
+            # Use sets to deduplicate the lists, but still preserve the order.
+            "path_params": [
+                param
+                for param in path_params_list
+                if not (param in path_seen_set or path_seen_set.add(param))
+            ],
+            "query_params": [
+                param
+                for param in query_params_list
+                if not (param in query_param_set or query_param_set.add(param))
+            ],
         }
 
     def _get_parameterized_url(self, span: Span) -> str:

--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -217,22 +217,19 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
             for key, value in query_params.items():
                 query_dict[key] += value
 
-        path_params_list = [f"{', '.join(param_group)}" for param_group in path_params]
-        path_seen_set = set()
-        query_params_list = [f"{key}: {', '.join(values)}" for key, values in query_dict.items()]
-        query_param_set = set()
+        # Note: dict.fromkeys() is just to deduplicate values and Python dicts are ordered
+        path_params_list: list[str] = list(
+            dict.fromkeys([f"{', '.join(param_group)}" for param_group in path_params]).keys()
+        )
+        query_params_list: list[str] = list(
+            dict.fromkeys(
+                [f"{key}: {', '.join(values)}" for key, values in query_dict.items()]
+            ).keys()
+        )
         return {
             # Use sets to deduplicate the lists, but still preserve the order.
-            "path_params": [
-                param
-                for param in path_params_list
-                if not (param in path_seen_set or path_seen_set.add(param))
-            ],
-            "query_params": [
-                param
-                for param in query_params_list
-                if not (param in query_param_set or query_param_set.add(param))
-            ],
+            "path_params": path_params_list,
+            "query_params": query_params_list,
         }
 
     def _get_parameterized_url(self, span: Span) -> str:

--- a/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/n_plus_one_api_calls_detector.py
@@ -187,6 +187,7 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
                 "repeating_spans_compact": get_span_evidence_value(self.spans[0], include_op=False),
                 "parameters": self._get_parameters()["query_params"],
                 "path_parameters": self._get_parameters()["path_params"],
+                "common_url": problem_description,
             },
             evidence_display=[
                 IssueEvidence(
@@ -215,9 +216,13 @@ class NPlusOneAPICallsExperimentalDetector(PerformanceDetector):
 
             for key, value in query_params.items():
                 query_dict[key] += value
+
+        path_params_list = [f"{', '.join(param_group)}" for param_group in path_params]
+        query_params_list = [f"{key}: {', '.join(values)}" for key, values in query_dict.items()]
         return {
-            "path_params": [f"{', '.join(param_group)}" for param_group in path_params],
-            "query_params": [f"{key}: {', '.join(values)}" for key, values in query_dict.items()],
+            # Use sets to deduplicate the lists.
+            "path_params": list(set(path_params_list)),
+            "query_params": list(set(query_params_list)),
         }
 
     def _get_parameterized_url(self, span: Span) -> str:


### PR DESCRIPTION
Since we catch these on two dimensions now (e.g, path params change or query params change or both) we need to dedupe the evidence now.  Some Examples:

```
example.com/user/1/data?region=1 
example.com/user/2/data?region=1  
example.com/user/3/data?region=1
> Path: [1, 2, 3]
> Old Query: [1, 1, 1]
> New Query: [1] 
```

```
example.com/user/1/data?region=1 
example.com/user/1/data?region=2  
example.com/user/1/data?region=3
> Old Path: [1, 1, 1]
> New Path: [1]
> Query: [1, 2, 3]
```

```
example.com/user/1/data?region=1 
example.com/user/2/data?region=2  
example.com/user/3/data?region=3
> Path: [1, 2, 3]
> Query: [1, 2, 3] 
```