### PR TITLE
fix(explore): Remove weird has syntax for quoted keys

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -814,7 +814,7 @@ class SearchResolver:
             else:
                 field_type = None
             # make sure to remove surrounding quotes if it's a tag
-            field = tag_match.group("tag").strip('"') if tag_match else column
+            field = tag_match.group("tag") if tag_match else column
             if field is None:
                 raise InvalidSearchQuery(f"Could not parse {column}")
             # Assume string if a type isn't passed. eg. tags[foo]

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4619,40 +4619,6 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert meta["dataset"] == self.dataset
         assert meta["dataset"] == self.dataset
 
-    def test_typed_attributes_with_colons(self):
-        span = self.create_span(
-            {
-                "data": {
-                    "flag.evaluation.feature.organizations:foo": True,
-                },
-            },
-            start_ts=self.ten_mins_ago,
-        )
-        self.store_spans(
-            [
-                self.create_span(start_ts=self.ten_mins_ago),
-                span,
-            ],
-            is_eap=self.is_eap,
-        )
-
-        response = self.do_request(
-            {
-                "field": ['tags["flag.evaluation.feature.organizations:foo",number]'],
-                "query": 'has:tags["flag.evaluation.feature.organizations:foo",number]',
-                "project": self.project.id,
-                "dataset": self.dataset,
-            }
-        )
-        assert response.status_code == 200, response.content
-        assert response.data["data"] == [
-            {
-                "id": span["span_id"],
-                "project.name": self.project.slug,
-                'tags["flag.evaluation.feature.organizations:foo",number]': 1,
-            },
-        ]
-
     def test_count_if_two_args(self):
         self.store_spans(
             [


### PR DESCRIPTION
This removes the ability to do `has:tags["key",number]` because it's strange to allow this syntax with quotes in the value but no quotes around the entire value.