### PR TITLE
feat(tx-clustering): API endpoint for a project option which controls transaction clustering

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -131,6 +131,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "tempestFetchScreenshots",
         "tempestFetchDumps",
         "autofixAutomationTuning",
+        "transactionNameClusteringDisabled",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -225,6 +226,7 @@ E.g. `['release', 'environment']`""",
     autofixAutomationTuning = serializers.ChoiceField(
         choices=["off", "low", "medium", "high", "always"], required=False
     )
+    transactionNameClusteringDisabled = serializers.BooleanField(required=False)
 
     # DO NOT ADD MORE TO OPTIONS
     # Each param should be a field in the serializer like above.
@@ -769,6 +771,17 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             if project.update_option("sentry:dynamic_sampling_biases", updated_biases):
                 changed_proj_settings["sentry:dynamic_sampling_biases"] = result[
                     "dynamicSamplingBiases"
+                ]
+
+        if result.get("transactionNameClusteringDisabled") is not None and features.has(
+            "organizations:disable-clustering-setting", project.organization, actor=request.user
+        ):
+            if project.update_option(
+                "performance:transaction-name-clustering-disabled",
+                bool(result["transactionNameClusteringDisabled"]),
+            ):
+                changed_proj_settings["performance:transaction-name-clustering-disabled"] = result[
+                    "transactionNameClusteringDisabled"
                 ]
 
         if result.get("autofixAutomationTuning") is not None:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -952,6 +952,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     tempestFetchScreenshots: NotRequired[bool]
     tempestFetchDumps: NotRequired[bool]
     autofixAutomationTuning: NotRequired[str]
+    transactionNameClusteringDisabled: NotRequired[bool]
 
 
 class DetailedProjectSerializer(ProjectWithTeamSerializer):
@@ -1110,6 +1111,11 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "sentry:tempest_fetch_screenshots", False
             )
             data["tempestFetchDumps"] = attrs["options"].get("sentry:tempest_fetch_dumps", False)
+
+        if features.has("organizations:disable-clustering-setting", obj.organization, actor=user):
+            data["transactionNameClusteringDisabled"] = attrs["options"].get(
+                "performance:transaction-name-clustering-disabled", False
+            )
 
         return data
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -75,6 +75,7 @@ OPTION_KEYS = frozenset(
         "filters:react-hydration-errors",
         "filters:chunk-load-error",
         "relay.cardinality-limiter.limits",
+        "performance:transaction-name-clustering-disabled",
     ]
 )
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -199,3 +199,6 @@ register(key="sentry:tempest_fetch_dumps", default=False)
 
 # Should autofix run automatically on new issues
 register(key="sentry:autofix_automation_tuning", default="off")
+
+# Should transaction name clustering be disabled for this project
+register(key="performance:transaction-name-clustering-disabled", default=False)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1974,3 +1974,22 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsDynamicSamplingB
             )
             assert self.project.get_option("sentry:autofix_automation_tuning") == "off"
             assert resp.data["autofixAutomationTuning"] == "off"
+
+    def test_transaction_name_clustering_disabled(self):
+        # test without feature flag - should be ignored
+        resp = self.get_success_response(
+            self.org_slug, self.proj_slug, transactionNameClusteringDisabled=True
+        )
+        assert "disable-clustering-setting feature enabled" not in resp.data
+        assert self.project.get_option("performance:transaction-name-clustering-disabled") is False
+
+        # test with feature flag - should be updated
+        with self.feature("organizations:disable-clustering-setting"):
+            resp = self.get_success_response(
+                self.org_slug, self.proj_slug, transactionNameClusteringDisabled=True
+            )
+            assert (
+                self.project.get_option("performance:transaction-name-clustering-disabled") is True
+            )
+            assert "transactionNameClusteringDisabled" in resp.data
+            assert resp.data["transactionNameClusteringDisabled"] is True


### PR DESCRIPTION
Exposes project option `performance:transaction-name-clustering-disabled` via API, but behind a feature flag for now.

It will allow users to disable transaction clustering per project. Currently transaction clustering for some projects over-clusters and it causes unreadable transaction metrics.

[TET-538: Add setting to disable clusterer](https://linear.app/getsentry/issue/TET-538/add-setting-to-disable-clusterer)