### PR TITLE
fix(ourlogs): Remove page filter container

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -38,18 +38,16 @@ export function OurlogsSection({
   project: Project;
 }) {
   return (
-    <PageFiltersContainer>
-      <LogsPageParamsProvider
-        analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-        isTableFrozen
-        blockRowExpanding
-        limitToTraceId={event.contexts?.trace?.trace_id}
-      >
-        <LogsPageDataProvider>
-          <OurlogsSectionContent event={event} group={group} project={project} />
-        </LogsPageDataProvider>
-      </LogsPageParamsProvider>
-    </PageFiltersContainer>
+    <LogsPageParamsProvider
+      analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
+      isTableFrozen
+      blockRowExpanding
+      limitToTraceId={event.contexts?.trace?.trace_id}
+    >
+      <LogsPageDataProvider>
+        <OurlogsSectionContent event={event} group={group} project={project} />
+      </LogsPageDataProvider>
+    </LogsPageParamsProvider>
   );
 }
 

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import {OurlogsDrawer} from 'sentry/components/events/ourlogs/ourlogsDrawer';
 import useDrawer from 'sentry/components/globalDrawer';
-import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -76,19 +75,17 @@ function OurlogsSectionContent({
     });
     openDrawer(
       () => (
-        <PageFiltersContainer>
-          <LogsPageParamsProvider
-            analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-            isTableFrozen
-            limitToTraceId={limitToTraceId}
-          >
-            <LogsPageDataProvider>
-              <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
-                <OurlogsDrawer group={group} event={event} project={project} />
-              </TraceItemAttributeProvider>
-            </LogsPageDataProvider>
-          </LogsPageParamsProvider>
-        </PageFiltersContainer>
+        <LogsPageParamsProvider
+          analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
+          isTableFrozen
+          limitToTraceId={limitToTraceId}
+        >
+          <LogsPageDataProvider>
+            <TraceItemAttributeProvider traceItemType={TraceItemDataset.LOGS} enabled>
+              <OurlogsDrawer group={group} event={event} project={project} />
+            </TraceItemAttributeProvider>
+          </LogsPageDataProvider>
+        </LogsPageParamsProvider>
       ),
       {
         ariaLabel: 'logs drawer',


### PR DESCRIPTION
### Summary
This is affecting other parts of the issues detail page; the page already has a container [here](https://github.com/getsentry/sentry/blob/master/static/app/views/issueDetails/groupDetails.tsx#L899-L903)

