### PR TITLE
chore(github): add org slug to the frontnend props

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -958,6 +958,7 @@ class GithubOrganizationSelection(PipelineView):
                 props={
                     "installation_info": installation_info,
                     "has_scm_multi_org": has_scm_multi_org,
+                    "organization_slug": self.active_user_organization.organization.slug,
                 },
             )
 

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1316,7 +1316,11 @@ class GitHubIntegrationTest(IntegrationTestCase):
         mock_render.assert_called_with(
             request=ANY,
             pipeline_name="githubInstallationSelect",
-            props={"installation_info": installations, "has_scm_multi_org": True},
+            props={
+                "installation_info": installations,
+                "has_scm_multi_org": True,
+                "organization_slug": "foo",
+            },
         )
 
         # SLO assertions
@@ -1524,7 +1528,11 @@ class GitHubIntegrationTest(IntegrationTestCase):
         mock_render.assert_called_with(
             request=ANY,
             pipeline_name="githubInstallationSelect",
-            props={"installation_info": installations, "has_scm_multi_org": False},
+            props={
+                "installation_info": installations,
+                "has_scm_multi_org": False,
+                "organization_slug": "foo",
+            },
         )
 
         # SLO assertions
@@ -1575,7 +1583,11 @@ class GitHubIntegrationTest(IntegrationTestCase):
         mock_render.assert_called_with(
             request=ANY,
             pipeline_name="githubInstallationSelect",
-            props={"installation_info": installations, "has_scm_multi_org": False},
+            props={
+                "installation_info": installations,
+                "has_scm_multi_org": False,
+                "organization_slug": "foo",
+            },
         )
 
         # We rendered the GithubOrganizationSelection UI and the user chose to skip

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1319,7 +1319,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             props={
                 "installation_info": installations,
                 "has_scm_multi_org": True,
-                "organization_slug": "foo",
+                "organization_slug": self.organization.slug,
             },
         )
 
@@ -1531,7 +1531,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             props={
                 "installation_info": installations,
                 "has_scm_multi_org": False,
-                "organization_slug": "foo",
+                "organization_slug": self.organization.slug,
             },
         )
 
@@ -1586,7 +1586,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             props={
                 "installation_info": installations,
                 "has_scm_multi_org": False,
-                "organization_slug": "foo",
+                "organization_slug": self.organization.slug,
             },
         )
 


### PR DESCRIPTION
We'll need this for various frontend providers/contexts to fetch `Organization` in order to use certain fe components (`upsellModal`, `upgradeOrTrialButton` etc.)