### PR TITLE
Do not use `dicts` in `.set_data()`. 

### DIFF
--- a/src/sentry/api/endpoints/group_current_release.py
+++ b/src/sentry/api/endpoints/group_current_release.py
@@ -69,7 +69,6 @@ class GroupCurrentReleaseEndpoint(GroupEndpoint):
             # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
             # If a stringified JSON of the dict is OK, nothing needs to be done.
             # Otherwise it needs to be split up into multiple set_data calls.
-
             span.set_data(
                 "Raw Parameters",
                 {

--- a/src/sentry/api/endpoints/group_current_release.py
+++ b/src/sentry/api/endpoints/group_current_release.py
@@ -66,6 +66,10 @@ class GroupCurrentReleaseEndpoint(GroupEndpoint):
 
         with sentry_sdk.start_span(op="CurrentReleaseEndpoint.get.current_release") as span:
             span.set_data("Environment Count", len(environments))
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
+
             span.set_data(
                 "Raw Parameters",
                 {

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -190,6 +190,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         query_source = self.get_request_source(request)
 
         with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             span.set_data("organization", organization)
 
             top_events = 0

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -152,6 +152,9 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
 
     def get(self, request: Request, organization: Organization) -> Response:
         with sentry_sdk.start_span(op="discover.endpoint", name="filter_params") as span:
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             span.set_data("organization", organization)
 
             top_events = self.get_top_events(request)

--- a/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_on_demand_metrics_estimation_stats.py
@@ -67,6 +67,9 @@ class OrganizationOnDemandMetricsEstimationStatsEndpoint(OrganizationEventsV2End
             return Response({"detail": "missing required parameter yAxis"}, status=400)
 
         with sentry_sdk.start_span(op="discover.metrics.endpoint", name="get_full_metrics") as span:
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             span.set_data("organization", organization)
 
             try:

--- a/src/sentry/issues/endpoints/organization_issues_count.py
+++ b/src/sentry/issues/endpoints/organization_issues_count.py
@@ -63,6 +63,9 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
 
             query_kwargs["actor"] = request.user
         with start_span(op="start_search") as span:
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             span.set_data("query_kwargs", query_kwargs)
             result = search.backend.query(**query_kwargs)
             return result.hits

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -126,6 +126,9 @@ class GroupTypeRegistry:
             span.set_tag("has_batch_features", batch_features is not None)
             span.set_tag("released", released)
             span.set_tag("enabled", enabled)
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             span.set_data("feature_to_grouptype", feature_to_grouptype)
             return released + enabled
 

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -793,6 +793,9 @@ def _convert_aggregate_and_query_to_metrics(
     }
 
     with sentry_sdk.start_span(op="converting_aggregate_and_query") as span:
+        # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+        # If a stringified JSON of the dict is OK, nothing needs to be done.
+        # Otherwise it needs to be split up into multiple set_data calls.
         span.set_data("widget_query_args", {"query": query, "aggregate": aggregate})
         # Create as many specs as we support
         for spec_version in OnDemandMetricSpecVersioning.get_spec_versions():

--- a/src/sentry/snuba/query_subscriptions/consumer.py
+++ b/src/sentry/snuba/query_subscriptions/consumer.py
@@ -163,6 +163,9 @@ def handle_message(
                 tags={"dataset": dataset},
             ),
         ):
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             span.set_data("payload", contents)
             span.set_data("subscription_dataset", subscription.snuba_query.dataset)
             span.set_data("subscription_query", subscription.snuba_query.query)

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -366,6 +366,7 @@ class SnubaTagStorage(TagStorage):
                     op="cache.put", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
                 ) as span:
                     cache.set(cache_key, result, 300)
+
                     # TODO: Do not set a list as a data attribute, because opentelemetry does not support it.
                     # If a stringified JSON of the dict is OK, nothing needs to be done.
                     # Otherwise it needs to be split up into multiple set_data calls.

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -334,8 +334,10 @@ class SnubaTagStorage(TagStorage):
                 op="cache.get", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
             ) as span:
                 result = cache.get(cache_key, None)
-
-                span.set_data("cache.key", [cache_key])
+                # TODO: Do not set a list as a data attribute, because opentelemetry does not support it.
+                # If a stringified JSON of the dict is OK, nothing needs to be done.
+                # Otherwise it needs to be split up into multiple set_data calls.
+                span.set_data("cache.key", cache_key)
 
                 if result is not None:
                     span.set_data("cache.hit", True)
@@ -364,6 +366,9 @@ class SnubaTagStorage(TagStorage):
                     op="cache.put", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
                 ) as span:
                     cache.set(cache_key, result, 300)
+                    # TODO: Do not set a list as a data attribute, because opentelemetry does not support it.
+                    # If a stringified JSON of the dict is OK, nothing needs to be done.
+                    # Otherwise it needs to be split up into multiple set_data calls.
                     span.set_data("cache.key", [cache_key])
                     span.set_data("cache.item_size", len(str(result)))
                     metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -334,10 +334,7 @@ class SnubaTagStorage(TagStorage):
                 op="cache.get", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
             ) as span:
                 result = cache.get(cache_key, None)
