### PR TITLE
:bug: fix(plugins): only disable plugins if they are installed on a project during migration

### DIFF
--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -55,7 +55,7 @@ class PluginManager(InstanceManager):
                 return True
         return False
 
-    def for_project(self, project, version=1):
+    def for_project(self, project, version=1) -> Generator[Plugin | Plugin2]:
         for plugin in self.all(version=version):
             if not safe_execute(plugin.is_enabled, project):
                 continue

--- a/src/sentry/plugins/migrator.py
+++ b/src/sentry/plugins/migrator.py
@@ -29,13 +29,14 @@ class Migrator:
 
                 if self.all_repos_migrated(plugin.slug):
                     try:
-                        logger.info(
-                            "plugin.disabled",
-                            extra=self._logging_context(
-                                {"project": project.slug, "plugin": plugin.slug}
-                            ),
-                        )
-                        plugin.disable(project=project)
+                        if plugin.is_enabled(project):
+                            logger.info(
+                                "plugin.disabled",
+                                extra=self._logging_context(
+                                    {"project": project.slug, "plugin": plugin.slug}
+                                ),
+                            )
+                            plugin.disable(project=project)
                     except NotImplementedError:
                         pass
 

--- a/src/sentry/plugins/migrator.py
+++ b/src/sentry/plugins/migrator.py
@@ -38,14 +38,17 @@ class Migrator:
 
     def disable_for_all_projects(self, plugin: Plugin2 | Plugin) -> None:
         for project in self.projects:
-            try:
-                logger.info(
-                    "plugin.disabled",
-                    extra=self._logging_context({"project": project.slug, "plugin": plugin.slug}),
-                )
-                plugin.disable(project=project)
-            except NotImplementedError:
-                pass
+            if plugin.is_enabled(project):
+                try:
+                    logger.info(
+                        "plugin.disabled",
+                        extra=self._logging_context(
+                            {"project": project.slug, "plugin": plugin.slug}
+                        ),
+                    )
+                    plugin.disable(project=project)
+                except NotImplementedError:
+                    pass
 
     def repos_for_provider(self, provider: str) -> list[RpcRepository]:
         return [r for r in self.repositories if r.provider == provider]

--- a/src/sentry/plugins/migrator.py
+++ b/src/sentry/plugins/migrator.py
@@ -28,27 +28,19 @@ class Migrator:
                     continue
 
                 if self.all_repos_migrated(plugin.slug):
-                    # Since repos are Org-level, if they're all migrated, we
-                    # can disable the Plugin for all Projects. There'd be no
-                    # Repos left, associated with the Plugin.
-                    self.disable_for_all_projects(plugin)
+                    try:
+                        logger.info(
+                            "plugin.disabled",
+                            extra=self._logging_context(
+                                {"project": project.slug, "plugin": plugin.slug}
+                            ),
+                        )
+                        plugin.disable(project=project)
+                    except NotImplementedError:
+                        pass
 
     def all_repos_migrated(self, provider: str) -> bool:
         return all(r.integration_id is not None for r in self.repos_for_provider(provider))
-
-    def disable_for_all_projects(self, plugin: Plugin2 | Plugin) -> None:
-        for project in self.projects:
-            if plugin.is_enabled(project):
-                try:
-                    logger.info(
-                        "plugin.disabled",
-                        extra=self._logging_context(
-                            {"project": project.slug, "plugin": plugin.slug}
-                        ),
-                    )
-                    plugin.disable(project=project)
-                except NotImplementedError:
-                    pass
 
     def repos_for_provider(self, provider: str) -> list[RpcRepository]:
         return [r for r in self.repositories if r.provider == provider]

--- a/tests/sentry/plugins/test_migrate.py
+++ b/tests/sentry/plugins/test_migrate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from unittest import mock
 
 import pytest
 
@@ -54,6 +55,30 @@ class MigratorTest(TestCase):
         assert plugin in plugins.for_project(self.project)
 
         self.migrator.disable_for_all_projects(plugin)
+
+        assert plugin not in plugins.for_project(self.project)
+
+    def test_only_disable_enabled_plugins(self):
+        plugin = plugins.get("example")
+        plugin_2 = plugins.get("webhooks")
+        plugin.enable(self.project)
+        plugin_2.disable(self.project)
+
+        with mock.patch("sentry.plugins.migrator.logger.info") as mock_logger:
+            self.migrator.disable_for_all_projects(plugin)
+
+            # Should only disable the enabled plugin
+            assert mock_logger.call_count == 1
+            mock_logger.assert_called_with(
+                "plugin.disabled",
+                extra={
+                    "project": self.project.slug,
+                    "plugin": plugin.slug,
+                    "org": self.organization.slug,
+                    "integration_id": self.integration.id,
+                    "integration_provider": self.integration.provider,
+                },
+            )
 
         assert plugin not in plugins.for_project(self.project)
 

--- a/tests/sentry/plugins/test_migrate.py
+++ b/tests/sentry/plugins/test_migrate.py
@@ -54,7 +54,7 @@ class MigratorTest(TestCase):
 
         assert plugin in plugins.for_project(self.project)
 
-        self.migrator.disable_for_all_projects(plugin)
+        self.migrator.run()
 
         assert plugin not in plugins.for_project(self.project)
 
@@ -65,7 +65,7 @@ class MigratorTest(TestCase):
         plugin_2.disable(self.project)
 
         with mock.patch("sentry.plugins.migrator.logger.info") as mock_logger:
-            self.migrator.disable_for_all_projects(plugin)
+            self.migrator.run()
 
             # Should only disable the enabled plugin
             assert mock_logger.call_count == 1


### PR DESCRIPTION
The Plugin Migration is invoked in the `migrate_repos` task which is kicked off during installation of `bitbucket`, `bitbucket_server`, and `github` modern integration installations incase an org has the legacy version of those integrations so they don't  have to manually link their repos again

the problem with the existing implementation is that it disabled the plugin for all projects of an org even though the plugin might not have been installed on all projects. This can spam our db.

Instead, lets check first if the plugin is even installed on a project before disabling it

https://sentry.slack.com/archives/CD4NYFD34/p1748453688917249

fixes RTC-944
