### PR TITLE
fix(alerts): Skip validation for EAP columns; EXP-301

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -27,6 +27,7 @@ from sentry.monitors.models import Monitor
 from sentry.sentry_apps.models.sentry_app_installation import prepare_ui_component
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQueryEventType
 from sentry.uptime.models import ProjectUptimeSubscription
 from sentry.users.models.user import User
@@ -262,7 +263,10 @@ class AlertRuleSerializer(Serializer):
         )
         # Temporary: Translate aggregate back here from `tags[sentry:user]` to `user` for the frontend.
         aggregate = translate_aggregate_field(
-            obj.snuba_query.aggregate, reverse=True, allow_mri=allow_mri
+            obj.snuba_query.aggregate,
+            reverse=True,
+            allow_mri=allow_mri,
+            allow_eap=obj.snuba_query.dataset == Dataset.EventsAnalyticsPlatform.value,
         )
 
         data: AlertRuleSerializerResponse = {

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -126,7 +126,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
             self.context["organization"],
             actor=self.context.get("user", None),
         )
-        allow_eap = self.initial_data.get("dataset") == Dataset.EventsAnalyticsPlatform.value
+        allow_eap = self.data.get("dataset") == Dataset.EventsAnalyticsPlatform.value
         try:
             if not check_aggregate_column_support(
                 value,


### PR DESCRIPTION
There's some really strict validation which does not need to happen
for EAP alerts. Skipping column validation, we still validate aggregate.