### PR TITLE
feat(seer): Enable Seer on perf issues

### DIFF
--- a/static/app/utils/issueTypeConfig/dbQueryConfig.tsx
+++ b/static/app/utils/issueTypeConfig/dbQueryConfig.tsx
@@ -35,7 +35,7 @@ const dbQueryConfig: IssueCategoryConfigMapping = {
       replays: {enabled: true},
       tagsTab: {enabled: true},
     },
-    autofix: false,
+    autofix: true,
     mergedIssues: {enabled: false},
     similarIssues: {enabled: false},
     stacktrace: {enabled: false},
@@ -43,7 +43,7 @@ const dbQueryConfig: IssueCategoryConfigMapping = {
     // Performance issues render a custom SpanEvidence component
     evidence: null,
     usesIssuePlatform: true,
-    issueSummary: {enabled: false},
+    issueSummary: {enabled: true},
   },
   [IssueType.PERFORMANCE_CONSECUTIVE_DB_QUERIES]: {
     resources: {

--- a/static/app/utils/issueTypeConfig/frontendConfig.tsx
+++ b/static/app/utils/issueTypeConfig/frontendConfig.tsx
@@ -58,6 +58,8 @@ const frontendConfig: IssueCategoryConfigMapping = {
       links: [],
       linksByPlatform: {},
     },
+    issueSummary: {enabled: true},
+    autofix: true,
   },
   [IssueType.PERFORMANCE_RENDER_BLOCKING_ASSET]: {
     spanEvidence: {enabled: true},
@@ -74,6 +76,8 @@ const frontendConfig: IssueCategoryConfigMapping = {
       ],
       linksByPlatform: {},
     },
+    issueSummary: {enabled: true},
+    autofix: true,
   },
 };
 

--- a/static/app/utils/issueTypeConfig/httpClientConfig.tsx
+++ b/static/app/utils/issueTypeConfig/httpClientConfig.tsx
@@ -35,7 +35,7 @@ const httpClientConfig: IssueCategoryConfigMapping = {
       replays: {enabled: true},
       tagsTab: {enabled: true},
     },
-    autofix: false,
+    autofix: true,
     mergedIssues: {enabled: false},
     similarIssues: {enabled: false},
     stacktrace: {enabled: false},
@@ -43,7 +43,7 @@ const httpClientConfig: IssueCategoryConfigMapping = {
     // Performance issues render a custom SpanEvidence component
     evidence: null,
     usesIssuePlatform: true,
-    issueSummary: {enabled: false},
+    issueSummary: {enabled: true},
   },
   [IssueType.PERFORMANCE_CONSECUTIVE_HTTP]: {
     resources: {

--- a/static/app/utils/issueTypeConfig/mobileConfig.tsx
+++ b/static/app/utils/issueTypeConfig/mobileConfig.tsx
@@ -35,7 +35,7 @@ const mobileConfig: IssueCategoryConfigMapping = {
       replays: {enabled: true},
       tagsTab: {enabled: true},
     },
-    autofix: false,
+    autofix: true,
     mergedIssues: {enabled: false},
     similarIssues: {enabled: false},
     stacktrace: {enabled: false},
@@ -43,7 +43,7 @@ const mobileConfig: IssueCategoryConfigMapping = {
     // Should render a custom SpanEvidence component
     evidence: null,
     usesIssuePlatform: true,
-    issueSummary: {enabled: false},
+    issueSummary: {enabled: true},
   },
   [IssueType.PERFORMANCE_FILE_IO_MAIN_THREAD]: {
     resources: {


### PR DESCRIPTION
Enables Issue Summary and Autofix on performance issues. Tested locally that the backend correctly reads the span evidence.

Excludes rage clicks, metric alerts, endpoint/function regressions, and user feedback

<img width="1215" alt="Screenshot 2025-05-27 at 2 12 28 PM" src="https://github.com/user-attachments/assets/f6049559-b993-4103-84e7-a1317f83edec" />
