### PR TITLE
fix(detectors): Fix type error in SQL Injection Detector

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -85,7 +85,6 @@ class SQLInjectionDetector(PerformanceDetector):
 
             if not isinstance(query_value, str):
                 continue
-
             if query_key == query_value:
                 continue
             if query_value.upper() in SQL_KEYWORDS:

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -80,12 +80,15 @@ class SQLInjectionDetector(PerformanceDetector):
             request_data.extend(self.request_body.items())
 
         for query_pair in request_data:
-            query_value = query_pair[1].upper()
-            query_key = query_pair[0].upper()
+            query_value = query_pair[1]
+            query_key = query_pair[0]
+
+            if not isinstance(query_value, str):
+                continue
 
             if query_key == query_value:
                 continue
-            if query_value in SQL_KEYWORDS:
+            if query_value.upper() in SQL_KEYWORDS:
                 continue
             valid_parameters.append(query_pair)
 


### PR DESCRIPTION
assumed that the value in the request query/body was a string, which is not always true. we only care about strings for this detector so we can skip any values that aren't strings. 