### PR TITLE
chore(autofix): Seer beta banner copy changes

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -193,6 +193,7 @@ type ComponentHooks = {
   'component:replay-onboarding-alert': () => React.ComponentType<ReplayOnboardingAlertProps>;
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
   'component:replay-settings-alert': () => React.ComponentType | null;
+  'component:seer-beta-closing-alert': () => React.ComponentType;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;
   'component:superuser-warning-excluded': SuperuserWarningExcluded;

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -18,13 +18,13 @@ import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {IconChevron, IconClose} from 'sentry/icons';
+import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import {FieldKey} from 'sentry/utils/fields';
-import useDismissAlert from 'sentry/utils/useDismissAlert';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
@@ -37,41 +37,10 @@ interface SeerNoticesProps {
   hasGithubIntegration?: boolean;
 }
 
-// Temporary Seer beta closing alert
-function SeerBetaClosingAlert() {
-  const {isDismissed, dismiss} = useDismissAlert({
-    key: 'seer-beta-closing-alert-dismissed',
-  });
-  if (isDismissed) return null;
-  return (
-    <StyledAlert
-      type="info"
-      showIcon
-      trailingItems={
-        <Button
-          aria-label="dismiss"
-          icon={<IconClose />}
-          onClick={dismiss}
-          size="zero"
-          borderless
-        />
-      }
-    >
-      <AlertBody>
-        <span>
-          <b>Seer beta is ending soon</b>
-        </span>
-        <span>
-          Thanks for trying Seer. FYI: Starting June 10th, Seer will require a $20/month
-          subscription to continue scanning and fixing issues.
-        </span>
-        <ExternalLink href="https://docs.sentry.io/pricing/#seer-pricing/">
-          Learn more
-        </ExternalLink>
-      </AlertBody>
-    </StyledAlert>
-  );
-}
+const SeerBetaClosingAlert = HookOrDefault({
+  hookName: 'component:seer-beta-closing-alert',
+  defaultComponent: () => <div data-test-id="seer-beta-closing-alert" />,
+});
 
 export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNoticesProps) {
   const organization = useOrganization();
@@ -392,12 +361,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
 
 const StyledAlert = styled(Alert)`
   margin-bottom: ${space(2)};
-`;
-
-const AlertBody = styled('div')`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(0.5)};
 `;
 
 const NoticesContainer = styled('div')`

--- a/static/gsApp/components/ai/SeerBetaClosingAlert.tsx
+++ b/static/gsApp/components/ai/SeerBetaClosingAlert.tsx
@@ -1,0 +1,90 @@
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {IconClose} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+
+import useSubscription from 'getsentry/hooks/useSubscription';
+import {BillingType} from 'getsentry/types';
+
+// Temporary Seer beta closing alert
+function SeerBetaClosingAlert() {
+  const {isDismissed, dismiss} = useDismissAlert({
+    key: 'seer-beta-closing-alert-dismissed',
+  });
+  const subscription = useSubscription();
+  const isTouchCustomer = subscription?.type === BillingType.INVOICED;
+
+  if (isDismissed) return null;
+  if (isTouchCustomer) {
+    return (
+      <StyledAlert
+        type="info"
+        showIcon
+        trailingItems={
+          <Button
+            aria-label="dismiss"
+            icon={<IconClose />}
+            onClick={dismiss}
+            size="zero"
+            borderless
+          />
+        }
+      >
+        <AlertBody>
+          <span>
+            <b>Seer beta is ending soon</b>
+          </span>
+          <span>
+            Thanks for trying Seer. Starting June 10, Seer will require a committed budget
+            to continue scanning and fixing issues. Reach out to your account manager to
+            learn more.
+          </span>
+        </AlertBody>
+      </StyledAlert>
+    );
+  }
+  return (
+    <StyledAlert
+      type="info"
+      showIcon
+      trailingItems={
+        <Button
+          aria-label="dismiss"
+          icon={<IconClose />}
+          onClick={dismiss}
+          size="zero"
+          borderless
+        />
+      }
+    >
+      <AlertBody>
+        <span>
+          <b>Seer beta is ending soon</b>
+        </span>
+        <span>
+          Thanks for trying Seer. Starting June 10, Seer will require a $20/month
+          subscription to continue scanning and fixing issues.
+        </span>
+        <ExternalLink href="https://docs.sentry.io/pricing/#seer-pricing/">
+          Learn more
+        </ExternalLink>
+      </AlertBody>
+    </StyledAlert>
+  );
+}
+
+export default SeerBetaClosingAlert;
+
+const AlertBody = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(2)};
+`;

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -6,6 +6,7 @@ import HookStore from 'sentry/stores/hookStore';
 import type {Hooks} from 'sentry/types/hooks';
 
 import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
+import SeerBetaClosingAlert from 'getsentry/components/ai/SeerBetaClosingAlert';
 import CronsBillingBanner from 'getsentry/components/crons/cronsBillingBanner';
 import DashboardBanner from 'getsentry/components/dashboardBanner';
 import DataConsentBanner from 'getsentry/components/dataConsentBanner';
@@ -204,6 +205,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'component:insights-date-range-query-limit-footer': () =>
     InsightsDateRangeQueryLimitFooter,
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
+  'component:seer-beta-closing-alert': () => SeerBetaClosingAlert,
   'component:codecov-integration-settings-link': () => CodecovSettingsLink,
   'component:continuous-profiling-beta-banner': () => ContinuousProfilingBetaAlertBanner,
   'component:continuous-profiling-beta-sdk-banner': () =>


### PR DESCRIPTION
Show different banners depending on whether a customer is sales led or not.

<img width="761" alt="Screenshot 2025-05-30 at 12 03 05 PM" src="https://github.com/user-attachments/assets/11ec6c56-45af-4786-9319-b29fe3c53844" />
