### PR TITLE
fix(explore): Reset argument when switching away from epm

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -169,7 +169,11 @@ export function updateVisualizeAggregate({
   }
 
   // switching away from count_unique means we need to reset the field
-  if (oldAggregate === AggregationKey.COUNT_UNIQUE) {
+  if (
+    oldAggregate === AggregationKey.COUNT_UNIQUE ||
+    oldAggregate === AggregationKey.EPM ||
+    oldAggregate === AggregationKey.EPS
+  ) {
     return `${newAggregate}(${DEFAULT_VISUALIZATION_FIELD})`;
   }
 

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -172,6 +172,12 @@ describe('ExploreToolbar', function () {
     await userEvent.click(within(section).getByRole('option', {name: 'epm'}));
 
     expect(visualizes).toEqual([new Visualize(['epm()'], {label: 'A'})]);
+
+    // try changing the aggregate
+    await userEvent.click(within(section).getByRole('button', {name: 'epm'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+
+    expect(visualizes).toEqual([new Visualize(['avg(span.duration)'], {label: 'A'})]);
   });
 
   it('defaults count_unique argument to span.op', async function () {


### PR DESCRIPTION
When switching away from epm, where there is no argument, make sure we reset the argument.