### PR TITLE
ref(aci): ref updateAction to update integrationId, config, or data blob

### DIFF
--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -1,8 +1,21 @@
 export interface Action {
+  config: {
+    target_type: ActionTarget;
+    target_display?: string;
+    target_identifier?: string;
+  };
   data: Record<string, unknown>;
   id: string;
   type: ActionType;
   integrationId?: string;
+}
+
+export enum ActionTarget {
+  SPECIFIC = 0,
+  USER = 1,
+  TEAM = 2,
+  SENTRY_APP = 3,
+  ISSUE_OWNERS = 4,
 }
 
 export enum ActionType {

--- a/static/app/views/automations/components/actionNodeList.tsx
+++ b/static/app/views/automations/components/actionNodeList.tsx
@@ -23,7 +23,7 @@ interface ActionNodeListProps {
   onAddRow: (actionId: string, actionHandler: ActionHandler) => void;
   onDeleteRow: (id: string) => void;
   placeholder: string;
-  updateAction: (id: string, data: Record<string, any>) => void;
+  updateAction: (id: string, params: Record<string, any>) => void;
 }
 
 interface Option {

--- a/static/app/views/automations/components/actionNodes.tsx
+++ b/static/app/views/automations/components/actionNodes.tsx
@@ -21,7 +21,7 @@ interface ActionNodeProps {
   action: Action;
   actionId: string;
   handler: ActionHandler;
-  onUpdate: (condition: Record<string, any>) => void;
+  onUpdate: (params: Record<string, any>) => void;
 }
 
 export const ActionNodeContext = createContext<ActionNodeProps | null>(null);

--- a/static/app/views/automations/components/actions/email.tsx
+++ b/static/app/views/automations/components/actions/email.tsx
@@ -6,14 +6,9 @@ import AutomationBuilderSelectField, {
   selectControlStyles,
 } from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {tct} from 'sentry/locale';
+import {ActionTarget} from 'sentry/types/workflowEngine/actions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
-
-enum TargetType {
-  USER = 'user',
-  TEAM = 'team',
-  ISSUE_OWNERS = 'issue_owners',
-}
 
 enum FallthroughChoiceType {
   ALL_MEMBERS = 'AllMembers',
@@ -22,9 +17,9 @@ enum FallthroughChoiceType {
 }
 
 const TARGET_TYPE_CHOICES = [
-  {value: TargetType.ISSUE_OWNERS, label: 'Suggested assignees'},
-  {value: TargetType.TEAM, label: 'Team'},
-  {value: TargetType.USER, label: 'Member'},
+  {value: ActionTarget.ISSUE_OWNERS, label: 'Suggested assignees'},
+  {value: ActionTarget.TEAM, label: 'Team'},
+  {value: ActionTarget.USER, label: 'Member'},
 ];
 
 const FALLTHROUGH_CHOICES = [
@@ -44,10 +39,12 @@ function TargetTypeField() {
   const {action, actionId, onUpdate} = useActionNodeContext();
   return (
     <AutomationBuilderSelectField
-      name={`${actionId}.data.targetType`}
-      value={action.data.targetType}
+      name={`${actionId}.config.target_type`}
+      value={action.config.target_type}
       options={TARGET_TYPE_CHOICES}
-      onChange={(value: string) => onUpdate({targetType: value, targetIdentifier: ''})}
+      onChange={(value: string) =>
+        onUpdate({config: {target_type: value, target_identifier: undefined}})
+      }
     />
   );
 }
@@ -56,27 +53,31 @@ function IdentifierField() {
   const {action, actionId, onUpdate} = useActionNodeContext();
   const organization = useOrganization();
 
-  if (action.data.targetType === TargetType.TEAM) {
+  if (action.config.target_type === ActionTarget.TEAM) {
     return (
       <SelectWrapper>
         <TeamSelector
-          name={`${actionId}.data.targetIdentifier`}
-          value={action.data.targetIdentifier}
-          onChange={(value: any) => onUpdate({targetIdentifier: value.actor.id})}
+          name={`${actionId}.config.target_identifier`}
+          value={action.config.target_identifier}
+          onChange={(value: any) =>
+            onUpdate({config: {target_identifier: value.actor.id}})
+          }
           useId
           styles={selectControlStyles}
         />
       </SelectWrapper>
     );
   }
-  if (action.data.targetType === TargetType.USER) {
+  if (action.config.target_type === ActionTarget.USER) {
     return (
       <SelectWrapper>
         <SelectMembers
           organization={organization}
-          key={`${actionId}.data.targetIdentifier`}
-          value={action.data.targetIdentifier}
-          onChange={(value: any) => onUpdate({targetIdentifier: value.actor.id})}
+          key={`${actionId}.config.target_identifier`}
+          value={action.config.target_identifier}
+          onChange={(value: any) =>
+            onUpdate({config: {target_identifier: value.actor.id}})
+          }
           styles={selectControlStyles}
         />
       </SelectWrapper>
@@ -94,7 +95,7 @@ function FallthroughField() {
       name={`${actionId}.data.fallthroughType`}
       value={action.data.fallthroughType}
       options={FALLTHROUGH_CHOICES}
-      onChange={(value: string) => onUpdate({fallthroughType: value})}
+      onChange={(value: string) => onUpdate({data: {fallthroughType: value}})}
     />
   );
 }

--- a/static/app/views/automations/components/actions/opsgenie.tsx
+++ b/static/app/views/automations/components/actions/opsgenie.tsx
@@ -32,7 +32,7 @@ function PriorityField() {
       }))}
       onChange={(value: string) => {
         onUpdate({
-          priority: value,
+          data: {priority: value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/pagerduty.tsx
+++ b/static/app/views/automations/components/actions/pagerduty.tsx
@@ -32,7 +32,7 @@ function SeverityField() {
       }))}
       onChange={(value: string) => {
         onUpdate({
-          severity: value,
+          data: {severity: value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/serviceField.tsx
+++ b/static/app/views/automations/components/actions/serviceField.tsx
@@ -12,15 +12,15 @@ export function ServiceField() {
 
   return (
     <AutomationBuilderSelectField
-      name={`${actionId}.data.targetId`}
-      value={action.data.targetId}
+      name={`${actionId}.config.target_identifier`}
+      value={action.config.target_identifier}
       options={integration.services?.map(service => ({
         label: service.name,
         value: service.id,
       }))}
       onChange={(value: string) => {
         onUpdate({
-          targetId: value,
+          config: {target_identifier: value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -55,7 +55,7 @@ function NotesField() {
       value={action.data.tags}
       onChange={(value: string) => {
         onUpdate({
-          tags: value,
+          data: {tags: value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/tagsField.tsx
+++ b/static/app/views/automations/components/actions/tagsField.tsx
@@ -11,7 +11,7 @@ export function TagsField() {
       value={action.data.tags}
       onChange={(value: string) => {
         onUpdate({
-          tags: value,
+          data: {tags: value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/targetDisplayField.tsx
+++ b/static/app/views/automations/components/actions/targetDisplayField.tsx
@@ -6,12 +6,12 @@ export function TargetDisplayField({placeholder}: {placeholder?: string}) {
   const {action, actionId, onUpdate} = useActionNodeContext();
   return (
     <AutomationBuilderInputField
-      name={`${actionId}.data.targetDisplay`}
+      name={`${actionId}.config.target_display`}
       placeholder={placeholder ? placeholder : t('channel name or ID')}
-      value={action.data.targetDisplay}
+      value={action.config.target_display}
       onChange={(value: string) => {
         onUpdate({
-          targetDisplay: value,
+          config: {target_display: value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/webhook.tsx
+++ b/static/app/views/automations/components/actions/webhook.tsx
@@ -14,15 +14,17 @@ function ServicesField() {
 
   return (
     <AutomationBuilderSelectField
-      name={`${actionId}.data.targetIdentifier`}
-      value={action.data.targetIdentifier}
+      name={`${actionId}.data.target_identifier`}
+      value={action.data.target_identifier}
       options={services?.map(service => ({
         label: service.name,
         value: service.slug,
       }))}
       onChange={(value: string) => {
         onUpdate({
-          targetIdentifier: value,
+          config: {
+            targetIdentifier: value,
+          },
         });
       }}
     />

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -1,7 +1,11 @@
 import {createContext, type Reducer, useCallback, useContext, useReducer} from 'react';
 import {uuid4} from '@sentry/core';
 
-import type {ActionHandler} from 'sentry/types/workflowEngine/actions';
+import {
+  type ActionHandler,
+  ActionTarget,
+  ActionType,
+} from 'sentry/types/workflowEngine/actions';
 import {
   type DataConditionGroup,
   DataConditionGroupLogicType,
@@ -110,8 +114,15 @@ export function useAutomationBuilderReducer() {
       [dispatch]
     ),
     updateIfAction: useCallback(
-      (groupId: string, actionId: string, data: Record<string, any>) =>
-        dispatch({type: 'UPDATE_IF_ACTION', groupId, actionId, data}),
+      (
+        groupId: string,
+        actionId: string,
+        params: {
+          config?: Record<string, any>;
+          data?: Record<string, any>;
+          integrationId?: string;
+        }
+      ) => dispatch({type: 'UPDATE_IF_ACTION', groupId, actionId, params}),
       [dispatch]
     ),
     updateIfLogicType: useCallback(
@@ -142,7 +153,15 @@ interface AutomationActions {
   removeIfAction: (groupId: string, actionId: string) => void;
   removeIfCondition: (groupId: string, conditionId: string) => void;
   removeWhenCondition: (id: string) => void;
-  updateIfAction: (groupId: string, actionId: string, data: Record<string, any>) => void;
+  updateIfAction: (
+    groupId: string,
+    actionId: string,
+    params: {
+      config?: Record<string, any>;
+      data?: Record<string, any>;
+      integrationId?: string;
+    }
+  ) => void;
   updateIfCondition: (
     groupId: string,
     conditionId: string,
@@ -259,8 +278,12 @@ type RemoveIfActionAction = {
 
 type UpdateIfActionAction = {
   actionId: string;
-  data: Record<string, any>;
   groupId: string;
+  params: {
+    config?: Record<string, any>;
+    data?: Record<string, any>;
+    integrationId?: string;
+  };
   type: 'UPDATE_IF_ACTION';
 };
 
@@ -465,11 +488,25 @@ function updateIfCondition(
   };
 }
 
+function getActionTargetType(actionType: ActionType): ActionTarget {
+  switch (actionType) {
+    case ActionType.EMAIL:
+      return ActionTarget.ISSUE_OWNERS;
+    case ActionType.SENTRY_APP:
+      return ActionTarget.SENTRY_APP;
+    default:
+      return ActionTarget.SPECIFIC;
+  }
+}
+
 function addIfAction(
   state: AutomationBuilderState,
   action: AddIfActionAction
 ): AutomationBuilderState {
   const {groupId, actionId, actionHandler} = action;
+
+  const targetType = getActionTargetType(actionHandler.type);
+
   return {
     ...state,
     actionFilters: state.actionFilters.map(group => {
@@ -483,11 +520,13 @@ function addIfAction(
           {
             id: actionId,
             type: actionHandler.type,
-            data: {
+            config: {
+              target_type: targetType,
               ...(actionHandler.sentryApp
-                ? {targetIdentifier: actionHandler.sentryApp.id}
+                ? {target_identifier: actionHandler.sentryApp.id}
                 : {}),
             },
+            data: {},
           },
         ],
       };
@@ -518,9 +557,10 @@ function updateIfAction(
   state: AutomationBuilderState,
   action: UpdateIfActionAction
 ): AutomationBuilderState {
-  const {groupId, actionId, data} = action;
-  // special case for integrationId which is outside of data
-  if ('integrationId' in data) {
+  const {groupId, actionId, params} = action;
+  const {integrationId, config, data} = params;
+
+  if (integrationId) {
     return {
       ...state,
       actionFilters: state.actionFilters.map(group => {
@@ -530,26 +570,48 @@ function updateIfAction(
         return {
           ...group,
           actions: group.actions?.map(a =>
-            a.id === actionId ? {...a, integrationId: data.integrationId} : a
+            a.id === actionId ? {...a, integrationId} : a
           ),
         };
       }),
     };
   }
-  return {
-    ...state,
-    actionFilters: state.actionFilters.map(group => {
-      if (group.id !== groupId) {
-        return group;
-      }
-      return {
-        ...group,
-        actions: group.actions?.map(a =>
-          a.id === actionId ? {...a, data: {...a.data, ...data}} : a
-        ),
-      };
-    }),
-  };
+
+  if (config) {
+    return {
+      ...state,
+      actionFilters: state.actionFilters.map(group => {
+        if (group.id !== groupId) {
+          return group;
+        }
+        return {
+          ...group,
+          actions: group.actions?.map(a =>
+            a.id === actionId ? {...a, config: {...a.config, ...config}} : a
+          ),
+        };
+      }),
+    };
+  }
+
+  if (data) {
+    return {
+      ...state,
+      actionFilters: state.actionFilters.map(group => {
+        if (group.id !== groupId) {
+          return group;
+        }
+        return {
+          ...group,
+          actions: group.actions?.map(a =>
+            a.id === actionId ? {...a, data: {...a.data, ...data}} : a
+          ),
+        };
+      }),
+    };
+  }
+
+  return state;
 }
 
 function updateIfLogicType(

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -560,58 +560,27 @@ function updateIfAction(
   const {groupId, actionId, params} = action;
   const {integrationId, config, data} = params;
 
-  if (integrationId) {
-    return {
-      ...state,
-      actionFilters: state.actionFilters.map(group => {
-        if (group.id !== groupId) {
-          return group;
-        }
-        return {
-          ...group,
-          actions: group.actions?.map(a =>
-            a.id === actionId ? {...a, integrationId} : a
-          ),
-        };
-      }),
-    };
-  }
-
-  if (config) {
-    return {
-      ...state,
-      actionFilters: state.actionFilters.map(group => {
-        if (group.id !== groupId) {
-          return group;
-        }
-        return {
-          ...group,
-          actions: group.actions?.map(a =>
-            a.id === actionId ? {...a, config: {...a.config, ...config}} : a
-          ),
-        };
-      }),
-    };
-  }
-
-  if (data) {
-    return {
-      ...state,
-      actionFilters: state.actionFilters.map(group => {
-        if (group.id !== groupId) {
-          return group;
-        }
-        return {
-          ...group,
-          actions: group.actions?.map(a =>
-            a.id === actionId ? {...a, data: {...a.data, ...data}} : a
-          ),
-        };
-      }),
-    };
-  }
-
-  return state;
+  return {
+    ...state,
+    actionFilters: state.actionFilters.map(group => {
+      if (group.id !== groupId) {
+        return group;
+      }
+      return {
+        ...group,
+        actions: group.actions?.map(a =>
+          a.id === actionId
+            ? {
+                ...a,
+                ...(integrationId && {integrationId}),
+                ...(config && {config: {...a.config, ...config}}),
+                ...(data && {data: {...a.data, ...data}}),
+              }
+            : a
+        ),
+      };
+    }),
+  };
 }
 
 function updateIfLogicType(


### PR DESCRIPTION
- fixed the `Action` type to include `config`
- updated the `updateActionAction` in the automation builder context to be able to update `integrationId`, `config`, or `data`
- fixed the action nodes to store `target_type`, `target_display`, and `target_identifier` in `config` instead of `data`