### PR TITLE
fix(workflow_engine): Graceful Data Condition Eval Handling

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from sentry.models.group import GroupStatus
 from sentry.models.groupopenperiod import get_latest_open_period
-from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.models.data_condition import Condition, DataConditionEvaluationException
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
@@ -21,7 +21,7 @@ class IssuePriorityDeescalatingConditionHandler(DataConditionHandler[WorkflowEve
         current_priority = group.priority
         open_period = get_latest_open_period(group)
         if open_period is None:
-            raise Exception("No open period found")
+            raise DataConditionEvaluationException("No open period found")
         # use this to determine if we've breached the comparison priority before
         highest_seen_priority = open_period.data.get("highest_seen_priority", current_priority)
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -81,7 +81,7 @@ class DataSourceTypeHandler(Generic[T]):
     @staticmethod
     def bulk_get_query_object(data_sources) -> dict[int, T | None]:
         """
-        Bulk fetch related data-source models reutrning a dict of the
+        Bulk fetch related data-source models returning a dict of the
         `DataSource.id -> T`.
         """
         raise NotImplementedError


### PR DESCRIPTION
# Description
- Introduce a new pattern for `DataConditionEvaluationException` to allow us to raise exceptions to interrupt the control flow
- Override a specific problem in `issue_priority_deescalating_handler`
- Includes tests to ensure we are gracefully handling `DataConditionEvaluationException`s