### PR TITLE
:wrench: chore(vsts): handle invalid identity errors for `check_file` correctly

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -159,8 +159,10 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                     return None
                 # TODO(ecosystem): Remove this once we have a better way to handle this
                 # It involves decomposing this logic
+                #  {"$id":"1","innerException":null,"message":"According to Microsoft Entra, your Identity xxx is currently Disabled within the following Microsoft Entra tenant: xxx. Please contact your Microsoft Entra administrator to resolve this.","typeName":"Microsoft.TeamFoundation.Framework.Server.AadUserStateException, Microsoft.TeamFoundation.Framework.Server","typeKey":"AadUserStateException","errorCode":0,"eventId":3000}"
                 elif (
-                    "is currently Deleted within the following Microsoft Entra tenant" in str(e)
+                    e.json
+                    and e.json.get("typeKey") == "AadUserStateException"
                     and self.integration_name == IntegrationProviderSlug.AZURE_DEVOPS.value
                 ):
                     lifecycle.record_halt(e)

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -381,7 +381,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
     @mock.patch(
         "sentry.integrations.vsts.client.VstsApiClient.check_file",
         side_effect=ApiError(
-            text="According to Microsoft Entra, your Identity xxx is currently Deleted within the following Microsoft Entra tenant: xxx Please contact your Microsoft Entra administrator to resolve this."
+            text='{"$id":"1","innerException":null,"message":"According to Microsoft Entra, your Identity xxx is currently Disabled within the following Microsoft Entra tenant: xxx. Please contact your Microsoft Entra administrator to resolve this.","typeName":"Microsoft.TeamFoundation.Framework.Server.AadUserStateException, Microsoft.TeamFoundation.Framework.Server","typeKey":"AadUserStateException","errorCode":0,"eventId":3000}'
         ),
     )
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
@@ -418,7 +418,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         assert halt.args[0] == EventLifecycleOutcome.HALTED
         assert (
             halt.args[1].text
-            == "According to Microsoft Entra, your Identity xxx is currently Deleted within the following Microsoft Entra tenant: xxx Please contact your Microsoft Entra administrator to resolve this."
+            == '{"$id":"1","innerException":null,"message":"According to Microsoft Entra, your Identity xxx is currently Disabled within the following Microsoft Entra tenant: xxx. Please contact your Microsoft Entra administrator to resolve this.","typeName":"Microsoft.TeamFoundation.Framework.Server.AadUserStateException, Microsoft.TeamFoundation.Framework.Server","typeKey":"AadUserStateException","errorCode":0,"eventId":3000}'
         )
 
 


### PR DESCRIPTION
for some reaosn, vsts decides to send us a different shape of the invalid identity error for certain endpoints, so my previous fix didn't work.

the good news is, i can use the `typeKey` to figure out the specific error which makes this a bit more robust