### PR TITLE
ref: remove react-resizable imports

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -1,5 +1,4 @@
 import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
 
 import {Component} from 'react';
 import type {Layouts} from 'react-grid-layout';

--- a/static/app/views/dashboards/manage/gridPreview/index.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/index.tsx
@@ -1,5 +1,4 @@
 import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
 
 import GridLayout, {WidthProvider} from 'react-grid-layout';
 import styled from '@emotion/styled';


### PR DESCRIPTION
This PR removes css imports from `react-resizable`, as we don't have `react-resizable` as a dependency in `package.json`. It’s a pre-requisite to enable the lint rule [import/no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/da5f6ec13160cb288338db0c2a00c34b2d932f0d/docs/rules/no-extraneous-dependencies.md).

`react-resizable` is a dependency of `react-grid-layout`, which we do use. The import we have only adds styles for the resizable handle, which `react-grid-layout` also adds.

I’ve tested this change on the dashboard page, and the resize handle still looks like and works exactly like before.

I’m unsure where to find `gridPreview/index.tsx`, but I doubt that it would behave differently.