### PR TITLE
releases: fix button overflow

### DIFF
--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -272,7 +272,5 @@ const CrashFreeWrapper = styled('div')`
 `;
 
 const ViewColumn = styled('div')`
-  ${p => p.theme.overflowEllipsis};
-  line-height: 20px;
   text-align: right;
 `;


### PR DESCRIPTION
This column only ever contains a single button with `View` text, meaning we can remove the overflow: hidden rule entirely.

```
<ViewColumn>
    <GuideAnchor disabled={!isTopRelease || index !== 0} target="view_release">
      <LinkButton ...>
        {t('View')}
      </LinkButton>
    </GuideAnchor>
  </ViewColumn>
```

![CleanShot 2025-05-27 at 15 23 14@2x](https://github.com/user-attachments/assets/0a7c37a1-fe20-442b-8599-6d6f7f2168de)
