### PR TITLE
ref: update knip

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -33,8 +33,6 @@ const testingEntryPoints = [
 const storyBookEntryPoints = [
   // our storybook implementation is here
   'static/app/stories/storyBook.tsx',
-  // custom webpack loaders for stories
-  'static/app/stories/*loader.ts',
   // we have some stories in mdx format
   'static/app/**/*.mdx',
 ];

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-fail-on-console": "3.3.0",
     "jest-junit": "16.0.0",
-    "knip": "^5.57.0",
+    "knip": "^5.58.0",
     "postcss-styled-syntax": "0.7.0",
     "react-refresh": "0.16.0",
     "stylelint": "16.10.0",

--- a/static/app/stories/noop-type-loader.ts
+++ b/static/app/stories/noop-type-loader.ts
@@ -1,6 +1,0 @@
-import type {LoaderContext} from 'webpack';
-
-export default function noopTypeLoader(this: LoaderContext<any>, _source: string) {
-  const callback = this.async();
-  return callback(null, 'export default {}');
-}

--- a/static/app/stories/type-loader.ts
+++ b/static/app/stories/type-loader.ts
@@ -8,7 +8,7 @@ import type {LoaderContext} from 'webpack';
  * @param {string} source source file as string
  * @returns {void}
  */
-export default function typeloader(this: LoaderContext<any>, _source: string) {
+function prodTypeloader(this: LoaderContext<any>, _source: string) {
   const callback = this.async();
   const entries = docgen.parse(this.resourcePath, {
     shouldExtractLiteralValuesFromEnum: true,
@@ -34,4 +34,18 @@ export default function typeloader(this: LoaderContext<any>, _source: string) {
       .map(entry => [entry.displayName, {...entry, filename: this.resourcePath}])
   );
   return callback(null, `export default ${JSON.stringify(typeIndex)}`);
+}
+
+function noopTypeLoader(this: LoaderContext<any>, _source: string) {
+  const callback = this.async();
+  return callback(null, 'export default {}');
+}
+
+export default function typeLoader(this: LoaderContext<any>, _source: string) {
+  const STORYBOOK_TYPES =
+    Boolean(process.env.STORYBOOK_TYPES) || process.env.node_ENV === 'production';
+
+  return STORYBOOK_TYPES
+    ? prodTypeloader.call(this, _source)
+    : noopTypeLoader.call(this, _source);
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -77,9 +77,6 @@ const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
 const SHOULD_ADD_RSDOCTOR = Boolean(env.RSDOCTOR);
 
-// Storybook related flag configuration
-const STORYBOOK_TYPES = Boolean(env.STORYBOOK_TYPES) || IS_PRODUCTION;
-
 // Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.
 const DEPLOY_PREVIEW_CONFIG = IS_DEPLOY_PREVIEW && {
@@ -412,9 +409,7 @@ const appConfig: webpack.Configuration = {
 
   resolveLoader: {
     alias: {
-      'type-loader': STORYBOOK_TYPES
-        ? path.resolve(__dirname, 'static/app/stories/type-loader.ts')
-        : path.resolve(__dirname, 'static/app/stories/noop-type-loader.ts'),
+      'type-loader': path.resolve(__dirname, 'static/app/stories/type-loader.ts'),
     },
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9463,10 +9463,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-knip@^5.57.0:
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/knip/-/knip-5.57.0.tgz#705ec5472a8108cf163b68d83fe483ddf61e242b"
-  integrity sha512-3i2neotCfFWOEGByzz8kzSFePZahelhwZfHXT5SM9FlpMxzN1PE8wV+M65Sl+itd2Z+v7FBXeVd96YLwXnviGg==
+knip@^5.58.0:
+  version "5.58.0"
+  resolved "https://registry.yarnpkg.com/knip/-/knip-5.58.0.tgz#54fe4b71e6ddb0b060de3c2cf45ff4fb68e5373b"
+  integrity sha512-U3+ADL9mylwia7bU85CYeHSdMI7DIpaCzH37NZ8rru/dgq56iyiS0oTELhfNaCYu+TcRyuijU2YQf9o0zUGA5w==
   dependencies:
     "@nodelib/fs.walk" "^1.2.3"
     fast-glob "^3.3.3"


### PR DESCRIPTION
it now correctly identifies custom loaders set in resolveLoader.alias, so we don't need them as a manual entry point anymore
