### PR TITLE
fix(dashboards): scroll overflow if dashboard column is expanded too far

### DIFF
--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -339,7 +339,7 @@ function DashboardTable({
     <GridEditable
       data={dashboards ?? []}
       // necessary for edit access dropdown
-      bodyStyle={{overflow: 'visible'}}
+      bodyStyle={{overflow: 'scroll'}}
       columnOrder={columnOrder}
       columnSortBy={[]}
       grid={{


### PR DESCRIPTION
### Changes
Allow the user to scroll the dashboard table if they overflow it by expanding one of the columns too far. This is to allow them to drag the column back.

### Before
See video in https://linear.app/getsentry/issue/DAIN-569/fix-column-resizing-overflow-in-tables

### After
User is able to scroll the table sideways on overflow
![Screenshot 2025-06-02 at 11 05 50 AM](https://github.com/user-attachments/assets/b885efb2-f0ef-4c22-8c69-358c99515124)


