### PR TITLE
fix(eap-alerts): Open in Explore link respects custom time

### DIFF
--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -54,7 +54,7 @@ export function makeDefaultCta({
       to: getAlertRuleExploreUrl({
         rule,
         organization,
-        period: timePeriod.period,
+        timePeriod,
         projectId: projects[0]!.id,
       }),
     };

--- a/static/app/views/alerts/rules/utils.spec.tsx
+++ b/static/app/views/alerts/rules/utils.spec.tsx
@@ -15,7 +15,14 @@ describe('getExploreUrl', () => {
     const url = getAlertRuleExploreUrl({
       rule,
       organization: OrganizationFixture({slug: 'slug'}),
-      period: '7d',
+      timePeriod: {
+        period: '7d',
+        usingPeriod: true,
+        start: new Date().toISOString(),
+        end: new Date().toISOString(),
+        display: '',
+        label: '',
+      },
       projectId: '1',
     });
     expect(url).toBe(
@@ -32,11 +39,44 @@ describe('getExploreUrl', () => {
     const url = getAlertRuleExploreUrl({
       rule,
       organization: OrganizationFixture({slug: 'slug'}),
-      period: '9998m',
+      timePeriod: {
+        period: '7d',
+        usingPeriod: true,
+        start: new Date().toISOString(),
+        end: new Date().toISOString(),
+        display: '',
+        label: '',
+      },
       projectId: '1',
     });
     expect(url).toBe(
       '/organizations/slug/traces/?environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&statsPeriod=7d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
+    );
+  });
+  it('should respect custom time ranges', () => {
+    const rule = MetricRuleFixture();
+    rule.dataset = Dataset.EVENTS_ANALYTICS_PLATFORM;
+    rule.timeWindow = TimeWindow.THIRTY_MINUTES;
+    rule.aggregate = 'p75(span.duration)';
+    rule.query = 'span.op:http.client';
+    rule.environment = 'prod';
+    const start = new Date('2017-10-12T12:00:00.000Z').toISOString();
+    const end = new Date('2017-10-19T12:00:00.000Z').toISOString();
+    const url = getAlertRuleExploreUrl({
+      rule,
+      organization: OrganizationFixture({slug: 'slug'}),
+      timePeriod: {
+        period: '7d',
+        usingPeriod: false,
+        start,
+        end,
+        display: '',
+        label: '',
+      },
+      projectId: '1',
+    });
+    expect(url).toBe(
+      '/organizations/slug/traces/?end=2017-10-19T12%3A00%3A00.000Z&environment=prod&interval=30m&project=1&query=span.op%3Ahttp.client&start=2017-10-12T12%3A00%3A00.000Z&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D'
     );
   });
 });

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -5,6 +5,7 @@ import {IssueAlertActionType, RuleActionsCategories} from 'sentry/types/alerts';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import {TIME_WINDOW_TO_INTERVAL} from 'sentry/views/alerts/rules/metric/triggers/chart';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
@@ -120,13 +121,13 @@ export function shouldUseErrorsDiscoverDataset(
 export function getAlertRuleExploreUrl({
   rule,
   organization,
-  period,
+  timePeriod,
   projectId,
 }: {
   organization: Organization;
-  period: string;
   projectId: string;
   rule: MetricRule;
+  timePeriod: TimePeriodType;
 }) {
   if (rule.dataset !== Dataset.EVENTS_ANALYTICS_PLATFORM) {
     return '';
@@ -138,10 +139,14 @@ export function getAlertRuleExploreUrl({
     organization,
     selection: {
       datetime: {
-        period: period === '9998m' ? '7d' : period,
-        start: null,
-        end: null,
-        utc: null,
+        period: timePeriod.usingPeriod
+          ? timePeriod.period === '9998m'
+            ? '7d'
+            : timePeriod.period
+          : null,
+        start: timePeriod.usingPeriod ? null : timePeriod.start,
+        end: timePeriod.usingPeriod ? null : timePeriod.end,
+        utc: timePeriod.utc || null,
       },
       environments: rule.environment ? [rule.environment] : [],
       projects: [parseInt(projectId, 10)],


### PR DESCRIPTION
Open in explore was not respecting custom time ranges
because we were only passing `period`. This uses `start`
and `end` in the case where a custom range is selected.