### PR TITLE
fix: imports from react-router

### DIFF
--- a/static/app/utils/browserHistory.tsx
+++ b/static/app/utils/browserHistory.tsx
@@ -1,4 +1,4 @@
-import type {Router} from '@remix-run/router/dist/router';
+import type {Router} from '@remix-run/router';
 import * as Sentry from '@sentry/react';
 import type {History} from 'history';
 

--- a/static/app/views/admin/adminUserEdit.tsx
+++ b/static/app/views/admin/adminUserEdit.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useState} from 'react';
-import {useParams} from 'react-router';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -24,6 +23,7 @@ import {
 } from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useParams} from 'sentry/utils/useParams';
 
 const userEditForm: JsonFormObject = {
   title: 'User details',


### PR DESCRIPTION
This PR is a pre-requisite to enable the lint rule [import/no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/da5f6ec13160cb288338db0c2a00c34b2d932f0d/docs/rules/no-extraneous-dependencies.md).
