### PR TITLE
fix(spans): Increase spans per segment limit to 1001

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -146,7 +146,7 @@ class SpansBuffer:
         span_buffer_root_timeout_secs: int = 10,
         segment_page_size: int = 100,
         max_segment_bytes: int = 10 * 1024 * 1024,  # 10 MiB
-        max_segment_spans: int = 1000,
+        max_segment_spans: int = 1001,
         redis_ttl: int = 3600,
     ):
         self.assigned_shards = list(assigned_shards)


### PR DESCRIPTION
Relay currently enforces a limit of 1000 spans per segment, but that does not
count the transaction span itself. For this reason, we receive a high number of
errors for segments exceeding the maximum span count.

To silence this error for expected cases, we increase the limit to 1001 for now.
Soon this limit will be further increased.

Ref VIEPF-15