### PR TITLE
revert: feat(spans): Evict spans during insert

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -27,7 +27,7 @@ local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
-for i = 0, 1000 do
+for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
     local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
     redirect_depth = i
     if not new_set_span or new_set_span == set_span_id then
@@ -40,28 +40,18 @@ end
 redis.call("hset", main_redirect_key, span_id, set_span_id)
 redis.call("expire", main_redirect_key, set_timeout)
 
-local span_count = 0
-
 local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
-if not is_root_span and redis.call("zcard", span_key) > 0 then
-    span_count = redis.call("zunionstore", set_key, 2, set_key, span_key)
+if not is_root_span and redis.call("scard", span_key) > 0 then
+    redis.call("sunionstore", set_key, set_key, span_key)
     redis.call("unlink", span_key)
 end
 
 local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
-if set_span_id ~= parent_span_id and redis.call("zcard", parent_key) > 0 then
-    span_count = redis.call("zunionstore", set_key, 2, set_key, parent_key)
+if set_span_id ~= parent_span_id and redis.call("scard", parent_key) > 0 then
+    redis.call("sunionstore", set_key, set_key, parent_key)
     redis.call("unlink", parent_key)
 end
 redis.call("expire", set_key, set_timeout)
-
-if span_count == 0 then
-    span_count = redis.call("zcard", set_key)
-end
-
-if span_count > 1000 then
-    redis.call("zpopmin", set_key, span_count - 1000)
-end
 
 local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
 local has_root_span = redis.call("get", has_root_span_key) == "1" or is_root_span

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -21,8 +21,8 @@ local span_id = ARGV[2]
 local parent_span_id = ARGV[3]
 local set_timeout = tonumber(ARGV[4])
 
-local span_key = string.format("sb:s:{%s}:%s", project_and_trace, span_id)
-local main_redirect_key = string.format("sb:sr:{%s}", project_and_trace)
+local span_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
 
 local set_span_id = parent_span_id
 local redirect_depth = 0
@@ -42,13 +42,13 @@ redis.call("expire", main_redirect_key, set_timeout)
 
 local span_count = 0
 
-local set_key = string.format("sb:s:{%s}:%s", project_and_trace, set_span_id)
+local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
 if not is_root_span and redis.call("zcard", span_key) > 0 then
     span_count = redis.call("zunionstore", set_key, 2, set_key, span_key)
     redis.call("unlink", span_key)
 end
 
-local parent_key = string.format("sb:s:{%s}:%s", project_and_trace, parent_span_id)
+local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
 if set_span_id ~= parent_span_id and redis.call("zcard", parent_key) > 0 then
     span_count = redis.call("zunionstore", set_key, 2, set_key, parent_key)
     redis.call("unlink", parent_key)
@@ -63,7 +63,7 @@ if span_count > 1000 then
     redis.call("zpopmin", set_key, span_count - 1000)
 end
 
-local has_root_span_key = string.format("sb:hrs:%s", set_key)
+local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
 local has_root_span = redis.call("get", has_root_span_key) == "1" or is_root_span
 if has_root_span then
     redis.call("setex", has_root_span_key, set_timeout, "1")

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -33,8 +33,8 @@ Segments are flushed out to `buffered-spans` topic under two conditions:
 Now how does that look like in Redis? For each incoming span, we:
 
 1. Try to figure out what the name of the respective span buffer is (`set_key` in `add-buffer.lua`)
-  a. We look up any "redirects" from the span buffer's parent_span_id (hashmap at "sb:sr:{project_id:trace_id}") to another key.
-  b. Otherwise we use "sb:s:{project_id:trace_id}:span_id"
+  a. We look up any "redirects" from the span buffer's parent_span_id (hashmap at "span-buf:sr:{project_id:trace_id}") to another key.
+  b. Otherwise we use "span-buf:s:{project_id:trace_id}:span_id"
 2. Rename any span buffers keyed under the span's own span ID to `set_key`, merging their contents.
 3. Add the ingested span's payload to the set under `set_key`.
 4. To a "global queue", we write the set's key, sorted by timeout.
