### PR TITLE
fix(aci): Reduce deadlock risk in ActionGroupStatus updates

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -112,9 +112,9 @@ def filter_recently_fired_workflow_actions(
         statuses.filter(difference__gt=F("frequency_minutes")).values_list("action_id", flat=True)
     )
 
-    ActionGroupStatus.objects.filter(action__in=actions_to_include, group=group).update(
-        date_updated=now
-    )
+    ActionGroupStatus.objects.filter(
+        action__in=actions_to_include, group=group, date_updated__lt=now
+    ).order_by("id").update(date_updated=now)
     ActionGroupStatus.objects.bulk_create(
         [
             ActionGroupStatus(action=action, group=group, date_updated=now)


### PR DESCRIPTION
Order ActionGroupStatus updates to ensure consistent row locking order across concurrent executions, potentially avoiding deadlocks.
Also limit updates to where date_updated is actually newer, which could theoretically reduce overlap between concurrent update queries.

See SENTRY-3WEA.