### PR TITLE
fix(aci): Clean up the update logic for open periods 

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -645,8 +645,8 @@ def process_group_resolution(
         update_group_open_period(
             group=group,
             new_status=GroupStatus.RESOLVED,
-            activity=activity,
-            should_reopen_open_period=False,
+            resolution_time=now,
+            resolution_activity=activity,
         )
 
 

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -156,9 +156,7 @@ def handle_status_update(
         if update_open_period:
             update_group_open_period(
                 group=group,
-                new_status=new_status,
-                activity=activity,
-                should_reopen_open_period=True,
+                new_status=GroupStatus.UNRESOLVED,
             )
 
         # TODO(dcramer): we need a solution for activity rollups

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -502,7 +502,7 @@ class GroupManager(BaseManager["Group"]):
                 update_group_open_period(
                     group=group,
                     new_status=GroupStatus.RESOLVED,
-                    resolution_time=group.resolved_at,
+                    resolution_time=activity.datetime,
                     resolution_activity=activity,
                 )
             elif status == GroupStatus.UNRESOLVED and should_reopen_open_period[group.id]:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -496,7 +496,20 @@ class GroupManager(BaseManager["Group"]):
                 )
                 record_group_history(group, PRIORITY_TO_GROUP_HISTORY_STATUS[new_priority])
 
-            update_group_open_period(group, status, activity, should_reopen_open_period[group.id])
+            # The open period is only updated when a group is resolved or reopened. We don't want to
+            # update the open period when a group transitions between different substatuses within UNRESOLVED.
+            if status == GroupStatus.RESOLVED:
+                update_group_open_period(
+                    group=group,
+                    new_status=GroupStatus.RESOLVED,
+                    resolution_time=group.resolved_at,
+                    resolution_activity=activity,
+                )
+            elif status == GroupStatus.UNRESOLVED and should_reopen_open_period[group.id]:
+                update_group_open_period(
+                    group=group,
+                    new_status=GroupStatus.UNRESOLVED,
+                )
 
     def from_share_id(self, share_id: str) -> Group:
         if not share_id or len(share_id) != 32:

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -247,7 +247,13 @@ def update_group_open_period(
             activity = (
                 Activity.objects.filter(
                     group=group,
-                    type=ActivityType.SET_RESOLVED.value,
+                    type__in=[
+                        ActivityType.SET_RESOLVED.value,
+                        ActivityType.SET_RESOLVED_BY_AGE.value,
+                        ActivityType.SET_RESOLVED_IN_RELEASE.value,
+                        ActivityType.SET_RESOLVED_IN_COMMIT.value,
+                        ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
+                    ],
                 )
                 .order_by("-datetime")
                 .first()

--- a/src/sentry/models/groupopenperiod.py
+++ b/src/sentry/models/groupopenperiod.py
@@ -71,6 +71,28 @@ class GroupOpenPeriod(DefaultFieldsModel):
 
     __repr__ = sane_repr("project_id", "group_id", "date_started", "date_ended", "user_id")
 
+    def close_open_period(
+        self,
+        resolution_activity: Activity,
+        resolution_time: datetime,
+    ) -> None:
+        if self.date_ended is not None:
+            logger.warning("Open period is already closed", extra={"group_id": self.group.id})
+            return
+
+        self.update(
+            date_ended=resolution_time,
+            resolution_activity=resolution_activity,
+            user_id=resolution_activity.user_id,
+        )
+
+    def reopen_open_period(self) -> None:
+        if self.date_ended is None:
+            logger.warning("Open period is not closed", extra={"group_id": self.group.id})
+            return
+
+        self.update(date_ended=None, resolution_activity=None, user_id=None)
+
 
 def get_last_checked_for_open_period(group: Group) -> datetime:
     from sentry.incidents.models.alert_rule import AlertRule
@@ -195,11 +217,31 @@ def get_open_periods_for_group(
     return open_periods
 
 
+def create_open_period(group: Group, start_time: datetime) -> None:
+    if not features.has("organizations:issue-open-periods", group.project.organization):
+        return
+
+    latest_open_period = get_latest_open_period(group)
+    if latest_open_period and latest_open_period.date_ended is None:
+        logger.warning("Latest open period is not closed", extra={"group_id": group.id})
+        return
+
+    # There are some historical cases where we log multiple regressions for the same group,
+    # but we only want to create a new open period for the first regression
+    GroupOpenPeriod.objects.create(
+        group=group,
+        project=group.project,
+        date_started=start_time,
+        date_ended=None,
+        resolution_activity=None,
+    )
+
+
 def update_group_open_period(
     group: Group,
     new_status: int,
-    activity: Activity | None,
-    should_reopen_open_period: bool,
+    resolution_time: datetime | None = None,
+    resolution_activity: Activity | None = None,
 ) -> None:
     """
     Update an existing open period when the group is resolved or unresolved.
@@ -217,56 +259,25 @@ def update_group_open_period(
     if not has_initial_open_period(group):
         return
 
-    if new_status not in (GroupStatus.RESOLVED, GroupStatus.UNRESOLVED):
-        return
-
     open_period = get_latest_open_period(group)
     if open_period is None:
-        return
-
-    if open_period.date_ended is None and new_status == GroupStatus.UNRESOLVED:
-        logger.warning(
-            "Attempting to unresolve group with no closed open period",
-            extra={"group_id": group.id},
-        )
-        return
-
-    if open_period.date_ended is not None and new_status == GroupStatus.RESOLVED:
-        logger.warning(
-            "Attempting to resolve group with no active open period",
-            extra={"group_id": group.id},
-        )
+        logger.warning("No open period found for group", extra={"group_id": group.id})
         return
 
     if new_status == GroupStatus.RESOLVED:
-        if activity is None:
+        if resolution_activity is None or resolution_time is None:
             logger.warning(
-                "Missing activity for group resolution, querying for it",
+                "Missing information to close open period",
                 extra={"group_id": group.id},
             )
-            activity = (
-                Activity.objects.filter(
-                    group=group,
-                    type__in=[
-                        ActivityType.SET_RESOLVED.value,
-                        ActivityType.SET_RESOLVED_BY_AGE.value,
-                        ActivityType.SET_RESOLVED_IN_RELEASE.value,
-                        ActivityType.SET_RESOLVED_IN_COMMIT.value,
-                        ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value,
-                    ],
-                )
-                .order_by("-datetime")
-                .first()
-            )
+            return
 
-        end_time = group.resolved_at or (activity.datetime if activity else None)
-        open_period.update(
-            date_ended=end_time,
-            resolution_activity=activity,
-            user_id=activity.user_id if activity else None,
+        open_period.close_open_period(
+            resolution_activity=resolution_activity,
+            resolution_time=resolution_time,
         )
-    elif new_status == GroupStatus.UNRESOLVED and should_reopen_open_period:
-        open_period.update(date_ended=None, resolution_activity=None, user_id=None)
+    elif new_status == GroupStatus.UNRESOLVED:
+        open_period.reopen_open_period()
 
 
 def has_initial_open_period(group: Group) -> bool:

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -106,13 +106,14 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
     might_have_more = len(queryset) == chunk_size
 
     for group in queryset:
+        resolution_time = django_timezone.now()
         happened = Group.objects.filter(
             id=group.id,
             status=GroupStatus.UNRESOLVED,
             last_seen__lte=cutoff,
         ).update(
             status=GroupStatus.RESOLVED,
-            resolved_at=django_timezone.now(),
+            resolved_at=resolution_time,
             substatus=None,
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -129,8 +129,8 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
             update_group_open_period(
                 group=group,
                 new_status=GroupStatus.RESOLVED,
-                activity=activity,
-                should_reopen_open_period=False,
+                resolution_time=resolution_time,
+                resolution_activity=activity,
             )
 
             kick_off_status_syncs.apply_async(

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -420,8 +420,14 @@ class IssueSyncIntegration(TestCase):
         group.substatus = None
         group.save()
         assert group.status == GroupStatus.RESOLVED
+        activity = Activity.objects.create(
+            group=group,
+            project=group.project,
+            type=ActivityType.SET_RESOLVED.value,
+            datetime=timezone.now(),
+        )
         open_period = GroupOpenPeriod.objects.get(group=group, project=group.project)
-        open_period.update(date_ended=timezone.now())
+        open_period.close_open_period(resolution_time=timezone.now(), resolution_activity=activity)
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             integration = self.create_provider_integration(provider="example", external_id="123456")
@@ -590,7 +596,15 @@ class IssueDefaultTest(TestCase):
         self.group.substatus = None
         self.group.save()
 
-        GroupOpenPeriod.objects.get(group_id=self.group.id).update(date_ended=timezone.now())
+        activity = Activity.objects.create(
+            group=self.group,
+            project=self.group.project,
+            type=ActivityType.SET_RESOLVED.value,
+            datetime=timezone.now(),
+        )
+        GroupOpenPeriod.objects.get(group_id=self.group.id).close_open_period(
+            resolution_time=timezone.now(), resolution_activity=activity
+        )
 
         integration = self.create_integration(
             organization=self.group.organization, provider="example", external_id="123456"


### PR DESCRIPTION
We've seen incorrect writes to rows as issues go through the auto-resolve/regress cycle and don't get updated correctly.  This PR simplifies the logic in `update_group_open_period` and tightens the requirements around what data we need to re-open/close an open period so we can hopefully avoid getting into those bad states. 

Part of the issue is that `group.resolved_at` is not always set for resolved groups, so we instead need to pass the resolution time or use the resolution_activity's time. https://github.com/getsentry/sentry/pull/92516 fixes this going forward

