### PR TITLE
feat(2fa): Switch webAuthnEnroll to a FormField

### DIFF
--- a/static/app/components/webAuthn/webAuthnEnroll.tsx
+++ b/static/app/components/webAuthn/webAuthnEnroll.tsx
@@ -2,68 +2,72 @@ import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
-import FieldGroup from 'sentry/components/forms/fieldGroup';
+import FormField from 'sentry/components/forms/formField';
+import type FormModel from 'sentry/components/forms/model';
 import {t} from 'sentry/locale';
 import type {ChallengeData} from 'sentry/types/auth';
 
 import {handleEnroll} from './handlers';
 
-interface WebAuthnParams {
-  challenge: string;
-  response: string;
-}
-
 interface WebAuthnEnrollProps {
   challengeData: ChallengeData;
-  /**
-   * Callback for when the webAuthn flow is completed.
-   */
-  onWebAuthn?: (result: WebAuthnParams) => void;
 }
 
 const UNSUPPORTED_NOTICE = t(
   'Your browser does not support WebAuthn (passkey). You need to use a different two-factor method or switch to a browser that supports it (Google Chrome or Microsoft Edge)'
 );
 
-export function WebAuthnEnroll({onWebAuthn, challengeData}: WebAuthnEnrollProps) {
+const FAILURE_MESSAGE = t('There was a problem enrolling, please try again.');
+
+export function WebAuthnEnroll({challengeData}: WebAuthnEnrollProps) {
   const isSupported = !!window.PublicKeyCredential;
   const challenge = JSON.stringify(challengeData);
 
   const [activated, setActivated] = useState(false);
-  const [failed, setFailed] = useState(false);
 
-  const triggerEnroll = useCallback(async () => {
-    setActivated(false);
-    setFailed(false);
-
-    try {
-      const webAuthnResponse = await handleEnroll(challengeData);
-
-      if (!webAuthnResponse) {
-        setFailed(true);
-        return;
-      }
-
-      setActivated(true);
-      onWebAuthn?.({response: webAuthnResponse, challenge});
-    } catch (err) {
-      setFailed(true);
+  const triggerEnroll = useCallback(
+    async (model: FormModel) => {
       setActivated(false);
-    }
-  }, [onWebAuthn, challenge, challengeData]);
+      model.setError('challenge', false);
+
+      try {
+        const webAuthnResponse = await handleEnroll(challengeData);
+
+        if (!webAuthnResponse) {
+          model.setError('challenge', FAILURE_MESSAGE);
+          return;
+        }
+
+        setActivated(true);
+        model.setValue('response', webAuthnResponse);
+        model.setValue('challenge', challenge);
+      } catch (err) {
+        model.setError('challenge', FAILURE_MESSAGE);
+        setActivated(false);
+      }
+    },
+    [challenge, challengeData]
+  );
 
   return (
-    <FieldGroup
+    <FormField
+      name="challenge"
       label={t('Enroll Device')}
+      help={t('Enroll your Passkey, Security Key, or Biometric authenticator.')}
+      required
       disabled={!isSupported}
       disabledReason={UNSUPPORTED_NOTICE}
       flexibleControlStateSize
-      error={failed && t('There was a problem enrolling, please try again.')}
     >
-      <EnrollButton onClick={triggerEnroll} disabled={!isSupported || activated}>
-        {t('Start Enrollment')}
-      </EnrollButton>
-    </FieldGroup>
+      {({model}) => (
+        <EnrollButton
+          onClick={() => triggerEnroll(model)}
+          disabled={!isSupported || activated}
+        >
+          {model.getValue('response') ? t('Enrolled!') : t('Start Enrollment')}
+        </EnrollButton>
+      )}
+    </FormField>
   );
 }
 


### PR DESCRIPTION
Right now the moment you click "start enrollment" on the webauthn add page, it will submit the form. A better flow is to enroll, and then fill out the name of the device. and THEN submit the form.

This changes the webAuthnEnroll component to render a FormField with a button to trigger the webauthn enrollment. This stores the response into the form model, so the form can be submitted as normal.