### PR TITLE
feat(agents-insights): extend AI span queries

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -11,7 +11,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {
   AI_MODEL_ID_ATTRIBUTE,
-  getLLMGenerationsFilter,
+  getAIGenerationsFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -39,7 +39,7 @@ export default function LLMGenerationsWidget() {
 
   const theme = useTheme();
 
-  const fullQuery = `${getLLMGenerationsFilter()} ${query}`.trim();
+  const fullQuery = `${getAIGenerationsFilter()} ${query}`.trim();
 
   const generationsRequest = useEAPSpans(
     {

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -13,7 +13,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {
   AI_MODEL_ID_ATTRIBUTE,
   AI_TOKEN_USAGE_ATTRIBUTE_SUM,
-  getLLMGenerationsFilter,
+  getAIGenerationsFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -40,7 +40,7 @@ export default function TokenUsageWidget() {
     granularity: 'spans-low',
   });
 
-  const fullQuery = `${getLLMGenerationsFilter()} ${query}`.trim();
+  const fullQuery = `${getAIGenerationsFilter()} ${query}`.trim();
 
   const tokensRequest = useEAPSpans(
     {
@@ -113,7 +113,7 @@ export default function TokenUsageWidget() {
           <div>
             <ModelText>{item[AI_MODEL_ID_ATTRIBUTE]}</ModelText>
           </div>
-          <span>{formatAbbreviatedNumber(item['sum(ai.total_tokens.used)'] || 0)}</span>
+          <span>{formatAbbreviatedNumber(item[AI_TOKEN_USAGE_ATTRIBUTE_SUM] || 0)}</span>
         </Fragment>
       ))}
     </WidgetFooterTable>
@@ -132,7 +132,7 @@ export default function TokenUsageWidget() {
               visualize: [
                 {
                   chartType: ChartType.BAR,
-                  yAxes: ['sum(ai.total_tokens.used)'],
+                  yAxes: [AI_TOKEN_USAGE_ATTRIBUTE_SUM],
                 },
               ],
               groupBy: [AI_MODEL_ID_ATTRIBUTE],

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -2,17 +2,41 @@
 
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 
-// They will probably change and maybe it will be enough to inline them in the widgets.
-const AI_PIPELINE_OPS = ['ai.pipeline.generateText', 'ai.pipeline.generateObject'];
-const AI_GENERATION_OPS = ['ai.run.doGenerate'];
-const AI_TOOL_CALL_OPS = ['ai.toolCall'];
-const AI_OPS = [...AI_PIPELINE_OPS, ...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS];
+// AI Runs - equivalent to OTEL Invoke Agent span
+// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-agent-spans.md#invoke-agent-span
+const AI_RUN_OPS = [
+  'ai.run.generateText',
+  'ai.run.generateObject',
+  'gen_ai.invoke_agent',
+];
+const AI_RUN_DESCRIPTIONS = ['ai.generateText', 'generateText'];
+
+// AI Generations - equivalent to OTEL Inference span
+// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#inference
+const AI_GENERATION_OPS = [
+  'ai.run.doGenerate',
+  'gen_ai.chat',
+  'gen_ai.generate_content',
+  'gen_ai.text_completion',
+];
+const AI_GENERATION_DESCRIPTIONS = [
+  'ai.generateText.doGenerate',
+  'generateText.doGenerate',
+];
+
+// AI Tool Calls - equivalent to OTEL Execute tool span
+// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
+const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool', 'ai.toolCall'];
 
 export const AI_MODEL_ID_ATTRIBUTE = 'ai.model.id' as EAPSpanProperty;
 export const AI_TOOL_NAME_ATTRIBUTE = 'ai.toolCall.name' as EAPSpanProperty;
-const AI_TOKEN_USAGE_ATTRIBUTE = 'ai.total_tokens.used';
 
-export const AI_TOKEN_USAGE_ATTRIBUTE_SUM = `sum(${AI_TOKEN_USAGE_ATTRIBUTE})`;
+export const AI_TOKEN_USAGE_ATTRIBUTE_SUM =
+  `sum(tags[gen_ai.usage.total_tokens,number])` as EAPSpanProperty;
+export const AI_INPUT_TOKENS_ATTRIBUTE_SUM =
+  `sum(tags[gen_ai.usage.input_tokens,number])` as EAPSpanProperty;
+export const AI_OUTPUT_TOKENS_ATTRIBUTE_SUM =
+  `sum(tags[gen_ai.usage.output_tokens,number])` as EAPSpanProperty;
 
 export const legacyAttributeKeys = new Map<string, string[]>([
   ['gen_ai.request.model', ['ai.model.id']],
@@ -39,17 +63,19 @@ function mapMissingSpanOp({
   return op;
 }
 
+const AI_OPS = [...AI_RUN_OPS, ...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS];
+
 export function getIsAiSpan({op, description}: {description?: string; op?: string}) {
   const mappedOp = mapMissingSpanOp({op, description});
   return AI_OPS.includes(mappedOp);
 }
 
 export const getAgentRunsFilter = () => {
-  return `span.op:[${AI_PIPELINE_OPS.join(',')}]`;
+  return `span.op:[${AI_RUN_OPS.join(',')}] or span.description:[${AI_RUN_DESCRIPTIONS.join(',')}]`;
 };
 
-export const getLLMGenerationsFilter = () => {
-  return `span.op:[${AI_GENERATION_OPS.join(',')}]`;
+export const getAIGenerationsFilter = () => {
+  return `span.op:[${AI_GENERATION_OPS.join(',')}] or span.description:[${AI_GENERATION_DESCRIPTIONS.join(',')}]`;
 };
 
 export const getAIToolCallsFilter = () => {


### PR DESCRIPTION
- Extends queries performed by Agents dashboards to account for data inconsistencies
- Adds future standardised span ops to the queries
- Splits token usage in models table into input and output tokens