### PR TITLE
ref(aci): group data condition choices

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -65,3 +65,22 @@ export interface DataConditionGroup {
   logicType: DataConditionGroupLogicType;
   actions?: Action[];
 }
+
+export enum DataConditionHandlerGroupType {
+  DETECTOR_TRIGGER = 'detector_trigger',
+  WORKFLOW_TRIGGER = 'workflow_trigger',
+  ACTION_FILTER = 'action_filter',
+}
+
+export enum DataConditionHandlerSubgroupType {
+  ISSUE_ATTRIBUTES = 'issue_attributes',
+  FREQUENCY = 'frequency',
+  EVENT_ATTRIBUTES = 'event_attributes',
+}
+
+export interface DataConditionHandler {
+  comparisonJsonSchema: Record<string, any>;
+  handlerGroup: DataConditionHandlerGroupType;
+  handlerSubgroup: DataConditionHandlerSubgroupType;
+  type: DataConditionType;
+}

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -1,29 +1,10 @@
 import {t} from 'sentry/locale';
-import {
-  DataConditionGroupLogicType,
-  DataConditionType,
-} from 'sentry/types/workflowEngine/dataConditions';
+import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
 
 export const FILTER_MATCH_OPTIONS = [
   {value: DataConditionGroupLogicType.ALL, label: t('all')},
   {value: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT, label: t('any')},
   {value: DataConditionGroupLogicType.NONE, label: t('none')},
-];
-
-export const FILTER_DATA_CONDITION_TYPES = [
-  DataConditionType.AGE_COMPARISON,
-  DataConditionType.ISSUE_OCCURRENCES,
-  DataConditionType.ASSIGNED_TO,
-  DataConditionType.ISSUE_PRIORITY_EQUALS,
-  DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
-  DataConditionType.LATEST_ADOPTED_RELEASE,
-  DataConditionType.LATEST_RELEASE,
-  DataConditionType.EVENT_ATTRIBUTE,
-  DataConditionType.TAGGED_EVENT,
-  DataConditionType.LEVEL,
-  DataConditionType.EVENT_FREQUENCY,
-  DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
-  DataConditionType.PERCENT_SESSIONS,
 ];
 
 export enum MatchType {

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -11,19 +11,14 @@ import {IconAdd, IconDelete, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
+import {DataConditionHandlerGroupType} from 'sentry/types/workflowEngine/dataConditions';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import {
-  FILTER_DATA_CONDITION_TYPES,
-  FILTER_MATCH_OPTIONS,
-} from 'sentry/views/automations/components/actionFilters/constants';
+import {FILTER_MATCH_OPTIONS} from 'sentry/views/automations/components/actionFilters/constants';
 import ActionNodeList from 'sentry/views/automations/components/actionNodeList';
 import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import DataConditionNodeList from 'sentry/views/automations/components/dataConditionNodeList';
-import {
-  TRIGGER_DATA_CONDITION_TYPES,
-  TRIGGER_MATCH_OPTIONS,
-} from 'sentry/views/automations/components/triggers/constants';
+import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
 
 export default function AutomationBuilder() {
   const {state, actions} = useAutomationBuilderContext();
@@ -69,8 +64,7 @@ export default function AutomationBuilder() {
         </StepLead>
       </Step>
       <DataConditionNodeList
-        // TODO: replace constant dataConditionTypes with DataConditions API response
-        dataConditionTypes={TRIGGER_DATA_CONDITION_TYPES}
+        handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
         placeholder={t('Select a trigger...')}
         conditions={state.triggers.conditions}
         group="triggers"
@@ -154,8 +148,7 @@ function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
             />
           </Flex>
           <DataConditionNodeList
-            // TODO: replace constant dataConditionTypes with DataConditions API response
-            dataConditionTypes={FILTER_DATA_CONDITION_TYPES}
+            handlerGroup={DataConditionHandlerGroupType.ACTION_FILTER}
             placeholder={t('Filter by...')}
             group={`actionFilters.${actionFilter.id}`}
             conditions={actionFilter?.conditions || []}

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -1,22 +1,27 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Select} from 'sentry/components/core/select';
-import type {
-  DataCondition,
+import {t} from 'sentry/locale';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionHandlerGroupType,
+  DataConditionHandlerSubgroupType,
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import AutomationBuilderRow from 'sentry/views/automations/components/automationBuilderRow';
 import {
   DataConditionNodeContext,
   dataConditionNodesMap,
+  frequencyTypeMapping,
   useDataConditionNodeContext,
 } from 'sentry/views/automations/components/dataConditionNodes';
+import {useDataConditionsQuery} from 'sentry/views/automations/hooks';
 
 interface DataConditionNodeListProps {
   conditions: DataCondition[];
-  dataConditionTypes: DataConditionType[];
   group: string;
+  handlerGroup: DataConditionHandlerGroupType;
   onAddRow: (type: DataConditionType) => void;
   onDeleteRow: (id: string) => void;
   placeholder: string;
@@ -24,8 +29,13 @@ interface DataConditionNodeListProps {
   updateConditionType?: (id: string, type: DataConditionType) => void;
 }
 
+interface Option {
+  label: string;
+  value: DataConditionType;
+}
+
 export default function DataConditionNodeList({
-  dataConditionTypes,
+  handlerGroup,
   group,
   placeholder,
   conditions,
@@ -34,9 +44,67 @@ export default function DataConditionNodeList({
   updateCondition,
   updateConditionType,
 }: DataConditionNodeListProps) {
-  const options = Array.from(dataConditionNodesMap.entries())
-    .map(([value, {label}]) => ({value, label}))
-    .filter(({value}) => dataConditionTypes.includes(value));
+  const {data: dataConditionHandlers = []} = useDataConditionsQuery(handlerGroup);
+
+  const options = useMemo(() => {
+    if (handlerGroup === DataConditionHandlerGroupType.WORKFLOW_TRIGGER) {
+      return dataConditionHandlers.map(handler => ({
+        value: handler.type,
+        label: dataConditionNodesMap.get(handler.type)?.label || handler.type,
+      }));
+    }
+
+    const issueAttributeOptions: Option[] = [];
+    const frequencyOptions: Option[] = [];
+    const eventAttributeOptions: Option[] = [];
+
+    dataConditionHandlers.forEach(handler => {
+      const percentageTypes = [
+        DataConditionType.EVENT_FREQUENCY_PERCENT,
+        DataConditionType.PERCENT_SESSIONS_PERCENT,
+        DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+      ];
+
+      if (percentageTypes.includes(handler.type)) {
+        return; // Skip percentage types so that frequency conditions are not duplicated
+      }
+
+      const conditionType = frequencyTypeMapping[handler.type] || handler.type;
+
+      const newDataCondition: Option = {
+        value: conditionType,
+        label: dataConditionNodesMap.get(handler.type)?.label || handler.type,
+      };
+
+      if (handler.handlerSubgroup === DataConditionHandlerSubgroupType.EVENT_ATTRIBUTES) {
+        eventAttributeOptions.push(newDataCondition);
+      } else if (handler.handlerSubgroup === DataConditionHandlerSubgroupType.FREQUENCY) {
+        frequencyOptions.push(newDataCondition);
+      } else if (
+        handler.handlerSubgroup === DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES
+      ) {
+        issueAttributeOptions.push(newDataCondition);
+      }
+    });
+
+    return [
+      {
+        key: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
+        label: t('Filter by Issue Attributes'),
+        options: issueAttributeOptions,
+      },
+      {
+        key: DataConditionHandlerSubgroupType.FREQUENCY,
+        label: t('Filter by Frequency'),
+        options: Array.from(new Set(frequencyOptions)),
+      },
+      {
+        key: DataConditionHandlerSubgroupType.EVENT_ATTRIBUTES,
+        label: t('Filter by Event Attributes'),
+        options: eventAttributeOptions,
+      },
+    ];
+  }, [dataConditionHandlers, handlerGroup]);
 
   return (
     <Fragment>

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -58,13 +58,13 @@ export default function DataConditionNodeList({
     const frequencyOptions: Option[] = [];
     const eventAttributeOptions: Option[] = [];
 
-    dataConditionHandlers.forEach(handler => {
-      const percentageTypes = [
-        DataConditionType.EVENT_FREQUENCY_PERCENT,
-        DataConditionType.PERCENT_SESSIONS_PERCENT,
-        DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
-      ];
+    const percentageTypes = [
+      DataConditionType.EVENT_FREQUENCY_PERCENT,
+      DataConditionType.PERCENT_SESSIONS_PERCENT,
+      DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+    ];
 
+    dataConditionHandlers.forEach(handler => {
       if (percentageTypes.includes(handler.type)) {
         return; // Skip percentage types so that frequency conditions are not duplicated
       }
@@ -96,7 +96,7 @@ export default function DataConditionNodeList({
       {
         key: DataConditionHandlerSubgroupType.FREQUENCY,
         label: t('Filter by Frequency'),
-        options: Array.from(new Set(frequencyOptions)),
+        options: frequencyOptions,
       },
       {
         key: DataConditionHandlerSubgroupType.EVENT_ATTRIBUTES,

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -181,3 +181,15 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     },
   ],
 ]);
+
+export const frequencyTypeMapping: Partial<Record<DataConditionType, DataConditionType>> =
+  {
+    [DataConditionType.PERCENT_SESSIONS_COUNT]: DataConditionType.PERCENT_SESSIONS,
+    [DataConditionType.PERCENT_SESSIONS_PERCENT]: DataConditionType.PERCENT_SESSIONS,
+    [DataConditionType.EVENT_FREQUENCY_COUNT]: DataConditionType.EVENT_FREQUENCY,
+    [DataConditionType.EVENT_FREQUENCY_PERCENT]: DataConditionType.EVENT_FREQUENCY,
+    [DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT]:
+      DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
+    [DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT]:
+      DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
+  };

--- a/static/app/views/automations/components/triggers/constants.tsx
+++ b/static/app/views/automations/components/triggers/constants.tsx
@@ -1,16 +1,7 @@
 import {t} from 'sentry/locale';
-import {
-  DataConditionGroupLogicType,
-  DataConditionType,
-} from 'sentry/types/workflowEngine/dataConditions';
+import {DataConditionGroupLogicType} from 'sentry/types/workflowEngine/dataConditions';
 
 export const TRIGGER_MATCH_OPTIONS = [
   {value: DataConditionGroupLogicType.ALL, label: t('all')},
   {value: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT, label: t('any')},
-];
-
-export const TRIGGER_DATA_CONDITION_TYPES = [
-  DataConditionType.FIRST_SEEN_EVENT,
-  DataConditionType.REGRESSION_EVENT,
-  DataConditionType.REAPPEARED_EVENT,
 ];

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -21,11 +21,11 @@ export function useAutomationsQuery(_options: UseAutomationsQueryOptions = {}) {
   });
 }
 
-export function useDataConditionsQuery(group: DataConditionHandlerGroupType) {
+export function useDataConditionsQuery(groupType: DataConditionHandlerGroupType) {
   const {slug} = useOrganization();
 
   return useApiQuery<DataConditionHandler[]>(
-    [`/organizations/${slug}/data-conditions/`, {query: {group}}],
+    [`/organizations/${slug}/data-conditions/`, {query: {group: groupType}}],
     {
       staleTime: Infinity,
       retry: false,

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -1,5 +1,9 @@
 import type {ActionHandler} from 'sentry/types/workflowEngine/actions';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import type {
+  DataConditionHandler,
+  DataConditionHandlerGroupType,
+} from 'sentry/types/workflowEngine/dataConditions';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -16,6 +20,19 @@ export function useAutomationsQuery(_options: UseAutomationsQueryOptions = {}) {
     retry: false,
   });
 }
+
+export function useDataConditionsQuery(group: DataConditionHandlerGroupType) {
+  const {slug} = useOrganization();
+
+  return useApiQuery<DataConditionHandler[]>(
+    [`/organizations/${slug}/data-conditions/`, {query: {group}}],
+    {
+      staleTime: Infinity,
+      retry: false,
+    }
+  );
+}
+
 const makeAutomationsQueryKey = (orgSlug: string): ApiQueryKey => [
   `/organizations/${orgSlug}/workflows/`,
 ];


### PR DESCRIPTION
updated dataConditionNodeList to use response data from the data conditions endpoint + added grouping by handler subgroup

had to add special logic for the frequency conditions that have additional branching to determine whether to use count/percent frequency so that we don't list those conditions twice

<img width="911" alt="Screenshot 2025-05-28 at 1 10 36 PM" src="https://github.com/user-attachments/assets/d23b8a8e-40da-4bd6-96d6-72b0cad1aa18" />



example of branching frequency condition, for reference:
<img width="555" alt="Screenshot 2025-05-28 at 1 15 09 PM" src="https://github.com/user-attachments/assets/9180d78a-d59a-44dd-b067-031a1c0f1f5a" />

