### PR TITLE
ref(aci): Use sentry_sdk.trace to simplify scope in delayed_workflow

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -214,6 +214,7 @@ def generate_unique_queries(
     return unique_queries
 
 
+@sentry_sdk.trace
 def get_condition_query_groups(
     data_condition_groups: list[DataConditionGroup],
     dcg_to_groups: DataConditionGroupGroups,
@@ -234,6 +235,7 @@ def get_condition_query_groups(
     return condition_groups
 
 
+@sentry_sdk.trace
 def get_condition_group_results(
     queries_to_groups: dict[UniqueConditionQuery, set[int]],
 ) -> dict[UniqueConditionQuery, QueryResult]:
@@ -265,6 +267,7 @@ def get_condition_group_results(
     return condition_group_results
 
 
+@sentry_sdk.trace
 def get_groups_to_fire(
     data_condition_groups: list[DataConditionGroup],
     workflows_to_envs: WorkflowEnvMapping,
@@ -397,6 +400,7 @@ def get_group_to_groupevent(
     return group_to_groupevent
 
 
+@sentry_sdk.trace
 def fire_actions_for_groups(
     groups_to_fire: dict[int, set[DataConditionGroup]],
     trigger_group_to_dcg_model: dict[DataConditionHandler.Group, dict[int, int]],
@@ -479,6 +483,7 @@ def fire_actions_for_groups(
                         action.trigger(event_data, detector)
 
 
+@sentry_sdk.trace
 def cleanup_redis_buffer(
     project_id: int, workflow_event_dcg_data: dict[str, str], batch_key: str | None
 ) -> None:
@@ -488,6 +493,10 @@ def cleanup_redis_buffer(
         filters["batch_key"] = batch_key
 
     buffer.backend.delete_hash(model=Workflow, filters=filters, fields=hashes_to_delete)
+
+
+def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
+    return {repr(key): value for key, value in d.items()}
 
 
 @instrumented_task(
@@ -546,47 +555,38 @@ def process_delayed_workflows(
         },
     )
 
-    with sentry_sdk.start_span(op="delayed_workflow.get_condition_query_groups"):
-        # Get unique query groups to query Snuba
-        condition_groups = get_condition_query_groups(
-            data_condition_groups, dcg_to_groups, dcg_to_workflow, workflows_to_envs
-        )
-
+    # Get unique query groups to query Snuba
+    condition_groups = get_condition_query_groups(
+        data_condition_groups, dcg_to_groups, dcg_to_workflow, workflows_to_envs
+    )
     if not condition_groups:
         return
-
-    repr_condition_groups = {
-        repr(condition_group): group_ids for condition_group, group_ids in condition_groups.items()
-    }
     logger.info(
         "delayed_workflow.condition_query_groups",
         extra={
-            "condition_groups": repr_condition_groups,
+            "condition_groups": repr_keys(condition_groups),
             "num_condition_groups": len(condition_groups),
             "project_id": project_id,
         },
     )
-    with sentry_sdk.start_span(op="delayed_workflow.get_condition_group_results"):
-        condition_group_results = get_condition_group_results(condition_groups)
 
-    serialized_results = {
-        str(query): count_dict for query, count_dict in condition_group_results.items()
-    }
+    condition_group_results = get_condition_group_results(condition_groups)
     logger.info(
         "delayed_workflow.condition_group_results",
-        extra={"condition_group_results": serialized_results, "project_id": project_id},
+        extra={
+            "condition_group_results": repr_keys(condition_group_results),
+            "project_id": project_id,
+        },
     )
 
-    with sentry_sdk.start_span(op="delayed_workflow.get_groups_to_fire"):
-        # Evaluate DCGs
-        groups_to_dcgs = get_groups_to_fire(
-            data_condition_groups,
-            workflows_to_envs,
-            dcg_to_workflow,
-            dcg_to_groups,
-            condition_group_results,
-        )
-
+    # Evaluate DCGs
+    groups_to_dcgs = get_groups_to_fire(
+        data_condition_groups,
+        workflows_to_envs,
+        dcg_to_workflow,
+        dcg_to_groups,
+        condition_group_results,
+    )
     logger.info(
         "delayed_workflow.groups_to_fire",
         extra={"groups_to_dcgs": groups_to_dcgs, "project_id": project_id},
@@ -604,13 +604,8 @@ def process_delayed_workflows(
             project_id,
         )
 
-    with sentry_sdk.start_span(op="delayed_workflow.fire_actions"):
-        fire_actions_for_groups(groups_to_dcgs, trigger_group_to_dcg_model, group_to_groupevent)
-
-    with sentry_sdk.start_span(
-        op="delayed_workflow.cleanup_redis_buffer",
-    ):
-        cleanup_redis_buffer(project_id, workflow_event_dcg_data, batch_key)
+    fire_actions_for_groups(groups_to_dcgs, trigger_group_to_dcg_model, group_to_groupevent)
+    cleanup_redis_buffer(project_id, workflow_event_dcg_data, batch_key)
 
 
 @delayed_processing_registry.register("delayed_workflow")


### PR DESCRIPTION
Move to `sentry_sdk.trace`  annotations instead of `with sentry_sdk.start_span` to improve readability.
NOTE: This changes our span annotation values.
However, by using `sentry_sdk.trace`, we're presumably using more conventional uses of `op` and `name`, it remains accurate ever when we rename, and we can use function calls as parameters to other functions without losing tracing.
We only _not_ want to do this if we want to avoid tracing calls outside of this particular function, or we want to use the current span annotation scheme.

Also, adds a helper to make `str`-keyed dicts to allow some logging logic to be inlined.