### PR TITLE
fix(insights): add min height to insights backend widgets

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -301,6 +301,7 @@ const StackedWidgetWrapper = styled('div')`
   flex-direction: column;
   gap: ${space(2)};
   height: 100%;
+  min-height: 502px;
 `;
 
 const TripleRowWidgetWrapper = styled('div')`


### PR DESCRIPTION
Adds a min height to the backend widgets so they appear correctly when no issues are found. The height matches the issues widget height

Before
<img width="1220" alt="image" src="https://github.com/user-attachments/assets/c0b94dd2-30a8-49ce-9bf2-ee87fed537bf" />


After
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/4447a170-23ce-48f6-a0a4-33df51c9de7f" />
