### PR TITLE
fix(issue-stream): Replace checks for issue-stream-custom-views with prefersStackedNav

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -190,19 +190,5 @@ export default function getGuidesContent(
         },
       ],
     },
-    {
-      guide: 'issue_views_page_filters_persistence',
-      requiredTargets: ['issue_views_page_filters_persistence'],
-      steps: [
-        {
-          title: t('Save Filters to Issue Views'),
-          target: 'issue_views_page_filters_persistence',
-          description: t(
-            'We heard your feedback — Issue Views now save project, environment, and time range filters.'
-          ),
-        },
-      ],
-      dateThreshold: new Date('2025-02-11'),
-    },
   ];
 }

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -154,13 +154,9 @@ function GroupPriorityLearnMore() {
         <strong>{t('Time to prioritize')}</strong>
       </p>
       <p>
-        {organization.features.includes('issue-stream-custom-views')
-          ? t(
-              'Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues.'
-            )
-          : t(
-              'Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues and filter low priority issues from the default view.'
-            )}
+        {t(
+          'Use priority to make your issue stream more actionable. Sentry will automatically assign a priority score to new issues.'
+        )}
       </p>
       <LinkButton
         href="https://docs.sentry.io/product/issues/issue-priority/"

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -4,6 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import {SeerNotices} from 'sentry/views/issueDetails/streamline/sidebar/seerNotices';
 
 describe('SeerNotices', function () {
@@ -110,10 +111,17 @@ describe('SeerNotices', function () {
       },
     });
     const project = getProjectWithAutomation('high');
+    ConfigStore.set('user', {
+      ...ConfigStore.get('user'),
+      options: {
+        ...ConfigStore.get('user').options,
+        prefersStackedNavigation: true,
+      },
+    });
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['issue-stream-custom-views', 'trigger-autofix-on-issue-summary'],
+        features: ['trigger-autofix-on-issue-summary'],
       },
     });
     expect(screen.getByText('Get Some Quick Wins')).toBeInTheDocument();

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -1,6 +1,7 @@
 import {GroupSearchViewFixture} from 'sentry-fixture/groupSearchView';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -53,6 +54,7 @@ describe('SeerNotices', function () {
       url: `/projects/${organization.slug}/${ProjectFixture().slug}/autofix-repos/`,
       body: [createRepository()],
     });
