### PR TITLE
fix(taskworker) Add shim for __start_time

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -310,6 +310,13 @@ def child_process(
                 )
                 span.set_data(SPANDATA.MESSAGING_SYSTEM, "taskworker")
 
+            # TODO(taskworker) remove this when doing cleanup
+            # The `__start_time` parameter is spliced into task parameters by
+            # sentry.celery.SentryTask._add_metadata and needs to be removed
+            # from kwargs like sentry.tasks.base.instrumented_task does.
+            if "__start_time" in kwargs:
+                kwargs.pop("__start_time")
+
             try:
                 task_func(*args, **kwargs)
                 transaction.set_status(SPANSTATUS.OK)


### PR DESCRIPTION
Our celery wrappers inject `__start_time` into the keyword args of tasks. Under celery this parameter is popped before the task function is invoked. This change emulates that behavior which will make partial rollouts of task namespaces less noisy.
