### PR TITLE
fix(discover): Override parser configs to account for `is:` filters

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -35,6 +35,7 @@ from sentry.search.events.builder.discover import UnresolvedQuery
 from sentry.search.events.fields import is_function
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 from sentry.tasks.on_demand_metrics import (
     _get_widget_on_demand_specs,
     check_field_cardinality,
@@ -44,7 +45,6 @@ from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.users.models.user import User
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.strings import oxfordize_list
-from src.sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 
 AGGREGATE_PATTERN = r"^(\w+)\((.*)?\)$"
 AGGREGATE_BASE = r".*(\w+)\((.*)?\)"

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta
 from enum import Enum
 from math import floor
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 import sentry_sdk
 from django.db.models import Max
@@ -57,6 +57,13 @@ DATASET_SOURCE_MAP = {source[1]: source[0] for source in DatasetSourcesTypes.as_
 class QueryWarning(TypedDict):
     queries: list[str | None]
     columns: dict[str, str]
+
+
+class QueryBuilderConfigDict(TypedDict):
+    equation_config: dict[str, bool]
+    use_aggregate_conditions: bool
+    parser_config_overrides: NotRequired[dict]
+    has_metrics: NotRequired[bool]
 
 
 def is_equation(field: str) -> bool:
@@ -273,7 +280,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
             # or to provide the start/end so that the interval can be computed.
             # This uses a hard coded start/end to ensure the validation succeeds
             # since the values themselves don't matter.
-            builder_config = {
+            builder_config: QueryBuilderConfigDict = {
                 "equation_config": {
                     "auto_add": bool(not is_table or injected_orderby_equation),
                     "aggregates_only": not is_table,

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -22,7 +22,6 @@ from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.users.models import User
 from sentry.utils.dates import parse_stats_period, validate_interval
-from src.sentry.search.events.builder.errors import ErrorsQueryBuilder
 from src.sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 
 
@@ -243,18 +242,13 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
 
                 equations, columns = categorize_columns(query["fields"])
 
-                BuilderClass = (
-                    ErrorsQueryBuilder
-                    if data.get("queryDataset") == DiscoverSavedQueryTypes.ERROR_EVENTS
-                    else DiscoverQueryBuilder
-                )
                 builder_config = {}
                 if data.get("queryDataset") == DiscoverSavedQueryTypes.ERROR_EVENTS:
                     builder_config["parser_config_overrides"] = ERROR_PARSER_CONFIG_OVERRIDES
                 elif data.get("queryDataset") == DiscoverSavedQueryTypes.TRANSACTION_LIKE:
                     builder_config["has_metrics"] = use_metrics
 
-                builder = BuilderClass(
+                builder = DiscoverQueryBuilder(
                     dataset=Dataset.Discover,
                     params=self.context["params"],
                     query=query["query"],

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import NotRequired, TypedDict
 
 import sentry_sdk
 from django.db.models import Count, Max, QuerySet
@@ -23,6 +24,11 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 from sentry.users.models import User
 from sentry.utils.dates import parse_stats_period, validate_interval
+
+
+class QueryBuilderConfigDict(TypedDict):
+    parser_config_overrides: NotRequired[dict]
+    has_metrics: NotRequired[bool]
 
 
 @extend_schema_serializer(
@@ -242,7 +248,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
 
                 equations, columns = categorize_columns(query["fields"])
 
-                builder_config = {}
+                builder_config: QueryBuilderConfigDict = {}
                 if data.get("queryDataset") == DiscoverSavedQueryTypes.ERROR_EVENTS:
                     builder_config["parser_config_overrides"] = ERROR_PARSER_CONFIG_OVERRIDES
                 elif data.get("queryDataset") == DiscoverSavedQueryTypes.TRANSACTION_LIKE:

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -20,9 +20,9 @@ from sentry.models.team import Team
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 from sentry.users.models import User
 from sentry.utils.dates import parse_stats_period, validate_interval
-from src.sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 
 
 @extend_schema_serializer(

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from typing import NotRequired, TypedDict
 
 import sentry_sdk
 from django.db.models import Count, Max, QuerySet
@@ -24,11 +23,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
 from sentry.users.models import User
 from sentry.utils.dates import parse_stats_period, validate_interval
-
-
-class QueryBuilderConfigDict(TypedDict):
-    parser_config_overrides: NotRequired[dict]
-    has_metrics: NotRequired[bool]
 
 
 @extend_schema_serializer(
@@ -248,11 +242,11 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
 
                 equations, columns = categorize_columns(query["fields"])
 
-                builder_config: QueryBuilderConfigDict = {}
+                config = QueryBuilderConfig()
                 if data.get("queryDataset") == DiscoverSavedQueryTypes.ERROR_EVENTS:
-                    builder_config["parser_config_overrides"] = ERROR_PARSER_CONFIG_OVERRIDES
+                    config.parser_config_overrides = ERROR_PARSER_CONFIG_OVERRIDES
                 elif data.get("queryDataset") == DiscoverSavedQueryTypes.TRANSACTION_LIKE:
-                    builder_config["has_metrics"] = use_metrics
+                    config.has_metrics = use_metrics
 
                 builder = DiscoverQueryBuilder(
                     dataset=Dataset.Discover,
@@ -261,7 +255,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                     selected_columns=columns,
                     equations=equations,
                     orderby=query.get("orderby"),
-                    config=QueryBuilderConfig(**builder_config),
+                    config=config,
                 )
                 builder.get_snql_query().validate()
             except (InvalidSearchQuery, ArithmeticError) as err:

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -2479,6 +2479,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "widgets": [
                 {
                     "title": "EPM table",
+                    "widgetType": "transaction-like",
                     "displayType": "table",
                     "queries": [
                         {

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1329,3 +1329,25 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data == {
             "limit": "limit is required. The maximum limit is 5."
         }
+
+    def test_valid_widget_is_filters(self):
+        data = {
+            "title": "Errors over time",
+            "displayType": "line",
+            "queries": [
+                {
+                    "name": "errors",
+                    "conditions": "is:unresolved",
+                    "fields": ["count()"],
+                    "columns": [],
+                    "aggregates": ["count()"],
+                },
+            ],
+            "widgetType": "error-events",
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -710,3 +710,27 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                 },
             )
         assert response.status_code == 400, response.content
+
+    def test_post_success_is_filter(self):
+        with self.feature(self.feature_name):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "new query",
+                    "projects": self.project_ids,
+                    "fields": ["title"],
+                    "query": "is:unresolved",
+                    "range": "24h",
+                    "yAxis": ["count(id)"],
+                    "display": "releases",
+                    "version": 2,
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["fields"] == ["title"]
+        assert data["range"] == "24h"
+        assert data["query"] == "is:unresolved"
+        assert data["yAxis"] == ["count(id)"]
+        assert data["display"] == "releases"
+        assert data["version"] == 2


### PR DESCRIPTION
Discover queries on the errors dataset and error widgets in dashboards were unable to be saved because of missing setup in the config to account for `is:` filters. The data was there but it doesn't seem like the queries were allowing saving or dashboard updates (since the widgets go through validation).

I added code to the relevant serializers to detect the dataset type and if it's errors, we add the `PARSER_CONFIG_OVERRIDES` into the config.

Fixes #92095