### PR TITLE
Fix typo s/writting/written

### DIFF
--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -544,7 +544,7 @@ export function SourceMapsDebuggerModal({
         <DebuggerSection title={t('Why Configure Source Maps?')}>
           <p>
             {t(
-              "With properly configured source maps, you'll see the code that was writting instead of minified, obfuscated code. This makes debugging significantly easier and faster."
+              "With properly configured source maps, you'll see the code that was written instead of minified, obfuscated code. This makes debugging significantly easier and faster."
             )}
           </p>
           <p>


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fix typo in source map debugger modal s/writting/written as shown in screen below:

![Source map debugger modal typo](https://github.com/user-attachments/assets/56005bcd-c7bd-41d9-902d-acf3f77ca8a4)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
