### PR TITLE
fix(dev-infra): Fix test discovery for Cursor

### DIFF
--- a/src/sentry/testutils/region.py
+++ b/src/sentry/testutils/region.py
@@ -16,6 +16,8 @@ class _TemporaryRegionDirectoryState:
 
 
 class TestEnvRegionDirectory(RegionDirectory):
+    __test__ = False
+
     def __init__(self, regions: Collection[Region]) -> None:
         super().__init__(regions)
         self._tmp_state = _TemporaryRegionDirectoryState(

--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -13,6 +13,7 @@ def in_test_environment() -> bool:
     return (
         "pytest" in sys.argv[0]
         or "vscode" in sys.argv[0]
+        or "cursor" in sys.argv[0]
         or os.environ.get("SENTRY_IN_TEST_ENVIRONMENT") in {"1", "true"}
         or "PYTEST_XDIST_WORKER" in os.environ
     )


### PR DESCRIPTION
<!-- Describe your PR here. -->

The Test Discovery feature in Cursor was broken due to a couple errors. First, we were checking for the presence of `vscode` but not `cursor` in the `in_test_environment()` function, causing several internal functions to throw an error. 

Second, `TestEnvRegionDirectory` was being detected as a test due to the naming, though it doesn't appear to be:

```
_______________ ERROR collecting src/sentry/testutils/region.py ________________
.venv/lib/python3.13/site-packages/_pytest/runner.py:340: in from_call
    result: Optional[TResult] = func()
.venv/lib/python3.13/site-packages/_pytest/runner.py:388: in collect
    return list(collector.collect())
.venv/lib/python3.13/site-packages/_pytest/python.py:774: in collect
    self.warn(
.venv/lib/python3.13/site-packages/_pytest/nodes.py:275: in warn
    warnings.warn_explicit(
E   pytest.PytestCollectionWarning: cannot collect test class 'TestEnvRegionDirectory' because it has a __init__ constructor (from: src/sentry/testutils/region.py)
```

After my changes I'm able to see all of our tests:
<img width="372" alt="Screenshot 2025-05-27 at 7 08 31 PM" src="https://github.com/user-attachments/assets/c30987d2-dfb1-4350-8462-caf5766a52aa" />
