### PR TITLE
ref(insights): pass in search to web vitals module charts

### DIFF
--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -112,6 +112,7 @@ export default function PerformanceScoreBreakdownChartWidget(
   return (
     <InsightsTimeSeriesWidget
       {...props}
+      search={search}
       id="performanceScoreBreakdownChartWidget"
       title={t('Score Breakdown')}
       height="100%"


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/92337 but for web vitals breakdown chart