### PR TITLE
fix(detectors): Exclude "prisma:engine:connection" from MN+1 Experiment Issues

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/experiments/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/mn_plus_one_db_span_detector.py
@@ -236,6 +236,10 @@ class ContinuingMNPlusOne(MNPlusOneState):
             metrics.incr("mn_plus_one_db_span_detector.no_db_span")
             return None
 
+        # Don't create a problem if the repeating span is Prisma engine connection
+        if get_span_evidence_value(db_span, include_op=False) == "prisma:engine:connection":
+            return None
+
         db_span_ids = [span["span_id"] for span in offender_db_spans]
         offender_span_ids = [span["span_id"] for span in offender_spans]
 

--- a/src/sentry/utils/performance_issues/detectors/experiments/mn_plus_one_db_span_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/experiments/mn_plus_one_db_span_detector.py
@@ -231,13 +231,9 @@ class ContinuingMNPlusOne(MNPlusOneState):
             metrics.incr("mn_plus_one_db_span_detector.no_parent_span")
             return None
 
-        db_span = self._first_db_span()
+        db_span = self._first_relevant_db_span()
         if not db_span:
             metrics.incr("mn_plus_one_db_span_detector.no_db_span")
-            return None
-
-        # Don't create a problem if the repeating span is Prisma engine connection
-        if get_span_evidence_value(db_span, include_op=False) == "prisma:engine:connection":
             return None
 
         db_span_ids = [span["span_id"] for span in offender_db_spans]
@@ -278,9 +274,12 @@ class ContinuingMNPlusOne(MNPlusOneState):
             ],
         )
 
-    def _first_db_span(self) -> Span | None:
+    def _first_relevant_db_span(self) -> Span | None:
         for span in self.spans:
-            if span["op"].startswith("db"):
+            if (
+                span["op"].startswith("db")
+                and get_span_evidence_value(span, include_op=False) != "prisma:engine:connection"
+            ):
                 return span
         return None
 


### PR DESCRIPTION
When looking at results from the MN+1 Experiment, we noticed a lot of issues were being created with "prisma:engine:connection" as the repeating span, which isn't actually useful as an MN+1 Issue. Now, if this is seen an the span, we don't create the performance issue 