### PR TITLE
fix(nav): Fix new nav when user is not associated with any orgs

### DIFF
--- a/static/app/views/nav/index.tsx
+++ b/static/app/views/nav/index.tsx
@@ -2,6 +2,9 @@ import {useEffect} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import {PRIMARY_SIDEBAR_WIDTH} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
 import MobileTopbar from 'sentry/views/nav/mobileTopbar';
 import {Sidebar} from 'sentry/views/nav/sidebar';
@@ -10,6 +13,7 @@ import {
   useStackedNavigationTour,
 } from 'sentry/views/nav/tour/tour';
 import {NavLayout} from 'sentry/views/nav/types';
+import {UserDropdown} from 'sentry/views/nav/userDropdown';
 import {useResetActiveNavGroup} from 'sentry/views/nav/useResetActiveNavGroup';
 
 function NavContent() {
@@ -38,10 +42,20 @@ function NavContent() {
   );
 }
 
+function NoOrganizationNav() {
+  return (
+    <NoOrganizationSidebar>
+      <UserDropdown />
+    </NoOrganizationSidebar>
+  );
+}
+
 function Nav() {
+  const organization = useOrganization({allowNull: true});
+
   return (
     <NavigationTourProvider>
-      <NavContent />
+      {organization ? <NavContent /> : <NoOrganizationNav />}
     </NavigationTourProvider>
   );
 }
@@ -65,6 +79,18 @@ const NavContainer = styled('div')<{isMobile: boolean; tourIsActive: boolean}>`
       height: 100vh;
       height: 100dvh;
     `}
+`;
+
+const NoOrganizationSidebar = styled('div')`
+  z-index: ${p => p.theme.zIndex.sidebarPanel};
+  width: ${PRIMARY_SIDEBAR_WIDTH}px;
+  padding: ${space(1.5)} 0 ${space(1)} 0;
+  border-right: 1px solid
+    ${p => (p.theme.isChonk ? p.theme.border : p.theme.translucentGray200)};
+  background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface300)};
+  display: flex;
+  align-items: center;
+  flex-direction: column;
 `;
 
 export default Nav;

--- a/static/app/views/nav/index.tsx
+++ b/static/app/views/nav/index.tsx
@@ -42,20 +42,20 @@ function NavContent() {
   );
 }
 
-function NoOrganizationNav() {
-  return (
-    <NoOrganizationSidebar>
-      <UserDropdown />
-    </NoOrganizationSidebar>
-  );
-}
-
 function Nav() {
   const organization = useOrganization({allowNull: true});
 
+  if (!organization) {
+    return (
+      <NoOrganizationSidebar data-test-id="no-organization-sidebar">
+        <UserDropdown />
+      </NoOrganizationSidebar>
+    );
+  }
+
   return (
     <NavigationTourProvider>
-      {organization ? <NavContent /> : <NoOrganizationNav />}
+      <NavContent />
     </NavigationTourProvider>
   );
 }

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -102,7 +102,8 @@ export function SidebarMenu({
   disableTooltip,
 }: SidebarItemDropdownProps) {
   const theme = useTheme();
-  const organization = useOrganization();
+  // This component can be rendered without an organization in some cases
+  const organization = useOrganization({allowNull: true});
   const {layout} = useNavContext();
 
   const showLabel = layout === NavLayout.MOBILE;
@@ -123,7 +124,9 @@ export function SidebarMenu({
               {...props}
               aria-label={showLabel ? undefined : label}
               onClick={event => {
-                recordPrimaryItemClick(analyticsKey, organization);
+                if (organization) {
+                  recordPrimaryItemClick(analyticsKey, organization);
+                }
                 props.onClick?.(event);
                 onOpen?.(event);
               }}

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -73,7 +73,7 @@ interface LayoutProps extends Props {
   organization: Organization | null;
 }
 
-function AppLayout({children, organization}: LayoutProps) {
+function AppDrawers() {
   useFeedbackOnboardingDrawer();
   useReplaysOnboardingDrawer();
   usePerformanceOnboardingDrawer();
@@ -81,6 +81,10 @@ function AppLayout({children, organization}: LayoutProps) {
   useFeatureFlagOnboardingDrawer();
   useReleasesDrawer();
 
+  return null;
+}
+
+function AppLayout({children, organization}: LayoutProps) {
   return (
     <NavContextProvider>
       <AppContainer>
@@ -95,6 +99,7 @@ function AppLayout({children, organization}: LayoutProps) {
           <Footer />
         </BodyContainer>
       </AppContainer>
+      {organization ? <AppDrawers /> : null}
     </NavContextProvider>
   );
 }


### PR DESCRIPTION
Fixes JAVASCRIPT-3199

The new navigation has quite a few `useOrganization()` usages which assume there is an org. There almost always is, except for some edge cases like when a user is not associated with any orgs. This ensure that we render a simple version of the sidebar with just the user dropdown in that case.

![CleanShot 2025-06-02 at 16 37 13](https://github.com/user-attachments/assets/f4e7cc9c-7e88-4d3c-9aac-b5a4b10d677c)