### PR TITLE
feat(seer): Trial and checkout UI

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -12,6 +12,9 @@ interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
 }
 
 export interface AutofixSetupResponse {
+  billing: {
+    hasAutofixQuota: boolean;
+  } | null;
   integration: {
     ok: boolean;
     reason: string | null;
@@ -59,5 +62,6 @@ export function useAutofixSetup(
         queryData.data?.setupAcknowledgement.userHasAcknowledged
     ),
     canCreatePullRequests: Boolean(queryData.data?.githubWriteIntegration?.ok),
+    hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),
   };
 }

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -8,6 +8,7 @@ import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 interface AiConfigResult {
   areAiFeaturesAllowed: boolean;
   hasAutofix: boolean;
+  hasAutofixQuota: boolean;
   hasGithubIntegration: boolean;
   hasResources: boolean;
   hasSummary: boolean;
@@ -18,7 +19,11 @@ interface AiConfigResult {
 
 export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const organization = useOrganization();
-  const {data: autofixSetupData, isPending: isAutofixSetupLoading} = useAutofixSetup({
+  const {
+    data: autofixSetupData,
+    isPending: isAutofixSetupLoading,
+    hasAutofixQuota,
+  } = useAutofixSetup({
     groupId: group.id,
   });
 
@@ -56,5 +61,6 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     isAutofixSetupLoading,
     areAiFeaturesAllowed,
     hasGithubIntegration,
+    hasAutofixQuota,
   };
 };

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -167,8 +167,6 @@ describe('SeerDrawer', () => {
 
     expect(screen.getByText(mockEvent.id)).toBeInTheDocument();
 
-    expect(screen.getByRole('heading', {name: 'Seer'})).toBeInTheDocument();
-
     expect(screen.getByTestId('ai-setup-data-consent')).toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -189,6 +189,10 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
     lastTriggeredAt = lastTriggeredAt + 'Z';
   }
 
+  const showWelcomeScreen =
+    aiConfig.needsGenAiAcknowledgement ||
+    (!aiConfig.hasAutofix && organization.features.includes('seer-billing'));
+
   return (
     <SeerDrawerContainer className="seer-drawer-container">
       <SeerDrawerHeader>
@@ -207,83 +211,85 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
           ]}
         />
       </SeerDrawerHeader>
-      <SeerDrawerNavigator>
-        <Flex align="center" gap={space(1)}>
-          <Header>{t('Seer')}</Header>
-          <FeatureBadge
-            type="beta"
-            tooltipProps={{
-              title: tct(
-                'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
-                {email: <a href="mailto:autofix@sentry.io" />}
-              ),
-              isHoverable: true,
-            }}
-          />
-          <QuestionTooltip
-            isHoverable
-            title={
-              <Flex column gap={space(1)}>
-                <div>
-                  {tct(
-                    'Seer models are powered by generative Al. Per our [dataDocs:data usage policies], Sentry does not use your data to train Seer models or share your data with other customers without your express consent.',
-                    {
-                      dataDocs: (
-                        <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/#data-processing" />
+      {(!showWelcomeScreen || aiConfig.isAutofixSetupLoading) && (
+        <SeerDrawerNavigator>
+          <Flex align="center" gap={space(1)}>
+            <Header>{t('Seer')}</Header>
+            <FeatureBadge
+              type="beta"
+              tooltipProps={{
+                title: tct(
+                  'This feature is in beta. Try it out and let us know your feedback at [email:autofix@sentry.io].',
+                  {email: <a href="mailto:autofix@sentry.io" />}
+                ),
+                isHoverable: true,
+              }}
+            />
+            <QuestionTooltip
+              isHoverable
+              title={
+                <Flex column gap={space(1)}>
+                  <div>
+                    {tct(
+                      'Seer models are powered by generative Al. Per our [dataDocs:data usage policies], Sentry does not use your data to train Seer models or share your data with other customers without your express consent.',
+                      {
+                        dataDocs: (
+                          <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/sentry-ai/#data-processing" />
+                        ),
+                      }
+                    )}
+                  </div>
+                  <div>
+                    {tct('Seer can be turned off in [settingsDocs:Settings].', {
+                      settingsDocs: (
+                        <Link
+                          to={{
+                            pathname: `/settings/${organization.slug}/`,
+                            hash: '#hideAiFeatures',
+                          }}
+                        />
                       ),
+                    })}
+                  </div>
+                </Flex>
+              }
+              size="sm"
+            />
+          </Flex>
+          {!aiConfig.needsGenAiAcknowledgement && (
+            <ButtonBarWrapper data-test-id="seer-button-bar">
+              <ButtonBar gap={1}>
+                <Feature features={['organizations:autofix-seer-preferences']}>
+                  <LinkButton
+                    to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+                    size="xs"
+                    title={t('Project Settings for Seer')}
+                    aria-label={t('Project Settings for Seer')}
+                    icon={<IconSettings />}
+                  />
+                </Feature>
+                <AutofixFeedback />
+                {aiConfig.hasAutofix && (
+                  <Button
+                    size="xs"
+                    onClick={reset}
+                    title={
+                      autofixData?.last_triggered_at
+                        ? tct('Last run at [date]', {
+                            date: <DateTime date={lastTriggeredAt} />,
+                          })
+                        : null
                     }
-                  )}
-                </div>
-                <div>
-                  {tct('Seer can be turned off in [settingsDocs:Settings].', {
-                    settingsDocs: (
-                      <Link
-                        to={{
-                          pathname: `/settings/${organization.slug}/`,
-                          hash: '#hideAiFeatures',
-                        }}
-                      />
-                    ),
-                  })}
-                </div>
-              </Flex>
-            }
-            size="sm"
-          />
-        </Flex>
-        {!aiConfig.needsGenAiAcknowledgement && (
-          <ButtonBarWrapper data-test-id="seer-button-bar">
-            <ButtonBar gap={1}>
-              <Feature features={['organizations:autofix-seer-preferences']}>
-                <LinkButton
-                  to={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
-                  size="xs"
-                  title={t('Project Settings for Seer')}
-                  aria-label={t('Project Settings for Seer')}
-                  icon={<IconSettings />}
-                />
-              </Feature>
-              <AutofixFeedback />
-              {aiConfig.hasAutofix && (
-                <Button
-                  size="xs"
-                  onClick={reset}
-                  title={
-                    autofixData?.last_triggered_at
-                      ? tct('Last run at [date]', {
-                          date: <DateTime date={lastTriggeredAt} />,
-                        })
-                      : null
-                  }
-                  disabled={!autofixData}
-                >
-                  {t('Start Over')}
-                </Button>
-              )}
-            </ButtonBar>
-          </ButtonBarWrapper>
-        )}
-      </SeerDrawerNavigator>
+                    disabled={!autofixData}
+                  >
+                    {t('Start Over')}
+                  </Button>
+                )}
+              </ButtonBar>
+            </ButtonBarWrapper>
+          )}
+        </SeerDrawerNavigator>
+      )}
 
       <SeerDrawerBody ref={scrollContainerRef} onScroll={handleScroll}>
         {aiConfig.isAutofixSetupLoading ? (
@@ -292,7 +298,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
             <Placeholder height="15rem" />
             <Placeholder height="15rem" />
           </PlaceholderStack>
-        ) : aiConfig.needsGenAiAcknowledgement ? (
+        ) : showWelcomeScreen ? (
           <AiSetupDataConsent groupId={group.id} />
         ) : (
           <Fragment>

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -191,7 +191,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
 
   const showWelcomeScreen =
     aiConfig.needsGenAiAcknowledgement ||
-    (!aiConfig.hasAutofix && organization.features.includes('seer-billing'));
+    (!aiConfig.hasAutofixQuota && organization.features.includes('seer-billing'));
 
   return (
     <SeerDrawerContainer className="seer-drawer-container">

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -136,23 +136,11 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                   <ErrorText>{t('Something went wrong.')}</ErrorText>
                 )}
               </ButtonWrapper>
-              <LegalText>
-                {tct(
-                  'Seer models are powered by generative AI. Per our [dataLink:data usage policies], Sentry does not share AI-generated output from your data with other customers or use your data to train generative AI models without your express consent.',
-                  {
-                    dataLink: (
-                      <ExternalLink href="https://docs.sentry.io/product/security/ai-ml-policy/#use-of-identifying-data-for-generative-ai-features" />
-                    ),
-                  }
-                )}
-                {canStartTrial && (
-                  <React.Fragment>
-                    <br />
-                    <br />
-                    {t('By clicking above, you will begin a 14 day free trial.')}
-                  </React.Fragment>
-                )}
-              </LegalText>
+              {canStartTrial && (
+                <LegalText>
+                  {t('By clicking above, you will begin a 14 day free trial.')}
+                </LegalText>
+              )}
             </Fragment>
           )
         ) : (
@@ -182,19 +170,19 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                 <ErrorText>{t('Something went wrong.')}</ErrorText>
               )}
             </ButtonWrapper>
-            {!orgHasAcknowledged && (
-              <LegalText>
-                {tct(
-                  'Seer models are powered by generative AI. Per our [dataLink:data usage policies], Sentry does not share AI-generated output from your data with other customers or use your data to train generative AI models without your express consent.',
-                  {
-                    dataLink: (
-                      <ExternalLink href="https://docs.sentry.io/product/security/ai-ml-policy/#use-of-identifying-data-for-generative-ai-features" />
-                    ),
-                  }
-                )}
-              </LegalText>
-            )}
           </Fragment>
+        )}
+        {!orgHasAcknowledged && (
+          <LegalText>
+            {tct(
+              'Seer models are powered by generative AI. Per our [dataLink:data usage policies], Sentry does not share AI-generated output from your data with other customers or use your data to train generative AI models without your express consent.',
+              {
+                dataLink: (
+                  <ExternalLink href="https://docs.sentry.io/product/security/ai-ml-policy/#use-of-identifying-data-for-generative-ai-features" />
+                ),
+              }
+            )}
+          </LegalText>
         )}
       </SingleCard>
     </ConsentItemsContainer>

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -78,7 +78,10 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
         <img src={autofixSetupImg} alt="Seer looking at a root cause for a solution" />
       </Flex>
       <SingleCard>
-        <MeetSeerHeader>MEET SEER</MeetSeerHeader>
+        <Flex align="center" gap={space(1)}>
+          <MeetSeerHeader>MEET SEER</MeetSeerHeader>
+          <StyledSeerWaitingIcon size="lg" />
+        </Flex>
         <Paragraph>
           {t(
             "Seer is Sentry's AI agent that helps you troubleshoot and fix problems with your applications, including bugs and performance issues. Seer includes:"
@@ -131,7 +134,6 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                     )}
                   </Button>
                 )}
