### PR TITLE
fix(ui): Consistently use getFormat with getFormattedDate

### DIFF
--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -15,7 +15,7 @@ import type {Series} from 'sentry/types/echarts';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {escape} from 'sentry/utils';
-import {getFormattedDate, getUtcDateString} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate, getUtcDateString} from 'sentry/utils/dates';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import withApi from 'sentry/utils/withApi';
@@ -287,9 +287,13 @@ class ReleaseSeries extends Component<ReleaseSeriesProps, State> {
           // XXX using this.props here as this function does not get re-run
           // unless projects are changed. Using a closure variable would result
           // in stale values.
-          const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
-            local: !this.props.utc,
-          });
+          const time = getFormattedDate(
+            data.value,
+            getFormat({timeZone: true, year: true}),
+            {
+              local: !this.props.utc,
+            }
+          );
           const version = escape(formatVersion(data.name, true));
           return [
             '<div class="tooltip-series">',

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -13,7 +13,7 @@ import type {
   MultiSeriesEventsStats,
 } from 'sentry/types/organization';
 import {defined, escape} from 'sentry/utils';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import oxfordizeArray from 'sentry/utils/oxfordizeArray';
@@ -402,12 +402,12 @@ export function computeEchartsAriaLabels(
     ? series.filter(s => s && !!s.data && s.data.length > 0)
     : [series];
 
-  const dateFormat = computeShortInterval({
+  const isShortInterval = computeShortInterval({
     start: filteredSeries[0]?.data?.[0][0],
     end: filteredSeries[0]?.data?.slice(-1)[0][0],
-  })
-    ? `MMMM D, h:mm A`
-    : 'MMMM Do';
+  });
+
+  const dateFormat = isShortInterval ? getFormat({timeZone: true}) : 'MMMM Do';
 
   function formatDate(date: any) {
     return getFormattedDate(date, dateFormat, {

--- a/static/app/components/events/eventStatisticalDetector/eventRegressionSummary.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventRegressionSummary.tsx
@@ -9,7 +9,7 @@ import type {Group, KeyValueListData} from 'sentry/types/group';
 import {IssueType} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -147,9 +147,11 @@ function formatDurationChange(
 }
 
 function formatBreakpoint(breakpoint: number) {
-  return getFormattedDate(breakpoint * 1000, 'MMM D, YYYY hh:mm:ss A z', {
-    local: true,
-  });
+  return getFormattedDate(
+    breakpoint * 1000,
+    getFormat({year: true, seconds: true, timeZone: true}),
+    {local: true}
+  );
 }
 
 const StyledKeyValueList = styled(KeyValueList)`

--- a/static/app/components/featureFlags/hooks/useFlagSeries.tsx
+++ b/static/app/components/featureFlags/hooks/useFlagSeries.tsx
@@ -5,7 +5,7 @@ import MarkLine from 'sentry/components/charts/components/markLine';
 import {hydrateToFlagSeries, type RawFlag} from 'sentry/components/featureFlags/utils';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 interface FlagSeriesProps {
@@ -40,9 +40,13 @@ export function useFlagSeries({event, flags}: FlagSeriesProps) {
     tooltip: {
       trigger: 'item',
       formatter: ({data}: any) => {
-        const time = getFormattedDate(data.xAxis, 'MMM D, YYYY LT z', {
-          local: !selection.datetime.utc,
-        });
+        const time = getFormattedDate(
+          data.xAxis,
+          getFormat({timeZone: true, year: true}),
+          {
+            local: !selection.datetime.utc,
+          }
+        );
 
         const eventIsBefore = moment(event?.dateCreated).isBefore(moment(time));
         const formattedDate = moment(time).from(event?.dateCreated, true);

--- a/static/app/components/group/releaseChart.tsx
+++ b/static/app/components/group/releaseChart.tsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import type {TimeseriesValue} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import type {Release} from 'sentry/types/release';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 
 /**
@@ -93,9 +93,13 @@ export function getGroupReleaseChartMarkers(
     show: true,
     trigger: 'item',
     formatter: ({data}: any) => {
-      const time = getFormattedDate(data.displayValue, 'MMM D, YYYY LT', {
-        local: true,
-      });
+      const time = getFormattedDate(
+        data.displayValue,
+        getFormat({timeZone: true, year: true}),
+        {
+          local: true,
+        }
+      );
       return [
         '<div class="tooltip-series">',
         `<div><span class="tooltip-label"><strong>${data.name}</strong></span></div>`,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/releaseSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/releaseSeries.tsx
@@ -4,7 +4,7 @@ import type {CustomSeriesOption} from 'echarts';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import {escape} from 'sentry/utils';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import type {Release} from 'sentry/views/dashboards/widgets/common/types';
 
@@ -45,9 +45,13 @@ export function ReleaseSeries(
       tooltip: {
         trigger: 'item',
         formatter: function (params: any) {
-          const time = getFormattedDate(params.value, 'MMM D, YYYY LT', {
-            local: utc,
-          });
+          const time = getFormattedDate(
+            params.value,
+            getFormat({timeZone: true, year: true}),
+            {
+              local: utc,
+            }
+          );
 
           const version = escape(formatVersion(params.name, true));
 

--- a/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useEventMarkLineSeries.tsx
@@ -5,7 +5,7 @@ import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {useIssueDetailsEventView} from 'sentry/views/issueDetails/streamline/hooks/useIssueDetailsDiscoverQuery';
 
 interface UseEventMarklineSeriesProps {
@@ -67,9 +67,13 @@ export function useCurrentEventMarklineSeries({
         trigger: 'item',
         formatter: () => {
           // Do not use date from xAxis here since we've placed it on the nearest bar
-          const time = getFormattedDate(event.dateCreated, 'MMM D, YYYY LT', {
-            local: !eventView.utc,
-          });
+          const time = getFormattedDate(
+            event.dateCreated,
+            getFormat({timeZone: true, year: true}),
+            {
+              local: !eventView.utc,
+            }
+          );
           return [
             '<div class="tooltip-series">',
             `<div><span class="tooltip-label"><strong>${t('Current Event')}</strong></span></div>`,

--- a/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useReleaseMarkLineSeries.tsx
@@ -5,7 +5,7 @@ import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {ReleaseMetaBasic} from 'sentry/types/release';
 import {escape} from 'sentry/utils';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
@@ -63,9 +63,13 @@ export function useReleaseMarkLineSeries({
     tooltip: {
       trigger: 'item',
       formatter: ({data}: any) => {
-        const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
-          local: !eventView.utc,
-        });
+        const time = getFormattedDate(
+          data.value,
+          getFormat({timeZone: true, year: true}),
+          {
+            local: !eventView.utc,
+          }
+        );
         const version = escape(formatVersion(data.name, true));
         return [
           '<div class="tooltip-series">',

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -22,7 +22,7 @@ import {space} from 'sentry/styles/space';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import toArray from 'sentry/utils/array/toArray';
 import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import formatDuration from 'sentry/utils/duration/formatDuration';
 import type {MemoryFrame} from 'sentry/utils/replays/types';
 
@@ -163,7 +163,7 @@ const MemoryChartSeries = memo(
               return `
           <div class="tooltip-series">${seriesTooltips.join('')}</div>
             <div class="tooltip-footer">
-              ${t('Date: %s', getFormattedDate(startTimestampMs + (firstValue as any).axisValue, 'MMM D, YYYY hh:mm:ss A z', {local: false}))}
+              ${t('Date: %s', getFormattedDate(startTimestampMs + (firstValue as any).axisValue, getFormat({year: true, seconds: true, timeZone: true}), {local: false}))}
             </div>
             <div class="tooltip-footer" style="border: none;">
               ${t(

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuth.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuth.tsx
@@ -1,7 +1,7 @@
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
 import Link from 'sentry/components/links/link';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 
 import PageHeader from 'admin/components/pageHeader';
 import ResultGrid from 'admin/components/resultGrid';
@@ -17,7 +17,7 @@ const getRow = (row: any) => [
     {row.clientID}
   </td>,
   <td key="created" style={{textAlign: 'right'}}>
-    {getFormattedDate(row.dateAdded, 'MMM Do YYYY')}
+    {getFormattedDate(row.dateAdded, getFormat({dateOnly: true, year: true}))}
   </td>,
 ];
 

--- a/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
@@ -96,7 +96,7 @@ describe('Renders QuotaExceededAlert correctly', function () {
     ).toBeInTheDocument();
     expect(screen.getByText(/Dec 31, 2024/)).toBeInTheDocument();
     expect(screen.getByText(/or adjust your date range prior to/)).toBeInTheDocument();
-    expect(screen.getByText(/Dec 07, 2024/)).toBeInTheDocument();
+    expect(screen.getByText(/Dec 7, 2024/)).toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {name: /increase your on-demand budget/})

--- a/static/gsApp/components/performance/quotaExceededAlert.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.tsx
@@ -6,7 +6,7 @@ import Link from 'sentry/components/links/link';
 import {tct} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import {getFormattedDate} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -16,20 +16,20 @@ import {usePerformanceUsageStats} from 'getsentry/hooks/performance/usePerforman
 import type {Subscription} from 'getsentry/types';
 import trackGetsentryAnalytics from 'getsentry/utils/trackGetsentryAnalytics';
 
-const DATE_FORMAT = 'MMM DD, YYYY';
-
 // Returns the beggining of statsPeriod formatted like "Jan 1, 2022"
 // or absolute date range formatted like "Jan 1, 2022 - Jan 2, 2022"
 function getFormattedDateTime(dateTime: PageFilters['datetime']): string | null {
   const {start, end, period} = dateTime;
+  const format = getFormat({dateOnly: true, year: true});
+
   if (period) {
     const periodToHours = parsePeriodToHours(period);
     const periodStartDate = new Date(Date.now() - periodToHours * 60 * 60 * 1000);
-    return getFormattedDate(periodStartDate, DATE_FORMAT);
+    return getFormattedDate(periodStartDate, format);
   }
 
   if (start && end) {
-    return `${getFormattedDate(new Date(start), DATE_FORMAT)} - ${getFormattedDate(new Date(end), DATE_FORMAT)}`;
+    return `${getFormattedDate(new Date(start), format)} - ${getFormattedDate(new Date(end), format)}`;
   }
 
   return null;

--- a/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.spec.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.spec.tsx
@@ -167,6 +167,6 @@ describe('SpikeProtectionHistoryTable', () => {
     await screen.findByTestId('spike-protection-history-table');
     screen.getByText('Ongoing');
     screen.getByText('200K');
-    screen.getByText('Jan 2nd 2022 - present');
+    screen.getByText('Jan 2, 2022 - present');
   });
 });

--- a/static/gsApp/views/spikeProtection/spikeProtectionTimeDetails.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionTimeDetails.tsx
@@ -3,18 +3,20 @@ import styled from '@emotion/styled';
 import {AlertBadge} from 'sentry/components/core/badge/alertBadge';
 import {IconCalendar} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import {getFormattedDate, getTimeFormat} from 'sentry/utils/dates';
+import {getFormat, getFormattedDate} from 'sentry/utils/dates';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 
 import type {SpikeDetails} from 'getsentry/views/spikeProtection/types';
 
 function SpikeProtectionTimeDetails({spike}: {spike: SpikeDetails}) {
   const {start, end} = spike;
-  const timeFormat = getTimeFormat();
+  const format = getFormat({timeOnly: true});
   const formattedTime = end
-    ? `${getFormattedDate(start, timeFormat)} - ${getFormattedDate(end, timeFormat)}`
-    : `${getFormattedDate(start, timeFormat)} - present`;
-  const [startDate, endDate] = [start, end].map(d => getFormattedDate(d, 'MMM Do YYYY'));
+    ? `${getFormattedDate(start, format)} - ${getFormattedDate(end, format)}`
+    : `${getFormattedDate(start, format)} - present`;
+  const [startDate, endDate] = [start, end].map(d =>
+    getFormattedDate(d, getFormat({dateOnly: true, year: true}))
+  );
   const dateFormat =
     startDate === endDate
       ? startDate


### PR DESCRIPTION
There were a number of places where we hardcode a date format, this
breaks settings like the 24 hour clock. Instead always use the getFormat
which handles respecting user settings

References https://github.com/getsentry/sentry/issues/54925