### PR TITLE
:wrench: chore(vsts): mark user config and api unauthorized errors as halts

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -15,7 +15,12 @@ from sentry.integrations.mixins.issues import IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.activity import Activity
-from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiUnauthorized,
+    IntegrationError,
+    IntegrationFormError,
+)
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
 from sentry.users.models.user import User
@@ -33,6 +38,10 @@ VSTS_IDENTITY_DELETED_ERROR_SUBSTRING = [
 ]
 
 VSTS_ISSUE_TITLE_MAX_LENGTH = 128
+
+# Represents error codes caused by misconfiguration when creating a ticket
+# Example: Error Communicating with Azure DevOps (HTTP 400): TF401320: Rule Error for field xxx. Error code: Required, HasValues, LimitedToValues, AllowsOldValue, InvalidEmpty.
+VSTS_INTEGRATION_FORM_ERROR_CODES_SUBSTRINGS = ["TF401320"]
 
 
 class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
@@ -61,6 +70,17 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
             substring in str(exc) for substring in VSTS_IDENTITY_DELETED_ERROR_SUBSTRING
         ):
             raise ApiUnauthorized(text=str(exc))
+        elif isinstance(exc, ApiError) and any(
+            substring in str(exc) for substring in VSTS_INTEGRATION_FORM_ERROR_CODES_SUBSTRINGS
+        ):
+            # Parse the field name from the error message
+            # Example: TF401320: Rule Error for field Empowered Team. Error code: Required, HasValues, LimitedToValues, AllowsOldValue, InvalidEmpty.
+            try:
+                field_name = str(exc).split("Error for field ")[1].split(".")[0]
+                raise IntegrationFormError(field_errors={field_name: f"{field_name} is required."})
+            except IndexError:
+                # raise a generic error on the `project` field
+                raise IntegrationFormError()
         raise super().raise_error(exc, identity)
 
     def get_project_choices(

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -79,7 +79,6 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
                 field_name = str(exc).split("Error for field ")[1].split(".")[0]
                 raise IntegrationFormError(field_errors={field_name: f"{field_name} is required."})
             except IndexError:
-                # raise a generic error on the `project` field
                 raise IntegrationFormError()
         raise super().raise_error(exc, identity)
 

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -21,6 +21,7 @@ from sentry.integrations.services.integration.service import integration_service
 from sentry.models.grouplink import GroupLink
 from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.shared_integrations.exceptions import (
+    ApiUnauthorized,
     IntegrationFormError,
     IntegrationInstallationConfigurationError,
 )
@@ -179,6 +180,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 IntegrationInstallationConfigurationError,
                 IntegrationFormError,
                 InvalidIdentity,
+                ApiUnauthorized,
             ) as e:
                 # Most of the time, these aren't explicit failures, they're
                 # some misconfiguration of an issue field - typically Jira.

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -189,7 +189,7 @@ class DuplicateDisplayNameError(IntegrationError):
 
 
 class IntegrationFormError(IntegrationError):
-    def __init__(self, field_errors: Mapping[str, Any]) -> None:
+    def __init__(self, field_errors: Mapping[str, Any] | None = None) -> None:
         error = "Invalid integration action"
         if field_errors:
             error = str(field_errors)


### PR DESCRIPTION
`Error Communicating with Azure DevOps (HTTP 400): TF401320: Rule Error for field xxx. Error code: Required, HasValues, LimitedToValues, AllowsOldValue, InvalidEmpty.` means the user has misconfigured the ticket form during creation, so marking this as a halt

fixes RTC-914