### PR TITLE
feat(issue-stream): Add back realtime for issue feed with the new nav

### DIFF
--- a/static/app/views/issueList/issueViewsHeader.spec.tsx
+++ b/static/app/views/issueList/issueViewsHeader.spec.tsx
@@ -17,6 +17,7 @@ describe('IssueViewsHeader', function () {
   const view = GroupSearchViewFixture();
 
   beforeEach(function () {
+    jest.clearAllMocks();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/group-search-views/123/',
@@ -28,6 +29,8 @@ describe('IssueViewsHeader', function () {
   const defaultProps = {
     selectedProjectIds: [],
     title: 'Issues',
+    realtimeActive: false,
+    onRealtimeChange: jest.fn(),
   };
 
   const organization = OrganizationFixture({

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -1,12 +1,13 @@
 import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
+import DisableInDemoMode from 'sentry/components/acl/demoModeDisabled';
 import {Button} from 'sentry/components/core/button';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {IconEllipsis, IconStar} from 'sentry/icons';
+import {IconEllipsis, IconPause, IconPlay, IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -14,6 +15,7 @@ import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {EditableIssueViewHeader} from 'sentry/views/issueList/editableIssueViewHeader';
@@ -29,6 +31,8 @@ import type {GroupSearchView} from 'sentry/views/issueList/types';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 type IssueViewsHeaderProps = {
+  onRealtimeChange: (active: boolean) => void;
+  realtimeActive: boolean;
   selectedProjectIds: number[];
   title: ReactNode;
   description?: ReactNode;
@@ -204,12 +208,19 @@ function IssueViewsHeader({
   selectedProjectIds,
   title,
   description,
+  realtimeActive,
+  onRealtimeChange,
 }: IssueViewsHeaderProps) {
   const {projects} = useProjects();
   const prefersStackedNav = usePrefersStackedNav();
   const selectedProjects = projects.filter(({id}) =>
     selectedProjectIds.includes(Number(id))
   );
+  const {viewId} = useParams<{viewId?: string}>();
+
+  const realtimeLabel = realtimeActive
+    ? t('Pause real-time updates')
+    : t('Enable real-time updates');
 
   return (
     <Layout.Header noActionWrap unified={prefersStackedNav}>
@@ -217,6 +228,17 @@ function IssueViewsHeader({
         <StyledLayoutTitle>
           <PageTitle title={title} description={description} />
           <Actions>
+            {!viewId && (
+              <DisableInDemoMode>
+                <Button
+                  size="sm"
+                  title={realtimeLabel}
+                  aria-label={realtimeLabel}
+                  icon={realtimeActive ? <IconPause /> : <IconPlay />}
+                  onClick={() => onRealtimeChange(!realtimeActive)}
+                />
+              </DisableInDemoMode>
+            )}
             <IssueViewStarButton />
             <IssueViewEditMenu />
           </Actions>

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -170,9 +170,10 @@ function IssueListOverview({
   const {selection} = usePageFilters();
   const api = useApi();
   const prefersStackedNav = usePrefersStackedNav();
+  const urlParams = useParams<{viewId?: string}>();
   const realtimeActiveCookie = Cookies.get('realtimeActive');
   const [realtimeActive, setRealtimeActive] = useState(
-    prefersStackedNav || typeof realtimeActiveCookie === 'undefined'
+    typeof realtimeActiveCookie === 'undefined' || urlParams.viewId
       ? false
       : realtimeActiveCookie === 'true'
   );
@@ -190,7 +191,6 @@ function IssueListOverview({
   const undoRef = useRef(false);
   const pollerRef = useRef<CursorPoller | undefined>(undefined);
   const actionTakenRef = useRef(false);
-  const urlParams = useParams<{viewId?: string}>();
 
   const {savedSearch, savedSearchLoading, selectedSearchId} = useSavedSearches();
 
@@ -1095,6 +1095,8 @@ function IssueListOverview({
           selectedProjectIds={selection.projects}
           title={title}
           description={titleDescription}
+          realtimeActive={realtimeActive}
+          onRealtimeChange={onRealtimeChange}
         />
       ) : (
         <IssueListHeader


### PR DESCRIPTION
Adds the realtime button when on Feed or the taxonomy pages. Will not be available in the issue views for now.