### PR TITLE
fix(search): Properly parse explicit tags and flags in aggregate filters

### DIFF
--- a/fixtures/search-syntax/aggregate_filter_on_explicit_typed_attributes.json
+++ b/fixtures/search-syntax/aggregate_filter_on_explicit_typed_attributes.json
@@ -1,0 +1,192 @@
+[
+  {
+    "query": "count_unique(tags[foo]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count_unique", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "avg(tags[foo,number]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo,number]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "avg(tags[foo:bar,number]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo:bar,number]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "count_unique(tags[foo,string]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count_unique", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo,string]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "count_unique(tags[foo:bar,string]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count_unique", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo:bar,string]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  }
+]

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -135,18 +135,20 @@ text_in_filter = negation? text_key sep text_in_list
 text_filter = negation? text_key sep operator? search_value
 
 key                    = ~r"[a-zA-Z0-9_.-]+"
-quoted_key             = '"' ~r"[a-zA-Z0-9_.:-]+" '"'
-explicit_flag_key       = "flags" open_bracket search_key closed_bracket
-explicit_string_flag_key = "flags" open_bracket search_key spaces comma spaces "string" closed_bracket
-explicit_number_flag_key = "flags" open_bracket search_key spaces comma spaces "number" closed_bracket
-explicit_tag_key       = "tags" open_bracket search_key closed_bracket
-explicit_string_tag_key = "tags" open_bracket search_key spaces comma spaces "string" closed_bracket
-explicit_number_tag_key = "tags" open_bracket search_key spaces comma spaces "number" closed_bracket
+escaped_key            = ~r"[a-zA-Z0-9_.:-]+"
+quoted_key             = '"' escaped_key '"'
+explicit_flag_key       = "flags" open_bracket escaped_key closed_bracket
+explicit_string_flag_key = "flags" open_bracket escaped_key spaces comma spaces "string" closed_bracket
+explicit_number_flag_key = "flags" open_bracket escaped_key spaces comma spaces "number" closed_bracket
+explicit_tag_key       = "tags" open_bracket escaped_key closed_bracket
+explicit_string_tag_key = "tags" open_bracket escaped_key spaces comma spaces "string" closed_bracket
+explicit_number_tag_key = "tags" open_bracket escaped_key spaces comma spaces "number" closed_bracket
 aggregate_key          = key open_paren spaces function_args? spaces closed_paren
 function_args          = aggregate_param (spaces comma spaces !comma aggregate_param?)*
-aggregate_param        = quoted_aggregate_param / raw_aggregate_param
+aggregate_param        = explicit_tag_key_aggregate_param / quoted_aggregate_param / raw_aggregate_param
 raw_aggregate_param    = ~r"[^()\t\n, \"]+"
 quoted_aggregate_param = '"' ('\\"' / ~r'[^\t\n\"]')* '"'
+explicit_tag_key_aggregate_param = explicit_tag_key / explicit_number_tag_key / explicit_string_tag_key
 search_key             = explicit_number_flag_key / explicit_number_tag_key / key / quoted_key
 text_key               = explicit_flag_key / explicit_string_flag_key / explicit_tag_key / explicit_string_tag_key / search_key
 value                  = ~r"[^()\t\n ]*"
@@ -1344,8 +1346,19 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
     def visit_key(self, node: Node, children: object) -> str:
         return node.text
 
-    def visit_quoted_key(self, node: Node, children: tuple[Node, Node, Node]) -> str:
-        return children[1].text
+    def visit_escaped_key(self, node: Node, children: object) -> str:
+        return node.text
+
+    def visit_quoted_key(
+        self,
+        node: Node,
+        children: tuple[
+            Node,  # '"'
+            str,  # escaped_key
+            Node,  # '"'
+        ],
+    ) -> str:
+        return children[1]
 
     def visit_explicit_tag_key(
         self,
@@ -1353,11 +1366,11 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         children: tuple[
             Node,  # "tags"
             str,  # '['
-            SearchKey,
+            str,  # escaped_key
             str,  # ']'
         ],
     ) -> SearchKey:
-        return SearchKey(f"tags[{children[2].name}]")
+        return SearchKey(f"tags[{children[2]}]")
 
     def visit_explicit_string_tag_key(
         self,
@@ -1365,7 +1378,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         children: tuple[
             Node,  # "tags"
             str,  # '['
-            SearchKey,
+            str,  # escaped_key
             str,  # ' '
             Node,  # ','
             str,  # ' '
@@ -1373,7 +1386,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             str,  # ']'
         ],
     ) -> SearchKey:
-        return SearchKey(f"tags[{children[2].name},string]")
+        return SearchKey(f"tags[{children[2]},string]")
 
     def visit_explicit_number_tag_key(
         self,
@@ -1381,7 +1394,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         children: tuple[
             Node,  # "tags"
             str,  # '['
-            SearchKey,
+            str,  # escaped_key
             str,  # ' '
             Node,  # ','
             str,  # ' '
@@ -1389,7 +1402,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             str,  # ']'
         ],
     ) -> SearchKey:
