### PR TITLE
fix(issues): Fix safari checkbox visibility

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -691,7 +691,7 @@ const Wrapper = styled(PanelItem)<{
   padding: ${space(1)} 0;
   min-height: 82px;
 
-  &:not(:hover):not(:has(input:checked)) {
+  &:not(:has(:hover)):not(:has(input:checked)) {
     ${CheckboxLabel} {
       ${p => p.theme.visuallyHidden};
     }


### PR DESCRIPTION
fixes #92538 issues stream checkbox not visible on hover in safari
