### PR TITLE
layout: remove overflow from header container

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -60,7 +60,6 @@ export const HeaderContent = styled('div')<{unified?: boolean}>`
   display: flex;
   flex-direction: column;
   justify-content: normal;
-  overflow: hidden;
   max-width: 100%;
 `;
 


### PR DESCRIPTION
As far as I can tell, Header.Title already uses overflow ellipsis styling, and the second case where we set breadcrumbs above the title seems to do so as well.

I looked at a lot of pages and tried mocking either long titles or breadcrumbs, but I did not find any case that would break this.

Example of long breadcrumbs:
![CleanShot 2025-05-27 at 19 12 40@2x](https://github.com/user-attachments/assets/2fbb13b2-ea97-498d-9b0c-30f3511e2550)