### PR TITLE
tests: Skip test_comment_workflow

### DIFF
--- a/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_open_pr_comment.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 from django.utils import timezone
 
@@ -381,6 +382,9 @@ class TestOpenPRCommentWorkflow(GitlabCommentTestCase):
         self.groups.reverse()
 
     @responses.activate
+    @pytest.mark.skip(
+        reason="Intermittent failure. See https://github.com/getsentry/sentry/issues/92620"
+    )
     def test_comment_workflow(
         self,
         mock_analytics,


### PR DESCRIPTION
To be re-enabled in https://github.com/getsentry/sentry/issues/92620

See failure here: https://sentry.sentry.io/issues/6648285092/?project=2423079