### PR TITLE
fix(autofix): Fix chevron directions

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -199,7 +199,7 @@ function AutofixInsightCard({
                       title={isExpanded ? t('Hide evidence') : t('Show evidence')}
                       icon={
                         <StyledIconChevron
-                          direction={isExpanded ? 'down' : 'right'}
+                          direction={isExpanded ? 'up' : 'down'}
                           size="xs"
                         />
                       }
@@ -344,10 +344,7 @@ function CollapsibleChainLink({
               size="zero"
               borderless
               icon={
-                <CollapseIconChevron
-                  direction={isCollapsed ? 'right' : 'down'}
-                  size="sm"
-                />
+                <CollapseIconChevron direction={isCollapsed ? 'down' : 'up'} size="sm" />
               }
               aria-label={t('Toggle reasoning visibility')}
             />

--- a/static/app/components/events/autofix/autofixSolutionEventItem.tsx
+++ b/static/app/components/events/autofix/autofixSolutionEventItem.tsx
@@ -147,7 +147,7 @@ export function SolutionEventItem({
           </AutofixHighlightWrapper>
           <IconWrapper>
             {!isHumanAction && event.code_snippet_and_analysis && isSelected && (
-              <StyledIconChevron direction={isExpanded ? 'down' : 'right'} size="xs" />
+              <StyledIconChevron direction={isExpanded ? 'up' : 'down'} size="xs" />
             )}
             <SelectionButtonWrapper>
               <Tooltip

--- a/static/app/components/events/autofix/autofixTimelineItem.tsx
+++ b/static/app/components/events/autofix/autofixTimelineItem.tsx
@@ -103,7 +103,7 @@ export function AutofixTimelineItem({
           >
             <div dangerouslySetInnerHTML={titleHtml} />
           </AutofixHighlightWrapper>
-          <StyledIconChevron direction={isExpanded ? 'down' : 'right'} size="xs" />
+          <StyledIconChevron direction={isExpanded ? 'up' : 'down'} size="xs" />
         </StyledTimelineHeader>
       }
       isActive={isMostImportantEvent}


### PR DESCRIPTION
Expandable section chevrons should point down/up, not right/down. Should make it more clear these are expandable.
<img width="658" alt="Screenshot 2025-05-29 at 6 56 45 AM" src="https://github.com/user-attachments/assets/93b02cce-70d5-42b5-9240-2ebde6028d8b" />

