### PR TITLE
stories: export APIReference on storybook namespace

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.stories.tsx
+++ b/static/app/components/charts/chartWidgetLoader.stories.tsx
@@ -6,8 +6,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/charts/chartWidgetLoader';
 
-export default Storybook.story('ChartWidgetLoader', (story, APIReference) => {
-  APIReference(types.ChartWidgetLoader);
+export default Storybook.story('ChartWidgetLoader', story => {
+  Storybook.APIReference(types.ChartWidgetLoader);
 
   story('Getting Started', () => {
     return (

--- a/static/app/components/core/alert/alertLink.stories.tsx
+++ b/static/app/components/core/alert/alertLink.stories.tsx
@@ -17,8 +17,8 @@ const ALERT_LINK_VARIANTS: Array<AlertLinkProps['type']> = [
   'muted',
 ];
 
-export default Storybook.story('AlertLink', (story, APIReference) => {
-  APIReference(types.AlertLink);
+export default Storybook.story('AlertLink', story => {
+  Storybook.APIReference(types.AlertLink);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/alert/index.stories.tsx
+++ b/static/app/components/core/alert/index.stories.tsx
@@ -21,8 +21,8 @@ const RECOMMENDED_USAGE: Partial<AlertProps> = {
   showIcon: true,
 };
 
-export default Storybook.story('Alert', (story, APIReference) => {
-  APIReference(types.Alert);
+export default Storybook.story('Alert', story => {
+  Storybook.APIReference(types.Alert);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/avatar/index.stories.tsx
+++ b/static/app/components/core/avatar/index.stories.tsx
@@ -11,8 +11,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/avatar/projectAvatar';
 
-export default Storybook.story('Avatar', (story, APIReference) => {
-  APIReference(types.Avatar);
+export default Storybook.story('Avatar', story => {
+  Storybook.APIReference(types.Avatar);
   story('User', () => {
     return (
       <Fragment>

--- a/static/app/components/core/badge/index.stories.tsx
+++ b/static/app/components/core/badge/index.stories.tsx
@@ -6,8 +6,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/badge';
 
-export default Storybook.story('Badge', (story, APIReference) => {
-  APIReference(types.Badge);
+export default Storybook.story('Badge', story => {
+  Storybook.APIReference(types.Badge);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/badge/tag.stories.tsx
+++ b/static/app/components/core/badge/tag.stories.tsx
@@ -9,8 +9,8 @@ import useDismissAlert from 'sentry/utils/useDismissAlert';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/badge/tag.tsx';
 
-export default Storybook.story('Tag', (story, APIReference) => {
-  APIReference(types.Tag);
+export default Storybook.story('Tag', story => {
+  Storybook.APIReference(types.Tag);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -7,8 +7,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/button/buttonBar';
 
-export default Storybook.story('ButtonBar', (story, APIReference) => {
-  APIReference(types.ButtonBar);
+export default Storybook.story('ButtonBar', story => {
+  Storybook.APIReference(types.ButtonBar);
 
   story('Default', () => {
     const [active, setActive] = useState('One');

--- a/static/app/components/core/button/index.stories.tsx
+++ b/static/app/components/core/button/index.stories.tsx
@@ -7,8 +7,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/button';
 
-export default Storybook.story('Button', (story, APIReference) => {
-  APIReference(types.Button);
+export default Storybook.story('Button', story => {
+  Storybook.APIReference(types.Button);
 
   story('Default', () => {
     const theme = useTheme();

--- a/static/app/components/core/button/linkButton.stories.tsx
+++ b/static/app/components/core/button/linkButton.stories.tsx
@@ -6,8 +6,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/button';
 
-export default Storybook.story('LinkButton', (story, APIReference) => {
-  APIReference(types.LinkButton);
+export default Storybook.story('LinkButton', story => {
+  Storybook.APIReference(types.LinkButton);
 
   story('Default', () => {
     const theme = useTheme();

--- a/static/app/components/core/checkbox/index.stories.tsx
+++ b/static/app/components/core/checkbox/index.stories.tsx
@@ -8,8 +8,8 @@ import {space} from 'sentry/styles/space';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/checkbox/index.tsx';
 
-export default Storybook.story('Checkbox', (story, APIReference) => {
-  APIReference(types.Checkbox);
+export default Storybook.story('Checkbox', story => {
+  Storybook.APIReference(types.Checkbox);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/input/index.stories.tsx
+++ b/static/app/components/core/input/index.stories.tsx
@@ -8,8 +8,8 @@ import {space} from 'sentry/styles/space';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input';
 
-export default Storybook.story('Input', (story, APIReference) => {
-  APIReference(types.Input);
+export default Storybook.story('Input', story => {
+  Storybook.APIReference(types.Input);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/input/inputGroup.stories.tsx
+++ b/static/app/components/core/input/inputGroup.stories.tsx
@@ -11,8 +11,8 @@ import {InputGroup} from './inputGroup';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input/inputGroup';
 
-export default Storybook.story('InputGroup', (story, APIReference) => {
-  APIReference(types.InputGroup);
+export default Storybook.story('InputGroup', story => {
+  Storybook.APIReference(types.InputGroup);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/input/numberDragInput.stories.tsx
+++ b/static/app/components/core/input/numberDragInput.stories.tsx
@@ -7,8 +7,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input/numberDragInput';
 
-export default Storybook.story('NumberDragInput', (story, APIReference) => {
-  APIReference(types.NumberDragInput);
+export default Storybook.story('NumberDragInput', story => {
+  Storybook.APIReference(types.NumberDragInput);
 
   story('Default', () => {
     const [horizontalValue, setHorizontalValue] = useState(10);

--- a/static/app/components/core/input/numberInput.stories.tsx
+++ b/static/app/components/core/input/numberInput.stories.tsx
@@ -7,8 +7,8 @@ import {NumberInput} from './numberInput';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input/numberInput';
 
-export default Storybook.story('NumberInput', (story, APIReference) => {
-  APIReference(types.NumberInput);
+export default Storybook.story('NumberInput', story => {
+  Storybook.APIReference(types.NumberInput);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/menuListItem/index.stories.tsx
+++ b/static/app/components/core/menuListItem/index.stories.tsx
@@ -7,8 +7,8 @@ import {space} from 'sentry/styles/space';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/menuListItem';
 
-export default Storybook.story('MenuListItem', (story, APIReference) => {
-  APIReference(types.MenuListItem);
+export default Storybook.story('MenuListItem', story => {
+  Storybook.APIReference(types.MenuListItem);
 
   story('focused', () => {
     return <SizeVariants isFocused />;

--- a/static/app/components/core/radio/index.stories.tsx
+++ b/static/app/components/core/radio/index.stories.tsx
@@ -8,8 +8,8 @@ import {space} from 'sentry/styles/space';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/radio';
 
-export default Storybook.story('Radio', (story, APIReference) => {
-  APIReference(types.Radio);
+export default Storybook.story('Radio', story => {
+  Storybook.APIReference(types.Radio);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/select/index.stories.tsx
+++ b/static/app/components/core/select/index.stories.tsx
@@ -7,8 +7,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/select';
 
-export default Storybook.story('Select', (story, APIReference) => {
-  APIReference(types.Select);
+export default Storybook.story('Select', story => {
+  Storybook.APIReference(types.Select);
 
   story('Sizes', () => {
     return (

--- a/static/app/components/core/slider/index.stories.tsx
+++ b/static/app/components/core/slider/index.stories.tsx
@@ -8,8 +8,8 @@ import {space} from 'sentry/styles/space';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/slider';
 
-export default Storybook.story('Slider', (story, APIReference) => {
-  APIReference(types.Slider);
+export default Storybook.story('Slider', story => {
+  Storybook.APIReference(types.Slider);
   story('Default', () => {
     return (
       <Fragment>

--- a/static/app/components/core/switch/index.stories.tsx
+++ b/static/app/components/core/switch/index.stories.tsx
@@ -8,8 +8,8 @@ import {space} from 'sentry/styles/space';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/switch';
 
-export default Storybook.story('Switch', (story, APIReference) => {
-  APIReference(types.Switch);
+export default Storybook.story('Switch', story => {
+  Storybook.APIReference(types.Switch);
 
   story('Default', () => {
     return (

--- a/static/app/components/core/toast/index.stories.tsx
+++ b/static/app/components/core/toast/index.stories.tsx
@@ -20,8 +20,8 @@ function makeToastProps(type: 'success' | 'error' | 'loading' | 'undo'): ToastPr
     },
   };
 }
-export default Storybook.story('Toast', (story, APIReference) => {
-  APIReference(types.Toast);
+export default Storybook.story('Toast', story => {
+  Storybook.APIReference(types.Toast);
 
   story('Toast types', () => {
     return (

--- a/static/app/components/core/tooltip/index.stories.tsx
+++ b/static/app/components/core/tooltip/index.stories.tsx
@@ -7,8 +7,8 @@ import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/tooltip';
 
-export default Storybook.story('Tooltip', (story, APIReference) => {
-  APIReference(types.Tooltip);
+export default Storybook.story('Tooltip', story => {
+  Storybook.APIReference({types: types.Tooltip});
 
   story('Default', () => {
     return (

--- a/static/app/stories/index.tsx
+++ b/static/app/stories/index.tsx
@@ -5,3 +5,4 @@ export {SideBySide} from './layout';
 export {SizingWindow, Grid} from './layout';
 export {story} from './storybook';
 export {ThemeSwitcher, ThemeToggle} from './theme';
+export {APIReference} from './apiReference';

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -72,8 +72,8 @@ const releases = [
   },
 ].filter(hasTimestamp);
 
-export default Storybook.story('TimeSeriesWidgetVisualization', (story, APIReference) => {
-  APIReference(types.TimeSeriesWidgetVisualization);
+export default Storybook.story('TimeSeriesWidgetVisualization', story => {
+  Storybook.APIReference(types.TimeSeriesWidgetVisualization);
 
   story('Getting Started', () => {
     return (

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -14,8 +14,8 @@ import {Widget} from './widget';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/views/dashboards/widgets/widget/widget';
 
-export default Storybook.story('Widget', (story, APIReference) => {
-  APIReference(types.exported);
+export default Storybook.story('Widget', story => {
+  Storybook.APIReference(types.exported);
 
   story('Getting Started', () => {
     return (


### PR DESCRIPTION
In hindsight, the 2nd argument providing the API reference wasn't a good choice, as it goes against the declarative nature of React, and makes it hard to understand what and where this is actually being rendered at.