### PR TITLE
ref(uptime): Remove project_subscription_id from fingerprint

### DIFF
--- a/src/sentry/uptime/issue_platform.py
+++ b/src/sentry/uptime/issue_platform.py
@@ -10,14 +10,13 @@ from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.models import ProjectUptimeSubscription, get_project_subscription
+from sentry.uptime.models import get_project_subscription, get_uptime_subscription
 from sentry.workflow_engine.models.detector import Detector
 
 
 def create_issue_platform_occurrence(result: CheckResult, detector: Detector):
-    project_subscription = get_project_subscription(detector)
-    occurrence = build_occurrence_from_result(result, detector, project_subscription)
-    event_data = build_event_data_for_occurrence(result, project_subscription, occurrence)
+    occurrence = build_occurrence_from_result(result, detector)
+    event_data = build_event_data_for_occurrence(result, detector, occurrence)
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE,
         occurrence=occurrence,
@@ -29,16 +28,12 @@ def build_detector_fingerprint_component(detector: Detector) -> str:
     return f"uptime-detector:{detector.id}"
 
 
-def build_fingerprint_for_project_subscription(
-    detector: Detector,
-    project_subscription: ProjectUptimeSubscription,
-) -> list[str]:
-    return [build_detector_fingerprint_component(detector), str(project_subscription.id)]
+def build_fingerprint(detector: Detector) -> list[str]:
+    return [build_detector_fingerprint_component(detector)]
 
 
-def build_occurrence_from_result(
-    result: CheckResult, detector: Detector, project_subscription: ProjectUptimeSubscription
-) -> IssueOccurrence:
+def build_occurrence_from_result(result: CheckResult, detector: Detector) -> IssueOccurrence:
+    uptime_subscription = get_uptime_subscription(detector)
     status_reason = result["status_reason"]
     assert status_reason
     failure_reason = f'{status_reason["type"]} - {status_reason["description"]}'
