### PR TITLE
fix(settings): Add text search key to org switcher breadcrumb

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/organizationCrumb.tsx
@@ -80,6 +80,7 @@ function OrganizationCrumb({routes, route, ...props}: SettingsBreadcrumbProps) {
       items={sortBy(organizations, ['name']).map((org, index) => ({
         index,
         value: org,
+        searchKey: org.name,
         label: (
           <MenuItem>
             <IdBadge organization={org} />


### PR DESCRIPTION
Fixes filter not displaying any results

![image](https://github.com/user-attachments/assets/d1d226f5-720f-4ef0-8fa6-dda474163b5d)
