### PR TITLE
:wrench: chore(integrations): don't log full exception for slo failures

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -147,13 +146,11 @@ class EventLifecycle:
         }
 
         if isinstance(outcome_reason, BaseException):
-            # (iamrajjoshi): Log the full exception 50% of the time otherwise log the repr of the exception
+            # (iamrajjoshi): Log the full exception and the repr of the exception
             # This is an experiment to dogfood Sentry logs
-            #  Logs are paid by bytes, we save money by making optimizations like this - we should try to dogfood from a similar perspective
-            if random.random() < 0.5:
-                log_params["exc_info"] = outcome_reason
-            else:
-                log_params["exception_summary"] = repr(outcome_reason)
+            #  Logs are paid by bytes, we save money by mking optimizations like this - we should try to dogfood from a similar perspective
+            log_params["exc_info"] = outcome_reason
+            log_params["exception_summary"] = repr(outcome_reason)
         elif isinstance(outcome_reason, str):
             extra["outcome_reason"] = outcome_reason
 

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -146,7 +147,13 @@ class EventLifecycle:
         }
 
         if isinstance(outcome_reason, BaseException):
-            log_params["exc_info"] = outcome_reason
+            # (iamrajjoshi): Log the full exception 50% of the time otherwise log the repr of the exception
+            # This is an experiment to dogfood Sentry logs
+            #  Logs are paid by bytes, we save money by making optimizations like this - we should try to dogfood from a similar perspective
+            if random.random() < 0.5:
+                log_params["exc_info"] = outcome_reason
+            else:
+                log_params["exception_summary"] = repr(outcome_reason)
         elif isinstance(outcome_reason, str):
             extra["outcome_reason"] = outcome_reason
 

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -150,7 +150,7 @@ class EventLifecycle:
             # This is an experiment to dogfood Sentry logs
             #  Logs are paid by bytes, we save money by mking optimizations like this - we should try to dogfood from a similar perspective
             log_params["exc_info"] = outcome_reason
-            log_params["exception_summary"] = repr(outcome_reason)
+            log_params["extra"]["exception_summary"] = repr(outcome_reason)
         elif isinstance(outcome_reason, str):
             extra["outcome_reason"] = outcome_reason
 

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -93,6 +93,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "exception_summary": repr(ExampleException("")),
             },
             exc_info=mock.ANY,
         )
@@ -125,7 +126,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         with pytest.raises(ExampleException):
             with metric_obj.capture() as lifecycle:
                 lifecycle.add_extra("extra", "value")
-                raise ExampleException
+                raise ExampleException()
 
         self._check_metrics_call_args(mock_metrics, "failure")
         mock_logger.error.assert_called_once_with(
@@ -135,6 +136,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "exception_summary": repr(ExampleException()),
             },
             exc_info=mock.ANY,
         )
@@ -146,7 +148,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         with metric_obj.capture() as lifecycle:
             try:
                 lifecycle.add_extra("extra", "value")
-                raise ExampleException
+                raise ExampleException()
             except ExampleException as exc:
                 lifecycle.record_failure(exc, extra={"even": "more"})
 
@@ -159,6 +161,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "exception_summary": repr(ExampleException()),
             },
             exc_info=mock.ANY,
         )


### PR DESCRIPTION
Relevant thread: https://sentry.slack.com/archives/C081M1KEQ0L/p1748551046199699

In our current Logs product, we don't send the `exc_info`  extra because its ~ 1KB and we would need to run symbolicator/stack trace parsing on it.

Before we add this to the SDK and into Sentry, lets first experiment if we can solve issues using `repr` of the exception.

Logs are paid by bytes, we save money by making optimizations like this, so lets try to see if we can triage problems with just the `repr` of the exception.

Since we still want to be able to solve problems, we only use the `repr` 50% of the time