### PR TITLE
featurebadge: drop symbol badge representations

### DIFF
--- a/static/app/components/core/badge/featureBadge.stories.tsx
+++ b/static/app/components/core/badge/featureBadge.stories.tsx
@@ -26,7 +26,6 @@ export default Storybook.story('FeatureBadge', story => {
           </span>
         )}
         propMatrix={{
-          variant: ['badge', 'indicator', 'short'],
           type: ['alpha', 'beta', 'new', 'experimental'],
         }}
         selectedProps={['type', 'variant']}

--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -1,7 +1,5 @@
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import CircleIndicator from 'sentry/components/circleIndicator';
 import {Badge, type BadgeProps} from 'sentry/components/core/badge';
 import {Tooltip, type TooltipProps} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
@@ -25,48 +23,20 @@ const labels: Record<FeatureBadgeProps['type'], string> = {
   experimental: t('experimental'),
 };
 
-const shortLabels: Record<FeatureBadgeProps['type'], string> = {
-  alpha: 'A',
-  beta: 'B',
-  new: 'N',
-  experimental: 'E',
-};
-
-const useFeatureBadgeIndicatorColor = () => {
-  const theme = useTheme();
-
-  return {
-    alpha: theme.pink300,
-    beta: theme.purple300,
-    new: theme.green300,
-    experimental: theme.gray100,
-  } satisfies Record<FeatureBadgeProps['type'], string>;
-};
-
 export interface FeatureBadgeProps extends Omit<BadgeProps, 'children'> {
   type: 'alpha' | 'beta' | 'new' | 'experimental';
   tooltipProps?: Partial<TooltipProps>;
-  variant?: 'badge' | 'indicator' | 'short';
+  variant?: 'badge';
 }
 
