### PR TITLE
fix(dashboards): Update error toast with message

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -368,7 +368,7 @@ export function flattenErrors(
 ): FlatValidationError {
   if (typeof data === 'string') {
     update.error = data;
-  } else {
+  } else if (defined(data)) {
     Object.keys(data).forEach((key: string) => {
       const value = data[key];
       if (typeof value === 'string') {

--- a/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/saveButton.tsx
@@ -11,6 +11,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import type {Widget} from 'sentry/views/dashboards/types';
+import {flattenErrors} from 'sentry/views/dashboards/utils';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 
@@ -40,10 +41,15 @@ function SaveButton({isEditing, onSave, setError}: SaveButtonProps) {
       await validateWidget(api, organization.slug, widget);
       onSave({index: defined(widgetIndex) ? Number(widgetIndex) : undefined, widget});
     } catch (error) {
+      let errorMessage = t('Unable to save widget');
       setIsSaving(false);
-      const errorDetails = error.responseJSON || error;
+      const errorDetails = flattenErrors(error.responseJSON || error, {});
       setError(errorDetails);
-      addErrorMessage(t('Unable to save widget'));
+
+      if (Object.keys(errorDetails).length > 0) {
+        errorMessage = errorDetails[Object.keys(errorDetails)[0]!] as string;
+      }
+      addErrorMessage(errorMessage);
     }
   }, [api, onSave, organization, state, widgetIndex, setError, isEditing]);
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -281,7 +281,7 @@ describe('WidgetBuilderSlideout', () => {
     await userEvent.click(await screen.findByText('Add Widget'));
 
     await waitFor(() => {
-      expect(addErrorMessage).toHaveBeenCalledWith('Unable to save widget');
+      expect(addErrorMessage).toHaveBeenCalledWith('Title is required during creation');
     });
 
     expect(screen.getByText('Custom Widget Builder')).toBeInTheDocument();

--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -22,6 +22,7 @@ import {
   SavedQueryDatasets,
 } from 'sentry/utils/discover/types';
 import {decodeScalar} from 'sentry/utils/queryString';
+import type RequestError from 'sentry/utils/requestError/requestError';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
 import {DATASET_PARAM} from 'sentry/views/discover/savedQuery/datasetSelectorTabs';
@@ -198,8 +199,16 @@ export function handleUpdateHomepageQuery(
       addSuccessMessage(t('Saved as Discover default'));
       return savedQuery;
     })
-    .catch(() => {
-      addErrorMessage(t('Unable to set query as Discover default'));
+    .catch((e: RequestError) => {
+      let errorMessage = t('Unable to set query as Discover default');
+
+      if ('responseJSON' in e) {
+        const response = e.responseJSON;
+        if (response?.non_field_errors && Array.isArray(response.non_field_errors)) {
+          errorMessage = response.non_field_errors[0];
+        }
+      }
+      addErrorMessage(errorMessage);
     });
 }
 


### PR DESCRIPTION
The error toasts were putting up generic messages. Update the toasts so the user doesn't have to look at the network tab to explain their problem.

This fix is applied to Discover, where at the moment `is:unresolved` results in an error when trying to save a query or save as a homepage. In dashboards this fixes the toast to pick the first error message to display in the toast. This isn't ideal, it would be better if the message appeared with the specific field in the form but for now I wanted to make a quick improvement.