### PR TITLE
layout: headers have the same background color

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -38,7 +38,12 @@ export const Header = styled('header')<{
     p.noActionWrap ? 'minmax(0, 1fr) auto' : 'minmax(0, 1fr)'};
 
   padding: ${space(2)} ${space(2)} 0 ${space(2)};
-  background-color: ${p => (p.unified ? p.theme.background : 'transparent')};
+  background-color: ${p =>
+    p.theme.isChonk
+      ? p.theme.background
+      : p.unified
+        ? p.theme.background
+        : 'transparent'};
 
   ${p =>
     !p.unified &&


### PR DESCRIPTION
Headers will have the same header backgrounds in UI2 regardless of if they are unified or not.

Fixes DE-117

