### PR TITLE
fix(dashboards): place releases drawer above widget modal

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -334,13 +334,16 @@ export async function openWidgetViewerModal({
   onClose,
   ...options
 }: WidgetViewerModalOptions & {onClose?: () => void}) {
-  const {default: Modal, modalCss} = await import(
-    'sentry/components/modals/widgetViewerModal'
-  );
+  const {
+    default: Modal,
+    modalCss,
+    backdropCss,
+  } = await import('sentry/components/modals/widgetViewerModal');
 
   openModal(deps => <Modal {...deps} {...options} />, {
     closeEvents: 'none',
     modalCss,
+    backdropCss,
     onClose,
   });
 }

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -26,6 +26,11 @@ type ModalOptions = {
    */
   backdrop?: boolean;
   /**
+   * Additional CSS which will be applied to the modal's backdrop.
+   * Allows specific control over the positioning of z-index for the entire modal
+   */
+  backdropCss?: ReturnType<typeof css>;
+  /**
    * By default, the modal is closed when the backdrop is clicked or the
    * escape key is pressed. This prop allows you to modify that behavior.
    * Only use when completely necessary, the defaults are important for
@@ -217,12 +222,14 @@ function GlobalModal({onClose}: Props) {
     <Fragment>
       <Backdrop
         style={backdrop && visible ? {opacity: 0.5, pointerEvents: 'auto'} : {}}
+        css={options?.backdropCss}
       />
       <Container
         data-test-id="modal-backdrop"
         ref={containerRef}
         style={{pointerEvents: visible ? 'auto' : 'none'}}
         onClick={backdrop ? clickClose : undefined}
+        css={options?.backdropCss}
       >
         <TooltipContext
           value={{

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -157,6 +157,7 @@ function GlobalModal({onClose}: Props) {
       preventScroll: true,
       escapeDeactivates: false,
       fallbackFocus: portal,
+      allowOutsideClick: true,
     });
     ModalStore.setFocusTrap(focusTrap.current);
   }, [portal]);

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1192,6 +1192,10 @@ export const modalCss = css`
   max-width: 1200px;
 `;
 
+export const backdropCss = css`
+  z-index: 9998 !important;
+`;
+
 const Container = styled('div')<{height?: number | null}>`
   display: flex;
   flex-direction: column;

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1193,7 +1193,7 @@ export const modalCss = css`
 `;
 
 export const backdropCss = css`
-  z-index: 9998 !important;
+  z-index: 9998;
 `;
 
 const Container = styled('div')<{height?: number | null}>`


### PR DESCRIPTION
### Changes
- Redid the z-index so the modal appears behind the release drawer
- Allow clicks in the modal focus trap (so user can interact with the drawer links)

### Before
![Screenshot 2025-05-26 at 12 44 14 PM](https://github.com/user-attachments/assets/c9b99f48-dedb-4632-b6d1-2b346d60d6fe)

### After
![Screenshot 2025-05-26 at 12 44 49 PM](https://github.com/user-attachments/assets/c2179109-2c99-411b-9a04-72683337ee60)
