### PR TITLE
feat(agent-insights): Handle new keys

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -14,6 +14,14 @@ const AI_TOKEN_USAGE_ATTRIBUTE = 'ai.total_tokens.used';
 
 export const AI_TOKEN_USAGE_ATTRIBUTE_SUM = `sum(${AI_TOKEN_USAGE_ATTRIBUTE})`;
 
+export const legacyAttributeKeys = new Map<string, string[]>([
+  ['gen_ai.request.model', ['ai.model.id']],
+  ['gen_ai.usage.input_tokens', ['ai.prompt_tokens.used']],
+  ['gen_ai.usage.output_tokens', ['ai.completion_tokens.used']],
+  ['gen_ai.usage.total_tokens', ['ai.total_tokens.used']],
+  ['gen_ai.usage.total_cost', ['ai.total_cost.used']],
+]);
+
 // TODO: Remove once tool spans have their own op
 function mapMissingSpanOp({
   op = 'default',


### PR DESCRIPTION
Access span properties via the new keys while also using the old ones as fallback.

- part of [TET-498: Trace View - AI Span details](https://linear.app/getsentry/issue/TET-498/trace-view-ai-span-details)
- relay started mapping to new keys in https://github.com/getsentry/relay/pull/4768