### PR TITLE
fix(ownership-rules): Update email filter to create less conditions

### DIFF
--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from django.db import router, transaction
 from django.db.models import F, Q, QuerySet
+from django.db.models.functions import Upper
 from django.utils.text import slugify
 
 from sentry.api.serializers.base import Serializer, serialize
@@ -313,7 +314,12 @@ class DatabaseBackedUserService(UserService):
             if "email_verified" in filters:
                 query = query.filter(emails__is_verified=filters["email_verified"])
             if "emails" in filters:
-                query = query.filter(in_iexact("emails__email", filters["emails"]))
+                # Since we can have a lot of emails, the in_iexact helper creates too many
+                # conditions in the query, so we annotate the email and filter by the
+                # lowercased version of the email for case insensitive search
+                query = query.annotate(lower_emails__email=Upper("emails__email")).filter(
+                    lower_emails__email__in=map(lambda x: x.upper(), filters["emails"])
+                )
             if "query" in filters:
                 query = query.filter(
                     Q(emails__email__icontains=filters["query"])

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -316,9 +316,9 @@ class DatabaseBackedUserService(UserService):
             if "emails" in filters:
                 # Since we can have a lot of emails, the in_iexact helper creates too many
                 # conditions in the query, so we annotate the email and filter by the
-                # lowercased version of the email for case insensitive search
-                query = query.annotate(lower_emails__email=Upper("emails__email")).filter(
-                    lower_emails__email__in=map(lambda x: x.upper(), filters["emails"])
+                # uppercased version of the email for case insensitive search
+                query = query.annotate(upper_emails=Upper("emails__email")).filter(
+                    upper_emails__in=map(lambda x: x.upper(), filters["emails"])
                 )
             if "query" in filters:
                 query = query.filter(


### PR DESCRIPTION
Trying to improve the performance of this filter. The current implementation creates an OR condition and calls upper on both the column and the email of the condition for each email passed. This reduces it to a single IN check and a single usage of `upper` to do the case insensitive check.

This tries to improve the performance of [this query](https://sentry.sentry.io/explore/traces/trace/9ec6750101a040ed9fcf09d0f3c3c911/?end=2025-05-29T16%3A27%3A49&fov=0%2C88401.99975585938&node=span-862c1dd548d34b56&node=txn-762dfb9f329f4a2d9fe18cdf374762ec&pageEnd=2025-05-29T16%3A27%3A49.000&pageStart=2025-05-29T16%3A25%3A13.000&project=-1&query=trace%3A9ec6750101a040ed9fcf09d0f3c3c911&source=traces&start=2025-05-29T16%3A25%3A13&targetId=bfbc97a674e16357&timestamp=1748535996) (the trace might not point to the correct span, it is the `db` span) by reducing the repeated work of calling `UPPER` in so many conditions. Instead, I've updated the emails filter to annotate the queryset with the uppercased emails, then use the built in `__in` lookup against the emails in an uppercased format.

This breaks us away from the `in_iexact` helper that was there before, but that helper is what generates the large condition and there is no clean way to do the lookup with `__in` in a case insensitive way that encapsulates the behaviour as cleanly.