### PR TITLE
fix(syntax): Handle quoted colons in keys for mutable search

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -194,6 +194,15 @@ describe('utils/tokenizeSearch', function () {
           ],
         },
       },
+      {
+        name: 'should handle explicit tags keys containing colons when quoted',
+        string: 'tags["foo:bar",string]:asdf',
+        object: {
+          tokens: [
+            {type: TokenType.FILTER, key: 'tags["foo:bar",string]', value: 'asdf'},
+          ],
+        },
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -478,7 +478,27 @@ function isSpace(s: string) {
  * both sides of the split as strings.
  */
 function parseFilter(filter: string) {
-  const idx = filter.indexOf(':');
+  let idx = 0;
+  let quoted = false;
+
+  // look for the first `:` that is not in quotes
+  for (; idx < filter.length; idx++) {
+    const c = filter[idx];
+
+    if (c === '"') {
+      quoted = !quoted;
+      continue;
+    }
+
+    if (c === ':' && !quoted) {
+      const key = removeSurroundingQuotes(filter.slice(0, idx));
+      const value = removeSurroundingQuotes(filter.slice(idx + 1));
+      return [key, value];
+    }
+  }
+
+  // something went wrong, fallback to the naive approach of spliting the filter
+  idx = filter.indexOf(':');
   const key = removeSurroundingQuotes(filter.slice(0, idx));
   const value = removeSurroundingQuotes(filter.slice(idx + 1));
 


### PR DESCRIPTION
Mutable search isn't splitting filters that use keys with colons correctly. Colons are permitted within quotes in the key name.