### PR TITLE
fix(ui2): Use better colours for `BaselineMarkline`

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/baselineMarkline.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/baselineMarkline.tsx
@@ -25,8 +25,8 @@ export function BaselineMarkLine({theme, value, label}: Props) {
       position: 'insideEndBottom',
       formatter: () => label ?? t('Baseline'),
       fontSize: 14,
-      color: theme.chartLabel,
-      backgroundColor: theme.chartOther,
+      color: theme.tokens.content.muted,
+      backgroundColor: theme.tokens.background.primary,
     },
   });
 }


### PR DESCRIPTION
`BaselineMarkline` didn't look good under UI2, since the background colour and foreground colour were the same. This sets new ones, that look better in both the old theme and in UI2

**Before:**
![Screenshot 2025-05-27 at 12 16 48 PM](https://github.com/user-attachments/assets/a44a62a4-890b-4c4c-9dff-278631d71cc0)

**After:**
![Screenshot 2025-05-27 at 12 17 09 PM](https://github.com/user-attachments/assets/e1fe755c-1554-49fe-9bc6-b6917c8ec2f9)
