### PR TITLE
fix(search): Remove quotes from tags and flags

### DIFF
--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -220,42 +220,68 @@ text_filter
 
 // Filter keys
 key
-  = value:[a-zA-Z0-9_.-]+ {
-      return tc.tokenKeySimple(value.join(''), false);
+  = key:[a-zA-Z0-9_.-]+ {
+      return tc.tokenKeySimple(key.join(''), false);
+    }
+
+escaped_key
+  = key:[a-zA-Z0-9_.:-]+ {
+      return tc.tokenKeySimple(key.join(''), false);
     }
 
 quoted_key
-  = '"' key:[a-zA-Z0-9_.:-]+ '"' {
-      return tc.tokenKeySimple(key.join(''), true);
+  = '"' key:escaped_key '"' {
+      return tc.tokenKeySimple(key.value, true);
     }
 
-explicit_flag_key
-  = prefix:"flags" open_bracket key:search_key closed_bracket {
+explicit_flag_key_unquoted
+  = prefix:"flags" open_bracket key:escaped_key closed_bracket {
       return tc.tokenKeyExplicitFlag(prefix, key);
     }
 
-explicit_string_flag_key
-  = prefix:"flags" open_bracket key:search_key spaces comma spaces 'string' closed_bracket {
+explicit_flag_key_quoted
+  = prefix:"flags" open_bracket key:quoted_key closed_bracket {
+      return tc.tokenKeyExplicitFlag(prefix, key);
+    }
+
+explicit_flag_key = explicit_flag_key_unquoted / explicit_flag_key_quoted
+
+explicit_string_flag_key_unquoted
+  = prefix:"flags" open_bracket key:escaped_key spaces comma spaces 'string' closed_bracket {
       return tc.tokenKeyExplicitStringFlag(prefix, key)
     }
 
-explicit_number_flag_key
-  = prefix:"flags" open_bracket key:search_key spaces comma spaces 'number' closed_bracket {
+explicit_string_flag_key_quoted
+  = prefix:"flags" open_bracket key:quoted_key spaces comma spaces 'string' closed_bracket {
+      return tc.tokenKeyExplicitStringFlag(prefix, key)
+    }
+
+explicit_string_flag_key = explicit_string_flag_key_unquoted / explicit_string_flag_key_quoted
+
+explicit_number_flag_key_unquoted
+  = prefix:"flags" open_bracket key:escaped_key spaces comma spaces 'number' closed_bracket {
       return tc.tokenKeyExplicitNumberFlag(prefix, key)
     }
 
+explicit_number_flag_key_quoted
+  = prefix:"flags" open_bracket key:quoted_key spaces comma spaces 'number' closed_bracket {
+      return tc.tokenKeyExplicitNumberFlag(prefix, key)
+    }
+
+explicit_number_flag_key = explicit_number_flag_key_unquoted / explicit_number_flag_key_quoted
+
 explicit_tag_key
-  = prefix:"tags" open_bracket key:search_key closed_bracket {
+  = prefix:"tags" open_bracket key:escaped_key closed_bracket {
       return tc.tokenKeyExplicitTag(prefix, key);
     }
 
 explicit_string_tag_key
-  = prefix:"tags" open_bracket key:search_key spaces comma spaces 'string' closed_bracket {
+  = prefix:"tags" open_bracket key:escaped_key spaces comma spaces 'string' closed_bracket {
       return tc.tokenKeyExplicitStringTag(prefix, key)
     }
 
 explicit_number_tag_key
-  = prefix:"tags" open_bracket key:search_key spaces comma spaces 'number' closed_bracket {
+  = prefix:"tags" open_bracket key:escaped_key spaces comma spaces 'number' closed_bracket {
       return tc.tokenKeyExplicitNumberTag(prefix, key)
     }
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1055,3 +1055,53 @@ def test_translate_wildcard_as_clickhouse_pattern(pattern, clickhouse):
 def test_invalid_translate_wildcard_as_clickhouse_pattern(pattern):
     with pytest.raises(InvalidSearchQuery):
         assert translate_wildcard_as_clickhouse_pattern(pattern)
+
+
+@pytest.mark.parametrize(
+    ["query", "key", "value"],
+    [
+        pytest.param("tags[foo/bar]:baz", "message", "tags[foo/bar]:baz"),
+        pytest.param("flags[foo/bar]:baz", "message", "flags[foo/bar]:baz"),
+        pytest.param("tags[foo]:true", "tags[foo]", "true"),
+        pytest.param("tags[foo,string]:true", "tags[foo,string]", "true"),
+        pytest.param("tags[foo:bar,string]:true", "tags[foo:bar,string]", "true"),
+        pytest.param("tags[foo,number]:0", "tags[foo,number]", "0"),
+        pytest.param("tags[foo:bar,number]:0", "tags[foo:bar,number]", "0"),
+        pytest.param("flags[foo]:true", "flags[foo]", "true"),
+        pytest.param("flags[foo,string]:true", "flags[foo,string]", "true"),
+        pytest.param("flags[foo:bar,string]:true", "flags[foo:bar,string]", "true"),
+        pytest.param("flags[foo,number]:0", "flags[foo,number]", "0"),
+        pytest.param("flags[foo:bar,number]:0", "flags[foo:bar,number]", "0"),
+        # the quoted versions are supported for flags for backwards compatibility
+        pytest.param('flags["foo"]:true', "flags[foo]", "true"),
+        pytest.param('flags["foo",string]:true', "flags[foo,string]", "true"),
+        pytest.param('flags["foo:bar",string]:true', "flags[foo:bar,string]", "true"),
+        pytest.param('flags["foo",number]:0', "flags[foo,number]", "0"),
+        pytest.param('flags["foo:bar",number]:0', "flags[foo:bar,number]", "0"),
+    ],
+)
+def test_handles_special_character_in_tags_and_flags(query, key, value):
+    parsed = parse_search_query(query)
+    assert parsed == [SearchFilter(SearchKey(key), "=", SearchValue(value))]
+
+
+@pytest.mark.parametrize(
+    ["query", "key"],
+    [
+        pytest.param("has:tags[foo]", "tags[foo]"),
+        pytest.param("has:tags[foo,string]", "tags[foo,string]"),
+        pytest.param("has:tags[foo,number]", "tags[foo,number]"),
+        pytest.param("has:tags[foo:bar]", "tags[foo:bar]"),
+        pytest.param("has:tags[foo:bar,string]", "tags[foo:bar,string]"),
+        pytest.param("has:tags[foo:bar,number]", "tags[foo:bar,number]"),
+        pytest.param("has:flags[foo]", "flags[foo]"),
+        pytest.param("has:flags[foo,string]", "flags[foo,string]"),
+        pytest.param("has:flags[foo,number]", "flags[foo,number]"),
+        pytest.param("has:flags[foo:bar]", "flags[foo:bar]"),
+        pytest.param("has:flags[foo:bar,string]", "flags[foo:bar,string]"),
+        pytest.param("has:flags[foo:bar,number]", "flags[foo:bar,number]"),
+    ],
+)
+def test_handles_has_tags_and_flags(query, key):
+    parsed = parse_search_query(query)
+    assert parsed == [SearchFilter(SearchKey(key), "!=", SearchValue(""))]


### PR DESCRIPTION
This removes the quotes from the explicit tags and flags syntax so we can specify them as `tags[foo:bar]` and `flags[foo:bar]`. One small caveat here is that because the frontend is still autocompleting flags with the quotes, we're continuing to support quotes in flags until it's removed.

Closes EXP-262