### PR TITLE
ref(replays): Increase thread-pool queue depth

### DIFF
--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -32,7 +32,7 @@ class ProcessReplayRecordingStrategyFactory(ProcessingStrategyFactory[KafkaPaylo
         output_block_size: int | None,
         num_threads: int = 4,  # Defaults to 4 for self-hosted.
         force_synchronous: bool = False,  # Force synchronous runner (only used in test suite).
-        max_pending_futures: int = 48,
+        max_pending_futures: int = 512,
     ) -> None:
         # For information on configuring this consumer refer to this page:
         #   https://getsentry.github.io/arroyo/strategies/run_task_with_multiprocessing.html


### PR DESCRIPTION
Production to the consumer has been spikey and this has led to false positive throttling events.  This causes an unwinding of the consumer and could possibly lead to starvation of the thread-pool if the message re-submission is aggressive enough.  Increasing this limit is not an indication that the buffer will ever be that deep.  Only that this is a large, safely-allowable limit which utilizes some of our excess memory and enables extreme spikes in demand to be absorbed.

This is an initial step to improve the consumer after our learnings from INC-1184.