### PR TITLE
fix(search-bar): Autocompolete as aggregate filter when it looks like…

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3167,6 +3167,25 @@ describe('SearchQueryBuilder', function () {
           ).toHaveTextContent('operator: string');
         });
       });
+
+      it('focuses on the filter value when user selects an aggregate filter with no arguments', async function () {
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />);
+
+        await userEvent.click(getLastInput());
+        await userEvent.keyboard('count');
+        await userEvent.click(screen.getByRole('option', {name: 'count()'}));
+        expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
+        expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
+      });
+
+      it('focuses on the filter value when user input looks like an aggregate filter with no arguments', async function () {
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />);
+
+        await userEvent.click(getLastInput());
+        await userEvent.keyboard('count(');
+        expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
+        expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
+      });
     });
   });
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -492,14 +492,46 @@ function SearchQueryBuilderInputInternal({
         onInputChange={e => {
           // Parse text to see if this keystroke would have created any tokens.
           // Add a trailing quote in case the user wants to wrap with quotes.
-          const parsedText = parseSearch(e.target.value + '"');
+          const rawValue = e.target.value;
+          const parsedText = parseSearch(rawValue + '"');
 
-          if (
-            parsedText?.some(
+          const parenIndex =
+            parsedText?.findIndex(
               textToken =>
                 textToken.type === Token.L_PAREN || textToken.type === Token.R_PAREN
-            )
-          ) {
+            ) ?? -1;
+
+          if (parenIndex > -1) {
+            // There's a chance they're trying to type a function.
+            // If so we should autocomplete it as a function.
+            const paren = parsedText![parenIndex]!;
+            if (paren.type === Token.L_PAREN) {
+              const maybeSpaces = parsedText![parenIndex - 1];
+              const maybeFunction = parsedText![parenIndex - 2];
+              if (
+                maybeSpaces?.type === Token.SPACES &&
+                maybeSpaces.value === '' &&
+                maybeFunction?.type === Token.FREE_TEXT &&
+                getFieldDefinition(maybeFunction.value)?.kind === FieldKind.FUNCTION
+              ) {
+                dispatch({
+                  type: 'UPDATE_FREE_TEXT',
+                  tokens: [token],
+                  text: replaceFocusedWordWithFilter(
+                    inputValue,
+                    selectionIndex,
+                    filterValue,
+                    getFieldDefinition
+                  ),
+                  focusOverride: calculateNextFocusForFilter(state),
+                  shouldCommitQuery: false,
+                });
+                resetInputValue();
+                return;
+              }
+            }
+
+            // It's not a function so treat it as just a parenthesis
             dispatch({
               type: 'UPDATE_FREE_TEXT',
               tokens: [token],


### PR DESCRIPTION
… function

Before, when typing something like `count(`, it was forcibly converted into 2 tokens:`count` + `(`. This meant that the only way to search an aggregate filter is to select it from the dropdown. This change makes it so that when the input looks like a function name immediately followed by a parenthesis, we turn it into an aggregate filter instead.

Closes EXP-305