-function InnerFeatureBadge({
-  type,
-  variant = 'badge',
-  tooltipProps,
-  ...props
-}: FeatureBadgeProps) {
-  const indicatorColors = useFeatureBadgeIndicatorColor();
+function InnerFeatureBadge({type, tooltipProps, ...props}: FeatureBadgeProps) {
   const title = tooltipProps?.title ?? defaultTitles[type] ?? '';
 
   return (
     <Tooltip title={title} position="right" {...tooltipProps} skipWrapper>
-      {variant === 'badge' || variant === 'short' ? (
-        <StyledBadge type={type} {...props}>
-          {variant === 'short' ? shortLabels[type] : labels[type]}
-        </StyledBadge>
-      ) : (
-        <CircleIndicator color={indicatorColors[type]} size={8} />
-      )}
+      <StyledBadge type={type} {...props}>
+        {labels[type]}
+      </StyledBadge>
     </Tooltip>
   );
 }

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -253,7 +253,6 @@ function Sidebar() {
         {...sidebarItemProps}
         icon={<IconMegaphone />}
         label={t('User Feedback')}
-        variant="short"
         to={`/organizations/${organization.slug}/feedback/`}
         id="feedback"
       />

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -118,10 +118,6 @@ export type SidebarItemProps = {
    * Content to render at the end of the item.
    */
   trailingItems?: React.ReactNode;
-  /**
-   * Content to render at the end of the item.
-   */
-  variant?: 'badge' | 'indicator' | 'short' | undefined;
 };
 
 function SidebarItem({
@@ -144,7 +140,6 @@ function SidebarItem({
   isNewSeenKeySuffix,
   onClick,
   trailingItems,
-  variant,
   isNested,
   isMainItem,
   isOpenInFloatingSidebar,
@@ -200,15 +195,9 @@ function SidebarItem({
 
   const badges = (
     <Fragment>
-      {showIsNew && (
-        <FeatureBadge type="new" variant={variant} tooltipProps={{title: badgeTitle}} />
-      )}
-      {isBeta && (
-        <FeatureBadge type="beta" variant={variant} tooltipProps={{title: badgeTitle}} />
-      )}
-      {isAlpha && (
-        <FeatureBadge type="alpha" variant={variant} tooltipProps={{title: badgeTitle}} />
-      )}
+      {showIsNew && <FeatureBadge type="new" tooltipProps={{title: badgeTitle}} />}
+      {isBeta && <FeatureBadge type="beta" tooltipProps={{title: badgeTitle}} />}
+      {isAlpha && <FeatureBadge type="alpha" tooltipProps={{title: badgeTitle}} />}
     </Fragment>
   );
 
@@ -282,25 +271,13 @@ function SidebarItem({
                 </SidebarItemLabel>
               )}
               {isInCollapsedState && showIsNew && (
-                <CollapsedFeatureBadge
-                  type="new"
-                  variant="indicator"
-                  tooltipProps={tooltipDisabledProps}
-                />
+                <CollapsedFeatureBadge type="new" tooltipProps={tooltipDisabledProps} />
               )}
               {isInCollapsedState && isBeta && (
-                <CollapsedFeatureBadge
-                  type="beta"
-                  variant="indicator"
-                  tooltipProps={tooltipDisabledProps}
-                />
+                <CollapsedFeatureBadge type="beta" tooltipProps={tooltipDisabledProps} />
               )}
               {isInCollapsedState && isAlpha && (
-                <CollapsedFeatureBadge
-                  type="alpha"
-                  variant="indicator"
-                  tooltipProps={tooltipDisabledProps}
-                />
+                <CollapsedFeatureBadge type="alpha" tooltipProps={tooltipDisabledProps} />
               )}
               {badge !== undefined && badge > 0 && (
                 <SidebarItemBadge collapsed={isInCollapsedState}>

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -233,7 +233,9 @@ function EAPBackendOverviewPage() {
               </ToolRibbon>
             </ModuleLayout.Full>
             <PageAlert />
-            {!showOnboarding && (
+            {showOnboarding ? (
+              <LegacyOnboarding project={onboardingProject} organization={organization} />
+            ) : (
               <Fragment>
                 <ModuleLayout.Third>
                   <StackedWidgetWrapper>
@@ -261,9 +263,6 @@ function EAPBackendOverviewPage() {
                   <BackendOverviewTable response={response} sort={sorts[1]} />
                 </ModuleLayout.Full>
               </Fragment>
-            )}
-            {showOnboarding && (
-              <LegacyOnboarding project={onboardingProject} organization={organization} />
             )}
           </ModuleLayout.Layout>
         </Layout.Main>

--- a/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/oldBackendOverviewPage.tsx
@@ -267,7 +267,12 @@ export function OldBackendOverviewPage() {
             </ModuleLayout.Full>
             <PageAlert />
             <ModuleLayout.Full>
-              {!showOnboarding && (
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
                 <PerformanceDisplayProvider
                   value={{performanceType: ProjectPerformanceType.BACKEND}}
                 >
@@ -295,13 +300,6 @@ export function OldBackendOverviewPage() {
                     />
                   </TeamKeyTransactionManager.Provider>
                 </PerformanceDisplayProvider>
-              )}
-
-              {showOnboarding && (
-                <LegacyOnboarding
-                  project={onboardingProject}
-                  organization={organization}
-                />
               )}
             </ModuleLayout.Full>
           </ModuleLayout.Layout>

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -252,7 +252,12 @@ function EAPOverviewPage() {
             </ModuleLayout.Full>
             <PageAlert />
             <ModuleLayout.Full>
-              {!showOnboarding && (
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
                 <PerformanceDisplayProvider
                   value={{performanceType: ProjectPerformanceType.FRONTEND_OTHER}}
                 >
@@ -264,13 +269,6 @@ function EAPOverviewPage() {
                   <TripleChartRow allowedCharts={tripleChartRowCharts} {...sharedProps} />
                   <FrontendOverviewTable response={response} sort={sorts[1]} />
                 </PerformanceDisplayProvider>
-              )}
-
-              {showOnboarding && (
-                <LegacyOnboarding
-                  project={onboardingProject}
-                  organization={organization}
-                />
               )}
             </ModuleLayout.Full>
           </ModuleLayout.Layout>

--- a/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/oldFrontendOverviewPage.tsx
@@ -234,7 +234,12 @@ export function OldFrontendOverviewPage() {
             </ModuleLayout.Full>
             <PageAlert />
             <ModuleLayout.Full>
-              {!showOnboarding && (
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
                 <PerformanceDisplayProvider
                   value={{performanceType: ProjectPerformanceType.FRONTEND_OTHER}}
                 >
@@ -259,13 +264,6 @@ export function OldFrontendOverviewPage() {
                     />
                   </TeamKeyTransactionManager.Provider>
                 </PerformanceDisplayProvider>
-              )}
-
-              {showOnboarding && (
-                <LegacyOnboarding
-                  project={onboardingProject}
-                  organization={organization}
-                />
               )}
             </ModuleLayout.Full>
           </ModuleLayout.Layout>

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -246,7 +246,12 @@ function EAPMobileOverviewPage() {
             </ModuleLayout.Full>
             <PageAlert />
             <ModuleLayout.Full>
-              {!showOnboarding && (
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
                 <PerformanceDisplayProvider
                   value={{performanceType: ProjectPerformanceType.MOBILE}}
                 >
@@ -258,13 +263,6 @@ function EAPMobileOverviewPage() {
                   <TripleChartRow allowedCharts={tripleChartRowCharts} {...sharedProps} />
                   <MobileOverviewTable response={response} sort={sorts[1]} />
                 </PerformanceDisplayProvider>
-              )}
-
-              {showOnboarding && (
-                <LegacyOnboarding
-                  project={onboardingProject}
-                  organization={organization}
-                />
               )}
             </ModuleLayout.Full>
           </ModuleLayout.Layout>

--- a/static/app/views/insights/pages/mobile/oldMobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/oldMobileOverviewPage.tsx
@@ -238,7 +238,12 @@ export function OldMobileOverviewPage() {
             </ModuleLayout.Full>
             <PageAlert />
             <ModuleLayout.Full>
-              {!showOnboarding && (
+              {showOnboarding ? (
+                <LegacyOnboarding
+                  project={onboardingProject}
+                  organization={organization}
+                />
+              ) : (
                 <PerformanceDisplayProvider
                   value={{performanceType: ProjectPerformanceType.MOBILE}}
                 >
@@ -266,13 +271,6 @@ export function OldMobileOverviewPage() {
                     />
                   </TeamKeyTransactionManager.Provider>
                 </PerformanceDisplayProvider>
-              )}
-
-              {showOnboarding && (
-                <LegacyOnboarding
-                  project={onboardingProject}
-                  organization={organization}
-                />
               )}
             </ModuleLayout.Full>
           </ModuleLayout.Layout>

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -68,7 +68,12 @@ function DestinationSummaryPage() {
                     <ModulePageFilterBar moduleName={ModuleName.QUEUE} />
                   </ToolRibbon>
 
-                  {!onboardingProject && (
+                  {onboardingProject ? (
+                    <LegacyOnboarding
+                      organization={organization}
+                      project={onboardingProject}
+                    />
+                  ) : (
                     <ReadoutRibbon>
                       <MetricReadout
                         title={t('Avg Time In Queue')}
@@ -110,13 +115,6 @@ function DestinationSummaryPage() {
                   )}
                 </HeaderContainer>
               </ModuleLayout.Full>
-
-              {onboardingProject && (
-                <LegacyOnboarding
-                  organization={organization}
-                  project={onboardingProject}
-                />
-              )}
 
               {!onboardingProject && (
                 <Fragment>

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -100,14 +100,14 @@ function ConfigureSection({baseUrl}: {baseUrl: string}) {
       {hasWorkflowEngine ? (
         <Fragment>
           <SecondaryNav.Item
-            trailingItems={<FeatureBadge type="alpha" variant="short" />}
+            trailingItems={<FeatureBadge type="alpha" />}
             to={`${baseUrl}/monitors/`}
             activeTo={`${baseUrl}/monitors`}
           >
             {t('Monitors')}
           </SecondaryNav.Item>
           <SecondaryNav.Item
-            trailingItems={<FeatureBadge type="alpha" variant="short" />}
+            trailingItems={<FeatureBadge type="alpha" />}
             to={`${baseUrl}/automations/`}
             activeTo={`${baseUrl}/automations`}
           >

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -264,7 +264,7 @@ export function LegacyOnboarding({organization, project}: OnboardingProps) {
   }
 
   return (
-    <Fragment>
+    <PerformanceOnboardingContainer>
       {noPerformanceSupport && (
         <UnsupportedAlert projectSlug={project.slug} featureName="Performance" />
       )}
@@ -306,9 +306,13 @@ export function LegacyOnboarding({organization, project}: OnboardingProps) {
           )}
         </FeatureTourModal>
       </LegacyOnboardingPanel>
-    </Fragment>
+    </PerformanceOnboardingContainer>
   );
 }
+
+const PerformanceOnboardingContainer = styled('div')`
+  grid-column: 1/-1;
+`;
 
 const PerfImage = styled('img')`
   @media (min-width: ${p => p.theme.breakpoints.small}) {

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -26,7 +26,7 @@ const LabelHook = HookOrDefault({
 
 function SettingsNavBadge({badge}: {badge: string | number | null | ReactElement}) {
   if (badge === 'new' || badge === 'beta' || badge === 'alpha') {
-    return <FeatureBadge type={badge} variant="short" />;
+    return <FeatureBadge type={badge} />;
   }
   if (badge === 'warning') {
     return (


### PR DESCRIPTION
The single letter is awfully close to what the letter avatar looks like while the circled dot looks like a notification symbol. Neither of those two looks convey the feature aspect of this component very well, so their respective variants are being removed for the fully spelled out version.

It may be that these variants were useful in previous UIs, but we seem to have enough space to be able to afford writing out the entire feature string now.

Some examples from after this change
![CleanShot 2025-05-27 at 13 33 05@2x](https://github.com/user-attachments/assets/5bf93333-8de9-4689-b873-eeef87863220)

![CleanShot 2025-05-27 at 13 33 24@2x](https://github.com/user-attachments/assets/b52baa27-f4c7-4948-8dab-89d59f963208)

![CleanShot 2025-05-27 at 13 33 14@2x](https://github.com/user-attachments/assets/402cbe01-edd2-4c7b-8fed-b6485afdc15e)


Fixed DE-113