### PR TITLE
fix(issue-details): Fix event navigation label

### DIFF
--- a/static/app/views/issueDetails/streamline/eventNavigation.tsx
+++ b/static/app/views/issueDetails/streamline/eventNavigation.tsx
@@ -197,9 +197,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
             )
           }
         />
-        <LargeInThisIssueText aria-hidden>
-          {t('matching your filters')}
-        </LargeInThisIssueText>
+        <LargeInThisIssueText aria-hidden>{t('in this issue')}</LargeInThisIssueText>
       </LargeDropdownButtonWrapper>
       <TourElement<IssueDetailsTour>
         tourContext={IssueDetailsTourContext}


### PR DESCRIPTION
this pr undos the change from https://github.com/getsentry/sentry/pull/91744/files. replays and user feedback are not being filtered which means the current label is incorrect. 