### PR TITLE
ref(aci): dual write workflow group action status

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -206,12 +206,15 @@ def update_workflow_action_group_statuses(
         actual_workflows = {status.workflow_id for status in wags}
         missing_workflows = expected_workflows - actual_workflows
 
-        for workflow_id in missing_workflows:
-            missing_statuses.append(
+        missing_statuses.extend(
+            [
                 WorkflowActionGroupStatus(
                     workflow_id=workflow_id, action_id=action_id, group=group, date_updated=now
                 )
-            )
+                for workflow_id in missing_workflows
+            ]
+        )
+        if missing_workflows:
             action_ids.add(action_id)
 
     WorkflowActionGroupStatus.objects.bulk_create(

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -96,22 +96,6 @@ def create_workflow_fire_histories(
     return WorkflowFireHistory.objects.bulk_create(fire_histories)
 
 
-def create_workflow_fire_histories_from_statuses(
-    statuses: BaseQuerySet[WorkflowActionGroupStatus], event_data: WorkflowEventData
-) -> list[WorkflowFireHistory]:
-    # Create WorkflowFireHistory objects for workflows we fire actions for
-    workflow_ids = set(statuses.values_list("workflow_id", flat=True))
-    fire_histories = [
-        WorkflowFireHistory(
-            workflow_id=workflow_id,
-            group=event_data.event.group,
-            event_id=event_data.event.event_id,
-        )
-        for workflow_id in workflow_ids
-    ]
-    return WorkflowFireHistory.objects.bulk_create(fire_histories)
-
-
 # TODO(cathy): only reinforce workflow frequency for certain issue types
 def filter_recently_fired_actions(
     filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
@@ -255,7 +239,7 @@ def filter_recently_fired_workflow_actions(
     )
 
     # TODO: write this in a single spot
-    # create_workflow_fire_histories_from_statuses(event_data=event_data, statuses=statuses)
+    # create_workflow_fire_histories
 
     return Action.objects.filter(id__in=action_ids).distinct()
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -175,12 +175,12 @@ def get_workflow_group_action_statuses(action_to_workflows: dict[int, set[int]],
 
 
 def update_workflow_action_group_statuses(
-    now: datetime,
     action_to_workflows: dict[int, set[int]],
     action_statuses: dict[int, list[WorkflowActionGroupStatus]],
     workflows: BaseQuerySet[Workflow],
     group: Group,
 ) -> set[int]:
+    now = timezone.now()
     status_ids: set[int] = set()
     workflow_frequencies = {
         workflow.id: workflow.config.get("frequency", 0) * timedelta(minutes=1)
@@ -220,6 +220,7 @@ def update_workflow_action_group_statuses(
         ignore_conflicts=True,
     )
 
+    # TODO: need to know the exact workflow that fired the action
     return action_ids
 
 
@@ -239,13 +240,11 @@ def filter_recently_fired_workflow_actions(
 
     workflows = Workflow.objects.filter(id__in=workflow_ids)
 
-    now = timezone.now()
     action_statuses = get_workflow_group_action_statuses(
         action_to_workflows=action_to_workflows,
         group=event_data.event.group,
     )
     action_ids = update_workflow_action_group_statuses(
-        now=now,
         action_to_workflows=action_to_workflows,
         action_statuses=action_statuses,
         workflows=workflows,

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -138,7 +138,9 @@ def filter_recently_fired_actions(
     return filtered_actions
 
 
-def get_workflow_group_action_statuses(action_to_workflows_ids: dict[int, set[int]], group: Group):
+def get_workflow_group_action_statuses(
+    action_to_workflows_ids: dict[int, set[int]], group: Group
+) -> dict[int, list[WorkflowActionGroupStatus]]:
     all_statuses = WorkflowActionGroupStatus.objects.filter(
         group=group, action_id__in=action_to_workflows_ids.keys()
     )

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -45,7 +45,7 @@ from sentry.workflow_engine.models.data_condition import (
     Condition,
 )
 from sentry.workflow_engine.models.data_condition_group import get_slow_conditions
-from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
+from sentry.workflow_engine.processors.action import filter_recently_fired_actions
 from sentry.workflow_engine.processors.data_condition_group import evaluate_data_conditions
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.processors.log_util import track_batch_performance
@@ -438,9 +438,7 @@ def fire_actions_for_groups(
                         action_filters.add(dcg)
 
                 # process action filters
-                filtered_actions = filter_recently_fired_workflow_actions(
-                    action_filters, event_data
-                )
+                filtered_actions = filter_recently_fired_actions(action_filters, event_data)
 
                 # process workflow_triggers
                 workflows = set(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -18,7 +18,7 @@ from sentry.workflow_engine.models import (
     Detector,
     Workflow,
 )
-from sentry.workflow_engine.processors.action import filter_recently_fired_workflow_actions
+from sentry.workflow_engine.processors.action import filter_recently_fired_actions
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.types import WorkflowEventData
@@ -177,7 +177,7 @@ def evaluate_workflows_action_filters(
         },
     )
 
-    return filter_recently_fired_workflow_actions(filtered_action_groups, event_data)
+    return filter_recently_fired_actions(filtered_action_groups, event_data)
 
 
 def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -204,9 +204,10 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status = WorkflowActionGroupStatus.objects.create(
             workflow=self.workflow, action=self.action, group=self.group
         )
+        workflow_ids = {self.workflow.id, workflow.id}
 
         action_to_statuses = get_workflow_group_action_statuses(
-            {self.action.id: {self.workflow.id}}, self.group
+            {self.action.id: {self.workflow.id}}, self.group, workflow_ids
         )
         assert action_to_statuses == {self.action.id: [status]}
 

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -9,7 +9,7 @@ from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFi
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import (
     create_workflow_fire_histories,
-    filter_recently_fired_workflow_actions,
+    filter_recently_fired_actions,
     is_action_permitted,
 )
 from sentry.workflow_engine.types import WorkflowEventData
@@ -17,7 +17,7 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 @freeze_time("2024-01-09")
-class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
+class TestFilterRecentlyFiredActions(BaseWorkflowTest):
     def setUp(self):
         (
             self.workflow,
@@ -41,7 +41,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         _, action = self.create_workflow_action(workflow=self.workflow)
         status_2 = ActionGroupStatus.objects.create(action=action, group=self.group)
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions = filter_recently_fired_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action}
@@ -63,7 +63,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_3 = ActionGroupStatus.objects.create(action=action_3, group=self.group)
         status_3.update(date_updated=timezone.now() - timedelta(days=2))
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions = filter_recently_fired_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action, action_3}

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -5,11 +5,17 @@ from django.utils import timezone
 
 from sentry.integrations.base import IntegrationFeatures
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
+from sentry.workflow_engine.models import (
+    Action,
+    DataConditionGroup,
+    WorkflowActionGroupStatus,
+    WorkflowFireHistory,
+)
 from sentry.workflow_engine.models.action_group_status import ActionGroupStatus
 from sentry.workflow_engine.processors.action import (
     create_workflow_fire_histories,
     filter_recently_fired_actions,
+    filter_recently_fired_workflow_actions,
     is_action_permitted,
 )
 from sentry.workflow_engine.types import WorkflowEventData
@@ -71,6 +77,121 @@ class TestFilterRecentlyFiredActions(BaseWorkflowTest):
         for status in [status_1, status_2, status_3]:
             status.refresh_from_db()
             assert status.date_updated == timezone.now()
+
+
+@freeze_time("2024-01-09")
+class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
+    def setUp(self):
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow()
+
+        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+
+        self.group, self.event, self.group_event = self.create_group_event(
+            occurrence=self.build_occurrence(evidence_data={"detector_id": self.detector.id})
+        )
+        self.event_data = WorkflowEventData(event=self.group_event)
+
+    def test(self):
+        status_1 = WorkflowActionGroupStatus.objects.create(
+            workflow=self.workflow, action=self.action, group=self.group
+        )
+        status_1.update(date_updated=timezone.now() - timedelta(days=1))
+
+        _, action = self.create_workflow_action(workflow=self.workflow)
+        status_2 = WorkflowActionGroupStatus.objects.create(
+            workflow=self.workflow, action=action, group=self.group
+        )
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.event_data
+        )
+        assert set(triggered_actions) == {self.action}
+
+        for status in [status_1, status_2]:
+            status.refresh_from_db()
+            assert status.date_updated == timezone.now()
+
+    def test_multiple_workflows(self):
+        status_1 = WorkflowActionGroupStatus.objects.create(
+            workflow=self.workflow, action=self.action, group=self.group
+        )
+        status_1.update(date_updated=timezone.now() - timedelta(hours=1))
+
+        workflow = self.create_workflow(organization=self.organization, config={"frequency": 1440})
+        self.create_detector_workflow(detector=self.detector, workflow=workflow)
+        _, action_2 = self.create_workflow_action(workflow=workflow)
+        status_2 = WorkflowActionGroupStatus.objects.create(
+            workflow=workflow, action=action_2, group=self.group
+        )
+
+        _, action_3 = self.create_workflow_action(workflow=workflow)
+        status_3 = WorkflowActionGroupStatus.objects.create(
+            workflow=workflow, action=action_3, group=self.group
+        )
+        status_3.update(date_updated=timezone.now() - timedelta(days=2))
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.event_data
+        )
+        assert set(triggered_actions) == {self.action, action_3}
+
+        for status in [status_1, status_2, status_3]:
+            status.refresh_from_db()
+            assert status.date_updated == timezone.now()
+
+    def test_multiple_workflows_single_action__first_fire(self):
+        workflow = self.create_workflow(organization=self.organization, config={"frequency": 1440})
+        action_group = self.create_data_condition_group(logic_type="any-short")
+        self.create_data_condition_group_action(
+            condition_group=action_group,
+            action=self.action,
+        )  # shared action
+        self.create_workflow_data_condition_group(workflow, action_group)
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.event_data
+        )
+        # dedupes action if both workflows will fire it
+        assert set(triggered_actions) == {self.action}
+
+        assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
+
+    def test_multiple_workflows_single_action__later_fire(self):
+        workflow = self.create_workflow(organization=self.organization, config={"frequency": 1440})
+        action_group = self.create_data_condition_group(logic_type="any-short")
+        self.create_data_condition_group_action(
+            condition_group=action_group,
+            action=self.action,
+        )  # shared action
+        self.create_workflow_data_condition_group(workflow, action_group)
+
+        status = WorkflowActionGroupStatus.objects.create(
+            workflow=workflow, action=self.action, group=self.group
+        )
+        status.update(date_updated=timezone.now() - timedelta(hours=1))
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.event_data
+        )
+        # fires one action for the workflow that can fire it
+        assert set(triggered_actions) == {self.action}
+
+        assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
+
+        assert (
+            WorkflowActionGroupStatus.objects.get(
+                workflow=self.workflow, action=self.action, group=self.group
+            ).date_updated
+            == timezone.now()
+        )
+
+        status.refresh_from_db()
+        assert status.date_updated == timezone.now() - timedelta(hours=1)
 
 
 class TestWorkflowFireHistory(BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -108,7 +108,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             },
         )
 
-    @patch("sentry.workflow_engine.processors.workflow.filter_recently_fired_workflow_actions")
+    @patch("sentry.workflow_engine.processors.workflow.filter_recently_fired_actions")
     def test_populate_workflow_env_for_filters(self, mock_filter):
         # this should not pass because the environment is not None
         self.error_workflow.update(environment=self.group_event.get_environment())


### PR DESCRIPTION
Must merge https://github.com/getsentry/sentry/pull/92478 first

Dual write `WorkflowGroupActionStatus` alongside `ActionGroupStatus`. We need a new function to do this because each action can be associated with its own set of workflows, and we want to enforce each workflow's frequency independently for each workflow+action combo. It's also difficult to query specific combinations of workflow+action statuses, so I query all the statuses for the actions+group and iterate to find the valid ones.

I renamed the old function to `filter_recently_fired_actions` and the new function is called `filter_recently_fired_workflow_actions` :)