### PR TITLE
feat(insights): convert app starts "average cold start" widget to widget library

### DIFF
--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -58,7 +58,7 @@ export interface InsightsTimeSeriesWidgetProps
   samples?: Samples;
   search?: MutableSearch;
   showLegend?: TimeSeriesWidgetVisualizationProps['showLegend'];
-  showReleaseAs?: 'line' | 'bubble';
+  showReleaseAs?: 'line' | 'bubble' | 'none';
   stacked?: boolean;
 }
 

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -68,7 +68,9 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const pageFiltersSelection = props.pageFilters || pageFilters.selection;
-  const {releases: releasesWithDate} = useReleaseStats(pageFiltersSelection);
+  const {releases: releasesWithDate} = useReleaseStats(pageFiltersSelection, {
+    enabled: props.showReleaseAs !== 'none',
+  });
   const releases =
     releasesWithDate?.map(({date, version}) => ({
       timestamp: date,

--- a/static/app/views/insights/common/components/widgets/types.tsx
+++ b/static/app/views/insights/common/components/widgets/types.tsx
@@ -48,5 +48,5 @@ export interface LoadableChartWidgetProps {
   /**
    * Show releases as either lines per release or a bubble for a group of releases.
    */
-  showReleaseAs?: 'bubble' | 'line';
+  showReleaseAs?: 'bubble' | 'line' | 'none';
 }

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.spec.tsx
@@ -80,7 +80,7 @@ describe('StartDurationWidget', () => {
       },
     } as Location);
 
-    render(<StartDurationWidget chartHeight={200} />);
+    render(<StartDurationWidget />);
     expect(await screen.findByText('Average Cold Start')).toBeInTheDocument();
   });
 
@@ -92,7 +92,7 @@ describe('StartDurationWidget', () => {
       },
     } as Location);
 
-    render(<StartDurationWidget chartHeight={200} />);
+    render(<StartDurationWidget />);
     expect(await screen.findByText('Average Warm Start')).toBeInTheDocument();
   });
 

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
@@ -1,22 +1,19 @@
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import type {MultiSeriesEventsStats} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {
   PRIMARY_RELEASE_COLOR,
   SECONDARY_RELEASE_COLOR,
 } from 'sentry/views/insights/colors';
-import Chart, {ChartType} from 'sentry/views/insights/common/components/chart';
-import MiniChartPanel from 'sentry/views/insights/common/components/miniChartPanel';
+// TODO(release-drawer): Only used in mobile/appStarts/components/
+// eslint-disable-next-line no-restricted-imports
+import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
-import {formatVersionAndCenterTruncate} from 'sentry/views/insights/common/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import {COLD_START_TYPE} from 'sentry/views/insights/mobile/appStarts/components/startTypeSelector';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
@@ -58,11 +55,10 @@ export function transformData(data?: MultiSeriesEventsStats, primaryRelease?: st
 }
 
 interface Props {
-  chartHeight: number;
   additionalFilters?: string[];
 }
 
-function StartDurationWidget({additionalFilters, chartHeight}: Props) {
+function StartDurationWidget({additionalFilters}: Props) {
   const location = useLocation();
   const {
     primaryRelease,
@@ -84,6 +80,7 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
   }
 
   const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
+  const search = new MutableSearch(queryString);
 
   const {
     data,
@@ -94,7 +91,7 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
       yAxis: ['avg(span.duration)'],
       fields: ['release', 'avg(span.duration)'],
       topN: 2,
-      search: queryString,
+      search,
       enabled: !isReleasesLoading,
     },
     'api.starfish.mobile-startup-series'
@@ -106,43 +103,18 @@ function StartDurationWidget({additionalFilters, chartHeight}: Props) {
   );
 
   return (
-    <MiniChartPanel
+    <InsightsLineChartWidget
       title={
         startType === COLD_START_TYPE ? t('Average Cold Start') : t('Average Warm Start')
       }
-      subtitle={
-        primaryRelease
-          ? t(
-              '%s v. %s',
-              formatVersionAndCenterTruncate(primaryRelease, 12),
-              secondaryRelease ? formatVersionAndCenterTruncate(secondaryRelease, 12) : ''
-            )
-          : ''
-      }
-    >
-      <Chart
-        data={sortedSeries}
-        height={chartHeight}
-        loading={isSeriesLoading}
-        grid={{
-          left: '0',
-          right: '0',
-          top: space(2),
-          bottom: '0',
-        }}
-        showLegend
-        definedAxisTicks={2}
-        type={ChartType.LINE}
-        aggregateOutputFormat="duration"
-        tooltipFormatterOptions={{
-          valueFormatter: value =>
-            tooltipFormatterUsingAggregateOutputType(value, 'duration'),
-          nameFormatter: value => formatVersion(value),
-        }}
-        legendFormatter={value => formatVersion(value)}
-        error={seriesError}
-      />
-    </MiniChartPanel>
+      series={sortedSeries}
+      isLoading={isSeriesLoading}
+      error={seriesError}
+      search={search}
+      showReleaseAs="none"
+      showLegend="always"
+      height={'100%'}
+    />
   );
 }
 

--- a/static/app/views/insights/mobile/appStarts/components/widgets.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/widgets.tsx
@@ -9,12 +9,12 @@ function SummaryWidgets({additionalFilters}: any) {
   return (
     <WidgetLayout>
       <div style={{gridArea: '1 / 1'}}>
-        <StartDurationWidget additionalFilters={additionalFilters} chartHeight={120} />
+        <StartDurationWidget additionalFilters={additionalFilters} />
       </div>
       <div style={{gridArea: '1 / 2'}}>
         <DeviceClassBreakdownBarChart
           additionalFilters={additionalFilters}
-          chartHeight={120}
+          chartHeight={140}
         />
       </div>
     </WidgetLayout>
@@ -25,9 +25,8 @@ export default SummaryWidgets;
 
 const WidgetLayout = styled('div')`
   display: grid;
-  grid-template-rows: 200px;
   grid-template-columns: 1fr 1fr;
-  gap: ${space(1.5)};
+  gap: ${space(2)};
 
   ${Panel} {
     height: 100%;


### PR DESCRIPTION
1.  convert app starts "average cold start" widget to use the standard widget, this makes it easy to add open in explore functionality directly from the chart, and has benefits like full screen mode
<img width="613" alt="image" src="https://github.com/user-attachments/assets/6fc9a195-6596-4697-b99d-fd09b3b61d06" />

2. Add a `none` option to the `showReleaseAs` prop in the widget. Release bubbles aren't supported in mobile because the data is explicitly filtered by two releases, therefore it doesn't make sense to overlay all releases. 

3. Add `always` option to `showLegend`. Originally the legend would hide when there is only one series, but there is a case where you select two releases and we only have series data for one. We wouldn't want to hide the legend in this case because you won't know which release the series pertains to