### PR TITLE
fix(symbolicator): copy source to avoid modification of settings

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -585,7 +585,7 @@ def get_sources_for_project(project):
                 # token could not be fetched successfully
                 if token is not None:
                     # Create a new dict to avoid reference issues
-                    source = source.copy()
+                    source = deepcopy(source)
                     source["bearer_token"] = token
 
                     # Remove other credentials if we have a token

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -584,6 +584,8 @@ def get_sources_for_project(project):
                 # if target_credentials.token is None it means that the
                 # token could not be fetched successfully
                 if token is not None:
+                    # Create a new dict to avoid reference issues
+                    source = source.copy()
                     source["bearer_token"] = token
 
                     # Remove other credentials if we have a token

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -1,3 +1,4 @@
+import copy
 from unittest.mock import patch
 
 import jsonschema
@@ -70,8 +71,12 @@ class TestGcpBearerAuthentication:
         }
         default_project.update_option("sentry:builtin_symbol_sources", ["ccc"])
 
+        builtin_sources_before = copy.deepcopy(settings.SENTRY_BUILTIN_SOURCES)
+
         with Feature(features):
             sources = get_sources_for_project(default_project)
+
+        assert builtin_sources_before == copy.deepcopy(settings.SENTRY_BUILTIN_SOURCES)
 
         # Make sure that we expanded successfully here
         # Source 1 will be sentry, the following 2 will be the expanded gcs sources


### PR DESCRIPTION
Before this change, calling `fetch_token_for_gcp_source` twice produces an error:
```
Unable to acquire impersonated credentials
...
"message": "Invalid form of account ID None. Should be [Gaia ID |Email |Unique ID |] of the account"
```

This was happening because the `source` argument in `fetch_token_for_gcp_source(source, organization)` method is being passed by reference, hence the original `client_email` was overwritten, and the second call received its value as `None`.