### PR TITLE
feat: Update suspension modal with all valid reasons, and suspension modal copy

### DIFF
--- a/static/gsAdmin/components/suspendAccountAction.tsx
+++ b/static/gsAdmin/components/suspendAccountAction.tsx
@@ -1,67 +1,69 @@
-import {Component} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 
 import type {
   AdminConfirmParams,
   AdminConfirmRenderProps,
 } from 'admin/components/adminConfirmationModal';
 
+// Make sure these match the values in the backend
+// See https://github.com/getsentry/getsentry/blob/cf837619ae7c76e852666afc5578abc0f3f0a97b/getsentry/models/subscription.py#L147
 const suspendReasons = [
   ['event_volume', 'Event Volume', 'This account has greatly exceeded its paid volume'],
   ['fraud', 'Fraudulent', 'This account was reported as fraudulent'],
+  ['dispute', 'Dispute', 'This account has recently had a charge disputed'],
+  ['past_due', 'Past Due', 'This account has a past balance which needs to be paid.'],
 ] as const;
-
-type State = {
-  suspensionReason: (typeof suspendReasons)[number][0] | null;
-};
 
 /**
  * Rendered as part of a openAdminConfirmModal call
  */
-class SuspendAccountAction extends Component<AdminConfirmRenderProps, State> {
-  state: State = {
-    suspensionReason: null,
-  };
+function SuspendAccountAction(props: AdminConfirmRenderProps) {
+  const [suspensionReason, setSuspensionReason] = useState<
+    (typeof suspendReasons)[number][0] | null
+  >(null);
 
-  componentDidMount() {
-    this.props.setConfirmCallback(this.handleConfirm);
-  }
+  const {setConfirmCallback, onConfirm, disableConfirmButton} = props;
 
-  handleConfirm = (_params: AdminConfirmParams) => {
-    // XXX(epurkhiser): In the original implementation none of the audit params
-    // were passed, is that an oversight?
-    this.props.onConfirm?.({suspensionReason: this.state.suspensionReason});
-  };
+  const handleConfirm = useCallback(
+    (_params: AdminConfirmParams) => {
+      // XXX(epurkhiser): In the original implementation none of the audit params
+      // were passed, is that an oversight?
+      onConfirm?.({suspensionReason});
+    },
+    [onConfirm, suspensionReason]
+  );
 
-  getReasonChoices = () => [
-    ['event_volume', 'Event Volume', 'This account has greatly exceeded its paid volume'],
-    ['fraud', 'Fraudulent', 'This account was reported as fraudulent'],
-  ];
+  useEffect(() => {
+    setConfirmCallback(handleConfirm);
+  }, [setConfirmCallback, handleConfirm]);
 
-  render() {
-    return suspendReasons.map(([key, label, help]) => (
-      <label style={{marginBottom: 10, position: 'relative'}} key={key}>
-        <div style={{position: 'absolute', left: 0, width: 20}}>
-          <input
-            data-test-id={`suspend-radio-btn-${key}`}
-            aria-label={label}
-            type="radio"
-            name="suspensionReason"
-            value={key}
-            checked={this.state.suspensionReason === key}
-            onChange={() => {
-              this.setState({suspensionReason: key});
-              this.props.disableConfirmButton(false);
-            }}
-          />
-        </div>
-        <div style={{marginLeft: 25}}>
-          <strong>{label}</strong>
-          <br />
-          <small style={{fontWeight: 'normal'}}>{help}</small>
-        </div>
-      </label>
-    ));
-  }
+  return (
+    <Fragment>
+      {suspendReasons.map(([key, label, help]) => (
+        <label style={{marginBottom: 10, position: 'relative'}} key={key}>
+          <div style={{position: 'absolute', left: 0, width: 20}}>
+            <input
+              data-test-id={`suspend-radio-btn-${key}`}
+              aria-label={label}
+              type="radio"
+              name="suspensionReason"
+              value={key}
+              checked={suspensionReason === key}
+              onChange={() => {
+                setSuspensionReason(key);
+                disableConfirmButton(false);
+              }}
+            />
+          </div>
+          <div style={{marginLeft: 25}}>
+            <strong>{label}</strong>
+            <br />
+            <small style={{fontWeight: 'normal'}}>{help}</small>
+          </div>
+        </label>
+      ))}
+    </Fragment>
+  );
 }
 
 export default SuspendAccountAction;

--- a/static/gsAdmin/components/suspendAccountAction.tsx
+++ b/static/gsAdmin/components/suspendAccountAction.tsx
@@ -5,6 +5,8 @@ import type {
   AdminConfirmRenderProps,
 } from 'admin/components/adminConfirmationModal';
 
+// Make sure these match the values in the backend
+// See https://github.com/getsentry/getsentry/blob/cf837619ae7c76e852666afc5578abc0f3f0a97b/getsentry/models/subscription.py#L147
 const suspendReasons = [
   ['event_volume', 'Event Volume', 'This account has greatly exceeded its paid volume'],
   ['fraud', 'Fraudulent', 'This account was reported as fraudulent'],

--- a/static/gsAdmin/components/suspendAccountAction.tsx
+++ b/static/gsAdmin/components/suspendAccountAction.tsx
@@ -1,12 +1,10 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Component} from 'react';
 
 import type {
   AdminConfirmParams,
   AdminConfirmRenderProps,
 } from 'admin/components/adminConfirmationModal';
 
-// Make sure these match the values in the backend
-// See https://github.com/getsentry/getsentry/blob/cf837619ae7c76e852666afc5578abc0f3f0a97b/getsentry/models/subscription.py#L147
 const suspendReasons = [
   ['event_volume', 'Event Volume', 'This account has greatly exceeded its paid volume'],
   ['fraud', 'Fraudulent', 'This account was reported as fraudulent'],
@@ -14,56 +12,53 @@ const suspendReasons = [
   ['past_due', 'Past Due', 'This account has a past balance which needs to be paid.'],
 ] as const;
 
+type State = {
+  suspensionReason: (typeof suspendReasons)[number][0] | null;
+};
+
 /**
  * Rendered as part of a openAdminConfirmModal call
  */
-function SuspendAccountAction(props: AdminConfirmRenderProps) {
-  const [suspensionReason, setSuspensionReason] = useState<
-    (typeof suspendReasons)[number][0] | null
-  >(null);
+class SuspendAccountAction extends Component<AdminConfirmRenderProps, State> {
+  state: State = {
+    suspensionReason: null,
+  };
 
-  const {setConfirmCallback, onConfirm, disableConfirmButton} = props;
+  componentDidMount() {
+    this.props.setConfirmCallback(this.handleConfirm);
+  }
 
-  const handleConfirm = useCallback(
-    (_params: AdminConfirmParams) => {
-      // XXX(epurkhiser): In the original implementation none of the audit params
-      // were passed, is that an oversight?
-      onConfirm?.({suspensionReason});
-    },
-    [onConfirm, suspensionReason]
-  );
+  handleConfirm = (_params: AdminConfirmParams) => {
+    // XXX(epurkhiser): In the original implementation none of the audit params
+    // were passed, is that an oversight?
+    this.props.onConfirm?.({suspensionReason: this.state.suspensionReason});
+  };
 
-  useEffect(() => {
-    setConfirmCallback(handleConfirm);
-  }, [setConfirmCallback, handleConfirm]);
-
-  return (
-    <Fragment>
-      {suspendReasons.map(([key, label, help]) => (
-        <label style={{marginBottom: 10, position: 'relative'}} key={key}>
-          <div style={{position: 'absolute', left: 0, width: 20}}>
-            <input
-              data-test-id={`suspend-radio-btn-${key}`}
-              aria-label={label}
-              type="radio"
-              name="suspensionReason"
-              value={key}
-              checked={suspensionReason === key}
-              onChange={() => {
-                setSuspensionReason(key);
-                disableConfirmButton(false);
-              }}
-            />
-          </div>
-          <div style={{marginLeft: 25}}>
-            <strong>{label}</strong>
-            <br />
-            <small style={{fontWeight: 'normal'}}>{help}</small>
-          </div>
-        </label>
-      ))}
-    </Fragment>
-  );
+  render() {
+    return suspendReasons.map(([key, label, help]) => (
+      <label style={{marginBottom: 10, position: 'relative'}} key={key}>
+        <div style={{position: 'absolute', left: 0, width: 20}}>
+          <input
+            data-test-id={`suspend-radio-btn-${key}`}
+            aria-label={label}
+            type="radio"
+            name="suspensionReason"
+            value={key}
+            checked={this.state.suspensionReason === key}
+            onChange={() => {
+              this.setState({suspensionReason: key});
+              this.props.disableConfirmButton(false);
+            }}
+          />
+        </div>
+        <div style={{marginLeft: 25}}>
+          <strong>{label}</strong>
+          <br />
+          <small style={{fontWeight: 'normal'}}>{help}</small>
+        </div>
+      </label>
+    ));
+  }
 }
 
 export default SuspendAccountAction;

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -131,6 +131,17 @@ describe('GSBanner', function () {
     renderGlobalModal({deprecatedRouterMocks: true});
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Your account has been suspended with the following reason:'
+      )
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Until this situation is resolved you will not be able to send events to Sentry. Please contact support if you have any questions or need assistance.'
+      )
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Contact Support')).toBeInTheDocument();
   });
 
   it('renders usage exceeded modal', async function () {
@@ -1190,7 +1201,7 @@ describe('GSBanner', function () {
     expect(screen.getByTestId('modal-continue-button')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'There was an issue with your payment. Update your payment information to ensure uniterrupted access to Sentry.'
+        'There was an issue with your payment. Update your payment information to ensure uninterrupted access to Sentry.'
       )
     ).toBeInTheDocument();
     await userEvent.click(screen.getByTestId('modal-continue-button'));

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -132,16 +132,14 @@ describe('GSBanner', function () {
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(
-      await screen.findByText(
-        'Your account has been suspended with the following reason:'
-      )
+      screen.getByText('Your account has been suspended with the following reason:')
     ).toBeInTheDocument();
     expect(
-      await screen.findByText(
+      screen.getByText(
         'Until this situation is resolved you will not be able to send events to Sentry. Please contact support if you have any questions or need assistance.'
       )
     ).toBeInTheDocument();
-    expect(await screen.findByText('Contact Support')).toBeInTheDocument();
+    expect(screen.getByText('Contact Support')).toBeInTheDocument();
   });
 
   it('renders usage exceeded modal', async function () {

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -222,7 +222,7 @@ function NoticeModal({
       title = t('Unable to bill your account');
       body = billingPermissions
         ? t(
-            `There was an issue with your payment. Update your payment information to ensure uniterrupted access to Sentry.`
+            `There was an issue with your payment. Update your payment information to ensure uninterrupted access to Sentry.`
           )
         : t(
             `There was an issue with your payment. Please have the Org Owner or Billing Member update your payment information to ensure continued access to Sentry.`

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -128,7 +128,7 @@ function SuspensionModal({Header, Body, Footer, subscription}: SuspensionModalPr
         </ul>
         <p>
           {t(
-            'Until this situation is resolved you will not be able to send events to Sentry.'
+            'Until this situation is resolved you will not be able to send events to Sentry. Please contact support if you have any questions or need assistance.'
           )}
         </p>
       </Body>


### PR DESCRIPTION
This PR is a small set of copy changes / updates to the suspension modal and suspension admin workflow. Also removes an unnecessary function in the suspension modal that wasn't being used anywhere.

Part 1 of https://linear.app/getsentry/issue/BIL-785/account-suspension-account-suspension-message-is-inaccurate

<img width="631" alt="Screenshot 2025-05-30 at 9 26 32 AM" src="https://github.com/user-attachments/assets/a3d32574-21d3-4d8c-8df9-d69273df65d8" />
<img width="629" alt="Screenshot 2025-05-30 at 10 51 30 AM" src="https://github.com/user-attachments/assets/097c82f2-f5ad-41e0-854b-5866d044a297" />
<img width="628" alt="Screenshot 2025-05-30 at 10 51 54 AM" src="https://github.com/user-attachments/assets/18918341-6f81-4971-9476-afe5ed4988b1" />



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
