### PR TITLE
feat(releases): Fix adoption threshold criteria to be 10% of sessions

### DIFF
--- a/tests/sentry/release_health/test_tasks.py
+++ b/tests/sentry/release_health/test_tasks.py
@@ -13,7 +13,11 @@ from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.repository import Repository
 from sentry.release_health.release_monitor.base import BaseReleaseMonitorBackend
 from sentry.release_health.release_monitor.metrics import MetricReleaseMonitorBackend
-from sentry.release_health.tasks import monitor_release_adoption, process_projects_with_sessions
+from sentry.release_health.tasks import (
+    has_been_adopted,
+    monitor_release_adoption,
+    process_projects_with_sessions,
+)
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import BaseMetricsTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -544,3 +548,13 @@ class BaseTestReleaseMonitor(TestCase, BaseMetricsTestCase):
 
 class TestMetricReleaseMonitor(BaseTestReleaseMonitor, BaseMetricsTestCase):
     backend_class = MetricReleaseMonitorBackend
+
+
+def test_has_been_adopted():
+    """An adopted session has at least 10% of the environment's sessions."""
+    assert has_been_adopted(10, 1)
+    assert has_been_adopted(100, 10)
+    assert has_been_adopted(1000, 100)
+    assert not has_been_adopted(100, 0)
+    assert not has_been_adopted(100, 1)
+    assert not has_been_adopted(100, 9)


### PR DESCRIPTION
Updates the threshold formula to be "Total number of sessions for an environment * 10%" rather than "Total number of active releases for an environment / 10%" which is nonsensical for multiple reasons.

Because the "adopted" and "unadopted" columns are stateful we can not fix them**.  There is no migration we can write to fix this error***.  After this fix releases which were previously marked as "adopted" may be marked as "unadopted" leading to customer confusion.  This also can't be fixed.

** Can not fix them without product changes which would take a significant amount of effort to implement.
*** Technically we have a 90 day history of sessions (AFAIK its 90). We could reset everyone's releases back to the default empty state and then re-run the session calculations for every hour from now to 90 days ago. This would be an expensive operation (90 * 24 * num orgs * num releases queries to clickhouse plus 90 * 24 * num projects * num release * ~5 for postgres) and we would need to write additional code to support this data migration. To prevent customers from seeing broken data we would need to disable the release task this PR fixes but we would need to communicate an extended outage is occurring.