### PR TITLE
fix(admin): user booleans should not be required

### DIFF
--- a/static/app/views/admin/adminUserEdit.tsx
+++ b/static/app/views/admin/adminUserEdit.tsx
@@ -51,7 +51,7 @@ const userEditForm: JsonFormObject = {
     {
       name: 'isActive',
       type: 'boolean',
-      required: true,
+      required: false,
       label: t('Active'),
       help: t(
         'Designates whether this user should be treated as active. Unselect this instead of deleting accounts.'
@@ -60,14 +60,14 @@ const userEditForm: JsonFormObject = {
     {
       name: 'isStaff',
       type: 'boolean',
-      required: true,
+      required: false,
       label: t('Admin'),
       help: t('Designates whether this user can perform administrative functions.'),
     },
     {
       name: 'isSuperuser',
       type: 'boolean',
-      required: true,
+      required: false,
       label: t('Superuser'),
       help: t(
         'Designates whether this user has all permissions without explicitly assigning them.'


### PR DESCRIPTION
closes https://github.com/getsentry/self-hosted/issues/3689
closes https://linear.app/getsentry/issue/ENG-3783/error-in-deactivating-user

the admin user settings were broken -- the booleans `isStaff` and `isActive` and `isAdmin` should not be required


before:

https://github.com/user-attachments/assets/223fca33-63d3-4b21-8f7e-ff88b95da847



after:

https://github.com/user-attachments/assets/7b930551-4814-4fea-8f56-a4fbb747c07f
