### PR TITLE
fix(insights): pass in `groupBy` for queue throughput chart

### DIFF
--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -11,7 +11,7 @@ import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/use
 import {renameDiscoverSeries} from 'sentry/views/insights/common/utils/renameDiscoverSeries';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {FIELD_ALIASES} from 'sentry/views/insights/queues/settings';
-import type {SpanQueryFilters} from 'sentry/views/insights/types';
+import {SpanFields, SpanQueryFilters} from 'sentry/views/insights/types';
 
 interface Props {
   id: string;
@@ -27,6 +27,7 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
   const search = MutableSearch.fromQueryObject({
     'span.op': '[queue.publish, queue.process]',
   } satisfies SpanQueryFilters);
+  const groupBy = SpanFields.SPAN_OP;
 
   if (destination) {
     search.addFilterValue('messaging.destination.name', destination, false);
@@ -40,7 +41,7 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
     {
       search,
       yAxis: ['epm()'],
-      fields: ['epm()', 'span.op'],
+      fields: ['epm()', groupBy],
       topN: 2,
       transformAliasToInputFormat: true,
     },
@@ -62,6 +63,7 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
     <InsightsLineChartWidget
       id={id}
       search={search}
+      groupBy={[groupBy]}
       title={t('Published vs Processed')}
       series={[
         renameDiscoverSeries(

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -11,7 +11,8 @@ import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/use
 import {renameDiscoverSeries} from 'sentry/views/insights/common/utils/renameDiscoverSeries';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {FIELD_ALIASES} from 'sentry/views/insights/queues/settings';
-import {SpanFields, SpanQueryFilters} from 'sentry/views/insights/types';
+import type {SpanQueryFilters} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 interface Props {
   id: string;


### PR DESCRIPTION
We should pass in the `groupBy` prop in the queue throughput chart, so that the explore page correctly groups when you click `open in explore`