### PR TITLE
ref(echarts): Tighten up types for ECharts

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -1,9 +1,9 @@
 import {captureException} from '@sentry/core';
 import {useQuery} from '@tanstack/react-query';
-import type {EChartsInstance} from 'echarts-for-react';
 
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
+import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {EVENT_GRAPH_WIDGET_ID} from 'sentry/views/issueDetails/streamline/eventGraphWidget';
 
@@ -14,7 +14,7 @@ interface Props extends LoadableChartWidgetProps {
    */
   id: ChartId;
 
-  ref?: React.Ref<EChartsInstance>;
+  ref?: React.Ref<ReactEchartsRef>;
 }
 // We need to map the widget id to the dynamic import because we want the import paths to be statically analyzable.
 const CHART_MAP = {

--- a/static/app/components/charts/treeCoverageSunburstChart.tsx
+++ b/static/app/components/charts/treeCoverageSunburstChart.tsx
@@ -147,7 +147,9 @@ export function TreeCoverageSunburstChart({
                 setBreadCrumbs(params.data.fullPath);
               }
             },
-            click: (params: Parameters<EChartClickHandler>[0]) => {
+            click: (
+              params: Parameters<EChartClickHandler<ProcessedTreeCoverageSunburstData>>[0]
+            ) => {
               if (typeof params.data !== 'object') {
                 return;
               }
@@ -160,8 +162,8 @@ export function TreeCoverageSunburstChart({
                 }
 
                 setRenderData(() => {
-                  if (params.data.depth > 0 && parent) {
-                    const children = bfsFilter(node, params.data?.depth + 1);
+                  if ((params.data.depth ?? 0) > 0 && parent) {
+                    const children = bfsFilter(node, (params.data?.depth ?? 0) + 1);
 
                     return {
                       ...parent,
@@ -171,7 +173,7 @@ export function TreeCoverageSunburstChart({
                     } satisfies ProcessedTreeCoverageSunburstData;
                   }
 
-                  return bfsFilter(node, params.data?.depth + 2);
+                  return bfsFilter(node, (params.data?.depth ?? 0) + 2);
                 });
               }
             },

--- a/static/app/components/charts/treeCoverageSunburstChart.tsx
+++ b/static/app/components/charts/treeCoverageSunburstChart.tsx
@@ -134,11 +134,11 @@ export function TreeCoverageSunburstChart({
         <ReactEchartsCore
           echarts={echarts}
           onEvents={{
-            mouseover: (params: Parameters<EChartMouseOverHandler>[0]) => {
-              if (typeof params.data !== 'object') {
-                return;
-              }
-
+            mouseover: (
+              params: Parameters<
+                EChartMouseOverHandler<ProcessedTreeCoverageSunburstData>
+              >[0]
+            ) => {
               const splitPaths = params.data.fullPath.split('/');
 
               if (splitPaths.length > 2) {
@@ -150,10 +150,6 @@ export function TreeCoverageSunburstChart({
             click: (
               params: Parameters<EChartClickHandler<ProcessedTreeCoverageSunburstData>>[0]
             ) => {
-              if (typeof params.data !== 'object') {
-                return;
-              }
-
               if (params?.data?.type === 'dir') {
                 const parent = rootNode.edges.get(params.data.fullPath);
                 const node = rootNode.nodeMap.get(params.data?.fullPath);

--- a/static/app/components/charts/treeCoverageSunburstChart.tsx
+++ b/static/app/components/charts/treeCoverageSunburstChart.tsx
@@ -135,6 +135,10 @@ export function TreeCoverageSunburstChart({
           echarts={echarts}
           onEvents={{
             mouseover: (params: Parameters<EChartMouseOverHandler>[0]) => {
+              if (typeof params.data !== 'object') {
+                return;
+              }
+
               const splitPaths = params.data.fullPath.split('/');
 
               if (splitPaths.length > 2) {
@@ -144,6 +148,10 @@ export function TreeCoverageSunburstChart({
               }
             },
             click: (params: Parameters<EChartClickHandler>[0]) => {
+              if (typeof params.data !== 'object') {
+                return;
+              }
+
               if (params?.data?.type === 'dir') {
                 const parent = rootNode.edges.get(params.data.fullPath);
                 const node = rootNode.nodeMap.get(params.data?.fullPath);

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -4,7 +4,8 @@ import type {
   LineSeriesOption,
   PatternObject,
 } from 'echarts';
-import type ReactEchartsCore from 'echarts-for-react/lib/core';
+// @eslint-disable-next-line no-restricted-imports This is the only file allowed to import `EChartsReact` since we re-export it for use
+import type EChartsReact from 'echarts-for-react';
 
 import type {Confidence} from 'sentry/types/organization';
 
@@ -38,7 +39,7 @@ export type Series = {
   z?: number;
 };
 
-export type ReactEchartsRef = ReactEchartsCore;
+export type ReactEchartsRef = EChartsReact;
 
 export type EChartEventHandler<P> = (params: P, instance: ECharts) => void;
 

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -1,9 +1,15 @@
 import type {
   AxisPointerComponentOption,
+  Color,
   ECharts as EChartsType,
   LineSeriesOption,
   PatternObject,
 } from 'echarts';
+import type {
+  Dictionary,
+  OptionDataItemObject,
+  OptionDataValue,
+} from 'echarts/types/src/util/types';
 import type EChartsReact from 'echarts-for-react';
 
 import type {Confidence} from 'sentry/types/organization';
@@ -72,8 +78,6 @@ export type EChartDownplayHandler = EChartEventHandler<EChartsHighlightEventPara
  * Taken from https://echarts.apache.org/en/api.html#events.Mouse%20events
  */
 interface EChartMouseEventParam {
-  // color of component (make sense when componentType is 'series')
-  color: string;
   // subtype of the component to which the clicked glyph belongs
   // i.e. 'scatter', 'line', etc
   componentSubType: string;
@@ -81,29 +85,37 @@ interface EChartMouseEventParam {
   // i.e., 'series', 'markLine', 'markPoint', 'timeLine'
   componentType: string;
   // incoming raw data item
-  data: Record<string, any>;
+  data: string | number | Record<string, any>;
   // data index in incoming data array
   dataIndex: number;
+  // data name, category name
+  name: string;
+  // incoming data value
+  value:
+    | number
+    | string
+    | OptionDataValue[]
+    | Date
+    | Dictionary<OptionDataValue>
+    | OptionDataItemObject<OptionDataValue>;
+  // color of component (make sense when componentType is 'series')
+  color?: Color;
+
   // Some series, such as sankey or graph, maintains more than
   // one types of data (nodeData and edgeData), which can be
   // distinguished from each other by dataType with its value
   // 'node' and 'edge'.
   // On the other hand, most series has only one type of data,
   // where dataType is not needed.
-  dataType: string;
-  // data name, category name
-  name: string;
-
-  seriesId: string;
+  dataType?: string;
+  seriesId?: string;
   // series index in incoming option.series (make sense when componentType is 'series')
-  seriesIndex: number;
+  seriesIndex?: number;
   // series name (make sense when componentType is 'series')
-  seriesName: string;
+  seriesName?: string;
   // series type (make sense when componentType is 'series')
   // i.e., 'line', 'bar', 'pie'
-  seriesType: string;
-  // incoming data value
-  value: number | number[];
+  seriesType?: string;
 }
 
 export type EChartMouseOutHandler = EChartEventHandler<EChartMouseEventParam>;

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -72,12 +72,13 @@ export type EChartHighlightHandler = EChartEventHandler<EChartsHighlightEventPar
 
 export type EChartDownplayHandler = EChartEventHandler<EChartsHighlightEventParam>;
 
+type EChartMouseEventData = string | number | Record<string, any>;
 /**
  * XXX: These are incomplete types and can also vary depending on the component type
  *
  * Taken from https://echarts.apache.org/en/api.html#events.Mouse%20events
  */
-interface EChartMouseEventParam {
+interface EChartMouseEventParam<T = EChartMouseEventData> {
   // subtype of the component to which the clicked glyph belongs
   // i.e. 'scatter', 'line', etc
   componentSubType: string;
@@ -85,7 +86,7 @@ interface EChartMouseEventParam {
   // i.e., 'series', 'markLine', 'markPoint', 'timeLine'
   componentType: string;
   // incoming raw data item
-  data: string | number | Record<string, any>;
+  data: T;
   // data index in incoming data array
   dataIndex: number;
   // data name, category name
@@ -118,11 +119,17 @@ interface EChartMouseEventParam {
   seriesType?: string;
 }
 
-export type EChartMouseOutHandler = EChartEventHandler<EChartMouseEventParam>;
+export type EChartMouseOutHandler<T = EChartMouseEventData> = EChartEventHandler<
+  EChartMouseEventParam<T>
+>;
 
-export type EChartMouseOverHandler = EChartEventHandler<EChartMouseEventParam>;
+export type EChartMouseOverHandler<T = EChartMouseEventData> = EChartEventHandler<
+  EChartMouseEventParam<T>
+>;
 
-export type EChartClickHandler = EChartEventHandler<EChartMouseEventParam>;
+export type EChartClickHandler<T = EChartMouseEventData> = EChartEventHandler<
+  EChartMouseEventParam<T>
+>;
 
 export type EChartDataZoomHandler = EChartEventHandler<{
   /**

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -4,7 +4,6 @@ import type {
   LineSeriesOption,
   PatternObject,
 } from 'echarts';
-// @eslint-disable-next-line no-restricted-imports This is the only file allowed to import `EChartsReact` since we re-export it for use
 import type EChartsReact from 'echarts-for-react';
 
 import type {Confidence} from 'sentry/types/organization';

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -8,7 +8,6 @@ import type {
   TooltipFormatterCallback,
   TopLevelFormatterParams,
 } from 'echarts/types/dist/shared';
-import type {EChartsInstance} from 'echarts-for-react';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
 import sum from 'lodash/sum';
@@ -79,7 +78,7 @@ export interface TimeSeriesWidgetVisualizationProps
   /**
    * Reference to the chart instance
    */
-  chartRef?: React.Ref<EChartsInstance>;
+  chartRef?: React.Ref<ReactEchartsRef>;
   /**
    * A mapping of time series field name to boolean. If the value is `false`, the series is hidden from view
    */

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -562,9 +562,13 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const allSeries = [...seriesFromPlottables, releaseSeries].filter(defined);
 
   const runHandler = (
-    batch: {dataIndex: number; seriesIndex: number},
+    batch: {dataIndex: number; seriesIndex?: number},
     handlerName: 'onClick' | 'onHighlight' | 'onDownplay'
   ): void => {
+    if (batch.seriesIndex === undefined) {
+      return;
+    }
+
     const affectedRange = seriesIndexToPlottableRangeMap.getRange(batch.seriesIndex);
     const affectedPlottable = affectedRange?.value;
 
@@ -706,7 +710,7 @@ function getPlottableEventDataIndex(
   series: SeriesOption[],
   event: {
     dataIndex: number;
-    seriesIndex: number;
+    seriesIndex?: number;
   },
   affectedRange: Range<Plottable>
 ): number {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -9,7 +9,6 @@ import type {
   TopLevelFormatterParams,
 } from 'echarts/types/dist/shared';
 import type {EChartsInstance} from 'echarts-for-react';
-import type EChartsReactCore from 'echarts-for-react/lib/core';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
 import sum from 'lodash/sum';
@@ -133,7 +132,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // have the same difference in `timestamp`s) even though this is rare, since
   // the backend zerofills the data
 
-  const chartRef = useRef<EChartsReactCore | null>(null);
+  const chartRef = useRef<ReactEchartsRef | null>(null);
   const {register: registerWithWidgetSyncContext} = useWidgetSyncContext();
 
   const pageFilters = usePageFilters();

--- a/static/app/views/insights/common/components/widgets/types.tsx
+++ b/static/app/views/insights/common/components/widgets/types.tsx
@@ -1,7 +1,5 @@
-import type {EChartsInstance} from 'echarts-for-react';
-
 import type {PageFilters} from 'sentry/types/core';
-import type {EChartDataZoomHandler} from 'sentry/types/echarts';
+import type {EChartDataZoomHandler, ReactEchartsRef} from 'sentry/types/echarts';
 
 /**
  * These props are common across components that are required to dynamically
@@ -11,7 +9,7 @@ export interface LoadableChartWidgetProps {
   /**
    * Reference to the chart instance
    */
-  chartRef?: React.Ref<EChartsInstance>;
+  chartRef?: React.Ref<ReactEchartsRef>;
 
   /**
    * Chart height, needed to ensure that the chart height is consistent with

--- a/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraphWidget.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import type {EChartsInstance} from 'echarts-for-react';
 
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
+import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {Group} from 'sentry/types/group';
 import {useParams} from 'sentry/utils/useParams';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
@@ -52,7 +52,7 @@ function EventGraphLoadedWidget({
 }: {
   group: Group;
   pageFilters: PageFilters | undefined;
-  chartRef?: React.Ref<EChartsInstance>;
+  chartRef?: React.Ref<ReactEchartsRef>;
 }) {
   const eventView = useIssueDetailsEventView({
     group,

--- a/static/app/views/releases/drawer/releasesDrawerList.tsx
+++ b/static/app/views/releases/drawer/releasesDrawerList.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useRef} from 'react';
-import type {SeriesOption} from 'echarts';
+import type {ECharts, SeriesOption} from 'echarts';
 import type {MarkLineOption} from 'echarts/types/dist/shared';
-import type {EChartsInstance} from 'echarts-for-react';
 
 import {
   type ChartId,
@@ -41,7 +40,7 @@ type MarkLineDataCallbackFn = (item: SeriesDataUnit) => boolean;
 
 function createMarkLineUpdater(lineStyle: Partial<MarkLineOption['lineStyle']>) {
   return (
-    echartsInstance: EChartsInstance,
+    echartsInstance: ECharts,
     seriesId: string,
     callbackFn: MarkLineDataCallbackFn
   ) => {

--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -1,5 +1,6 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import type {LineSeriesOption} from 'echarts';
 import type {Location} from 'history';
 import compact from 'lodash/compact';
@@ -122,6 +123,11 @@ class ReleasesAdoptionChart extends Component<Props> {
     const {organization, router, selection, location} = this.props;
 
     const project = selection.projects[0];
+
+    if (!params.seriesId) {
+      Sentry.logger.warn('Releases: Adoption Chart clicked with no seriesId');
+      return;
+    }
 
     router.push(
       normalizeUrl({

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -8,7 +8,6 @@ import type {
   CustomSeriesRenderItemReturn,
   ElementEvent,
 } from 'echarts';
-import type EChartsReact from 'echarts-for-react';
 import debounce from 'lodash/debounce';
 import moment from 'moment-timezone';
 
@@ -325,7 +324,7 @@ export function useReleaseBubbles({
     defined(endTimeToUse) && !Array.isArray(endTimeToUse)
       ? new Date(endTimeToUse).getTime()
       : Date.now();
-  const chartRef = useRef<EChartsReact | null>(null);
+  const chartRef = useRef<ReactEchartsRef | null>(null);
   const hasReleaseBubbles = organization.features.includes('release-bubbles-ui');
   const totalBubblePaddingY = bubblePadding * 2;
   const defaultBubbleXAxis = useMemo(

--- a/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -8,7 +8,7 @@ import type {
   CustomSeriesRenderItemReturn,
   ElementEvent,
 } from 'echarts';
-import type {EChartsInstance} from 'echarts-for-react';
+import type EChartsReact from 'echarts-for-react';
 import debounce from 'lodash/debounce';
 import moment from 'moment-timezone';
 
@@ -325,7 +325,7 @@ export function useReleaseBubbles({
     defined(endTimeToUse) && !Array.isArray(endTimeToUse)
       ? new Date(endTimeToUse).getTime()
       : Date.now();
-  const chartRef = useRef<ReactEchartsRef | null>(null);
+  const chartRef = useRef<EChartsReact | null>(null);
   const hasReleaseBubbles = organization.features.includes('release-bubbles-ui');
   const totalBubblePaddingY = bubblePadding * 2;
   const defaultBubbleXAxis = useMemo(
@@ -397,14 +397,18 @@ export function useReleaseBubbles({
     (e: ReactEchartsRef | null) => {
       chartRef.current = e;
 
-      const echartsInstance: EChartsInstance = e?.getEchartsInstance?.();
+      const echartsInstance = e?.getEchartsInstance?.();
       const highlightedBuckets = new Set();
 
       const handleMouseMove = (params: ElementEvent) => {
+        if (!echartsInstance) {
+          return;
+        }
+
         // Tracks movement across the chart and highlights the corresponding release bubble
         const pointInPixel = [params.offsetX, params.offsetY];
         const pointInGrid = echartsInstance.convertFromPixel('grid', pointInPixel);
-        const series = echartsInstance.getOption().series;
+        const series = echartsInstance.getOption().series as Series[];
         const seriesIndex = series.findIndex((s: Series) => s.id === BUBBLE_SERIES_ID);
 
         // No release bubble series found (shouldn't happen)
@@ -480,7 +484,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOver = (params: Parameters<EChartMouseOverHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
           return;
         }
 
@@ -515,7 +519,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
           return;
         }
 
@@ -538,7 +542,7 @@ export function useReleaseBubbles({
           return;
         }
 
-        const series = echartsInstance.getOption().series;
+        const series = echartsInstance.getOption().series as Series[];
         const seriesIndex = series.findIndex((s: Series) => s.id === BUBBLE_SERIES_ID);
         // We could find and include a `dataIndex` to be specific about which
         // bubble to "downplay", but I think it's ok to downplay everything
@@ -549,7 +553,11 @@ export function useReleaseBubbles({
       };
 
       const handleLegendSelectChanged = (params: LegendSelectChangedParams) => {
-        if (params.name !== 'Releases' || !('Releases' in params.selected)) {
+        if (
+          params.name !== 'Releases' ||
+          !('Releases' in params.selected) ||
+          !echartsInstance
+        ) {
           return;
         }
         const selected = params.selected.Releases;
@@ -583,6 +591,7 @@ export function useReleaseBubbles({
         echartsInstance.on('mouseover', handleMouseOver);
         echartsInstance.on('mouseout', handleMouseOut);
         echartsInstance.on('globalout', handleGlobalOut);
+        // @ts-expect-error ECharts types `params` as unknown
         echartsInstance.on('legendselectchanged', handleLegendSelectChanged);
         echartsInstance.getZr().on('mousemove', handleMouseMove);
       }


### PR DESCRIPTION
* Use the default export from `echarts-for-react` instead of `echarts-for-react/lib/core`
* Use `ReactEchartsRef` from `sentry/types/echarts` instead of the above ^ import directly (`ReactEchartsRef` is used more often in our codebase)
* Remove use of `EChartsInstance`, which is just aliased to `any`
* Update/modify types to support the replacement of `EChartsInstance` with `ReactEchartsRef`

I considered adding a lint rule to disallow the above imports, but that feels heavy-handed for how often these types will get used. Especially since the import plugin is slow enough already.
