### PR TITLE
fix(seer): calculate prepaid price and spend without reserved budgets

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.spec.tsx
@@ -1,7 +1,10 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
-import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {
+  SubscriptionFixture,
+  SubscriptionWithSeerFixture,
+} from 'getsentry-test/fixtures/subscription';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DataCategory} from 'sentry/types/core';
@@ -138,5 +141,40 @@ describe('UsageCard', () => {
       <UsageCard organization={organization} subscription={subscription} />
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should not show reserved budget under included in subscription', () => {
+    const seerSubscription = SubscriptionWithSeerFixture({
+      organization,
+      plan: 'am3_business',
+    });
+
+    render(<UsageCard organization={organization} subscription={seerSubscription} />);
+
+    expect(screen.queryByText('Reserved')).not.toBeInTheDocument();
+    expect(screen.queryByText('Included In Subscription')).not.toBeInTheDocument();
+    // $89 business plan + $20 for reserved budget
+    expect(screen.getByTestId('current-monthly-spend')).toHaveTextContent('$109');
+  });
+
+  it('should not calculate prepaid spend with reserved budget', () => {
+    const seerSubscription = SubscriptionWithSeerFixture({
+      organization,
+      plan: 'am3_business',
+    });
+    const errorsPrice = 1000;
+    seerSubscription.planDetails.planCategories.errors = [
+      {events: 100_000, price: errorsPrice, unitPrice: 0.1, onDemandPrice: 0.2},
+    ];
+    seerSubscription.categories.errors!.reserved = 100_000;
+
+    render(<UsageCard organization={organization} subscription={seerSubscription} />);
+
+    expect(screen.queryByText('Reserved')).not.toBeInTheDocument();
+    expect(screen.getByText('Included in Subscription').parentElement).toHaveTextContent(
+      '0% of $10'
+    );
+    // $89 business plan + $20 for reserved budget + $10 for errors
+    expect(screen.getByTestId('current-monthly-spend')).toHaveTextContent('$119');
   });
 });

--- a/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/usageCard.tsx
@@ -53,9 +53,16 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
       ? onDemandBudgets.sharedMaxBudget
       : getTotalBudget(onDemandBudgets);
 
-  const {prepaidTotalSpent, onDemandTotalSpent, prepaidTotalPrice} =
-    calculateTotalSpend(subscription);
+  const {
+    prepaidTotalSpent,
+    prepaidReservedBudgetPrice,
+    onDemandTotalSpent,
+    prepaidTotalPrice,
+  } = calculateTotalSpend(subscription);
+  const priceWithoutReservedBudgets = prepaidTotalPrice - prepaidReservedBudgetPrice;
+  const spendWithoutReservedBudgets = prepaidTotalSpent - prepaidReservedBudgetPrice;
   const showPrepaid = prepaidTotalPrice > 0;