-                <SeerWaitingIcon size="xl" />
                 {autofixAcknowledgeMutation.isError && (
                   <ErrorText>{t('Something went wrong.')}</ErrorText>
                 )}
@@ -165,7 +167,6 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                   t('Enable Seer')
                 )}
               </Button>
-              <SeerWaitingIcon size="xl" />
               {autofixAcknowledgeMutation.isError && (
                 <ErrorText>{t('Something went wrong.')}</ErrorText>
               )}
@@ -214,8 +215,12 @@ const SingleCard = styled('div')`
 `;
 
 const MeetSeerHeader = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
+  font-size: ${p => p.theme.fontSizeMedium};
   font-weight: ${p => p.theme.fontWeightBold};
+  color: ${p => p.theme.subText};
+`;
+
+const StyledSeerWaitingIcon = styled(SeerWaitingIcon)`
   color: ${p => p.theme.subText};
 `;
 

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -51,6 +51,8 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
 
   const isTouchCustomer = subscription?.type === BillingType.INVOICED;
 
+  const userHasBillingAccess = organization.access.includes('org:billing');
+
   const autofixAcknowledgeMutation = useMutation({
     mutationFn: () => {
       return promptsUpdate(api, {
@@ -146,6 +148,14 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                           autofixAcknowledgeMutation.mutate();
                         }}
                         size="md"
+                        disabled={!userHasBillingAccess}
+                        title={
+                          userHasBillingAccess
+                            ? undefined
+                            : t(
+                                "You don't have access to manage billing. Contact a billing admin for your org."
+                              )
+                        }
                       >
                         {t('Add Budget')}
                       </AddBudgetButton>

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -1,3 +1,4 @@
+import React, {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import autofixSetupImg from 'sentry-images/features/autofix-setup.svg';
@@ -11,9 +12,16 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {DataCategory} from 'sentry/types/core';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+
+import StartTrialButton from 'getsentry/components/startTrialButton';
+import useSubscription from 'getsentry/hooks/useSubscription';
+import {BillingType} from 'getsentry/types';
+import {getProductTrial} from 'getsentry/utils/billing';
 
 type AiSetupDataConsentProps = {
   groupId: string;
@@ -23,7 +31,21 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
   const queryClient = useQueryClient();
-  const {data: autofixSetupData} = useAutofixSetup({groupId});
+  const {data: autofixSetupData, hasAutofixQuota} = useAutofixSetup({groupId});
+  const navigate = useNavigate();
+  const subscription = useSubscription();
+
+  const trial = getProductTrial(
+    subscription?.productTrials ?? null,
+    DataCategory.SEER_AUTOFIX
+  );
+
+  const orgHasAcknowledged = autofixSetupData?.setupAcknowledgement.orgHasAcknowledged;
+  const shouldShowBilling =
+    organization.features.includes('seer-billing') && !hasAutofixQuota;
+  const canStartTrial = Boolean(!trial?.isStarted);
+
+  const isTouchCustomer = subscription?.type === BillingType.INVOICED;
 
   const autofixAcknowledgeMutation = useMutation({
     mutationFn: () => {
@@ -43,75 +65,137 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
     },
   });
 
+  function handlePurchaseSeer() {
+    navigate(`/settings/billing/checkout/?referrer=manage_subscription`);
+  }
+
   return (
     <ConsentItemsContainer>
       <Flex align="center" gap={space(1)}>
-        <SeerWaitingIcon size="xl" />
         <SayHelloHeader>{t('Say Hello to a Smarter Sentry')}</SayHelloHeader>
       </Flex>
       <Flex align="center" justify="center" gap={space(1)}>
         <img src={autofixSetupImg} alt="Seer looking at a root cause for a solution" />
       </Flex>
-      <HeaderItem>
-        <Title>{t('With Seer you get:')}</Title>
-      </HeaderItem>
-      <ConsentItem>
-        <ConsentTitle>{t('Issue Summaries')}</ConsentTitle>
+      <SingleCard>
+        <MeetSeerHeader>MEET SEER</MeetSeerHeader>
         <Paragraph>
-          {t(
-            "The fastest way to see what's going on, incorporating all data in the issue."
-          )}
+          Seer is Sentry's AI agent that helps you troubleshoot and fix problems with your
+          applications, including bugs and performance issues. Seer includes:
         </Paragraph>
-      </ConsentItem>
-      <ConsentItem>
-        <ConsentTitle>{t('Root Cause Analysis')}</ConsentTitle>
-        <Paragraph>
-          {t('A streamlined, collaborative workflow to find the root cause.')}
-        </Paragraph>
-      </ConsentItem>
-      <ConsentItem>
-        <ConsentTitle>{t('Solutions & Code Changes')}</ConsentTitle>
-        <Paragraph>
-          {t('Proposed fixes with test cases, ready to merge as draft pull requests.')}
-        </Paragraph>
-      </ConsentItem>
-      <ButtonWrapper>
-        <Button
-          priority="primary"
-          onClick={() => autofixAcknowledgeMutation.mutate()}
-          disabled={autofixAcknowledgeMutation.isPending}
-          analyticsEventKey="gen_ai_consent.in_drawer_clicked"
-          analyticsEventName="Gen AI Consent: Clicked In Drawer"
-          analyticsParams={{
-            is_first_user_in_org:
-              !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged,
-          }}
-          size="sm"
-        >
-          {autofixAcknowledgeMutation.isPending ? (
-            <StyledLoadingIndicator size={14} />
-          ) : autofixSetupData?.setupAcknowledgement.orgHasAcknowledged ? (
-            t('Try Seer')
+        <BulletList>
+          <li>Issue Triage</li>
+          <li>Root Cause Analysis</li>
+          <li>Solution & Code Changes</li>
+        </BulletList>
+        {shouldShowBilling ? (
+          isTouchCustomer ? (
+            <TouchCustomerMessage>
+              {t('Contact your customer success manager to get access to Seer.')}
+            </TouchCustomerMessage>
           ) : (
-            t('Enable Seer')
-          )}
-        </Button>
-        {autofixAcknowledgeMutation.isError && (
-          <ErrorText>{t('Something went wrong.')}</ErrorText>
+            <Fragment>
+              <ButtonWrapper>
+                {canStartTrial ? (
+                  <StartTrialButton
+                    organization={organization}
+                    source="ai-setup-consent"
+                    requestData={{
+                      productTrial: {
+                        category: DataCategory.SEER_AUTOFIX,
+                        reasonCode: 1001,
+                      },
+                    }}
+                    busy={autofixAcknowledgeMutation.isPending}
+                    handleClick={() => autofixAcknowledgeMutation.mutate()}
+                    size="md"
+                    priority="primary"
+                  >
+                    {t('Try Seer for Free')}
+                  </StartTrialButton>
+                ) : (
+                  <Button
+                    priority="primary"
+                    onClick={() => {
+                      autofixAcknowledgeMutation.mutate();
+                      handlePurchaseSeer();
+                    }}
+                    disabled={autofixAcknowledgeMutation.isPending}
+                    size="md"
+                  >
+                    {autofixAcknowledgeMutation.isPending ? (
+                      <StyledLoadingIndicator size={14} />
+                    ) : (
+                      t('Purchase Seer')
+                    )}
+                  </Button>
+                )}
+                <SeerWaitingIcon size="xl" />
+                {autofixAcknowledgeMutation.isError && (
+                  <ErrorText>{t('Something went wrong.')}</ErrorText>
+                )}
+              </ButtonWrapper>
+              <LegalText>
+                {tct(
+                  'Seer models are powered by generative AI. Per our [dataLink:data usage policies], Sentry does not share AI-generated output from your data with other customers or use your data to train generative AI models without your express consent.',
+                  {
+                    dataLink: (
+                      <ExternalLink href="https://docs.sentry.io/product/security/ai-ml-policy/#use-of-identifying-data-for-generative-ai-features" />
+                    ),
+                  }
+                )}
+                {canStartTrial && (
+                  <React.Fragment>
+                    <br />
+                    <br />
+                    {t('By clicking above, you will begin a 14 day free trial.')}
+                  </React.Fragment>
+                )}
+              </LegalText>
+            </Fragment>
+          )
+        ) : (
+          <Fragment>
+            <ButtonWrapper>
+              <Button
+                priority="primary"
+                onClick={() => autofixAcknowledgeMutation.mutate()}
+                disabled={autofixAcknowledgeMutation.isPending}
+                analyticsEventKey="gen_ai_consent.in_drawer_clicked"
+                analyticsEventName="Gen AI Consent: Clicked In Drawer"
+                analyticsParams={{
+                  is_first_user_in_org: !orgHasAcknowledged,
+                }}
+                size="md"
+              >
+                {autofixAcknowledgeMutation.isPending ? (
+                  <StyledLoadingIndicator size={14} />
+                ) : orgHasAcknowledged ? (
+                  t('Try Seer')
+                ) : (
+                  t('Enable Seer')
+                )}
+              </Button>
+              <SeerWaitingIcon size="xl" />
+              {autofixAcknowledgeMutation.isError && (
+                <ErrorText>{t('Something went wrong.')}</ErrorText>
+              )}
+            </ButtonWrapper>
+            {!orgHasAcknowledged && (
+              <LegalText>
+                {tct(
+                  'Seer models are powered by generative AI. Per our [dataLink:data usage policies], Sentry does not share AI-generated output from your data with other customers or use your data to train generative AI models without your express consent.',
+                  {
+                    dataLink: (
+                      <ExternalLink href="https://docs.sentry.io/product/security/ai-ml-policy/#use-of-identifying-data-for-generative-ai-features" />
+                    ),
+                  }
+                )}
+              </LegalText>
+            )}
+          </Fragment>
         )}
-      </ButtonWrapper>
-      {!autofixSetupData?.setupAcknowledgement.orgHasAcknowledged && (
-        <Paragraph>
-          {tct(
-            'Seer models are powered by generative Al. Per our [dataLink:data usage policies], Sentry does not share AI-generated output from your data with other customers or use your data to train generative AI models without your express consent.',
-            {
-              dataLink: (
-                <ExternalLink href="https://docs.sentry.io/product/security/ai-ml-policy/#use-of-identifying-data-for-generative-ai-features" />
-              ),
-            }
-          )}
-        </Paragraph>
-      )}
+      </SingleCard>
     </ConsentItemsContainer>
   );
 }
@@ -124,40 +208,46 @@ const ConsentItemsContainer = styled('div')`
   gap: ${space(2)};
 `;
 
-const HeaderItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.5)};
-  margin-top: ${space(2)};
-`;
-
-const ConsentItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.5)};
-  background-color: ${p => p.theme.background};
-  padding: ${space(1)} ${space(1.5)};
-  border-radius: ${p => p.theme.borderRadius};
-  border: 1px solid ${p => p.theme.border};
-`;
-
 const SayHelloHeader = styled('h3')`
   margin: 0;
 `;
 
-const Title = styled('h5')`
-  margin: 0;
-  font-size: ${p => p.theme.fontSizeMedium};
+const SingleCard = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1.5)};
+  background-color: ${p => p.theme.background};
+  padding: ${space(2)} ${space(2)};
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
+  margin-top: ${space(2)};
+  box-shadow: ${p => p.theme.dropShadowMedium};
+`;
+
+const MeetSeerHeader = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: ${p => p.theme.fontWeightBold};
+  color: ${p => p.theme.subText};
+`;
+
+const BulletList = styled('ul')`
+  margin: 0 0 ${space(1)} 0;
 `;
 
 const Paragraph = styled('p')`
   margin: 0;
 `;
 
