### PR TITLE
feat(ourlogs): Use /trace-logs endpoint

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -59,6 +59,11 @@ interface LogsPageParams {
    */
   readonly baseSearch?: MutableSearch;
   /**
+   * If provided, add a 'trace:{trace id}' to all queries.
+   * Used in embedded views like error page and trace page
+   */
+  readonly limitToTraceId?: string;
+  /**
    * If provided, ignores the project in the location and uses the provided project IDs.
    * Useful for cross-project traces when project is in the location.
    */
@@ -144,6 +149,7 @@ export function LogsPageParamsProvider({
         baseSearch,
         projectIds,
         analyticsPageSource,
+        limitToTraceId,
       }}
     >
       {children}
@@ -255,6 +261,11 @@ export function useLogsCursor() {
 export function useLogsIsFrozen() {
   const {isTableFrozen} = useLogsPageParams();
   return !!isTableFrozen;
+}
+
+export function useLogsLimitToTraceId() {
+  const {limitToTraceId} = useLogsPageParams();
+  return limitToTraceId;
 }
 
 export function useSetLogsCursor() {

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -252,6 +252,11 @@ export function useLogsCursor() {
   return cursor;
 }
 
+export function useLogsIsFrozen() {
+  const {isTableFrozen} = useLogsPageParams();
+  return !!isTableFrozen;
+}
+
 export function useSetLogsCursor() {
   const setPageParams = useSetLogsPageParams();
   const {setCursorForFrozenPages, isTableFrozen} = useLogsPageParams();

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -14,7 +14,6 @@ import {
   useInfiniteQuery,
   useQueryClient,
 } from 'sentry/utils/queryClient';
-import {TokenType} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -24,6 +23,7 @@ import {
   useLogsCursor,
   useLogsFields,
   useLogsIsFrozen,
+  useLogsLimitToTraceId,
   useLogsProjectIds,
   useLogsRefreshInterval,
   useLogsSearch,
@@ -98,15 +98,10 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   const _fields = useLogsFields();
   const sortBys = useLogsSortBys();
   const isFrozen = useLogsIsFrozen();
+  const limitToTraceId = useLogsLimitToTraceId();
   const {selection, isReady: pageFiltersReady} = usePageFilters();
   const location = useLocation();
   const projectIds = useLogsProjectIds();
-  const traceIds = baseSearch?.tokens
-    .filter(
-      token =>
-        token.key === OurLogKnownFieldKey.TRACE_ID && token.type === TokenType.FILTER
-    )
-    .map(token => token.value);
 
   const search = baseSearch ? _search.copy() : _search;
   if (baseSearch) {
@@ -121,7 +116,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   const params = {
     query: {
       ...eventView.getEventsAPIPayload(location),
-      ...(traceIds ? {traceId: traceIds} : {}),
+      ...(limitToTraceId ? {traceId: limitToTraceId} : {}),
       cursor,
       per_page: limit ? limit : undefined,
     },
@@ -131,7 +126,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   };
 
   const queryKey: ApiQueryKey = [
-    `/organizations/${organization.slug}/${traceIds && isFrozen ? 'trace-logs' : 'events'}/`,
+    `/organizations/${organization.slug}/${limitToTraceId && isFrozen ? 'trace-logs' : 'events'}/`,
     params,
   ];
 

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -23,6 +23,7 @@ import {
   useLogsBaseSearch,
   useLogsCursor,
   useLogsFields,
+  useLogsIsFrozen,
   useLogsProjectIds,
   useLogsRefreshInterval,
   useLogsSearch,
@@ -96,6 +97,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   const cursor = useLogsCursor();
   const _fields = useLogsFields();
   const sortBys = useLogsSortBys();
+  const isFrozen = useLogsIsFrozen();
   const {selection, isReady: pageFiltersReady} = usePageFilters();
   const location = useLocation();
   const projectIds = useLogsProjectIds();
@@ -129,7 +131,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   };
 
   const queryKey: ApiQueryKey = [
-    `/organizations/${organization.slug}/${traceIds ? 'trace-logs' : 'events'}/`,
+    `/organizations/${organization.slug}/${traceIds && isFrozen ? 'trace-logs' : 'events'}/`,
     params,
   ];
 
@@ -177,11 +179,8 @@ export function useLogsQuery({
     isError: queryResult.isError,
     isLoading: queryResult.isLoading,
     queryResult,
-    // /events and /trace-logs have slightly different output formats
-    data: Array.isArray(queryResult?.data) ? queryResult?.data : queryResult?.data?.data,
-    infiniteData: Array.isArray(queryResult?.data)
-      ? queryResult?.data
-      : queryResult?.data?.data,
+    data: queryResult?.data?.data,
+    infiniteData: queryResult?.data?.data,
     error: queryResult.error,
     meta: queryResult?.data?.meta,
     pageLinks: queryResult?.getResponseHeader?.('Link') ?? undefined,


### PR DESCRIPTION
The /events endpoint does not allow some users to use ?project=-1, we added a new endpoint which acts like /events but supports multi-project search if the trace ID is explicitly added.