### PR TITLE
perf(aci): Narrow locking in Rule creation dual write

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -1,16 +1,20 @@
 import logging
 from typing import Any
 
+from django.db import router, transaction
 from rest_framework import status
 
 from sentry.api.exceptions import SentryAPIException
 from sentry.constants import ObjectStatus
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.locks import locks
+from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
 from sentry.rules.conditions.every_event import EveryEventCondition
 from sentry.rules.processing.processor import split_conditions_and_filters
+from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     create_event_unique_user_frequency_condition_with_conditions,
     translate_to_data_condition,
@@ -43,6 +47,46 @@ class UnableToAcquireLockApiError(SentryAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
     code = "unable_to_acquire_lock"
     message = "Unable to acquire lock for issue alert migration."
+
+
+def ensure_default_error_detector(project: Project) -> Detector:
+    """
+    Ensure that the default error detector exists for a project.
+    If the Detector doesn't already exist, we try to acquire a lock to avoid double-creating,
+    and UnableToAcquireLockApiError if that fails.
+    """
+    # If it already exists, life is simple and we can return immediately.
+    # If there happen to be duplicates, we prefer the oldest.
+    existing = (
+        Detector.objects.filter(type=ErrorGroupType.slug, project=project).order_by("id").first()
+    )
+    if existing:
+        return existing
+
+    # If we may need to create it, we acquire a lock to avoid double-creating.
+    # There isn't a unique constraint on the detector, so we can't rely on get_or_create
+    # to avoid duplicates.
+    # However, by only locking during the one-time creation, the window for a race condition is small.
+    lock = locks.get(
+        f"workflow-engine-project-error-detector:{project.id}",
+        duration=2,
+        name="workflow_engine_default_error_detector",
+    )
+    try:
+        with (
+            # Creation should be fast, so it's worth blocking a little rather
+            # than failing a request.
+            lock.blocking_acquire(initial_delay=0.1, timeout=3),
+            transaction.atomic(router.db_for_write(Detector)),
+        ):
+            detector, _ = Detector.objects.get_or_create(
+                type=ErrorGroupType.slug,
+                project=project,
+                defaults={"config": {}, "name": "Error Detector"},
+            )
+            return detector
+    except UnableToAcquireLock:
+        raise UnableToAcquireLockApiError
 
 
 class IssueAlertMigrator:


### PR DESCRIPTION
Lock only when creating the default error Detector rather than across all of rule creation.
We added the lock to avoid duplicate Detector creation from concurrent requests, but this had the side-effect of only allowing one rule to be created at a time per project, which is a problem for customers that do large-scale batch rule creation regularly.
This narrows the lock retention to only when the Detector is being created, which should be very fast, and once per project, which should make any contention issues hard to hit and temporary.

This change is an extension of the work done in aa1ac8482978c7041fb79d9942cbc0963c6779c5 and 3d18ac5a6823fed435b3811e49e377a5ba8d0f96.