### PR TITLE
ref(feedback): check for associated_event_id in metadata for linked error indicator

### DIFF
--- a/static/app/utils/feedback/hasLinkedError.tsx
+++ b/static/app/utils/feedback/hasLinkedError.tsx
@@ -7,5 +7,10 @@ const CRASH_REPORT_SOURCES: string[] = [
 ] as const;
 
 export default function hasLinkedError(item: FeedbackIssueListItem): boolean {
-  return CRASH_REPORT_SOURCES.includes(item.metadata.source ?? '');
+  // If it is in CRASH_REPORT_SOURCES, it has a linked error, or if it is a new_feedback_envelope, check associated_event_id
+  // Can potentially remove this after all feedbacks have associated_event_id in their metadata (~90 days)
+  return (
+    CRASH_REPORT_SOURCES.includes(item.metadata.source ?? '') ||
+    item.metadata.hasOwnProperty('associated_event_id')
+  );
 }

--- a/static/app/utils/feedback/types.tsx
+++ b/static/app/utils/feedback/types.tsx
@@ -40,6 +40,7 @@ export type FeedbackIssueListItem = Overwrite<
       name: string;
       title: string;
       value: string;
+      associated_event_id?: string;
       sdk?: {
         name: string;
         name_normalized: string;


### PR DESCRIPTION
Frontend change that corresponds to https://github.com/getsentry/sentry/pull/92428, additionally checks for the existence of associated_event_id in the feedback issue's metadata to show the linked error icon.