### PR TITLE
feat(search-bar): Add string filter wildcard operators

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -19,6 +19,7 @@ import {getKeyLabel} from 'sentry/components/searchSyntax/utils';
 import {space} from 'sentry/styles/space';
 import type {TagCollection} from 'sentry/types/group';
 import {getFieldDefinition} from 'sentry/utils/fields';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export type FormattedQueryProps = {
   query: string;
@@ -48,9 +49,14 @@ function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
 }
 
 function Filter({token}: {token: TokenResult<Token.FILTER>}) {
+  const organization = useOrganization();
+  const hasWildcardOperators = organization.features.includes(
+    'search-query-builder-wildcard-operators'
+  );
+
   return (
     <FilterWrapper aria-label={token.text}>
-      <FilterKey token={token} /> {getOperatorInfo(token).label}{' '}
+      <FilterKey token={token} /> {getOperatorInfo(token, hasWildcardOperators).label}{' '}
       <FilterValue>
         <FilterValueText token={token} />
       </FilterValue>

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -6,9 +6,11 @@ import {
   getArgsToken,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {getDefaultValueForValueType} from 'sentry/components/searchQueryBuilder/tokens/utils';
-import type {
-  FieldDefinitionGetter,
-  FocusOverride,
+import {
+  type FETermOperators,
+  type FieldDefinitionGetter,
+  type FocusOverride,
+  isTermOperator,
 } from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
@@ -92,7 +94,7 @@ type UpdateFilterKeyAction = {
 };
 
 type UpdateFilterOpAction = {
-  op: TermOperator;
+  op: FETermOperators;
   token: TokenResult<Token.FILTER>;
   type: 'UPDATE_FILTER_OP';
 };
@@ -163,7 +165,7 @@ function deleteQueryTokens(
 function modifyFilterOperatorQuery(
   query: string,
   token: TokenResult<Token.FILTER>,
-  newOperator: TermOperator
+  newOperator: FETermOperators
 ): string {
   if (isDateToken(token)) {
     return modifyFilterOperatorDate(query, token, newOperator);
@@ -172,7 +174,13 @@ function modifyFilterOperatorQuery(
   const isNotEqual = newOperator === TermOperator.NOT_EQUAL;
 
   const newToken: TokenResult<Token.FILTER> = {...token};
-  newToken.operator = isNotEqual ? TermOperator.DEFAULT : newOperator;
+  if (isTermOperator(newOperator)) {
+    newToken.operator = isNotEqual ? TermOperator.DEFAULT : newOperator;
+  } else {
+    // whenever we have a wildcard operator, we want to set the operator to the default,
+    // because there is no special characters for the wildcard operators just the asterisk
+    newToken.operator = TermOperator.DEFAULT;
+  }
   newToken.negated = isNotEqual;
 
   return replaceQueryToken(query, token, stringifyToken(newToken));
@@ -198,7 +206,7 @@ function modifyFilterOperator(
 function modifyFilterOperatorDate(
   query: string,
   token: TokenResult<Token.FILTER>,
-  newOperator: TermOperator
+  newOperator: FETermOperators
 ): string {
   switch (newOperator) {
     case TermOperator.GREATER_THAN:

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -7,10 +7,10 @@ import {
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {getDefaultValueForValueType} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import {
-  type FETermOperators,
   type FieldDefinitionGetter,
   type FocusOverride,
   isTermOperator,
+  type SearchQueryBuilderOperators,
 } from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
@@ -94,7 +94,7 @@ type UpdateFilterKeyAction = {
 };
 
 type UpdateFilterOpAction = {
-  op: FETermOperators;
+  op: SearchQueryBuilderOperators;
   token: TokenResult<Token.FILTER>;
   type: 'UPDATE_FILTER_OP';
 };
@@ -165,7 +165,7 @@ function deleteQueryTokens(
 function modifyFilterOperatorQuery(
   query: string,
   token: TokenResult<Token.FILTER>,
-  newOperator: FETermOperators
+  newOperator: SearchQueryBuilderOperators
 ): string {
   if (isDateToken(token)) {
     return modifyFilterOperatorDate(query, token, newOperator);
@@ -206,7 +206,7 @@ function modifyFilterOperator(
 function modifyFilterOperatorDate(
   query: string,
   token: TokenResult<Token.FILTER>,
-  newOperator: FETermOperators
+  newOperator: SearchQueryBuilderOperators
 ): string {
   switch (newOperator) {
     case TermOperator.GREATER_THAN:

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2237,6 +2237,25 @@ describe('SearchQueryBuilder', function () {
           await screen.findByRole('row', {name: 'release.version:>1.0'})
         ).toBeInTheDocument();
       });
+
+      it('string filters have the correct operator options', async function () {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />,
+          {organization: {features: ['search-query-builder-wildcard-operators']}}
+        );
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+        );
+
+        expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'is not'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'contains'})).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', {name: 'does not contain'})
+        ).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'starts with'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'ends with'})).toBeInTheDocument();
+      });
     });
 
     describe('numeric', function () {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -116,7 +116,7 @@ export function getOperatorInfo(
     };
   }
 
-  const {operator, label} = getLabelAndOperatorFromToken(token);
+  const {operator, label} = getLabelAndOperatorFromToken(token, hasWildcardOperators);
 
   if (token.filter === FilterType.IS) {
     return {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -17,8 +17,7 @@ import {
   getValidOpsForFilter,
   OP_LABELS,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
-import type {FETermOperators} from 'sentry/components/searchQueryBuilder/types';
-import {ExtendedTermOperators} from 'sentry/components/searchQueryBuilder/types';
+import {type FETermOperators} from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
   recentSearchTypeToLabel,
@@ -26,7 +25,7 @@ import {
 import {
   FilterType,
   type ParseResultToken,
-  type TermOperator,
+  TermOperator,
   type Token,
   type TokenResult,
 } from 'sentry/components/searchSyntax/parser';
@@ -52,10 +51,10 @@ function getOperatorFromDateToken(token: TokenResult<Token.FILTER>) {
       return token.operator;
     case FilterType.RELATIVE_DATE:
       return token.value.sign === '+'
-        ? ExtendedTermOperators.LESS_THAN
-        : ExtendedTermOperators.GREATER_THAN;
+        ? TermOperator.LESS_THAN
+        : TermOperator.GREATER_THAN;
     default:
-      return ExtendedTermOperators.DEFAULT;
+      return TermOperator.DEFAULT;
   }
 }
 
@@ -103,8 +102,7 @@ export function getOperatorInfo(
     return {
       operator,
       label: <OpLabel>{opLabel}</OpLabel>,
-      options: DATE_OPTIONS.map((op): SelectOption<ExtendedTermOperators> => {
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      options: DATE_OPTIONS.map((op): SelectOption<FETermOperators> => {
         const optionOpLabel = DATE_OP_LABELS[op] ?? op;
 
         return {
@@ -125,13 +123,13 @@ export function getOperatorInfo(
         <FilterKeyOperatorLabel
           keyValue={token.key.value}
           keyLabel={token.key.text}
-          opLabel={operator === ExtendedTermOperators.NOT_EQUAL ? 'not' : undefined}
+          opLabel={operator === TermOperator.NOT_EQUAL ? 'not' : undefined}
           includeKeyLabel
         />
       ),
       options: [
         {
-          value: ExtendedTermOperators.DEFAULT,
+          value: TermOperator.DEFAULT,
           label: (
             <FilterKeyOperatorLabel
               keyLabel={token.key.text}
@@ -142,7 +140,7 @@ export function getOperatorInfo(
           textValue: 'is',
         },
         {
-          value: ExtendedTermOperators.NOT_EQUAL,
+          value: TermOperator.NOT_EQUAL,
           label: (
             <FilterKeyOperatorLabel
               keyLabel={token.key.text}
@@ -163,15 +161,13 @@ export function getOperatorInfo(
       label: (
         <FilterKeyOperatorLabel
           keyValue={token.key.value}
-          keyLabel={
-            operator === ExtendedTermOperators.NOT_EQUAL ? 'does not have' : 'has'
-          }
+          keyLabel={operator === TermOperator.NOT_EQUAL ? 'does not have' : 'has'}
           includeKeyLabel
         />
       ),
       options: [
         {
-          value: ExtendedTermOperators.DEFAULT,
+          value: TermOperator.DEFAULT,
           label: (
             <FilterKeyOperatorLabel
               keyLabel="has"
@@ -182,7 +178,7 @@ export function getOperatorInfo(
           textValue: 'has',
         },
         {
-          value: ExtendedTermOperators.NOT_EQUAL,
+          value: TermOperator.NOT_EQUAL,
           label: (
             <FilterKeyOperatorLabel
               keyLabel="does not have"
@@ -202,8 +198,8 @@ export function getOperatorInfo(
     operator,
     label: <OpLabel>{label}</OpLabel>,
     options: getValidOpsForFilter(token, hasWildcardOperators)
-      .filter(op => op !== ExtendedTermOperators.EQUAL)
-      .map((op): SelectOption<ExtendedTermOperators> => {
+      .filter(op => op !== TermOperator.EQUAL)
+      .map((op): SelectOption<FETermOperators> => {
         const optionOpLabel = OP_LABELS[op] ?? op;
 
         return {
@@ -263,7 +259,7 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
         dispatch({
           type: 'UPDATE_FILTER_OP',
           token,
-          op: option.value as unknown as TermOperator,
+          op: option.value,
         });
       }}
       offset={MENU_OFFSET}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -17,7 +17,7 @@ import {
   getValidOpsForFilter,
   OP_LABELS,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
-import {type FETermOperators} from 'sentry/components/searchQueryBuilder/types';
+import {type SearchQueryBuilderOperators} from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
   recentSearchTypeToLabel,
@@ -91,8 +91,8 @@ export function getOperatorInfo(
   hasWildcardOperators: boolean
 ): {
   label: ReactNode;
-  operator: FETermOperators;
-  options: Array<SelectOption<FETermOperators>>;
+  operator: SearchQueryBuilderOperators;
+  options: Array<SelectOption<SearchQueryBuilderOperators>>;
 } {
   if (isDateToken(token)) {
     const operator = getOperatorFromDateToken(token);
@@ -102,7 +102,7 @@ export function getOperatorInfo(
     return {
       operator,
       label: <OpLabel>{opLabel}</OpLabel>,
-      options: DATE_OPTIONS.map((op): SelectOption<FETermOperators> => {
+      options: DATE_OPTIONS.map((op): SelectOption<SearchQueryBuilderOperators> => {
         const optionOpLabel = DATE_OP_LABELS[op] ?? op;
 
         return {
@@ -199,7 +199,7 @@ export function getOperatorInfo(
     label: <OpLabel>{label}</OpLabel>,
     options: getValidOpsForFilter(token, hasWildcardOperators)
       .filter(op => op !== TermOperator.EQUAL)
-      .map((op): SelectOption<FETermOperators> => {
+      .map((op): SelectOption<SearchQueryBuilderOperators> => {
         const optionOpLabel = OP_LABELS[op] ?? op;
 
         return {

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -17,6 +17,7 @@ import {
   getValidOpsForFilter,
   OP_LABELS,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import type {FETermOperators} from 'sentry/components/searchQueryBuilder/types';
 import {ExtendedTermOperators} from 'sentry/components/searchQueryBuilder/types';
 import {
   isDateToken,
@@ -91,8 +92,8 @@ export function getOperatorInfo(
   hasWildcardOperators: boolean
 ): {
   label: ReactNode;
-  operator: ExtendedTermOperators;
-  options: Array<SelectOption<ExtendedTermOperators>>;
+  operator: FETermOperators;
+  options: Array<SelectOption<FETermOperators>>;
 } {
   if (isDateToken(token)) {
     const operator = getOperatorFromDateToken(token);

--- a/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parsers/string/parser.spec.tsx
@@ -1,5 +1,5 @@
 import {parseMultiSelectFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/string/parser';
-import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
+import {WildcardPositions} from 'sentry/components/searchSyntax/parser';
 
 describe('parseMultiSelectValue', function () {
   it('single value', function () {
@@ -140,7 +140,7 @@ describe('parseMultiSelectValue', function () {
       expect(result!.items).toHaveLength(1);
       expect(result!.items[0]!.value?.value).toBe('*a*');
       expect(result!.items[0]!.value?.text).toBe('*a*');
-      expect(result!.items[0]!.value?.wildcard).toBe(WildcardOperators.SURROUNDED);
+      expect(result!.items[0]!.value?.wildcard).toBe(WildcardPositions.SURROUNDED);
     });
 
     it('multiple value', function () {
@@ -151,11 +151,11 @@ describe('parseMultiSelectValue', function () {
       expect(result!.items).toHaveLength(3);
       expect(result?.items[0]!.value?.value).toBe('*a*');
       expect(result?.items[0]!.value?.text).toBe('*a*');
-      expect(result?.items[0]!.value?.wildcard).toBe(WildcardOperators.SURROUNDED);
+      expect(result?.items[0]!.value?.wildcard).toBe(WildcardPositions.SURROUNDED);
 
       expect(result?.items[1]!.value?.value).toBe('*b*');
       expect(result?.items[1]!.value?.text).toBe('*b*');
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.SURROUNDED);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.SURROUNDED);
 
       expect(result?.items[2]!.value?.value).toBe('c');
       expect(result?.items[2]!.value?.text).toBe('c');
@@ -173,7 +173,7 @@ describe('parseMultiSelectValue', function () {
       expect(result?.items[1]!.value?.value).toBe('*b*');
       expect(result?.items[1]!.value?.text).toBe('"*b*"');
       expect(result?.items[1]!.value?.quoted).toBe(true);
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.SURROUNDED);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.SURROUNDED);
 
       expect(result!.items[2]!.value?.value).toBe('c');
     });
@@ -188,7 +188,7 @@ describe('parseMultiSelectValue', function () {
       expect(result?.items[0]!.value?.value).toBe('a');
       expect(result?.items[1]!.value?.value).toBe('*b c*');
       expect(result?.items[1]!.value?.text).toBe('*b c*');
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.SURROUNDED);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.SURROUNDED);
 
       expect(result?.items[2]!.value?.value).toBe('d');
     });
@@ -202,7 +202,7 @@ describe('parseMultiSelectValue', function () {
       expect(result!.items).toHaveLength(1);
       expect(result!.items[0]!.value?.value).toBe('a*');
       expect(result!.items[0]!.value?.text).toBe('a*');
-      expect(result!.items[0]!.value?.wildcard).toBe(WildcardOperators.TRAILING);
+      expect(result!.items[0]!.value?.wildcard).toBe(WildcardPositions.TRAILING);
     });
 
     it('multiple value', function () {
@@ -213,11 +213,11 @@ describe('parseMultiSelectValue', function () {
       expect(result!.items).toHaveLength(3);
       expect(result?.items[0]!.value?.value).toBe('a*');
       expect(result?.items[0]!.value?.text).toBe('a*');
-      expect(result?.items[0]!.value?.wildcard).toBe(WildcardOperators.TRAILING);
+      expect(result?.items[0]!.value?.wildcard).toBe(WildcardPositions.TRAILING);
 
       expect(result?.items[1]!.value?.value).toBe('b*');
       expect(result?.items[1]!.value?.text).toBe('b*');
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.TRAILING);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.TRAILING);
 
       expect(result?.items[2]!.value?.value).toBe('c');
       expect(result?.items[2]!.value?.text).toBe('c');
@@ -235,7 +235,7 @@ describe('parseMultiSelectValue', function () {
       expect(result?.items[1]!.value?.value).toBe('b*');
       expect(result?.items[1]!.value?.text).toBe('"b*"');
       expect(result?.items[1]!.value?.quoted).toBe(true);
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.TRAILING);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.TRAILING);
 
       expect(result!.items[2]!.value?.value).toBe('c');
     });
@@ -250,7 +250,7 @@ describe('parseMultiSelectValue', function () {
       expect(result?.items[0]!.value?.value).toBe('a');
       expect(result?.items[1]!.value?.value).toBe('b c*');
       expect(result?.items[1]!.value?.text).toBe('b c*');
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.TRAILING);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.TRAILING);
 
       expect(result?.items[2]!.value?.value).toBe('d');
     });
@@ -264,7 +264,7 @@ describe('parseMultiSelectValue', function () {
       expect(result!.items).toHaveLength(1);
       expect(result!.items[0]!.value?.value).toBe('*a');
       expect(result!.items[0]!.value?.text).toBe('*a');
-      expect(result!.items[0]!.value?.wildcard).toBe(WildcardOperators.LEADING);
+      expect(result!.items[0]!.value?.wildcard).toBe(WildcardPositions.LEADING);
     });
 
     it('multiple value', function () {
@@ -275,11 +275,11 @@ describe('parseMultiSelectValue', function () {
       expect(result!.items).toHaveLength(3);
       expect(result?.items[0]!.value?.value).toBe('*a');
       expect(result?.items[0]!.value?.text).toBe('*a');
-      expect(result?.items[0]!.value?.wildcard).toBe(WildcardOperators.LEADING);
+      expect(result?.items[0]!.value?.wildcard).toBe(WildcardPositions.LEADING);
 
       expect(result?.items[1]!.value?.value).toBe('*b');
       expect(result?.items[1]!.value?.text).toBe('*b');
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.LEADING);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.LEADING);
 
       expect(result?.items[2]!.value?.value).toBe('c');
       expect(result?.items[2]!.value?.text).toBe('c');
@@ -297,7 +297,7 @@ describe('parseMultiSelectValue', function () {
       expect(result?.items[1]!.value?.value).toBe('*b');
       expect(result?.items[1]!.value?.text).toBe('"*b"');
       expect(result?.items[1]!.value?.quoted).toBe(true);
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.LEADING);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.LEADING);
 
       expect(result!.items[2]!.value?.value).toBe('c');
     });
@@ -312,7 +312,7 @@ describe('parseMultiSelectValue', function () {
       expect(result?.items[0]!.value?.value).toBe('a');
       expect(result?.items[1]!.value?.value).toBe('*b c');
       expect(result?.items[1]!.value?.text).toBe('*b c');
-      expect(result?.items[1]!.value?.wildcard).toBe(WildcardOperators.LEADING);
+      expect(result?.items[1]!.value?.wildcard).toBe(WildcardPositions.LEADING);
 
       expect(result?.items[2]!.value?.value).toBe('d');
     });

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -42,7 +42,7 @@ export const DATE_OP_LABELS = {
   [ExtendedTermOperators.DEFAULT]: 'is',
 };
 
-export const DATE_OPTIONS: FETermOperators[] = [
+export const DATE_OPTIONS = [
   ExtendedTermOperators.GREATER_THAN,
   ExtendedTermOperators.GREATER_THAN_EQUAL,
   ExtendedTermOperators.LESS_THAN,

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -206,8 +206,11 @@ function getIsEndsWith(tokenValue: TokenValue) {
   return tokenValue === WildcardOperators.LEADING;
 }
 
-export function getLabelAndOperatorFromToken(token: TokenResult<Token.FILTER>) {
-  if (token.value.type === Token.VALUE_TEXT) {
+export function getLabelAndOperatorFromToken(
+  token: TokenResult<Token.FILTER>,
+  hasWildcardOperators: boolean
+) {
+  if (token.value.type === Token.VALUE_TEXT && hasWildcardOperators) {
     if (getIsContains(token.value.wildcard)) {
       return {
         label: token.negated ? t('does not contain') : t('contains'),
@@ -230,7 +233,7 @@ export function getLabelAndOperatorFromToken(token: TokenResult<Token.FILTER>) {
         operator: ExtendedTermOperators.ENDS_WITH,
       };
     }
-  } else if (token.value.type === Token.VALUE_TEXT_LIST) {
+  } else if (token.value.type === Token.VALUE_TEXT_LIST && hasWildcardOperators) {
     if (token.value.items.every(entry => getIsContains(entry.value?.wildcard))) {
       return {
         label: token.negated ? t('does not contain') : t('contains'),

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -1,5 +1,5 @@
 import {
-  type FETermOperators,
+  type SearchQueryBuilderOperators,
   WildcardOperators,
 } from 'sentry/components/searchQueryBuilder/types';
 import {
@@ -73,11 +73,11 @@ export function isAggregateFilterToken(
 export function getValidOpsForFilter(
   filterToken: TokenResult<Token.FILTER>,
   hasWildcardOperators: boolean
-): readonly FETermOperators[] {
+): readonly SearchQueryBuilderOperators[] {
   const fieldDefinition = getFieldDefinition(filterToken.key.text);
 
   if (fieldDefinition?.allowComparisonOperators) {
-    const validOps = new Set<FETermOperators>(allOperators);
+    const validOps = new Set<SearchQueryBuilderOperators>(allOperators);
 
     return [...validOps];
   }
@@ -95,7 +95,7 @@ export function getValidOpsForFilter(
   const allValidTypes = [...new Set([...validTypes, ...interchangeableTypes.flat()])];
 
   // Find all valid operations
-  const validOps = new Set<FETermOperators>(
+  const validOps = new Set<SearchQueryBuilderOperators>(
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     allValidTypes.flatMap(type => filterTypeConfig[type].validOps)
   );

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -47,17 +47,6 @@ export function getValidOpsForFilter(
       allOperators as unknown as ExtendedTermOperators[]
     );
 
-    if (
-      isTextFilter &&
-      fieldDefinition?.allowWildcard === false &&
-      !hasWildcardOperators
-    ) {
-      validOps.delete(ExtendedTermOperators.CONTAINS);
-      validOps.delete(ExtendedTermOperators.DOES_NOT_CONTAIN);
-      validOps.delete(ExtendedTermOperators.STARTS_WITH);
-      validOps.delete(ExtendedTermOperators.ENDS_WITH);
-    }
-
     return [...validOps];
   }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -231,7 +231,7 @@ export function getLabelAndOperatorFromToken(token: TokenResult<Token.FILTER>) {
       };
     }
   } else if (token.value.type === Token.VALUE_TEXT_LIST) {
-    if (getIsContains(token.value.items.every(entry => entry.value?.wildcard))) {
+    if (token.value.items.every(entry => getIsContains(entry.value?.wildcard))) {
       return {
         label: token.negated ? t('does not contain') : t('contains'),
         operator: token.negated

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -19,6 +19,37 @@ import {
 
 const SHOULD_ESCAPE_REGEX = /[\s"(),]/;
 
+export const OP_LABELS = {
+  [ExtendedTermOperators.DEFAULT]: 'is',
+  [ExtendedTermOperators.GREATER_THAN]: '>',
+  [ExtendedTermOperators.GREATER_THAN_EQUAL]: '>=',
+  [ExtendedTermOperators.LESS_THAN]: '<',
+  [ExtendedTermOperators.LESS_THAN_EQUAL]: '<=',
+  [ExtendedTermOperators.EQUAL]: 'is',
+  [ExtendedTermOperators.NOT_EQUAL]: 'is not',
+  [ExtendedTermOperators.CONTAINS]: 'contains',
+  [ExtendedTermOperators.DOES_NOT_CONTAIN]: 'does not contain',
+  [ExtendedTermOperators.STARTS_WITH]: 'starts with',
+  [ExtendedTermOperators.ENDS_WITH]: 'ends with',
+};
+
+export const DATE_OP_LABELS = {
+  [ExtendedTermOperators.GREATER_THAN]: 'is after',
+  [ExtendedTermOperators.GREATER_THAN_EQUAL]: 'is on or after',
+  [ExtendedTermOperators.LESS_THAN]: 'is before',
+  [ExtendedTermOperators.LESS_THAN_EQUAL]: 'is on or before',
+  [ExtendedTermOperators.EQUAL]: 'is',
+  [ExtendedTermOperators.DEFAULT]: 'is',
+};
+
+export const DATE_OPTIONS: FETermOperators[] = [
+  ExtendedTermOperators.GREATER_THAN,
+  ExtendedTermOperators.GREATER_THAN_EQUAL,
+  ExtendedTermOperators.LESS_THAN,
+  ExtendedTermOperators.LESS_THAN_EQUAL,
+  ExtendedTermOperators.EQUAL,
+];
+
 export function isAggregateFilterToken(
   token: TokenResult<Token.FILTER>
 ): token is AggregateFilter {
@@ -175,7 +206,7 @@ function getIsEndsWith(tokenValue: TokenValue) {
   return tokenValue === WildcardOperators.LEADING;
 }
 
-export function getWildcardLabelAndOperator(token: TokenResult<Token.FILTER>) {
+export function getLabelAndOperatorFromToken(token: TokenResult<Token.FILTER>) {
   if (token.value.type === Token.VALUE_TEXT) {
     if (getIsContains(token.value.wildcard)) {
       return {
@@ -224,5 +255,11 @@ export function getWildcardLabelAndOperator(token: TokenResult<Token.FILTER>) {
     }
   }
 
-  return null;
+  const operator = token.negated ? ExtendedTermOperators.NOT_EQUAL : token.operator;
+  const label = OP_LABELS[operator] ?? operator;
+
+  return {
+    label,
+    operator,
+  };
 }

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -38,8 +38,8 @@ export enum WildcardOperators {
   ENDS_WITH = 'ends with',
 }
 
-export function isTermOperator(op: FETermOperators): op is TermOperator {
+export function isTermOperator(op: SearchQueryBuilderOperators): op is TermOperator {
   return typeof op === 'string' && Object.values(TermOperator).includes(op as any);
 }
 
-export type FETermOperators = TermOperator | WildcardOperators;
+export type SearchQueryBuilderOperators = TermOperator | WildcardOperators;

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -25,3 +25,17 @@ export type CallbackSearchState = {
   parsedQuery: ParseResult | null;
   queryIsValid: boolean;
 };
+
+export enum ExtendedTermOperators {
+  DEFAULT = '',
+  GREATER_THAN_EQUAL = '>=',
+  LESS_THAN_EQUAL = '<=',
+  GREATER_THAN = '>',
+  LESS_THAN = '<',
+  EQUAL = '=',
+  NOT_EQUAL = '!=',
+  CONTAINS = 'contains',
+  DOES_NOT_CONTAIN = 'does not contain',
+  STARTS_WITH = 'starts with',
+  ENDS_WITH = 'ends with',
+}

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 
-import type {ParseResult, TermOperator} from 'sentry/components/searchSyntax/parser';
+import {type ParseResult, TermOperator} from 'sentry/components/searchSyntax/parser';
 import type {FieldDefinition} from 'sentry/utils/fields';
 
 export type FilterKeySection = {
@@ -27,23 +27,19 @@ export type CallbackSearchState = {
 };
 
 /**
- * This is a list of operators that are used in the search query builder. That are only
- * present on the frontend. This is because of the wildcard operators, and the fact that
- * we utilize the underlying '*' character rather than introducing new operators on the
- * backend.
+ * This is a list of wildcard operators that are used in the search query builder.
+ * These are only present on the frontend. This is because we utilize the underlying
+ * '*' character rather than introducing new operators on the backend.
  */
-export enum ExtendedTermOperators {
-  DEFAULT = '',
-  GREATER_THAN_EQUAL = '>=',
-  LESS_THAN_EQUAL = '<=',
-  GREATER_THAN = '>',
-  LESS_THAN = '<',
-  EQUAL = '=',
-  NOT_EQUAL = '!=',
+export enum WildcardOperators {
   CONTAINS = 'contains',
   DOES_NOT_CONTAIN = 'does not contain',
   STARTS_WITH = 'starts with',
   ENDS_WITH = 'ends with',
 }
 
-export type FETermOperators = ExtendedTermOperators | TermOperator;
+export function isTermOperator(op: FETermOperators): op is TermOperator {
+  return op in TermOperator;
+}
+
+export type FETermOperators = TermOperator | WildcardOperators;

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -26,6 +26,12 @@ export type CallbackSearchState = {
   queryIsValid: boolean;
 };
 
+/**
+ * This is a list of operators that are used in the search query builder. That are only
+ * present on the frontend. This is because of the wildcard operators, and the fact that
+ * we utilize the underlying '*' character rather than introducing new operators on the
+ * backend.
+ */
 export enum ExtendedTermOperators {
   DEFAULT = '',
   GREATER_THAN_EQUAL = '>=',

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -39,7 +39,7 @@ export enum WildcardOperators {
 }
 
 export function isTermOperator(op: FETermOperators): op is TermOperator {
-  return op in TermOperator;
+  return typeof op === 'string' && Object.values(TermOperator).includes(op as any);
 }
 
 export type FETermOperators = TermOperator | WildcardOperators;

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 
-import type {ParseResult} from 'sentry/components/searchSyntax/parser';
+import type {ParseResult, TermOperator} from 'sentry/components/searchSyntax/parser';
 import type {FieldDefinition} from 'sentry/utils/fields';
 
 export type FilterKeySection = {
@@ -45,3 +45,5 @@ export enum ExtendedTermOperators {
   STARTS_WITH = 'starts with',
   ENDS_WITH = 'ends with',
 }
+
+export type FETermOperators = ExtendedTermOperators | TermOperator;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -112,7 +112,7 @@ export enum FilterType {
 }
 
 /**
- * The type of wildcard operator based off of positions of asterisks in the token value.
+ * The type of wildcard based off of positions of asterisks in the token value.
  * These can be used to determine the type of wildcard operator used in the token value,
  * and include the following:
  *
@@ -120,7 +120,7 @@ export enum FilterType {
  * - `trailing` (starts with): The value is suffixed with `*` e.g. `value*`
  * - `surrounded` (contains): The value is prefixed and suffixed with `*` e.g. `*value*`
  */
-export enum WildcardOperators {
+export enum WildcardPositions {
   /**
    * The value is leads with `*`, e.g. `*value`, i.e. the user is searching for values
    * that end with `<value>`.
@@ -730,13 +730,13 @@ export class TokenConverter {
     const valueSet = new Set(value);
     const onlyAsterisks = valueSet.size === 1 && valueSet.has('*');
 
-    let wildcard: WildcardOperators | false = false;
+    let wildcard: WildcardPositions | false = false;
     if (!onlyAsterisks && value.startsWith('*') && value.endsWith('*')) {
-      wildcard = WildcardOperators.SURROUNDED;
+      wildcard = WildcardPositions.SURROUNDED;
     } else if (!onlyAsterisks && value.endsWith('*')) {
-      wildcard = WildcardOperators.TRAILING;
+      wildcard = WildcardPositions.TRAILING;
     } else if (!onlyAsterisks && value.startsWith('*')) {
-      wildcard = WildcardOperators.LEADING;
+      wildcard = WildcardPositions.LEADING;
     }
 
     return {


### PR DESCRIPTION
This PR focuses on updating the `FilterOperator` component to display some upcoming wildcard operators options `"contains", "does not contain", "starts with", "ends with"`. 

To accomplish this, I added in a new enum with the new term operators as they aren't actual operators with related symbols (e.g. `>=`), instead they will detect wildcard (`*`) characters and their location and depending on those wildcards it will determine which operator to display. Currently if you select one of the operators it will break. The underlying work to update the value with the respective wildcards will come in a follow up PR.

Example:
![Screenshot 2025-05-30 at 15 20 38](https://github.com/user-attachments/assets/e1d4d5b6-017b-4ade-bda4-d26d08ce6d85)