### PR TITLE
feat(search-bar): Add in secondary loading indicator

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -129,12 +129,12 @@ const FooterContainer = styled('div')`
   gap: ${space(0.5)};
 `;
 
-const LoadingWrapper = styled('div')`
+const LoadingWrapper = styled('div')<{height?: string; width?: string}>`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 140px;
-  width: 200px;
+  height: ${p => p.height ?? '140px'};
+  width: ${p => p.width ?? '200px'};
 `;
 
 const Label = styled('div')``;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -66,12 +66,6 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
     return null;
   }
 
-  const showSearchingLoader =
-    isLoading &&
-    anyItemsShowing &&
-    !!listBoxRef.current &&
-    listBoxRef.current.scrollHeight <= listBoxRef.current.clientHeight;
-
   const valueListBoxContent = (
     <StyledPositionWrapper {...overlayProps} visible={isOpen}>
       <SectionedOverlay ref={popoverRef}>
@@ -93,7 +87,7 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
               size="sm"
               style={{maxWidth: overlayProps.style!.maxWidth}}
             />
-            {showSearchingLoader ? (
+            {isLoading && anyItemsShowing ? (
               <LoadingWrapper height="32px" width="100%">
                 <LoadingIndicator size={24} />
               </LoadingWrapper>

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueListBox.tsx
@@ -66,6 +66,12 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
     return null;
   }
 
+  const showSearchingLoader =
+    isLoading &&
+    anyItemsShowing &&
+    !!listBoxRef.current &&
+    listBoxRef.current.scrollHeight <= listBoxRef.current.clientHeight;
+
   const valueListBoxContent = (
     <StyledPositionWrapper {...overlayProps} visible={isOpen}>
       <SectionedOverlay ref={popoverRef}>
@@ -87,6 +93,11 @@ export function ValueListBox<T extends SelectOptionOrSectionWithKey<string>>({
               size="sm"
               style={{maxWidth: overlayProps.style!.maxWidth}}
             />
+            {showSearchingLoader ? (
+              <LoadingWrapper height="32px" width="100%">
+                <LoadingIndicator size={24} />
+              </LoadingWrapper>
+            ) : null}
             <Footer isMultiSelect={isMultiSelect} canUseWildcard={canUseWildcard} />
           </Fragment>
         )}


### PR DESCRIPTION
This PR adds in a secondary loader that will render to the users when we're loading data, and there are already some items showing in the list.

Closes EXP-283

![Screenshot 2025-05-30 at 07 39 13](https://github.com/user-attachments/assets/a1166d5c-34cc-4b88-a894-dc64ef116ad6)
(note: this is a mocked image)