### PR TITLE
feat(tx-clustering): Control txNameRuls in project configs with feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -511,6 +511,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:github-multi-org", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Relay extracting logs from breadcrumbs for a project.
     manager.add("projects:ourlogs-breadcrumb-extraction", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enables quick testing of disabling transaction name clustering for a project.
+    manager.add("projects:transaction-name-clustering-disabled", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=False)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1058,7 +1058,8 @@ def _get_project_config(
     add_experimental_config(config, "sampling", get_dynamic_sampling_config, project)
 
     # Rules to replace high cardinality transaction names
-    add_experimental_config(config, "txNameRules", get_transaction_names_config, project)
+    if not features.has("projects:transaction-name-clustering-disabled", project):
+        add_experimental_config(config, "txNameRules", get_transaction_names_config, project)
 
     # Mark the project as ready if it has seen >= 10 clusterer runs.
     # This prevents projects from prematurely marking all URL transactions as sanitized.

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -20,7 +20,7 @@ from sentry.dynamic_sampling.rules.base import NEW_MODEL_THRESHOLD_IN_MINUTES
 from sentry.models.projectkey import ProjectKey
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.transaction_threshold import TransactionMetric
-from sentry.relay.config import ProjectConfig, get_project_config
+from sentry.relay.config import ProjectConfig, TransactionNameRule, get_project_config
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import Feature
@@ -1222,3 +1222,30 @@ def test_project_config_with_generic_filters(default_project):
     _validate_project_config(config["config"])
 
     assert config["config"]["filterSettings"]["generic"]["filters"]
+
+
+@django_db_all
+@region_silo_test
+@mock.patch("sentry.relay.config.get_transaction_names_config")
+def test_project_config_with_transaction_name_clustering_disabled(
+    mock_get_transaction_name_config, default_project
+):
+    mock_get_transaction_name_config.return_value = [
+        TransactionNameRule(
+            pattern="dummy_rule",
+            expiry="2999-05-26T00:00:00Z",
+            redaction={"method": "replace", "substitution": "*"},
+        )
+    ]
+
+    # clustering is enabled (by default)
+    config = get_project_config(default_project).to_dict()
+    mock_get_transaction_name_config.assert_called_once()
+    _validate_project_config(config["config"])
+    assert "txNameRules" in config["config"]
+
+    # clustering is disabled (via explicit option)
+    with Feature({"projects:transaction-name-clustering-disabled": True}):
+        config = get_project_config(default_project).to_dict()
+        _validate_project_config(config["config"])
+        assert "txNameRules" not in config["config"]


### PR DESCRIPTION
This PR introduces new feature flag which controls for which projects transaction names clustering is disabled.

While this is not good UX, it will allow us to quickly test how will our system handle disabling of the clusterer on specific projects.