### PR TITLE
chore(codeowners): add codeowner for searchQueryBuilder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -577,6 +577,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /static/app/components/events/eventTags/                    @getsentry/issue-workflow
 /static/app/components/events/highlights/                   @getsentry/issue-workflow
 /static/app/components/issues/                              @getsentry/issue-workflow
+/static/app/components/searchQueryBuilder/                  @getsentry/issue-workflow
 /static/app/views/issueList                                 @getsentry/issue-workflow
 /static/app/views/issueDetails/                             @getsentry/issue-workflow
 /static/app/views/nav/secondary/sections/issues/            @getsentry/issue-workflow


### PR DESCRIPTION
- Trying to reduce issue assignment noise
- Example issue: [JAVASCRIPT-30XQ](https://sentry.sentry.io/issues/6627085327/) was assigned to telemetry-experience, but should be assigned to issue-workflow