### PR TITLE
ref(grouping): Fix `assemble_stacktrace_component` tests

### DIFF
--- a/tests/sentry/grouping/enhancements/test_hints.py
+++ b/tests/sentry/grouping/enhancements/test_hints.py
@@ -28,7 +28,7 @@ default_system_frame_hint = "non app frame"
 @pytest.mark.parametrize(
     [
         "variant_name",
-        "in_app",
+        "final_in_app",
         "client_in_app",
         "rust_hint",
         "incoming_hint",
@@ -38,7 +38,7 @@ default_system_frame_hint = "non app frame"
     # This represents every combo of:
     #
     #    variant_name: app or system
-    #    in_app: True or False
+    #    final_in_app: True or False
     #    client_in_app: None, True, or False
     #    rust_hint: in_app_hint, out_of_app_hint, ignored_hint, unignored_hint, or None
     #    incoming_hint: None or ignored_because_hint (the only kind of hint that gets set ahead of time)
@@ -415,7 +415,7 @@ default_system_frame_hint = "non app frame"
 )
 def test_get_hint_for_frame(
     variant_name: str,
-    in_app: bool,
+    final_in_app: bool,
     client_in_app: bool | None,
     rust_hint: str | None,
     incoming_hint: str | None,
@@ -423,8 +423,8 @@ def test_get_hint_for_frame(
     expected_result: str | None,
 ) -> None:
 
-    frame = {"in_app": in_app, "data": {"client_in_app": client_in_app}}
-    frame_component = FrameGroupingComponent(in_app=in_app, hint=incoming_hint, values=[])
+    frame = {"in_app": final_in_app, "data": {"client_in_app": client_in_app}}
+    frame_component = FrameGroupingComponent(in_app=final_in_app, hint=incoming_hint, values=[])
     rust_frame = DummyRustFrame(hint=rust_hint)
 
     assert (

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -722,6 +722,8 @@ class EnhancementsTest(TestCase):
         assert strategy_config.enhancements.id == DEFAULT_GROUPING_CONFIG
 
 
+# Note: This primarily tests `assemble_stacktrace_component`'s handling of `contributes` values, as
+# hints are tested separately in `test_hints.py`.
 class AssembleStacktraceComponentTest(TestCase):
 
     @dataclass

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -792,257 +792,30 @@ class AssembleStacktraceComponentTest(TestCase):
                 frame_component.hint == expected_hint
             ), f"frame {i} has incorrect `hint` value. Expected '{expected_hint}' but got '{frame_component.hint}'."
 
-    def test_uses_or_ignores_rust_results_as_appropriate(self):
-        """
-        Test that the rust results are used or ignored as appropriate:
-            - App variant frames never contribute if they're out of app
-            - App variant frame hints for system frames are only used if they relate to in-app-ness
-            - System variant frame hints are only used if they relate to ignoring/un-ignoring
-            - In-app hints in either variant aren't used if the rust result matches the incoming
-              value set by the client
-            - In all other cases, the frame results from rust are used
-            - For both variants, the rust stacktrace results are used. (There's one exception to
-              this rule, but it needs its own test - see
-              `test_marks_app_stacktrace_non_contributing_if_no_in_app_frames` below.)
-        """
-        incoming_frames: list[dict[str, Any]] = [
-            {"in_app": True},
-            {"in_app": True},
-            {"in_app": True},
-            {"in_app": True},
-            {"in_app": True},
-            {"in_app": True},
-            {
-                "in_app": True,
-                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
-            },
-            {
-                "in_app": True,
-                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
-            },
-            {
-                "in_app": True,
-                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
-            },
-            {
-                "in_app": True,
-                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
-            },
-            {
-                "in_app": True,
-                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
-            },
-            {
-                "in_app": True,
-                "data": {"client_in_app": True, "in_app_hint": "marked in-app by the client"},
-            },
-            {"in_app": False},
-            {"in_app": False},
-            {"in_app": False},
-            {"in_app": False},
-            {"in_app": False},
-            {"in_app": False},
-            {
-                "in_app": False,
-                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
-            },
-            {
-                "in_app": False,
-                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
-            },
-            {
-                "in_app": False,
-                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
-            },
-            {
-                "in_app": False,
-                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
-            },
-            {
-                "in_app": False,
-                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
-            },
-            {
-                "in_app": False,
-                "data": {"client_in_app": False, "in_app_hint": "marked out of app by the client"},
-            },
-        ]
+    def test_marks_system_frames_non_contributing_in_app_variant(self):
+        # For the app variant, out-of-app frames are automatically marked non-contributing when
+        # they're created. Thus the only way they could even _try_ to contribute is if they match
+        # an un-ignore rule.
 
-        app_variant_frame_components = [
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
-            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
-            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
-            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
-            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
-            self.in_app_frame(contributes=True, hint="marked in-app by the client"),
-            self.system_frame(contributes=False, hint="non app frame"),
-            self.system_frame(contributes=False, hint="non app frame"),
-            self.system_frame(contributes=False, hint="non app frame"),
-            self.system_frame(contributes=False, hint="non app frame"),
-            self.system_frame(contributes=False, hint="non app frame"),
-            self.system_frame(contributes=False, hint="non app frame"),
-            self.system_frame(contributes=False, hint="marked out of app by the client"),
-            self.system_frame(contributes=False, hint="marked out of app by the client"),
-            self.system_frame(contributes=False, hint="marked out of app by the client"),
-            self.system_frame(contributes=False, hint="marked out of app by the client"),
-            self.system_frame(contributes=False, hint="marked out of app by the client"),
-            self.system_frame(contributes=False, hint="marked out of app by the client"),
-        ]
-        system_variant_frame_components = [
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.in_app_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-            self.system_frame(contributes=True, hint=None),
-        ]
+        incoming_frames = [{"in_app": False}]
 
-        # Notes:
-        # - Regardless of the hint, the first value in each tuple is a `contributes` value, not an
-        #   `in_app` value.
-        # - Half of these change the `contributes` value of their respective frames, to show that
-        #   it's the rust value which gets used in the end.
-        # - In cases where the hint is about the in-app-ness of the frame, and the `contributes`
-        #   value doesn't seem to match, it means that both a `+/-group` rule and a `+/-app` rule
-        #   applied, with the latter second, such that its "marked in/out of app" hint overwrote the
-        #   "ignored/unignored" hint.
-        rust_frame_results = [
-            # All the possible results which could be sent back for in-app frames (IOW, everything
-            # but "marked out of app").
-            (False, "ignored by stacktrace rule (...)"),
-            (False, "marked in-app by stacktrace rule (...)"),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, "marked in-app by stacktrace rule (...)"),
-            (True, None),
-            (False, "ignored by stacktrace rule (...)"),
-            (False, "marked in-app by stacktrace rule (...)"),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, "marked in-app by stacktrace rule (...)"),
-            (True, None),
-            # All the possible results which could be sent back for system frames (IOW, everything
-            # but "marked in-app").
-            (False, "ignored by stacktrace rule (...)"),
-            (False, "marked out of app by stacktrace rule (...)"),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, "marked out of app by stacktrace rule (...)"),
-            (True, None),
-            (False, "ignored by stacktrace rule (...)"),
-            (False, "marked out of app by stacktrace rule (...)"),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, "marked out of app by stacktrace rule (...)"),
-            (True, None),
-        ]
+        frame_components = [self.system_frame(contributes=False, hint="non app frame")]
 
