### PR TITLE
feat(workflow_engine): DataConditionHandlerTestMixin

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2158,9 +2158,12 @@ class Factories:
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
     def create_data_condition_group(
+        organization: Organization | None = None,
         **kwargs,
     ) -> DataConditionGroup:
-        return DataConditionGroup.objects.create(**kwargs)
+        if organization is None:
+            organization = Factories.create_organization()
+        return DataConditionGroup.objects.create(organization=organization, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
@@ -2181,8 +2184,12 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)
-    def create_data_condition(**kwargs) -> DataCondition:
-        return DataCondition.objects.create(**kwargs)
+    def create_data_condition(
+        condition_group: DataConditionGroup | None = None, **kwargs
+    ) -> DataCondition:
+        if condition_group is None:
+            condition_group = Factories.create_data_condition_group()
+        return DataCondition.objects.create(condition_group=condition_group, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -657,11 +657,11 @@ class Fixtures:
     def create_data_source_detector(self, *args, **kwargs):
         return Factories.create_data_source_detector(*args, **kwargs)
 
-    def create_data_condition_group(self, *args, organization=None, **kwargs):
+    def create_data_condition_group(self, organization=None, **kwargs):
         if organization is None:
             organization = self.organization
 
-        return Factories.create_data_condition_group(*args, organization=organization, **kwargs)
+        return Factories.create_data_condition_group(organization=organization, **kwargs)
 
     def create_data_condition_group_action(self, *args, **kwargs):
         return Factories.create_data_condition_group_action(*args, **kwargs)

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -74,7 +74,7 @@ class EvaluateValueTest(DataConditionHandlerMixin, TestCase):
             raise DataConditionEvaluationException("A known error occurred")
 
         dc = self.setup_condition_mocks(
-            evaluate_value, "sentry.workflow_engine.models.data_condition"
+            evaluate_value, ["sentry.workflow_engine.models.data_condition"]
         )
 
         with mock.patch("sentry.workflow_engine.models.data_condition.logger.info") as mock_logger:
@@ -91,7 +91,7 @@ class EvaluateValueTest(DataConditionHandlerMixin, TestCase):
             raise Exception("Something went wrong")
 
         dc = self.setup_condition_mocks(
-            evaluate_value, "sentry.workflow_engine.models.data_condition"
+            evaluate_value, ["sentry.workflow_engine.models.data_condition"]
         )
 
         with pytest.raises(Exception):

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -4,7 +4,8 @@ import pytest
 
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models.data_condition import Condition, DataConditionEvaluationException
-from sentry.workflow_engine.types import DataConditionHandler, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorPriorityLevel
+from tests.sentry.workflow_engine.test_base import DataConditionHandlerMixin
 
 
 class GetConditionResultTest(TestCase):
@@ -37,7 +38,7 @@ class GetConditionResultTest(TestCase):
         assert dc.get_condition_result() is True
 
 
-class EvaluateValueTest(TestCase):
+class EvaluateValueTest(DataConditionHandlerMixin, TestCase):
     def test(self):
         dc = self.create_data_condition(
             type=Condition.GREATER, comparison=1.0, condition_result=DetectorPriorityLevel.HIGH
@@ -68,19 +69,12 @@ class EvaluateValueTest(TestCase):
         )
         assert dc.evaluate_value(2) is None
 
-    @mock.patch("sentry.workflow_engine.models.data_condition.condition_handler_registry")
-    def test_condition_evaluation__data_condition_exception(self, mock_registry):
-        class DataConditionHandlerMock(DataConditionHandler[int]):
-            @staticmethod
-            def evaluate_value(value: int, comparison: int) -> bool:
-                raise DataConditionEvaluationException("Something went wrong")
+    def test_condition_evaluation__data_condition_exception(self):
+        def evaluate_value(value: int, comparison: int) -> bool:
+            raise DataConditionEvaluationException("A known error occurred")
 
-        mock_registry.get.return_value = DataConditionHandlerMock()
-
-        dc = self.create_data_condition(
-            type=Condition.LEVEL,  # this will be overridden by the mock, cannot be a operator
-            comparison=1.0,
-            condition_result=DetectorPriorityLevel.HIGH,
+        dc = self.setup_condition_mocks(
+            evaluate_value, "sentry.workflow_engine.models.data_condition"
         )
 
         with mock.patch("sentry.workflow_engine.models.data_condition.logger.info") as mock_logger:
@@ -90,20 +84,17 @@ class EvaluateValueTest(TestCase):
                 == "A known error occurred while evaluating a data condition"
             )
 
-    @mock.patch("sentry.workflow_engine.models.data_condition.condition_handler_registry")
-    def test_condition_evaluation___exception(self, mock_registry):
-        class DataConditionHandlerMock(DataConditionHandler[int]):
-            @staticmethod
-            def evaluate_value(value: int, comparison: int) -> bool:
-                raise Exception("Something went wrong")
+        self.teardown_condition_mocks()
 
-        mock_registry.get.return_value = DataConditionHandlerMock()
+    def test_condition_evaluation___exception(self):
+        def evaluate_value(value: int, comparison: int) -> bool:
+            raise Exception("Something went wrong")
 
-        dc = self.create_data_condition(
-            type=Condition.LEVEL,  # this will be overridden by the mock, cannot be a operator
-            comparison=1.0,
-            condition_result=DetectorPriorityLevel.HIGH,
+        dc = self.setup_condition_mocks(
+            evaluate_value, "sentry.workflow_engine.models.data_condition"
         )
 
         with pytest.raises(Exception):
             dc.evaluate_value(2)
+
+        self.teardown_condition_mocks()


### PR DESCRIPTION
# Description
It's been difficult to setup and test data condition handlers, the registry + factories + mocking make it all a bit complex.

This PR aims to reduce the overhead by creating a mixin class that can be used to either mock the handler for all tests in setup / teardown or per test case (as illustrated in the `test_data_condition.py` update).