### PR TITLE
ref(aci): add attribute/tag branching on condition subfilters

### DIFF
--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -1,3 +1,4 @@
+import {createContext, Fragment, useContext, useState} from 'react';
 import styled from '@emotion/styled';
 import {uuid4} from '@sentry/core';
 
@@ -9,8 +10,28 @@ import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextBu
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {MatchType} from 'sentry/views/automations/components/actionFilters/constants';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  Attributes,
+  MatchType,
+} from 'sentry/views/automations/components/actionFilters/constants';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+interface SubfilterProps {
+  onUpdate: (comparison: Record<string, any>) => void;
+  subfilter: Record<string, any>;
+  subfilter_id: string;
+}
+
+export const SubfilterContext = createContext<SubfilterProps | null>(null);
+
+export function useSubfilterContext(): SubfilterProps {
+  const context = useContext(SubfilterContext);
+  if (!context) {
+    throw new Error('useSubfilterContext was called outside of Subfilter');
+  }
+  return context;
+}
 
 export function SubfiltersList() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
@@ -54,14 +75,20 @@ export function SubfiltersList() {
       <div>
         {subfilters.map((subfilter: Record<string, any>, i: number) => {
           return (
-            <SubfilterRow
-              subfilter={subfilter}
-              subfilter_id={`${condition_id}.comparison.filters.${subfilter.id}`}
-              onRemove={() => removeSubfilter(subfilter.id)}
-              onUpdate={comparison => updateSubfilter(subfilter.id, comparison)}
+            <SubfilterContext.Provider
+              value={{
+                subfilter,
+                subfilter_id: `${condition_id}.comparison.filters.${subfilter.id}`,
+                onUpdate: comparison => updateSubfilter(subfilter.id, comparison),
+              }}
               key={subfilter.id}
-              isLastRow={i === subfilterCount - 1}
-            />
+            >
+              <SubfilterRow
+                onRemove={() => removeSubfilter(subfilter.id)}
+                isFirstRow={i === 0}
+                isLastRow={i === subfilterCount - 1}
+              />
+            </SubfilterContext.Provider>
           );
         })}
       </div>
@@ -73,62 +100,18 @@ export function SubfiltersList() {
 }
 
 interface SubfilterRowProps {
+  isFirstRow: boolean;
+  isLastRow: boolean;
   onRemove: () => void;
-  onUpdate: (comparison: Record<string, any>) => void;
-  subfilter: Record<string, any>;
-  subfilter_id: string;
-  isLastRow?: boolean;
 }
 
-function SubfilterRow({
-  subfilter,
-  subfilter_id,
-  onRemove,
-  onUpdate,
-  isLastRow,
-}: SubfilterRowProps) {
+function SubfilterRow({onRemove, isFirstRow, isLastRow}: SubfilterRowProps) {
   return (
     <RowWrapper>
       <Branch lastChild={isLastRow} />
       <StyledRowLine>
-        <AutomationBuilderInputField
-          name={`${subfilter_id}.key`}
-          placeholder={t('key')}
-          value={subfilter.key}
-          onChange={(value: string) => {
-            onUpdate({
-              key: value,
-            });
-          }}
-        />
-        <AutomationBuilderSelectField
-          name={`${subfilter_id}.match`}
-          value={subfilter.match}
-          options={[
-            {
-              label: 'is',
-              value: MatchType.EQUAL,
-            },
-            {
-              label: 'is not',
-              value: MatchType.NOT_EQUAL,
-            },
-          ]}
-          onChange={(value: MatchType) => {
-            onUpdate({match: value});
-          }}
-        />
-        <AutomationBuilderInputField
-          name={`${subfilter_id}.value`}
-          placeholder={t('value')}
-          value={`${subfilter.value}`}
-          onChange={(value: string) => {
-            onUpdate({
-              value,
-            });
-          }}
-        />
-        {!isLastRow && t('and')}
+        {!isFirstRow && t('and')}
+        <ComparisonTypeField />
         <Button
           aria-label={t('Delete Subfilter')}
           size="sm"
@@ -138,6 +121,137 @@ function SubfilterRow({
         />
       </StyledRowLine>
     </RowWrapper>
+  );
+}
+
+interface BranchProps {
+  lastChild?: boolean;
+}
+
+function Branch({lastChild}: BranchProps) {
+  return (
+    <svg
+      width="26"
+      height="38"
+      viewBox="0 0 26 38"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <line x1="0.5" x2="0.5" y2={lastChild ? '19' : '38'} stroke="#80708F" />
+      <circle cx="23.5" cy="18.5" r="2.5" fill="#80708F" />
+      <line x1="22" y1="18.5" x2="1" y2="18.5" stroke="#80708F" />
+    </svg>
+  );
+}
+
+function ComparisonTypeField() {
+  const {subfilter, subfilter_id} = useSubfilterContext();
+  const [type, setType] = useState<DataConditionType | undefined>(undefined);
+
+  if (!type) {
+    return (
+      <AutomationBuilderSelectField
+        name={`${subfilter_id}.comparison_type`}
+        value={subfilter.comparison_type}
+        placeholder={t('Select value type')}
+        options={[
+          {
+            label: t('Attribute'),
+            value: DataConditionType.EVENT_ATTRIBUTE,
+          },
+          {
+            label: t('Tag'),
+            value: DataConditionType.TAGGED_EVENT,
+          },
+        ]}
+        onChange={(value: DataConditionType) => {
+          setType(value);
+        }}
+      />
+    );
+  }
+
+  return (
+    <Fragment>
+      {type === DataConditionType.EVENT_ATTRIBUTE ? <AttributeField /> : <KeyField />}
+      <MatchField />
+      <ValueField />
+    </Fragment>
+  );
+}
+
+function AttributeField() {
+  const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
+  return (
+    <AutomationBuilderSelectField
+      name={`${subfilter_id}.attribute`}
+      placeholder={t('Select attribute')}
+      value={subfilter.attribute}
+      options={Object.values(Attributes).map(attribute => ({
+        value: attribute,
+        label: attribute,
+      }))}
+      onChange={(value: string) => {
+        onUpdate({
+          attribute: value,
+        });
+      }}
+    />
+  );
+}
+
+function KeyField() {
+  const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
+  return (
+    <AutomationBuilderInputField
+      name={`${subfilter_id}.key`}
+      placeholder={t('Enter tag')}
+      value={subfilter.key}
+      onChange={(value: string) => {
+        onUpdate({
+          key: value,
+        });
+      }}
+    />
+  );
+}
+
+function MatchField() {
+  const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
+  return (
+    <AutomationBuilderSelectField
+      name={`${subfilter_id}.match`}
+      value={subfilter.match}
+      options={[
+        {
+          label: 'is',
+          value: MatchType.EQUAL,
+        },
+        {
+          label: 'is not',
+          value: MatchType.NOT_EQUAL,
+        },
+      ]}
+      onChange={(value: MatchType) => {
+        onUpdate({match: value});
+      }}
+    />
+  );
+}
+
+function ValueField() {
+  const {subfilter, subfilter_id, onUpdate} = useSubfilterContext();
+  return (
+    <AutomationBuilderInputField
+      name={`${subfilter_id}.value`}
+      placeholder={t('value')}
+      value={`${subfilter.value}`}
+      onChange={(value: string) => {
+        onUpdate({
+          value,
+        });
+      }}
+    />
   );
 }
 
@@ -164,23 +278,3 @@ const StyledRowLine = styled(RowLine)`
     }
   }
 `;
-
-interface BranchProps {
-  lastChild?: boolean;
-}
-
-function Branch({lastChild}: BranchProps) {
-  return (
-    <svg
-      width="26"
-      height="38"
-      viewBox="0 0 26 38"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <line x1="0.5" x2="0.5" y2={lastChild ? '19' : '38'} stroke="#80708F" />
-      <circle cx="23.5" cy="18.5" r="2.5" fill="#80708F" />
-      <line x1="22" y1="18.5" x2="1" y2="18.5" stroke="#80708F" />
-    </svg>
-  );
-}

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -23,9 +23,9 @@ interface SubfilterProps {
   subfilter_id: string;
 }
 
-export const SubfilterContext = createContext<SubfilterProps | null>(null);
+const SubfilterContext = createContext<SubfilterProps | null>(null);
 
-export function useSubfilterContext(): SubfilterProps {
+function useSubfilterContext(): SubfilterProps {
   const context = useContext(SubfilterContext);
   if (!context) {
     throw new Error('useSubfilterContext was called outside of Subfilter');


### PR DESCRIPTION
added a dropdown to select attribute or tag

https://github.com/user-attachments/assets/766518cc-5914-4ae2-b24d-4865857526a6

also split each field into it's own component for readability and added a subfilter context to avoid passing `subfilter`, `subfilter_id`, and `onUpdate` to every child