### PR TITLE
fix(ui): alignment issues in searchQueryBuilder

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -257,7 +257,7 @@ export function SearchQueryBuilder({...props}: SearchQueryBuilderProps) {
 }
 
 const Wrapper = styled(Input.withComponent('div'))`
-  min-height: 38px;
+  min-height: ${p => p.theme.form.md.minHeight};
   padding: 0;
   height: auto;
   width: 100%;

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -191,8 +191,8 @@ export function TokenizedQueryGrid({
 }
 
 const SearchQueryGridWrapper = styled('div')`
-  padding-top: ${space(0.75)};
-  padding-bottom: ${space(0.75)};
+  padding-top: ${p => (p.theme.isChonk ? space(0.5) : space(0.75))};
+  padding-bottom: ${p => (p.theme.isChonk ? space(0.5) : space(0.75))};
   padding-left: 32px;
   padding-right: ${space(0.75)};
   display: flex;


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-06-03 at 13 36 58](https://github.com/user-attachments/assets/83cdd71e-1eab-444a-9994-00d8af991978) | ![Screenshot 2025-06-03 at 13 37 17](https://github.com/user-attachments/assets/9952f141-d01b-4eea-8098-f776615706bc)  | 

`Last Seen` is now properly aligned with the search box