+    ConfigStore.set('user', UserFixture());
   });
 
   it('shows automation step if automation is allowed and tuning is off', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -31,6 +31,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 interface SeerNoticesProps {
   groupId: string;
@@ -71,9 +72,8 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const isAutomationAllowed = organization.features.includes(
     'trigger-autofix-on-issue-summary'
   );
-  const isStarredViewAllowed = organization.features.includes(
-    'issue-stream-custom-views'
-  );
+  const prefersStackedNav = usePrefersStackedNav();
+  const isStarredViewAllowed = prefersStackedNav;
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
   const githubRepos = unreadableRepos.filter(repo => repo.provider.includes('github'));

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,13 +1,11 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {space} from 'sentry/styles/space';
-import useOrganization from 'sentry/utils/useOrganization';
 import IssueListSortOptions from 'sentry/views/issueList/actions/sortOptions';
 import {IssueSearchWithSavedSearches} from 'sentry/views/issueList/issueSearchWithSavedSearches';
 import {IssueViewSaveButton} from 'sentry/views/issueList/issueViews/issueViewSaveButton';
@@ -22,23 +20,15 @@ interface Props {
 }
 
 function IssueListFilters({query, sort, onSortChange, onSearch}: Props) {
-  const organization = useOrganization();
-
-  const hasIssueViews = organization.features.includes('issue-stream-custom-views');
   const prefersStackedNav = usePrefersStackedNav();
 
   return (
     <FiltersContainer prefersStackedNav={prefersStackedNav}>
-      <GuideAnchor
-        target="issue_views_page_filters_persistence"
-        disabled={!hasIssueViews}
-      >
-        <StyledPageFilterBar>
-          <ProjectPageFilter />
-          <EnvironmentPageFilter />
-          <DatePageFilter />
-        </StyledPageFilterBar>
-      </GuideAnchor>
+      <StyledPageFilterBar>
+        <ProjectPageFilter />
+        <EnvironmentPageFilter />
+        <DatePageFilter />
+      </StyledPageFilterBar>
 
       <Search {...{query, onSearch}} />
 

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -74,16 +74,13 @@ function StreamWrapper({children}: Props) {
   const {viewId} = useParams<{orgId?: string; viewId?: string}>();
 
   const onNewIssuesFeed = prefersStackedNav && !viewId;
-  const useGlobalPageFilters =
-    !organization.features.includes('issue-stream-custom-views') || onNewIssuesFeed;
+  const useGlobalPageFilters = !prefersStackedNav || onNewIssuesFeed;
 
   return (
     <PageFiltersContainer
       skipLoadLastUsed={!useGlobalPageFilters}
       disablePersistence={!useGlobalPageFilters}
-      skipInitializeUrlParams={
-        !onNewIssuesFeed && organization.features.includes('issue-stream-custom-views')
-      }
+      skipInitializeUrlParams={!onNewIssuesFeed && prefersStackedNav}
     >
       <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
     </PageFiltersContainer>

--- a/static/app/views/issueList/issueSearchWithSavedSearches.tsx
+++ b/static/app/views/issueList/issueSearchWithSavedSearches.tsx
@@ -8,7 +8,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueList/utils';
 import {useSelectedSavedSearch} from 'sentry/views/issueList/utils/useSelectedSavedSearch';
-import {usePrefersOldNavWithEnforcedStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 import IssueListSearchBar from './searchBar';
 
@@ -30,11 +30,9 @@ export function IssueSearchWithSavedSearches({
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
     false
   );
-  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
+  const prefersStackedNav = usePrefersStackedNav();
 
-  const shouldShowSavedSearchesButton =
-    !organization.features.includes('issue-stream-custom-views') ||
-    prefersOldNavWithEnforcement;
+  const shouldShowSavedSearchesButton = !prefersStackedNav;
 
   function onSavedSearchesToggleClicked() {
     const newOpenState = !isSavedSearchesOpen;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -125,11 +125,12 @@ function useIssuesINPObserver() {
 
 function useSavedSearches() {
   const organization = useOrganization();
+  const prefersStackedNav = usePrefersStackedNav();
   const {data: savedSearches = [], isPending} = useFetchSavedSearchesForOrg(
     {
       orgSlug: organization.slug,
     },
-    {enabled: !organization.features.includes('issue-stream-custom-views')}
+    {enabled: !prefersStackedNav}
   );
 
   const params = useParams();
@@ -137,8 +138,7 @@ function useSavedSearches() {
 
   return {
     savedSearches,
-    savedSearchLoading:
-      !organization.features.includes('issue-stream-custom-views') && isPending,
+    savedSearchLoading: !prefersStackedNav && isPending,
     savedSearch: selectedSavedSearch,
     selectedSearchId: params.searchId ?? null,
   };
@@ -224,10 +224,7 @@ function IssueListOverview({
 
   const getQueryFromSavedSearchOrLocation = useCallback(
     (props: {location: Location; savedSearch: SavedSearch | null}): string => {
-      if (
-        !organization.features.includes('issue-stream-custom-views') &&
-        props.savedSearch
-      ) {
+      if (!prefersStackedNav && props.savedSearch) {
         return props.savedSearch.query;
       }
 
@@ -239,7 +236,7 @@ function IssueListOverview({
 
       return initialQuery;
     },
-    [organization.features, initialQuery]
+    [prefersStackedNav, initialQuery]
   );
 
   const getSortFromSavedSearchOrLocation = useCallback(
@@ -658,7 +655,6 @@ function IssueListOverview({
     query,
     num_issues: groups.length,
     total_issues_count: queryCount,
-    issue_views_enabled: organization.features.includes('issue-stream-custom-views'),
     sort,
     realtime_active: realtimeActive,
     is_view: urlParams.viewId ? true : false,

--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -24,7 +24,7 @@ import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageStat
 import {useDeleteSavedSearchOptimistic} from 'sentry/views/issueList/mutations/useDeleteSavedSearch';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
 import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueList/utils';
-import {usePrefersOldNavWithEnforcedStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 interface SavedIssueSearchesProps {
   onSavedSearchSelect: (savedSearch: SavedSearch) => void;
@@ -175,11 +175,9 @@ function SavedIssueSearches({
     refetch,
   } = useFetchSavedSearchesForOrg({orgSlug: organization.slug});
   const isMobile = useMedia(`(max-width: ${theme.breakpoints.small})`);
-  const prefersOldNavWithEnforcement = usePrefersOldNavWithEnforcedStackedNav();
+  const prefersStackedNav = usePrefersStackedNav();
 
-  const shouldShowSavedSearches =
-    !organization.features.includes('issue-stream-custom-views') ||
-    prefersOldNavWithEnforcement;
+  const shouldShowSavedSearches = !prefersStackedNav;
 
   if (!isOpen || isMobile || !shouldShowSavedSearches) {
     return null;

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -36,7 +36,6 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-view',
   'performance-trace-explorer',
   'profiling',
-  'issue-stream-custom-views',
   'enforce-stacked-navigation',
 ];
 

--- a/static/app/views/nav/usePrefersStackedNav.tsx
+++ b/static/app/views/nav/usePrefersStackedNav.tsx
@@ -19,13 +19,3 @@ export function usePrefersStackedNav() {
 
   return userStackedNavOption ?? false;
 }
-
-export function usePrefersOldNavWithEnforcedStackedNav() {
-  const organization = useOrganization({allowNull: true});
-  const user = useUser();
-
-  return (
-    !!organization?.features.includes('enforce-stacked-navigation') &&
-    user?.options?.prefersStackedNavigation === false
-  );
-}


### PR DESCRIPTION
This was a bit outdated - now issue views are synonymous with the new navigation. It was also causing saved searches to be broken for EA users who opted out of the nav.