### PR TITLE
:wrench: chore(integrations): make api unauthorized errors as halts

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -18,7 +18,12 @@ from sentry.integrations.source_code_management.metrics import (
 )
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiError, ApiRetryError, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiRetryError,
+    ApiUnauthorized,
+    IntegrationError,
+)
 from sentry.users.models.identity import Identity
 
 
@@ -144,6 +149,10 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                     return None
                 else:
                     raise
+            except ApiUnauthorized as e:
+                lifecycle.record_halt(e)
+                return None
+
             except ApiError as e:
                 if e.code in (404, 400):
                     lifecycle.record_halt(e)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import orjson
-import pytest
 import responses
 from django.core.cache import cache
 from django.test import override_settings
@@ -21,7 +20,6 @@ from sentry.integrations.source_code_management.commit_context import (
     SourceLineInfo,
 )
 from sentry.models.repository import Repository
-from sentry.shared_integrations.exceptions import ApiUnauthorized
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegrationTestCase
@@ -323,9 +321,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             json={},
         )
 
-        with pytest.raises(ApiUnauthorized) as excinfo:
-            installation.get_stacktrace_link(repo, "README.md", ref, version)
-        assert excinfo.value.code == 401
+        assert installation.get_stacktrace_link(repo, "README.md", ref, version) is None
 
     @responses.activate
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")


### PR DESCRIPTION
We should mark `ApiUnauthorized` errors as halts

fixes RTC-917