@@ -74,30 +69,32 @@ def build_occurrence_from_result(
     return IssueOccurrence(
         id=uuid.uuid4().hex,
         resource_id=None,
-        project_id=project_subscription.project_id,
+        project_id=detector.project_id,
         event_id=uuid.uuid4().hex,
-        fingerprint=build_fingerprint_for_project_subscription(detector, project_subscription),
+        fingerprint=build_fingerprint(detector),
         type=UptimeDomainCheckFailure,
-        issue_title=f"Downtime detected for {project_subscription.uptime_subscription.url}",
+        issue_title=f"Downtime detected for {uptime_subscription.url}",
         subtitle="Your monitored domain is down",
         evidence_display=evidence_display,
         evidence_data={},
         culprit="",  # TODO: The url?
         detection_time=datetime.now(timezone.utc),
         level="error",
-        assignee=project_subscription.owner,
+        assignee=detector.owner,
     )
 
 
 def build_event_data_for_occurrence(
     result: CheckResult,
-    project_subscription: ProjectUptimeSubscription,
+    detector: Detector,
     occurrence: IssueOccurrence,
 ):
     # Default environment when it hasn't been configured
-    env = "prod"
-    if project_subscription.environment:
-        env = project_subscription.environment.name
+    env = detector.config.get("environment", "prod")
+
+    # XXX(epurkhiser): This can be changed over to using the detector ID in the
+    # future once we're no longer using the ProjectUptimeSubscription.id as a tag.
+    project_subscription = get_project_subscription(detector)
 
     return {
         "environment": env,
@@ -120,10 +117,9 @@ def resolve_uptime_issue(detector: Detector):
     """
     Sends an update to the issue platform to resolve the uptime issue for this monitor.
     """
-    project_subscription = get_project_subscription(detector)
     status_change = StatusChangeMessage(
-        fingerprint=build_fingerprint_for_project_subscription(detector, project_subscription),
-        project_id=project_subscription.project_id,
+        fingerprint=build_fingerprint(detector),
+        project_id=detector.project_id,
         new_status=GroupStatus.RESOLVED,
         new_substatus=None,
     )

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -349,6 +349,15 @@ def get_detector(uptime_subscription: UptimeSubscription) -> Detector | None:
         return None
 
 
+def get_uptime_subscription(detector: Detector) -> UptimeSubscription:
+    """
+    Given a detector get the matching uptime subscription
+    """
+    data_source = detector.data_sources.first()
+    assert data_source
+    return UptimeSubscription.objects.get_from_cache(id=int(data_source.source_id))
+
+
 def get_project_subscription(detector: Detector) -> ProjectUptimeSubscription:
     """
     Given a detector get the matching project subscription

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -39,6 +39,7 @@ from sentry.uptime.detectors.result_handler import (
 )
 from sentry.uptime.detectors.tasks import is_failed_url
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
+from sentry.uptime.issue_platform import build_detector_fingerprint_component
 from sentry.uptime.models import (
     ProjectUptimeSubscription,
     UptimeStatus,
@@ -154,7 +155,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         group = Group.objects.get(grouphash__hash=hashed_fingerprint)
         assert group.issue_type == UptimeDomainCheckFailure
         assignee = group.get_assignee()
@@ -218,7 +220,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             )
 
         # Issue is not created
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
@@ -316,7 +319,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
         self.project_subscription.refresh_from_db()
@@ -348,7 +352,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
         self.project_subscription.refresh_from_db()
@@ -407,7 +412,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         group = Group.objects.get(grouphash__hash=hashed_fingerprint)
         assert group.issue_type == UptimeDomainCheckFailure
         assert group.status == GroupStatus.UNRESOLVED
@@ -526,7 +532,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 ]
             )
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
@@ -558,7 +565,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                     ),
                 ]
             )
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
@@ -587,7 +595,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 "handle_result_for_project.missed",
                 extra={"project_id": self.project.id, **result},
             )
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
@@ -632,7 +641,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             )
         assert redis.get(key) == "1"
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
@@ -695,7 +705,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         # the values we want to check.
         assert remove_call_vals == [(DataCategory.UPTIME, self.project_subscription.id)]
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
         with pytest.raises(UptimeSubscription.DoesNotExist):
@@ -746,7 +757,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             )
         assert not redis.exists(key)
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
@@ -811,7 +823,8 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             )
         assert not redis.exists(key)
 
-        hashed_fingerprint = md5(str(self.project_subscription.id).encode("utf-8")).hexdigest()
+        fingerprint = build_detector_fingerprint_component(self.detector).encode("utf-8")
+        hashed_fingerprint = md5(fingerprint).hexdigest()
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -16,7 +16,10 @@ from sentry.testutils.helpers import override_options
 from sentry.testutils.skips import requires_kafka
 from sentry.types.actor import Actor
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.issue_platform import create_issue_platform_occurrence
+from sentry.uptime.issue_platform import (
+    build_detector_fingerprint_component,
+    create_issue_platform_occurrence,
+)
 from sentry.uptime.models import (
     ProjectUptimeSubscription,
     UptimeStatus,
@@ -748,7 +751,8 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
                 ),
                 detector,
             )
-            hashed_fingerprint = md5(str(proj_sub.id).encode("utf-8")).hexdigest()
+            fingerprint = build_detector_fingerprint_component(detector).encode("utf-8")
+            hashed_fingerprint = md5(fingerprint).hexdigest()
             assert Group.objects.filter(
                 grouphash__hash=hashed_fingerprint, status=GroupStatus.UNRESOLVED
             ).exists()

--- a/tests/sentry/uptime/test_issue_platform.py
+++ b/tests/sentry/uptime/test_issue_platform.py
@@ -13,7 +13,7 @@ from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.issue_platform import (
     build_detector_fingerprint_component,
     build_event_data_for_occurrence,
-    build_fingerprint_for_project_subscription,
+    build_fingerprint,
     build_occurrence_from_result,
     create_issue_platform_occurrence,
     resolve_uptime_issue,
@@ -37,11 +37,8 @@ class BuildFingerprintForProjectSubscriptionTest(UptimeTestCase):
         detector = get_detector(project_subscription.uptime_subscription)
         assert detector
 
-        fingerprint = build_fingerprint_for_project_subscription(detector, project_subscription)
-        expected_fingerprint = [
-            build_detector_fingerprint_component(detector),
-            str(project_subscription.id),
-        ]
+        fingerprint = build_fingerprint(detector)
+        expected_fingerprint = [build_detector_fingerprint_component(detector)]
         assert fingerprint == expected_fingerprint
 
 
@@ -59,11 +56,11 @@ class CreateIssuePlatformOccurrenceTest(UptimeTestCase):
         assert mock_produce_occurrence_to_kafka.call_count == 1
         assert mock_produce_occurrence_to_kafka.call_args_list[0][0] == ()
         call_kwargs = mock_produce_occurrence_to_kafka.call_args_list[0][1]
-        occurrence = build_occurrence_from_result(result, detector, project_subscription)
+        occurrence = build_occurrence_from_result(result, detector)
         assert call_kwargs == {
             "payload_type": PayloadType.OCCURRENCE,
             "occurrence": occurrence,
-            "event_data": build_event_data_for_occurrence(result, project_subscription, occurrence),
+            "event_data": build_event_data_for_occurrence(result, detector, occurrence),
         }
 
 
@@ -79,13 +76,11 @@ class BuildOccurrenceFromResultTest(UptimeTestCase):
         detector = get_detector(project_subscription.uptime_subscription)
         assert detector
 
-        assert build_occurrence_from_result(
-            result, detector, project_subscription
-        ) == IssueOccurrence(
+        assert build_occurrence_from_result(result, detector) == IssueOccurrence(
             id=occurrence_id.hex,
             project_id=1,
             event_id=event_id.hex,
-            fingerprint=[build_detector_fingerprint_component(detector), result["subscription_id"]],
+            fingerprint=[build_detector_fingerprint_component(detector)],
             issue_title="Downtime detected for https://sentry.io",
             subtitle="Your monitored domain is down",
             resource_id=None,
@@ -120,7 +115,7 @@ class BuildEventDataForOccurrenceTest(UptimeTestCase):
             id=uuid.uuid4().hex,
             project_id=1,
             event_id=event_id.hex,
-            fingerprint=[build_detector_fingerprint_component(detector), result["subscription_id"]],
+            fingerprint=[build_detector_fingerprint_component(detector)],
             issue_title="Downtime detected for https://sentry.io",
             subtitle="Your monitored domain is down",
             resource_id=None,
@@ -132,13 +127,12 @@ class BuildEventDataForOccurrenceTest(UptimeTestCase):
             culprit="",
         )
 
-        event_data = build_event_data_for_occurrence(result, project_subscription, occurrence)
+        event_data = build_event_data_for_occurrence(result, detector, occurrence)
         assert event_data == {
             "environment": "development",
             "event_id": event_id.hex,
             "fingerprint": [
                 build_detector_fingerprint_component(detector),
-                result["subscription_id"],
             ],
             "platform": "other",
             "project_id": 1,
@@ -163,15 +157,9 @@ class ResolveUptimeIssueTest(UptimeTestCase):
         result = self.create_uptime_result(subscription.subscription_id)
         with self.feature(UptimeDomainCheckFailure.build_ingest_feature_name()):
             create_issue_platform_occurrence(result, detector)
-        hashed_detector_fingerprint = md5(
-            build_detector_fingerprint_component(detector).encode("utf-8")
-        ).hexdigest()
-        hashed_subscription_fingerprint = md5(
-            str(project_subscription.id).encode("utf-8")
-        ).hexdigest()
+        fingerprint = build_detector_fingerprint_component(detector).encode("utf-8")
+        hashed_detector_fingerprint = md5(fingerprint).hexdigest()
         group_detector = Group.objects.get(grouphash__hash=hashed_detector_fingerprint)
-        group_sub = Group.objects.get(grouphash__hash=hashed_subscription_fingerprint)
-        assert group_detector.id == group_sub.id
         assert group_detector.status == GroupStatus.UNRESOLVED
         resolve_uptime_issue(detector)
         group_detector.refresh_from_db()


### PR DESCRIPTION
We no longer need to include this in issue fingerprints, we've been dual-writing the detector ID as a fingerprint, and we've backfilled old issue's with the detector ID fingerprints.

Dual Write: 
https://github.com/getsentry/sentry/pull/91087

Backfills:
https://github.com/getsentry/sentry/pull/91194
https://github.com/getsentry/sentry/pull/91356
https://github.com/getsentry/sentry/pull/91377