### PR TITLE
ref(feedback): logs FeedbackEvent's extract_metadata method

### DIFF
--- a/src/sentry/eventtypes/feedback.py
+++ b/src/sentry/eventtypes/feedback.py
@@ -1,11 +1,16 @@
+import logging
+
 from sentry.eventtypes.base import BaseEvent
 from sentry.utils.safe import get_path
+
+logger = logging.getLogger(__name__)
 
 
 class FeedbackEvent(BaseEvent):
     key = "feedback"
 
     def extract_metadata(self, data):
+        logger.info("Extract metadata called in the FeedbackEvent class")
         contact_email = get_path(data, "contexts", "feedback", "contact_email")
         message = get_path(data, "contexts", "feedback", "message")
         name = get_path(data, "contexts", "feedback", "name")


### PR DESCRIPTION
Through a bit of testing, it seemed as though feedback events had type `GenericEvent` when `materialize_metadata` is called in `issues/ingest.py`, and the if statement in the function handled adding the metadata that a feedback event requires. This log tests that assumption.