### PR TITLE
:sparkles: feat(aci): add workflow id in `event_data` in `process_workflows` before firing actions

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+from django.db import models
 from django.db.models import DurationField, ExpressionWrapper, F, IntegerField, Value
 from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Coalesce
@@ -101,9 +102,15 @@ def filter_recently_fired_actions(
     filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
 ) -> BaseQuerySet[Action]:
     # get the actions for any of the triggered data condition groups
-    actions = Action.objects.filter(
-        dataconditiongroupaction__condition_group__in=filtered_action_groups
-    ).distinct()
+    actions = (
+        Action.objects.filter(dataconditiongroupaction__condition_group__in=filtered_action_groups)
+        .annotate(
+            workflow_id=models.F(
+                "dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow__id"
+            )
+        )
+        .distinct()
+    )
 
     group = event_data.event.group
 

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -7,6 +7,7 @@ from django.db import router, transaction
 from django.db.models import F, Q
 
 from sentry import buffer, features
+from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.utils import json
@@ -137,7 +138,7 @@ def evaluate_workflow_triggers(
 def evaluate_workflows_action_filters(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
-) -> set[DataConditionGroup]:
+) -> BaseQuerySet[Action]:
     filtered_action_groups: set[DataConditionGroup] = set()
     action_conditions = (
         DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow__in=workflows)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -7,7 +7,6 @@ from django.db import router, transaction
 from django.db.models import F, Q
 
 from sentry import buffer, features
-from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.utils import json
@@ -138,7 +137,7 @@ def evaluate_workflow_triggers(
 def evaluate_workflows_action_filters(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
-) -> BaseQuerySet[Action]:
+) -> set[DataConditionGroup]:
     filtered_action_groups: set[DataConditionGroup] = set()
     action_conditions = (
         DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow__in=workflows)

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -56,6 +56,8 @@ class TestFilterRecentlyFiredActions(BaseWorkflowTest):
         )
         assert set(triggered_actions) == {self.action}
 
+        assert {action.workflow_id for action in triggered_actions} == {self.workflow.id}
+
         for status in [status_1, status_2]:
             status.refresh_from_db()
             assert status.date_updated == timezone.now()
@@ -77,6 +79,11 @@ class TestFilterRecentlyFiredActions(BaseWorkflowTest):
             set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action, action_3}
+
+        assert {action.workflow_id for action in triggered_actions} == {
+            self.workflow.id,
+            workflow.id,
+        }
 
         for status in [status_1, status_2, status_3]:
             status.refresh_from_db()

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -56,7 +56,9 @@ class TestFilterRecentlyFiredActions(BaseWorkflowTest):
         )
         assert set(triggered_actions) == {self.action}
 
-        assert {action.workflow_id for action in triggered_actions} == {self.workflow.id}
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
+            self.workflow.id
+        }
 
         for status in [status_1, status_2]:
             status.refresh_from_db()
@@ -80,7 +82,7 @@ class TestFilterRecentlyFiredActions(BaseWorkflowTest):
         )
         assert set(triggered_actions) == {self.action, action_3}
 
-        assert {action.workflow_id for action in triggered_actions} == {
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
             self.workflow.id,
             workflow.id,
         }

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -573,7 +573,9 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def test_basic__no_filter(self) -> None:
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
         assert set(triggered_actions) == {self.action_group}
-        assert {action.workflow_id for action in triggered_actions} == {self.workflow.id}
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
+            self.workflow.id
+        }
 
     def test_basic__with_filter__passes(self):
         self.create_data_condition(
@@ -585,7 +587,9 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
         assert set(triggered_actions) == {self.action_group}
-        assert {action.workflow_id for action in triggered_actions} == {self.workflow.id}
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
+            self.workflow.id
+        }
 
     def test_basic__with_filter__filtered(self):
         # Add a filter to the action's group

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -573,6 +573,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def test_basic__no_filter(self) -> None:
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
         assert set(triggered_actions) == {self.action_group}
+        assert {action.workflow_id for action in triggered_actions} == {self.workflow.id}
 
     def test_basic__with_filter__passes(self):
         self.create_data_condition(
@@ -584,6 +585,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
 
         triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
         assert set(triggered_actions) == {self.action_group}
+        assert {action.workflow_id for action in triggered_actions} == {self.workflow.id}
 
     def test_basic__with_filter__filtered(self):
         # Add a filter to the action's group


### PR DESCRIPTION
Putting up https://github.com/getsentry/sentry/pull/91031 again since I didn't want to rebase a month old PR

This PR adds the corresponding workflow_id to the `WorkflowEventData` dataclass.

This allows us to use that in the Notification Action