@@ -55,10 +55,10 @@ than the original topic.
 
 Glossary for types of keys:
 
-    * sb:s:* -- the actual set keys, containing span payloads. Each key contains all data for a segment. The most memory-intensive kind of key.
-    * sb:q:* -- the priority queue, used to determine which segments are ready to be flushed.
-    * sb:hrs:* -- simple bool key to flag a segment as "has root span" (HRS)
-    * sb:sr:* -- redirect mappings so that each incoming span ID can be mapped to the right sb:s: set.
+    * span-buf:s:* -- the actual set keys, containing span payloads. Each key contains all data for a segment. The most memory-intensive kind of key.
+    * span-buf:q:* -- the priority queue, used to determine which segments are ready to be flushed.
+    * span-buf:hrs:* -- simple bool key to flag a segment as "has root span" (HRS)
+    * span-buf:sr:* -- redirect mappings so that each incoming span ID can be mapped to the right span-buf:s: set.
 """
 
 from __future__ import annotations
@@ -78,7 +78,7 @@ from sentry.utils import metrics, redis
 
 # SegmentKey is an internal identifier used by the redis buffer that is also
 # directly used as raw redis key. the format is
-# "sb:s:{project_id:trace_id}:span_id", and the type is bytes because our
+# "span-buf:s:{project_id:trace_id}:span_id", and the type is bytes because our
 # redis client is bytes.
 #
 # The segment ID in the Kafka protocol is only the span ID.
@@ -193,7 +193,7 @@ class SpansBuffer:
 
             with self.client.pipeline(transaction=False) as p:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
-                    set_key = f"sb:s:{{{project_and_trace}}}:{parent_span_id}"
+                    set_key = f"span-buf:s:{{{project_and_trace}}}:{parent_span_id}"
                     p.zadd(
                         set_key, {span.payload: span.end_timestamp_precise for span in subsegment}
                     )
@@ -287,7 +287,7 @@ class SpansBuffer:
         return self.add_buffer_sha
 
     def _get_queue_key(self, shard: int) -> bytes:
-        return f"sb:q:{shard}".encode("ascii")
+        return f"span-buf:q:{shard}".encode("ascii")
 
     def _group_by_parent(self, spans: Sequence[Span]) -> dict[tuple[str, str], list[Span]]:
         """
@@ -467,12 +467,12 @@ class SpansBuffer:
         with metrics.timer("spans.buffer.done_flush_segments"):
             with self.client.pipeline(transaction=False) as p:
                 for segment_key, flushed_segment in segment_keys.items():
-                    hrs_key = b"sb:hrs:" + segment_key
+                    hrs_key = b"span-buf:hrs:" + segment_key
                     p.delete(hrs_key)
                     p.unlink(segment_key)
 
                     project_id, trace_id, _ = parse_segment_key(segment_key)
-                    redirect_map_key = b"sb:sr:{%s:%s}" % (project_id, trace_id)
+                    redirect_map_key = b"span-buf:sr:{%s:%s}" % (project_id, trace_id)
                     p.zrem(flushed_segment.queue_key, segment_key)
 
                     for span_batch in itertools.batched(flushed_segment.spans, 100):

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -2,7 +2,6 @@ import logging
 import time
 from collections.abc import Callable, Mapping
 from functools import partial
-from typing import cast
 
 import rapidjson
 import sentry_sdk
@@ -12,7 +11,6 @@ from arroyo.processing.strategies.batching import BatchStep, ValuesBatch
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, FilteredPayload, Message, Partition
-from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 from sentry.spans.buffer import Span, SpansBuffer
 from sentry.spans.consumers.process.flusher import SpanFlusher
