### PR TITLE
ref(auto_config): Split FrameInfo into its own module

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -13,7 +13,8 @@ from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.manager import default_manager as integrations
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
-from sentry.issues.auto_source_code_config.code_mapping import FrameInfo, find_roots
+from sentry.issues.auto_source_code_config.code_mapping import find_roots
+from sentry.issues.auto_source_code_config.frame_info import FrameInfo
 from sentry.models.repository import Repository
 
 

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -10,7 +10,6 @@ from sentry.integrations.source_code_management.repo_trees import (
     RepoAndBranch,
     RepoTree,
     RepoTreesIntegration,
-    get_extension,
 )
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -18,9 +17,17 @@ from sentry.models.repository import Repository
 from sentry.utils import metrics
 from sentry.utils.event_frames import EventFrame, try_munge_frame_path
 
-from .constants import METRIC_PREFIX, SECOND_LEVEL_TLDS, STACK_ROOT_MAX_LEVEL
+from .constants import METRIC_PREFIX
+from .errors import (
+    DoesNotFollowJavaPackageNamingConvention,
+    MissingModuleOrAbsPath,
+    NeedsExtension,
+    UnexpectedPathException,
+    UnsupportedFrameInfo,
+)
+from .frame_info import FrameInfo
 from .integration_utils import InstallationNotFoundError, get_installation
-from .utils.platform import PlatformConfig
+from .utils.misc import get_straight_path_prefix_end_index
 
 logger = logging.getLogger(__name__)
 
@@ -33,33 +40,6 @@ class CodeMapping(NamedTuple):
 
 SLASH = "/"
 BACKSLASH = "\\"  # This is the Python representation of a single backslash
