### PR TITLE
chore(devtools): Remove explicit check for webpack bin file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -193,7 +193,7 @@ if [ "${SENTRY_DEVENV_SKIP_FRONTEND}" != "1" ]; then
         die "Unexpected $(command -v node) version. Please run devenv sync."
     fi
 
-    if [ ! -x "node_modules/.bin/webpack" ]; then
+    if [ ! -d "node_modules" ]; then
         die "You don't seem to have yarn packages installed. Please run devenv sync."
     fi
 fi


### PR DESCRIPTION
Checks more broadly for node_modules folder instead. Fixes getsentry which was linking to the sentry webpack bin as a workaround before. Fixes getsentry `devenv allow` not working.

related https://github.com/getsentry/getsentry/pull/17558