### PR TITLE
chore: Clean up message truncation char limit flag

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -1,6 +1,5 @@
 from warnings import warn
 
-from sentry import options
 from sentry.utils.safe import get_path
 from sentry.utils.strings import strip, truncatechars
 
@@ -49,11 +48,7 @@ class DefaultEvent(BaseEvent):
         )
 
         if message:
-            if options.get("sentry.save-event.title-char-limit-256.enabled"):
-                truncate_to = 256
-            else:
-                truncate_to = 100
-            title = truncatechars(message.splitlines()[0], truncate_to)
+            title = truncatechars(message.splitlines()[0], 256)
         else:
             title = "<unlabeled event>"
 

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import Any
 
-from sentry import options
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
 
@@ -77,12 +76,8 @@ class ErrorEvent(BaseEvent):
         title = metadata.get("type")
         if title is not None:
             value = metadata.get("value")
-            if options.get("sentry.save-event.title-char-limit-256.enabled"):
-                truncate_to = 256
-            else:
-                truncate_to = 100
             if value:
-                title += f": {truncatechars(value.splitlines()[0], truncate_to)}"
+                title += f": {truncatechars(value.splitlines()[0], 256)}"
 
         return title or metadata.get("function") or "<unknown>"
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3099,14 +3099,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Increases event title character limit
-register(
-    "sentry.save-event.title-char-limit-256.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     "sentry.demo_mode.sync_artifact_bundles.enable",
     type=Bool,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3099,6 +3099,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Increases event title character limit
+register(
+    "sentry.save-event.title-char-limit-256.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "sentry.demo_mode.sync_artifact_bundles.enable",
     type=Bool,


### PR DESCRIPTION
This has been enabled for the last ~4 months, just cleaning up the flag.
Will remove flag in a follow up after they've been removed from sentry-options-automator