### PR TITLE
chore(replay): Cleanup replay.render-player "Rendered ReplayPlayer" analytics event

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -11,8 +11,6 @@ import {
   sentryReplayerCss,
 } from 'sentry/components/replays/player/styles';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {trackAnalytics} from 'sentry/utils/analytics';
-import useOrganization from 'sentry/utils/useOrganization';
 
 import UnmaskAlert from './unmaskAlert';
 
@@ -39,44 +37,6 @@ interface Props {
    */
   isPreview?: boolean;
   overlayContent?: React.ReactNode;
-}
-
-function useVideoSizeLogger({
-  videoDimensions,
-  windowDimensions,
-}: {
-  videoDimensions: Dimensions;
-  windowDimensions: Dimensions;
-}) {
-  const organization = useOrganization();
-  const [didLog, setDidLog] = useState<boolean>(false);
-  const {analyticsContext} = useReplayContext();
-
-  useEffect(() => {
-    if (didLog || (videoDimensions.width === 0 && videoDimensions.height === 0)) {
-      return;
-    }
-
-    const aspect_ratio =
-      videoDimensions.width > videoDimensions.height ? 'landscape' : 'portrait';
-
-    const scale = Math.min(
-      windowDimensions.width / videoDimensions.width,
-      windowDimensions.height / videoDimensions.height,
-      1
-    );
-    const scale_bucket = (Math.floor(scale * 10) * 10) as Parameters<
-      typeof trackAnalytics<'replay.render-player'>
-    >[1]['scale_bucket'];
-
-    trackAnalytics('replay.render-player', {
-      organization,
-      aspect_ratio,
-      context: analyticsContext,
-      scale_bucket,
-    });
-    setDidLog(true);
-  }, [organization, windowDimensions, videoDimensions, didLog, analyticsContext]);
 }
 
 function BasePlayerRoot({
@@ -112,8 +72,6 @@ function BasePlayerRoot({
     width: 0,
     height: 0,
   });
-
-  useVideoSizeLogger({videoDimensions, windowDimensions});
 
   // Sets the parent element where the player
   // instance will use as root (i.e. where it will

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -110,16 +110,6 @@ export type ReplayEventParameters = {
   'replay.render-missing-replay-alert': {
     surface: string;
   };
-  'replay.render-player': {
-    aspect_ratio: 'portrait' | 'landscape';
-    context: string;
-    // What scale is the video as a percent, bucketed into ranges of 10% increments
-    // example:
-    //  - The video is shown at 25% the normal size
-    //  - in CSS we use the statement `transform: scale(0.25);`
-    //  - The logged value is `20`, because the scale is in the range of 20% to 30%.
-    scale_bucket: 0 | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 | 100;
-  };
   'replay.search': {
     search_keys: string;
   };
@@ -159,7 +149,6 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.rage-click-sdk-banner.rendered': 'Replay Rage Click SDK Banner Rendered',
   'replay.render-issues-group-list': 'Render Issues Detail Replay List',
   'replay.render-missing-replay-alert': 'Render Missing Replay Alert',
-  'replay.render-player': 'Rendered ReplayPlayer',
   'replay.search': 'Searched Replay',
   'replay.toggle-fullscreen': 'Toggled Replay Fullscreen',
 };


### PR DESCRIPTION
This event is happening a lot and creating a lot of volume on the event aggregator. We don't query for it much anymore so it's time to retire it. 

History: It was added to get signal on replay dimensions and aspect ratio, especially interesting when mobile aspect ratios were added.