### PR TITLE
feat(ourlogs): Hoisted row expansion state

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -4,7 +4,13 @@ import {LogFixture} from 'sentry-fixture/log';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -230,6 +236,7 @@ describe('LogsInfiniteTable', function () {
     expect(allTreeRows).toHaveLength(3);
     for (const row of allTreeRows) {
       for (const field of visibleColumnFields) {
+        await userEvent.hover(row);
         const cell = await within(row).findByTestId(`log-table-cell-${field}`);
         const actionsButton = within(cell).queryByRole('button', {
           name: 'Actions',


### PR DESCRIPTION
### Summary
This moves row expanded into the table for infinite tables in order to not lose expansion when scrolling past then back. This also sets a lower overhead render state to not render hoverable components (tooltip and dropdowns) as they significantly increase the per row rendering time.

#### Other
- Switched the next page scrolling over to which virtual item is currently in view. It's a bit too sensitive for reverse scroll so I've left it as pixel based when scrolling up.

Closes LOGS-157