### PR TITLE
fix(spans): Catch errors converting span.data

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -46,7 +46,6 @@ def convert_span_to_item(span: Span) -> TraceItem:
                 attributes[k] = _anyvalue(v)
             except Exception:
                 sentry_sdk.capture_exception()
-                pass
 
     for k, v in (span.get("measurements") or {}).items():
         if k is not None and v is not None:

--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -1,6 +1,7 @@
 from collections.abc import MutableMapping
 from typing import Any
 
+import sentry_sdk
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import (
@@ -41,7 +42,11 @@ def convert_span_to_item(span: Span) -> TraceItem:
 
     for k, v in (span.get("data") or {}).items():
         if v is not None:
-            attributes[k] = _anyvalue(v)
+            try:
+                attributes[k] = _anyvalue(v)
+            except Exception:
+                sentry_sdk.capture_exception()
+                pass
 
     for k, v in (span.get("measurements") or {}).items():
         if k is not None and v is not None:

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
-from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, KeyValue, KeyValueList
+from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, KeyValue, KeyValueList
 
 from sentry.spans.consumers.process_segments.convert import convert_span_to_item
 from sentry.spans.consumers.process_segments.types import Span
@@ -35,6 +35,7 @@ SPAN_KAFKA_MESSAGE = {
             "name": "test",
         },
         "my.u64.field": 9447000002305251000,
+        "my.array.field": [1, 2, ["nested", "array"]],
     },
     "measurements": {
         "num_of_spans": {"value": 50.0},
@@ -159,4 +160,17 @@ def test_convert_span_to_item():
             )
         ),
         "my.u64.field": AnyValue(double_value=9447000002305251000.0),
+        "my.array.field": AnyValue(
+            array_value=ArrayValue(
+                values=[
+                    AnyValue(int_value=1),
+                    AnyValue(int_value=2),
+                    AnyValue(
+                        array_value=ArrayValue(
+                            values=[AnyValue(string_value="nested"), AnyValue(string_value="array")]
+                        )
+                    ),
+                ]
+            )
+        ),
     }


### PR DESCRIPTION
Converting span.data to AnyValue in trace items can fail due to multiple
reasons. Since span.data is freely defined and can contain nested data
structures, we catch errors and for now report them to Sentry. This error
reporting may be removed in the future.

Fixes SENTRY-FOR-SENTRY-5MQ4