### PR TITLE
chore(autofix): Clearer autofix settings

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import addIntegrationProvider from 'sentry-images/spot/add-integration-provider.svg';
@@ -89,6 +89,8 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     needsAutomation ||
     needsFixabilityView;
 
+  const [hideSteps, setHideSteps] = useState(false);
+
   const handleStarFixabilityView = () => {
     createIssueView({
       name: 'Easy Fixes 🤖',
@@ -108,7 +110,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
 
   return (
     <NoticesContainer>
-      {anyStepIncomplete && (
+      {anyStepIncomplete && !hideSteps && (
         <Fragment>
           <StepsHeader>
             <SeerWaitingIcon size="xl" />
@@ -257,6 +259,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                   </StepImageCol>
                 </StepContentRow>
                 <GuidedSteps.StepButtons>
+                  <Button onClick={() => setHideSteps(true)} size="sm">
+                    {t('Skip for Now')}
+                  </Button>
                   <Button onClick={handleStarFixabilityView} size="sm" priority="primary">
                     {t('Star Recommended View')}
                   </Button>

--- a/static/app/views/settings/projectSeer/addAutofixRepoModal.tsx
+++ b/static/app/views/settings/projectSeer/addAutofixRepoModal.tsx
@@ -6,11 +6,13 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
+import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconSearch} from 'sentry/icons';
-import {t, tn} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Repository} from 'sentry/types/integrations';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {SelectableRepoItem} from './selectableRepoItem';
 
@@ -48,6 +50,7 @@ export function AddAutofixRepoModalContent({
   isFetchingRepositories,
   maxReposLimit,
 }: Props) {
+  const organization = useOrganization();
   const [modalSearchQuery, setModalSearchQuery] = useState('');
   const [showMaxLimitAlert, setShowMaxLimitAlert] = useState(false);
   const [modalSelectedRepoIds, setModalSelectedRepoIds] =
@@ -180,25 +183,44 @@ export function AddAutofixRepoModalContent({
         )}
       </Body>
       <Footer>
-        <Button
-          priority="primary"
-          onClick={() => {
-            onSave(modalSelectedRepoIds);
-            closeModal();
-          }}
-        >
-          {newModalSelectedRepoIds.length > 0
-            ? tn(
-                'Add %s Repository',
-                'Add %s Repositories',
-                newModalSelectedRepoIds.length
-              )
-            : t('Done')}
-        </Button>
+        <FooterRow>
+          <div>
+            {tct(
+              "Don't see the repo you want? [manageRepositoriesLink:Manage repositories here.]",
+              {
+                manageRepositoriesLink: (
+                  <Link to={`/settings/${organization.slug}/repos/`} />
+                ),
+              }
+            )}
+          </div>
+          <Button
+            priority="primary"
+            onClick={() => {
+              onSave(modalSelectedRepoIds);
+              closeModal();
+            }}
+          >
+            {newModalSelectedRepoIds.length > 0
+              ? tn(
+                  'Add %s Repository',
+                  'Add %s Repositories',
+                  newModalSelectedRepoIds.length
+                )
+              : t('Done')}
+          </Button>
+        </FooterRow>
       </Footer>
     </Fragment>
   );
 }
+
+const FooterRow = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+`;
 
 const ModalReposContainer = styled('div')`
   height: 35vh;

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -199,7 +199,7 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
     <Panel>
       <PanelHeader hasButtons>
         <Flex align="center" gap={space(0.5)}>
-          {t('Seer Repositories')}
+          {t('Working Repositories')}
           <QuestionTooltip
             title={t(
               'Below are the repositories that Seer will work on. Seer will only be able to see code from and make PRs to the repositories that you select here.'

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -5,6 +5,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Flex} from 'sentry/components/container/flex';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {useOrganizationRepositories} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
@@ -15,7 +16,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {IconAdd} from 'sentry/icons';
+import {IconAdd, IconGithub} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -201,13 +202,25 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         <Flex align="center" gap={space(0.5)}>
           {t('Working Repositories')}
           <QuestionTooltip
-            title={t(
-              'Below are the repositories that Seer will work on. Seer will only be able to see code from and make PRs to the repositories that you select here.'
+            title={tct(
+              'Seer will only be able to see code from and make PRs to the repos that you select here. The [link:GitHub integration] is required for Seer to access these repos.',
+              {
+                link: <Link to={`/settings/${organization.slug}/integrations/github/`} />,
+              }
             )}
             size="sm"
+            isHoverable
           />
         </Flex>
-        <div>
+        <div style={{display: 'flex', alignItems: 'center', gap: space(1)}}>
+          <LinkButton
+            size="xs"
+            icon={<IconGithub />}
+            to={`/settings/${organization.slug}/integrations/github/`}
+            style={{textTransform: 'none'}}
+          >
+            {t('Manage GitHub Integration')}
+          </LinkButton>
           <Tooltip
             isHoverable
             title={

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -47,7 +47,7 @@ export const autofixAutomatingTuningField = {
   label: t('Automatically Fix Issues with Seer'),
   help: props =>
     tct(
-      "Set how frequently Seer runs root cause analysis and fixes on issues. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager.[break][break][link:You can configure automation for other projects too.]",
+      "Set how frequently Seer runs root cause analysis and fixes on issues. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager. This may have billing implications.[break][break][link:You can configure automation for other projects too.]",
       {
         break: <br />,
         link: <Link to={`/settings/${props.organization?.slug}/seer`} />,

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -9,8 +9,9 @@ import FieldGroup from 'sentry/components/forms/fieldGroup';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
+import Link from 'sentry/components/links/link';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
@@ -46,9 +47,14 @@ export function formatSeerValue(value: string | undefined) {
 export const autofixAutomatingTuningField = {
   name: 'autofixAutomationTuning',
   label: t('Automatically Fix Issues with Seer'),
-  help: t(
-    "Set how frequently Seer runs root cause analysis and fixes on issues. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager."
-  ),
+  help: props =>
+    tct(
+      "Set how frequently Seer runs root cause analysis and fixes on issues. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager.[break][break][link:You can configure automation for other projects too.]",
+      {
+        break: <br />,
+        link: <Link to={`/settings/${props.organization?.slug}/seer`} />,
+      }
+    ),
   type: 'range',
   min: 0,
   max: SEER_THRESHOLD_MAP.length - 1,
@@ -68,33 +74,6 @@ export const autofixAutomatingTuningField = {
   saveMessage: t('Automatic Seer settings updated'),
 } satisfies FieldObject;
 
-const configureAllProjectsField = {
-  name: 'configureAutomationForAllProjects',
-  type: 'custom' as const,
-  Component: () => {
-    const organization = useOrganization();
-    return (
-      <FieldGroup
-        label={t('Configure Automation for Other Projects')}
-        help={t(
-          'Allow Seer to automatically fix issues for other projects in addition to this one.'
-        )}
-        alignRight
-      >
-        <div style={{width: 'auto'}}>
-          <LinkButton
-            to={`/settings/${organization.slug}/seer`}
-            priority="link"
-            size="sm"
-          >
-            {t('Go to Seer Automation Settings')}
-          </LinkButton>
-        </div>
-      </FieldGroup>
-    );
-  },
-};
-
 const configureSourceIntegration = {
   name: 'configureSourceIntegration',
   type: 'custom' as const,
@@ -102,7 +81,7 @@ const configureSourceIntegration = {
     const organization = useOrganization();
     return (
       <FieldGroup
-        label={t('Configure GitHub Integration')}
+        label={t('Integrate with Your Codebase')}
         help={t(
           'The GitHub integration allows Seer to analyze your code to find more accurate root causes and solutions to your issues. Support for other source providers is coming soon.'
         )}
@@ -114,7 +93,7 @@ const configureSourceIntegration = {
             priority="link"
             size="sm"
           >
-            {t('Go to GitHub Integration Settings')}
+            {t('Go to Integration Settings')}
           </LinkButton>
         </div>
       </FieldGroup>
@@ -125,11 +104,7 @@ const configureSourceIntegration = {
 const seerFormGroups: JsonFormObject[] = [
   {
     title: t('General'),
-    fields: [
-      autofixAutomatingTuningField,
-      configureAllProjectsField,
-      configureSourceIntegration,
-    ],
+    fields: [autofixAutomatingTuningField, configureSourceIntegration],
   },
 ];
 
@@ -165,6 +140,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
           ),
         }}
         onSubmitSuccess={handleSubmitSuccess}
+        additionalFieldProps={{organization}}
       >
         <JsonForm
           forms={seerFormGroups}

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -75,7 +75,7 @@ const configureAllProjectsField = {
     const organization = useOrganization();
     return (
       <FieldGroup
-        label={t('Configure Automation for All Projects')}
+        label={t('Configure Automation for Other Projects')}
         help={t(
           'Allow Seer to automatically fix issues for other projects in addition to this one.'
         )}

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -4,8 +4,6 @@ import {useQueryClient} from '@tanstack/react-query';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {Alert} from 'sentry/components/core/alert';
-import {LinkButton} from 'sentry/components/core/button/linkButton';
-import FieldGroup from 'sentry/components/forms/fieldGroup';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
@@ -74,37 +72,10 @@ export const autofixAutomatingTuningField = {
   saveMessage: t('Automatic Seer settings updated'),
 } satisfies FieldObject;
 
-const configureSourceIntegration = {
-  name: 'configureSourceIntegration',
-  type: 'custom' as const,
-  Component: () => {
-    const organization = useOrganization();
-    return (
-      <FieldGroup
-        label={t('Integrate with Your Codebase')}
-        help={t(
-          'The GitHub integration allows Seer to analyze your code to find more accurate root causes and solutions to your issues. Support for other source providers is coming soon.'
-        )}
-        alignRight
-      >
-        <div style={{width: 'auto'}}>
-          <LinkButton
-            to={`/settings/${organization.slug}/integrations/github/`}
-            priority="link"
-            size="sm"
-          >
-            {t('Go to Integration Settings')}
-          </LinkButton>
-        </div>
-      </FieldGroup>
-    );
-  },
-};
-
 const seerFormGroups: JsonFormObject[] = [
   {
     title: t('General'),
-    fields: [autofixAutomatingTuningField, configureSourceIntegration],
+    fields: [autofixAutomatingTuningField],
   },
 ];
 

--- a/static/app/views/settings/projectSeer/selectableRepoItem.tsx
+++ b/static/app/views/settings/projectSeer/selectableRepoItem.tsx
@@ -17,39 +17,42 @@ interface Props {
 export function SelectableRepoItem({repo, isSelected, onToggle}: Props) {
   const isSupportedProvider = isSupportedAutofixProvider(repo.provider?.name || '');
 
-  const tooltipMessage = isSupportedProvider
-    ? ''
-    : t('Support for %s will be coming soon', repo.provider?.name || t('this provider'));
-
-  const repoContent = (
+  return (
     <RepoListItemContainer
       selected={isSelected}
       disabled={!isSupportedProvider}
       role="button"
       tabIndex={0}
       data-repo-id={repo.externalId}
-      onClick={() => onToggle(repo.externalId)}
+      onClick={() => {
+        if (isSupportedProvider) {
+          onToggle(repo.externalId);
+        }
+      }}
     >
-      <RepoHeader>
-        <RepoInfoWrapper>
-          <RepoName>{repo.name}</RepoName>
-          <SelectionWrapper>
-            <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
-            {isSupportedProvider && (
-              <StyledCheckbox checked={isSelected} size="sm" readOnly />
-            )}
-          </SelectionWrapper>
-        </RepoInfoWrapper>
-      </RepoHeader>
-    </RepoListItemContainer>
-  );
+      <Tooltip
+        title={t('Support for %s will be coming soon', repo.provider?.name)}
+        showUnderline={false}
+        disabled={isSupportedProvider}
+      >
+        <RepoHeader>
+          <RepoInfoWrapper>
+            <RepoName>{repo.name}</RepoName>
 
-  return isSupportedProvider ? (
-    repoContent
-  ) : (
-    <Tooltip title={tooltipMessage} showUnderline={false}>
-      {repoContent}
-    </Tooltip>
+            <SelectionWrapper>
+              <RepoProvider>{repo.provider?.name || t('Unknown Provider')}</RepoProvider>
+
+              <StyledCheckbox
+                checked={isSelected}
+                size="sm"
+                readOnly
+                disabled={!isSupportedProvider}
+              />
+            </SelectionWrapper>
+          </RepoInfoWrapper>
+        </RepoHeader>
+      </Tooltip>
+    </RepoListItemContainer>
   );
 }
 

--- a/static/gsApp/views/seerAutomation/index.spec.tsx
+++ b/static/gsApp/views/seerAutomation/index.spec.tsx
@@ -45,7 +45,7 @@ describe('SeerAutomation', function () {
     expect(projectItem.parentElement!.parentElement).toHaveTextContent('Off');
 
     const slider = await screen.findByRole('slider', {
-      name: /Default for new projects/i,
+      name: /Default for New Projects/i,
     });
 
     act(() => {

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -17,6 +17,9 @@ export function SeerAutomationDefault() {
     ...autofixAutomatingTuningField,
     name: 'defaultAutofixAutomationTuning',
     label: t('Default for New Projects'),
+    help: t(
+      "Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager."
+    ),
   } satisfies FieldObject;
 
   const seerFormGroups: JsonFormObject[] = [

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -18,7 +18,7 @@ export function SeerAutomationDefault() {
     name: 'defaultAutofixAutomationTuning',
     label: t('Default for New Projects'),
     help: t(
-      "Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager."
+      "Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis. A 'Low' setting means Seer runs only on the most actionable issues, while a 'High' setting enables Seer to be more eager. This may have billing implications."
     ),
   } satisfies FieldObject;
 

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -1,3 +1,4 @@
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
@@ -10,11 +11,12 @@ import {
 
 export function SeerAutomationDefault() {
   const organization = useOrganization();
+  const canWrite = hasEveryAccess(['org:write'], {organization});
 
   const orgDefaultAutomationTuning = {
     ...autofixAutomatingTuningField,
     name: 'defaultAutofixAutomationTuning',
-    label: t('Default for new projects'),
+    label: t('Default for New Projects'),
   } satisfies FieldObject;
 
   const seerFormGroups: JsonFormObject[] = [
@@ -35,7 +37,7 @@ export function SeerAutomationDefault() {
         ),
       }}
     >
-      <JsonForm forms={seerFormGroups} />
+      <JsonForm forms={seerFormGroups} disabled={!canWrite} />
     </Form>
   );
 }


### PR DESCRIPTION
Clarify some of the settings based on some confusion we saw in feedback
- add links to manage github integration and bulk automation settings from the project settings page
- show messages when you don't have permission to edit a setting
- fix alignment bug in repo selection modal
- small copy tweaks

Also allow the onboarding to be skipped temporarily in the drawer

<img width="816" alt="Screenshot 2025-05-26 at 10 54 25 AM" src="https://github.com/user-attachments/assets/cfdf0f1c-3634-4774-862d-8427fe19599e" />


<img width="1211" alt="Screenshot 2025-05-26 at 10 47 25 AM" src="https://github.com/user-attachments/assets/9695cd40-ded2-4423-9bb4-181b2bdba632" />



<img width="619" alt="Screenshot 2025-05-26 at 9 08 30 AM" src="https://github.com/user-attachments/assets/1f2602e2-2d1e-404b-acd4-afff14b6941d" />

