### PR TITLE
fix: Add eap_items entity key

### DIFF
--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -61,6 +61,7 @@ class EntityKey(Enum):
     Sessions = "sessions"
     Spans = "spans"
     EAPItemsSpan = "eap_items_span"
+    EAPItems = "eap_items"
     Transactions = "transactions"
     MetricsSets = "metrics_sets"
     MetricsCounters = "metrics_counters"


### PR DESCRIPTION
Fixes: SENTRY-3X43
caused by stale subscriptions referencing the `eap_items`
entity key. Add it as a valid entity key so they get deleted
correctly.

We're going to be supporting eap_items soon too.