-                # TODO: Do not set a list as a data attribute, because opentelemetry does not support it.
-                # If a stringified JSON of the dict is OK, nothing needs to be done.
-                # Otherwise it needs to be split up into multiple set_data calls.
-                span.set_data("cache.key", cache_key)
+                span.set_data("cache.key", [cache_key])
 
                 if result is not None:
                     span.set_data("cache.hit", True)
@@ -367,9 +364,6 @@ class SnubaTagStorage(TagStorage):
                 ) as span:
                     cache.set(cache_key, result, 300)
 
-                    # TODO: Do not set a list as a data attribute, because opentelemetry does not support it.
-                    # If a stringified JSON of the dict is OK, nothing needs to be done.
-                    # Otherwise it needs to be split up into multiple set_data calls.
                     span.set_data("cache.key", [cache_key])
                     span.set_data("cache.item_size", len(str(result)))
                     metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -334,6 +334,7 @@ class SnubaTagStorage(TagStorage):
                 op="cache.get", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
             ) as span:
                 result = cache.get(cache_key, None)
+
                 span.set_data("cache.key", [cache_key])
 
                 if result is not None:
@@ -363,7 +364,6 @@ class SnubaTagStorage(TagStorage):
                     op="cache.put", name="sentry.tagstore.cache.__get_tag_keys_for_projects"
                 ) as span:
                     cache.set(cache_key, result, 300)
-
                     span.set_data("cache.key", [cache_key])
                     span.set_data("cache.item_size", len(str(result)))
                     metrics.incr("testing.tagstore.cache_tag_key.len", amount=len(result))

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -302,6 +302,10 @@ def child_process(
             track_memory_usage("taskworker.worker.memory_change"),
             sentry_sdk.start_transaction(transaction),
         ):
+
+            # TODO: Do not set a dict as a data attribute, because opentelemetry does not support it.
+            # If a stringified JSON of the dict is OK, nothing needs to be done.
+            # Otherwise it needs to be split up into multiple set_data calls.
             transaction.set_data(
                 "taskworker-task", {"args": args, "kwargs": kwargs, "id": activation.id}
             )


### PR DESCRIPTION
The new major version of the Python SDK 3.0.0 will used Opentelemetry (OTel) under the hood. OTel does not allow `dict` or certain `list` values in `span.set_data()` (or `transaction.set_data()`)

Lists are handled like this in Otel: they are allowed if the items in the list do not mix types and are of one of those types: `int`, `str`, `float`, `bool`.

If we use `lists` of `dicts` in `.set_data()` the SDK will coerce those values into strings automatically.

This is part of a bigger change tracked here: https://github.com/getsentry/sentry/pull/92011

## Help Wanted:

Can you have a look at the marked call sites in the PR (marked with `TODO` comment) and check if coercing this data into a string will lead to problems?

## Example:

See this example code:
```python
    with sentry_sdk.start_span(name="test-root-span") as root_span:
        root_span.set_data("test-root-data-string", "test-value")
        root_span.set_data("test-root-data-int", 1)
        root_span.set_data("test-root-data-float", 1.0)
        root_span.set_data("test-root-data-bool", True)
        root_span.set_data("test-root-data-list", [1, 2, 3])
        root_span.set_data("test-root-data-dict", {"key": "value", "key2": "value2"})
        root_span.set_data("test-root-data-none", None)
        root_span.set_data("test-root-data-dict-list", [{"key1": "value1"}, {"key2": "value2"}, {"key3": "value3"}])

        with sentry_sdk.start_span(name="test-span") as span:
            span.set_data("test-span-data-string", "test-value")
            span.set_data("test-span-data-int", 1)
            span.set_data("test-span-data-float", 1.0)
            span.set_data("test-span-data-bool", True)
            span.set_data("test-span-data-list", [1, 2, 3])
            span.set_data("test-span-data-dict", {"key": "value", "key2": "value2"})
            span.set_data("test-span-data-none", None)
            span.set_data("test-span-data-dict-list", [{"key1": "value1"}, {"key2": "value2"}, {"key3": "value3"}])
```

This will lead to this experience in Sentry: 
https://sentry-sdks.sentry.io/explore/traces/trace/82b6ba5fd87d5eaab3addf3bd59f35bc/?fov=0%2C1&node=txn-c156cfa393da4e3da62cbfb09080662f&project=5461230&source=traces&statsPeriod=1h&targetId=53b4846abceb1593&timestamp=1748949174

Here some screenshots of the link above:

**Transaction:** (NOTE: the selected items are strings and can not be collapsed/expanded, the simple list below can be collapsed/expanded)
![Screenshot 2025-06-03 at 13 25 12](https://github.com/user-attachments/assets/1c44c145-c32f-4874-85e1-bfda1156405a)


**Span:** (NOTE: the selected items are strings and can not be collapsed/expanded, the simple list below can be collapsed/expanded)
![Screenshot 2025-06-03 at 13 26 00](https://github.com/user-attachments/assets/f1ff461e-e0bd-49ca-9d41-6df218bff8d6)



