### PR TITLE
feat(trace-items): Use different options for trace items autocomplete

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -186,7 +186,7 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
         attribute_type = serialized.get("attribute_type")
         item_type = serialized.get("item_type")
 
-        max_attributes = options.get("performance.spans-tags-key.max")
+        max_attributes = options.get("explore.trace-items.keys.max")
         value_substring_match = translate_escape_sequences(substring_match)
         trace_item_type = SupportedTraceItemType(item_type)
         referrer = resolve_attribute_referrer(trace_item_type, attribute_type)
@@ -295,7 +295,7 @@ class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttribut
         item_type = serialized.get("item_type")
         substring_match = serialized.get("substring_match", "")
 
-        max_attribute_values = options.get("performance.spans-tags-values.max")
+        max_attribute_values = options.get("explore.trace-items.values.max")
 
         definitions = (
             SPAN_DEFINITIONS

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1898,6 +1898,18 @@ register(
     default=1000,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "explore.trace-items.keys.max",
+    type=Int,
+    default=1000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "explore.trace-items.values.max",
+    type=Int,
+    default=1000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # In Single Tenant with 100% DS, we may need to reverse the UI change made by dynamic-sampling
 # if metrics extraction isn't ready.

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -291,7 +291,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             {"key": "span.duration", "name": "span.duration"},
         ]
 
-    @override_options({"performance.spans-tags-key.max": 3})
+    @override_options({"explore.trace-items.keys.max": 3})
     def test_pagination(self):
         for tag in ["foo", "bar", "baz"]:
             self.store_segment(
@@ -1170,7 +1170,7 @@ class OrganizationTraceItemAttributeValuesEndpointSpansTest(
         response = self.do_request(key="tag")
         assert response.status_code == 400, response.data
 
-    @override_options({"performance.spans-tags-values.max": 2})
+    @override_options({"explore.trace-items.values.max": 2})
     def test_pagination(self):
         timestamp = before_now(days=0, minutes=10).replace(microsecond=0)
         for tag in ["foo", "bar", "baz", "qux"]:


### PR DESCRIPTION
This is using the same options as some other places. Switching it out as we want to tweak just the trace items autocomplete endpoint.