### PR TITLE
fix(schema-hints): Don't submit query on schema hint click

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -50,16 +50,11 @@ type CommitQueryAction = {
   type: 'COMMIT_QUERY';
 };
 
-type UpdateQueryWithoutCommitAction = {
-  query: string;
-  type: 'UPDATE_QUERY_WITHOUT_COMMIT';
-  focusOverride?: FocusOverride | null;
-};
-
 type UpdateQueryAction = {
   query: string;
   type: 'UPDATE_QUERY';
   focusOverride?: FocusOverride | null;
+  shouldCommitQuery?: boolean;
 };
 
 type ResetFocusOverrideAction = {type: 'RESET_FOCUS_OVERRIDE'};
@@ -123,7 +118,6 @@ type UpdateAggregateArgsAction = {
 export type QueryBuilderActions =
   | ClearAction
   | CommitQueryAction
-  | UpdateQueryWithoutCommitAction
   | UpdateQueryAction
   | ResetFocusOverrideAction
   | DeleteTokenAction
@@ -564,19 +558,15 @@ export function useQueryBuilderState({
             ...state,
             committedQuery: state.query,
           };
-        case 'UPDATE_QUERY_WITHOUT_COMMIT':
+        case 'UPDATE_QUERY': {
+          const shouldCommitQuery = action.shouldCommitQuery ?? true;
           return {
             ...state,
             query: action.query,
+            committedQuery: shouldCommitQuery ? action.query : state.committedQuery,
             focusOverride: action.focusOverride ?? null,
           };
-        case 'UPDATE_QUERY':
-          return {
-            ...state,
-            query: action.query,
-            committedQuery: action.query,
-            focusOverride: action.focusOverride ?? null,
-          };
+        }
         case 'RESET_FOCUS_OVERRIDE':
           return {
             ...state,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -50,6 +50,12 @@ type CommitQueryAction = {
   type: 'COMMIT_QUERY';
 };
 
+type UpdateQueryWithoutCommitAction = {
+  query: string;
+  type: 'UPDATE_QUERY_WITHOUT_COMMIT';
+  focusOverride?: FocusOverride | null;
+};
+
 type UpdateQueryAction = {
   query: string;
   type: 'UPDATE_QUERY';
@@ -117,6 +123,7 @@ type UpdateAggregateArgsAction = {
 export type QueryBuilderActions =
   | ClearAction
   | CommitQueryAction
+  | UpdateQueryWithoutCommitAction
   | UpdateQueryAction
   | ResetFocusOverrideAction
   | DeleteTokenAction
@@ -556,6 +563,12 @@ export function useQueryBuilderState({
           return {
             ...state,
             committedQuery: state.query,
+          };
+        case 'UPDATE_QUERY_WITHOUT_COMMIT':
+          return {
+            ...state,
+            query: action.query,
+            focusOverride: action.focusOverride ?? null,
           };
         case 'UPDATE_QUERY':
           return {

--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -123,7 +123,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
 
       handleQueryChange(filterQuery);
       searchBarDispatch({
-        type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+        type: 'UPDATE_QUERY',
         query: filterQuery.formatString(),
         focusOverride: {
           itemKey: `filter:${filterQuery
@@ -133,6 +133,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
             .lastIndexOf(hint.key)}`,
           part: 'value',
         },
+        shouldCommitQuery: false,
       });
       trackAnalytics('trace.explorer.schema_hints_click', {
         hint_key: hint.key,

--- a/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsDrawer.tsx
@@ -123,7 +123,7 @@ function SchemaHintsDrawer({hints, searchBarDispatch, queryRef}: SchemaHintsDraw
 
       handleQueryChange(filterQuery);
       searchBarDispatch({
-        type: 'UPDATE_QUERY',
+        type: 'UPDATE_QUERY_WITHOUT_COMMIT',
         query: filterQuery.formatString(),
         focusOverride: {
           itemKey: `filter:${filterQuery

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -122,12 +122,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Hint);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'stringTag1:""',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
   });
 
@@ -184,12 +185,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Checkbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'stringTag1:""',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
   });
 
@@ -205,12 +207,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(countUniquePill);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'count_unique(user):>0',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
 
     const seeFullList = screen.getByText('See full list');
@@ -221,12 +224,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(countUniqueCheckbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'count_unique(user):>0',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
   });
 
@@ -259,12 +263,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Checkbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'numberTag1:>0',
       focusOverride: {
         itemKey: 'filter:-1',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
 
     mockUseSearchQueryBuilder.mockRestore();
@@ -299,12 +304,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(countUniqueCheckbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'stringTag1:"" numberTag1:>0',
       focusOverride: {
         itemKey: 'filter:-1',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
 
     mockUseSearchQueryBuilder.mockRestore();
@@ -389,12 +395,13 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Hint);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+      type: 'UPDATE_QUERY',
       query: 'stringTag1:something stringTag1:""',
       focusOverride: {
         itemKey: 'filter:1',
         part: 'value',
       },
+      shouldCommitQuery: false,
     });
 
     mockUseSearchQueryBuilder.mockRestore();

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -122,7 +122,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Hint);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'stringTag1:""',
       focusOverride: {
         itemKey: 'filter:0',
@@ -184,7 +184,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Checkbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'stringTag1:""',
       focusOverride: {
         itemKey: 'filter:0',
@@ -205,7 +205,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(countUniquePill);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'count_unique(user):>0',
       focusOverride: {
         itemKey: 'filter:0',
@@ -221,7 +221,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(countUniqueCheckbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'count_unique(user):>0',
       focusOverride: {
         itemKey: 'filter:0',
@@ -259,7 +259,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Checkbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'numberTag1:>0',
       focusOverride: {
         itemKey: 'filter:-1',
@@ -299,7 +299,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(countUniqueCheckbox);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'stringTag1:"" numberTag1:>0',
       focusOverride: {
         itemKey: 'filter:-1',
@@ -389,7 +389,7 @@ describe('SchemaHintsList', () => {
     await userEvent.click(stringTag1Hint);
 
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'UPDATE_QUERY',
+      type: 'UPDATE_QUERY_WITHOUT_COMMIT',
       query: 'stringTag1:something stringTag1:""',
       focusOverride: {
         itemKey: 'filter:1',

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -375,7 +375,7 @@ function SchemaHintsList({
       const newQuery = newSearchQuery.formatString();
 
       dispatch({
-        type: 'UPDATE_QUERY',
+        type: 'UPDATE_QUERY_WITHOUT_COMMIT',
         query: newQuery,
         focusOverride: {
           itemKey: `filter:${newSearchQuery

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -375,7 +375,7 @@ function SchemaHintsList({
       const newQuery = newSearchQuery.formatString();
 
       dispatch({
-        type: 'UPDATE_QUERY_WITHOUT_COMMIT',
+        type: 'UPDATE_QUERY',
         query: newQuery,
         focusOverride: {
           itemKey: `filter:${newSearchQuery
@@ -385,6 +385,7 @@ function SchemaHintsList({
             .lastIndexOf(hint.key)}`,
           part: 'value',
         },
+        shouldCommitQuery: false,
       });
 
       trackAnalytics('trace.explorer.schema_hints_click', {


### PR DESCRIPTION
With the new search bar changes, clicking a schema hint resulted in the query being submitted before the value was entered. The expected behaviour is that the query is submitted when the value is filled in. I've added a new action in the query builder dispatch called `UPDATE_QUERY_WITHOUT_COMMIT` which updates the query without submitting the search. I've only used this in schema hints and hence should not affect much of the internal search bar functionality.
