### PR TITLE
feat(traces): Add trace logs endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -1,0 +1,114 @@
+import sentry_sdk
+from django.http import HttpRequest, HttpResponse
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization
+from sentry.search.events.types import SnubaParams, SnubaRow
+from sentry.snuba import ourlogs
+from sentry.snuba.referrer import Referrer
+from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
+
+
+@region_silo_endpoint
+class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
+    """Replaces a call to events that isn't possible for team plans because of projects restrictions"""
+
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+
+    def get_projects(
+        self,
+        request: HttpRequest,
+        organization: Organization | RpcOrganization,
+        force_global_perms: bool = False,
+        include_all_accessible: bool = False,
+        project_ids: set[int] | None = None,
+        project_slugs: set[str] | None = None,
+    ) -> list[Project]:
+        """The trace endpoint always wants to get all projects regardless of what's passed into the API
+
+        This is because a trace can span any number of projects in an organization. But we still want to
+        use the get_projects function to check for any permissions. So we'll just pass project_ids=-1 everytime
+        which is what would be sent if we wanted all projects"""
+        return super().get_projects(
+            request,
+            organization,
+            project_ids={-1},
+            project_slugs=None,
+            include_all_accessible=True,
+        )
+
+    @sentry_sdk.tracing.trace
+    def query_logs_data(
+        self,
+        snuba_params: SnubaParams,
+        trace_ids: list[str],
+        orderby: list[str],
+        offset: int,
+        limit: int,
+    ) -> list[SnubaRow]:
+        """Queries log data for a given trace"""
+        selected_columns = [
+            "sentry.item_id",
+            "project.id",
+            "trace",
+            "severity_number",
+            "severity",
+            "timestamp",
+            "tags[sentry.timestamp_precise,number]",
+            "message",
+        ]
+        for column in orderby:
+            if column.lstrip("-") not in selected_columns:
+                raise ParseError(
+                    f"{column.lstrip('-')} must be one of {','.join(selected_columns)}"
+                )
+        results = ourlogs.query(
+            selected_columns=selected_columns,
+            query=(
+                f"trace:{trace_ids[0]}" if len(trace_ids) == 1 else f"trace:[{','.join(trace_ids)}]"
+            ),
+            snuba_params=snuba_params,
+            orderby=orderby,
+            offset=offset,
+            limit=limit,
+            referrer=Referrer.API_TRACE_VIEW_LOGS.value,
+        )
+        return results["data"]
+
+    def get(self, request: Request, organization: Organization) -> HttpResponse:
+        try:
+            # The trace view isn't useful without global views, so skipping the check here
+            snuba_params = self.get_snuba_params(request, organization, check_global_views=False)
+        except NoProjects:
+            return Response(status=404)
+
+        trace_ids = request.GET.getlist("traceId", [])
+        for trace_id in trace_ids:
+            if not is_event_id(trace_id):
+                raise ParseError(INVALID_ID_DETAILS.format(trace_id))
+        if len(trace_ids) == 0:
+            raise ParseError("Need to pass at least one traceId")
+
+        orderby = request.GET.getlist("orderby", ["-timestamp"])
+
+        update_snuba_params_with_timestamp(request, snuba_params)
+
+        def data_fn(offset: int, limit: int) -> list[SnubaRow]:
+            with handle_query_errors():
+                return self.query_logs_data(snuba_params, trace_ids, orderby, offset, limit)
+
+        return self.paginate(
+            request=request,
+            paginator=GenericOffsetPaginator(data_fn=data_fn),
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -610,6 +610,7 @@ from .endpoints.organization_tagkey_values import OrganizationTagKeyValuesEndpoi
 from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
 from .endpoints.organization_trace import OrganizationTraceEndpoint
+from .endpoints.organization_trace_logs import OrganizationTraceLogsEndpoint
 from .endpoints.organization_trace_meta import OrganizationTraceMetaEndpoint
 from .endpoints.organization_traces import (
     OrganizationTracesEndpoint,
@@ -1687,6 +1688,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/trace-meta/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
         OrganizationTraceMetaEndpoint.as_view(),
         name="sentry-api-0-organization-trace-meta",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/trace-logs/$",
+        OrganizationTraceLogsEndpoint.as_view(),
+        name="sentry-api-0-organization-trace-logs",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/trace-summary/$",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -680,6 +680,7 @@ class Referrer(StrEnum):
     API_TRACE_VIEW_SPAN_OP_META = "api.trace-view.spans-op-count"
     API_TRACE_VIEW_TRANSACTION_CHILDREN = "api.trace-view.transaction-children"
     API_TRACE_VIEW_LOGS_META = "api.trace-view.logs-meta"
+    API_TRACE_VIEW_LOGS = "api.trace-view.logs"
     API_TRACE_VIEW_HOVER_CARD = "api.trace-view.hover-card"
     API_TRACE_VIEW_SPAN_DETAIL = "api.trace-view.span-detail"
     API_TRACE_VIEW_COUNT_PERFORMANCE_ISSUES = "api.trace-view.count-performance-issues"

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -184,7 +184,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
                 ),
                 self.create_ourlog(
                     {"body": "bar", "trace_id": trace_id_2},
-                    timestamp=self.ten_mins_ago,
+                    timestamp=self.eleven_mins_ago,
                     project=project2,
                 ),
             ]

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -1,0 +1,208 @@
+import logging
+from uuid import uuid4
+
+from django.urls import reverse
+
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
+    url_name = "sentry-api-0-organization-trace-logs"
+
+    def setUp(self):
+        super().setUp()
+        self.features = {
+            "organizations:ourlogs-enabled": True,
+        }
+        self.login_as(user=self.user)
+        self.url = reverse(
+            self.url_name,
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    def test_no_projects(self):
+        response = self.client.get(
+            self.url,
+            data={"traceId": uuid4().hex},
+            format="json",
+        )
+
+        assert response.status_code == 404, response.content
+
+    def test_invalid_trace_id(self):
+        trace_id_1 = "1" * 32
+        trace_id_2 = "2" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": trace_id_1},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id_2},
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+        for trace_id in ["1" * 16, "test"]:
+            response = self.client.get(
+                self.url,
+                data={"traceId": trace_id},
+                format="json",
+            )
+            assert response.status_code == 400, response.content
+
+    def test_simple(self):
+        trace_id_1 = "1" * 32
+        trace_id_2 = "2" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": trace_id_1},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id_2},
+                    timestamp=self.ten_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": trace_id_1},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 1
+        log_data = data[0]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["trace"] == trace_id_1
+        assert log_data["message"] == "foo"
+
+    def test_multiple_traces(self):
+        trace_id_1 = "1" * 32
+        trace_id_2 = "2" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": trace_id_1},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id_2},
+                    timestamp=self.eleven_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": [trace_id_1, trace_id_2]},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 2
+        log_data = data[0]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["trace"] == trace_id_1
+        assert log_data["message"] == "foo"
+        log_data = data[1]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["trace"] == trace_id_2
+        assert log_data["message"] == "bar"
+
+    def test_orderby(self):
+        trace_id_1 = "1" * 32
+        trace_id_2 = "2" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": trace_id_1},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id_2},
+                    timestamp=self.eleven_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": [trace_id_1, trace_id_2], "orderby": "timestamp"},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 2
+        log_data = data[0]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["trace"] == trace_id_2
+        assert log_data["message"] == "bar"
+        log_data = data[1]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["trace"] == trace_id_1
+        assert log_data["message"] == "foo"
+
+    def test_orderby_validation(self):
+        trace_id_1 = "1" * 32
+        trace_id_2 = "2" * 32
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": trace_id_1},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id_2},
+                    timestamp=self.eleven_mins_ago,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": [trace_id_1, trace_id_2], "orderby": "foobar"},
+            format="json",
+        )
+        assert response.status_code == 400, response.content
+
+    def test_cross_project_query(self):
+        trace_id_1 = "1" * 32
+        trace_id_2 = "2" * 32
+        project2 = self.create_project(organization=self.organization)
+        self.store_ourlogs(
+            [
+                self.create_ourlog(
+                    {"body": "foo", "trace_id": trace_id_1},
+                    timestamp=self.ten_mins_ago,
+                ),
+                self.create_ourlog(
+                    {"body": "bar", "trace_id": trace_id_2},
+                    timestamp=self.ten_mins_ago,
+                    project=project2,
+                ),
+            ]
+        )
+
+        response = self.client.get(
+            self.url,
+            data={"traceId": [trace_id_1, trace_id_2]},
+            format="json",
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 2
+        log_data = data[0]
+        assert log_data["project.id"] == self.project.id
+        assert log_data["trace"] == trace_id_1
+        assert log_data["message"] == "foo"
+        log_data = data[1]
+        assert log_data["project.id"] == project2.id
+        assert log_data["trace"] == trace_id_2
+        assert log_data["message"] == "bar"


### PR DESCRIPTION
- This adds an endpoint to replace a call to events since we can't always call events with projects=-1 (eg. if the customer is on a team plan)
- This endpoint should effectively be the same except that the selected columns & query is locked down. Pagination and orderby should both operate as expected