### PR TITLE
fix(workflow_engine): Fix unbound event_data / detector_result

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -433,6 +433,7 @@ class StatefulDetectorHandler(
         to create a detector occurrence.
         """
         detector_result: IssueOccurrence | StatusChangeMessage
+        event_data = None
 
         # TODO ensure this is not a duplicate packet or reprocessing
 
@@ -566,8 +567,8 @@ class StatefulGroupingDetectorHandler(
         is_triggered = new_status != DetectorPriorityLevel.OK
         self.state_manager.enqueue_state_update(group_key, is_triggered, new_status)
 
-        event_data = None
         result: StatusChangeMessage | IssueOccurrence
+        event_data = None
 
         if new_status == DetectorPriorityLevel.OK:
             result = StatusChangeMessage(


### PR DESCRIPTION
The `event_data` variable may be unbound when the detector is resolving
an issue. detector_result would never be unbound since it's set in both
branches, but we should be consistent here and declare it and it's type.