### PR TITLE
fix(traceTree): Fix re-parenting to only re-parent on SSR

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.ssr.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.ssr.spec.tsx
@@ -99,8 +99,18 @@ describe('server side rendering', () => {
     const pageload = tree.root.children[0]!.children[0]!;
     const serverHandler = pageload.children[0]!;
 
+    // @ts-expect-error implicit any
+    expect(pageload?.value['transaction.op']).toBe('pageload');
+    // @ts-expect-error implicit any
+    expect(serverHandler?.value['transaction.op']).toBe('http.server');
+
+    expect(serverHandler.parent).toBe(pageload);
+
+    // Usually, an SSR server handler gets a reparent reason, but we want to test that it does not
+    // get re-parented again when there is no reparent reason.
     serverHandler.reparent_reason = null;
 
+    // This is where it would re-parent again
     TraceTree.FromSpans(pageload, ssrSpans, makeEventTransaction());
 
     const browserRequestSpan = tree.root.children[0]!.children[0]!.children.find(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -59,8 +59,6 @@ import {TraceTreeNode} from './traceTreeNode';
 
 const {info, fmt} = Sentry.logger;
 
-const REPARENT_REASON_SSR = 'pageload server handler';
-
 /**
  *
  * This file implements the tree data structure that is used to represent a trace. We do
@@ -523,7 +521,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         //   // The swap can occur at a later point when new transactions are fetched,
         //   // which means we need to invalidate the tree and re-render the UI.
         const parent = c.parent.parent;
-        TraceTree.Swap({parent: c.parent, child: c, reason: REPARENT_REASON_SSR});
+        TraceTree.Swap({parent: c.parent, child: c, reason: 'pageload server handler'});
         TraceTree.invalidate(parent!, true);
       }
     });
@@ -672,7 +670,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
             isServerRequestHandlerTransactionNode(n)
           );
 
-          if (serverRequestHandler?.reparent_reason === REPARENT_REASON_SSR) {
+          if (serverRequestHandler?.reparent_reason === 'pageload server handler') {
             serverRequestHandler.parent!.children =
               serverRequestHandler.parent!.children.filter(
                 n => n !== serverRequestHandler

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -664,19 +664,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
         for (const error of getRelatedSpanErrorsFromTransaction(c.value, node)) {
           c.errors.add(error);
         }
-        if (isBrowserRequestSpan(c.value)) {
-          const serverRequestHandler = c.parent?.children.find(n =>
-            isServerRequestHandlerTransactionNode(n)
-          );
-          if (serverRequestHandler) {
-            serverRequestHandler.parent!.children =
-              serverRequestHandler.parent!.children.filter(
-                n => n !== serverRequestHandler
-              );
-            c.children.push(serverRequestHandler);
-            serverRequestHandler.parent = c;
-          }
-        }
       }
       c.children.sort(traceChronologicalSort);
     });
@@ -1854,6 +1841,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
   }
 
   // Only supports parent/child swaps (the only ones we need)
+  // E.g. needed for swapping SSR spans: https://github.com/getsentry/rfcs/blob/main/text/0138-achieving-order-between-pageload-and-srr-spans.md
   static Swap({
     parent,
     child,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -672,7 +672,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
             isServerRequestHandlerTransactionNode(n)
           );
 
-          // todo: add test to only reparent with ssr reason
           if (serverRequestHandler?.reparent_reason === REPARENT_REASON_SSR) {
             serverRequestHandler.parent!.children =
               serverRequestHandler.parent!.children.filter(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -667,10 +667,6 @@ export class TraceTree extends TraceTreeEventDispatcher {
           c.errors.add(error);
         }
 
-      if (isBrowserRequestSpan(c.value)) {
-        const serverRequestHandler = c.parent?.children.find(n =>
-          isServerRequestHandlerTransactionNode(n)
-        );
         if (isBrowserRequestSpan(c.value)) {
           const serverRequestHandler = c.parent?.children.find(n =>
             isServerRequestHandlerTransactionNode(n)

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -666,19 +666,25 @@ export class TraceTree extends TraceTreeEventDispatcher {
         for (const error of getRelatedSpanErrorsFromTransaction(c.value, node)) {
           c.errors.add(error);
         }
-      }
 
       if (isBrowserRequestSpan(c.value)) {
         const serverRequestHandler = c.parent?.children.find(n =>
           isServerRequestHandlerTransactionNode(n)
         );
+        if (isBrowserRequestSpan(c.value)) {
+          const serverRequestHandler = c.parent?.children.find(n =>
+            isServerRequestHandlerTransactionNode(n)
+          );
 
-        // todo: add test to only reparent with ssr reason
-        if (serverRequestHandler?.reparent_reason === REPARENT_REASON_SSR) {
-          serverRequestHandler.parent!.children =
-            serverRequestHandler.parent!.children.filter(n => n !== serverRequestHandler);
-          c.children.push(serverRequestHandler);
-          serverRequestHandler.parent = c;
+          // todo: add test to only reparent with ssr reason
+          if (serverRequestHandler?.reparent_reason === REPARENT_REASON_SSR) {
+            serverRequestHandler.parent!.children =
+              serverRequestHandler.parent!.children.filter(
+                n => n !== serverRequestHandler
+              );
+            c.children.push(serverRequestHandler);
+            serverRequestHandler.parent = c;
+          }
         }
       }
 

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -59,6 +59,8 @@ import {TraceTreeNode} from './traceTreeNode';
 
 const {info, fmt} = Sentry.logger;
 
+const REPARENT_REASON_SSR = 'pageload server handler';
+
 /**
  *
  * This file implements the tree data structure that is used to represent a trace. We do
@@ -521,7 +523,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
         //   // The swap can occur at a later point when new transactions are fetched,
         //   // which means we need to invalidate the tree and re-render the UI.
         const parent = c.parent.parent;
-        TraceTree.Swap({parent: c.parent, child: c, reason: 'pageload server handler'});
+        TraceTree.Swap({parent: c.parent, child: c, reason: REPARENT_REASON_SSR});
         TraceTree.invalidate(parent!, true);
       }
     });
@@ -665,6 +667,21 @@ export class TraceTree extends TraceTreeEventDispatcher {
           c.errors.add(error);
         }
       }
+
+      if (isBrowserRequestSpan(c.value)) {
+        const serverRequestHandler = c.parent?.children.find(n =>
+          isServerRequestHandlerTransactionNode(n)
+        );
+
+        // todo: add test to only reparent with ssr reason
+        if (serverRequestHandler?.reparent_reason === REPARENT_REASON_SSR) {
+          serverRequestHandler.parent!.children =
+            serverRequestHandler.parent!.children.filter(n => n !== serverRequestHandler);
+          c.children.push(serverRequestHandler);
+          serverRequestHandler.parent = c;
+        }
+      }
+
       c.children.sort(traceChronologicalSort);
     });
 


### PR DESCRIPTION


We discovered an issue with re-parenting: Usually, the SSR server GET span is moved to be a child of the `browser.request` span. But in this case, it's re-parenting a POST span which it should not re-parent:

![image](https://github.com/user-attachments/assets/89eff464-9153-43bc-b282-b2f6e393c427)

This is the same span (it's a sibling of `browser.request` and child of `pageload`):
![image](https://github.com/user-attachments/assets/baecea20-f1bd-4a05-bb29-0148283bb0cb)

---
This is a correct case:
![image](https://github.com/user-attachments/assets/26f6afa0-f75a-4342-a28c-5715e6ae258b)

---

Turns out, [this code block](https://github.com/getsentry/sentry/pull/78306/files#diff-c30c9c6d7f1f5efa81bbe73dac576ece319b2cd5e2bac9d14ebe118f1a6fc923R502-R514) is looking for the first sibling with `http.server`. When first looking at this, I was confused why it's looking for a sibling as the `http.server` span is not a sibling of `browser.request` but the parent of the parent. 

Before [this PR](https://github.com/getsentry/sentry/pull/78306) (also linked in the previous paragraph), the re-parenting happened in one step - so the parent-parent was moved down. Now, it's a two-step approach. Where first `http.server` is moved to to be a sibling of `browser.request` with `.Swap` and in the second step it goes through the logic of looking for the first sibling which is `http.server`. I am just wondering if it makes sense to have the "span moving" split up as it creates some complexity. 

---

This is a quick fix now which changes the conditional of looking for a `serverRequestHandler` to also check for a re-parenting reason.





