### PR TITLE
ref(spans): Report errors from spans pipeline to Sentry

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -38,8 +38,6 @@ logger = logging.getLogger(__name__)
 
 UNSAFE_FILES = (
     "sentry/event_manager.py",
-    "sentry/spans/consumers/process/factory.py",
-    "sentry/spans/consumers/process_segments/factory.py",
     "sentry/tasks/process_buffer.py",
     "sentry/ingest/consumer/processors.py",
     # This consumer lives outside of sentry but is just as unsafe.


### PR DESCRIPTION
Both consumers in the spans pipeline were marked in `UNSAFE_FILES` in our SDK
utilities. This caused errors to be reported to S4S but not to the main Sentry
instance.

Since errors do not flow through the spans pipeline, we can mark the consumers
as safe, which restores error reporting in our main instance.

