### PR TITLE
fix(billing): Get availableReservedBudgetTypes from subscription

### DIFF
--- a/static/gsApp/views/amCheckout/checkoutOverview.tsx
+++ b/static/gsApp/views/amCheckout/checkoutOverview.tsx
@@ -72,11 +72,13 @@ class CheckoutOverview extends Component<Props> {
   };
 
   renderProducts = () => {
-    const {formData, activePlan} = this.props;
+    const {formData, activePlan, subscription} = this.props;
 
     return Object.entries(formData.selectedProducts ?? {}).map(([apiName, product]) => {
       const productInfo =
-        activePlan.availableReservedBudgetTypes[apiName as ReservedBudgetCategoryType];
+        subscription?.planDetails?.availableReservedBudgetTypes[
+          apiName as ReservedBudgetCategoryType
+        ];
       if (!productInfo || !product.enabled) {
         return null;
       }

--- a/static/gsApp/views/amCheckout/checkoutOverviewV2.tsx
+++ b/static/gsApp/views/amCheckout/checkoutOverviewV2.tsx
@@ -34,7 +34,12 @@ type Props = {
   discountInfo?: Promotion['discountInfo'];
 };
 
-function CheckoutOverviewV2({activePlan, formData, onUpdate: _onUpdate}: Props) {
+function CheckoutOverviewV2({
+  activePlan,
+  formData,
+  onUpdate: _onUpdate,
+  subscription,
+}: Props) {
   const shortInterval = useMemo(() => {
     return utils.getShortInterval(activePlan.billingInterval);
   }, [activePlan.billingInterval]);
@@ -115,7 +120,7 @@ function CheckoutOverviewV2({activePlan, formData, onUpdate: _onUpdate}: Props) 
 
   const renderProductBreakdown = () => {
     const hasAtLeastOneSelectedProduct = Object.values(
-      activePlan.availableReservedBudgetTypes
+      subscription?.planDetails?.availableReservedBudgetTypes
     ).some(budgetTypeInfo => {
       return formData.selectedProducts?.[
         budgetTypeInfo.apiName as string as SelectableProduct
@@ -131,7 +136,7 @@ function CheckoutOverviewV2({activePlan, formData, onUpdate: _onUpdate}: Props) 
         <Separator />
         <Section>
           <ReservedVolumes>
-            {Object.values(activePlan.availableReservedBudgetTypes).map(
+            {Object.values(subscription?.planDetails?.availableReservedBudgetTypes).map(
               budgetTypeInfo => {
                 const formDataForProduct =
                   formData.selectedProducts?.[
@@ -172,7 +177,7 @@ function CheckoutOverviewV2({activePlan, formData, onUpdate: _onUpdate}: Props) 
                       <Title>
                         {utils.displayPrice({
                           cents: utils.getReservedPriceForReservedBudgetCategory({
-                            plan: activePlan,
+                            plan: subscription?.planDetails || activePlan,
                             reservedBudgetCategory: budgetTypeInfo.apiName,
                           }),
                         })}
@@ -199,7 +204,7 @@ function CheckoutOverviewV2({activePlan, formData, onUpdate: _onUpdate}: Props) 
     ];
 
     const budgetCategories = Object.values(
-      activePlan.availableReservedBudgetTypes
+      subscription?.planDetails?.availableReservedBudgetTypes
     ).reduce((acc, type) => {
       acc.push(...type.dataCategories);
       return acc;

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -20,6 +20,7 @@ import {space} from 'sentry/styles/space';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 import type {Color} from 'sentry/utils/theme';
 
+import useSubscription from 'getsentry/hooks/useSubscription';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {SelectableProduct, type StepProps} from 'getsentry/views/amCheckout/types';
 import * as utils from 'getsentry/views/amCheckout/utils';
@@ -30,7 +31,10 @@ function ProductSelect({
   onUpdate,
   organization,
 }: Pick<StepProps, 'activePlan' | 'organization' | 'onUpdate' | 'formData'>) {
-  const availableProducts = Object.values(activePlan.availableReservedBudgetTypes)
+  const subscription = useSubscription();
+  const availableProducts = Object.values(
+    subscription?.planDetails?.availableReservedBudgetTypes ?? {}
+  )
     .filter(
       productInfo =>
         productInfo.isFixed && // NOTE: for now, we only supported fixed budget products in checkout
@@ -71,7 +75,7 @@ function ProductSelect({
 
         const cost = formatCurrency(
           utils.getReservedPriceForReservedBudgetCategory({
-            plan: activePlan,
+            plan: subscription?.planDetails || activePlan,
             reservedBudgetCategory: productInfo.apiName,
           })
         );
@@ -167,9 +171,9 @@ function ProductSelect({
                     {
                       includedBudget,
                       budgetTerm:
-                        activePlan.budgetTerm === 'pay-as-you-go'
+                        subscription?.planDetails?.budgetTerm === 'pay-as-you-go'
                           ? 'PAYG'
-                          : activePlan.budgetTerm,
+                          : subscription?.planDetails?.budgetTerm,
                       productName: toTitleCase(productInfo.productName),
                     }
                   )}

--- a/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
+++ b/static/gsApp/views/amCheckout/steps/setPayAsYouGo.tsx
@@ -58,8 +58,8 @@ function SetPayAsYouGo({
   }, [activePlan]);
 
   const availableReservedBudgetTypes = useMemo(() => {
-    return activePlan.availableReservedBudgetTypes;
-  }, [activePlan]);
+    return subscription?.planDetails?.availableReservedBudgetTypes;
+  }, [subscription?.planDetails]);
 
   const paygOnlyCategories = useMemo(() => {
     return activePlan.categories.filter(


### PR DESCRIPTION
Closes: https://linear.app/getsentry/issue/BIL-810/fix-the-availablereservedbudgettypes-in-checkout

Reads the `availableReservedBudgetTypes` from the subscription planDetails instead of activePlan. This is required for pre-launch testing efforts.