### PR TITLE
feat(processing) Define EventProcessingStore.__all__

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -27,6 +27,8 @@ class EventProcessingStore(Service):
     implementations.
     """
 
+    __all__ = ("exists", "store", "get", "delete", "delete_by_key")
+
     def __init__(self, inner: KVStorage[str, Event]):
         self.inner = inner
         self.timeout = timedelta(seconds=DEFAULT_TIMEOUT)


### PR DESCRIPTION
The base `Service` class requires `__all__` to be defined for metrics to be collected on methods. I missed that in #92447