-const ConsentTitle = styled('h4')`
-  margin: 0;
-  font-size: ${p => p.theme.fontSizeMedium};
+const TouchCustomerMessage = styled('p')`
+  color: ${p => p.theme.pink400};
   font-weight: ${p => p.theme.fontWeightBold};
+  margin-top: ${space(2)};
+`;
+
+const LegalText = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  margin-top: ${space(1)};
 `;
 
 const ButtonWrapper = styled('div')`

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -86,7 +86,7 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
         <BulletList>
           <li>Issue Triage</li>
           <li>Root Cause Analysis</li>
-          <li>Solution & Code Changes</li>
+          <li>Solutions & Code Changes</li>
         </BulletList>
         {shouldShowBilling ? (
           isTouchCustomer ? (

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -50,6 +50,7 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
     shouldShowBilling && organization.features.includes('seer-added');
 
   const isTouchCustomer = subscription?.type === BillingType.INVOICED;
+  const isSponsoredCustomer = subscription?.type === BillingType.PARTNER;
 
   const userHasBillingAccess = organization.access.includes('org:billing');
 
@@ -109,9 +110,11 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
           <li>{t('Solutions & Code Changes')}</li>
         </BulletList>
         {shouldShowBilling ? (
-          isTouchCustomer ? (
+          isTouchCustomer || isSponsoredCustomer ? (
             <TouchCustomerMessage>
-              {t('Contact your customer success manager to get access to Seer.')}
+              {isTouchCustomer
+                ? t('Contact your customer success manager to get access to Seer.')
+                : t('Seer is not available on Sponsored plans.')}
             </TouchCustomerMessage>
           ) : (
             <Fragment>

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -50,7 +50,7 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
     shouldShowBilling && organization.features.includes('seer-added');
 
   const isTouchCustomer = subscription?.type === BillingType.INVOICED;
-  const isSponsoredCustomer = subscription?.type === BillingType.PARTNER;
+  const isSponsoredCustomer = Boolean(subscription?.isSponsored);
 
   const userHasBillingAccess = organization.access.includes('org:billing');
 
@@ -113,8 +113,20 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
           isTouchCustomer || isSponsoredCustomer ? (
             <TouchCustomerMessage>
               {isTouchCustomer
-                ? t('Contact your customer success manager to get access to Seer.')
-                : t('Seer is not available on Sponsored plans.')}
+                ? tct(
+                    'Contact your customer success manager to get access to Seer.[break]Send us an [link:email] if you need help.',
+                    {
+                      link: <ExternalLink href="mailto:sales@sentry.io" />,
+                      break: <br />,
+                    }
+                  )
+                : tct(
+                    'Seer is not available on Sponsored plans.[break]Send us an [link:email] if you need help.',
+                    {
+                      link: <ExternalLink href="mailto:support@sentry.io" />,
+                      break: <br />,
+                    }
+                  )}
             </TouchCustomerMessage>
           ) : (
             <Fragment>

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -140,7 +140,9 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
               </ButtonWrapper>
               {canStartTrial && (
                 <LegalText>
-                  {t('By clicking above, you will begin a 14 day free trial.')}
+                  {t(
+                    'By clicking above, you will begin a 14 day free trial. After the trial ends, it will not auto-renew.'
+                  )}
                 </LegalText>
               )}
             </Fragment>

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -141,7 +141,10 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                     <Flex>
                       <AddBudgetButton
                         priority="primary"
-                        onClick={() => handleAddBudget()}
+                        onClick={() => {
+                          handleAddBudget();
+                          autofixAcknowledgeMutation.mutate();
+                        }}
                         size="md"
                       >
                         {t('Add Budget')}

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -80,13 +80,14 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
       <SingleCard>
         <MeetSeerHeader>MEET SEER</MeetSeerHeader>
         <Paragraph>
-          Seer is Sentry's AI agent that helps you troubleshoot and fix problems with your
-          applications, including bugs and performance issues. Seer includes:
+          {t(
+            "Seer is Sentry's AI agent that helps you troubleshoot and fix problems with your applications, including bugs and performance issues. Seer includes:"
+          )}
         </Paragraph>
         <BulletList>
-          <li>Issue Triage</li>
-          <li>Root Cause Analysis</li>
-          <li>Solutions & Code Changes</li>
+          <li>{t('Issue Triage')}</li>
+          <li>{t('Root Cause Analysis')}</li>
+          <li>{t('Solutions & Code Changes')}</li>
         </BulletList>
         {shouldShowBilling ? (
           isTouchCustomer ? (

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -43,7 +43,7 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const orgHasAcknowledged = autofixSetupData?.setupAcknowledgement.orgHasAcknowledged;
   const shouldShowBilling =
     organization.features.includes('seer-billing') && !hasAutofixQuota;
-  const canStartTrial = Boolean(!trial?.isStarted);
+  const canStartTrial = Boolean(trial && !trial.isStarted);
 
   const isTouchCustomer = subscription?.type === BillingType.INVOICED;
 

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import autofixSetupImg from 'sentry-images/features/autofix-setup.svg';

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -22,7 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import StartTrialButton from 'getsentry/components/startTrialButton';
 import useSubscription from 'getsentry/hooks/useSubscription';
 import {BillingType} from 'getsentry/types';
-import {getProductTrial} from 'getsentry/utils/billing';
+import {getPotentialProductTrial} from 'getsentry/utils/billing';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 
 type AiSetupDataConsentProps = {
@@ -37,7 +37,7 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const navigate = useNavigate();
   const subscription = useSubscription();
 
-  const trial = getProductTrial(
+  const trial = getPotentialProductTrial(
     subscription?.productTrials ?? null,
     DataCategory.SEER_AUTOFIX
   );
@@ -123,21 +123,26 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                     requestData={{
                       productTrial: {
                         category: DataCategory.SEER_AUTOFIX,
-                        reasonCode: 1001,
+                        reasonCode: trial?.reasonCode,
                       },
                     }}
                     busy={autofixAcknowledgeMutation.isPending}
                     handleClick={() => autofixAcknowledgeMutation.mutate()}
                     size="md"
                     priority="primary"
+                    analyticsEventKey="seer_drawer.free_trial_clicked"
+                    analyticsEventName="Seer Drawer: Clicked Free Trial"
                   >
                     {t('Try Seer for Free')}
                   </StartTrialButton>
                 ) : hasSeerButNeedsPayg ? (
                   <Flex gap={space(2)} column>
                     <ErrorText>
-                      {t(
-                        "You've run out of pay-as-you-go budget. Please add more to keep using Seer."
+                      {tct(
+                        "You've run out of [budgetTerm] budget. Please add more to keep using Seer.",
+                        {
+                          budgetTerm: subscription?.planDetails.budgetTerm,
+                        }
                       )}
                     </ErrorText>
                     <Flex>
@@ -156,6 +161,8 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                                 "You don't have access to manage billing. Contact a billing admin for your org."
                               )
                         }
+                        analyticsEventKey="seer_drawer.add_budget_clicked"
+                        analyticsEventName="Seer Drawer: Clicked Add Budget"
                       >
                         {t('Add Budget')}
                       </AddBudgetButton>
@@ -178,6 +185,8 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                     }}
                     disabled={autofixAcknowledgeMutation.isPending}
                     size="md"
+                    analyticsEventKey="seer_drawer.checkout_clicked"
+                    analyticsEventName="Seer Drawer: Clicked Checkout"
                   >
                     {autofixAcknowledgeMutation.isPending ? (
                       <StyledLoadingIndicator size={14} />

--- a/tests/js/fixtures/autofixSetupFixture.ts
+++ b/tests/js/fixtures/autofixSetupFixture.ts
@@ -16,6 +16,9 @@ export function AutofixSetupFixture(
       ok: true,
       repos: [],
     },
+    billing: {
+      hasAutofixQuota: true,
+    },
     ...params,
   };
 }


### PR DESCRIPTION
In the drawer, if the `seer-billing` flag is enabled, shows buttons to start trials/go to checkout. These buttons implicitly trigger the acknowledgement check as well. If billing is satisfied and missing acknowledgement, the old acknowledgement buttons will still show.

If no autofix quota in the set up check > show welcome screen > if trial available and not started, prompt to start trial, else prompt to checkout

Note: pls double check my billing logic is correct, I'm new to the code here. in `yarn dev-ui` I was getting a 400 when clicking "start trial" for example but I'm hoping that's just because billing hasn't released yet or because i'm testing locally.

<img width="762" alt="Screenshot 2025-05-27 at 6 25 04 PM" src="https://github.com/user-attachments/assets/28582cca-be10-410f-be45-b0dc422cea64" />
<img width="739" alt="Screenshot 2025-05-27 at 7 05 36 PM" src="https://github.com/user-attachments/assets/4f167d02-0fdd-48fb-b0c1-c4d2e70a8152" />
<img width="775" alt="Screenshot 2025-05-27 at 7 08 36 PM" src="https://github.com/user-attachments/assets/533d15ef-6c9f-4b1b-afe4-69362218f4f8" />
<img width="760" alt="Screenshot 2025-05-27 at 7 21 59 PM" src="https://github.com/user-attachments/assets/62af061f-434b-4495-8fd4-dfe8a78d647b" />
<img width="735" alt="Screenshot 2025-05-29 at 8 52 35 AM" src="https://github.com/user-attachments/assets/554c1b19-427e-44d9-afde-b3129a19d7b0" />

