### PR TITLE
hovercard: remove header border radius

### DIFF
--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -218,7 +218,6 @@ const Header = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   background: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.border};
-  border-radius: 8px 8px 0 0;
   font-weight: ${p => p.theme.fontWeightBold};
   word-wrap: break-word;
   padding: ${space(1.5)};

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.tsx
@@ -178,6 +178,7 @@ const StyledHovercard = styled(Hovercard)`
   ${Body} {
     padding: 0;
   }
+  overflow: hidden;
   min-width: max-content;
 `;
 


### PR DESCRIPTION
The overlay of the hovercard already contains a border radius, so this should not be required as it results in a double border in some cases like so

![CleanShot 2025-05-28 at 10 27 05@2x](https://github.com/user-attachments/assets/0291a7a6-8997-480d-959e-0656180c9d6c)

Fixes DE-102