### PR TITLE
feat(errors) - Handle client sample rate on error events

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -748,13 +748,15 @@ def _derive_client_error_sampling_rate(jobs: Sequence[Job], projects: ProjectsMa
                     .get("error_sampling", {})
                     .get("client_sample_rate")
                 )
-                # Only set sample_rate if it's a valid number between 0 and 1
-                if (
-                    client_sample_rate is not None
-                    and isinstance(client_sample_rate, (int, float))
-                    and 0 <= client_sample_rate <= 1
-                ):
-                    job["data"]["sample_rate"] = client_sample_rate
+
+                if client_sample_rate is not None and isinstance(client_sample_rate, (int, float)):
+                    if 0 <= client_sample_rate <= 1:
+                        job["data"]["sample_rate"] = client_sample_rate
+                    else:
+                        metrics.incr(
+                            "events.client_sample_rate.invalid_range",
+                            tags={"project_id": project.id},
+                        )
             except (KeyError, TypeError, AttributeError):
                 pass
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -742,13 +742,20 @@ def _derive_client_error_sampling_rate(jobs: Sequence[Job], projects: ProjectsMa
         project = projects[job["project_id"]]
         if project.id in options.get("issues.client_error_sampling.project_allowlist"):
             try:
-                job["data"]["sample_rate"] = (
+                client_sample_rate = (
                     job["data"]
                     .get("contexts", {})
                     .get("error_sampling", {})
                     .get("client_sample_rate")
                 )
-            except (KeyError, TypeError):
+                # Only set sample_rate if it's a valid number between 0 and 1
+                if (
+                    client_sample_rate is not None
+                    and isinstance(client_sample_rate, (int, float))
+                    and 0 <= client_sample_rate <= 1
+                ):
+                    job["data"]["sample_rate"] = client_sample_rate
+            except (KeyError, TypeError, AttributeError):
                 pass
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3390,3 +3390,10 @@ register(
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.
 register("chunk-upload.no-compression", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+register(
+    "issues.client_error_sampling.project_allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2864,6 +2864,20 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             metrics_logged = [call.args[0] for call in mock_metrics_incr.mock_calls]
             assert "grouping.in_app_frame_mix" not in metrics_logged
 
+    def test_derive_client_error_sampling_rate_with_option_enabled(self) -> None:
+        """Test that sample_rate is extracted from contexts when option is enabled."""
+        with self.options({"issues.client_error_sampling.project_allowlist": [self.project.id]}):
+            event_data = make_event(
+                contexts={"error_sampling": {"client_sample_rate": 0.75}}, platform="python"
+            )
+
+            manager = EventManager(event_data)
+            manager.normalize()
+            event = manager.save(self.project.id)
+
+            # Check that sample_rate was extracted and stored
+            assert event.data["sample_rate"] == 0.75
+
 
 class ReleaseIssueTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Added the ability to receive a client sampling rate on error events through the `contexts` field. This gets parsed and placed on the event as `["data"]["sample_rate"]` as part of processing before saving the event. Only enabled for specific projects, defined via a new option.