### PR TITLE
fix(explore): Properly check chart type in multi query mode

### DIFF
--- a/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/chart.tsx
@@ -135,7 +135,7 @@ export function MultiQueryModeChart({
     isTopN
   );
 
-  const chartType = queryParts.chartType || determineDefaultChartType(yAxes);
+  const chartType = queryParts.chartType ?? determineDefaultChartType(yAxes);
 
   const visualizationType =
     chartType === ChartType.LINE ? 'line' : chartType === ChartType.AREA ? 'area' : 'bar';


### PR DESCRIPTION
If the default chart type isn't `BAR`, this effectively made it impossible to select it as `BAR` has a value of 0 meaning it was always forced to the default