### PR TITLE
:wrench: chore(vsts): raise IntegrationFormError for missing project

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -214,7 +214,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
         """
         project_id = data.get("project")
         if project_id is None:
-            raise ValueError("Azure DevOps expects project")
+            raise IntegrationFormError({"project": "Project is required."})
 
         client = self.get_client()
 

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -257,7 +257,7 @@ class VstsIssueSyncTest(VstsIssueBase):
             "description": "Goodnight, sweet prince",
         }
 
-        with pytest.raises(ValueError):
+        with pytest.raises(IntegrationFormError):
             self.integration.create_issue(form_data)
 
     @responses.activate


### PR DESCRIPTION
by raising `IntegrationFormError`, we can classify as a halt