### PR TITLE
feat(nav): Add slight delay to nav hover interactions

### DIFF
--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -5,3 +5,4 @@ export const SECONDARY_SIDEBAR_WIDTH = 190;
 
 // Slightly delay closing the nav to prevent accidental dismissal
 export const NAV_SIDEBAR_COLLAPSE_DELAY_MS = 200;
+export const NAV_SIDEBAR_OPEN_DELAY_MS = 200;

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -301,10 +301,12 @@ describe('Nav', function () {
         await userEvent.hover(
           screen.getByRole('navigation', {name: 'Primary Navigation'})
         );
-        expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
-          'data-visible',
-          'true'
-        );
+        await waitFor(() => {
+          expect(screen.getByTestId('collapsed-secondary-sidebar')).toHaveAttribute(
+            'data-visible',
+            'true'
+          );
+        });
 
         // Moving pointer away should hide the sidebar
         await userEvent.unhover(

--- a/static/app/views/nav/useCollapsedNav.tsx
+++ b/static/app/views/nav/useCollapsedNav.tsx
@@ -1,7 +1,10 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useInteractOutside} from '@react-aria/interactions';
 
-import {NAV_SIDEBAR_COLLAPSE_DELAY_MS} from 'sentry/views/nav/constants';
+import {
+  NAV_SIDEBAR_COLLAPSE_DELAY_MS,
+  NAV_SIDEBAR_OPEN_DELAY_MS,
+} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 
 const IGNORE_ELEMENTS = [
@@ -73,14 +76,23 @@ export function useCollapsedNav() {
 
     const navParentEl = navParentRef.current;
     let closeTimer: NodeJS.Timeout;
+    let openTimer: NodeJS.Timeout;
 
     const hoverIn = () => {
       clearTimeout(closeTimer);
+      clearTimeout(openTimer);
+
       isHoveredRef.current = true;
-      setIsOpen(true);
+
+      openTimer = setTimeout(() => {
+        setIsOpen(true);
+      }, NAV_SIDEBAR_OPEN_DELAY_MS);
     };
 
     const hoverOut = () => {
+      clearTimeout(openTimer);
+      clearTimeout(closeTimer);
+
       isHoveredRef.current = false;
 
       closeTimer = setTimeout(() => {


### PR DESCRIPTION
Adds a 200ms delay before activating a nav group, and when opening the collapsed nav on hover. This should prevent help accidental triggers, both when the user doesn't want to preview a group and when they are moving their move from the primary button to the secondary menu.