### PR TITLE
chore(nav): Replace enforce-stacked-nav flag checks with usePrefersStackedNav hook

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
+import ConfigStore from 'sentry/stores/configStore';
 import IssueViewsList from 'sentry/views/issueList/issueViews/issueViewsList/issueViewsList';
 
 const organization = OrganizationFixture({
@@ -64,6 +65,14 @@ describe('IssueViewsList', function () {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/prompts-activity/',
+    });
+
+    ConfigStore.set('user', {
+      ...ConfigStore.get('user'),
+      options: {
+        ...ConfigStore.get('user').options,
+        prefersStackedNavigation: true,
+      },
     });
   });
 

--- a/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
+++ b/static/app/views/issueList/issueViews/issueViewsList/issueViewsList.tsx
@@ -43,6 +43,7 @@ import {
 } from 'sentry/views/issueList/types';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import useDefaultProject from 'sentry/views/nav/secondary/sections/issues/issueViews/useDefaultProject';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 type IssueViewSectionProps = {
   createdBy: GroupSearchViewCreatedBy;
@@ -307,8 +308,9 @@ export default function IssueViewsList() {
   const {mutate: createGroupSearchView, isPending: isCreatingView} =
     useCreateGroupSearchView();
   const defaultProject = useDefaultProject();
+  const prefersStackedNav = usePrefersStackedNav();
 
-  if (!organization.features.includes('enforce-stacked-navigation')) {
+  if (!prefersStackedNav) {
     return <Redirect to={`/organizations/${organization.slug}/issues/`} />;
   }
 

--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -11,6 +11,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import IssueViewsHeader from 'sentry/views/issueList/issueViewsHeader';
 
 describe('IssueViewsHeader', function () {
@@ -48,6 +49,14 @@ describe('IssueViewsHeader', function () {
     },
     route: '/organizations/:orgId/issues/',
   };
+
+  ConfigStore.set('user', {
+    ...ConfigStore.get('user'),
+    options: {
+      ...ConfigStore.get('user').options,
+      prefersStackedNavigation: true,
+    },
+  });
 
   describe('edit menu', function () {
     it('does not render if not on a view', async function () {

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -66,6 +66,8 @@ function IssueViewStarButton() {
   const organization = useOrganization();
   const user = useUser();
   const queryClient = useQueryClient();
+  const prefersStackedNav = usePrefersStackedNav();
+
   const {data: groupSearchView} = useSelectedGroupSearchView();
   const {mutate: mutateViewStarred} = useUpdateGroupSearchViewStarred({
     onMutate: variables => {
@@ -96,7 +98,7 @@ function IssueViewStarButton() {
     },
   });
 
-  if (!organization.features.includes('enforce-stacked-navigation') || !groupSearchView) {
+  if (!prefersStackedNav || !groupSearchView) {
     return null;
   }
 
@@ -142,8 +144,9 @@ function IssueViewEditMenu() {
   const user = useUser();
   const {mutateAsync: deleteIssueView} = useDeleteGroupSearchView();
   const navigate = useNavigate();
+  const prefersStackedNav = usePrefersStackedNav();
 
-  if (!organization.features.includes('enforce-stacked-navigation') || !groupSearchView) {
+  if (!prefersStackedNav || !groupSearchView) {
     return null;
   }
 

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -66,17 +66,15 @@ export function IssuesSecondaryNav() {
             </SecondaryNav.Section>
           </Fragment>
         )}
-        {organization.features.includes('enforce-stacked-navigation') && (
-          <SecondaryNav.Section id="issues-views-all">
-            <SecondaryNav.Item
-              to={`${baseUrl}/views/`}
-              analyticsItemName="issues_all_views"
-              end
-            >
-              {t('All Views')}
-            </SecondaryNav.Item>
-          </SecondaryNav.Section>
-        )}
+        <SecondaryNav.Section id="issues-views-all">
+          <SecondaryNav.Item
+            to={`${baseUrl}/views/`}
+            analyticsItemName="issues_all_views"
+            end
+          >
+            {t('All Views')}
+          </SecondaryNav.Item>
+        </SecondaryNav.Section>
         <IssueViews sectionRef={sectionRef} />
         <ConfigureSection baseUrl={baseUrl} />
       </SecondaryNav.Body>


### PR DESCRIPTION
There were a few places that still checked the `enforce-stacked-navigation` flag directly, rather than using the `usePrefersStackedNav` flag. 