### PR TITLE
fix(projects): Improve wording for AppHangsV2

### DIFF
--- a/static/app/views/releases/utils/sessionTerm.spec.tsx
+++ b/static/app/views/releases/utils/sessionTerm.spec.tsx
@@ -477,7 +477,7 @@ describe('Release Health Session Term', function () {
       'apple-ios'
     );
     expect(anrRateSessionTerm).toBe(
-      'Percentage of unique users that experienced a fatal App Hang. You have to enable AppHangsV2 to see this metric.'
+      "Percentage of unique users that experienced a fatal App Hang. You must enable AppHangsV2 to get the correct statistics for the App Hang Rate. AppHangV1 events don't impact this metric."
     );
   });
 

--- a/static/app/views/releases/utils/sessionTerm.tsx
+++ b/static/app/views/releases/utils/sessionTerm.tsx
@@ -124,7 +124,7 @@ function getTermDescriptions(platform: PlatformKey | null) {
         ...mobileTermsDescription,
         [SessionTerm.CRASHED]: t('An error that resulted in the application crashing'),
         [SessionTerm.ANR_RATE]: t(
-          'Percentage of unique users that experienced a fatal App Hang. You have to enable AppHangsV2 to see this metric.'
+          "Percentage of unique users that experienced a fatal App Hang. You must enable AppHangsV2 to get the correct statistics for the App Hang Rate. AppHangV1 events don't impact this metric."
         ),
       };
     }


### PR DESCRIPTION
Explain that AppHangV1 events don't impact the app hang rate.

