### PR TITLE
fix(api): Correct team member counts

### DIFF
--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -75,6 +75,7 @@ def get_member_totals(
         Team.objects.filter(
             id__in=[t.pk for t in team_list],
             organizationmember__invite_status=InviteStatus.APPROVED.value,
+            organizationmember__user_is_active=True,
         )
         .annotate(member_count=Count("organizationmemberteam"))
         .values("id", "member_count")

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -38,9 +38,14 @@ class TeamSerializerTest(TestCase):
         user = self.create_user(username="foo")
         other_user = self.create_user(username="bar")
         third_user = self.create_user(username="baz")
+        # Inactive users are not included in the member count
+        inactive_user = self.create_user(username="qux", is_active=False)
 
         organization = self.create_organization(owner=user)
-        team = self.create_team(organization=organization, members=[user, other_user, third_user])
+        team = self.create_team(
+            organization=organization,
+            members=[user, other_user, third_user, inactive_user],
+        )
 
         result = serialize(team, user)
         assert result["memberCount"] == 3


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/26336
Fixes [RTC-721: Counter error on teams page in organization settings](https://linear.app/getsentry/issue/RTC-721/counter-error-on-teams-page-in-organization-settings)