### PR TITLE
fix(feedback): Only try to mark feedback as read if the user is a member of the project

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -14,6 +14,7 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
 
 interface Props {
   eventData: Event | undefined;
@@ -62,6 +63,8 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
     onMarkAsReadClick,
   } = useFeedbackActions({feedbackItem});
 
+  const project = useProjectFromId({project_id: feedbackItem.project?.id});
+
   return (
     <Fragment>
       <Button
@@ -74,12 +77,17 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
       <Button size="xs" priority="default" onClick={onSpamClick}>
         {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
       </Button>
-      <Button size="xs" onClick={onMarkAsReadClick}>
-        {hasSeen ? t('Mark Unread') : t('Mark Read')}
-      </Button>
+      <Tooltip
+        disabled={project?.isMember}
+        title={t('You must be a member of the project')}
+      >
+        <Button size="xs" onClick={onMarkAsReadClick} disabled={!project?.isMember}>
+          {hasSeen ? t('Mark Unread') : t('Mark Read')}
+        </Button>
+      </Tooltip>
       <Tooltip
         disabled={!disableDelete}
-        title={t('You must be an admin to delete feedback.')}
+        title={t('You must be an admin to delete feedback')}
       >
         <Button size="xs" onClick={onDelete} disabled={disableDelete}>
           {t('Delete')}

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -41,6 +41,9 @@ export default function FeedbackListBulkSelection({
   const hasDelete = selectedIds !== 'all';
   const disableDelete = !organization.access.includes('event:admin');
 
+  // TODO(ryan953): We should disable markAsRead if you're not a member of any project selected
+  const disableMarkAsRead = false;
+
   return (
     <Flex gap={space(1)} align="center" justify="space-between" flex="1 0 auto">
       <span>
@@ -86,6 +89,7 @@ export default function FeedbackListBulkSelection({
                 key: 'mark read',
                 label: t('Mark Read'),
                 onAction: onMarkAsRead,
+                disabled: disableMarkAsRead,
               },
               {
                 key: 'mark unread',

--- a/static/app/components/feedback/useFetchFeedbackData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackData.tsx
@@ -6,6 +6,7 @@ import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
 import type {FeedbackEvent, FeedbackIssue} from 'sentry/utils/feedback/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
 
 interface Props {
   feedbackId: string;
@@ -43,16 +44,18 @@ export default function useFetchFeedbackData({feedbackId}: Props) {
     projectIds: issueData?.project ? [issueData.project.id] : [],
   });
 
+  const project = useProjectFromId({project_id: issueData?.project?.id});
+
   // TODO: it would be excellent if `PUT /issues/` could return the same data
   // as `GET /issues/` when query params are set. IE: it should expand inbox & owners.
   // Then we could avoid firing off 2-3 requests whenever a feedback is selected.
   // Until that is fixed, we're going to run `markAsRead` after the issue is
   // initially fetched in order to speedup initial fetch and avoid race conditions.
   useEffect(() => {
-    if (issueResult.isFetched && issueData && !issueData.hasSeen) {
+    if (project?.isMember && issueResult.isFetched && issueData && !issueData.hasSeen) {
       markAsRead(true);
     }
-  }, [issueData, issueResult.isFetched, markAsRead]);
+  }, [project?.isMember, issueData, issueResult.isFetched, markAsRead]);
 
   return {
     eventData,


### PR DESCRIPTION
If the user is not a member then we silently don't commit the update here: https://github.com/getsentry/sentry/blob/f5dce95837c77ddadacba23b5f0b0e63aaa394d7/src/sentry/api/helpers/group_index/update.py#L922-L927

I think the server is wrong here.. but it's been wrong for 7+ years... the UI, feedback and issues as well, was always trying to set the hasSeen state, and failing many times. With our caching and inconsistent data refreshing it probably wasn't directly noticeable to anyone until now where feedback does it's optimistic update, then refetches for accurate data.
Probably people would see an issue because it's marked as 'new', and then the next day without anything changed.. see the same thing again and again.