### PR TITLE
feat(trace-eap-waterfall): Adding detail sections to drawer from nodestore

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -345,7 +345,16 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
       return null;
     }
 
-    return <SpanProfileDetails span={props.node.value} event={props.event} />;
+    return (
+      <SpanProfileDetails
+        span={{
+          span_id: props.node.value.span_id,
+          start_timestamp: props.node.value.start_timestamp,
+          end_timestamp: props.node.value.timestamp,
+        }}
+        event={props.event}
+      />
+    );
   }
 
   function renderSpanDetails() {

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -401,7 +401,16 @@ function SpanDetail(props: Props) {
       return null;
     }
 
-    return <SpanProfileDetails span={span} event={event} />;
+    return (
+      <SpanProfileDetails
+        span={{
+          span_id: span.span_id,
+          start_timestamp: span.start_timestamp,
+          end_timestamp: span.timestamp,
+        }}
+        event={event}
+      />
+    );
   }
 
   function renderSpanDetails() {

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -30,16 +30,18 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
-import type {SpanType} from './types';
-
 const MAX_STACK_DEPTH = 8;
 const MAX_TOP_NODES = 5;
 const MIN_TOP_NODES = 3;
 const TOP_NODE_MIN_COUNT = 3;
 
-interface SpanProfileDetailsProps {
+export interface SpanProfileDetailsProps {
   event: Readonly<EventTransaction>;
-  span: Readonly<SpanType>;
+  span: Readonly<{
+    end_timestamp: number;
+    span_id: string;
+    start_timestamp: number;
+  }>;
   onNoProfileFound?: () => void;
 }
 
@@ -47,7 +49,7 @@ export function useSpanProfileDetails(
   organization: Organization,
   project: Project | undefined,
   event: Readonly<EventTransaction>,
-  span: Readonly<SpanType>
+  span: SpanProfileDetailsProps['span']
 ) {
   const profileGroup = useProfileGroup();
 
@@ -97,7 +99,7 @@ export function useSpanProfileDetails(
       profile.unit
     );
     const relativeStopTimestamp = formatTo(
-      span.timestamp - startTimestamp,
+      span.end_timestamp - startTimestamp,
       'second',
       profile.unit
     );

--- a/static/app/views/performance/newTraceDetails/traceApi/useTransaction.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTransaction.tsx
@@ -1,18 +1,17 @@
 import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
-import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 interface UseTransactionProps {
-  node: TraceTreeNode<TraceTree.Transaction> | null;
+  event_id: string;
   organization: Organization;
+  project_slug: string;
 }
 
 export function useTransaction(props: UseTransactionProps) {
   return useApiQuery<EventTransaction>(
     [
-      `/organizations/${props.organization.slug}/events/${props.node?.value?.project_slug}:${props?.node?.value.event_id}/`,
+      `/organizations/${props.organization.slug}/events/${props.project_slug}:${props.event_id}/`,
       {
         query: {
           referrer: 'trace-details-summary',
@@ -22,7 +21,7 @@ export function useTransaction(props: UseTransactionProps) {
     {
       // 10 minutes
       staleTime: 1000 * 60 * 10,
-      enabled: !!props.node?.value?.project_slug && !!props.node?.value.event_id,
+      enabled: !!props.project_slug && !!props.event_id,
     }
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -13,6 +13,7 @@ import {
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {EventTransaction} from 'sentry/types/event';
@@ -452,7 +453,14 @@ function EAPSpanNodeDetails({
                     <AIOutputSection node={node} attributes={attributes} />
                     <FoldSection
                       sectionKey={SectionKey.SPAN_ATTRIBUTES}
-                      title={t('Attributes')}
+                      title={
+                        <SectionTitleWithQuestionTooltip
+                          title={t('Attributes')}
+                          tooltipText={t(
+                            'These attributes are indexed and can be queries in the Trace Explorer.'
+                          )}
+                        />
+                      }
                       disableCollapsePersistence
                     >
                       <AttributesTree
@@ -469,7 +477,14 @@ function EAPSpanNodeDetails({
                     {isTransaction ? (
                       <FoldSection
                         sectionKey={SectionKey.CONTEXTS}
-                        title={t('Contexts')}
+                        title={
+                          <SectionTitleWithQuestionTooltip
+                            title={t('Contexts')}
+                            tooltipText={t(
+                              "This data is not indexed and can't be queries in the Trace Explorer. For querying, attach these as attributes to your spans."
+                            )}
+                          />
+                        }
                         disableCollapsePersistence
                       >
                         <Request event={eventTransaction} />
@@ -536,3 +551,24 @@ function EAPSpanNodeDetails({
     </TraceDrawerComponents.DetailContainer>
   );
 }
+
+function SectionTitleWithQuestionTooltip({
+  title,
+  tooltipText,
+}: {
+  title: string;
+  tooltipText: string;
+}) {
+  return (
+    <Flex>
+      <div>{title}</div>
+      <QuestionTooltip title={tooltipText} size="sm" />
+    </Flex>
+  );
+}
+
+const Flex = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -3,11 +3,14 @@ import {type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import {EventAttachments} from 'sentry/components/events/eventAttachments';
+import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {
   SpanProfileDetails,
+  SpanProfileDetailsProps,
   useSpanProfileDetails,
 } from 'sentry/components/events/interfaces/spans/spanProfileDetails';
-import type {SpanType} from 'sentry/components/events/interfaces/spans/types';
+import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -37,16 +40,23 @@ import {useSpansQueryWithoutPageFilters} from 'sentry/views/insights/common/quer
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
+import {useTransaction} from 'sentry/views/performance/newTraceDetails/traceApi/useTransaction';
 import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issues';
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
 import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {BreadCrumbs} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs';
+import ReplayPreview from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview';
+import {Request} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/request';
 import {
   getProfileMeta,
   sortAttributes,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
-import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
+import {
+  isEAPSpanNode,
+  isEAPTransactionNode,
+} from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 import {useTraceState} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
@@ -172,7 +182,7 @@ function ProfileDetails({
   event: Readonly<EventTransaction>;
   organization: Organization;
   project: Project | undefined;
-  span: Readonly<SpanType>;
+  span: Readonly<SpanProfileDetailsProps['span']>;
 }) {
   const {profile, frames} = useSpanProfileDetails(organization, project, event, span);
 
@@ -275,7 +285,11 @@ export function SpanNodeDetails(
                       organization={organization}
                       project={project}
                       event={node.event!}
-                      span={node.value}
+                      span={{
+                        span_id: node.value.span_id,
+                        start_timestamp: node.value.start_timestamp,
+                        end_timestamp: node.value.timestamp,
+                      }}
                     />
                   ) : null}
                 </ProfileGroupProvider>
@@ -344,7 +358,11 @@ function EAPSpanNodeDetails({
   traceId,
   theme,
 }: EAPSpanNodeDetailsProps) {
-  const {data, isPending, isError} = useTraceItemDetails({
+  const {
+    data: traceItemData,
+    isPending: isTraceItemPending,
+    isError: isTraceItemError,
+  } = useTraceItemDetails({
     traceItemId: node.value.event_id,
     projectId: node.value.project_id.toString(),
     traceId,
@@ -353,24 +371,39 @@ function EAPSpanNodeDetails({
     enabled: true,
   });
 
+  const {
+    data: eventTransaction,
+    isPending: isEventTransactionPending,
+    isError: isEventTransactionError,
+  } = useTransaction({
+    event_id: node.value.transaction_id,
+    project_slug: node.value.project_slug,
+    organization,
+  });
+
   const avgSpanDuration = useAvgSpanDuration(node.value, location);
 
   const traceState = useTraceState();
 
-  if (isPending) {
+  if (isTraceItemPending || isEventTransactionPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError) {
+  if (isTraceItemError || isEventTransactionError) {
     return <LoadingError message={t('Failed to fetch span details')} />;
   }
 
-  const attributes = data?.attributes;
+  const attributes = traceItemData?.attributes;
   const columnCount =
     traceState.preferences.layout === 'drawer left' ||
     traceState.preferences.layout === 'drawer right'
       ? 1
       : undefined;
+
+  const isTransaction = isEAPTransactionNode(node);
+  const profileMeta = getProfileMeta(eventTransaction) || '';
+  const profileId =
+    typeof profileMeta === 'string' ? profileMeta : profileMeta.profiler_id;
 
   return (
     <TraceDrawerComponents.DetailContainer>
@@ -380,45 +413,125 @@ function EAPSpanNodeDetails({
         onTabScrollToNode={onTabScrollToNode}
       />
       <TraceDrawerComponents.BodyContainer>
-        <LogsPageParamsProvider
-          isTableFrozen
-          limitToTraceId={traceId}
-          limitToSpanId={node.value.event_id}
-          limitToProjectIds={[node.value.project_id]}
-          analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
+        <ProfilesProvider
+          orgSlug={organization.slug}
+          projectSlug={node.value.project_slug}
+          profileMeta={profileMeta}
         >
-          <LogsPageDataProvider>
-            {issues.length > 0 ? (
-              <IssueList organization={organization} issues={issues} node={node} />
-            ) : null}
-            <EAPSpanDescription
-              node={node}
-              project={project}
-              organization={organization}
-              location={location}
-              attributes={attributes}
-              avgSpanDuration={avgSpanDuration}
-            />
-            <AIInputSection node={node} attributes={attributes} />
-            <AIOutputSection node={node} attributes={attributes} />
-            <FoldSection
-              sectionKey={SectionKey.SPAN_ATTRIBUTES}
-              title={t('Attributes')}
-              disableCollapsePersistence
-            >
-              <AttributesTree
-                columnCount={columnCount}
-                attributes={sortAttributes(attributes)}
-                rendererExtra={{
-                  theme,
-                  location,
-                  organization,
-                }}
-              />
-            </FoldSection>
-            <LogDetails />
-          </LogsPageDataProvider>
-        </LogsPageParamsProvider>
+          <ProfileContext.Consumer>
+            {profiles => (
+              <ProfileGroupProvider
+                type="flamechart"
+                input={profiles?.type === 'resolved' ? profiles.data : null}
+                traceID={profileId || ''}
+              >
+                <LogsPageParamsProvider
+                  isTableFrozen
+                  limitToTraceId={traceId}
+                  limitToSpanId={node.value.event_id}
+                  limitToProjectIds={[node.value.project_id]}
+                  analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
+                >
+                  <LogsPageDataProvider>
+                    {issues.length > 0 ? (
+                      <IssueList
+                        organization={organization}
+                        issues={issues}
+                        node={node}
+                      />
+                    ) : null}
+                    <EAPSpanDescription
+                      node={node}
+                      project={project}
+                      organization={organization}
+                      location={location}
+                      attributes={attributes}
+                      avgSpanDuration={avgSpanDuration}
+                    />
+                    <AIInputSection node={node} attributes={attributes} />
+                    <AIOutputSection node={node} attributes={attributes} />
+                    <FoldSection
+                      sectionKey={SectionKey.SPAN_ATTRIBUTES}
+                      title={t('Attributes')}
+                      disableCollapsePersistence
+                    >
+                      <AttributesTree
+                        columnCount={columnCount}
+                        attributes={sortAttributes(attributes)}
+                        rendererExtra={{
+                          theme,
+                          location,
+                          organization,
+                        }}
+                      />
+                    </FoldSection>
+
+                    {isTransaction ? (
+                      <FoldSection
+                        sectionKey={SectionKey.CONTEXTS}
+                        title={t('Contexts')}
+                        disableCollapsePersistence
+                      >
+                        <Request event={eventTransaction} />
+                      </FoldSection>
+                    ) : null}
+
+                    <LogDetails />
+
+                    {isTransaction && organization.features.includes('profiling') ? (
+                      <ProfileDetails
+                        organization={organization}
+                        project={project}
+                        event={eventTransaction}
+                        span={{
+                          span_id: node.value.event_id,
+                          start_timestamp: node.value.start_timestamp,
+                          end_timestamp: node.value.end_timestamp,
+                        }}
+                      />
+                    ) : null}
+
+                    {isTransaction ? (
+                      <ReplayPreview
+                        event={eventTransaction}
+                        organization={organization}
+                      />
+                    ) : null}
+
+                    {isTransaction ? (
+                      <BreadCrumbs event={eventTransaction} organization={organization} />
+                    ) : null}
+
+                    {isTransaction && project ? (
+                      <EventAttachments
+                        event={eventTransaction}
+                        project={project}
+                        group={undefined}
+                      />
+                    ) : null}
+
+                    {isTransaction && project ? (
+                      <EventViewHierarchy
+                        event={eventTransaction}
+                        project={project}
+                        disableCollapsePersistence
+                      />
+                    ) : null}
+
+                    {isTransaction && eventTransaction.projectSlug ? (
+                      <EventRRWebIntegration
+                        event={eventTransaction}
+                        orgId={organization.slug}
+                        projectSlug={eventTransaction.projectSlug}
+                        disableCollapsePersistence
+                      />
+                    ) : null}
+                  </LogsPageDataProvider>
+                </LogsPageParamsProvider>
+              </ProfileGroupProvider>
+            )}
+          </ProfileContext.Consumer>
+        </ProfilesProvider>
       </TraceDrawerComponents.BodyContainer>
     </TraceDrawerComponents.DetailContainer>
   );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -5,9 +5,9 @@ import type {Location} from 'history';
 
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
+import type {SpanProfileDetailsProps} from 'sentry/components/events/interfaces/spans/spanProfileDetails';
 import {
   SpanProfileDetails,
-  SpanProfileDetailsProps,
   useSpanProfileDetails,
 } from 'sentry/components/events/interfaces/spans/spanProfileDetails';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1082,7 +1082,8 @@ function NodeActions(props: {
   const params = useParams<{traceSlug?: string}>();
 
   const {data: transaction} = useTransaction({
-    node: isTransactionNode(props.node) ? props.node : null,
+    event_id: props.node.value.event_id,
+    project_slug: props.node.value.project_slug,
     organization,
   });
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -98,7 +98,8 @@ export function TransactionNodeDetails({
     isError,
     isPending,
   } = useTransaction({
-    node,
+    event_id: node.value.event_id,
+    project_slug: node.value.project_slug,
     organization,
   });
   const {data: cacheMetrics} = useSpanMetrics(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -169,6 +169,7 @@ export declare namespace TraceTree {
     project_slug: string;
     start_timestamp: number;
     transaction: string;
+    transaction_id: string;
     description?: string;
     measurements?: Record<string, number>;
   };


### PR DESCRIPTION
We don't yet support loading attachments based components, breadcrumbs and request contexts in eap. Therefore, we've added a `transaction_id` attr (which corresponds to the nodestore transaction event id),  to all EAP spans. We use it to load the non-queryable sections below, in order:
 
<img width="1299" alt="Screenshot 2025-06-01 at 6 58 41 PM" src="https://github.com/user-attachments/assets/53654daf-d7e1-4808-89ec-c805787b84a6" />