-        return SearchKey(f"tags[{children[2].name},number]")
+        return SearchKey(f"tags[{children[2]},number]")
 
     def visit_explicit_flag_key(
         self,
@@ -1397,11 +1410,11 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         children: tuple[
             Node,  # "flags"
             str,  # [
-            SearchKey,
+            str,  # escaped_key
             str,  # ]
         ],
     ) -> SearchKey:
-        return SearchKey(f"flags[{children[2].name}]")
+        return SearchKey(f"flags[{children[2]}]")
 
     def visit_explicit_string_flag_key(
         self,
@@ -1409,7 +1422,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         children: tuple[
             Node,  # "flags"
             str,  # '['
-            SearchKey,
+            str,  # escaped_key
             str,  # ' '
             Node,  # ','
             str,  # ' '
@@ -1417,7 +1430,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             str,  # ']'
         ],
     ) -> SearchKey:
-        return SearchKey(f"flags[{children[2].name},string]")
+        return SearchKey(f"flags[{children[2]},string]")
 
     def visit_explicit_number_flag_key(
         self,
@@ -1425,7 +1438,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
         children: tuple[
             Node,  # "flags"
             str,  # '['
-            SearchKey,
+            str,  # escaped_key
             str,  # ' '
             Node,  # ','
             str,  # ' '
@@ -1433,7 +1446,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             str,  # ']'
         ],
     ) -> SearchKey:
-        return SearchKey(f"flags[{children[2].name},number]")
+        return SearchKey(f"flags[{children[2]},number]")
 
     def visit_aggregate_key(
         self,
@@ -1491,6 +1504,13 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             value = "".join(node.text for node in flatten(children[1]))
 
         return f'"{value}"'
+
+    def visit_explicit_tag_key_aggregate_param(
+        self,
+        node: Node,
+        children: tuple[SearchKey],
+    ) -> str:
+        return children[0].name
 
     def visit_search_key(self, node: Node, children: tuple[str | SearchKey]) -> SearchKey:
         key = children[0]

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -224,38 +224,43 @@ key
       return tc.tokenKeySimple(value.join(''), false);
     }
 
+escaped_key
+  = value:[a-zA-Z0-9_.:-]+ {
+      return tc.tokenKeySimple(value.join(''), false);
+    }
+
 quoted_key
-  = '"' key:[a-zA-Z0-9_.:-]+ '"' {
-      return tc.tokenKeySimple(key.join(''), true);
+  = '"' key:escaped_key '"' {
+      return tc.tokenKeySimple(key.value, true);
     }
 
 explicit_flag_key
-  = prefix:"flags" open_bracket key:search_key closed_bracket {
+  = prefix:"flags" open_bracket key:escaped_key closed_bracket {
       return tc.tokenKeyExplicitFlag(prefix, key);
     }
 
 explicit_string_flag_key
-  = prefix:"flags" open_bracket key:search_key spaces comma spaces 'string' closed_bracket {
+  = prefix:"flags" open_bracket key:escaped_key spaces comma spaces 'string' closed_bracket {
       return tc.tokenKeyExplicitStringFlag(prefix, key)
     }
 
 explicit_number_flag_key
-  = prefix:"flags" open_bracket key:search_key spaces comma spaces 'number' closed_bracket {
+  = prefix:"flags" open_bracket key:escaped_key spaces comma spaces 'number' closed_bracket {
       return tc.tokenKeyExplicitNumberFlag(prefix, key)
     }
 
 explicit_tag_key
-  = prefix:"tags" open_bracket key:search_key closed_bracket {
+  = prefix:"tags" open_bracket key:escaped_key closed_bracket {
       return tc.tokenKeyExplicitTag(prefix, key);
     }
 
 explicit_string_tag_key
-  = prefix:"tags" open_bracket key:search_key spaces comma spaces 'string' closed_bracket {
+  = prefix:"tags" open_bracket key:escaped_key spaces comma spaces 'string' closed_bracket {
       return tc.tokenKeyExplicitStringTag(prefix, key)
     }
 
 explicit_number_tag_key
-  = prefix:"tags" open_bracket key:search_key spaces comma spaces 'number' closed_bracket {
+  = prefix:"tags" open_bracket key:escaped_key spaces comma spaces 'number' closed_bracket {
       return tc.tokenKeyExplicitNumberTag(prefix, key)
     }
 
@@ -271,7 +276,7 @@ function_args
     }
 
 aggregate_param
-  = quoted_aggregate_param / raw_aggregate_param
+  = explicit_tag_aggregate_param / quoted_aggregate_param / raw_aggregate_param
 
 raw_aggregate_param
   = param:[^()\t\n, \"]+ {
@@ -281,6 +286,11 @@ raw_aggregate_param
 quoted_aggregate_param
   = '"' param:('\\"' / [^\t\n\"])* '"' {
       return tc.tokenKeyAggregateParam(`"${param.join('')}"`, true);
+    }
+
+explicit_tag_aggregate_param
+  = key:(explicit_tag_key / explicit_string_tag_key / explicit_number_tag_key) {
+      return tc.tokenKeyAggregateParam(key.text, false);
     }
 
 search_key


### PR DESCRIPTION
When using explicit tags/flags in aggregate filters, they get split on the comma that they can have to delimit the comma. This ensures they are properly parsed as a single argument.