### PR TITLE
feat(explore): Boilerplate for aggregate fields editor modal

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/aggregateFields.tsx
@@ -39,6 +39,7 @@ export function isVisualize(value: GroupBy | Visualize): value is Visualize {
   return 'yAxes' in value && Array.isArray(value.yAxes);
 }
 
+export type BaseAggregateField = GroupBy | BaseVisualize;
 export type AggregateField = GroupBy | Visualize;
 
 export function defaultAggregateFields(): AggregateField[] {

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -13,7 +13,7 @@ import {
   updateLocationWithId,
 } from 'sentry/views/explore/contexts/pageParamsContext/id';
 
-import type {AggregateField, GroupBy} from './aggregateFields';
+import type {AggregateField, BaseAggregateField, GroupBy} from './aggregateFields';
 import {
   defaultAggregateFields,
   getAggregateFieldsFromLocation,
@@ -167,6 +167,11 @@ export function useExploreDataset(): DiscoverDatasets {
   return DiscoverDatasets.SPANS_EAP_RPC;
 }
 
+export function useExploreAggregateFields(): AggregateField[] {
+  const pageParams = useExplorePageParams();
+  return pageParams.aggregateFields;
+}
+
 export function useExploreFields(): string[] {
   const pageParams = useExplorePageParams();
   return pageParams.fields;
@@ -233,6 +238,16 @@ export function useSetExplorePageParams(): (pageParams: WritablePageParams) => v
       navigate(target);
     },
     [location, navigate]
+  );
+}
+
+export function useSetExploreAggregateFields() {
+  const setPageParams = useSetExplorePageParams();
+  return useCallback(
+    (aggregateFields: BaseAggregateField[]) => {
+      setPageParams({aggregateFields});
+    },
+    [setPageParams]
   );
 }
 

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -1,0 +1,159 @@
+import {Fragment, useCallback, useState} from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
+import styled from '@emotion/styled';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
+import type {SelectOption} from 'sentry/components/core/compactSelect';
+import {SPAN_PROPS_DOCS_URL} from 'sentry/constants';
+import {IconAdd} from 'sentry/icons/iconAdd';
+import {IconDelete} from 'sentry/icons/iconDelete';
+import {IconGrabbable} from 'sentry/icons/iconGrabbable';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {TagCollection} from 'sentry/types/group';
+import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
+import type {
+  AggregateField,
+  BaseAggregateField,
+} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
+import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
+
+interface AggregateColumnEditorModalProps extends ModalRenderProps {
+  columns: AggregateField[];
+  numberTags: TagCollection;
+  onColumnsChange: (columns: BaseAggregateField[]) => void;
+  stringTags: TagCollection;
+}
+
+export function AggregateColumnEditorModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  columns,
+  onColumnsChange,
+}: AggregateColumnEditorModalProps) {
+  // We keep a temporary state for the columns so that we can apply the changes
+  // only when the user clicks on the apply button.
+  const [tempColumns, setTempColumns] = useState<AggregateField[]>(columns);
+
+  const handleApply = useCallback(() => {
+    onColumnsChange(tempColumns);
+    closeModal();
+  }, [closeModal, onColumnsChange, tempColumns]);
+
+  return (
+    <DragNDropContext
+      columns={tempColumns}
+      setColumns={setTempColumns}
+      defaultColumn={() => ({groupBy: ''})}
+    >
+      {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => (
+        <Fragment>
+          <Header closeButton data-test-id="editor-header">
+            <h4>{t('Edit Table')}</h4>
+          </Header>
+          <Body data-test-id="editor-body">
+            {editableColumns.map((column, i) => {
+              return (
+                <ColumnEditorRow
+                  key={column.id}
+                  canDelete={editableColumns.length > 1}
+                  column={column}
+                  options={[]}
+                  onColumnChange={c => updateColumnAtIndex(i, c)}
+                  onColumnDelete={() => deleteColumnAtIndex(i)}
+                />
+              );
+            })}
+            <RowContainer>
+              <ButtonBar gap={1}>
+                <Button
+                  size="sm"
+                  aria-label={t('Add a Column')}
+                  onClick={insertColumn}
+                  icon={<IconAdd isCircled />}
+                >
+                  {t('Add a Column')}
+                </Button>
+              </ButtonBar>
+            </RowContainer>
+          </Body>
+          <Footer data-test-id="editor-footer">
+            <ButtonBar gap={1}>
+              <LinkButton priority="default" href={SPAN_PROPS_DOCS_URL} external>
+                {t('Read the Docs')}
+              </LinkButton>
+              <Button aria-label={t('Apply')} priority="primary" onClick={handleApply}>
+                {t('Apply')}
+              </Button>
+            </ButtonBar>
+          </Footer>
+        </Fragment>
+      )}
+    </DragNDropContext>
+  );
+}
+
+interface ColumnEditorRowProps {
+  canDelete: boolean;
+  column: Column<AggregateField>;
+  onColumnChange: (column: AggregateField) => void;
+  onColumnDelete: () => void;
+  options: Array<SelectOption<string>>;
+}
+
+function ColumnEditorRow({canDelete, column, onColumnDelete}: ColumnEditorRowProps) {
+  const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
+    id: column.id,
+  });
+
+  return (
+    <RowContainer
+      key={column.id}
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+      {...attributes}
+    >
+      <StyledButton
+        aria-label={t('Drag to reorder')}
+        borderless
+        size="sm"
+        icon={<IconGrabbable size="sm" />}
+        {...listeners}
+      />
+      {JSON.stringify(column.column)}
+      <StyledButton
+        aria-label={t('Remove Column')}
+        borderless
+        disabled={!canDelete}
+        size="sm"
+        icon={<IconDelete size="sm" />}
+        onClick={onColumnDelete}
+      />
+    </RowContainer>
+  );
+}
+
+const RowContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${space(1)};
+
+  :not(:first-child) {
+    margin-top: ${space(1)};
+  }
+`;
+
+const StyledButton = styled(Button)`
+  padding-left: 0;
+  padding-right: 0;
+`;

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -26,7 +26,7 @@ import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 interface ColumnEditorModalProps extends ModalRenderProps {
   columns: string[];
   numberTags: TagCollection;
-  onColumnsChange: (fields: string[]) => void;
+  onColumnsChange: (columns: string[]) => void;
   stringTags: TagCollection;
   handleReset?: () => void;
   hiddenKeys?: string[];

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -11,8 +11,10 @@ import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
+  useExploreAggregateFields,
   useExploreFields,
   useExploreMode,
+  useSetExploreAggregateFields,
   useSetExploreFields,
   useSetExploreMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
@@ -22,6 +24,7 @@ import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreA
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
 import {Tab} from 'sentry/views/explore/hooks/useTab';
+import {AggregateColumnEditorModal} from 'sentry/views/explore/tables/aggregateColumnEditorModal';
 import {AggregatesTable} from 'sentry/views/explore/tables/aggregatesTable';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
 import {SpansTable} from 'sentry/views/explore/tables/spansTable';
@@ -41,6 +44,9 @@ interface ExploreTablesProps extends BaseExploreTablesProps {
 
 export function ExploreTables(props: ExploreTablesProps) {
   const organization = useOrganization();
+
+  const aggregateFields = useExploreAggregateFields();
+  const setAggregateFields = useSetExploreAggregateFields();
 
   const mode = useExploreMode();
   const setMode = useSetExploreMode();
@@ -66,7 +72,20 @@ export function ExploreTables(props: ExploreTablesProps) {
     );
   }, [fields, setFields, stringTags, numberTags]);
 
-  const openAggregateColumnEditor = useCallback(() => {}, []);
+  const openAggregateColumnEditor = useCallback(() => {
+    openModal(
+      modalProps => (
+        <AggregateColumnEditorModal
+          {...modalProps}
+          columns={aggregateFields}
+          onColumnsChange={setAggregateFields}
+          stringTags={stringTags}
+          numberTags={numberTags}
+        />
+      ),
+      {closeEvents: 'escape-key'}
+    );
+  }, [aggregateFields, setAggregateFields, stringTags, numberTags]);
 
   // HACK: This is pretty gross but to not break anything in the
   // short term, we avoid introducing/removing any fields on the


### PR DESCRIPTION
This adds the boilerplate for the aggregate fields editor modal to allow users to change/re-order the group bys and visualizes.