### PR TITLE
fix(alerts): Should only load trace items from selected projects

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -189,22 +189,12 @@ function IndexedSpanSearchQueryBuilder({
   return <SearchQueryBuilder {...searchQueryBuilderProps} />;
 }
 
-function EapSpanSearchQueryBuilder({
-  initialQuery,
-  searchSource,
-  datetime,
-  onSearch,
-  onBlur,
-}: SpanSearchQueryBuilderProps) {
+function EapSpanSearchQueryBuilder(props: SpanSearchQueryBuilderProps) {
   const {tags: numberTags} = useSpanTags('number');
   const {tags: stringTags} = useSpanTags('string');
 
   const eapSearchQueryBuilderProps = useEAPSpanSearchQueryBuilderProps({
-    initialQuery,
-    searchSource,
-    datetime,
-    onSearch,
-    onBlur,
+    ...props,
     numberTags,
     stringTags,
   });

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -522,6 +522,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
         ) : (
           <Fragment>
             <SpanTagsProvider
+              projects={[project]}
               dataset={DiscoverDatasets.SPANS_EAP}
               enabled={
                 organization.features.includes('visibility-explore-view') &&

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 
+import type {Project} from 'sentry/types/project';
 import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   TraceItemAttributeProvider,
@@ -11,11 +12,16 @@ interface SpanTagsProviderProps {
   children: React.ReactNode;
   dataset: DiscoverDatasets;
   enabled: boolean;
+  projects?: Project[];
 }
 
-export function SpanTagsProvider({children, enabled}: SpanTagsProviderProps) {
+export function SpanTagsProvider({children, enabled, projects}: SpanTagsProviderProps) {
   return (
-    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled={enabled}>
+    <TraceItemAttributeProvider
+      traceItemType={TraceItemDataset.SPANS}
+      enabled={enabled}
+      projects={projects}
+    >
       {children}
     </TraceItemAttributeProvider>
   );

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import {createContext, useContext, useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
 import {FieldKind} from 'sentry/utils/fields';
 import {
   SENTRY_LOG_NUMBER_TAGS,
@@ -30,18 +31,21 @@ interface TraceItemAttributeProviderProps {
   children: React.ReactNode;
   enabled: boolean;
   traceItemType: TraceItemDataset;
+  projects?: Project[];
 }
 
 export function TraceItemAttributeProvider({
   children,
   traceItemType,
   enabled,
+  projects,
 }: TraceItemAttributeProviderProps) {
   const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
     useTraceItemAttributeKeys({
       enabled,
       type: 'number',
       traceItemType,
+      projects,
     });
 
   const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
@@ -49,6 +53,7 @@ export function TraceItemAttributeProvider({
       enabled,
       type: 'string',
       traceItemType,
+      projects,
     });
 
   const allNumberAttributes = useMemo(() => {

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -2,6 +2,8 @@ import {useMemo} from 'react';
 
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {Tag, TagCollection} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+import {defined} from 'sentry/utils';
 import {FieldKind} from 'sentry/utils/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -18,6 +20,10 @@ export interface UseTraceItemAttributeBaseProps {
    * The attribute type supported by the endpoint, currently only supports string and number.
    */
   type: 'number' | 'string';
+  /**
+   * Optional list of projects to search. If not provided, it'll use the page filters.
+   */
+  projects?: Project[];
 }
 
 interface UseTraceItemAttributeKeysProps extends UseTraceItemAttributeBaseProps {
@@ -28,6 +34,7 @@ export function useTraceItemAttributeKeys({
   enabled,
   type,
   traceItemType,
+  projects,
 }: UseTraceItemAttributeKeysProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -35,7 +42,9 @@ export function useTraceItemAttributeKeys({
   const path = `/organizations/${organization.slug}/trace-items/attributes/`;
   const endpointOptions = {
     query: {
-      project: selection.projects,
+      project: defined(projects)
+        ? projects.map(project => project.id)
+        : selection.projects,
       environment: selection.environments,
       ...normalizeDateTimeParams(selection.datetime),
       itemType: traceItemType,

--- a/static/app/views/insights/pages/transactionNameSearchBar.tsx
+++ b/static/app/views/insights/pages/transactionNameSearchBar.tsx
@@ -56,7 +56,6 @@ export function TransactionNameSearchBar(props: SearchBarProps) {
     attributeKey: 'transaction',
     enabled: true,
     type: 'string',
-    projectIds: projectIds.map(id => parseInt(id, 10)),
   });
 
   const handleSearchChange = (query: any) => {


### PR DESCRIPTION
Alerts don't set the page filters with the right projects so we have to explicitly pass the current project.