-        app_expected_frame_results = [
-            # With the in-app frames with no `client_in_app` value, all of the rust results are used
-            (False, "ignored by stacktrace rule (...)"),
-            (False, "marked in-app by stacktrace rule (...)"),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, "marked in-app by stacktrace rule (...)"),
-            (True, None),
-            # With the in-app frames which do have a `client_in_app` value, the rust results are
-            # used only if they aren't taking credit for marking the frame in-app, since the frame
-            # already was in-app.
-            (False, "ignored by stacktrace rule (...)"),
-            (False, "marked in-app by the client"),
-            (False, "marked in-app by the client"),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, "marked in-app by the client"),
-            (True, "marked in-app by the client"),
-            # With the system frames, none of them contributes (regardless of what rust says),
-            # because they're all out of app. For the ones with no `client_in_app` value, the rust
-            # hint is only used when it relates to a `-app` rule.
-            (False, "non app frame"),
-            (False, "marked out of app by stacktrace rule (...)"),
-            (False, "non app frame"),
-            (False, "non app frame"),
-            (False, "marked out of app by stacktrace rule (...)"),
-            (False, "non app frame"),
-            # For the ones which do have a `client_in_app` value, the rust hint is never used,
-            # because either it's for a +/-group rule or it's taking credit for marking the frame
-            # out of app, even though it already was out of app.
-            (False, "marked out of app by the client"),
-            (False, "marked out of app by the client"),
-            (False, "marked out of app by the client"),
-            (False, "marked out of app by the client"),
-            (False, "marked out of app by the client"),
-            (False, "marked out of app by the client"),
-        ]
-        system_expected_frame_results = [
-            # For all frames in this variant, the rust hint is used when it relates to a `+/-group`
-            # rule, but not when it relates to a `+/-app` rule
-            (False, "ignored by stacktrace rule (...)"),
-            (False, None),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, None),
-            (True, None),
-            (False, "ignored by stacktrace rule (...)"),
-            (False, None),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, None),
-            (True, None),
-            (False, "ignored by stacktrace rule (...)"),
-            (False, None),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, None),
-            (True, None),
-            (False, "ignored by stacktrace rule (...)"),
-            (False, None),
-            (False, None),
-            (True, "un-ignored by stacktrace rule (...)"),
-            (True, None),
-            (True, None),
-        ]
+        rust_frame_results = [(True, "un-ignored by stacktrace rule (...)")]
+
+        app_expected_frame_results = [(False, "non app frame")]
 
         enhancements = Enhancements.from_rules_text("")
         mock_rust_enhancements = self.MockRustEnhancements(
-            frame_results=rust_frame_results,
-            stacktrace_results=(True, "some stacktrace hint"),
+            frame_results=rust_frame_results, stacktrace_results=(False, "some stacktrace hint")
         )
 
