### PR TITLE
chore(autofix): remove propose your own root cause

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.spec.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.spec.tsx
@@ -5,10 +5,8 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {AutofixRootCause} from 'sentry/components/events/autofix/autofixRootCause';
 
 describe('AutofixRootCause', function () {
-  let mockApi: jest.Mock<any, any, any>;
-
   beforeEach(function () {
-    mockApi = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/autofix/update/',
       method: 'POST',
       body: {success: true},
@@ -86,51 +84,6 @@ describe('AutofixRootCause', function () {
     );
   });
 
-  it('can edit and submit custom root cause', async function () {
-    render(<AutofixRootCause {...defaultProps} />);
-
-    // Wait for initial render
-    await waitFor(
-      () => {
-        expect(screen.getByText('Root Cause')).toBeInTheDocument();
-      },
-      {timeout: 2000}
-    );
-
-    // Click edit button
-    await userEvent.click(screen.getByTestId('autofix-root-cause-edit-button'));
-
-    // Verify textarea appears
-    const textarea = screen.getByPlaceholderText('Propose your own root cause...');
-    expect(textarea).toBeInTheDocument();
-
-    // Enter custom root cause
-    await userEvent.type(textarea, 'This is a custom root cause');
-
-    // Click Save button
-    await userEvent.click(screen.getByTestId('autofix-root-cause-save-edit-button'));
-
-    // Wait for API call to complete
-    await waitFor(
-      () => {
-        expect(mockApi).toHaveBeenCalledWith(
-          '/organizations/org-slug/issues/1/autofix/update/',
-          expect.objectContaining({
-            method: 'POST',
-            data: {
-              run_id: '101',
-              payload: {
-                type: 'select_root_cause',
-                custom_root_cause: 'This is a custom root cause',
-              },
-            },
-          })
-        );
-      },
-      {timeout: 2000}
-    );
-  });
-
   it('shows selected root cause when rootCauseSelection is provided', async function () {
     const selectedCause = AutofixRootCauseData();
     render(
@@ -157,34 +110,6 @@ describe('AutofixRootCause', function () {
         expect(
           screen.getByText(selectedCause.root_cause_reproduction![0]!.title)
         ).toBeInTheDocument();
-      },
-      {timeout: 2000}
-    );
-  });
-
-  it('shows custom root cause when rootCauseSelection has custom_root_cause', async function () {
-    render(
-      <AutofixRootCause
-        {...{
-          ...defaultProps,
-          rootCauseSelection: {
-            custom_root_cause: 'This is a custom root cause',
-          },
-        }}
-      />
-    );
-
-    // Wait for custom root cause to render
-    await waitFor(
-      () => {
-        expect(screen.getByText('Custom Root Cause')).toBeInTheDocument();
-      },
-      {timeout: 2000}
-    );
-
-    await waitFor(
-      () => {
-        expect(screen.getByText('This is a custom root cause')).toBeInTheDocument();
       },
       {timeout: 2000}
     );


### PR DESCRIPTION
Remove the feature allowing you to "propose your own root cause." Seems like no one uses it, so it's just clutter on the UI.
Keeping the code for rendering custom root causes though for the sake of backwards compatability.