### PR TITLE
fix(ui): adjust colors of icons inside segmentedControl

### DIFF
--- a/static/app/components/core/segmentedControl/index.chonk.tsx
+++ b/static/app/components/core/segmentedControl/index.chonk.tsx
@@ -2,6 +2,7 @@ import type {DO_NOT_USE_ChonkTheme} from '@emotion/react';
 import {css} from '@emotion/react';
 
 import {DO_NOT_USE_getChonkButtonStyles} from 'sentry/components/core/button/styles.chonk';
+import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
 import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 
@@ -82,16 +83,11 @@ export const ChonkStyledSegmentWrap = chonkStyled('label')<{
   }
 `;
 
-export const ChonkStyledVisibleLabel = chonkStyled('span')<{
-  isSelected: boolean;
-  priority: Priority;
-  size: FormSize;
-}>`
+export const ChonkStyledVisibleLabel = chonkStyled('span')`
   ${p => p.theme.overflowEllipsis}
   user-select: none;
   font-weight: ${p => p.theme.fontWeightBold};
   text-align: center;
-  color: ${p => getTextColor(p)};
 `;
 
 function getTextColor({
@@ -110,3 +106,16 @@ function getTextColor({
 
   return theme.subText;
 }
+
+export const ChonkStyledLabelWrap = chonkStyled('span')<{
+  isSelected: boolean;
+  priority: Priority;
+  size: FormSize;
+}>`
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  gap: ${p => (p.size === 'xs' ? space(0.5) : space(0.75))};
+  z-index: 1;
+  color: ${p => getTextColor(p)};
+`;

--- a/static/app/components/core/segmentedControl/index.tsx
+++ b/static/app/components/core/segmentedControl/index.tsx
@@ -21,6 +21,7 @@ import {withChonk} from 'sentry/utils/theme/withChonk';
 
 import {
   ChonkStyledGroupWrap,
+  ChonkStyledLabelWrap,
   ChonkStyledSegmentWrap,
   ChonkStyledVisibleLabel,
   type Priority,
@@ -219,7 +220,12 @@ function Segment<Value extends string>({
         <Divider visible={showDivider} role="separator" aria-hidden />
       )}
 
-      <LabelWrap size={size} role="presentation">
+      <LabelWrap
+        size={size}
+        isSelected={isSelected}
+        priority={priority}
+        role="presentation"
+      >
         {icon}
         {props.children && label}
       </LabelWrap>
@@ -373,13 +379,20 @@ const SegmentSelectionIndicator = styled(motion.div)<{priority: Priority}>`
   `}
 `;
 
-const LabelWrap = styled('span')<{size: FormSize}>`
-  display: grid;
-  grid-auto-flow: column;
-  align-items: center;
-  gap: ${p => (p.size === 'xs' ? space(0.5) : space(0.75))};
-  z-index: 1;
-`;
+const LabelWrap = withChonk(
+  styled('span')<{
+    isSelected: boolean;
+    priority: Priority;
+    size: FormSize;
+  }>`
+    display: grid;
+    grid-auto-flow: column;
+    align-items: center;
+    gap: ${p => (p.size === 'xs' ? space(0.5) : space(0.75))};
+    z-index: 1;
+  `,
+  ChonkStyledLabelWrap
+);
 
 const InnerLabelWrap = styled('span')`
   position: relative;


### PR DESCRIPTION
to match textColor

| before | after |
|--------|--------|
| ![Screenshot 2025-05-27 at 15 57 49](https://github.com/user-attachments/assets/b53921cb-b79b-49ac-9508-924c39ea25f9) | ![Screenshot 2025-05-27 at 16 04 13](https://github.com/user-attachments/assets/f4b4a88e-6431-4a8e-97ef-b125a01c6a86) | 
