### PR TITLE
ref(uptime): Extract GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE

### DIFF
--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -5,14 +5,17 @@ from dataclasses import dataclass
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import (
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+    ProjectUptimeSubscriptionMode,
+)
 from sentry.workflow_engine.types import DetectorSettings
 
 
 @dataclass(frozen=True)
 class UptimeDomainCheckFailure(GroupType):
     type_id = 7001
-    slug = "uptime_domain_failure"
+    slug = GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE
     description = "Uptime Domain Monitor Failure"
     category = GroupCategory.UPTIME.value
     category_v2 = GroupCategory.OUTAGE.value

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -28,8 +28,11 @@ from sentry.deletions.base import ModelRelation
 from sentry.models.organization import Organization
 from sentry.remote_subscriptions.models import BaseRemoteSubscription
 from sentry.types.actor import Actor
-from sentry.uptime.grouptype import UptimeDomainCheckFailure
-from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, ProjectUptimeSubscriptionMode
+from sentry.uptime.types import (
+    DATA_SOURCE_UPTIME_SUBSCRIPTION,
+    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
+    ProjectUptimeSubscriptionMode,
+)
 from sentry.utils.function_cache import cache_func, cache_func_for_models
 from sentry.utils.json import JSONEncoder
 from sentry.workflow_engine.models import (
@@ -248,7 +251,7 @@ def get_org_from_detector(detector: Detector) -> tuple[Organization]:
 @cache_func_for_models([(Detector, get_org_from_detector)])
 def get_active_auto_monitor_count_for_org(organization: Organization) -> int:
     return Detector.objects.filter(
-        type=UptimeDomainCheckFailure.slug,
+        type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
         project__organization=organization,
         config__mode__in=[
             ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
@@ -344,7 +347,9 @@ def get_detector(uptime_subscription: UptimeSubscription) -> Detector | None:
             type=DATA_SOURCE_UPTIME_SUBSCRIPTION,
             source_id=str(uptime_subscription.id),
         )
-        return Detector.objects.get(type=UptimeDomainCheckFailure.slug, data_sources=data_source)
+        return Detector.objects.get(
+            type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, data_sources=data_source
+        )
     except (DataSource.DoesNotExist, Detector.DoesNotExist):
         return None
 
@@ -394,7 +399,7 @@ def create_detector_from_project_subscription(project_sub: ProjectUptimeSubscrip
     )
     env = project_sub.environment.name if project_sub.environment else None
     detector = Detector.objects.create(
-        type=UptimeDomainCheckFailure.slug,
+        type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
         project=project_sub.project,
         name=project_sub.name,
         owner_user_id=project_sub.owner_user_id,

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -13,6 +13,10 @@ The workflow engine DataSource type used for registering handlers and fetching
 the uptime sbuscription data source.
 """
 
+GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE = "uptime_domain_failure"
+"""
+The GroupType slug for UptimeDomainCheckFailure GroupTypes.
+"""
 
 RegionScheduleMode = Literal["round_robin"]
 """


### PR DESCRIPTION
Moving this to the common 'types.py' (though `constants.py` maybe better). We need to use this in a few places that will have cyclic imports without extracting it like this.