### PR TITLE
fix(replay): only show tooltip over selectors tab when the tab is disabled

### DIFF
--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -45,7 +45,10 @@ export default function ReplayTabs({selected}: Props) {
           }}
           disabled={allMobileProj}
         >
-          <Tooltip title={t('Selectors are not available with mobile replays')}>
+          <Tooltip
+            disabled={!allMobileProj}
+            title={t('Selectors are not available with mobile replays')}
+          >
             {t('Selectors')}
           </Tooltip>
         </TabList.Item>


### PR DESCRIPTION
before:

<img width="1192" alt="SCR-20250602-nmdn" src="https://github.com/user-attachments/assets/b5818ce6-93b5-4436-8bb4-1c6ddbc30c4e" />
