### PR TITLE
feat(explore): Remove group by timestamp from explore

### DIFF
--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -1,10 +1,10 @@
-import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {
   type ReadableExploreQueryParts,
   useUpdateQueryAtIndex,
@@ -22,20 +22,11 @@ export function GroupBySection({query, index}: Props) {
 
   const updateGroupBys = useUpdateQueryAtIndex(index);
 
-  const enabledOptions: Array<SelectOption<string>> = useMemo(() => {
-    const potentialOptions = Object.keys(tags).filter(key => key !== 'id');
-    potentialOptions.sort((a, b) => {
-      if (query.groupBys.includes(a) === query.groupBys.includes(b)) {
-        return a.localeCompare(b);
-      }
-      if (query.groupBys.includes(a)) {
-        return -1;
-      }
-      return 1;
-    });
-
-    return potentialOptions.map(key => ({label: key, value: key, textValue: key}));
-  }, [tags, query.groupBys]);
+  const enabledOptions: Array<SelectOption<string>> = useGroupByFields({
+    groupBys: [],
+    tags,
+    hideEmptyOption: true,
+  });
 
   return (
     <Section data-test-id={`section-group-by-${index}`}>


### PR DESCRIPTION
Grouping by timestamp produces a high cardinality result that is not very useful so disallow it in the UI.