-
-# List of file paths prefixes that should become stack trace roots
-FILE_PATH_PREFIX_LENGTH = {
-    "app:///": 7,
-    "../": 3,
-    "./": 2,
-}
-
-
-class UnexpectedPathException(Exception):
-    pass
-
-
-class UnsupportedFrameInfo(Exception):
-    pass
-
-
-class NeedsExtension(Exception):
-    pass
-
-
-class MissingModuleOrAbsPath(Exception):
-    pass
-
-
-class DoesNotFollowJavaPackageNamingConvention(Exception):
-    pass
 
 
 def derive_code_mappings(
@@ -79,82 +59,6 @@ def derive_code_mappings(
         logger.warning("Needs extension: %s", frame.get("filename"))
 
     return []
-
-
-# XXX: Look at sentry.interfaces.stacktrace and maybe use that
-class FrameInfo:
-    def __init__(self, frame: Mapping[str, Any], platform: str | None = None) -> None:
-        if platform:
-            platform_config = PlatformConfig(platform)
-            if platform_config.extracts_filename_from_module():
-                self.frame_info_from_module(frame)
-                return
-
-        frame_file_path = frame["filename"]
-        frame_file_path = self.transformations(frame_file_path)
-
-        # Using regexes would be better but this is easier to understand
-        if (
-            not frame_file_path
-            or frame_file_path[0] in ["[", "<"]
-            or frame_file_path.find(" ") > -1
-            or frame_file_path.find("/") == -1
-        ):
-            raise UnsupportedFrameInfo("This path is not supported.")
-
-        if not get_extension(frame_file_path):
-            raise NeedsExtension("It needs an extension.")
-
-        start_at_index = get_straight_path_prefix_end_index(frame_file_path)
-
-        # We normalize the path to be as close to what the path would
-        # look like in the source code repository, hence why we remove
-        # the straight path prefix and drive letter
-        self.normalized_path = frame_file_path[start_at_index:]
-        if start_at_index == 0:
-            self.stack_root = frame_file_path.split("/")[0]
-        else:
-            slash_index = frame_file_path.find("/", start_at_index)
-            self.stack_root = frame_file_path[0:slash_index]
-
-    def transformations(self, frame_file_path: str) -> str:
-        self.raw_path = frame_file_path
-
-        is_windows_path = False
-        if "\\" in frame_file_path:
-            is_windows_path = True
-            frame_file_path = frame_file_path.replace("\\", "/")
-
-        # Remove leading slash if it exists
-        if frame_file_path[0] == "/" or frame_file_path[0] == "\\":
-            frame_file_path = frame_file_path[1:]
-
-        # Remove drive letter if it exists
-        if is_windows_path and frame_file_path[1] == ":":
-            frame_file_path = frame_file_path[2:]
-            # windows drive letters can be like C:\ or C:
-            # so we need to remove the slash if it exists
-            if frame_file_path[0] == "/":
-                frame_file_path = frame_file_path[1:]
-
-        return frame_file_path
-
-    def frame_info_from_module(self, frame: Mapping[str, Any]) -> None:
-        if frame.get("module") and frame.get("abs_path"):
-            stack_root, filepath = get_path_from_module(frame["module"], frame["abs_path"])
-            self.stack_root = stack_root
-            self.raw_path = filepath
-            self.normalized_path = filepath
-        else:
-            raise MissingModuleOrAbsPath("Investigate why the data is missing.")
-
-    def __repr__(self) -> str:
-        return f"FrameInfo: {self.raw_path}"
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, FrameInfo):
-            return False
-        return self.raw_path == other.raw_path
 
 
 # call generate_code_mappings() after you initialize CodeMappingTreesHelper
@@ -508,20 +412,6 @@ def get_sorted_code_mapping_configs(project: Project) -> list[RepositoryProjectP
     return sorted_configs
 
 
-def get_straight_path_prefix_end_index(file_path: str) -> int:
-    """
-    Get the index where the straight path prefix ends in the file path.
-    This is  used for Node projects where the file path can start with
-    "app:///", "../", or "./"
-    """
-    index = 0
-    for prefix in FILE_PATH_PREFIX_LENGTH:
-        while file_path.startswith(prefix):
-            index += FILE_PATH_PREFIX_LENGTH[prefix]
-            file_path = file_path[FILE_PATH_PREFIX_LENGTH[prefix] :]
-    return index
-
-
 def find_roots(frame_filename: FrameInfo, source_path: str) -> tuple[str, str]:
     """
     Returns a tuple containing the stack_root, and the source_root.
@@ -573,42 +463,3 @@ def find_roots(frame_filename: FrameInfo, source_path: str) -> tuple[str, str]:
     # validate_source_url should have ensured the file names match
     # so if we get here something went wrong and there is a bug
     raise UnexpectedPathException("Could not find common root from paths")
-
-
-# Based on # https://github.com/getsentry/symbolicator/blob/450f1d6a8c346405454505ed9ca87e08a6ff34b7/crates/symbolicator-proguard/src/symbolication.rs#L450-L485
-def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
-    """This attempts to generate a modified module and a real path from a Java module name and filename.
-    Returns a tuple of (stack_root, source_path).
-    """
-    # An `abs_path` is valid if it contains a `.` and doesn't contain a `$`.
-    if "$" in abs_path or "." not in abs_path:
-        # Split the module at the first '$' character and take the part before it
-        # If there's no '$', use the entire module
-        file_path = module.split("$", 1)[0] if "$" in module else module
-        stack_root = module.rsplit(".", 1)[0].replace(".", "/") + "/"
-        return stack_root, file_path.replace(".", "/")
-
-    if "." not in module:
-        raise DoesNotFollowJavaPackageNamingConvention
-
-    # Gets rid of the class name
-    parts = module.rsplit(".", 1)[0].split(".")
-    dirpath = "/".join(parts)
-    # a.Bar, Bar.kt -> stack_root: a/, file_path:  a/Bar.kt
-    granularity = 1
-
-    if len(parts) > 1:
-        # com.example.foo.bar.Baz$InnerClass, Baz.kt ->
-        #    stack_root: com/example/foo/
-        #    file_path:  com/example/foo/bar/Baz.kt
-        granularity = STACK_ROOT_MAX_LEVEL - 1
-
-        if parts[1] in SECOND_LEVEL_TLDS:
-            # uk.co.example.foo.bar.Baz$InnerClass, Baz.kt ->
-            #    stack_root: uk/co/example/foo/
-            #    file_path:  uk/co/example/foo/bar/Baz.kt
-            granularity = STACK_ROOT_MAX_LEVEL
-
-    stack_root = "/".join(parts[:granularity]) + "/"
-    file_path = f"{dirpath}/{abs_path}"
-    return stack_root, file_path

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -8,7 +8,8 @@ from sentry.integrations.source_code_management.repo_trees import (
 )
 from sentry.models.organization import Organization
 
-from .code_mapping import CodeMapping, CodeMappingTreesHelper, FrameInfo
+from .code_mapping import CodeMapping, CodeMappingTreesHelper
+from .frame_info import FrameInfo
 from .integration_utils import get_installation
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/issues/auto_source_code_config/errors.py
+++ b/src/sentry/issues/auto_source_code_config/errors.py
@@ -1,0 +1,18 @@
+class UnexpectedPathException(Exception):
+    pass
+
+
+class UnsupportedFrameInfo(Exception):
+    pass
+
+
+class NeedsExtension(Exception):
+    pass
+
+
+class MissingModuleOrAbsPath(Exception):
+    pass
+
+
+class DoesNotFollowJavaPackageNamingConvention(Exception):
+    pass

--- a/src/sentry/issues/auto_source_code_config/frame_info.py
+++ b/src/sentry/issues/auto_source_code_config/frame_info.py
@@ -1,0 +1,128 @@
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.integrations.source_code_management.repo_trees import get_extension
+
+from .constants import SECOND_LEVEL_TLDS, STACK_ROOT_MAX_LEVEL
+from .errors import (
+    DoesNotFollowJavaPackageNamingConvention,
+    MissingModuleOrAbsPath,
+    NeedsExtension,
+    UnsupportedFrameInfo,
+)
+from .utils.misc import get_straight_path_prefix_end_index
+from .utils.platform import PlatformConfig
+
+
+class FrameInfo:
+    def __init__(self, frame: Mapping[str, Any], platform: str | None = None) -> None:
+        if platform:
+            platform_config = PlatformConfig(platform)
+            if platform_config.extracts_filename_from_module():
+                self.frame_info_from_module(frame)
+                return
+
+        frame_file_path = frame["filename"]
+        frame_file_path = self.transformations(frame_file_path)
+
+        # Using regexes would be better but this is easier to understand
+        if (
+            not frame_file_path
+            or frame_file_path[0] in ["[", "<"]
+            or frame_file_path.find(" ") > -1
+            or frame_file_path.find("/") == -1
+        ):
+            raise UnsupportedFrameInfo("This path is not supported.")
+
+        if not get_extension(frame_file_path):
+            raise NeedsExtension("It needs an extension.")
+
+        start_at_index = get_straight_path_prefix_end_index(frame_file_path)
+
+        # We normalize the path to be as close to what the path would
+        # look like in the source code repository, hence why we remove
+        # the straight path prefix and drive letter
+        self.normalized_path = frame_file_path[start_at_index:]
+        if start_at_index == 0:
+            self.stack_root = frame_file_path.split("/")[0]
+        else:
+            slash_index = frame_file_path.find("/", start_at_index)
+            self.stack_root = frame_file_path[0:slash_index]
+
+    def transformations(self, frame_file_path: str) -> str:
+        self.raw_path = frame_file_path
+
+        is_windows_path = False
+        if "\\" in frame_file_path:
+            is_windows_path = True
+            frame_file_path = frame_file_path.replace("\\", "/")
+
+        # Remove leading slash if it exists
+        if frame_file_path[0] == "/" or frame_file_path[0] == "\\":
+            frame_file_path = frame_file_path[1:]
+
+        # Remove drive letter if it exists
+        if is_windows_path and frame_file_path[1] == ":":
+            frame_file_path = frame_file_path[2:]
+            # windows drive letters can be like C:\ or C:
+            # so we need to remove the slash if it exists
+            if frame_file_path[0] == "/":
+                frame_file_path = frame_file_path[1:]
+
+        return frame_file_path
+
+    def frame_info_from_module(self, frame: Mapping[str, Any]) -> None:
+        if frame.get("module") and frame.get("abs_path"):
+            stack_root, filepath = get_path_from_module(frame["module"], frame["abs_path"])
+            self.stack_root = stack_root
+            self.raw_path = filepath
+            self.normalized_path = filepath
+        else:
+            raise MissingModuleOrAbsPath("Investigate why the data is missing.")
+
+    def __repr__(self) -> str:
+        return f"FrameInfo: {self.raw_path}"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FrameInfo):
+            return False
+        return self.raw_path == other.raw_path
+
+
+# Based on # https://github.com/getsentry/symbolicator/blob/450f1d6a8c346405454505ed9ca87e08a6ff34b7/crates/symbolicator-proguard/src/symbolication.rs#L450-L485
+def get_path_from_module(module: str, abs_path: str) -> tuple[str, str]:
+    """This attempts to generate a modified module and a real path from a Java module name and filename.
+    Returns a tuple of (stack_root, source_path).
+    """
+    # An `abs_path` is valid if it contains a `.` and doesn't contain a `$`.
+    if "$" in abs_path or "." not in abs_path:
+        # Split the module at the first '$' character and take the part before it
+        # If there's no '$', use the entire module
+        file_path = module.split("$", 1)[0] if "$" in module else module
+        stack_root = module.rsplit(".", 1)[0].replace(".", "/") + "/"
+        return stack_root, file_path.replace(".", "/")
+
+    if "." not in module:
+        raise DoesNotFollowJavaPackageNamingConvention
+
+    # Gets rid of the class name
+    parts = module.rsplit(".", 1)[0].split(".")
+    dirpath = "/".join(parts)
+    # a.Bar, Bar.kt -> stack_root: a/, file_path:  a/Bar.kt
+    granularity = 1
+
+    if len(parts) > 1:
+        # com.example.foo.bar.Baz$InnerClass, Baz.kt ->
+        #    stack_root: com/example/foo/
+        #    file_path:  com/example/foo/bar/Baz.kt
+        granularity = STACK_ROOT_MAX_LEVEL - 1
+
+        if parts[1] in SECOND_LEVEL_TLDS:
+            # uk.co.example.foo.bar.Baz$InnerClass, Baz.kt ->
+            #    stack_root: uk/co/example/foo/
+            #    file_path:  uk/co/example/foo/bar/Baz.kt
+            granularity = STACK_ROOT_MAX_LEVEL
+
+    stack_root = "/".join(parts[:granularity]) + "/"
+    file_path = f"{dirpath}/{abs_path}"
+    return stack_root, file_path

--- a/src/sentry/issues/auto_source_code_config/utils/misc.py
+++ b/src/sentry/issues/auto_source_code_config/utils/misc.py
@@ -1,0 +1,20 @@
+# List of file paths prefixes that should become stack trace roots
+FILE_PATH_PREFIX_LENGTH = {
+    "app:///": 7,
+    "../": 3,
+    "./": 2,
+}
+
+
+def get_straight_path_prefix_end_index(file_path: str) -> int:
+    """
+    Get the index where the straight path prefix ends in the file path.
+    This is  used for Node projects where the file path can start with
+    "app:///", "../", or "./"
+    """
+    index = 0
+    for prefix in FILE_PATH_PREFIX_LENGTH:
+        while file_path.startswith(prefix):
+            index += FILE_PATH_PREFIX_LENGTH[prefix]
+            file_path = file_path[FILE_PATH_PREFIX_LENGTH[prefix] :]
+    return index

--- a/src/sentry/issues/endpoints/organization_derive_code_mappings.py
+++ b/src/sentry/issues/endpoints/organization_derive_code_mappings.py
@@ -13,11 +13,12 @@ from sentry.api.bases.organization import (
     OrganizationIntegrationsLoosePermission,
 )
 from sentry.api.serializers import serialize
-from sentry.issues.auto_source_code_config.code_mapping import NeedsExtension, create_code_mapping
+from sentry.issues.auto_source_code_config.code_mapping import create_code_mapping
 from sentry.issues.auto_source_code_config.derived_code_mappings_endpoint import (
     get_code_mapping_from_request,
     get_file_and_repo_matches,
 )
+from sentry.issues.auto_source_code_config.errors import NeedsExtension
 from sentry.issues.auto_source_code_config.integration_utils import (
     InstallationCannotGetTreesError,
     InstallationNotFoundError,

--- a/src/sentry/utils/event_frames.py
+++ b/src/sentry/utils/event_frames.py
@@ -47,10 +47,10 @@ def java_frame_munger(frame: EventFrame) -> str | None:
     if not frame.module or not frame.abs_path:
         return None
 
-    from sentry.issues.auto_source_code_config.code_mapping import (
+    from sentry.issues.auto_source_code_config.errors import (
         DoesNotFollowJavaPackageNamingConvention,
-        get_path_from_module,
     )
+    from sentry.issues.auto_source_code_config.frame_info import get_path_from_module
 
     try:
         _, stacktrace_path = get_path_from_module(frame.module, frame.abs_path)

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -14,16 +14,12 @@ from sentry.integrations.source_code_management.repo_trees import (
 from sentry.issues.auto_source_code_config.code_mapping import (
     CodeMapping,
     CodeMappingTreesHelper,
-    DoesNotFollowJavaPackageNamingConvention,
-    FrameInfo,
-    MissingModuleOrAbsPath,
-    NeedsExtension,
-    UnexpectedPathException,
-    UnsupportedFrameInfo,
     convert_stacktrace_frame_path_to_source_path,
     find_roots,
     get_sorted_code_mapping_configs,
 )
+from sentry.issues.auto_source_code_config.errors import UnexpectedPathException
+from sentry.issues.auto_source_code_config.frame_info import FrameInfo
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
@@ -39,23 +35,6 @@ SENTRY_FILES = [
     "src/sentry/web/urls.py",
     "src/sentry/wsgi.py",
     "src/sentry_plugins/slack/client.py",
-]
-UNSUPPORTED_FRAME_FILENAMES = [
-    "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
-    "/gtm.js",  # Top source; starts with backslash
-    "<anonymous>",
-    "<frozen importlib._bootstrap>",
-    "[native code]",
-    "O$t",
-    "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
-    "README",  # top level file
-    "ssl.py",
-    # XXX: The following will need to be supported
-    "initialization.dart",
-    "backburner.js",
-]
-NO_EXTENSION_FRAME_FILENAMES = [
-    "/foo/bar/baz",  # no extension
 ]
 
 
@@ -100,7 +79,7 @@ def test_buckets_logic() -> None:
         {"filename": "./app/utils/handleXhrErrorResponse.tsx"},
         {"filename": "getsentry/billing/tax/manager.py"},
         {"filename": "/cronscripts/monitoringsync.php"},
-    ] + [{"filename": f} for f in UNSUPPORTED_FRAME_FILENAMES]
+    ]
     helper = CodeMappingTreesHelper({})
     buckets = helper._stacktrace_buckets(frames)
     assert buckets == {
@@ -109,104 +88,6 @@ def test_buckets_logic() -> None:
         "cronscripts": [FrameInfo({"filename": "/cronscripts/monitoringsync.php"})],
         "getsentry": [FrameInfo({"filename": "getsentry/billing/tax/manager.py"})],
     }
-
-
-class TestFrameInfo:
-    def test_frame_filename_repr(self) -> None:
-        path = "getsentry/billing/tax/manager.py"
-        assert FrameInfo({"filename": path}).__repr__() == f"FrameInfo: {path}"
-
-    def test_raises_unsupported(self) -> None:
-        for filepath in UNSUPPORTED_FRAME_FILENAMES:
-            with pytest.raises(UnsupportedFrameInfo):
-                FrameInfo({"filename": filepath})
-
-    def test_raises_no_extension(self) -> None:
-        for filepath in NO_EXTENSION_FRAME_FILENAMES:
-            with pytest.raises(NeedsExtension):
-                FrameInfo({"filename": filepath})
-
-    @pytest.mark.parametrize(
-        "frame, expected_exception",
-        [
-            pytest.param({}, MissingModuleOrAbsPath, id="no_module"),
-            pytest.param({"module": "foo"}, MissingModuleOrAbsPath, id="no_abs_path"),
-            pytest.param(
-                # Classes without declaring a package are placed in
-                # the unnamed package which cannot be imported.
-                # https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.2
-                {"module": "NoPackageName", "abs_path": "OtherActivity.java"},
-                DoesNotFollowJavaPackageNamingConvention,
-                id="unnamed_package",
-            ),
-        ],
-    )
-    def test_java_raises_exception(
-        self, frame: dict[str, Any], expected_exception: type[Exception]
-    ) -> None:
-        with pytest.raises(expected_exception):
-            FrameInfo(frame, "java")
-
-    @pytest.mark.parametrize(
-        "frame, expected_stack_root, expected_normalized_path",
-        [
-            pytest.param(
-                {"module": "foo.bar.Baz$handle$1", "abs_path": "baz.java"},
-                "foo/bar/",
-                "foo/bar/baz.java",
-                id="dollar_symbol_in_module",
-            ),
-            pytest.param(
-                {"module": "foo.bar.Baz", "abs_path": "baz.extra.java"},
-                "foo/bar/",
-                "foo/bar/baz.extra.java",
-                id="two_dots_in_abs_path",
-            ),
-            pytest.param(
-                {"module": "foo.bar.Baz", "abs_path": "no_extension"},
-                "foo/bar/",
-                "foo/bar/Baz",  # The path does not use the abs_path
-                id="invalid_abs_path_no_extension",
-            ),
-            pytest.param(
-                {"module": "foo.bar.Baz", "abs_path": "foo$bar"},
-                "foo/bar/",
-                "foo/bar/Baz",  # The path does not use the abs_path
-                id="invalid_abs_path_dollar_sign",
-            ),
-        ],
-    )
-    def test_java_valid_frames(
-        self, frame: dict[str, Any], expected_stack_root: str, expected_normalized_path: str
-    ) -> None:
-        frame_info = FrameInfo(frame, "java")
-        assert frame_info.stack_root == expected_stack_root
-        assert frame_info.normalized_path == expected_normalized_path
-
-    @pytest.mark.parametrize(
-        "frame_filename, prefix",
-        [
-            pytest.param(
-                "app:///utils/something.py",
-                "app:///utils",
-            ),
-            pytest.param(
-                "./app/utils/something.py",
-                "./app",
-            ),
-            pytest.param(
-                "../../../../../../packages/something.py",
-                "../../../../../../packages",
-            ),
-            pytest.param(
-                "app:///../services/something.py",
-                "app:///../services",
-            ),
-        ],
-    )
-    def test_straight_path_prefix(self, frame_filename: str, prefix: str) -> None:
-        frame_info = FrameInfo({"filename": frame_filename})
-        assert frame_info.stack_root == prefix
 
 
 class TestDerivedCodeMappings(TestCase):

--- a/tests/sentry/issues/auto_source_code_config/test_frame_info.py
+++ b/tests/sentry/issues/auto_source_code_config/test_frame_info.py
@@ -1,0 +1,128 @@
+from typing import Any
+
+import pytest
+
+from sentry.issues.auto_source_code_config.errors import (
+    DoesNotFollowJavaPackageNamingConvention,
+    MissingModuleOrAbsPath,
+    NeedsExtension,
+    UnsupportedFrameInfo,
+)
+from sentry.issues.auto_source_code_config.frame_info import FrameInfo
+
+UNSUPPORTED_FRAME_FILENAMES = [
+    "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+    "/gtm.js",  # Top source; starts with backslash
+    "<anonymous>",
+    "<frozen importlib._bootstrap>",
+    "[native code]",
+    "O$t",
+    "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+    "README",  # top level file
+    "ssl.py",
+    # XXX: The following will need to be supported
+    "initialization.dart",
+    "backburner.js",
+]
+
+NO_EXTENSION_FRAME_FILENAMES = [
+    "/foo/bar/baz",  # no extension
+]
+
+
+class TestFrameInfo:
+    def test_frame_filename_repr(self) -> None:
+        path = "getsentry/billing/tax/manager.py"
+        assert FrameInfo({"filename": path}).__repr__() == f"FrameInfo: {path}"
+
+    def test_raises_unsupported(self) -> None:
+        for filepath in UNSUPPORTED_FRAME_FILENAMES:
+            with pytest.raises(UnsupportedFrameInfo):
+                FrameInfo({"filename": filepath})
+
+    def test_raises_no_extension(self) -> None:
+        for filepath in NO_EXTENSION_FRAME_FILENAMES:
+            with pytest.raises(NeedsExtension):
+                FrameInfo({"filename": filepath})
+
+    @pytest.mark.parametrize(
+        "frame, expected_exception",
+        [
+            pytest.param({}, MissingModuleOrAbsPath, id="no_module"),
+            pytest.param({"module": "foo"}, MissingModuleOrAbsPath, id="no_abs_path"),
+            pytest.param(
+                # Classes without declaring a package are placed in
+                # the unnamed package which cannot be imported.
+                # https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.2
+                {"module": "NoPackageName", "abs_path": "OtherActivity.java"},
+                DoesNotFollowJavaPackageNamingConvention,
+                id="unnamed_package",
+            ),
+        ],
+    )
+    def test_java_raises_exception(
+        self, frame: dict[str, Any], expected_exception: type[Exception]
+    ) -> None:
+        with pytest.raises(expected_exception):
+            FrameInfo(frame, "java")
+
+    @pytest.mark.parametrize(
+        "frame, expected_stack_root, expected_normalized_path",
+        [
+            pytest.param(
+                {"module": "foo.bar.Baz$handle$1", "abs_path": "baz.java"},
+                "foo/bar/",
+                "foo/bar/baz.java",
+                id="dollar_symbol_in_module",
+            ),
+            pytest.param(
+                {"module": "foo.bar.Baz", "abs_path": "baz.extra.java"},
+                "foo/bar/",
+                "foo/bar/baz.extra.java",
+                id="two_dots_in_abs_path",
+            ),
+            pytest.param(
+                {"module": "foo.bar.Baz", "abs_path": "no_extension"},
+                "foo/bar/",
+                "foo/bar/Baz",  # The path does not use the abs_path
+                id="invalid_abs_path_no_extension",
+            ),
+            pytest.param(
+                {"module": "foo.bar.Baz", "abs_path": "foo$bar"},
+                "foo/bar/",
+                "foo/bar/Baz",  # The path does not use the abs_path
+                id="invalid_abs_path_dollar_sign",
+            ),
+        ],
+    )
+    def test_java_valid_frames(
+        self, frame: dict[str, Any], expected_stack_root: str, expected_normalized_path: str
+    ) -> None:
+        frame_info = FrameInfo(frame, "java")
+        assert frame_info.stack_root == expected_stack_root
+        assert frame_info.normalized_path == expected_normalized_path
+
+    @pytest.mark.parametrize(
+        "frame_filename, prefix",
+        [
+            pytest.param(
+                "app:///utils/something.py",
+                "app:///utils",
+            ),
+            pytest.param(
+                "./app/utils/something.py",
+                "./app",
+            ),
+            pytest.param(
+                "../../../../../../packages/something.py",
+                "../../../../../../packages",
+            ),
+            pytest.param(
+                "app:///../services/something.py",
+                "app:///../services",
+            ),
+        ],
+    )
+    def test_straight_path_prefix(self, frame_filename: str, prefix: str) -> None:
+        frame_info = FrameInfo({"filename": frame_filename})
+        assert frame_info.stack_root == prefix


### PR DESCRIPTION
The primary purpose of this change is to decouple the frame information logic from the code mappings module.