### PR TITLE
feat(agent-insights): Highlighted span attributes

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/features.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/features.tsx
@@ -1,7 +1,12 @@
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
+import type {Organization} from 'sentry/types/organization';
 
 type AgentInsightsFeatureProps = Omit<Parameters<typeof Feature>[0], 'features'>;
+
+export function hasAgentInsightsFeature(organization: Organization) {
+  return organization.features.includes('agents-insights');
+}
 
 export function AgentInsightsFeature(props: AgentInsightsFeatureProps) {
   return (

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -3,6 +3,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {getIsAiSpan} from 'sentry/views/insights/agentMonitoring/utils/query';
 
 function ensureAttributeObject(
   attributes: Record<string, string> | TraceItemResponseAttribute[]
@@ -20,11 +21,19 @@ function ensureAttributeObject(
   return attributes;
 }
 
-export function getHighlightedSpanAttributes(
-  organization: Organization,
-  attributes: Record<string, string> | undefined | TraceItemResponseAttribute[] = {}
-) {
-  if (!hasAgentInsightsFeature(organization)) {
+export function getHighlightedSpanAttributes({
+  op,
+  description,
+  attributes = {},
+  organization,
+}: {
+  attributes: Record<string, string> | undefined | TraceItemResponseAttribute[];
+  description: string | undefined;
+  op: string | undefined;
+
+  organization: Organization;
+}) {
+  if (!hasAgentInsightsFeature(organization) && !getIsAiSpan({op, description})) {
     return [];
   }
 

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -1,0 +1,62 @@
+import {IconArrow} from 'sentry/icons';
+import type {Organization} from 'sentry/types/organization';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
+
+function ensureAttributeObject(
+  attributes: Record<string, string> | TraceItemResponseAttribute[]
+) {
+  if (Array.isArray(attributes)) {
+    return attributes.reduce(
+      (acc, attribute) => {
+        acc[attribute.name] = attribute.value.toString();
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+  }
+
+  return attributes;
+}
+
+export function getHighlightedSpanAttributes(
+  organization: Organization,
+  attributes: Record<string, string> | undefined | TraceItemResponseAttribute[] = {}
+) {
+  if (!hasAgentInsightsFeature(organization)) {
+    return [];
+  }
+
+  const attributeObject = ensureAttributeObject(attributes);
+  const highlightedAttributes = [];
+
+  if (attributeObject['ai.model.id']) {
+    highlightedAttributes.push({
+      name: 'Model',
+      value: attributeObject['ai.model.id'],
+    });
+  }
+
+  const promptTokens = attributeObject['ai.prompt_tokens.used'];
+  const completionTokens = attributeObject['ai.completion_tokens.used'];
+  const totalTokens = attributeObject['ai.total_tokens.used'];
+  if (promptTokens && completionTokens && totalTokens) {
+    highlightedAttributes.push({
+      name: 'Tokens',
+      value: (
+        <span>
+          {promptTokens} <IconArrow direction="right" size="xs" />{' '}
+          {`${completionTokens} (Σ ${totalTokens})`}
+        </span>
+      ),
+    });
+  }
+
+  if (attributeObject['ai.toolCall.name']) {
+    highlightedAttributes.push({
+      name: 'Tool Name',
+      value: attributeObject['ai.toolCall.name'],
+    });
+  }
+  return highlightedAttributes;
+}

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -1,4 +1,5 @@
 import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
@@ -32,7 +33,7 @@ export function getHighlightedSpanAttributes(
 
   if (attributeObject['ai.model.id']) {
     highlightedAttributes.push({
-      name: 'Model',
+      name: t('Model'),
       value: attributeObject['ai.model.id'],
     });
   }
@@ -42,7 +43,7 @@ export function getHighlightedSpanAttributes(
   const totalTokens = attributeObject['ai.total_tokens.used'];
   if (promptTokens && completionTokens && totalTokens) {
     highlightedAttributes.push({
-      name: 'Tokens',
+      name: t('Tokens'),
       value: (
         <span>
           {promptTokens} <IconArrow direction="right" size="xs" />{' '}
@@ -54,7 +55,7 @@ export function getHighlightedSpanAttributes(
 
   if (attributeObject['ai.toolCall.name']) {
     highlightedAttributes.push({
-      name: 'Tool Name',
+      name: t('Tool Name'),
       value: attributeObject['ai.toolCall.name'],
     });
   }

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -1,6 +1,7 @@
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
 import {getIsAiSpan} from 'sentry/views/insights/agentMonitoring/utils/query';
@@ -11,7 +12,9 @@ function ensureAttributeObject(
   if (Array.isArray(attributes)) {
     return attributes.reduce(
       (acc, attribute) => {
-        acc[attribute.name] = attribute.value.toString();
+        // Some attribute keys include prefixes and metadata (e.g. "tags[ai.prompt_tokens.used,number]")
+        // prettifyAttributeName normalizes those
+        acc[prettifyAttributeName(attribute.name)] = attribute.value.toString();
         return acc;
       },
       {} as Record<string, string>

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -6,12 +6,35 @@ import type {EAPSpanProperty} from 'sentry/views/insights/types';
 const AI_PIPELINE_OPS = ['ai.pipeline.generateText', 'ai.pipeline.generateObject'];
 const AI_GENERATION_OPS = ['ai.run.doGenerate'];
 const AI_TOOL_CALL_OPS = ['ai.toolCall'];
+const AI_OPS = [...AI_PIPELINE_OPS, ...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS];
 
 export const AI_MODEL_ID_ATTRIBUTE = 'ai.model.id' as EAPSpanProperty;
 export const AI_TOOL_NAME_ATTRIBUTE = 'ai.toolCall.name' as EAPSpanProperty;
 const AI_TOKEN_USAGE_ATTRIBUTE = 'ai.total_tokens.used';
 
 export const AI_TOKEN_USAGE_ATTRIBUTE_SUM = `sum(${AI_TOKEN_USAGE_ATTRIBUTE})`;
+
+// TODO: Remove once tool spans have their own op
+function mapMissingSpanOp({
+  op = 'default',
+  description,
+}: {
+  description?: string;
+  op?: string;
+}) {
+  if (op !== 'default') {
+    return op;
+  }
+  if (description === 'ai.toolCall') {
+    return 'ai.toolCall';
+  }
+  return op;
+}
+
+export function getIsAiSpan({op, description}: {description?: string; op?: string}) {
+  const mappedOp = mapMissingSpanOp({op, description});
+  return AI_OPS.includes(mappedOp);
+}
 
 export const getAgentRunsFilter = () => {
   return `span.op:[${AI_PIPELINE_OPS.join(',')}]`;

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -82,6 +82,9 @@ export const enum SectionKey {
   REGRESSION_EVENT_COMPARISON = 'regression-event-comparison',
   REGRESSION_POTENTIAL_CAUSES = 'regression-potential-causes',
   REGRESSION_AFFECTED_TRANSACTIONS = 'regression-affected-transactions',
+
+  AI_INPUT = 'ai-input',
+  AI_OUTPUT = 'ai-output',
 }
 
 /**

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -82,9 +82,6 @@ export const enum SectionKey {
   REGRESSION_EVENT_COMPARISON = 'regression-event-comparison',
   REGRESSION_POTENTIAL_CAUSES = 'regression-potential-causes',
   REGRESSION_AFFECTED_TRANSACTIONS = 'regression-affected-transactions',
-
-  AI_INPUT = 'ai-input',
-  AI_OUTPUT = 'ai-output',
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -212,7 +212,12 @@ export function SpanDescription({
       avgDuration={avgSpanDuration ? avgSpanDuration / 1000 : undefined}
       headerContent={value}
       bodyContent={actions}
-      highlightedAttributes={getHighlightedSpanAttributes(organization, attributes)}
+      highlightedAttributes={getHighlightedSpanAttributes({
+        organization,
+        attributes,
+        op: span.op,
+        description: span.description,
+      })}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -16,6 +16,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {getHighlightedSpanAttributes} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import ResourceSize from 'sentry/views/insights/browser/resources/components/resourceSize';
 import {
   DisabledImages,
@@ -211,6 +212,7 @@ export function SpanDescription({
       avgDuration={avgSpanDuration ? avgSpanDuration / 1000 : undefined}
       headerContent={value}
       bodyContent={actions}
+      highlightedAttributes={getHighlightedSpanAttributes(organization, attributes)}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -219,7 +219,12 @@ export function SpanDescription({
       avgDuration={averageSpanDuration ? averageSpanDuration / 1000 : undefined}
       headerContent={value}
       bodyContent={actions}
-      highlightedAttributes={getHighlightedSpanAttributes(organization, span.data)}
+      highlightedAttributes={getHighlightedSpanAttributes({
+        organization,
+        attributes: span.data,
+        op: span.op,
+        description: span.description,
+      })}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -15,6 +15,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {SQLishFormatter} from 'sentry/utils/sqlish/SQLishFormatter';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {getHighlightedSpanAttributes} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import ResourceSize from 'sentry/views/insights/browser/resources/components/resourceSize';
 import {
   DisabledImages,
@@ -218,6 +219,7 @@ export function SpanDescription({
       avgDuration={averageSpanDuration ? averageSpanDuration / 1000 : undefined}
       headerContent={value}
       bodyContent={actions}
+      highlightedAttributes={getHighlightedSpanAttributes(organization, span.data)}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -416,6 +416,7 @@ type HighlightProps = {
   node: TraceTreeNode<TraceTree.NodeValue>;
   project: Project | undefined;
   transaction: EventTransaction | undefined;
+  highlightedAttributes?: Array<{name: string; value: React.ReactNode}>;
 };
 
 function Highlights({
@@ -425,6 +426,7 @@ function Highlights({
   project,
   headerContent,
   bodyContent,
+  highlightedAttributes,
 }: HighlightProps) {
   const dispatch = useTraceStateDispatch();
 
@@ -479,6 +481,16 @@ function Highlights({
               </HiglightsDurationComparison>
             ) : null}
           </HighlightsDurationWrapper>
+          {highlightedAttributes && highlightedAttributes.length > 0 ? (
+            <HighlightedAttributesWrapper>
+              {highlightedAttributes.map(({name, value}) => (
+                <Fragment key={name}>
+                  <HighlightedAttributeName>{name}</HighlightedAttributeName>
+                  <div>{value}</div>
+                </Fragment>
+              ))}
+            </HighlightedAttributesWrapper>
+          ) : null}
           <StyledPanel>
             <StyledPanelHeader>{headerContent}</StyledPanelHeader>
             <PanelBody>{bodyContent}</PanelBody>
@@ -651,6 +663,19 @@ const HighlightOp = styled('div')`
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeMedium};
   line-height: normal;
+`;
+
+const HighlightedAttributesWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: ${space(1.5)};
+  row-gap: ${space(0.5)};
+  margin-bottom: ${space(1.5)};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const HighlightedAttributeName = styled('div')`
+  color: ${p => p.theme.subText};
 `;
 
 const StyledPanelHeader = styled(PanelHeader)`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -86,10 +86,12 @@ export function TransactionHighlights(props: HighlightProps) {
       avgDuration={avgDurationInSeconds}
       headerContent={headerContent}
       bodyContent={bodyContent}
-      highlightedAttributes={getHighlightedSpanAttributes(
-        props.organization,
-        props.event.contexts.trace?.data
-      )}
+      highlightedAttributes={getHighlightedSpanAttributes({
+        organization: props.organization,
+        attributes: props.event.contexts.trace?.data,
+        op: props.node.value['transaction.op'],
+        description: props.node.value.transaction,
+      })}
     />
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -12,6 +12,7 @@ import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
+import {getHighlightedSpanAttributes} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import {useTraceAverageTransactionDuration} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceAverageTransactionDuration';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {isTransactionNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
@@ -85,6 +86,10 @@ export function TransactionHighlights(props: HighlightProps) {
       avgDuration={avgDurationInSeconds}
       headerContent={headerContent}
       bodyContent={bodyContent}
+      highlightedAttributes={getHighlightedSpanAttributes(
+        props.organization,
+        props.event.contexts.trace?.data
+      )}
     />
   );
 }


### PR DESCRIPTION
Highlight important ai related span attributes by displaying them on top of trace details.
![Screenshot 2025-05-26 at 15 17 29](https://github.com/user-attachments/assets/cb5ba7af-a935-44ea-8376-8a743cff55c7)
![Screenshot 2025-05-26 at 15 17 34](https://github.com/user-attachments/assets/3c38f264-3267-4fbc-8023-7f5605c6cc8d)

- part of [TET-498: Trace View - AI Span details](https://linear.app/getsentry/issue/TET-498/trace-view-ai-span-details)