### PR TITLE
feat(insights): pass in search into queue sample chart

### DIFF
--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -313,6 +313,7 @@ export function MessageSpanSamplesPanel() {
             <ModuleLayout.Full>
               <InsightsLineChartWidget
                 showLegend="never"
+                search={timeseriesFilters}
                 title={getDurationChartTitle('queue')}
                 isLoading={isDurationDataFetching}
                 error={durationError}


### PR DESCRIPTION
Pass in `search` prop in queue sample chart, so the correct query is pre-populated when you open the chart in explore.