### PR TITLE
fix(autofix): Fix overwriting last insight card on rethink

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -314,7 +314,7 @@ function CollapsibleChainLink({
       message: newInsightText,
       step_index: stepIndex,
       retain_insight_card_index:
-        insightCount !== undefined && insightCount > 0 ? insightCount - 1 : null,
+        insightCount !== undefined && insightCount > 0 ? insightCount : null,
     });
     setNewInsightText('');
   };


### PR DESCRIPTION
We were replacing the last insight card on the last "free" rethink button without an insight on a step.

This aligns the behavior with [the comment i see here](https://github.com/getsentry/seer/blob/45839bb98db503079baffd856e34bccc7b2f19bb/src/seer/automation/autofix/tasks.py#L578C8-L578C127)
