### PR TITLE
ref(insights): pass in search to cache module charts

### DIFF
--- a/static/app/views/insights/cache/components/charts/hitMissChart.tsx
+++ b/static/app/views/insights/cache/components/charts/hitMissChart.tsx
@@ -1,23 +1,40 @@
 // TODO(release-drawer): Only used in cache/components/samplePanel
+
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {Referrer} from 'sentry/views/insights/cache/referrers';
+// TODO(release-drawer): Only used in cache/components/samplePanel
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
-import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
+import {SpanFunction} from 'sentry/views/insights/types';
 
 type Props = {
-  isLoading: boolean;
-  series: DiscoverSeries;
-  error?: Error | null;
+  search: MutableSearch;
 };
 
-export function CacheHitMissChart({series, isLoading, error}: Props) {
+export function CacheHitMissChart({search}: Props) {
+  const {
+    data,
+    isPending: isCacheHitRateLoading,
+    error,
+  } = useSpanMetricsSeries(
+    {
+      search,
+      yAxis: [`${SpanFunction.CACHE_MISS_RATE}()`],
+      transformAliasToInputFormat: true,
+    },
+    Referrer.SAMPLES_CACHE_HIT_MISS_CHART
+  );
+
   return (
     <InsightsLineChartWidget
+      search={search}
       title={DataTitles[`cache_miss_rate()`]}
-      series={[series]}
+      series={[data[`cache_miss_rate()`]]}
       showLegend="never"
-      isLoading={isLoading}
-      error={error ?? null}
+      isLoading={isCacheHitRateLoading}
+      error={error}
     />
   );
 }

--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -13,12 +13,8 @@ import {
   useMetricsSeries,
 } from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
-import type {
-  MetricsFields,
-  SearchHook,
-  SpanFields,
-  type SpanQueryFilters,
-} from 'sentry/views/insights/types';
+import type {SearchHook, SpanQueryFilters} from 'sentry/views/insights/types';
+import {MetricsFields, SpanFields} from 'sentry/views/insights/types';
 
 type Props = {
   samples: Samples;

--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -13,8 +13,9 @@ import {
   useMetricsSeries,
 } from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
-import {
+import type {
   MetricsFields,
+  SearchHook,
   SpanFields,
   type SpanQueryFilters,
 } from 'sentry/views/insights/types';
@@ -31,9 +32,9 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
     },
   });
 
-  const {search, enabled} = useTransactionDurationSearch({transaction});
+  const {search} = useTransactionDurationSearch({transaction});
 
-  const {data, isPending, error} = useTransactionDurationSeries({search, enabled});
+  const {data, isPending, error} = useTransactionDurationSeries({search});
 
   return (
     <InsightsLineChartWidget
@@ -48,7 +49,11 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
   );
 }
 
-const useTransactionDurationSearch = ({transaction}: {transaction: string}) => {
+const useTransactionDurationSearch = ({
+  transaction,
+}: {
+  transaction: string;
+}): SearchHook => {
   const useEap = useInsightsEap();
   const search = useEap
     ? MutableSearch.fromQueryObject({
@@ -57,16 +62,10 @@ const useTransactionDurationSearch = ({transaction}: {transaction: string}) => {
       } satisfies SpanQueryFilters)
     : MutableSearch.fromQueryObject({transaction} satisfies SpanQueryFilters);
 
-  return {search, enabled: true};
+  return {search};
 };
 
-const useTransactionDurationSeries = ({
-  search,
-  enabled,
-}: {
-  enabled: boolean;
-  search: MutableSearch;
-}) => {
+const useTransactionDurationSeries = ({search}: {search: MutableSearch}) => {
   const useEap = useInsightsEap();
 
   const metricsResult = useMetricsSeries(
@@ -74,7 +73,7 @@ const useTransactionDurationSeries = ({
       yAxis: [`avg(${MetricsFields.TRANSACTION_DURATION})`],
       search,
       transformAliasToInputFormat: true,
-      enabled: !useEap && enabled,
+      enabled: !useEap,
     },
     Referrer.SAMPLES_CACHE_TRANSACTION_DURATION_CHART
   );
@@ -83,7 +82,7 @@ const useTransactionDurationSeries = ({
     {
       search,
       yAxis: [`avg(${SpanFields.SPAN_DURATION})`],
-      enabled: useEap && enabled,
+      enabled: useEap,
     },
     Referrer.SAMPLES_CACHE_TRANSACTION_DURATION
   );

--- a/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
@@ -10,10 +10,11 @@ import {SpanFunction} from 'sentry/views/insights/types';
 const {CACHE_MISS_RATE} = SpanFunction;
 
 export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps) {
+  const search = MutableSearch.fromQueryObject(BASE_FILTERS);
   const {isPending, data, error} = useSpanMetricsSeries(
     {
       yAxis: [`${CACHE_MISS_RATE}()`],
-      search: MutableSearch.fromQueryObject(BASE_FILTERS),
+      search,
       transformAliasToInputFormat: true,
     },
     Referrer.LANDING_CACHE_HIT_MISS_CHART,
@@ -23,6 +24,7 @@ export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps
   return (
     <InsightsLineChartWidget
       {...props}
+      search={search}
       id="cacheMissRateChartWidget"
       title={DataTitles[`${CACHE_MISS_RATE}()`]}
       series={[data[`${CACHE_MISS_RATE}()`]]}

--- a/static/app/views/insights/common/components/widgets/cacheThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheThroughputChartWidget.tsx
@@ -7,9 +7,10 @@ import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDisc
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 
 export default function CacheThroughputChartWidget(props: LoadableChartWidgetProps) {
+  const search = MutableSearch.fromQueryObject(BASE_FILTERS);
   const {isPending, data, error} = useSpanMetricsSeries(
     {
-      search: MutableSearch.fromQueryObject(BASE_FILTERS),
+      search,
       yAxis: ['epm()'],
       transformAliasToInputFormat: true,
     },
@@ -20,6 +21,7 @@ export default function CacheThroughputChartWidget(props: LoadableChartWidgetPro
   return (
     <InsightsLineChartWidget
       {...props}
+      search={search}
       id="cacheThroughputChartWidget"
       title={getThroughputChartTitle('cache.get_item')}
       series={[data['epm()']]}

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -1,4 +1,5 @@
 import type {PlatformKey} from 'sentry/types/project';
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/constants';
 
 export enum ModuleName {
@@ -731,3 +732,5 @@ export const subregionCodeToName = {
 };
 
 export type SubregionCode = keyof typeof subregionCodeToName;
+
+export type SearchHook = {search: MutableSearch; enabled?: boolean};


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/92337 but for cache