### PR TITLE
fix(dashboards): use location dashboard filters over saved dashboard filters

### DIFF
--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -18,7 +18,7 @@ import {useParams} from 'sentry/utils/useParams';
 
 import {assignTempId} from './layoutUtils';
 import type {DashboardDetails, DashboardListItem} from './types';
-import {hasSavedPageFilters} from './utils';
+import {getCurrentPageFilters, hasSavedPageFilters} from './utils';
 
 type OrgDashboardsChildrenProps = {
   dashboard: DashboardDetails | null;
@@ -93,11 +93,15 @@ function OrgDashboards(props: Props) {
   useEffect(() => {
     // Only redirect if there are saved filters and none of the filters
     // appear in the query params
+
+    // Get current query params from URL
+    const currentDashboardDetails = getCurrentPageFilters(location);
     if (
       !selectedDashboard ||
       !hasSavedPageFilters(selectedDashboard) ||
       // Apply redirect once for each dashboard id
-      dashboardRedirectRef.current === selectedDashboard.id
+      dashboardRedirectRef.current === selectedDashboard.id ||
+      hasSavedPageFilters(currentDashboardDetails)
     ) {
       return;
     }

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -93,31 +93,29 @@ function OrgDashboards(props: Props) {
   useEffect(() => {
     // Only redirect if there are saved filters and none of the filters
     // appear in the query params
-
-    // Get current query params from URL
-    const currentDashboardDetails = getCurrentPageFilters(location);
     if (
       !selectedDashboard ||
       !hasSavedPageFilters(selectedDashboard) ||
       // Apply redirect once for each dashboard id
-      dashboardRedirectRef.current === selectedDashboard.id ||
-      hasSavedPageFilters(currentDashboardDetails)
+      dashboardRedirectRef.current === selectedDashboard.id
     ) {
       return;
     }
 
+    // Get current query params from location to prioritize using
+    const locationFilters = getCurrentPageFilters(location);
     dashboardRedirectRef.current = selectedDashboard.id;
     navigate(
       {
         ...location,
         query: {
           ...location.query,
-          project: selectedDashboard.projects,
-          environment: selectedDashboard.environment,
-          statsPeriod: selectedDashboard.period,
-          start: selectedDashboard.start,
-          end: selectedDashboard.end,
-          utc: selectedDashboard.utc,
+          project: locationFilters.projects || selectedDashboard.projects,
+          environment: locationFilters.environment || selectedDashboard.environment,
+          statsPeriod: locationFilters.period || selectedDashboard.period,
+          start: locationFilters.start || selectedDashboard.start,
+          end: locationFilters.end || selectedDashboard.end,
+          utc: locationFilters.utc || selectedDashboard.utc,
         },
       },
       {replace: true}

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -93,29 +93,31 @@ function OrgDashboards(props: Props) {
   useEffect(() => {
     // Only redirect if there are saved filters and none of the filters
     // appear in the query params
+
+    // current filters based on location
+    const locationFilters = getCurrentPageFilters(location);
     if (
       !selectedDashboard ||
       !hasSavedPageFilters(selectedDashboard) ||
       // Apply redirect once for each dashboard id
-      dashboardRedirectRef.current === selectedDashboard.id
+      dashboardRedirectRef.current === selectedDashboard.id ||
+      hasSavedPageFilters(locationFilters)
     ) {
       return;
     }
 
-    // Get current query params from location to prioritize using
-    const locationFilters = getCurrentPageFilters(location);
     dashboardRedirectRef.current = selectedDashboard.id;
     navigate(
       {
         ...location,
         query: {
           ...location.query,
-          project: locationFilters.projects || selectedDashboard.projects,
-          environment: locationFilters.environment || selectedDashboard.environment,
-          statsPeriod: locationFilters.period || selectedDashboard.period,
-          start: locationFilters.start || selectedDashboard.start,
-          end: locationFilters.end || selectedDashboard.end,
-          utc: locationFilters.utc || selectedDashboard.utc,
+          project: selectedDashboard.projects,
+          environment: selectedDashboard.environment,
+          statsPeriod: selectedDashboard.period,
+          start: selectedDashboard.start,
+          end: selectedDashboard.end,
+          utc: selectedDashboard.utc,
         },
       },
       {replace: true}

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -454,12 +454,7 @@ export function isWidgetUsingTransactionName(widget: Widget) {
   );
 }
 
-export function hasSavedPageFilters(
-  dashboard: Pick<
-    DashboardDetails,
-    'projects' | 'environment' | 'period' | 'start' | 'end' | 'utc'
-  >
-) {
+export function hasSavedPageFilters(dashboard: DashboardDetails) {
   return !(
     (dashboard.projects === undefined || dashboard.projects.length === 0) &&
     dashboard.environment === undefined &&

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -454,7 +454,12 @@ export function isWidgetUsingTransactionName(widget: Widget) {
   );
 }
 
-export function hasSavedPageFilters(dashboard: DashboardDetails) {
+export function hasSavedPageFilters(
+  dashboard: Pick<
+    DashboardDetails,
+    'projects' | 'environment' | 'period' | 'start' | 'end' | 'utc'
+  >
+) {
   return !(
     (dashboard.projects === undefined || dashboard.projects.length === 0) &&
     dashboard.environment === undefined &&


### PR DESCRIPTION
### Changes
Pull out the dashboard filters from the current location and prioritize them over the saved dashboard filters. This way the user can share hardcoded links to view specific filters without overrides from saved filter.

### Before

https://github.com/user-attachments/assets/8b6e3920-0624-4579-aa56-2fd0c106ec88



### After

If the user has edit access, the save button will appear:

https://github.com/user-attachments/assets/71992050-e1c8-41fe-a585-a2715dbaad44

If they do not have edit access, the save button is greyed out:

https://github.com/user-attachments/assets/edc1338f-3981-4ac2-b2b9-09f3a9767430



