### PR TITLE
:bug: fix(slack): member invite messages

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -34,7 +34,7 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
             self.recipient, ExternalProviders.SLACK
         )
         actions = self.notification.get_message_actions(self.recipient, ExternalProviders.SLACK)
-        callback_id = orjson.dumps(callback_id_raw).decode() if callback_id_raw else None
+        block_id = orjson.dumps(callback_id_raw).decode() if callback_id_raw else None
 
         first_block_text = ""
         if title_link:
@@ -61,6 +61,4 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
         if actions_block:
             blocks.append({"type": "actions", "elements": [action for action in actions_block]})
 
-        return self._build_blocks(
-            *blocks, fallback_text=text if text else None, callback_id=callback_id
-        )
+        return self._build_blocks(*blocks, fallback_text=text if text else None, block_id=block_id)

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -232,8 +232,10 @@ class OrganizationInviteRequestCreateTest(
             == f"You are receiving this notification because you have the scope member:write | <http://testserver/settings/account/notifications/approval/?referrer=invite_request-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         member = OrganizationMember.objects.get(email="eric@localhost")
-        callback_id = orjson.loads(self.mock_post.call_args.kwargs["callback_id"])
-        assert callback_id == {
+        context_params = orjson.loads(
+            orjson.loads(self.mock_post.call_args.kwargs["blocks"])[0]["block_id"]
+        )
+        assert context_params == {
             "member_id": member.id,
             "member_email": "eric@localhost",
         }

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -206,11 +206,13 @@ class OrganizationJoinRequestTest(APITestCase, SlackActivityNotificationTest, Hy
                 "value": "link_clicked",
             },
         ]
-        callback_id = orjson.loads(self.mock_post.call_args.kwargs["callback_id"])
+        context_params = orjson.loads(
+            orjson.loads(self.mock_post.call_args.kwargs["blocks"])[0]["block_id"]
+        )
 
         with outbox_runner():
             member = OrganizationMember.objects.get(email=self.email)
-        assert callback_id == {
+        assert context_params == {
             "member_id": member.id,
             "member_email": self.email,
         }

--- a/tests/sentry/integrations/slack/notifications/test_nudge.py
+++ b/tests/sentry/integrations/slack/notifications/test_nudge.py
@@ -35,5 +35,7 @@ class SlackNudgeNotificationTest(SlackActivityNotificationTest):
         assert blocks[1]["elements"][0]["value"] == "all_slack"
 
         # Slack requires callback_id to handle enablement
-        callback_id = orjson.loads(self.mock_post.call_args.kwargs["callback_id"])
-        assert callback_id == {"enable_notifications": True}
+        context_params = orjson.loads(
+            orjson.loads(self.mock_post.call_args.kwargs["blocks"])[0]["block_id"]
+        )
+        assert context_params == {"enable_notifications": True}


### PR DESCRIPTION
Slack notifications for member invites were not working


the problem was we were passing `callback_id` in the payload which has been deprecated since we switched to block-kit.
reference: https://api.slack.com/messaging/attachments-to-blocks#callback_id_replacement

we were also trying to send a message to user based on a simple response to the webhook payload which isn't how things work in block kit.

I updated the logic to use the `Webhook` client to send a notification.

https://github.com/user-attachments/assets/7d3edd67-e783-4e0b-96b7-4441bd518001


There are other places where we use `callback_id`, 
I will make a linear ticket for folks to fix this during triage party based on my fix here