### PR TITLE
feat(ourlogs): Add a sidebar to aggregate on the logs page

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
@@ -8,7 +8,7 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
-import {IconTable} from 'sentry/icons';
+import {IconChevron, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -37,14 +37,17 @@ import {getIntervalOptionsForPageFilter} from 'sentry/views/explore/hooks/useCha
 import {HiddenColumnEditorLogFields} from 'sentry/views/explore/logs/constants';
 import {AutorefreshToggle} from 'sentry/views/explore/logs/logsAutoRefresh';
 import {LogsGraph} from 'sentry/views/explore/logs/logsGraph';
+import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
 import {
   BottomSectionBody,
   FilterBarContainer,
   LogsGraphContainer,
   LogsItemContainer,
+  LogsSidebarCollapseButton,
   LogsTableActionsContainer,
   StyledPageFilterBar,
   TableActionsContainer,
+  ToolbarAndBodyContainer,
   TopSectionBody,
 } from 'sentry/views/explore/logs/styles';
 import {LogsInfiniteTable as LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
@@ -64,6 +67,7 @@ export function LogsTabContent({
   maxPickableDays,
   relativeOptions,
 }: LogsTabProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const logsSearch = useLogsSearch();
   const fields = useLogsFields();
   const setFields = useSetLogsFields();
@@ -182,40 +186,61 @@ export function LogsTabContent({
           </SchemaHintsSection>
         </Layout.Main>
       </TopSectionBody>
-      <BottomSectionBody noRowGap>
-        <Layout.Main fullWidth>
-          <LogsGraphContainer>
-            <LogsGraph timeseriesResult={timeseriesResult} />
-          </LogsGraphContainer>
-          <LogsTableActionsContainer>
-            <TableActionsContainer>
-              <Feature features="organizations:ourlogs-live-refresh">
-                <AutorefreshToggle />
-              </Feature>
-              <Button onClick={openColumnEditor} icon={<IconTable />}>
-                {t('Edit Table')}
-              </Button>
-            </TableActionsContainer>
-          </LogsTableActionsContainer>
 
-          <LogsItemContainer>
-            <Feature
-              features="organizations:ourlogs-live-refresh"
-              renderDisabled={() => (
-                <LogsTable
+      <ToolbarAndBodyContainer sidebarOpen={sidebarOpen}>
+        {sidebarOpen && (
+          <LogsToolbar stringTags={stringAttributes} numberTags={numberAttributes} />
+        )}
+        <BottomSectionBody>
+          <section>
+            <Feature features="organizations:ourlogs-visualize-sidebar">
+              <LogsSidebarCollapseButton
+                sidebarOpen={sidebarOpen}
+                aria-label={sidebarOpen ? t('Collapse sidebar') : t('Expand sidebar')}
+                size="xs"
+                icon={
+                  <IconChevron
+                    isDouble
+                    direction={sidebarOpen ? 'left' : 'right'}
+                    size="xs"
+                  />
+                }
+                onClick={() => setSidebarOpen(x => !x)}
+              />
+            </Feature>
+            <LogsGraphContainer>
+              <LogsGraph timeseriesResult={timeseriesResult} />
+            </LogsGraphContainer>
+            <LogsTableActionsContainer>
+              <TableActionsContainer>
+                <Feature features="organizations:ourlogs-live-refresh">
+                  <AutorefreshToggle />
+                </Feature>
+                <Button onClick={openColumnEditor} icon={<IconTable />}>
+                  {t('Edit Table')}
+                </Button>
+              </TableActionsContainer>
+            </LogsTableActionsContainer>
+
+            <LogsItemContainer>
+              <Feature
+                features="organizations:ourlogs-live-refresh"
+                renderDisabled={() => (
+                  <LogsTable
+                    stringAttributes={stringAttributes}
+                    numberAttributes={numberAttributes}
+                  />
+                )}
+              >
+                <LogsInfiniteTable
                   stringAttributes={stringAttributes}
                   numberAttributes={numberAttributes}
                 />
-              )}
-            >
-              <LogsInfiniteTable
-                stringAttributes={stringAttributes}
-                numberAttributes={numberAttributes}
-              />
-            </Feature>
-          </LogsItemContainer>
-        </Layout.Main>
-      </BottomSectionBody>
+              </Feature>
+            </LogsItemContainer>
+          </section>
+        </BottomSectionBody>
+      </ToolbarAndBodyContainer>
     </SearchQueryBuilderProvider>
   );
 }

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -1,0 +1,159 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {TagCollection} from 'sentry/types/group';
+import {AggregationKey} from 'sentry/utils/fields';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+const TOOLBAR_AGGREGATES = [
+  {
+    label: t('count'),
+    value: AggregationKey.COUNT,
+    textValue: 'count',
+  },
+  {
+    label: t('sum'),
+    value: AggregationKey.SUM,
+    textValue: 'sum',
+  },
+];
+
+interface LogsToolbarProps {
+  numberTags?: TagCollection;
+  stringTags?: TagCollection;
+}
+
+export function LogsToolbar({stringTags, numberTags}: LogsToolbarProps) {
+  const [selected, setSelected] = useState(TOOLBAR_AGGREGATES[0]!.value);
+  const [groupBy, setGroupBy] = useState('');
+  const [sortBy, setSortBy] = useState(OurLogKnownFieldKey.TIMESTAMP as string);
+  const [sortAscending, setSortAscending] = useState(false);
+  return (
+    <Container>
+      <ToolbarItem>
+        <SectionHeader>
+          <Label>{t('Visualize')}</Label>
+        </SectionHeader>
+        <ToolbarSelectRow>
+          <Select
+            options={TOOLBAR_AGGREGATES}
+            onChange={val => setSelected(val.value as AggregationKey)}
+            value={selected}
+          />
+          <Select options={[{label: t('logs'), value: 'logs'}]} value="logs" disabled />
+        </ToolbarSelectRow>
+      </ToolbarItem>
+      <ToolbarItem>
+        <SectionHeader>
+          <Label>{t('Group By')}</Label>
+        </SectionHeader>
+        <Select
+          options={[
+            {
+              label: '\u2014',
+              value: '',
+              textValue: '\u2014',
+            },
+            ...Object.keys(stringTags ?? {}).map(key => ({
+              label: key,
+              value: key,
+              textValue: key,
+            })),
+          ]}
+          onChange={val => setGroupBy(val.value as string)}
+          value={groupBy}
+          searchable
+          triggerProps={{style: {width: '100%'}}}
+        />
+      </ToolbarItem>
+      <ToolbarItem>
+        <SectionHeader>
+          <Label>{t('Sort By')}</Label>
+        </SectionHeader>
+        <ToolbarSelectRow>
+          <Select
+            options={[
+              ...Object.keys(stringTags ?? {}),
+              ...Object.keys(numberTags ?? {}),
+            ].map(key => ({
+              label: key,
+              value: key,
+              textValue: key,
+            }))}
+            onChange={val => setSortBy(val.value as string)}
+            value={sortBy}
+            searchable
+            triggerProps={{style: {width: '100%'}}}
+          />
+          <Select
+            options={[
+              {
+                label: t('asc'),
+                value: 'asc',
+              },
+              {
+                label: t('desc'),
+                value: 'desc',
+              },
+            ]}
+            value={sortAscending ? 'asc' : 'desc'}
+            onChange={val => setSortAscending(val.value === 'asc')}
+            searchable
+            triggerProps={{style: {width: '100%'}}}
+          />
+        </ToolbarSelectRow>
+      </ToolbarItem>
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid ${p => p.theme.border};
+  border-top: 1px solid ${p => p.theme.border};
+  padding: ${space(2)};
+  gap: ${space(2)};
+  background-color: ${p => p.theme.background};
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)} ${space(4)};
+  }
+`;
+
+const SectionHeader = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+`;
+
+const Label = styled('h5')`
+  color: ${p => p.theme.gray500};
+  font-size: ${p => p.theme.form.md.fontSize};
+  margin: 0;
+`;
+
+const ToolbarItem = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: ${space(1)};
+`;
+
+const ToolbarSelectRow = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(90px, auto) auto;
+  gap: ${space(2)};
+`;
+
+const Select = styled(CompactSelect)`
+  width: 100%;
+  flex-grow: 1;
+
+  > button {
+    width: 100%;
+  }
+`;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -8,6 +8,8 @@ import {Body} from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import Panel from 'sentry/components/panels/panel';
 import {space} from 'sentry/styles/space';
+import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
+import {withChonk} from 'sentry/utils/theme/withChonk';
 import {unreachable} from 'sentry/utils/unreachable';
 import {
   TableBody,
@@ -310,12 +312,52 @@ export const TopSectionBody = styled(Body)`
   }
 `;
 
-export const BottomSectionBody = styled(Body)`
-  padding-top: 0;
+export const BottomSectionBody = styled('div')`
+  padding: ${space(2)} ${space(2)};
+  padding-top: ${space(1)};
   background-color: ${p => p.theme.backgroundSecondary};
   border-top: 1px solid ${p => p.theme.border};
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)} ${space(4)};
     padding-top: ${space(1)};
   }
 `;
+
+export const ToolbarAndBodyContainer = styled('div')<{sidebarOpen: boolean}>`
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    display: grid;
+    grid-template-columns: ${p => (p.sidebarOpen ? '325px minmax(100px, auto)' : 'auto')};
+  }
+`;
+
+export const LogsSidebarCollapseButton = withChonk(
+  styled(Button)<{sidebarOpen: boolean}>`
+    width: 28px;
+    border-left-color: ${p => p.theme.background};
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    margin-bottom: ${space(1)};
+    margin-left: -31px;
+    display: none;
+
+    @media (min-width: ${p => p.theme.breakpoints.medium}) {
+      display: block;
+    }
+  `,
+  chonkStyled(Button)<{sidebarOpen: boolean}>`
+    margin-bottom: ${space(1)};
+    display: none;
+    margin-left: -31px;
+
+    @media (min-width: ${p => p.theme.breakpoints.medium}) {
+      display: inline-flex;
+    }
+
+    &::after {
+      border-left-color: ${p => p.theme.background};
+      border-top-left-radius: 0px;
+      border-bottom-left-radius: 0px;
+    }
+  `
+);

--- a/static/app/views/explore/logs/tables/logsTable.tsx
+++ b/static/app/views/explore/logs/tables/logsTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useRef} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -73,7 +73,7 @@ export function LogsTable({
   });
 
   const isEmpty = !isPending && !isError && (data?.length ?? 0) === 0;
-  const highlightTerms = getLogBodySearchTerms(search);
+  const highlightTerms = useMemo(() => getLogBodySearchTerms(search), [search]);
   const sortBys = useLogsSortBys();
   const setSortBys = useSetLogsSortBys();
 


### PR DESCRIPTION
![Screenshot 2025-05-29 at 5 07 35 PM](https://github.com/user-attachments/assets/fcc713c0-755c-4f6f-9efc-a50434909118)

This is just the UI with no functionality, need to add aggregates to backend and plug this into the table / graph next.