### PR TITLE
feat(insights): create link from insight charts to explore and alerts

### DIFF
--- a/static/app/views/insights/common/components/createAlertButton.tsx
+++ b/static/app/views/insights/common/components/createAlertButton.tsx
@@ -9,10 +9,11 @@ import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 type Props = {
+  search?: MutableSearch;
   yAxis?: string;
 };
 
-export function CreateAlertButton({yAxis}: Props) {
+export function CreateAlertButton({yAxis, search}: Props) {
   const navigate = useNavigate();
   const organization = useOrganization();
   const {projects} = useProjects();
@@ -30,7 +31,7 @@ export function CreateAlertButton({yAxis}: Props) {
       navigate(
         getAlertsUrl({
           project,
-          query: '',
+          query: search?.formatString(),
           pageFilters: selection,
           aggregate: yAxis,
           organization,

--- a/static/app/views/insights/common/components/createAlertButton.tsx
+++ b/static/app/views/insights/common/components/createAlertButton.tsx
@@ -1,0 +1,49 @@
+import {Button} from 'sentry/components/core/button';
+import {t} from 'sentry/locale';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
+
+type Props = {
+  yAxis?: string;
+};
+
+export function CreateAlertButton({yAxis}: Props) {
+  const navigate = useNavigate();
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
+
+  const [interval] = useChartInterval();
+
+  const project =
+    projects.length === 1
+      ? projects[0]
+      : projects.find(p => p.id === `${selection.projects[0]}`);
+
+  const handleButtonClick = () => {
+    if (yAxis) {
+      navigate(
+        getAlertsUrl({
+          project,
+          query: '',
+          pageFilters: selection,
+          aggregate: yAxis,
+          organization,
+          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+          interval,
+        })
+      );
+    }
+  };
+
+  return (
+    <Button size="xs" disabled={!yAxis} onClick={handleButtonClick}>
+      {t('Create Alert')}
+    </Button>
+  );
+}

--- a/static/app/views/insights/common/components/createAlertButton.tsx
+++ b/static/app/views/insights/common/components/createAlertButton.tsx
@@ -1,10 +1,8 @@
-import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {t} from 'sentry/locale';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
@@ -14,7 +12,6 @@ type Props = {
 };
 
 export function CreateAlertButton({yAxis, search}: Props) {
-  const navigate = useNavigate();
   const organization = useOrganization();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
@@ -26,25 +23,20 @@ export function CreateAlertButton({yAxis, search}: Props) {
       ? projects[0]
       : projects.find(p => p.id === `${selection.projects[0]}`);
 
-  const handleButtonClick = () => {
-    if (yAxis) {
-      navigate(
-        getAlertsUrl({
-          project,
-          query: search?.formatString(),
-          pageFilters: selection,
-          aggregate: yAxis,
-          organization,
-          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          interval,
-        })
-      );
-    }
-  };
+  const url = yAxis
+    ? getAlertsUrl({
+        project,
+        query: search?.formatString(),
+        pageFilters: selection,
+        aggregate: yAxis,
+        organization,
+        interval,
+      })
+    : '';
 
   return (
-    <Button size="xs" disabled={!yAxis} onClick={handleButtonClick}>
+    <LinkButton size="xs" disabled={!yAxis} to={url}>
       {t('Create Alert')}
-    </Button>
+    </LinkButton>
   );
 }

--- a/static/app/views/insights/common/components/createAlertButton.tsx
+++ b/static/app/views/insights/common/components/createAlertButton.tsx
@@ -1,5 +1,6 @@
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {t} from 'sentry/locale';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -7,6 +7,7 @@ import {Button} from 'sentry/components/core/button';
 import {IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
@@ -167,9 +168,15 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
               <Widget.WidgetDescription description={props.description} />
             )}
             {hasChartActionsEnabled && (
-              <OpenInExploreButton yAxes={yAxes} title={props.title} />
+              <OpenInExploreButton
+                yAxes={yAxes}
+                title={props.title}
+                search={props.search}
+              />
             )}
-            {hasChartActionsEnabled && <CreateAlertButton yAxis={yAxes[0]} />}
+            {hasChartActionsEnabled && (
+              <CreateAlertButton yAxis={yAxes[0]} search={props.search} />
+            )}
             {props.loaderSource !== 'releases-drawer' && (
               <Button
                 size="xs"

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -30,6 +30,8 @@ import {
   HTTP_RESPONSE_5XX_COLOR,
   THROUGHPUT_COLOR,
 } from 'sentry/views/insights/colors';
+import {CreateAlertButton} from 'sentry/views/insights/common/components/createAlertButton';
+import {OpenInExploreButton} from 'sentry/views/insights/common/components/openInExploreButton';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
@@ -67,6 +69,9 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
       version,
     })) ?? [];
 
+  const hasChartActionsEnabled = organization.features.includes('insights-chart-actions');
+  const yAxes: string[] = [];
+
   const visualizationProps: TimeSeriesWidgetVisualizationProps = {
     showLegend: props.showLegend,
     plottables: (props.series.filter(Boolean) ?? [])?.map(serie => {
@@ -77,6 +82,8 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
           : props.visualizationType === 'area'
             ? Area
             : Bars;
+
+      yAxes.push(timeSeries.yAxis);
 
       return new PlottableDataConstructor(timeSeries, {
         color: serie.color ?? COMMON_COLORS(theme)[timeSeries.yAxis],
@@ -158,6 +165,8 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
             {props.description && (
               <Widget.WidgetDescription description={props.description} />
             )}
+            {hasChartActionsEnabled && <OpenInExploreButton yAxes={yAxes} />}
+            {hasChartActionsEnabled && <CreateAlertButton yAxis={yAxes[0]} />}
             {props.loaderSource !== 'releases-drawer' && (
               <Button
                 size="xs"

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -31,6 +31,7 @@ import {
   HTTP_RESPONSE_5XX_COLOR,
   THROUGHPUT_COLOR,
 } from 'sentry/views/insights/colors';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {CreateAlertButton} from 'sentry/views/insights/common/components/createAlertButton';
 import {OpenInExploreButton} from 'sentry/views/insights/common/components/openInExploreButton';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
@@ -148,6 +149,13 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
       } as const)
     : {};
 
+  let chartType = ChartType.LINE;
+  if (props.visualizationType === 'area') {
+    chartType = ChartType.AREA;
+  } else if (props.visualizationType === 'bar') {
+    chartType = ChartType.BAR;
+  }
+
   return (
     <ChartContainer height={props.height}>
       <Widget
@@ -169,6 +177,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
             )}
             {hasChartActionsEnabled && (
               <OpenInExploreButton
+                chartType={chartType}
                 yAxes={yAxes}
                 title={props.title}
                 search={props.search}

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -52,6 +52,7 @@ export interface InsightsTimeSeriesWidgetProps
   onLegendSelectionChange?: ((selection: LegendSelection) => void) | undefined;
   pageFilters?: PageFilters;
   samples?: Samples;
+  search?: MutableSearch;
   showLegend?: TimeSeriesWidgetVisualizationProps['showLegend'];
   showReleaseAs?: 'line' | 'bubble';
   stacked?: boolean;
@@ -165,7 +166,9 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
             {props.description && (
               <Widget.WidgetDescription description={props.description} />
             )}
-            {hasChartActionsEnabled && <OpenInExploreButton yAxes={yAxes} />}
+            {hasChartActionsEnabled && (
+              <OpenInExploreButton yAxes={yAxes} title={props.title} />
+            )}
             {hasChartActionsEnabled && <CreateAlertButton yAxis={yAxes[0]} />}
             {props.loaderSource !== 'releases-drawer' && (
               <Button

--- a/static/app/views/insights/common/components/openInExploreButton.tsx
+++ b/static/app/views/insights/common/components/openInExploreButton.tsx
@@ -4,22 +4,23 @@ import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
-import {ChartType} from 'sentry/views/insights/common/components/chart';
+import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
 type Props = {
+  chartType: ChartType;
   yAxes: string[];
   search?: MutableSearch;
   title?: string;
 };
 
-export function OpenInExploreButton({yAxes, title, search}: Props) {
+export function OpenInExploreButton({yAxes, title, search, chartType}: Props) {
   const organization = useOrganization();
 
   const url = getExploreUrl({
     organization,
     visualize: [
       {
-        chartType: ChartType.LINE,
+        chartType,
         yAxes,
       },
     ],

--- a/static/app/views/insights/common/components/openInExploreButton.tsx
+++ b/static/app/views/insights/common/components/openInExploreButton.tsx
@@ -1,0 +1,41 @@
+import {Button} from 'sentry/components/core/button';
+import {t} from 'sentry/locale';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+type Props = {
+  yAxes: string[];
+};
+
+export function OpenInExploreButton({yAxes}: Props) {
+  const navigate = useNavigate();
+  const organization = useOrganization();
+
+  const handleButtonClick = () => {
+    navigate(
+      getExploreUrl({
+        organization,
+        visualize: [
+          {
+            chartType: ChartType.LINE,
+            yAxes,
+          },
+        ],
+        mode: Mode.AGGREGATE,
+        title: 'chart title',
+        query: '',
+        sort: undefined,
+        groupBy: undefined,
+      })
+    );
+  };
+
+  return (
+    <Button size="xs" onClick={handleButtonClick}>
+      {t('Open in Explore')}
+    </Button>
+  );
+}

--- a/static/app/views/insights/common/components/openInExploreButton.tsx
+++ b/static/app/views/insights/common/components/openInExploreButton.tsx
@@ -1,5 +1,6 @@
 import {Button} from 'sentry/components/core/button';
 import {t} from 'sentry/locale';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -8,9 +9,11 @@ import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 type Props = {
   yAxes: string[];
+  search?: MutableSearch;
+  title?: string;
 };
 
-export function OpenInExploreButton({yAxes}: Props) {
+export function OpenInExploreButton({yAxes, title, search}: Props) {
   const navigate = useNavigate();
   const organization = useOrganization();
 
@@ -25,8 +28,8 @@ export function OpenInExploreButton({yAxes}: Props) {
           },
         ],
         mode: Mode.AGGREGATE,
-        title: 'chart title',
-        query: '',
+        title: title ?? yAxes[0],
+        query: search?.formatString(),
         sort: undefined,
         groupBy: undefined,
       })

--- a/static/app/views/insights/common/components/openInExploreButton.tsx
+++ b/static/app/views/insights/common/components/openInExploreButton.tsx
@@ -1,7 +1,6 @@
-import {Button} from 'sentry/components/core/button';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {t} from 'sentry/locale';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -14,31 +13,26 @@ type Props = {
 };
 
 export function OpenInExploreButton({yAxes, title, search}: Props) {
-  const navigate = useNavigate();
   const organization = useOrganization();
 
-  const handleButtonClick = () => {
-    navigate(
-      getExploreUrl({
-        organization,
-        visualize: [
-          {
-            chartType: ChartType.LINE,
-            yAxes,
-          },
-        ],
-        mode: Mode.AGGREGATE,
-        title: title ?? yAxes[0],
-        query: search?.formatString(),
-        sort: undefined,
-        groupBy: undefined,
-      })
-    );
-  };
+  const url = getExploreUrl({
+    organization,
+    visualize: [
+      {
+        chartType: ChartType.LINE,
+        yAxes,
+      },
+    ],
+    mode: Mode.AGGREGATE,
+    title: title ?? yAxes[0],
+    query: search?.formatString(),
+    sort: undefined,
+    groupBy: undefined,
+  });
 
   return (
-    <Button size="xs" onClick={handleButtonClick}>
+    <LinkButton size="xs" to={url}>
       {t('Open in Explore')}
-    </Button>
+    </LinkButton>
   );
 }

--- a/static/app/views/insights/common/components/widgets/httpDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDurationChartWidget.tsx
@@ -8,13 +8,14 @@ import {Referrer} from 'sentry/views/insights/http/referrers';
 
 export default function HttpDurationChartWidget(props: LoadableChartWidgetProps) {
   const chartFilters = useHttpLandingChartFilter();
+  const search = MutableSearch.fromQueryObject(chartFilters);
   const {
     isPending: isDurationDataLoading,
     data: durationData,
     error: durationError,
   } = useSpanMetricsSeries(
     {
-      search: MutableSearch.fromQueryObject(chartFilters),
+      search,
       yAxis: ['avg(span.self_time)'],
       transformAliasToInputFormat: true,
     },
@@ -25,6 +26,7 @@ export default function HttpDurationChartWidget(props: LoadableChartWidgetProps)
   return (
     <InsightsLineChartWidget
       {...props}
+      search={search}
       id="httpDurationChartWidget"
       title={getDurationChartTitle('http')}
       series={[durationData['avg(span.self_time)']]}

--- a/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
@@ -9,13 +9,14 @@ import {FIELD_ALIASES} from 'sentry/views/insights/http/settings';
 
 export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetProps) {
   const chartFilters = useHttpLandingChartFilter();
+  const search = MutableSearch.fromQueryObject(chartFilters);
   const {
     isPending: isResponseCodeDataLoading,
     data: responseCodeData,
     error: responseCodeError,
   } = useSpanMetricsSeries(
     {
-      search: MutableSearch.fromQueryObject(chartFilters),
+      search,
       yAxis: ['http_response_rate(3)', 'http_response_rate(4)', 'http_response_rate(5)'],
       transformAliasToInputFormat: true,
     },
@@ -27,6 +28,7 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
     <InsightsLineChartWidget
       {...props}
       id="httpResponseCodesChartWidget"
+      search={search}
       title={DataTitles.unsuccessfulHTTPCodes}
       series={[
         responseCodeData[`http_response_rate(3)`],

--- a/static/app/views/insights/common/components/widgets/httpThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpThroughputChartWidget.tsx
@@ -8,13 +8,14 @@ import {Referrer} from 'sentry/views/insights/http/referrers';
 
 export default function HttpThroughputChartWidget(props: LoadableChartWidgetProps) {
   const chartFilters = useHttpLandingChartFilter();
+  const search = MutableSearch.fromQueryObject(chartFilters);
   const {
     isPending: isThroughputDataLoading,
     data: throughputData,
     error: throughputError,
   } = useSpanMetricsSeries(
     {
-      search: MutableSearch.fromQueryObject(chartFilters),
+      search,
       yAxis: ['epm()'],
       transformAliasToInputFormat: true,
     },
@@ -25,6 +26,7 @@ export default function HttpThroughputChartWidget(props: LoadableChartWidgetProp
   return (
     <InsightsLineChartWidget
       {...props}
+      search={search}
       id="httpThroughputChartWidget"
       title={getThroughputChartTitle('http')}
       series={[throughputData['epm()']]}


### PR DESCRIPTION
Creates the foundation for the open to explore and create alert feature insight charts
<img width="406" alt="image" src="https://github.com/user-attachments/assets/d4b73efd-4f3d-4bad-ae73-574a95933eef" />


1. This is all under a flag
2. This doesn't work in every case (will create more PRs for specialized cases)
3. This may not be the final UX
4. Passing in search only from http landing charts (will do others in stages)