### PR TITLE
fix(ts): Fix type error in `useRecentSearchFilters`

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -25,7 +25,10 @@ function getFiltersFromParsedQuery(
     return [];
   }
 
-  return parsedQuery.filter(token => token.type === Token.FILTER);
+  // return parsedQuery.filter(token => token.type === Token.FILTER);
+  return parsedQuery.filter(
+    (token): token is TokenResult<Token.FILTER> => token.type === Token.FILTER
+  );
 }
 
 function getTokensFromQuery({


### PR DESCRIPTION
This fixes a type error in `useRecentSearchFilters` in typescript native

```
static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx:28:3 - error TS2322: Type 'ParseResultToken[]' is not assignable to type 'TokenResult<Token.FILTER>[]'.
```


h/t @scttcper 