### PR TITLE
ref(settings): don't show qmark tooltip if no text

### DIFF
--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -45,7 +45,7 @@ class OrganizationRoleSelect extends Component<Props> {
       <Panel>
         <StyledPanelHeader>
           <div>{t('Organization Role')}</div>
-          {disabled && <QuestionTooltip size="sm" title={helpText} />}
+          {disabled && helpText && <QuestionTooltip size="sm" title={helpText} />}
         </StyledPanelHeader>
 
         <PanelBody>


### PR DESCRIPTION
thought the tooltip was broken at first, turns out it just had no text

before:

https://github.com/user-attachments/assets/8b1ce7ed-b0da-4298-9fef-20df405e893b

after (no qmark):

<img width="932" alt="SCR-20250602-nuwj" src="https://github.com/user-attachments/assets/b9e30376-7728-4455-b55e-d26bd7ba826d" />
