### PR TITLE
fix(2fa): require 2FA for auth token requests (dry run 3)

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -167,22 +167,19 @@ class SentryPermission(ScopedPermission):
         organization = org_context.organization
         extra = {"organization_id": organization.id, "user_id": user_id}
 
-        is_token_access_allowed = False
-        if request.auth and request.user and request.user.is_authenticated:
-            request.access = access.from_request_org_and_scopes(
-                request=request,
-                rpc_user_org_context=org_context,
-                scopes=request.auth.get_scopes(),
-            )
-            is_token_access_allowed = True
-        elif request.auth:
-            request.access = access.from_rpc_auth(
-                auth=request.auth, rpc_user_org_context=org_context
-            )
-            is_token_access_allowed = True
+        if request.auth:
+            if request.user and request.user.is_authenticated:
+                request.access = access.from_request_org_and_scopes(
+                    request=request,
+                    rpc_user_org_context=org_context,
+                    scopes=request.auth.get_scopes(),
+                )
+            else:
+                request.access = access.from_rpc_auth(
+                    auth=request.auth, rpc_user_org_context=org_context
+                )
 
-        if is_token_access_allowed:
-            if self.is_not_2fa_compliant(request, organization):
+            if org_context.member and self.is_not_2fa_compliant(request, organization):
                 logger.info(
                     "access.not-2fa-compliant.dry-run",
                     extra=extra,

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -170,6 +170,21 @@ class OrganizationPermissionTest(PermissionBaseTestCase):
         with pytest.raises(SuperuserRequired):
             assert self.has_object_perm("GET", self.org, user=user)
 
+    def test_org_does_not_require_2fa_for_user_auth_token_request_if_no_membership(self):
+        # make sure that 2FA requirement is not visible to the outsiders
+        self.org_require_2fa()
+
+        other_org = self.create_organization()
+        user = self.create_user()
+        self.create_member(user=user, organization=other_org, role="owner")
+        token = self.create_user_auth_token(user)
+
+        request = drf_request_from_request(self.make_request(user=user, auth=token, method="GET"))
+        permission = self.permission_cls()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            permission.determine_access(request=request, organization=self.org)
+
     def test_sentryapp_passes_2fa(self):
         self.org_require_2fa()
         internal_sentry_app = self.create_internal_integration(


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry/pull/92015

Really make sure that 2FA requirement is not visible to users outside of the organization.
After this PR, cases logged with `access.not-2fa-compliant.dry-run` should be nearly zero.