### PR TITLE
chore(alerts): Add more tags to delayed processing logging

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -542,6 +542,7 @@ def fire_rules(
                             extra={
                                 "last_active": status.last_active,
                                 "freq_offset": freq_offset,
+                                "rule_id": rule.id,
                                 "project_id": project_id,
                                 "group_id": group.id,
                             },
@@ -559,6 +560,7 @@ def fire_rules(
                             "delayed_processing.not_updated",
                             extra={
                                 "status_id": status.id,
+                                "rule_id": rule.id,
                                 "project_id": project_id,
                                 "group_id": group.id,
                             },
@@ -602,6 +604,8 @@ def fire_rules(
                             extra={
                                 "total": len(callback_and_futures),
                                 "project_id": project_id,
+                                "group_id": group.id,
+                                "event_id": groupevent.event_id,
                                 "rule_id": rule.id,
                             },
                         )


### PR DESCRIPTION
Add more data to the logs so I can tell what might be going on with some rules that aren't firing.