### PR TITLE
ref(dropdown): Move deprecated dropdown to FC

### DIFF
--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -10,7 +10,11 @@
  */
 import {Component} from 'react';
 
-import type {GetActorArgs, GetMenuArgs} from 'sentry/components/deprecatedDropdownMenu';
+import type {
+  DeprecatedDropdownMenuProps,
+  GetActorArgs,
+  GetMenuArgs,
+} from 'sentry/components/deprecatedDropdownMenu';
 import DeprecatedDropdownMenu from 'sentry/components/deprecatedDropdownMenu';
 import {uniqueId} from 'sentry/utils/guid';
 
@@ -68,7 +72,7 @@ type GetItemArgs<T> = {
   onClick?: (item: T) => (e: React.MouseEvent) => void;
 };
 
-type ChildrenProps<T> = Parameters<DeprecatedDropdownMenu['props']['children']>[0] & {
+type ChildrenProps<T> = Parameters<DeprecatedDropdownMenuProps['children']>[0] & {
   /**
    * Returns props for the input element that handles searching the items
    */

--- a/static/app/components/deprecatedDropdownMenu.spec.tsx
+++ b/static/app/components/deprecatedDropdownMenu.spec.tsx
@@ -72,21 +72,13 @@ describe('dropdownMenuDeprecated', function () {
     expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 
-  it('keeps dropdown open when clicking on anything in menu with `keepMenuOpen` prop', async function () {
-    render(<DeprecatedDropdownImplementation keepMenuOpen />);
-    await userEvent.click(screen.getByRole('button'));
-    await userEvent.click(screen.getByRole('listitem'));
-
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
-  });
-
   it('render prop getters all extend props and call original onClick handlers', async function () {
     const rootClick = jest.fn();
     const actorClick = jest.fn();
     const menuClick = jest.fn();
 
     render(
-      <DeprecatedDropdownMenu keepMenuOpen>
+      <DeprecatedDropdownMenu>
         {({getRootProps, getActorProps, getMenuProps, isOpen}) => (
           <span {...getRootProps({onClick: rootClick})} data-test-id="root">
             <button {...getActorProps({onClick: actorClick})} data-test-id="actor">
@@ -112,8 +104,6 @@ describe('dropdownMenuDeprecated', function () {
 
     await userEvent.click(screen.getByTestId('menu'));
     expect(menuClick).toHaveBeenCalled();
-
-    expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 
   it('always rendered menus should attach document event listeners only when opened', async function () {

--- a/static/app/components/deprecatedDropdownMenu.spec.tsx
+++ b/static/app/components/deprecatedDropdownMenu.spec.tsx
@@ -138,10 +138,10 @@ describe('dropdownMenuDeprecated', function () {
 
     await userEvent.click(screen.getByRole('button'));
     expect(addSpy).toHaveBeenCalledWith('click', expect.anything(), true);
-    expect(removeSpy).not.toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledTimes(1);
 
     await userEvent.click(screen.getByRole('button'));
-    expect(removeSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledTimes(2);
 
     addSpy.mockRestore();
     removeSpy.mockRestore();

--- a/static/app/components/deprecatedDropdownMenu.tsx
+++ b/static/app/components/deprecatedDropdownMenu.tsx
@@ -1,4 +1,5 @@
-import {Component} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {mergeProps} from '@react-aria/utils';
 import * as Sentry from '@sentry/react';
 
 import {MENU_CLOSE_DELAY} from 'sentry/constants';
@@ -61,18 +62,7 @@ type RenderProps = {
   isOpen: boolean;
 };
 
-type DefaultProps = {
-  /**
-   * closes menu on "Esc" keypress
-   */
-  closeOnEscape: boolean;
-  /**
-   * Keeps dropdown menu open when menu is clicked
-   */
-  keepMenuOpen: boolean;
-};
-
-type Props = DefaultProps & {
+export type DeprecatedDropdownMenuProps = {
   /**
    * Render function
    */
@@ -82,6 +72,11 @@ type Props = DefaultProps & {
    * This will change where we attach event handlers
    */
   alwaysRenderMenu?: boolean;
+  /**
+   * closes menu on "Esc" keypress
+   * @default true
+   */
+  closeOnEscape?: boolean;
   /**
    * If this is set to true, the dropdown behaves as a "nested dropdown" and is
    * triggered on mouse enter and mouse leave
@@ -94,6 +89,11 @@ type Props = DefaultProps & {
    */
   isOpen?: boolean;
   /**
+   * Keeps dropdown menu open when menu is clicked
+   * @default false
+   */
+  keepMenuOpen?: boolean;
+  /**
    * Callback for when we get a click outside of dropdown menus.
    * Useful for when menu is controlled.
    */
@@ -105,10 +105,6 @@ type Props = DefaultProps & {
    * hide dropdown menu
    */
   shouldIgnoreClickOutside?: (event: MouseEvent) => boolean;
-};
-
-type State = {
-  isOpen: boolean;
 };
 
 /**
@@ -126,334 +122,348 @@ type State = {
  *
  * @deprecated
  */
-class DropdownMenu extends Component<Props, State> {
-  static defaultProps: DefaultProps = {
-    keepMenuOpen: false,
-    closeOnEscape: true,
-  };
+function DropdownMenu({
+  keepMenuOpen = false,
+  closeOnEscape = true,
+  children,
+  alwaysRenderMenu,
+  isNestedDropdown,
+  isOpen: isOpenProp,
+  onClickOutside,
+  onClose,
+  onOpen,
+  shouldIgnoreClickOutside,
+}: DeprecatedDropdownMenuProps) {
+  const [isOpenState, setIsOpenState] = useState(false);
 
-  state: State = {
-    isOpen: false,
-  };
-
-  componentWillUnmount() {
-    window.clearTimeout(this.mouseLeaveTimeout);
-    window.clearTimeout(this.mouseEnterTimeout);
-    document.removeEventListener('click', this.checkClickOutside, true);
-  }
-
-  dropdownMenu: Element | null = null;
-  dropdownActor: Element | null = null;
-
-  mouseLeaveTimeout: number | undefined = undefined;
-  mouseEnterTimeout: number | undefined = undefined;
+  const dropdownMenu = useRef<Element | null>(null);
+  const dropdownActor = useRef<Element | null>(null);
+  const mouseLeaveTimeout = useRef<number | undefined>(undefined);
+  const mouseEnterTimeout = useRef<number | undefined>(undefined);
 
   // Gets open state from props or local state when appropriate
-  isOpen = () => {
-    const {isOpen} = this.props;
-    const isControlled = typeof isOpen !== 'undefined';
-    return (isControlled && isOpen) || this.state.isOpen;
-  };
+  const isOpen = useCallback(() => {
+    const isControlled = typeof isOpenProp !== 'undefined';
+    return (isControlled && isOpenProp) || isOpenState;
+  }, [isOpenProp, isOpenState]);
+
+  // Closes dropdown menu
+  const handleClose = useCallback(
+    (e?: React.KeyboardEvent<Element> | React.MouseEvent<Element>) => {
+      const isControlled = typeof isOpenProp !== 'undefined';
+
+      if (!isControlled) {
+        setIsOpenState(false);
+      }
+
+      if (typeof onClose === 'function') {
+        onClose(e);
+      }
+    },
+    [isOpenProp, onClose]
+  );
 
   // Checks if click happens inside of dropdown menu (or its button)
   // Closes dropdownmenu if it is "outside"
-  checkClickOutside = async (e: MouseEvent) => {
-    const {onClickOutside, shouldIgnoreClickOutside} = this.props;
+  const checkClickOutside = useCallback(
+    async (e: MouseEvent) => {
+      if (!dropdownMenu.current || !isOpen()) {
+        return;
+      }
 
-    if (!this.dropdownMenu || !this.isOpen()) {
-      return;
+      if (!(e.target instanceof Element)) {
+        return;
+      }
+
+      // Dropdown menu itself
+      if (dropdownMenu.current?.contains(e.target)) {
+        return;
+      }
+
+      if (!dropdownActor.current) {
+        // Log an error, should be lower priority
+        Sentry.withScope(scope => {
+          scope.setLevel('warning');
+          Sentry.captureException(
+            new Error('DropdownMenu does not have "Actor" attached')
+          );
+        });
+      }
+
+      // Button that controls visibility of dropdown menu
+      if (dropdownActor.current?.contains(e.target)) {
+        return;
+      }
+
+      if (typeof shouldIgnoreClickOutside === 'function' && shouldIgnoreClickOutside(e)) {
+        return;
+      }
+
+      if (typeof onClickOutside === 'function') {
+        onClickOutside(e);
+      }
+
+      // Wait until the current macrotask completes, in the case that the click
+      // happened on a hovercard or some other element rendered outside of the
+      // dropdown, but controlled by the existence of the dropdown, we need to
+      // ensure any click handlers are run.
+      await new Promise(resolve => window.setTimeout(resolve));
+
+      handleClose();
+    },
+    [isOpen, onClickOutside, shouldIgnoreClickOutside, handleClose]
+  );
+
+  // Handled in a useEffect to avoid circular dependency from legacy class component
+  useEffect(() => {
+    // Clean up click handlers when the menu is closed for menus that are always rendered,
+    // otherwise the click handlers get cleaned up when menu is unmounted
+    if (!isOpenState && (alwaysRenderMenu || isNestedDropdown)) {
+      document.removeEventListener('click', checkClickOutside, true);
     }
-
-    if (!(e.target instanceof Element)) {
-      return;
-    }
-
-    // Dropdown menu itself
-    if (this.dropdownMenu.contains(e.target)) {
-      return;
-    }
-
-    if (!this.dropdownActor) {
-      // Log an error, should be lower priority
-      Sentry.withScope(scope => {
-        scope.setLevel('warning');
-        Sentry.captureException(new Error('DropdownMenu does not have "Actor" attached'));
-      });
-    }
-
-    // Button that controls visibility of dropdown menu
-    if (this.dropdownActor?.contains(e.target)) {
-      return;
-    }
-
-    if (typeof shouldIgnoreClickOutside === 'function' && shouldIgnoreClickOutside(e)) {
-      return;
-    }
-
-    if (typeof onClickOutside === 'function') {
-      onClickOutside(e);
-    }
-
-    // Wait until the current macrotask completes, in the case that the click
-    // happened on a hovercard or some other element rendered outside of the
-    // dropdown, but controlled by the existence of the dropdown, we need to
-    // ensure any click handlers are run.
-    await new Promise(resolve => window.setTimeout(resolve));
-
-    this.handleClose();
-  };
+  }, [isOpenState, alwaysRenderMenu, isNestedDropdown, checkClickOutside]);
 
   // Opens dropdown menu
-  handleOpen = (e?: React.MouseEvent<Element>) => {
-    const {onOpen, isOpen, alwaysRenderMenu, isNestedDropdown} = this.props;
-    const isControlled = typeof isOpen !== 'undefined';
-    if (!isControlled) {
-      this.setState({
-        isOpen: true,
-      });
-    }
+  const handleOpen = useCallback(
+    (e?: React.MouseEvent<Element>) => {
+      const isControlled = typeof isOpenProp !== 'undefined';
+      if (!isControlled) {
+        setIsOpenState(true);
+      }
 
-    window.clearTimeout(this.mouseLeaveTimeout);
+      window.clearTimeout(mouseLeaveTimeout.current);
 
-    // If we always render menu (e.g. DropdownLink), then add the check click outside handlers when we open the menu
-    // instead of when the menu component mounts. Otherwise we will have many click handlers attached on initial load.
-    if (alwaysRenderMenu || isNestedDropdown) {
-      document.addEventListener('click', this.checkClickOutside, true);
-    }
+      // If we always render menu (e.g. DropdownLink), then add the check click outside handlers when we open the menu
+      // instead of when the menu component mounts. Otherwise we will have many click handlers attached on initial load.
+      if (alwaysRenderMenu || isNestedDropdown) {
+        document.addEventListener('click', checkClickOutside, true);
+      }
 
-    if (typeof onOpen === 'function') {
-      onOpen(e);
-    }
-  };
+      if (typeof onOpen === 'function') {
+        onOpen(e);
+      }
+    },
+    [isOpenProp, alwaysRenderMenu, isNestedDropdown, onOpen, checkClickOutside]
+  );
 
   // Decide whether dropdown should be closed when mouse leaves element
   // Only for nested dropdowns
-  handleMouseLeave = (e: React.MouseEvent<Element>) => {
-    if (!this.props.isNestedDropdown) {
-      return;
-    }
-
-    const toElement = e.relatedTarget;
-
-    try {
-      if (
-        this.dropdownMenu &&
-        (!(toElement instanceof Element) || !this.dropdownMenu.contains(toElement))
-      ) {
-        window.clearTimeout(this.mouseLeaveTimeout);
-        this.mouseLeaveTimeout = window.setTimeout(() => {
-          this.handleClose(e);
-        }, MENU_CLOSE_DELAY);
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<Element>) => {
+      if (!isNestedDropdown) {
+        return;
       }
-    } catch (err) {
-      Sentry.withScope(scope => {
-        scope.setExtra('event', e);
-        scope.setExtra('relatedTarget', e.relatedTarget);
-        Sentry.captureException(err);
-      });
-    }
-  };
 
-  // Closes dropdown menu
-  handleClose = (e?: React.KeyboardEvent<Element> | React.MouseEvent<Element>) => {
-    const {onClose, isOpen, alwaysRenderMenu, isNestedDropdown} = this.props;
-    const isControlled = typeof isOpen !== 'undefined';
+      const toElement = e.relatedTarget;
 
-    if (!isControlled) {
-      this.setState({isOpen: false});
-    }
+      try {
+        if (
+          dropdownMenu.current &&
+          (!(toElement instanceof Element) || !dropdownMenu.current.contains(toElement))
+        ) {
+          window.clearTimeout(mouseLeaveTimeout.current);
+          mouseLeaveTimeout.current = window.setTimeout(() => {
+            handleClose(e);
+          }, MENU_CLOSE_DELAY);
+        }
+      } catch (err) {
+        Sentry.withScope(scope => {
+          scope.setExtra('event', e);
+          scope.setExtra('relatedTarget', e.relatedTarget);
+          Sentry.captureException(err);
+        });
+      }
+    },
+    [isNestedDropdown, handleClose]
+  );
 
-    // Clean up click handlers when the menu is closed for menus that are always rendered,
-    // otherwise the click handlers get cleaned up when menu is unmounted
-    if (alwaysRenderMenu || isNestedDropdown) {
-      document.removeEventListener('click', this.checkClickOutside, true);
-    }
-
-    if (typeof onClose === 'function') {
-      onClose(e);
-    }
-  };
-
-  // When dropdown menu is displayed and mounted to DOM,
-  // bind a click handler to `document` to listen for clicks outside of
-  // this component and close menu if so
-  handleMenuMount = (ref: Element | null) => {
-    if (ref && !(ref instanceof Element)) {
-      return;
-    }
-    const {alwaysRenderMenu, isNestedDropdown} = this.props;
-
-    this.dropdownMenu = ref;
-
-    // Don't add document event listeners here if we are always rendering menu
-    // Instead add when menu is opened
-    if (alwaysRenderMenu || isNestedDropdown) {
-      return;
-    }
-
-    if (this.dropdownMenu) {
-      // 3rd arg = useCapture = so event capturing vs event bubbling
-      document.addEventListener('click', this.checkClickOutside, true);
-    } else {
-      document.removeEventListener('click', this.checkClickOutside, true);
-    }
-  };
-
-  handleActorMount = (ref: Element | null) => {
-    if (ref && !(ref instanceof Element)) {
-      return;
-    }
-    this.dropdownActor = ref;
-  };
-
-  handleToggle = (e: React.MouseEvent<Element>) => {
-    if (this.isOpen()) {
-      this.handleClose(e);
-    } else {
-      this.handleOpen(e);
-    }
-  };
+  const handleToggle = useCallback(
+    (e: React.MouseEvent<Element>) => {
+      if (isOpen()) {
+        handleClose(e);
+      } else {
+        handleOpen(e);
+      }
+    },
+    [isOpen, handleClose, handleOpen]
+  );
 
   // Control whether we should hide dropdown menu when it is clicked
-  handleDropdownMenuClick = (e: React.MouseEvent<Element>) => {
-    if (this.props.keepMenuOpen) {
-      return;
-    }
+  const handleDropdownMenuClick = useCallback(
+    (e: React.MouseEvent<Element>) => {
+      if (keepMenuOpen) {
+        return;
+      }
 
-    this.handleClose(e);
-  };
+      handleClose(e);
+    },
+    [keepMenuOpen, handleClose]
+  );
 
-  getRootProps(props?: Record<string, unknown>) {
+  // This function does nothing?
+  const getRootProps = useCallback((props?: Record<string, unknown>) => {
     return props;
-  }
+  }, []);
 
   // Actor is the component that will open the dropdown menu
-  getActorProps: GetActorPropsFn = <E extends Element = Element>({
-    onClick,
-    onMouseEnter,
-    onMouseLeave,
-    onKeyDown,
-    style = {},
-    ...props
-  }: GetActorArgs<E> = {}) => {
-    const {isNestedDropdown, closeOnEscape} = this.props;
+  const getActorProps: GetActorPropsFn = useCallback(
+    <E extends Element = Element>({
+      onClick,
+      onMouseEnter,
+      onMouseLeave,
+      onKeyDown,
+      style = {},
+      ...props
+    }: GetActorArgs<E> = {}) => {
+      // Props that the actor needs to have <DropdownMenu> work
+      return mergeProps(props, {
+        ref: (ref: Element | null) => {
+          dropdownActor.current = ref;
+        },
+        style: {...style, outline: 'none'},
+        'aria-expanded': isOpen(),
+        'aria-haspopup': 'listbox',
 
-    const refProps = {ref: this.handleActorMount};
+        onKeyDown: (e: React.KeyboardEvent<E>) => {
+          if (typeof onKeyDown === 'function') {
+            onKeyDown(e);
+          }
 
-    // Props that the actor needs to have <DropdownMenu> work
-    return {
-      ...props,
-      ...refProps,
-      style: {...style, outline: 'none'},
-      'aria-expanded': this.isOpen(),
-      'aria-haspopup': 'listbox',
+          if (e.key === 'Escape' && closeOnEscape) {
+            handleClose(e);
+          }
+        },
 
-      onKeyDown: (e: React.KeyboardEvent<E>) => {
-        if (typeof onKeyDown === 'function') {
-          onKeyDown(e);
-        }
+        onMouseEnter: (e: React.MouseEvent<E>) => {
+          if (typeof onMouseEnter === 'function') {
+            onMouseEnter(e);
+          }
 
-        if (e.key === 'Escape' && closeOnEscape) {
-          this.handleClose(e);
-        }
-      },
+          // Only handle mouse enter for nested dropdowns
+          if (!isNestedDropdown) {
+            return;
+          }
 
-      onMouseEnter: (e: React.MouseEvent<E>) => {
-        if (typeof onMouseEnter === 'function') {
-          onMouseEnter(e);
-        }
+          window.clearTimeout(mouseEnterTimeout.current);
+          window.clearTimeout(mouseLeaveTimeout.current);
 
-        // Only handle mouse enter for nested dropdowns
-        if (!isNestedDropdown) {
-          return;
-        }
+          mouseEnterTimeout.current = window.setTimeout(() => {
+            handleOpen(e);
+          }, MENU_CLOSE_DELAY);
+        },
 
-        window.clearTimeout(this.mouseEnterTimeout);
-        window.clearTimeout(this.mouseLeaveTimeout);
+        onMouseLeave: (e: React.MouseEvent<E>) => {
+          if (typeof onMouseLeave === 'function') {
+            onMouseLeave(e);
+          }
 
-        this.mouseEnterTimeout = window.setTimeout(() => {
-          this.handleOpen(e);
-        }, MENU_CLOSE_DELAY);
-      },
+          window.clearTimeout(mouseEnterTimeout.current);
+          window.clearTimeout(mouseLeaveTimeout.current);
 
-      onMouseLeave: (e: React.MouseEvent<E>) => {
-        if (typeof onMouseLeave === 'function') {
-          onMouseLeave(e);
-        }
+          handleMouseLeave(e);
+        },
 
-        window.clearTimeout(this.mouseEnterTimeout);
-        window.clearTimeout(this.mouseLeaveTimeout);
+        onClick: (e: React.MouseEvent<E>) => {
+          // If we are a nested dropdown, clicking the actor
+          // should be a no-op so that the menu doesn't close.
+          if (isNestedDropdown) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
 
-        this.handleMouseLeave(e);
-      },
+          handleToggle(e);
 
-      onClick: (e: React.MouseEvent<E>) => {
-        // If we are a nested dropdown, clicking the actor
-        // should be a no-op so that the menu doesn't close.
-        if (isNestedDropdown) {
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        }
-
-        this.handleToggle(e);
-
-        if (typeof onClick === 'function') {
-          onClick(e);
-        }
-      },
-    };
-  };
+          if (typeof onClick === 'function') {
+            onClick(e);
+          }
+        },
+      });
+    },
+    [
+      isNestedDropdown,
+      closeOnEscape,
+      isOpen,
+      handleClose,
+      handleOpen,
+      handleMouseLeave,
+      handleToggle,
+    ]
+  );
 
   // Menu is the menu component that <DropdownMenu> will control
-  getMenuProps: GetMenuPropsFn = <E extends Element = Element>({
-    onClick,
-    onMouseLeave,
-    onMouseEnter,
-    ...props
-  }: GetMenuArgs<E> = {}): MenuProps<E> => {
-    const refProps = {ref: this.handleMenuMount};
+  const getMenuProps: GetMenuPropsFn = useCallback(
+    <E extends Element = Element>({
+      onClick,
+      onMouseLeave,
+      onMouseEnter,
+      ...props
+    }: GetMenuArgs<E> = {}): MenuProps<E> => {
+      // Props that the menu needs to have <DropdownMenu> work
+      return mergeProps(props, {
+        ref: (ref: Element | null) => {
+          dropdownMenu.current = ref;
 
-    // Props that the menu needs to have <DropdownMenu> work
-    return {
-      ...props,
-      ...refProps,
-      role: 'listbox',
-      onMouseEnter: (e: React.MouseEvent<E>) => {
-        onMouseEnter?.(e);
+          // Don't add document event listeners here if we are always rendering menu
+          // Instead add when menu is opened
+          if (alwaysRenderMenu || isNestedDropdown) {
+            return;
+          }
 
-        // There is a delay before closing a menu on mouse leave, cancel this
-        // action if mouse enters menu again
-        window.clearTimeout(this.mouseLeaveTimeout);
-      },
-      onMouseLeave: (e: React.MouseEvent<E>) => {
-        onMouseLeave?.(e);
-        this.handleMouseLeave(e);
-      },
-      onClick: (e: React.MouseEvent<E>) => {
-        this.handleDropdownMenuClick(e);
-        onClick?.(e);
-      },
+          if (dropdownMenu.current) {
+            // 3rd arg = useCapture = so event capturing vs event bubbling
+            // Use the ref to get the latest checkClickOutside function
+            document.addEventListener('click', checkClickOutside, true);
+          }
+        },
+        role: 'listbox',
+        onMouseEnter: (e: React.MouseEvent<E>) => {
+          onMouseEnter?.(e);
+
+          // There is a delay before closing a menu on mouse leave, cancel this
+          // action if mouse enters menu again
+          window.clearTimeout(mouseLeaveTimeout.current);
+        },
+        onMouseLeave: (e: React.MouseEvent<E>) => {
+          onMouseLeave?.(e);
+          handleMouseLeave(e);
+        },
+        onClick: (e: React.MouseEvent<E>) => {
+          handleDropdownMenuClick(e);
+          onClick?.(e);
+        },
+      });
+    },
+    [
+      alwaysRenderMenu,
+      isNestedDropdown,
+      handleMouseLeave,
+      handleDropdownMenuClick,
+      checkClickOutside,
+    ]
+  );
+
+  // Cleanup effect (equivalent to componentWillUnmount)
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(mouseLeaveTimeout.current);
+      window.clearTimeout(mouseEnterTimeout.current);
     };
-  };
+  }, []);
 
-  render() {
-    const {children} = this.props;
+  // Default anchor = left
+  const shouldShowDropdown = isOpen();
 
-    // Default anchor = left
-    const shouldShowDropdown = this.isOpen();
-
-    return children({
-      isOpen: shouldShowDropdown,
-      getRootProps: this.getRootProps,
-      getActorProps: this.getActorProps,
-      getMenuProps: this.getMenuProps,
-      actions: {
-        open: this.handleOpen,
-        close: this.handleClose,
-      },
-    });
-  }
+  return children({
+    isOpen: shouldShowDropdown,
+    getRootProps,
+    getActorProps,
+    getMenuProps,
+    actions: {
+      open: handleOpen,
+      close: handleClose,
+    },
+  });
 }
 
 export default DropdownMenu;

--- a/static/app/components/deprecatedDropdownMenu.tsx
+++ b/static/app/components/deprecatedDropdownMenu.tsx
@@ -62,7 +62,7 @@ type RenderProps = {
   isOpen: boolean;
 };
 
-export type DeprecatedDropdownMenuProps = {
+export interface DeprecatedDropdownMenuProps {
   /**
    * Render function
    */
@@ -89,23 +89,13 @@ export type DeprecatedDropdownMenuProps = {
    */
   isOpen?: boolean;
   /**
-   * Keeps dropdown menu open when menu is clicked
-   * @default false
-   */
-  keepMenuOpen?: boolean;
-  /**
    * Callback for when we get a click outside of dropdown menus.
    * Useful for when menu is controlled.
    */
   onClickOutside?: (e: MouseEvent) => void;
   onClose?: (e: React.KeyboardEvent | React.MouseEvent | undefined) => void;
   onOpen?: (e: React.MouseEvent | undefined) => void;
-  /**
-   * Callback function to check if we should ignore click outside to
-   * hide dropdown menu
-   */
-  shouldIgnoreClickOutside?: (event: MouseEvent) => boolean;
-};
+}
 
 /**
  * Deprecated dropdown menu. Use these alternatives instead:
@@ -123,7 +113,6 @@ export type DeprecatedDropdownMenuProps = {
  * @deprecated
  */
 function DropdownMenu({
-  keepMenuOpen = false,
   closeOnEscape = true,
   children,
   alwaysRenderMenu,
@@ -132,7 +121,6 @@ function DropdownMenu({
   onClickOutside,
   onClose,
   onOpen,
-  shouldIgnoreClickOutside,
 }: DeprecatedDropdownMenuProps) {
   const [isOpenState, setIsOpenState] = useState(false);
 
@@ -198,10 +186,6 @@ function DropdownMenu({
         return;
       }
 
-      if (typeof shouldIgnoreClickOutside === 'function' && shouldIgnoreClickOutside(e)) {
-        return;
-      }
-
       if (typeof onClickOutside === 'function') {
         onClickOutside(e);
       }
@@ -214,7 +198,7 @@ function DropdownMenu({
 
       handleClose();
     },
-    [isOpen, onClickOutside, shouldIgnoreClickOutside, handleClose]
+    [isOpen, onClickOutside, handleClose]
   );
 
   // Handled in a useEffect to avoid circular dependency from legacy class component
@@ -294,13 +278,9 @@ function DropdownMenu({
   // Control whether we should hide dropdown menu when it is clicked
   const handleDropdownMenuClick = useCallback(
     (e: React.MouseEvent<Element>) => {
-      if (keepMenuOpen) {
-        return;
-      }
-
       handleClose(e);
     },
-    [keepMenuOpen, handleClose]
+    [handleClose]
   );
 
   // This function does nothing?
@@ -393,12 +373,8 @@ function DropdownMenu({
           // action if mouse enters menu again
           window.clearTimeout(mouseLeaveTimeout.current);
         },
-        onMouseLeave: (e: React.MouseEvent<E>) => {
-          handleMouseLeave(e);
-        },
-        onClick: (e: React.MouseEvent<E>) => {
-          handleDropdownMenuClick(e);
-        },
+        onMouseLeave: handleMouseLeave,
+        onClick: handleDropdownMenuClick,
       });
     },
     [

--- a/static/app/components/dropdownLink.spec.tsx
+++ b/static/app/components/dropdownLink.spec.tsx
@@ -113,22 +113,6 @@ describe('DropdownLink', function () {
 
         expect(screen.queryByText('hi')).not.toBeInTheDocument();
       });
-
-      it('does not close when menu is clicked and `keepMenuOpen` is on', async function () {
-        render(
-          <DropdownLink title="test" alwaysRenderMenu={false} keepMenuOpen>
-            <li>hi</li>
-          </DropdownLink>
-        );
-
-        // Open menu
-        await userEvent.click(screen.getByText('test'), {delay: null});
-
-        // Click again
-        await userEvent.click(screen.getByText('test'), {delay: null});
-
-        expect(screen.getByText('test')).toBeInTheDocument();
-      });
     });
   });
 

--- a/static/app/components/dropdownLink.tsx
+++ b/static/app/components/dropdownLink.tsx
@@ -2,6 +2,7 @@ import type {Theme} from '@emotion/react';
 import {css, useTheme} from '@emotion/react';
 import classNames from 'classnames';
 
+import type {DeprecatedDropdownMenuProps} from 'sentry/components/deprecatedDropdownMenu';
 import DeprecatedDropdownMenu from 'sentry/components/deprecatedDropdownMenu';
 import {IconChevron} from 'sentry/icons';
 
@@ -36,34 +37,30 @@ const getRootCss = (theme: Theme) => css`
 // the extra container because dropdown-menu alignment is off if
 // `dropdown-actor` is a flexbox
 
-type Props = Omit<
-  Omit<DeprecatedDropdownMenu['props'], 'children'>,
-  keyof typeof DeprecatedDropdownMenu.defaultProps
-> &
-  Partial<typeof DeprecatedDropdownMenu.defaultProps> & {
-    children: React.ReactNode;
-    /**
-     * Always render children of dropdown menu, this is included to support menu
-     * items that open a confirm modal. Otherwise when dropdown menu hides, the
-     * modal also gets unmounted
-     */
-    alwaysRenderMenu?: boolean;
-    anchorMiddle?: boolean;
-    /**
-     * Anchors menu to the right
-     */
-    anchorRight?: boolean;
-    /**
-     * display dropdown caret
-     */
-    caret?: boolean;
-    className?: string;
-    customTitle?: React.ReactNode;
-    disabled?: boolean;
-    menuClasses?: string;
-    title?: React.ReactNode;
-    topLevelClasses?: string;
-  };
+type Props = Omit<DeprecatedDropdownMenuProps, 'children'> & {
+  children: React.ReactNode;
+  /**
+   * Always render children of dropdown menu, this is included to support menu
+   * items that open a confirm modal. Otherwise when dropdown menu hides, the
+   * modal also gets unmounted
+   */
+  alwaysRenderMenu?: boolean;
+  anchorMiddle?: boolean;
+  /**
+   * Anchors menu to the right
+   */
+  anchorRight?: boolean;
+  /**
+   * display dropdown caret
+   */
+  caret?: boolean;
+  className?: string;
+  customTitle?: React.ReactNode;
+  disabled?: boolean;
+  menuClasses?: string;
+  title?: React.ReactNode;
+  topLevelClasses?: string;
+};
 
 function DropdownLink({
   anchorMiddle,


### PR DESCRIPTION
I don't think this component is going away in the next six months and we were seeing some weird behavior where the wrong sidebar dropdown would open on click. I think it had to do with the circular dependencies within the class function. Depending on the js target may not bind the scope correctly. Removes some props that are no longer used.

onClickOutside -> handle close -> onClickOutside