@@ -134,14 +132,13 @@ def process_batch(
         if min_timestamp is None or timestamp < min_timestamp:
             min_timestamp = timestamp
 
-        val = cast(SpanEvent, rapidjson.loads(payload.value))
+        val = rapidjson.loads(payload.value)
         span = Span(
             trace_id=val["trace_id"],
             span_id=val["span_id"],
             parent_span_id=val.get("parent_span_id"),
             project_id=val["project_id"],
             payload=payload.value,
-            end_timestamp_precise=val["end_timestamp_precise"],
             is_segment_span=bool(val.get("parent_span_id") is None or val.get("is_remote")),
         )
         spans.append(span)

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -41,7 +41,6 @@ def test_basic(monkeypatch):
                             "project_id": 12,
                             "span_id": "a" * 16,
                             "trace_id": "b" * 32,
-                            "end_timestamp_precise": 1700000000.0,
                         }
                     ).encode("ascii"),
                     [],
@@ -70,7 +69,6 @@ def test_basic(monkeypatch):
                 "segment_id": "aaaaaaaaaaaaaaaa",
                 "span_id": "aaaaaaaaaaaaaaaa",
                 "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "end_timestamp_precise": 1700000000.0,
             },
         ],
     }

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -44,7 +44,6 @@ def test_backpressure(monkeypatch):
                 span_id="a" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
-                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"d" * 16),
@@ -52,7 +51,6 @@ def test_backpressure(monkeypatch):
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
-                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"c" * 16),
@@ -60,7 +58,6 @@ def test_backpressure(monkeypatch):
                 span_id="c" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
-                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"b" * 16),
@@ -69,7 +66,6 @@ def test_backpressure(monkeypatch):
                 parent_span_id=None,
                 is_segment_span=True,
                 project_id=1,
-                end_timestamp_precise=now,
             ),
         ]
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -123,7 +123,6 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="a" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -131,7 +130,6 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -139,7 +137,6 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -148,7 +145,6 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -192,7 +188,6 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 _SplitBatch(),
                 Span(
@@ -201,7 +196,6 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="b" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"a" * 16),
@@ -210,7 +204,6 @@ def test_basic(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -218,7 +211,6 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -262,7 +254,6 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="e" * 16,
                     parent_span_id="d" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -270,7 +261,6 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -278,7 +268,6 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="b" * 16,
                     parent_span_id="c" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -286,7 +275,6 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"a" * 16),
@@ -295,7 +283,6 @@ def test_deep(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -340,7 +327,6 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -348,7 +334,6 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"e" * 16),
@@ -356,7 +341,6 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="e" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
-                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -365,7 +349,6 @@ def test_deep2(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=2,
-                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -417,7 +400,6 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 parent_span_id="d" * 16,
                 project_id=1,
                 is_segment_span=True,
-                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"d" * 16),
@@ -425,7 +407,6 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
-                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"e" * 16),
@@ -433,7 +414,6 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 span_id="e" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
-                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"b" * 16),
@@ -442,7 +422,6 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 parent_span_id=None,
                 is_segment_span=True,
                 project_id=2,
-                end_timestamp_precise=1700000000.0,
             ),
         ]
     ),
@@ -497,7 +476,6 @@ def test_flush_rebalance(buffer: SpansBuffer):
             parent_span_id=None,
             project_id=1,
             is_segment_span=True,
-            end_timestamp_precise=1700000000.0,
         )
     ]
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -20,7 +20,7 @@ def shallow_permutations(spans: list[Span]) -> list[list[Span]]:
 
 
 def _segment_id(project_id: int, trace_id: str, span_id: str) -> SegmentKey:
-    return f"sb:s:{{{project_id}:{trace_id}}}:{span_id}".encode("ascii")
+    return f"span-buf:s:{{{project_id}:{trace_id}}}:{span_id}".encode("ascii")
 
 
 def _payload(span_id: bytes) -> bytes:


### PR DESCRIPTION
- **Revert "fix(spans): Rename span buf prefix (#92617)"**
- **Revert "feat(spans): Evict spans during insert (#92393)"**

This PR incurred 30% overhead on insert_spans. We only see this reported from the consumer/client -- we don't see additional time spent in redis commands as reported by the cluster itself.

Ref STREAM-162