### PR TITLE
fix(ourlogs): Fix 24 hour time in logs

### DIFF
--- a/static/app/components/dateTime.spec.tsx
+++ b/static/app/components/dateTime.spec.tsx
@@ -49,6 +49,16 @@ describe('DateTime', () => {
     expect(screen.getByText('Oct 16, 7:41:20 PM')).toBeInTheDocument();
   });
 
+  it('renders a date with milliseconds', () => {
+    renderPDT(<DateTime date={new Date()} milliseconds />);
+    expect(screen.getByText('Oct 16, 7:41:20.000 PM')).toBeInTheDocument();
+  });
+
+  it('renders a date with seconds and milliseconds', () => {
+    renderPDT(<DateTime date={new Date()} seconds milliseconds />);
+    expect(screen.getByText('Oct 16, 7:41:20.000 PM')).toBeInTheDocument();
+  });
+
   it('renders a date with the time zone', () => {
     renderPDT(<DateTime date={new Date()} timeZone />);
     expect(screen.getByText('Oct 16, 7:41 PM PDT')).toBeInTheDocument();
@@ -85,6 +95,16 @@ describe('DateTime', () => {
     it('renders only the time', () => {
       renderPDT(<DateTime date={new Date()} timeOnly />);
       expect(screen.getByText('19:41')).toBeInTheDocument();
+    });
+
+    it('renders a date with milliseconds', () => {
+      renderPDT(<DateTime date={new Date()} milliseconds />);
+      expect(screen.getByText('Oct 16, 19:41:20.000')).toBeInTheDocument();
+    });
+
+    it('renders a date with seconds and milliseconds', () => {
+      renderPDT(<DateTime date={new Date()} seconds milliseconds />);
+      expect(screen.getByText('Oct 16, 19:41:20.000')).toBeInTheDocument();
     });
 
     it('renders date with forced utc', () => {

--- a/static/app/components/dateTime.tsx
+++ b/static/app/components/dateTime.tsx
@@ -23,6 +23,10 @@ export interface DateTimeProps extends React.HTMLAttributes<HTMLTimeElement> {
    */
   format?: string;
   /**
+   * Whether to show the milliseconds. Is false by default.
+   */
+  milliseconds?: boolean;
+  /**
    * Whether to show the seconds. Is false by default.
    */
   seconds?: boolean;
@@ -57,6 +61,7 @@ export function DateTime({
   year,
   timeZone,
   seconds = false,
+  milliseconds = false,
   forcedTimezone,
   ...props
 }: DateTimeProps) {
@@ -77,6 +82,7 @@ export function DateTime({
       // UTC time.
       timeZone: timeZone ?? utc,
       seconds,
+      milliseconds,
       clock24Hours: user?.options.clock24Hours,
     });
 

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -208,17 +208,27 @@ export function getTimeFormat({
   clock24Hours,
   seconds,
   timeZone,
+  milliseconds,
 }: {
   clock24Hours?: boolean;
+  milliseconds?: boolean;
   seconds?: boolean;
   timeZone?: boolean;
 } = {}) {
   let format = '';
 
   if (clock24Hours ?? shouldUse24Hours()) {
-    format = seconds ? 'HH:mm:ss' : 'HH:mm';
+    if (milliseconds) {
+      format = 'HH:mm:ss.SSS';
+    } else {
+      format = seconds ? 'HH:mm:ss' : 'HH:mm';
+    }
   } else {
-    format = seconds ? 'LTS' : 'LT';
+    if (milliseconds) {
+      format = 'h:mm:ss.SSS A';
+    } else {
+      format = seconds ? 'LTS' : 'LT';
+    }
   }
 
   if (timeZone) {
@@ -237,6 +247,10 @@ interface FormatProps {
    * If true, will only return the date part, e.g. "Jan 1".
    */
   dateOnly?: boolean;
+  /**
+   * Whether to show the milliseconds.
+   */
+  milliseconds?: boolean;
   /**
    * Whether to show the seconds.
    */
@@ -264,6 +278,7 @@ export function getFormat({
   seconds,
   timeZone,
   clock24Hours,
+  milliseconds,
 }: FormatProps = {}) {
   if (dateOnly) {
     return getDateFormat({year});
@@ -277,6 +292,7 @@ export function getFormat({
   const timeFormat = getTimeFormat({
     clock24Hours,
     seconds,
+    milliseconds,
     timeZone,
   });
 

--- a/static/app/views/explore/logs/fieldRenderers.spec.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.spec.tsx
@@ -1,0 +1,156 @@
+import {Fragment} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ThemeFixture} from 'sentry-fixture/theme';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {TimezoneProvider} from 'sentry/components/timezoneProvider';
+import ConfigStore from 'sentry/stores/configStore';
+import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
+import {LogAttributesRendererMap} from 'sentry/views/explore/logs/fieldRenderers';
+import {type LogRowItem, OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+const TimestampRenderer = LogAttributesRendererMap[OurLogKnownFieldKey.TIMESTAMP];
+
+type LogFieldRendererProps = AttributesFieldRendererProps<RendererExtra>;
+
+describe('Logs Field Renderers', function () {
+  const organization = OrganizationFixture();
+
+  const makeRendererProps = (
+    timestamp: string,
+    attributes: Record<string, string | number> = {}
+  ): LogFieldRendererProps => ({
+    item: {
+      fieldKey: OurLogKnownFieldKey.TIMESTAMP,
+      value: timestamp,
+      metaFieldType: 'date',
+      unit: null,
+    } as LogRowItem,
+    meta: {
+      fields: {
+        [OurLogKnownFieldKey.TIMESTAMP]: 'date',
+      },
+      units: {},
+    },
+    extra: {
+      organization,
+      location: {} as any,
+      theme: ThemeFixture(),
+      attributes,
+      highlightTerms: [],
+      logColors: {
+        text: '#000',
+        background: '#fff',
+      } as any,
+      projectSlug: 'test-project',
+    },
+    basicRendered: <span>{timestamp}</span>,
+  });
+
+  beforeEach(() => {
+    ConfigStore.set('user', UserFixture());
+  });
+
+  describe('TimestampRenderer', function () {
+    const timestamp = '2024-01-15T14:30:45.123Z';
+
+    it('renders timestamp in 12h format by default', function () {
+      expect(TimestampRenderer).toBeDefined();
+      const props = makeRendererProps(timestamp);
+      const result = TimestampRenderer!(props);
+
+      render(
+        <TimezoneProvider timezone="UTC">
+          <Fragment>{result}</Fragment>
+        </TimezoneProvider>
+      );
+      expect(screen.getByText(/Jan 15, 2024 2:30:45\.123 PM/)).toBeInTheDocument();
+    });
+
+    it('renders timestamp in 24h format when user preference is set', function () {
+      expect(TimestampRenderer).toBeDefined();
+      const user = UserFixture();
+      user.options.clock24Hours = true;
+      ConfigStore.set('user', user);
+
+      const props = makeRendererProps(timestamp);
+      const result = TimestampRenderer!(props);
+
+      render(
+        <TimezoneProvider timezone="UTC">
+          <Fragment>{result}</Fragment>
+        </TimezoneProvider>
+      );
+      expect(screen.getByText(/Jan 15, 2024 14:30:45\.123/)).toBeInTheDocument();
+      expect(screen.queryByText(/AM|PM/)).not.toBeInTheDocument();
+    });
+
+    it('renders milliseconds when present', function () {
+      expect(TimestampRenderer).toBeDefined();
+      const props = makeRendererProps(timestamp);
+      const result = TimestampRenderer!(props);
+
+      render(
+        <TimezoneProvider timezone="UTC">
+          <Fragment>{result}</Fragment>
+        </TimezoneProvider>
+      );
+      expect(screen.getByText(/\.123/)).toBeInTheDocument();
+    });
+
+    it('uses precise timestamp when available', function () {
+      expect(TimestampRenderer).toBeDefined();
+      const preciseTimestamp = '1705329045123456789';
+      const props = makeRendererProps(timestamp, {
+        'tags[sentry.timestamp_precise,number]': preciseTimestamp,
+      });
+      const result = TimestampRenderer!(props);
+
+      render(
+        <TimezoneProvider timezone="UTC">
+          <Fragment>{result}</Fragment>
+        </TimezoneProvider>
+      );
+      expect(screen.getByText(/2:30:45\.123/)).toBeInTheDocument();
+    });
+
+    it('renders in different timezone', function () {
+      expect(TimestampRenderer).toBeDefined();
+      const user = UserFixture();
+      user.options.timezone = 'Europe/London';
+      ConfigStore.set('user', user);
+
+      const props = makeRendererProps(timestamp);
+      const result = TimestampRenderer!(props);
+
+      render(
+        <TimezoneProvider timezone="UTC">
+          <Fragment>{result}</Fragment>
+        </TimezoneProvider>
+      );
+      expect(screen.getByText(/Jan 15, 2024 2:30:45\.123 PM/)).toBeInTheDocument();
+    });
+
+    it('renders in 24h format with different timezone', function () {
+      expect(TimestampRenderer).toBeDefined();
+      const user = UserFixture();
+      user.options.timezone = 'Asia/Tokyo';
+      user.options.clock24Hours = true;
+      ConfigStore.set('user', user);
+
+      const props = makeRendererProps(timestamp);
+      const result = TimestampRenderer!(props);
+
+      render(
+        <TimezoneProvider timezone="Asia/Tokyo">
+          <Fragment>{result}</Fragment>
+        </TimezoneProvider>
+      );
+      expect(screen.getByText(/Jan 15, 2024 23:30:45\.123/)).toBeInTheDocument();
+      expect(screen.queryByText(/AM|PM/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -124,7 +124,7 @@ function TimestampRenderer(props: LogFieldRendererProps) {
 
   return (
     <LogDate align={props.extra.align}>
-      <DateTime seconds date={timestampToUse} format="MMM D, h:mm:ss.SSS A" />
+      <DateTime seconds milliseconds date={timestampToUse} />
     </LogDate>
   );
 }


### PR DESCRIPTION
### Summary
After our millisecond time change we dropped supporting 24h since it wasn't using 'useTimeFormat'. This add millisecond support in our datetimes instead, and adds a test to the fieldrenderer.

