### PR TITLE
fix(dashboards): Only prompt for unsaved changes if in editing mode

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -433,7 +433,11 @@ class DashboardDetail extends Component<Props, State> {
   handleBeforeUnload = (event: BeforeUnloadEvent) => {
     const {dashboard} = this.props;
     const {modifiedDashboard} = this.state;
-    if (defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard)) {
+    if (
+      defined(modifiedDashboard) &&
+      !isEqual(modifiedDashboard, dashboard) &&
+      this.isEditingDashboard
+    ) {
       event.preventDefault();
       event.returnValue = '';
     }

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1133,7 +1133,9 @@ class DashboardDetail extends Component<Props, State> {
               (checkDashboardRoute(locationChange.currentLocation.pathname) &&
                 checkDashboardRoute(locationChange.nextLocation.pathname));
             const hasUnsavedChanges =
-              defined(modifiedDashboard) && !isEqual(modifiedDashboard, dashboard);
+              defined(modifiedDashboard) &&
+              !isEqual(modifiedDashboard, dashboard) &&
+              this.isEditingDashboard;
             return (
               locationChange.currentLocation.pathname !==
                 locationChange.nextLocation.pathname &&


### PR DESCRIPTION
I was able to get into some states where navigating away after some updates triggered a prompt. The prompt shouldn't appear outside of the edit state