### PR TITLE
feat(trace-eap-waterfall): Rendering span descriptions correctly

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -73,7 +73,8 @@ export function SpanDescription({
 
   const category = findSpanAttributeValue(attributes, 'span.category');
   const dbSystem = findSpanAttributeValue(attributes, 'db.system');
-  const description = findSpanAttributeValue(attributes, 'raw_description');
+  const description =
+    findSpanAttributeValue(attributes, 'raw_description') ?? span.description;
   const group = findSpanAttributeValue(attributes, 'span.group');
 
   const resolvedModule: ModuleName = resolveSpanModule(span.op, category);
@@ -186,10 +187,10 @@ export function SpanDescription({
       <DescriptionWrapper>
         {formattedDescription ? (
           <Fragment>
-            <span>
+            <FormattedDescription>
               {formattedDescription}
               <LinkHint value={formattedDescription} />
-            </span>
+            </FormattedDescription>
             <CopyToClipboardButton
               borderless
               size="zero"
@@ -361,9 +362,15 @@ const StyledCodeSnippet = styled(CodeSnippet)`
   }
 `;
 
+const FormattedDescription = styled('div')`
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+`;
+
 const DescriptionWrapper = styled('div')`
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   font-size: ${p => p.theme.fontSizeMedium};
   width: 100%;
   justify-content: space-between;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -114,7 +114,7 @@ export function SpanDescription({
                 location,
                 node.event?.projectID,
                 SpanIndexedField.SPAN_DESCRIPTION,
-                span.description!,
+                span.description,
                 TraceDrawerActionKind.INCLUDE
               )
             : spanDetailsRouteWithQuery({

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -73,29 +73,27 @@ export function SpanDescription({
 
   const category = findSpanAttributeValue(attributes, 'span.category');
   const dbSystem = findSpanAttributeValue(attributes, 'db.system');
-  const description =
-    findSpanAttributeValue(attributes, 'raw_description') ?? span.description;
   const group = findSpanAttributeValue(attributes, 'span.group');
 
   const resolvedModule: ModuleName = resolveSpanModule(span.op, category);
 
   const formattedDescription = useMemo(() => {
     if (resolvedModule !== ModuleName.DB) {
-      return description ?? '';
+      return span.description ?? '';
     }
 
     if (
       dbSystem === SupportedDatabaseSystem.MONGODB &&
-      description &&
-      isValidJson(description)
+      span.description &&
+      isValidJson(span.description)
     ) {
-      return prettyPrintJsonString(description).prettifiedQuery;
+      return prettyPrintJsonString(span.description).prettifiedQuery;
     }
 
     return formatter.toString(span.description ?? '');
-  }, [span.description, resolvedModule, description, dbSystem]);
+  }, [span.description, resolvedModule, dbSystem]);
 
-  const actions = description ? (
+  const actions = span.description ? (
     <BodyContentWrapper
       padding={
         resolvedModule === ModuleName.DB ? `${space(1)} ${space(2)}` : `${space(1)}`


### PR DESCRIPTION
`raw_description` isn't always present. Using `span.description` instead.

Before: 
<img width="1321" alt="Screenshot 2025-05-26 at 4 16 41 PM" src="https://github.com/user-attachments/assets/c9183c4f-9f8c-4930-a27a-9a1e0c5b6913" />

After:
<img width="1273" alt="Screenshot 2025-05-26 at 4 15 43 PM" src="https://github.com/user-attachments/assets/eec9f402-b202-46a9-adc9-9f1d89f38c75" />
