### PR TITLE
chore(tasks) Simplify buffer tasks

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3564,10 +3564,6 @@ SENTRY_KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {}
 DEVSERVER_START_KAFKA_CONSUMERS: MutableSequence[str] = []
 
 
-# If set to True, buffer.incr will be spawned as background celery task. If false it's a direct call
-# to the buffer service.
-SENTRY_BUFFER_INCR_AS_CELERY_TASK = False
-
 # Feature flag to turn off role-swapping to help bridge getsentry transition.
 USE_ROLE_SWAPPING_IN_TESTS = True
 

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -3,8 +3,8 @@ from typing import Any
 
 import sentry_sdk
 from django.apps import apps
-from django.conf import settings
 
+from sentry.db.models.base import Model
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import buffer_tasks
@@ -102,33 +102,9 @@ def process_incr(
     )
 
 
-def buffer_incr(model, *args, **kwargs):
-    """
-    Call `buffer.incr` as a task on the given model, either directly or via celery depending on
-    `settings.SENTRY_BUFFER_INCR_AS_CELERY_TASK`.
-
-    See `Buffer.incr` for an explanation of the args and kwargs to pass here.
-    """
-    (buffer_incr_task.delay if settings.SENTRY_BUFFER_INCR_AS_CELERY_TASK else buffer_incr_task)(
-        app_label=model._meta.app_label, model_name=model._meta.model_name, args=args, kwargs=kwargs
-    )
-
-
-@instrumented_task(
-    name="sentry.tasks.process_buffer.buffer_incr_task",
-    queue="buffers.incr",
-    taskworker_config=TaskworkerConfig(
-        namespace=buffer_tasks,
-    ),
-)
-def buffer_incr_task(app_label: str, model_name: str, args: Any, kwargs: Any):
-    """
-    Call `buffer.incr`, resolving the model first.
-
-    `model_name` must be in form `app_label.model_name` e.g. `sentry.group`.
-    """
+def buffer_incr(model: type[Model], *args, **kwargs):
     from sentry import buffer
 
-    sentry_sdk.set_tag("model", model_name)
+    sentry_sdk.set_tag("model", model._meta.model_name)
 
-    buffer.backend.incr(apps.get_model(app_label=app_label, model_name=model_name), *args, **kwargs)
+    buffer.backend.incr(model, *args, **kwargs)


### PR DESCRIPTION
The indirection of being able to call buffer incr as a task or not is not currently used in any environment, and hasn't been used for a while. Removing this indirection makes buffers a bit simpler.