### PR TITLE
fix(ui): remove custom text selection color

### DIFF
--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -532,12 +532,6 @@ const Row = styled('div')`
       background-color: ${p => p.theme.gray100};
     }
   }
-
-  input {
-    &::selection {
-      background-color: ${p => p.theme.gray100};
-    }
-  }
 `;
 
 const GridCell = styled('div')`

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -649,12 +649,6 @@ const Row = styled('div')`
       background-color: ${p => p.theme.gray100};
     }
   }
-
-  input {
-    &::selection {
-      background-color: ${p => p.theme.gray100};
-    }
-  }
 `;
 
 const GridCell = styled('div')`


### PR DESCRIPTION
Not sure why we have set a custom text selection color of `gray.100`, but instead of fixing it for `UI2`, I just removed it. If we want gray text selection, I think we should build this into `Input` itself. @Jesse-Box FYI

before:

| - | light | dark |
|--------|--------|--------|
| old UI | ![Screenshot 2025-05-27 at 17 33 39](https://github.com/user-attachments/assets/a28dd381-2a3d-42e6-80f0-705d92fd9275) | ![Screenshot 2025-05-27 at 17 33 03](https://github.com/user-attachments/assets/4221e111-d7e2-4640-82af-35540d070f78) |
| new UI | ![Screenshot 2025-05-27 at 17 33 22](https://github.com/user-attachments/assets/7e4b1a30-2751-4fd5-8d32-fd6b4a4c7698) | ![Screenshot 2025-05-27 at 17 33 13](https://github.com/user-attachments/assets/41fc5524-c9b9-429f-ac72-aefb47da188e) | 

after:

| - | light | dark |
|--------|--------|--------|
| old UI | ![Screenshot 2025-05-27 at 17 31 31](https://github.com/user-attachments/assets/be55f162-a31a-43f5-9ec9-184b59cdf168) | ![Screenshot 2025-05-27 at 17 31 41](https://github.com/user-attachments/assets/57f1bdc5-f6c8-4e6c-90c6-c6fff5b3af31) |
| new UI | ![Screenshot 2025-05-27 at 17 31 21](https://github.com/user-attachments/assets/a0618501-be25-4fe4-86f3-3736414214d1) | ![Screenshot 2025-05-27 at 17 31 07](https://github.com/user-attachments/assets/8e59b606-bb16-4a92-aa74-e381c8b22bdd) | 