### PR TITLE
ref: remove SelectionManager type import

### DIFF
--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -3,7 +3,6 @@ import {useFocus, usePress} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 import type {ListState} from '@react-stately/list';
-import type {SelectionManager} from '@react-stately/selection';
 import type {Node, Selection} from '@react-types/shared';
 
 import {t} from 'sentry/locale';
@@ -186,7 +185,7 @@ export function getHiddenOptions<Value extends SelectKey>(
  */
 function toggleOptions<Value extends SelectKey>(
   optionKeys: Value[],
-  selectionManager: SelectionManager
+  selectionManager: ListState<any>['selectionManager']
 ) {
   const {selectedKeys} = selectionManager;
   const newSelectedKeys = new Set(selectedKeys);


### PR DESCRIPTION
This PR is a pre-requisite to enable the lint rule [import/no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/da5f6ec13160cb288338db0c2a00c34b2d932f0d/docs/rules/no-extraneous-dependencies.md).

we only import from react-stately/selection for this type, but we don't have this dependency in `package.json`

Instead of adding the dependency, we can extract the type from `ListState`.