### PR TITLE
fix(insights): total tokens used column shows as decimal

### DIFF
--- a/src/sentry/search/eap/spans/aggregates.py
+++ b/src/sentry/search/eap/spans/aggregates.py
@@ -372,6 +372,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
@@ -388,6 +389,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                     "duration",
                     "number",
                     "percentage",
+                    "integer",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
@@ -403,6 +405,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -422,6 +425,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -440,6 +444,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
@@ -456,6 +461,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -472,6 +478,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
                 },
@@ -488,6 +495,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -504,6 +512,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -520,6 +529,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -536,6 +546,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -552,6 +563,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -568,6 +580,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,
@@ -584,6 +597,7 @@ SPAN_AGGREGATE_DEFINITIONS = {
                 attribute_types={
                     "duration",
                     "number",
+                    "integer",
                     "percentage",
                     *constants.SIZE_TYPE,
                     *constants.DURATION_TYPE,

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -172,7 +172,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         ResolvedAttribute(
             public_alias="ai.total_tokens.used",
             internal_name="ai_total_tokens_used",
-            search_type="number",
+            search_type="integer",
         ),
         ResolvedAttribute(
             public_alias="ai.total_cost",

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -9,9 +9,9 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
     AttributeKey,
     AttributeValue,
-    DoubleArray,
     ExtrapolationMode,
     Function,
+    IntArray,
     StrArray,
     VirtualColumnContext,
 )
@@ -63,9 +63,9 @@ class SearchResolverQueryTest(TestCase):
         where, having, _ = self.resolver.resolve_query("ai.total_tokens.used:123")
         assert where == TraceItemFilter(
             comparison_filter=ComparisonFilter(
-                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_DOUBLE),
+                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_INT),
                 op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(val_double=123),
+                value=AttributeValue(val_int=123),
             )
         )
         assert having is None
@@ -111,9 +111,9 @@ class SearchResolverQueryTest(TestCase):
         where, having, _ = self.resolver.resolve_query("ai.total_tokens.used:[123,456,789]")
         assert where == TraceItemFilter(
             comparison_filter=ComparisonFilter(
-                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_DOUBLE),
+                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_INT),
                 op=ComparisonFilter.OP_IN,
-                value=AttributeValue(val_double_array=DoubleArray(values=[123, 456, 789])),
+                value=AttributeValue(val_int_array=IntArray(values=[123, 456, 789])),
             )
         )
         assert having is None
@@ -122,9 +122,9 @@ class SearchResolverQueryTest(TestCase):
         where, having, _ = self.resolver.resolve_query("ai.total_tokens.used:>123")
         assert where == TraceItemFilter(
             comparison_filter=ComparisonFilter(
-                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_DOUBLE),
+                key=AttributeKey(name="ai_total_tokens_used", type=AttributeKey.Type.TYPE_INT),
                 op=ComparisonFilter.OP_GREATER_THAN,
-                value=AttributeValue(val_double=123),
+                value=AttributeValue(val_int=123),
             )
         )
         assert having is None

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4695,3 +4695,34 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                     f"tag{c}": c,
                 }
             ]
+
+    def test_ai_total_tokens_returns_integer_meta(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"data": {"ai_total_tokens_used": 100}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"data": {"ai_total_tokens_used": 50}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["sum(ai.total_tokens.used)"],
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+
+        data, meta = response.data["data"], response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["sum(ai.total_tokens.used)"] == 150
+        assert meta["dataset"] == self.dataset
+        assert meta["fields"]["sum(ai.total_tokens.used)"] == "integer"


### PR DESCRIPTION
Due to extrapolation, it's possible for integer attribute types to come back as decimals when doing a sum aggregation on them. This cause decimal values when querying for `sum(ai.total_tokens.used)` which is incorrect. Ideally this is fixed on the rpc side, but we can still handle it properly on our end too. 

This Pr
1. Sets the meta of `ai.total_tokens.used` to `integer` which signals the frontend to format this value as an integer
2. Allows `integer` types to be used in `sum`, percentile, and other aggregates.
