### PR TITLE
fix(releases): Fix missing chartRef w/ `ChartWidgetLoader`

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -1,5 +1,6 @@
 import {captureException} from '@sentry/core';
 import {useQuery} from '@tanstack/react-query';
+import type {EChartsInstance} from 'echarts-for-react';
 
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -12,6 +13,8 @@ interface Props extends LoadableChartWidgetProps {
    * ID of the Chart
    */
   id: ChartId;
+
+  ref?: React.Ref<EChartsInstance>;
 }
 // We need to map the widget id to the dynamic import because we want the import paths to be statically analyzable.
 const CHART_MAP = {
@@ -229,5 +232,5 @@ export function ChartWidgetLoader(props: Props) {
     return <Placeholder height="100%" error={t('Error loading widget')} />;
   }
 
-  return <Component {...props} />;
+  return <Component {...props} chartRef={props.ref} />;
 }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -8,6 +8,7 @@ import type {
   TooltipFormatterCallback,
   TopLevelFormatterParams,
 } from 'echarts/types/dist/shared';
+import type {EChartsInstance} from 'echarts-for-react';
 import type EChartsReactCore from 'echarts-for-react/lib/core';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
@@ -77,9 +78,14 @@ export interface TimeSeriesWidgetVisualizationProps
    */
   axisRange?: 'auto' | 'dataMin';
   /**
+   * Reference to the chart instance
+   */
+  chartRef?: React.Ref<EChartsInstance>;
+  /**
    * A mapping of time series field name to boolean. If the value is `false`, the series is hidden from view
    */
   legendSelection?: LegendSelection;
+
   /**
    * Callback that returns an updated `LegendSelection` after a user manipulations the selection via the legend
    */
@@ -603,7 +609,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   return (
     <BaseChart
-      ref={mergeRefs(props.ref, chartRef, handleChartRef)}
+      ref={mergeRefs(props.ref, props.chartRef, chartRef, handleChartRef)}
       autoHeightResize
       series={allSeries}
       grid={{

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -165,6 +165,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
         Title={Title}
         Visualization={
           <TimeSeriesWidgetVisualization
+            chartRef={props.chartRef}
             id={props.id}
             pageFilters={props.pageFilters}
             {...enableReleaseBubblesProps}

--- a/static/app/views/insights/common/components/widgets/types.tsx
+++ b/static/app/views/insights/common/components/widgets/types.tsx
@@ -1,3 +1,5 @@
+import type {EChartsInstance} from 'echarts-for-react';
+
 import type {PageFilters} from 'sentry/types/core';
 import type {EChartDataZoomHandler} from 'sentry/types/echarts';
 
@@ -6,6 +8,11 @@ import type {EChartDataZoomHandler} from 'sentry/types/echarts';
  * render an Insight Chart Widget
  */
 export interface LoadableChartWidgetProps {
+  /**
+   * Reference to the chart instance
+   */
+  chartRef?: React.Ref<EChartsInstance>;
+
   /**
    * Chart height, needed to ensure that the chart height is consistent with
    * the loading placeholder height

--- a/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type {EChartsInstance} from 'echarts-for-react';
 
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -11,7 +12,10 @@ import {EventGraph} from 'sentry/views/issueDetails/streamline/eventGraph';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
-export default function EventGraphWidget({pageFilters}: LoadableChartWidgetProps) {
+export default function EventGraphWidget({
+  pageFilters,
+  chartRef,
+}: LoadableChartWidgetProps) {
   const {groupId} = useParams();
 
   const {data: groupData, isPending, isError} = useGroup({groupId: groupId!});
@@ -32,15 +36,23 @@ export default function EventGraphWidget({pageFilters}: LoadableChartWidgetProps
     );
   }
 
-  return <EventGraphLoadedWidget group={groupData} pageFilters={pageFilters} />;
+  return (
+    <EventGraphLoadedWidget
+      chartRef={chartRef}
+      group={groupData}
+      pageFilters={pageFilters}
+    />
+  );
 }
 
 function EventGraphLoadedWidget({
   group,
   pageFilters,
+  chartRef,
 }: {
   group: Group;
   pageFilters: PageFilters | undefined;
+  chartRef?: React.Ref<EChartsInstance>;
 }) {
   const eventView = useIssueDetailsEventView({
     group,
@@ -54,6 +66,7 @@ function EventGraphLoadedWidget({
       Visualization={
         <EventGraph
           event={undefined}
+          ref={chartRef}
           eventView={eventView}
           group={group}
           showSummary={false}

--- a/static/app/views/releases/drawer/releasesDrawerList.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerList.tsx
@@ -168,6 +168,7 @@ export function ReleasesDrawerList({chart, pageFilters}: ReleasesDrawerListProps
         {chart ? (
           <div style={{height: chartHeight}}>
             <ChartWidgetLoader
+              ref={chartRef}
               id={chart}
               height={chartHeight}
               pageFilters={pageFilters}


### PR DESCRIPTION
This fixes the releases drawer list not having a ref to the chart that is loaded via `<ChartWidgetLoader>` - we add a `chartRef` prop to the affected components that forwards ref to the underlying echarts component.
