### PR TITLE
:wrench: chore(msteams): mark resolve in upcoming release errors as halt

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -490,17 +490,24 @@ class MsTeamsWebhookEndpoint(Endpoint):
         with MessagingInteractionEvent(
             interaction_type, MsTeamsMessagingSpec()
         ).capture() as lifecycle:
-            response = client.put(
-                path=f"/projects/{group.project.organization.slug}/{group.project.slug}/issues/",
-                params={"id": group.id},
-                data=action_data,
-                user=user_service.get_user(user_id=identity.user_id),
-                auth=event_write_key,
-            )
-            if response.status_code == 403:
-                lifecycle.record_halt(response)
-            elif response.status_code >= 400:
-                lifecycle.record_failure(response)
+            try:
+                response = client.put(
+                    path=f"/projects/{group.project.organization.slug}/{group.project.slug}/issues/",
+                    params={"id": group.id},
+                    data=action_data,
+                    user=user_service.get_user(user_id=identity.user_id),
+                    auth=event_write_key,
+                )
+            except client.ApiError as e:
+                if e.status_code == 403:
+                    lifecycle.record_halt(e)
+                # If the user hasn't configured their releases properly, we recieve errors like:
+                # sentry.api.client.ApiError: status=400 body={'statusDetails': {'inNextRelease': [xxx])]}}"
+                # We can mark these as halt
+                elif e.status_code == 400 and e.body.get("statusDetails", {}).get("inNextRelease"):
+                    lifecycle.record_halt(e)
+                elif e.status_code >= 400:
+                    lifecycle.record_failure(e)
             return response
 
     def _handle_action_submitted(self, request: Request) -> Response:


### PR DESCRIPTION
mark errors like

`sentry.api.client.ApiError: status=400 body={'statusDetails': {'inNextRelease': [ErrorDetail(xxx]}}"` as halts because it means the user hasn't configured releases correctly.

also actually capture the other  `halt` and `failure` cases correctly b/c we weren't doing that before

closes ECO-576