### PR TITLE
fix(autofix): set taskworker time limit

### DIFF
--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -42,6 +42,7 @@ def check_autofix_status(run_id: int):
     soft_time_limit=25,
     taskworker_config=TaskworkerConfig(
         namespace=ingest_errors_tasks,
+        processing_deadline_duration=35,
         retry=Retry(
             times=1,
         ),


### PR DESCRIPTION
I set the wrong time limit last time. Bumping from 10s to 35s for the taskworker so tasks don't get killed.