### PR TITLE
feat(dashboards): custom title when create widget via traces

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -30,7 +30,12 @@ import type {
   DashboardListItem,
   Widget,
 } from 'sentry/views/dashboards/types';
-import {DisplayType, MAX_WIDGETS, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DEFAULT_WIDGET_NAME,
+  DisplayType,
+  MAX_WIDGETS,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {
   eventViewFromWidget,
   getDashboardFiltersFromURL,
@@ -81,7 +86,6 @@ export type AddToDashboardModalProps = {
 type Props = ModalRenderProps & AddToDashboardModalProps;
 
 const SELECT_DASHBOARD_MESSAGE = t('Select a dashboard');
-const DEFAULT_WIDGET_NAME = t('Custom Widget');
 
 const DEFAULT_ACTIONS: AddToDashboardModalActions[] = [
   'add-and-stay-on-current-page',

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -81,7 +81,7 @@ export type AddToDashboardModalProps = {
 type Props = ModalRenderProps & AddToDashboardModalProps;
 
 const SELECT_DASHBOARD_MESSAGE = t('Select a dashboard');
-const DEFAULT_WIDGET_NAME = 'Custom Widget';
+const DEFAULT_WIDGET_NAME = t('Custom Widget');
 
 const DEFAULT_ACTIONS: AddToDashboardModalActions[] = [
   'add-and-stay-on-current-page',
@@ -291,11 +291,11 @@ function AddToDashboardModal({
           />
         </Wrapper>
         <Wrapper>
-          <SectionHeader title={t('Widget Name')} />
+          <SectionHeader title={t('Widget Name')} optional />
           <Input
             type="text"
             aria-label={t('Optional Widget Name')}
-            placeholder={t('Name to override default name (optional)')}
+            placeholder={t('Name')}
             onChange={e => updateWidgetTitle(e.target.value)}
           />
         </Wrapper>

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -1,5 +1,6 @@
 import type {Layout} from 'react-grid-layout';
 
+import {t} from 'sentry/locale';
 import type {User} from 'sentry/types/user';
 import {type DatasetSource, SavedQueryDatasets} from 'sentry/utils/discover/types';
 
@@ -12,6 +13,8 @@ import type {ThresholdsConfig} from './widgetBuilder/buildSteps/thresholdsStep/t
 export const MAX_WIDGETS = 30;
 
 export const DEFAULT_TABLE_LIMIT = 5;
+
+export const DEFAULT_WIDGET_NAME = t('Custom Widget');
 
 export enum DisplayType {
   AREA = 'area',

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -49,6 +49,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {
   type DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
   DisplayType,
   type Widget,
   type WidgetQuery,
@@ -700,7 +701,7 @@ export function handleAddQueryToDashboard({
     widget: {
       // We need the event view name for when we're adding from a saved query page
       title: (query?.name ??
-        (eventView.name === 'All Errors' ? t('Custom Widget') : eventView.name))!,
+        (eventView.name === 'All Errors' ? DEFAULT_WIDGET_NAME : eventView.name))!,
       displayType: displayType === DisplayType.TOP_N ? DisplayType.AREA : displayType,
       queries: [
         {

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -1,6 +1,5 @@
 import {useCallback} from 'react';
 
-import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -10,6 +9,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {
   DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
   DisplayType,
   WidgetType,
 } from 'sentry/views/dashboards/types';
@@ -32,8 +32,6 @@ export const CHART_TYPE_TO_DISPLAY_TYPE = {
   [ChartType.BAR]: DisplayType.BAR,
   [ChartType.AREA]: DisplayType.AREA,
 };
-
-const DEFAULT_WIDGET_NAME = t('Custom Widget');
 
 export function useAddToDashboard() {
   const location = useLocation();

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -33,6 +33,8 @@ export const CHART_TYPE_TO_DISPLAY_TYPE = {
   [ChartType.AREA]: DisplayType.AREA,
 };
 
+const DEFAULT_WIDGET_NAME = t('Custom Widget');
+
 export function useAddToDashboard() {
   const location = useLocation();
   const router = useRouter();
@@ -62,7 +64,7 @@ export function useAddToDashboard() {
       const search = new MutableSearch(query);
 
       const discoverQuery: NewQuery = {
-        name: t('Custom Widget'),
+        name: DEFAULT_WIDGET_NAME,
         fields,
         orderby: sortBys.map(formatSort),
         query: search.formatString(),

--- a/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
@@ -21,6 +21,8 @@ import {
   type ReadableExploreQueryParts,
 } from 'sentry/views/explore/multiQueryMode/locationUtils';
 
+const DEFAULT_WIDGET_NAME = t('Custom Widget');
+
 export function useAddCompareQueryToDashboard(query: ReadableExploreQueryParts) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -46,7 +48,7 @@ export function useAddCompareQueryToDashboard(query: ReadableExploreQueryParts) 
     const search = new MutableSearch(qs);
 
     const discoverQuery: NewQuery = {
-      name: t('Custom Widget'),
+      name: DEFAULT_WIDGET_NAME,
       fields,
       orderby: sortBys.map(formatSort),
       query: search.formatString(),

--- a/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useAddCompareQueryToDashboard.tsx
@@ -1,6 +1,5 @@
 import {useCallback} from 'react';
 
-import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -9,7 +8,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
-import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DashboardWidgetSource,
+  DEFAULT_WIDGET_NAME,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {MAX_NUM_Y_AXES} from 'sentry/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -20,8 +23,6 @@ import {
   getQueryMode,
   type ReadableExploreQueryParts,
 } from 'sentry/views/explore/multiQueryMode/locationUtils';
-
-const DEFAULT_WIDGET_NAME = t('Custom Widget');
 
 export function useAddCompareQueryToDashboard(query: ReadableExploreQueryParts) {
   const organization = useOrganization();


### PR DESCRIPTION
### Changes
Allow users to optionally modify the widget name AND stay on the same page. Add a new input to hold this modified name. Associated ticket: https://linear.app/getsentry/issue/DAIN-371/allow-editing-widget-name-in-trace-explorer-modal

### Before
<img width="1430" alt="Screenshot 2025-06-02 at 9 58 59 AM" src="https://github.com/user-attachments/assets/81567210-872e-44ef-9c6b-c44aa3442b27" />


### After

If the user chooses to set a custom name it should stay if the user chooses to stay on the trace page:
https://github.com/user-attachments/assets/0882da8e-aff0-430e-b138-4671f5a7f615


Otherwise, it falls back to the default title (which was being used before this change):
https://github.com/user-attachments/assets/4e2fb922-4ef8-4e10-9db8-d6e4fca1c5cd