-        with mock.patch.object(enhancements, "rust_enhancements", mock_rust_enhancements):
+        with mock.patch.object(
+            enhancements, "contributes_rust_enhancements", mock_rust_enhancements
+        ):
             app_stacktrace_component = enhancements.assemble_stacktrace_component(
                 variant_name="app",
-                frame_components=app_variant_frame_components,
-                frames=incoming_frames,
-                platform="javascript",
-                exception_data={},
-            )
-            system_stacktrace_component = enhancements.assemble_stacktrace_component(
-                variant_name="system",
-                frame_components=system_variant_frame_components,
+                frame_components=frame_components,
                 frames=incoming_frames,
                 platform="javascript",
                 exception_data={},
@@ -1051,14 +824,6 @@ class AssembleStacktraceComponentTest(TestCase):
             self.assert_frame_values_match_expected(
                 app_stacktrace_component, expected_frame_results=app_expected_frame_results
             )
-            self.assert_frame_values_match_expected(
-                system_stacktrace_component, expected_frame_results=system_expected_frame_results
-            )
-
-            assert app_stacktrace_component.contributes is True
-            assert app_stacktrace_component.hint == "some stacktrace hint"
-            assert system_stacktrace_component.contributes is True
-            assert system_stacktrace_component.hint == "some stacktrace hint"
 
     def test_marks_app_stacktrace_non_contributing_if_no_in_app_frames(self):
         """


### PR DESCRIPTION
This updates one of the `assemble_stacktrace_component` tests to be more narrowly focused (on `contributes` values) since part of what it was testing (`hint` values) is tested more comprehensively in `test_hints.py`. The original form of the test was also going to need a somewhat substantial overhaul to make it work with the new split enhancements. (It was reaching into `assemble_stacktrace_component`'s internals probably more than it should have.)