### PR TITLE
feat(crons): Record logs for monitors-clock-pulse

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -427,6 +427,17 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
     monitor_slug = item.valid_monitor_slug
     environment = params.get("environment")
 
+    # XXX(epurkhiser): Adding VERY early logging specific to a sentry monitor
+    # that we're seeing have intermittent missed in-progress check-ins. We
+    # would like to verify that these check-ins truley are NOT being received
+    # at all (and not being drooped somewhere in this consumer)
+    if project_id == 1 and monitor_slug == "monitors-clock-pulse":
+        clock_time = item.ts.replace(second=0, microsecond=0, tzinfo=UTC)
+        logger.info(
+            "monitors.consumer.sentry_clock_pulse_debug_entry",
+            extra={"clock_time": clock_time, **params},
+        )
+
     project = Project.objects.get_from_cache(id=project_id)
 
     # Strip sdk version to reduce metric cardinality


### PR DESCRIPTION
We're seeing some missing 'in-progress' check-ins for this monitor. That's unexpected. Let's actually verify that those are REALLY not being received.