### PR TITLE
fix(crons): Don't use text for empty cells

### DIFF
--- a/static/app/views/insights/crons/components/checkInCell.tsx
+++ b/static/app/views/insights/crons/components/checkInCell.tsx
@@ -12,7 +12,6 @@ import {
   StatusIndicator,
   type StatusIndicatorProps,
 } from 'sentry/components/statusIndicator';
-import Text from 'sentry/components/text';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
@@ -44,7 +43,7 @@ const checkStatusToIndicatorStatus: Record<
   [CheckInStatus.UNKNOWN]: 'muted',
 };
 
-const emptyCell = <Text>{'\u2014'}</Text>;
+const emptyCell = '\u2014';
 
 /**
  * Represents the 'completion' of a check-in.


### PR DESCRIPTION
The text was causing extra padding. Thigns are a little tigher and more
aligned without this.

Before:

<img alt="clipboard.png" width="1103" src="https://i.imgur.com/CznmWE3.png" />

After:

<img alt="clipboard.png" width="1080" src="https://i.imgur.com/uBQ8tCX.png" />