### PR TITLE
feat(search): Make `first_release` autocomplete

### DIFF
--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -16,7 +16,7 @@ import {
 } from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {FieldKind} from 'sentry/utils/fields';
+import {FieldKey, FieldKind} from 'sentry/utils/fields';
 import useApi from 'sentry/utils/useApi';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
@@ -126,6 +126,28 @@ function IssueListSearchBar({
           ...fetchTagValuesPayload,
           organization,
         });
+      }
+
+      if (key === FieldKey.FIRST_RELEASE) {
+        const includeLatest = 'latest'.startsWith(search.toLowerCase());
+        return [
+          ...(includeLatest
+            ? [
+                {
+                  count: 1,
+                  firstSeen: '2021-01-01',
+                  lastSeen: '2021-01-01',
+                  name: 'latest',
+                  value: 'latest',
+                } as TagValue,
+              ]
+            : []),
+          ...(await fetchTagValues({
+            ...fetchTagValuesPayload,
+            tagKey: 'release',
+            dataset: Dataset.ERRORS,
+          })),
+        ];
       }
 
       const [eventsDatasetValues, issuePlatformDatasetValues] = await Promise.all([

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -336,8 +336,8 @@ function builtInIssuesFields({
     [FieldKey.FIRST_RELEASE]: {
       ...PREDEFINED_FIELDS[FieldKey.FIRST_RELEASE]!,
       name: 'First Release',
-      values: ['latest'],
-      predefined: true,
+      values: [],
+      predefined: false,
     },
     [FieldKey.EVENT_TIMESTAMP]: {
       ...PREDEFINED_FIELDS[FieldKey.EVENT_TIMESTAMP]!,


### PR DESCRIPTION
Makes the `first_release` autocomplete. Does some jank logic to make the hardcoded `latest` value also appear correctly. 

https://github.com/user-attachments/assets/7e2b30ff-8a7b-4864-977d-c3e8ab81264b

