### PR TITLE
fix(settings): Fix loading settings -> account -> notifications -> fine tuning

### DIFF
--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -27,7 +27,6 @@ import {useParams} from 'sentry/utils/useParams';
 import withOrganizations from 'sentry/utils/withOrganizations';
 import type {FineTuneField} from 'sentry/views/settings/account/notifications/fields';
 import {ACCOUNT_NOTIFICATION_FIELDS} from 'sentry/views/settings/account/notifications/fields';
-import {NotificationSettingsByType} from 'sentry/views/settings/account/notifications/notificationSettingsByType';
 import {OrganizationSelectHeader} from 'sentry/views/settings/account/notifications/organizationSelectHeader';
 import {
   getNotificationTypeFromPathname,
@@ -44,17 +43,6 @@ const PanelBodyLineItem = styled(PanelBody)`
   }
 `;
 
-const accountNotifications = [
-  'alerts',
-  'deploy',
-  'workflow',
-  'approval',
-  'quota',
-  'spikeProtection',
-  'reports',
-  'brokenMonitors',
-];
-
 type ANBPProps = {
   field: FineTuneField;
   projects: Project[];
@@ -63,8 +51,7 @@ type ANBPProps = {
 function AccountNotificationsByProject({projects, field}: ANBPProps) {
   const projectsByOrg = groupByOrganization(projects);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {title, description, ...fieldConfig} = field;
+  const {title: _title, description: _description, ...fieldConfig} = field;
 
   // Display as select box in this view regardless of the type specified in the config
   const data = Object.values(projectsByOrg).map(org => ({
@@ -112,8 +99,7 @@ type ANBOProps = {
 function AccountNotificationsByOrganization({field}: ANBOProps) {
   const {organizations} = useLegacyStore(OrganizationsStore);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {title, description, ...fieldConfig} = field;
+  const {title: _title, description: _description, ...fieldConfig} = field;
 
   // Display as select box in this view regardless of the type specified in the config
   const data = organizations.map(org => ({
@@ -161,7 +147,7 @@ function AccountNotificationFineTuning({
   const organizationId =
     (location?.query?.organizationId as string | undefined) ??
     organizations.find(({slug}) => slug === config?.customerDomain?.subdomain)?.id ??
-    organizations[0]?.id;
+    (organizations.length === 1 ? organizations[0]?.id : undefined);
 
   const {
     data: notifications,
@@ -187,7 +173,7 @@ function AccountNotificationFineTuning({
     ],
     {
       staleTime: 0,
-      enabled: projectsEnabled,
+      enabled: Boolean(projectsEnabled && organizationId),
     }
   );
   const isLoadingProjects = projectsEnabled ? isPendingProjects : false;
@@ -213,10 +199,6 @@ function AccountNotificationFineTuning({
     placeholderData: keepPreviousData,
   });
 
-  if (accountNotifications.includes(fineTuneType)) {
-    return <NotificationSettingsByType notificationType={fineTuneType} />;
-  }
-
   const isProject = isGroupedByProject(fineTuneType) && organizations.length > 0;
   const field = ACCOUNT_NOTIFICATION_FIELDS[fineTuneType]!;
   // TODO(isabella): once GA, remove this
@@ -231,7 +213,7 @@ function AccountNotificationFineTuning({
   }
 
   if (isEmail) {
-    // Vrified email addresses
+    // Verified email addresses
     const emailChoices: UserEmail[] = emails
       .filter(({isVerified}) => isVerified)
       .sort((a, b) => {
@@ -269,7 +251,7 @@ function AccountNotificationFineTuning({
       <LoadingIndicator />
     ) : (
       <Fragment>
-        {isProject && hasProjects && (
+        {isProject && hasProjects && organizationId && (
           <AccountNotificationsByProject projects={projects} field={field} />
         )}
 
@@ -321,21 +303,25 @@ function AccountNotificationFineTuning({
           )}
         </StyledPanelHeader>
         <PanelBody>
-          {/* Only email needs the form to change the emmail */}
-          {fineTuneType === 'email' && emailsByProject && !isPendingEmailsByProject ? (
-            <Form
-              saveOnBlur
-              apiMethod="PUT"
-              apiEndpoint="/users/me/notifications/email/"
-              initialData={emailsByProject}
-              onSubmitSuccess={() => {
-                refetchEmailsByProject();
-              }}
-            >
-              {mainContent}
-            </Form>
+          {/* Only email needs the form to change the email */}
+          {organizationId ? (
+            fineTuneType === 'email' && emailsByProject && !isPendingEmailsByProject ? (
+              <Form
+                saveOnBlur
+                apiMethod="PUT"
+                apiEndpoint="/users/me/notifications/email/"
+                initialData={emailsByProject}
+                onSubmitSuccess={() => {
+                  refetchEmailsByProject();
+                }}
+              >
+                {mainContent}
+              </Form>
+            ) : (
+              mainContent
+            )
           ) : (
-            mainContent
+            <EmptyMessage>{t('Select an organization to continue')}</EmptyMessage>
           )}
         </PanelBody>
       </Panel>

--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import EmptyMessage from 'sentry/components/emptyMessage';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
@@ -251,7 +252,7 @@ function AccountNotificationFineTuning({
       <LoadingIndicator />
     ) : (
       <Fragment>
-        {isProject && hasProjects && organizationId && (
+        {isProject && hasProjects && (
           <AccountNotificationsByProject projects={projects} field={field} />
         )}
 
@@ -321,7 +322,9 @@ function AccountNotificationFineTuning({
               mainContent
             )
           ) : (
-            <EmptyMessage>{t('Select an organization to continue')}</EmptyMessage>
+            <EmptyStateWarning withIcon={false}>
+              {t('Select an organization to continue')}
+            </EmptyStateWarning>
           )}
         </PanelBody>
       </Panel>

--- a/static/app/views/settings/account/accountNotificationFineTuningController.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuningController.tsx
@@ -1,7 +1,10 @@
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
+import {useParams} from 'sentry/utils/useParams';
 import withOrganizations from 'sentry/utils/withOrganizations';
+import {NotificationSettingsByType} from 'sentry/views/settings/account/notifications/notificationSettingsByType';
+import {getNotificationTypeFromPathname} from 'sentry/views/settings/account/notifications/utils';
 
 import AccountNotificationFineTuning from './accountNotificationFineTuning';
 
@@ -11,12 +14,31 @@ interface AccountNotificationFineTuningControllerProps
   organizationsLoading?: boolean;
 }
 
+const accountNotifications = [
+  'alerts',
+  'deploy',
+  'workflow',
+  'approval',
+  'quota',
+  'spikeProtection',
+  'reports',
+  'brokenMonitors',
+];
+
 function AccountNotificationFineTuningController({
   organizationsLoading,
   ...props
 }: AccountNotificationFineTuningControllerProps) {
+  const params = useParams<{fineTuneType: string}>();
+  const {fineTuneType: pathnameType} = params;
+  const fineTuneType = getNotificationTypeFromPathname(pathnameType);
+
   if (organizationsLoading) {
     return <LoadingIndicator />;
+  }
+
+  if (accountNotifications.includes(fineTuneType)) {
+    return <NotificationSettingsByType notificationType={fineTuneType} />;
   }
 
   return <AccountNotificationFineTuning {...props} />;

--- a/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
+++ b/static/app/views/settings/account/notifications/organizationSelectHeader.tsx
@@ -21,6 +21,7 @@ export function OrganizationSelectHeader({
     <OrgControlWrapper>
       {t('Settings for Organization')}
       <StyledSelectControl
+        allowEmpty
         options={organizations.map(org => {
           return {
             label: org.name,


### PR DESCRIPTION
Loading the Fine Tuning views can be problematic when these conditions occur:

* fresh page load (i.e. no organization in context)
* no org in subdomain
* no organization id URL query parameter
* user is a member of multiple organizations

When this happens, we do not know what organization to use and so the previous logic selected the first alphabetical organization. Depending on your org membership, this could leave you in a broken state (e.g. if the org is disabled or over the member limit).

This PR:

- removes the assumption of using the first alphabetical org (when you have more than 1 org) and forces the user to select an org
- pulls up `<NotificationSettingsByType>` into `<AccountNotificationFineTuningController>` which saves a bunch of un-necessary API requests

Test by visiting preview deploy (https://sentry-g53mk4t1m.sentry.dev/settings/account/notifications/) and clicking into each type, there are at least 3 different branches:


| link | entityType | component |
| ---- | ---------- | --------- |
| https://sentry-g53mk4t1m.sentry.dev/settings/account/notifications/alerts/ | `project` | `NotificationSettingsByEntity` |
| https://sentry-g53mk4t1m.sentry.dev/settings/account/notifications/reports/ | `organization` | `NotificationSettingsByEntity` |
| https://sentry-g53mk4t1m.sentry.dev/settings/account/notifications/email/ | N/A | `AccountNotificationFineTuning` |

Fixes JAVASCRIPT-300C