+  const showIncludedInSubscription = priceWithoutReservedBudgets > 0;
 
   // No reserved spend beyond the base subscription and no on-demand budgets
   if (!showPrepaid && !showOnDemand) {
@@ -66,7 +73,9 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
   // Prevent more than 100% width
   const prepaidPercentUsed = Math.max(
     0,
-    Math.round(Math.min((prepaidTotalSpent / prepaidTotalPrice) * 100, 100))
+    Math.round(
+      Math.min((spendWithoutReservedBudgets / priceWithoutReservedBudgets) * 100, 100)
+    )
   );
   const prepaidPercentUnused = 100 - prepaidPercentUsed;
   const onDemandPercentUsed = Math.round(
@@ -78,7 +87,9 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
   let prepaidMaxWidth = showOnDemand && showPrepaid ? 50 : showPrepaid ? 100 : 0;
   if (showOnDemand && showPrepaid && prepaidTotalSpent && onDemandTotalBudget) {
     prepaidMaxWidth = Math.round(
-      (prepaidTotalPrice / (prepaidTotalPrice + onDemandTotalBudget)) * 100
+      (priceWithoutReservedBudgets /
+        (priceWithoutReservedBudgets + onDemandTotalBudget)) *
+        100
     );
   }
 
@@ -87,7 +98,7 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
       <UsageSummary
         style={{gridTemplateColumns: `repeat(${showOnDemand ? 3 : 2}, auto)`}}
       >
-        {showPrepaid && (
+        {showIncludedInSubscription && (
           <SummaryWrapper>
             <SummaryTitleWrapper>
               <SummaryTitle>{t('Included In Subscription')}</SummaryTitle>
@@ -99,7 +110,7 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
               </Tooltip>
             </SummaryTitleWrapper>
             <SummaryTotal>
-              {formatCurrency(roundUpToNearestDollar(prepaidTotalPrice))}/mo
+              {formatCurrency(roundUpToNearestDollar(priceWithoutReservedBudgets))}/mo
             </SummaryTotal>
           </SummaryWrapper>
         )}
@@ -149,7 +160,7 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
         </SummaryWrapper>
       </UsageSummary>
       <PlanUseBarContainer>
-        {showPrepaid && (
+        {showIncludedInSubscription && (
           <PlanUseBarGroup style={{width: `${prepaidMaxWidth}%`}}>
             {prepaidPercentUsed > 1 && (
               <PlanUseBar
@@ -191,14 +202,14 @@ export function UsageCard({subscription, organization}: UsageCardProps) {
         )}
       </PlanUseBarContainer>
       <LegendPriceWrapper>
-        {showPrepaid && (
+        {showIncludedInSubscription && (
           <LegendContainer>
             <LegendDot style={{backgroundColor: COLORS.prepaid}} />
             <div>
               <LegendTitle>{t('Included in Subscription')}</LegendTitle>
               <LegendPrice>
                 {formatPercentage(prepaidPercentUsed / 100)} of{' '}
-                {formatCurrency(roundUpToNearestDollar(prepaidTotalPrice))}
+                {formatCurrency(roundUpToNearestDollar(priceWithoutReservedBudgets))}
               </LegendPrice>
             </div>
           </LegendContainer>

--- a/static/gsApp/views/subscriptionPage/utils.tsx
+++ b/static/gsApp/views/subscriptionPage/utils.tsx
@@ -81,12 +81,14 @@ export function calculateCategorySpend(
 
 export function calculateTotalSpend(subscription: Subscription): {
   onDemandTotalSpent: number;
+  prepaidReservedBudgetPrice: number;
   prepaidTotalPrice: number;
   prepaidTotalSpent: number;
 } {
   let prepaidTotalSpent = 0;
+  let prepaidReservedBudgetPrice = 0;
   let onDemandTotalSpent = 0;
-  let prepaidTotalPrice = 0;
+  let prepaidTotalPrice = 0; // Total price of the subscription (includes upgraded reserved volumes and reserved budgets)
   for (const category of subscription.planDetails.categories) {
     const {prepaidSpent, onDemandSpent, prepaidPrice} = calculateCategorySpend(
       subscription,
@@ -95,9 +97,17 @@ export function calculateTotalSpend(subscription: Subscription): {
     prepaidTotalSpent += prepaidSpent;
     onDemandTotalSpent += onDemandSpent;
     prepaidTotalPrice += prepaidPrice;
+    if (subscription.reservedBudgetCategories?.includes(category)) {
+      prepaidReservedBudgetPrice += prepaidPrice;
+    }
   }
 
-  return {prepaidTotalSpent, onDemandTotalSpent, prepaidTotalPrice};
+  return {
+    prepaidTotalSpent,
+    prepaidReservedBudgetPrice,
+    onDemandTotalSpent,
+    prepaidTotalPrice,
+  };
 }
 
 /**


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-806/remove-seer-usage-from-the-usagecard-chart

with seer and no other upgraded reserved
<img width="662" alt="Screenshot 2025-05-30 at 3 16 52 PM" src="https://github.com/user-attachments/assets/d3230c11-5260-4441-ac1a-d944c88aa7ac" />

with seer + $66 in upgraded reserved
<img width="662" alt="Screenshot 2025-05-30 at 3 45 09 PM" src="https://github.com/user-attachments/assets/4d86529d-6713-4d17-ac0d-9a792a809e47" />
