### PR TITLE
fix: Add vision pro device identifier

### DIFF
--- a/src/sentry/api/helpers/ios_models.py
+++ b/src/sentry/api/helpers/ios_models.py
@@ -288,4 +288,6 @@ IOS_MODELS: dict[str, str] = {
     "AppleTV11,1": "Apple TV 4K (2nd gen)",
     "i386": "iOS Simulator (i386)",
     "x86_64": "iOS Simulator (x86_64)",
+    # Vision Pro
+    "RealityDevice14,1": "Vision Pro",
 }

--- a/src/sentry/api/helpers/ios_models.py
+++ b/src/sentry/api/helpers/ios_models.py
@@ -289,5 +289,5 @@ IOS_MODELS: dict[str, str] = {
     "i386": "iOS Simulator (i386)",
     "x86_64": "iOS Simulator (x86_64)",
     # Vision Pro
-    "RealityDevice14,1": "Vision Pro",
+    "RealityDevice14,1": "Apple Vision Pro",
 }

--- a/src/sentry/api/helpers/ios_models.py
+++ b/src/sentry/api/helpers/ios_models.py
@@ -288,6 +288,4 @@ IOS_MODELS: dict[str, str] = {
     "AppleTV11,1": "Apple TV 4K (2nd gen)",
     "i386": "iOS Simulator (i386)",
     "x86_64": "iOS Simulator (x86_64)",
-    # Vision Pro
-    "RealityDevice14,1": "Apple Vision Pro",
 }

--- a/static/app/constants/ios-device-list.tsx
+++ b/static/app/constants/ios-device-list.tsx
@@ -226,8 +226,8 @@ const iOSDeviceMapping: Record<string, string> = {
   'AppleTV6,2': 'Apple TV 4K',
   'AppleTV11,1': 'Apple TV 4K (2nd generation)',
   'AppleTV14,1': 'Apple TV 4K (3rd generation)',
-  // Vision Pro
-  'RealityDevice14,1': 'Vision Pro',
+  // Apple Vision Pro
+  'RealityDevice14,1': 'Apple Vision Pro',
 };
 
 export {iOSDeviceMapping};

--- a/static/app/constants/ios-device-list.tsx
+++ b/static/app/constants/ios-device-list.tsx
@@ -226,6 +226,8 @@ const iOSDeviceMapping: Record<string, string> = {
   'AppleTV6,2': 'Apple TV 4K',
   'AppleTV11,1': 'Apple TV 4K (2nd generation)',
   'AppleTV14,1': 'Apple TV 4K (3rd generation)',
+  // Vision Pro
+  'RealityDevice14,1': 'Vision Pro',
 };
 
 export {iOSDeviceMapping};


### PR DESCRIPTION
Adds Vision Pro identifier so they don't show up as `RealityDevice14,1` anymore

![image](https://github.com/user-attachments/assets/f8254f8b-c001-4276-b2df-38b2333c56dd)
