### PR TITLE
ref(workflow_engine): Change the issue fingerprint to be prefixed with `detector`

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -138,15 +138,16 @@ class DetectorStateManager:
     def build_key(
         self, group_key: DetectorGroupKey = None, postfix: str | int | None = None
     ) -> str:
+        key = f"detector:{self.detector.id}"
         group_postfix = f"{group_key if group_key is not None else ''}"
 
         if postfix:
             group_postfix = f"{group_postfix}:{postfix}"
 
         if group_postfix:
-            return f"{self.detector.id}:{group_postfix}"
+            return f"{key}:{group_postfix}"
 
-        return f"{self.detector.id}"
+        return key
 
     def commit_state_updates(self):
         self._bulk_commit_detector_state()

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -223,9 +223,12 @@ class TestKeyBuilders(unittest.TestCase):
     def test(self):
         assert (
             self.build_handler().state_manager.build_key("test", "dedupe_value")
-            == "123:test:dedupe_value"
+            == "detector:123:test:dedupe_value"
         )
-        assert self.build_handler().state_manager.build_key("test", "name_1") == "123:test:name_1"
+        assert (
+            self.build_handler().state_manager.build_key("test", "name_1")
+            == "detector:123:test:name_1"
+        )
 
     def test_different_dedupe_keys(self):
         handler = self.build_handler()
@@ -477,7 +480,7 @@ class TestEvaluate(BaseDetectorHandlerTest):
                 group_key="val1",
                 is_triggered=False,
                 result=StatusChangeMessage(
-                    fingerprint=[f"{handler.detector.id}:val1"],
+                    fingerprint=[f"detector:{handler.detector.id}:val1"],
                     project_id=self.project.id,
                     new_status=1,
                     new_substatus=None,


### PR DESCRIPTION
## Description
@evanpurkhiser brought up a great point that it's not clear what's being stored and that the id could easily collide with other models. To address this, prefixing the fingerprint with `detector` will help illustrate the difference and avoid collisions.