### PR TITLE
perf(grouping): pre-allocation of issue short-ids in redis

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -947,6 +947,7 @@ CELERY_QUEUES_REGION = [
     Queue("events.save_event_highcpu", routing_key="events.save_event_highcpu"),
     Queue("events.save_event_transaction", routing_key="events.save_event_transaction"),
     Queue("events.save_event_attachments", routing_key="events.save_event_attachments"),
+    Queue("shortid.counters.refill", routing_key="shortid.counters.refill"),
     Queue("events.symbolicate_event", routing_key="events.symbolicate_event"),
     Queue("events.symbolicate_js_event", routing_key="events.symbolicate_js_event"),
     Queue("events.symbolicate_jvm_event", routing_key="events.symbolicate_jvm_event"),

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -545,6 +545,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("projects:ingest-spans-in-eap", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable num events in an issue debugging
     manager.add("projects:num-events-issue-debugging", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable cache based short-id pre-allocation counter
+    manager.add("projects:short-id-pre-allocation-counter", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Project plugin features
     manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -194,7 +194,7 @@ post_migrate.connect(create_counter_function, dispatch_uid="create_counter_funct
         retry=None,  # No retries since we want to try again on next counter increment
     ),
 )
-def refill_cached_short_ids(project_id, block_size: int, using="default") -> None:
+def refill_cached_short_ids(project_id, block_size: int, using="default", **kwargs) -> None:
     """Refills the Redis short-id counter block for a project."""
     from sentry.models.project import Project
 

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -181,7 +181,7 @@ post_migrate.connect(create_counter_function, dispatch_uid="create_counter_funct
 
 @instrumented_task(
     name="sentry.models.counter.refill_cached_short_ids",
-    queue="counters.refill",
+    queue="shortid.counters.refill",
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=ingest_errors_tasks,


### PR DESCRIPTION
# High Level Description
Short-id generation tends to become a bottleneck when projects are creating many groups per second. This is because it is using a postgres update for each increment. This has become a larger [problem](https://app.datadoghq.com/s/FH6-Y3/f28-vd8-4ad) recently.

This patch introduces a cache-based [hi/lo](https://en.wikipedia.org/wiki/Hi/Lo_algorithm) allocator that cuts Postgres traffic to one UPDATE per 1,000 groups, while keeping strong “no duplicates” guarantees.

We introduce this under a flag so we can test first on s4s, then internal projects, then a wider rollout.


# How it works

When we call `_get_next_short_id` from event_manager, we'll check to see if there is a short-id available in the project's redis key value of short-ids. If there is, we pop it and return it. If there is not, we fall back to the previous database based implementation, and queue up `refill_cached_short_ids`. If there is a value, and there are less than 20% of the current block size's (1000) ids available, we queue up the `refill_cached_short_ids` to add more ids to the queue.

This solution is nice because if redis goes down, we just fall back to the previous method, and because the max_value is always in postgres, there won't be duplicates in this case, only gaps, which for our use case, is acceptable.


# Operational impact
Redis memory: 1,000 ids per project. each id is 8 bytes. so 8 KB per project. so 8 GB per million projects.
8 * 1000 * 1,000,000 = 8GB.


New Celery queue counters.refill (tiny volume, bursty only for hot projects).

# Follow-ups
- I think we'll want this task on its own celery queue with a few workers.
- Do we need to delete redis keys when projects are deleted?
- Lua script for combining ops in the cache based increment? necessary?
- Lock duration sufficient under worst-case PG write latency?
- Regardless of how well this works, we probably want throttling of group creation at some RPS as well.

Proposed in #inc-1175 incident notes https://www.notion.so/sentry/notes-2018b10e4b5d8081ace5cea31a21b34b?source=copy_link#2018b10e4b5d804e8a15ec319fe3c3d5


