### PR TITLE
feat(issues): Add "unsupported" debug image status

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
@@ -79,7 +79,6 @@ function ProcessingIcon({status}: Props) {
       // 1. Relay filters out debug images with completely unknown/unrecognized types during event normalization
       // 2. Symbolicator finds a debug file but it's incompatible with the event type
       //    (e.g., trying to symbolicate .NET events with Windows PDB files)
-      // See: https://github.com/getsentry/team-ingest/issues/550
       return (
         <Tooltip
           containerDisplayMode="inline-flex"

--- a/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
@@ -15,7 +15,7 @@ function ProcessingIcon({status}: Props) {
     case ImageStatus.FETCHING_FAILED: {
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t('The debug information file for this image could not be downloaded')}
         >
           <IconWarning color="warningText" size="xs" />
@@ -25,7 +25,7 @@ function ProcessingIcon({status}: Props) {
     case ImageStatus.MALFORMED: {
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t('The debug information file for this image failed to process')}
         >
           <IconWarning color="warningText" size="xs" />
@@ -35,7 +35,7 @@ function ProcessingIcon({status}: Props) {
     case ImageStatus.MISSING: {
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t('No debug information could be found in any of the specified sources')}
         >
           <IconWarning color="warningText" size="xs" />
@@ -45,7 +45,7 @@ function ProcessingIcon({status}: Props) {
     case ImageStatus.FOUND: {
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t(
             'Debug information for this image was found and successfully processed'
           )}
@@ -57,7 +57,7 @@ function ProcessingIcon({status}: Props) {
     case ImageStatus.UNUSED: {
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t('The image was not required for processing the stack trace')}
         >
           <IconInfo color="subText" size="xs" />
@@ -67,7 +67,7 @@ function ProcessingIcon({status}: Props) {
     case ImageStatus.OTHER: {
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t('An internal error occurred while handling this image')}
         >
           <IconWarning color="warningText" size="xs" />
@@ -81,7 +81,7 @@ function ProcessingIcon({status}: Props) {
       //    (e.g., trying to symbolicate .NET events with Windows PDB files)
       return (
         <Tooltip
-          containerDisplayMode="inline-flex"
+          skipWrapper
           title={t(
             'The debug information file format is not supported or compatible with this event type'
           )}

--- a/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
@@ -74,7 +74,23 @@ function ProcessingIcon({status}: Props) {
         </Tooltip>
       );
     }
-
+    case ImageStatus.UNSUPPORTED: {
+      // UNSUPPORTED status occurs in two scenarios:
+      // 1. Relay filters out debug images with completely unknown/unrecognized types during event normalization
+      // 2. Symbolicator finds a debug file but it's incompatible with the event type
+      //    (e.g., trying to symbolicate .NET events with Windows PDB files)
+      // See: https://github.com/getsentry/team-ingest/issues/550
+      return (
+        <Tooltip
+          containerDisplayMode="inline-flex"
+          title={t(
+            'The debug information file format is not supported or compatible with this event type'
+          )}
+        >
+          <IconWarning color="warningText" size="xs" />
+        </Tooltip>
+      );
+    }
     default: {
       Sentry.withScope(scope => {
         scope.setLevel('warning');

--- a/static/app/components/events/interfaces/debugMeta/debugImage/status.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/status.tsx
@@ -17,6 +17,9 @@ function Status({status}: Props) {
     case ImageStatus.TIMEOUT: {
       return <StyledTag type="error">{t('Error')}</StyledTag>;
     }
+    case ImageStatus.UNSUPPORTED: {
+      return <StyledTag type="error">{t('Unsupported')}</StyledTag>;
+    }
     case ImageStatus.MISSING: {
       return <StyledTag type="error">{t('Missing')}</StyledTag>;
     }

--- a/static/app/types/debugImage.tsx
+++ b/static/app/types/debugImage.tsx
@@ -148,6 +148,7 @@ export enum ImageStatus {
   UNUSED = 'unused',
   MISSING = 'missing',
   MALFORMED = 'malformed',
+  UNSUPPORTED = 'unsupported',
   FETCHING_FAILED = 'fetching_failed',
   TIMEOUT = 'timeout',
   OTHER = 'other',


### PR DESCRIPTION
Instead of throwing a sentry error, adds a badge and tooltip.

The unsupported status is somewhat confusing, added some text about it and additional comments.
