### PR TITLE
:wrench: chore(vsts): mark api unathorized errors as halts for `outbound_status_sync`

### DIFF
--- a/src/sentry/integrations/tasks/sync_status_outbound.py
+++ b/src/sentry/integrations/tasks/sync_status_outbound.py
@@ -1,5 +1,6 @@
 from sentry import analytics, features
 from sentry.constants import ObjectStatus
+from sentry.exceptions import InvalidIdentity
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -88,7 +89,12 @@ def sync_status_outbound(group_id: int, external_issue_id: int) -> bool | None:
                     id=integration.id,
                     organization_id=external_issue.organization_id,
                 )
-        except (IntegrationFormError, ApiUnauthorized, OrganizationIntegrationNotFound) as e:
+        except (
+            IntegrationFormError,
+            ApiUnauthorized,
+            OrganizationIntegrationNotFound,
+            InvalidIdentity,
+        ) as e:
             lifecycle.record_halt(halt_reason=e)
             return None
     return None

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -314,7 +314,11 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
         self, external_issue: ExternalIssue, is_resolved: bool, project_id: int
     ) -> None:
         client = self.get_client()
-        work_item = client.get_work_item(external_issue.key)
+        try:
+            work_item = client.get_work_item(external_issue.key)
+        except Exception as e:
+            self.raise_error(e)
+
         # For some reason, vsts doesn't include the project id
         # in the work item response.
         # TODO(jess): figure out if there's a better way to do this
@@ -352,7 +356,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
 
         try:
             client.update_work_item(external_issue.key, state=status)
-        except (ApiUnauthorized, ApiError) as error:
+        except ApiUnauthorized as error:
             self.logger.info(
                 "vsts.failed-to-change-status",
                 extra={

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -366,6 +366,7 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
                     "exception": error,
                 },
             )
+            raise
         except Exception as e:
             self.raise_error(e)
 


### PR DESCRIPTION
i was reading through logs and saw that `client.get_work_item` can also fail with the `According to Microsoft Entra, your Identity xxx is currently Deleted` error, so wrapping that to raise the appropriate exception as well.

Also I realized the parent `raise_error` converts `ApiUnauthorized` exceptions into `InvalidIdentity` exceptions, so we need to catch that at the base and mark as a halt as well.