### PR TITLE
fix(search): Properly parse explicitly typed tags and flags in aggregate filters

### DIFF
--- a/fixtures/search-syntax/aggregate_filter_on_explicit_typed_attributes.json
+++ b/fixtures/search-syntax/aggregate_filter_on_explicit_typed_attributes.json
@@ -1,0 +1,192 @@
+[
+  {
+    "query": "count_unique(tags[foo]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count_unique", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "avg(tags[foo,number]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo,number]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "avg(tags[foo:bar,number]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo:bar,number]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "count_unique(tags[foo,string]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count_unique", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo,string]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "count_unique(tags[foo:bar,string]):>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregateNumeric",
+        "negated": false,
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "count_unique", "quoted": false},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "tags[foo:bar,string]",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""}
+        },
+        "operator": ">",
+        "value": {
+          "type": "valueNumber",
+          "value": "500",
+          "unit": null,
+          "parsed": {"value": 500}
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  }
+]

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -156,9 +156,11 @@ explicit_number_tag_key = "tags" open_bracket escaped_key spaces comma spaces "n
 
 aggregate_key          = key open_paren spaces function_args? spaces closed_paren
 function_args          = aggregate_param (spaces comma spaces !comma aggregate_param?)*
-aggregate_param        = quoted_aggregate_param / raw_aggregate_param
+aggregate_param        = explicit_tag_key_aggregate_param / quoted_aggregate_param / raw_aggregate_param
 raw_aggregate_param    = ~r"[^()\t\n, \"]+"
 quoted_aggregate_param = '"' ('\\"' / ~r'[^\t\n\"]')* '"'
+explicit_tag_key_aggregate_param = explicit_tag_key / explicit_number_tag_key / explicit_string_tag_key
+
 search_key             = explicit_number_flag_key / explicit_number_tag_key / key / quoted_key
 text_key               = explicit_flag_key / explicit_string_flag_key / explicit_tag_key / explicit_string_tag_key / search_key
 value                  = ~r"[^()\t\n ]*"
@@ -1571,6 +1573,13 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             value = "".join(node.text for node in flatten(children[1]))
 
         return f'"{value}"'
+
+    def visit_explicit_tag_key_aggregate_param(
+        self,
+        node: Node,
+        children: tuple[SearchKey],
+    ) -> str:
+        return children[0].name
 
     def visit_search_key(self, node: Node, children: tuple[str | SearchKey]) -> SearchKey:
         key = children[0]

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -297,7 +297,7 @@ function_args
     }
 
 aggregate_param
-  = quoted_aggregate_param / raw_aggregate_param
+  = explicit_tag_aggregate_param / quoted_aggregate_param / raw_aggregate_param
 
 raw_aggregate_param
   = param:[^()\t\n, \"]+ {
@@ -307,6 +307,11 @@ raw_aggregate_param
 quoted_aggregate_param
   = '"' param:('\\"' / [^\t\n\"])* '"' {
       return tc.tokenKeyAggregateParam(`"${param.join('')}"`, true);
+    }
+
+explicit_tag_aggregate_param
+  = key:(explicit_tag_key / explicit_string_tag_key / explicit_number_tag_key) {
+      return tc.tokenKeyAggregateParam(key.text, false);
     }
 
 search_key

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -328,7 +328,7 @@ class SearchResolverQueryTest(TestCase):
                 aggregation=AttributeAggregation(
                     aggregate=Function.FUNCTION_AVG,
                     key=AttributeKey(name="foo", type=AttributeKey.Type.TYPE_DOUBLE),
-                    label="avg(tags[foo, number])",
+                    label="avg(tags[foo,number])",
                     extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SAMPLE_WEIGHTED,
                 ),
                 op=AggregationComparisonFilter.OP_GREATER_THAN,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -4619,6 +4619,40 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert meta["dataset"] == self.dataset
         assert meta["dataset"] == self.dataset
 
+    def test_typed_attributes_with_colons(self):
+        span = self.create_span(
+            {
+                "data": {
+                    "flag.evaluation.feature.organizations:foo": True,
+                },
+            },
+            start_ts=self.ten_mins_ago,
+        )
+        self.store_spans(
+            [
+                self.create_span(start_ts=self.ten_mins_ago),
+                span,
+            ],
+            is_eap=self.is_eap,
+        )
+
+        response = self.do_request(
+            {
+                "field": ["tags[flag.evaluation.feature.organizations:foo,number]"],
+                "query": "has:tags[flag.evaluation.feature.organizations:foo,number] tags[flag.evaluation.feature.organizations:foo,number]:1",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": span["span_id"],
+                "project.name": self.project.slug,
+                "tags[flag.evaluation.feature.organizations:foo,number]": 1,
+            },
+        ]
+
     def test_count_if_two_args(self):
         self.store_spans(
             [


### PR DESCRIPTION
Previously, aggregate filters naively split on commas to get the arguments. Some valid arguments may contain commans, specifically, typed tags and flags. So make sure they're properly parsed.

Closes EXP-297