### PR TITLE
fix(issues): Add Feedback as a valid category on the frontend

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -108,6 +108,7 @@ export enum IssueCategory {
  */
 export const VALID_ISSUE_CATEGORIES_V2 = [
   IssueCategory.ERROR,
+  IssueCategory.FEEDBACK,
   IssueCategory.OUTAGE,
   IssueCategory.METRIC,
   IssueCategory.DB_QUERY,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -108,13 +108,13 @@ export enum IssueCategory {
  */
 export const VALID_ISSUE_CATEGORIES_V2 = [
   IssueCategory.ERROR,
-  IssueCategory.FEEDBACK,
   IssueCategory.OUTAGE,
   IssueCategory.METRIC,
   IssueCategory.DB_QUERY,
   IssueCategory.HTTP_CLIENT,
   IssueCategory.FRONTEND,
   IssueCategory.MOBILE,
+  IssueCategory.FEEDBACK,
 ];
 
 export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -59,6 +59,10 @@ const PREDEFINED_FIELDS = {
 // "environment" is excluded because it should be handled by the environment page filter
 const EXCLUDED_TAGS = ['environment'];
 
+const SEARCHABLE_ISSUE_CATEGORIES = VALID_ISSUE_CATEGORIES_V2.filter(
+  category => category !== IssueCategory.FEEDBACK
+);
+
 /**
  * Certain field keys may conflict with custom tags. In this case, the tag will be
  * renamed, e.g. `platform` -> `tags[platform]`
@@ -285,7 +289,7 @@ function builtInIssuesFields({
       ...PREDEFINED_FIELDS[FieldKey.ISSUE_CATEGORY]!,
       name: 'Issue Category',
       values: organization.features.includes('issue-taxonomy')
-        ? VALID_ISSUE_CATEGORIES_V2.map(value => ({
+        ? SEARCHABLE_ISSUE_CATEGORIES.map(value => ({
             icon: null,
             title: value,
             name: value,


### PR DESCRIPTION
Per the new taxonomy it's not deprecated so I think it was just omitted by accident, but I'll defer to the review 👍 