### PR TITLE
Revert "fix(taskworker) Remove countdown from relay tasks"

### DIFF
--- a/bin/invalidate-project-configs
+++ b/bin/invalidate-project-configs
@@ -37,7 +37,7 @@ def invalidate_project_configs(percentage):
     for org_id in RangeQuerySetWrapperWithProgressBar(queryset, result_value_getter=lambda x: x):
         if (org_id % 100) < percentage:
             schedule_invalidate_project_config(
-                trigger="invalidate-all-orgs", organization_id=org_id
+                trigger="invalidate-all-orgs", organization_id=org_id, countdown=0
             )
 
 

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -48,7 +48,9 @@ def _update_project_configs(
             for org_id in (
                 Organization.objects.values_list("id", flat=True).all().iterator(chunk_size=50_000)
             ):
-                schedule_invalidate_project_config(trigger="invalidate-all", organization_id=org_id)
+                schedule_invalidate_project_config(
+                    trigger="invalidate-all", organization_id=org_id, countdown=0
+                )
                 bar.update(1)
     else:
         with click.progressbar(changed_project_ids) as ids:

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -262,6 +262,7 @@ def schedule_invalidate_project_config(
     organization_id=None,
     project_id=None,
     public_key=None,
+    countdown=5,
     transaction_db=None,
 ):
     """Schedules the :func:`invalidate_project_config` task.
@@ -287,12 +288,15 @@ def schedule_invalidate_project_config(
     >>>     )
 
     If there is no active database transaction open for the provided ``transaction_db``,
-    the project config task is scheduled immediately.
+    the project config task is executed immediately.
 
     :param trigger: The reason for the invalidation.  This is used to tag metrics.
     :param organization_id: Invalidates all project keys for all projects in an organization.
     :param project_id: Invalidates all project keys for a project.
     :param public_key: Invalidate a single public key.
+    :param countdown: The time to delay running this task in seconds.  Normally there is a
+        slight delay to increase the likelihood of deduplicating invalidations but you can
+        tweak this, like e.g. the :func:`invalidate_all` task does.
     :param transaction_db: The database currently being used by an active transaction.
         This directs the on_commit handler for the task to the correct transaction.
     """
@@ -316,6 +320,7 @@ def schedule_invalidate_project_config(
                 organization_id=organization_id,
                 project_id=project_id,
                 public_key=public_key,
+                countdown=countdown,
             ),
             using=transaction_db,
         )
@@ -327,6 +332,7 @@ def _schedule_invalidate_project_config(
     organization_id=None,
     project_id=None,
     public_key=None,
+    countdown=5,
 ):
     """For param docs, see :func:`schedule_invalidate_project_config`."""
     from sentry.models.project import Project
@@ -375,6 +381,7 @@ def _schedule_invalidate_project_config(
     )
 
     invalidate_project_config.apply_async(
+        countdown=countdown,
         kwargs={
             "project_id": project_id,
             "organization_id": organization_id,

--- a/tests/sentry/runner/commands/test_killswitches.py
+++ b/tests/sentry/runner/commands/test_killswitches.py
@@ -161,5 +161,6 @@ class KillswitchesTest(CliTestCase):
             mock.call(
                 trigger="invalidate-all",
                 organization_id=mock_schedule.mock_calls[0].kwargs["organization_id"],
+                countdown=0,
             )
         ]

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -465,7 +465,9 @@ class TestInvalidationTask:
         schedule_inner,
         default_project,
     ):
-        schedule_invalidate_project_config(trigger="test", project_id=default_project.id)
+        schedule_invalidate_project_config(
+            trigger="test", project_id=default_project.id, countdown=2
+        )
 
         assert oncommit.call_count == 1
         assert schedule_inner.call_count == 1
@@ -474,6 +476,7 @@ class TestInvalidationTask:
             organization_id=None,
             project_id=default_project.id,
             public_key=None,
+            countdown=2,
         )
 
     @mock.patch("sentry.tasks.relay._schedule_invalidate_project_config")
@@ -484,13 +487,13 @@ class TestInvalidationTask:
     ):
         with transaction.atomic(router.db_for_write(ProjectOption)):
             schedule_invalidate_project_config(
-                trigger="inside-transaction", project_id=default_project
+                trigger="inside-transaction", project_id=default_project, countdown=2
             )
             assert schedule_inner.call_count == 0
 
         assert schedule_inner.call_count == 1
         schedule_invalidate_project_config(
-            trigger="outside-transaction", project_id=default_project
+            trigger="outside-transaction", project_id=default_project, countdown=2
         )
         assert schedule_inner.call_count == 2
 


### PR DESCRIPTION
Reverts getsentry/sentry#88819

Metrics show increased load since this PR was merged, which leads to increased calculation times overall.