### PR TITLE
feat(agent-insights): Highlight input and output in trace

### DIFF
--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -82,6 +82,9 @@ export const enum SectionKey {
   REGRESSION_EVENT_COMPARISON = 'regression-event-comparison',
   REGRESSION_POTENTIAL_CAUSES = 'regression-potential-causes',
   REGRESSION_AFFECTED_TRANSACTIONS = 'regression-affected-transactions',
+
+  AI_INPUT = 'ai-input',
+  AI_OUTPUT = 'ai-output',
 }
 
 /**

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -1,0 +1,197 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+
+import {StructuredData} from 'sentry/components/structuredEventData';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {EventTransaction} from 'sentry/types/event';
+import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {
+  getIsAiNode,
+  getTraceNodeAttribute,
+} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+function renderUserMessage(content: any) {
+  return content
+    .filter((part: any) => part.type === 'text')
+    .map((part: any) => part.text)
+    .join('\n');
+}
+
+function renderAssistantMessage(content: any) {
+  return content
+    .filter((part: any) => part.type === 'text')
+    .map((part: any) => part.text)
+    .join('\n');
+}
+
+function renderToolMessage(content: any) {
+  return <StructuredData value={content} maxDefaultDepth={2} withAnnotatedText />;
+}
+
+function parseAIMessages(messages: string) {
+  try {
+    const array: any[] = JSON.parse(messages);
+
+    return array
+      .map((message: any) => {
+        switch (message.role) {
+          case 'system':
+            return {
+              role: 'system' as const,
+              content: message.content.toString(),
+            };
+          case 'user':
+            return {
+              role: 'user' as const,
+              content: renderUserMessage(message.content),
+            };
+          case 'assistant':
+            return {
+              role: 'assistant' as const,
+              content: renderAssistantMessage(message.content),
+            };
+          case 'tool':
+            return {
+              role: 'tool' as const,
+              content: renderToolMessage(message.content),
+            };
+          default:
+            Sentry.captureMessage('Unknown AI message role', {
+              extra: {
+                role: message.role,
+              },
+            });
+            return null;
+        }
+      })
+      .filter(message => message !== null);
+  } catch (error) {
+    Sentry.captureMessage('Error parsing ai.prompt.messages', {
+      extra: {
+        error,
+      },
+    });
+    return messages;
+  }
+}
+
+function transformInputMessages(inputMessages: string) {
+  try {
+    const json = JSON.parse(inputMessages);
+    const result = [];
+    const {system, prompt} = json;
+    if (system) {
+      result.push({
+        role: 'system',
+        content: system,
+      });
+    }
+    if (prompt) {
+      result.push({
+        role: 'user',
+        content: [{type: 'text', text: prompt}],
+      });
+    }
+    return JSON.stringify(result);
+  } catch (error) {
+    Sentry.captureMessage('Error parsing ai.input_messages', {
+      extra: {
+        error,
+      },
+    });
+    return undefined;
+  }
+}
+
+const roleHeadings = {
+  system: t('System'),
+  user: t('User'),
+  assistant: t('Assistant'),
+  tool: t('Tool'),
+};
+
+export function AIInputSection({
+  node,
+  attributes,
+  event,
+}: {
+  node: TraceTreeNode<TraceTree.EAPSpan | TraceTree.Span | TraceTree.Transaction>;
+  attributes?: TraceItemResponseAttribute[];
+  event?: EventTransaction;
+}) {
+  const organization = useOrganization();
+  if (!hasAgentInsightsFeature(organization) && getIsAiNode(node)) {
+    return null;
+  }
+
+  let promptMessages = getTraceNodeAttribute(
+    'ai.prompt.messages',
+    node,
+    event,
+    attributes
+  );
+  if (!promptMessages) {
+    const inputMessages = getTraceNodeAttribute(
+      'ai.input_messages',
+      node,
+      event,
+      attributes
+    );
+    promptMessages = transformInputMessages(inputMessages);
+  }
+
+  const aiInput = defined(promptMessages) && parseAIMessages(promptMessages as string);
+
+  if (!aiInput) {
+    return null;
+  }
+
+  return (
+    <FoldSection
+      sectionKey={SectionKey.AI_INPUT}
+      title={t('Input')}
+      disableCollapsePersistence
+    >
+      {typeof aiInput === 'string' ? (
+        <MultilineText>{aiInput}</MultilineText>
+      ) : (
+        <Fragment>
+          {aiInput.map((message, index) => (
+            <Fragment key={index}>
+              <MessageLabel>{roleHeadings[message.role]}</MessageLabel>
+              <MultilineText>{message.content}</MultilineText>
+            </Fragment>
+          ))}
+        </Fragment>
+      )}
+    </FoldSection>
+  );
+}
+
+const MultilineText = styled('div')`
+  white-space: pre-wrap;
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(1)};
+  &:not(:last-child) {
+    margin-bottom: ${space(1.5)};
+  }
+
+  & p {
+    margin: 0;
+  }
+`;
+
+const MessageLabel = styled('div')`
+  font-weight: bold;
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -1,10 +1,8 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -16,6 +14,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
@@ -161,14 +160,21 @@ export function AIInputSection({
       title={t('Input')}
       disableCollapsePersistence
     >
+      {/* If parsing fails, we'll just show the raw string */}
       {typeof aiInput === 'string' ? (
-        <MultilineText>{aiInput}</MultilineText>
+        <TraceDrawerComponents.MultilineText>
+          {aiInput}
+        </TraceDrawerComponents.MultilineText>
       ) : (
         <Fragment>
           {aiInput.map((message, index) => (
             <Fragment key={index}>
-              <MessageLabel>{roleHeadings[message.role]}</MessageLabel>
-              <MultilineText>{message.content}</MultilineText>
+              <TraceDrawerComponents.MultilineTextLabel>
+                {roleHeadings[message.role]}
+              </TraceDrawerComponents.MultilineTextLabel>
+              <TraceDrawerComponents.MultilineText>
+                {message.content}
+              </TraceDrawerComponents.MultilineText>
             </Fragment>
           ))}
         </Fragment>
@@ -176,22 +182,3 @@ export function AIInputSection({
     </FoldSection>
   );
 }
-
-const MultilineText = styled('div')`
-  white-space: pre-wrap;
-  background-color: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(1)};
-  &:not(:last-child) {
-    margin-bottom: ${space(1.5)};
-  }
-
-  & p {
-    margin: 0;
-  }
-`;
-
-const MessageLabel = styled('div')`
-  font-weight: bold;
-  margin-bottom: ${space(1)};
-`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled';
+
+import {StructuredData} from 'sentry/components/structuredEventData';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {EventTransaction} from 'sentry/types/event';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {
+  getIsAiNode,
+  getTraceNodeAttribute,
+} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+function tryParseJson(value: any) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return value;
+  }
+}
+
+export function AIOutputSection({
+  node,
+  attributes,
+  event,
+}: {
+  node: TraceTreeNode<TraceTree.EAPSpan | TraceTree.Span | TraceTree.Transaction>;
+  attributes?: TraceItemResponseAttribute[];
+  event?: EventTransaction;
+}) {
+  const organization = useOrganization();
+  if (!hasAgentInsightsFeature(organization) && getIsAiNode(node)) {
+    return null;
+  }
+
+  const responseText = getTraceNodeAttribute('ai.response.text', node, event, attributes);
+  const toolCalls = getTraceNodeAttribute(
+    'ai.response.toolCalls',
+    node,
+    event,
+    attributes
+  );
+
+  if (!responseText && !toolCalls) {
+    return null;
+  }
+
+  return (
+    <FoldSection
+      sectionKey={SectionKey.AI_OUTPUT}
+      title={t('Output')}
+      disableCollapsePersistence
+    >
+      {responseText && (
+        <MultilineText>
+          <strong>{t('Response')}</strong>
+          <br />
+          {responseText}
+        </MultilineText>
+      )}
+      {toolCalls && (
+        <MultilineText>
+          <strong>{t('Tool Calls')}</strong>
+          <br />
+          <StructuredData
+            value={tryParseJson(toolCalls)}
+            maxDefaultDepth={2}
+            withAnnotatedText
+          />
+        </MultilineText>
+      )}
+    </FoldSection>
+  );
+}
+
+const MultilineText = styled('div')`
+  white-space: pre-wrap;
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(1)};
+  &:not(:last-child) {
+    margin-bottom: ${space(1.5)};
+  }
+
+  & p {
+    margin: 0;
+  }
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -1,8 +1,7 @@
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
 import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -13,6 +12,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
@@ -57,37 +57,29 @@ export function AIOutputSection({
       disableCollapsePersistence
     >
       {responseText && (
-        <MultilineText>
-          <strong>{t('Response')}</strong>
-          <br />
-          {responseText}
-        </MultilineText>
+        <Fragment>
+          <TraceDrawerComponents.MultilineTextLabel>
+            {t('Response')}
+          </TraceDrawerComponents.MultilineTextLabel>
+          <TraceDrawerComponents.MultilineText>
+            {responseText}
+          </TraceDrawerComponents.MultilineText>
+        </Fragment>
       )}
       {toolCalls && (
-        <MultilineText>
-          <strong>{t('Tool Calls')}</strong>
-          <br />
-          <StructuredData
-            value={tryParseJson(toolCalls)}
-            maxDefaultDepth={2}
-            withAnnotatedText
-          />
-        </MultilineText>
+        <Fragment>
+          <TraceDrawerComponents.MultilineTextLabel>
+            {t('Tool Calls')}
+          </TraceDrawerComponents.MultilineTextLabel>
+          <TraceDrawerComponents.MultilineText>
+            <StructuredData
+              value={tryParseJson(toolCalls)}
+              maxDefaultDepth={2}
+              withAnnotatedText
+            />
+          </TraceDrawerComponents.MultilineText>
+        </Fragment>
       )}
     </FoldSection>
   );
 }
-
-const MultilineText = styled('div')`
-  white-space: pre-wrap;
-  background-color: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(1)};
-  &:not(:last-child) {
-    margin-bottom: ${space(1.5)};
-  }
-
-  & p {
-    margin: 0;
-  }
-`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -36,6 +36,8 @@ import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issues';
+import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
   getProfileMeta,
@@ -250,6 +252,8 @@ export function SpanNodeDetails(
                     organization={organization}
                     location={location}
                   />
+                  <AIInputSection node={node} />
+                  <AIOutputSection node={node} />
                   <SpanSections
                     node={node}
                     project={project}
@@ -386,6 +390,8 @@ function EAPSpanNodeDetails({
               attributes={attributes}
               avgSpanDuration={avgSpanDuration}
             />
+            <AIInputSection node={node} attributes={attributes} />
+            <AIOutputSection node={node} attributes={attributes} />
             <FoldSection
               sectionKey={SectionKey.SPAN_ATTRIBUTES}
               title={t('Attributes')}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -55,6 +55,8 @@ import {
   SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS,
   SENTRY_SEARCHABLE_SPAN_STRING_TAGS,
 } from 'sentry/views/explore/constants';
+import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {getIsAiNode} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {useDrawerContainerRef} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/drawerContainerRefContext';
@@ -429,6 +431,7 @@ function Highlights({
   highlightedAttributes,
 }: HighlightProps) {
   const dispatch = useTraceStateDispatch();
+  const organization = useOrganization();
 
   const onOpsBreakdownRowClick = useCallback(
     (op: string) => {
@@ -440,6 +443,8 @@ function Highlights({
   if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
     return null;
   }
+
+  const isAiNode = getIsAiNode(node);
 
   const startTimestamp = node.space[0];
   const endTimestamp = node.space[0] + node.space[1];
@@ -491,15 +496,25 @@ function Highlights({
               ))}
             </HighlightedAttributesWrapper>
           ) : null}
-          <StyledPanel>
-            <StyledPanelHeader>{headerContent}</StyledPanelHeader>
-            <PanelBody>{bodyContent}</PanelBody>
-          </StyledPanel>
-          {isEAPSpanNode(node) ? (
-            <HighLightEAPOpsBreakdown onRowClick={onOpsBreakdownRowClick} node={node} />
-          ) : event ? (
-            <HighLightsOpsBreakdown onRowClick={onOpsBreakdownRowClick} event={event} />
-          ) : null}
+          {isAiNode && hasAgentInsightsFeature(organization) ? null : (
+            <Fragment>
+              <StyledPanel>
+                <StyledPanelHeader>{headerContent}</StyledPanelHeader>
+                <PanelBody>{bodyContent}</PanelBody>
+              </StyledPanel>
+              {isEAPSpanNode(node) ? (
+                <HighLightEAPOpsBreakdown
+                  onRowClick={onOpsBreakdownRowClick}
+                  node={node}
+                />
+              ) : event ? (
+                <HighLightsOpsBreakdown
+                  onRowClick={onOpsBreakdownRowClick}
+                  event={event}
+                />
+              ) : null}
+            </Fragment>
+          )}
         </HighlightsRightColumn>
       </HighlightsWrapper>
       <SectionDivider />
@@ -670,8 +685,10 @@ const HighlightedAttributesWrapper = styled('div')`
   grid-template-columns: max-content 1fr;
   column-gap: ${space(1.5)};
   row-gap: ${space(0.5)};
