### PR TITLE
ref(feedback): Refactor feedback layout so banners sit on top of the grid

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/feedbackWidgetBanner.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackWidgetBanner.tsx
@@ -1,5 +1,3 @@
-import type {CSSProperties} from 'react';
-
 import replaysDeadRageBackground from 'sentry-images/spot/replay-dead-rage-changelog.svg';
 
 import PageBanner from 'sentry/components/alerts/pageBanner';
@@ -9,7 +7,7 @@ import {t} from 'sentry/locale';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function FeedbackWidgetBanner({style}: {style?: CSSProperties}) {
+export default function FeedbackWidgetBanner() {
   const {activateSidebar} = useFeedbackOnboardingSidebarPanel();
   const organization = useOrganization();
 
@@ -23,7 +21,6 @@ export default function FeedbackWidgetBanner({style}: {style?: CSSProperties}) {
 
   return (
     <PageBanner
-      style={style}
       button={
         <Button
           priority="primary"

--- a/static/app/components/feedback/feedbackWhatsNewBanner.tsx
+++ b/static/app/components/feedback/feedbackWhatsNewBanner.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {useEffect} from 'react';
 
 import replaysDeadRageBackground from 'sentry-images/spot/replay-dead-rage-changelog.svg';
@@ -11,12 +10,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
-interface Props {
-  className?: string;
-  style?: CSSProperties;
-}
-
-export default function FeedbackWhatsNewBanner({className, style}: Props) {
+export default function FeedbackWhatsNewBanner() {
   const organization = useOrganization();
 
   const {dismiss, isDismissed} = useDismissAlert({
@@ -37,8 +31,6 @@ export default function FeedbackWhatsNewBanner({className, style}: Props) {
 
   return (
     <PageBanner
-      className={className}
-      style={style}
       button={
         <LinkButton
           external

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/container/flex';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackFilters from 'sentry/components/feedback/feedbackFilters';
 import FeedbackItemLoader from 'sentry/components/feedback/feedbackItem/feedbackItemLoader';
@@ -74,31 +75,35 @@ export default function FeedbackListPage() {
           </Layout.Header>
           <PageFiltersContainer>
             <ErrorBoundary>
-              <LayoutGrid data-banner={showWhatsNewBanner}>
-                {showWidgetBanner ? (
-                  <FeedbackWidgetBanner style={{gridArea: 'banner'}} />
-                ) : showWhatsNewBanner ? (
-                  <FeedbackWhatsNewBanner style={{gridArea: 'banner'}} />
-                ) : null}
-                <FeedbackFilters style={{gridArea: 'filters'}} />
-                {hasSetupOneFeedback || hasSlug ? (
-                  <Fragment>
-                    <Container style={{gridArea: 'list'}}>
-                      <FeedbackList />
-                    </Container>
-                    <SearchContainer>
-                      <FeedbackSearch />
-                    </SearchContainer>
-                    <Container style={{gridArea: 'details'}}>
-                      <FeedbackItemLoader />
-                    </Container>
-                  </Fragment>
-                ) : (
-                  <SetupContainer>
-                    <FeedbackSetupPanel />
-                  </SetupContainer>
-                )}
-              </LayoutGrid>
+              <Background>
+                <Flex column gap={space(2)} align="stretch" w="100%">
+                  {showWidgetBanner ? (
+                    <FeedbackWidgetBanner />
+                  ) : showWhatsNewBanner ? (
+                    <FeedbackWhatsNewBanner />
+                  ) : null}
+                  <LayoutGrid>
+                    <FeedbackFilters style={{gridArea: 'filters'}} />
+                    {hasSetupOneFeedback || hasSlug ? (
+                      <Fragment>
+                        <Container style={{gridArea: 'list'}}>
+                          <FeedbackList />
+                        </Container>
+                        <SearchContainer>
+                          <FeedbackSearch />
+                        </SearchContainer>
+                        <Container style={{gridArea: 'details'}}>
+                          <FeedbackItemLoader />
+                        </Container>
+                      </Fragment>
+                    ) : (
+                      <SetupContainer>
+                        <FeedbackSetupPanel />
+                      </SetupContainer>
+                    )}
+                  </LayoutGrid>
+                </Flex>
+              </Background>
             </ErrorBoundary>
           </PageFiltersContainer>
         </FeedbackQueryKeys>
@@ -107,10 +112,28 @@ export default function FeedbackListPage() {
   );
 }
 
-const LayoutGrid = styled('div')`
+const Background = styled('div')`
   background: ${p => p.theme.background};
   overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
 
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    padding: ${space(2)} ${space(4)};
+  }
+`;
+
+const LayoutGrid = styled('div')`
+  overflow: hidden;
   flex-grow: 1;
 
   display: grid;
@@ -122,42 +145,23 @@ const LayoutGrid = styled('div')`
     'filters search'
     'list details';
 
-  &[data-banner='true'] {
-    grid-template-rows: max-content max-content 1fr;
-    grid-template-areas:
-      'banner banner'
-      'filters search'
-      'list details';
-  }
-
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    padding: ${space(2)};
     grid-template-columns: 1fr;
     grid-template-areas:
       'filters'
       'search'
       'list'
       'details';
-
-    &[data-banner='true'] {
-      grid-template-areas:
-        'banner'
-        'filters'
-        'search'
-        'list'
-        'details';
-    }
   }
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding: ${space(2)};
     grid-template-columns: minmax(1fr, 195px) 1fr;
   }
 
   @media (min-width: ${p => p.theme.breakpoints.large}) {
-    padding: ${space(2)} ${space(4)} ${space(2)} ${space(4)};
     grid-template-columns: 390px 1fr;
   }
+
   @media (min-width: ${p => p.theme.breakpoints.large}) {
     grid-template-columns: minmax(390px, 1fr) 2fr;
   }

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/container/flex';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackFilters from 'sentry/components/feedback/feedbackFilters';
 import FeedbackItemLoader from 'sentry/components/feedback/feedbackItem/feedbackItemLoader';
@@ -76,33 +75,31 @@ export default function FeedbackListPage() {
           <PageFiltersContainer>
             <ErrorBoundary>
               <Background>
-                <Flex column gap={space(2)} align="stretch" w="100%">
-                  {showWidgetBanner ? (
-                    <FeedbackWidgetBanner />
-                  ) : showWhatsNewBanner ? (
-                    <FeedbackWhatsNewBanner />
-                  ) : null}
-                  <LayoutGrid>
-                    <FeedbackFilters style={{gridArea: 'filters'}} />
-                    {hasSetupOneFeedback || hasSlug ? (
-                      <Fragment>
-                        <Container style={{gridArea: 'list'}}>
-                          <FeedbackList />
-                        </Container>
-                        <SearchContainer>
-                          <FeedbackSearch />
-                        </SearchContainer>
-                        <Container style={{gridArea: 'details'}}>
-                          <FeedbackItemLoader />
-                        </Container>
-                      </Fragment>
-                    ) : (
-                      <SetupContainer>
-                        <FeedbackSetupPanel />
-                      </SetupContainer>
-                    )}
-                  </LayoutGrid>
-                </Flex>
+                {showWidgetBanner ? (
+                  <FeedbackWidgetBanner />
+                ) : showWhatsNewBanner ? (
+                  <FeedbackWhatsNewBanner />
+                ) : null}
+                <LayoutGrid>
+                  <FeedbackFilters style={{gridArea: 'filters'}} />
+                  {hasSetupOneFeedback || hasSlug ? (
+                    <Fragment>
+                      <Container style={{gridArea: 'list'}}>
+                        <FeedbackList />
+                      </Container>
+                      <SearchContainer>
+                        <FeedbackSearch />
+                      </SearchContainer>
+                      <Container style={{gridArea: 'details'}}>
+                        <FeedbackItemLoader />
+                      </Container>
+                    </Fragment>
+                  ) : (
+                    <SetupContainer>
+                      <FeedbackSetupPanel />
+                    </SetupContainer>
+                  )}
+                </LayoutGrid>
               </Background>
             </ErrorBoundary>
           </PageFiltersContainer>
@@ -116,8 +113,9 @@ const Background = styled('div')`
   background: ${p => p.theme.background};
   overflow: hidden;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: stretch;
+  gap: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(2)};


### PR DESCRIPTION
I saw a situation once where a banner appeared, and i dismissed it. Then afterwards the search bar was stacked on top of the page filters. It can be reproduced by going to a project where `showWhatsNewBanner` is true, then dismissing the banner... which means we're going to set `data-banner=true` and mess with the layout. Then since the banner is dismissed we put `null` into that position and the layout was broken.

So this adds a flex div to wrap the grid layout. If there's a banner the flex will hold it without messing with the grid below.

I didn't take screenshots, but the scrollable areas inside the feedback list and details both work as before when the content is too short, or too tall and needs scrolling. A good way to test that is with this project: https://demo.dev.getsentry.net:7999/issues/feedback?statsPeriod=30d.. try changing the inbox to get a scrolling list or not. And then select a message so that area scrolls too. 

**Before**
<img width="1460" alt="SCR-20250526-nkym" src="https://github.com/user-attachments/assets/a52e1789-e2a6-4b9c-9075-ae86060663f3" />


**After**

| Width | Img |
| --- | --- |
| Wide | <img width="1589" alt="SCR-20250526-ngyg" src="https://github.com/user-attachments/assets/d3b4fd59-86fa-4bfb-b9f9-b4e1fe2663ab" />
| With Sidebar | <img width="1437" alt="SCR-20250526-ngwq" src="https://github.com/user-attachments/assets/6e17b563-57ed-4457-ab84-59d799955bc0" />
| Narrow | <img width="729" alt="SCR-20250526-ngxo" src="https://github.com/user-attachments/assets/d50976ba-9282-40dd-89dd-52b79c606a8c" />
| SetupContainer | <img width="1153" alt="SCR-20250526-nohe" src="https://github.com/user-attachments/assets/9448be5f-1bbb-4708-852a-7cb7d7330e98" />
