### PR TITLE
fix(2fa): require 2FA for auth token requests (enforce)

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -181,9 +181,10 @@ class SentryPermission(ScopedPermission):
 
             if org_context.member and self.is_not_2fa_compliant(request, organization):
                 logger.info(
-                    "access.not-2fa-compliant.dry-run",
+                    "access.not-2fa-compliant.auth-token",
                     extra=extra,
                 )
+                raise TwoFactorRequired()
             return
 
         request.access = access.from_request_org_and_scopes(


### PR DESCRIPTION
This will cause user auth token requests to fail if:
- 2FA is enforced on the organization,
- but the corresponding user does not have a 2FA method.