-  margin-bottom: ${space(1.5)};
   font-size: ${p => p.theme.fontSizeMedium};
+  &:not(:last-child) {
+    margin-bottom: ${space(1.5)};
+  }
 `;
 
 const HighlightedAttributeName = styled('div')`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1331,6 +1331,21 @@ const CardValueText = styled('span')`
   overflow-wrap: anywhere;
 `;
 
+const MultilineText = styled('div')`
+  white-space: pre-wrap;
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  padding: ${space(1)};
+  &:not(:last-child) {
+    margin-bottom: ${space(1.5)};
+  }
+`;
+
+const MultilineTextLabel = styled('div')`
+  font-weight: bold;
+  margin-bottom: ${space(1)};
+`;
+
 const TraceDrawerComponents = {
   DetailContainer,
   BodyContainer,
@@ -1362,6 +1377,8 @@ const TraceDrawerComponents = {
   TraceDataSection,
   SectionCardGroup,
   DropdownMenuWithPortal,
+  MultilineText,
+  MultilineTextLabel,
 };
 
 export {TraceDrawerComponents};

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -28,6 +28,8 @@ import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnal
 import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {getCustomInstrumentationLink} from 'sentry/views/performance/newTraceDetails/traceConfigurations';
 import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issues';
+import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
+import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -156,6 +158,9 @@ export function TransactionNodeDetails({
           project={project}
           organization={organization}
         />
+
+        <AIInputSection node={node} event={event} />
+        <AIOutputSection node={node} event={event} />
 
         <TransactionSpecificSections
           event={event}


### PR DESCRIPTION


https://github.com/user-attachments/assets/4f3a3c8a-ce7a-4e83-a2bf-282551faf9e7


Note: Hiding the highlighted attributes from the rest of the details will be in a follow-up.

- part of [TET-498: Trace View - AI Span details](https://linear.app/getsentry/issue/TET-498/trace-view-ai-span-details)