### PR TITLE
fix(search): Fix issue with tags name 'constructor'

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2581,11 +2581,11 @@ export const getFieldDefinition = (
 ): FieldDefinition | null => {
   switch (type) {
     case 'replay':
-      if (key in REPLAY_FIELD_DEFINITIONS) {
+      if (REPLAY_FIELD_DEFINITIONS.hasOwnProperty(key)) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         return REPLAY_FIELD_DEFINITIONS[key];
       }
-      if (key in REPLAY_CLICK_FIELD_DEFINITIONS) {
+      if (REPLAY_CLICK_FIELD_DEFINITIONS.hasOwnProperty(key)) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         return REPLAY_CLICK_FIELD_DEFINITIONS[key];
       }
@@ -2595,7 +2595,7 @@ export const getFieldDefinition = (
       }
       return null;
     case 'feedback':
-      if (key in FEEDBACK_FIELD_DEFINITIONS) {
+      if (FEEDBACK_FIELD_DEFINITIONS.hasOwnProperty(key)) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         return FEEDBACK_FIELD_DEFINITIONS[key];
       }
@@ -2625,7 +2625,7 @@ export const getFieldDefinition = (
       return null;
 
     case 'log':
-      if (key in LOG_FIELD_DEFINITIONS) {
+      if (LOG_FIELD_DEFINITIONS.hasOwnProperty(key)) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         return LOG_FIELD_DEFINITIONS[key];
       }
@@ -2644,8 +2644,11 @@ export const getFieldDefinition = (
 
     case 'event':
     default:
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      return EVENT_FIELD_DEFINITIONS[key] ?? null;
+      if (EVENT_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+        return EVENT_FIELD_DEFINITIONS[key];
+      }
+      return null;
   }
 };
 


### PR DESCRIPTION
Fixes JAVASCRIPT-316S
Fixes JAVASCRIPT-310F

Javascript is so fun.

When there is a tag named `constructor`, we were being returned the contructor function from the field definition mapping instead of undefined like the code had expected, causing a crash later on.