### PR TITLE
fix(replay): don't reset search bar after replay index loads

### DIFF
--- a/static/app/views/replays/list/listContent.tsx
+++ b/static/app/views/replays/list/listContent.tsx
@@ -39,26 +39,15 @@ export default function ListContent() {
     true
   );
 
-  const showDeadRageClickCards = !rageClicksSdkVersion.needsUpdate && !allMobileProj;
+  const isLoading = hasSentReplays.fetching || rageClicksSdkVersion.isFetching;
+  const showDeadRageClickCards =
+    !rageClicksSdkVersion.needsUpdate && !allMobileProj && !isLoading;
 
   useRouteAnalyticsParams({
     hasSessionReplay,
     hasSentReplays: hasSentReplays.hasSentOneReplay,
     hasRageClickMinSDK: !rageClicksSdkVersion.needsUpdate,
   });
-
-  // show loading
-  if (hasSentReplays.fetching || rageClicksSdkVersion.isFetching) {
-    return (
-      <Fragment>
-        <FiltersContainer>
-          <ReplaysFilters />
-          <ReplaysSearch />
-        </FiltersContainer>
-        <LoadingIndicator />
-      </Fragment>
-    );
-  }
 
   // show onboarding
   if (!hasSessionReplay || !hasSentReplays.hasSentOneReplay) {
@@ -87,7 +76,7 @@ export default function ListContent() {
         </SearchWrapper>
       </FiltersContainer>
       {widgetIsOpen && showDeadRageClickCards ? <DeadRageSelectorCards /> : null}
-      <ReplaysList />
+      {isLoading ? <LoadingIndicator /> : <ReplaysList />}
     </Fragment>
   );
 }


### PR DESCRIPTION
don't reset the search bar after the replay index loads. we were rendering a completely new view when the page is done loading, so i just removed that separate condition -- now we only rerender the bottom section (e.g. not the search & filters) when loading is complete. 

closes https://linear.app/getsentry/issue/REPLAY-225/replays-index-search-bar-resets-after-table-is-loaded


before:

https://github.com/user-attachments/assets/2c193fcb-d056-44df-b7cb-d2ac715d88ea


after:

https://github.com/user-attachments/assets/ec760007-35af-4252-ae4e-6dc583be4d3d

