### PR TITLE
chore(github): Allow forks to be added as repositories

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -161,7 +161,7 @@ class GithubInstallationInfo(TypedDict):
 
 def build_repository_query(metadata: Mapping[str, Any], name: str, query: str) -> bytes:
     account_type = "user" if metadata["account_type"] == "User" else "org"
-    return f"{account_type}:{name} {query}".encode()
+    return f"{account_type}:{name} fork:true {query}".encode()
 
 
 def error(

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -160,8 +160,12 @@ class GithubInstallationInfo(TypedDict):
 
 
 def build_repository_query(metadata: Mapping[str, Any], name: str, query: str) -> bytes:
+    """
+    Builds a query for the GitHub Search API. Always includes both forks and original repositories.
+    Test out your query updates here: https://github.com/search/advanced
+    """
     account_type = "user" if metadata["account_type"] == "User" else "org"
-    return f"{account_type}:{name} fork:true {query}".encode()
+    return f"fork:true {account_type}:{name} {query}".encode()
 
 
 def error(

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -586,7 +586,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         with self.tasks():
             self.assert_setup_flow()
 
-        querystring = urlencode({"q": "org:Test Organization fork:true ex"})
+        querystring = urlencode({"q": "fork:true org:Test Organization ex"})
         responses.add(
             responses.GET,
             f"{self.base_url}/search/repositories?{querystring}",

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -586,7 +586,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         with self.tasks():
             self.assert_setup_flow()
 
-        querystring = urlencode({"q": "org:Test Organization ex"})
+        querystring = urlencode({"q": "org:Test Organization fork:true ex"})
         responses.add(
             responses.GET,
             f"{self.base_url}/search/repositories?{querystring}",

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -247,7 +247,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         with self.tasks():
             self.assert_setup_flow()
 
-        querystring = urlencode({"q": "org:Test Organization ex"})
+        querystring = urlencode({"q": "fork:true org:Test Organization ex"})
         responses.add(
             responses.GET,
             f"{self.base_url}/search/repositories?{querystring}",


### PR DESCRIPTION
Default to allowing forks to be searched. Equivalent to adding it to your query.


<img width="320" alt="image" src="https://github.com/user-attachments/assets/63300a42-e713-4a36-8060-d74abae5d550" />


<img width="299" alt="image" src="https://github.com/user-attachments/assets/94ce73b0-8693-4963-9d70-5d161508b1f4" />