### PR TITLE
ref(span-buffer): Make lua script batched

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -1,62 +1,72 @@
 --[[
 
-Add a span to the span buffer.
+Add a set of spans to the span buffer.
 
 KEYS:
 - "project_id:trace_id" -- just for redis-cluster routing, all keys that the script uses are sharded like this/have this hashtag.
 
 ARGS:
-- payload -- str
-- is_root_span -- bool
-- span_id -- str
+- num_spans -- int
 - parent_span_id -- str
 - set_timeout -- int
+- *span_id -- str[]
 
 ]]--
 
 local project_and_trace = KEYS[1]
 
-local is_root_span = ARGV[1] == "true"
-local span_id = ARGV[2]
-local parent_span_id = ARGV[3]
-local set_timeout = tonumber(ARGV[4])
+local num_spans = ARGV[1]
+local parent_span_id = ARGV[2]
+local set_timeout = tonumber(ARGV[3])
 
-local span_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
+local return_value = {}
 
-local set_span_id = parent_span_id
-local redirect_depth = 0
+for i = 4, num_spans + 3 do
+    local span_id = ARGV[i]
+    local is_root_span = span_id == parent_span_id
 
-for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
-    local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
-    redirect_depth = i
-    if not new_set_span or new_set_span == set_span_id then
-        break
+    local span_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+    local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
+
+    local set_span_id = parent_span_id
+    local redirect_depth = 0
+
+    for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
+        local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
+        redirect_depth = i
+        if not new_set_span or new_set_span == set_span_id then
+            break
+        end
+
+        set_span_id = new_set_span
     end
 
-    set_span_id = new_set_span
+    redis.call("hset", main_redirect_key, span_id, set_span_id)
+    redis.call("expire", main_redirect_key, set_timeout)
+
+    local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
+    if not is_root_span and redis.call("scard", span_key) > 0 then
+        redis.call("sunionstore", set_key, set_key, span_key)
+        redis.call("unlink", span_key)
+    end
+
+    local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
+    if set_span_id ~= parent_span_id and redis.call("scard", parent_key) > 0 then
+        redis.call("sunionstore", set_key, set_key, parent_key)
+        redis.call("unlink", parent_key)
+    end
+    redis.call("expire", set_key, set_timeout)
+
+    local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
+    local has_root_span = redis.call("get", has_root_span_key) == "1" or is_root_span
+    if has_root_span then
+        redis.call("setex", has_root_span_key, set_timeout, "1")
+    end
+
+    table.insert(return_value, redirect_depth)
+    table.insert(return_value, span_key)
+    table.insert(return_value, set_key)
+    table.insert(return_value, has_root_span)
 end
 
-redis.call("hset", main_redirect_key, span_id, set_span_id)
-redis.call("expire", main_redirect_key, set_timeout)
-
-local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
-if not is_root_span and redis.call("scard", span_key) > 0 then
-    redis.call("sunionstore", set_key, set_key, span_key)
-    redis.call("unlink", span_key)
-end
-
-local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
-if set_span_id ~= parent_span_id and redis.call("scard", parent_key) > 0 then
-    redis.call("sunionstore", set_key, set_key, parent_key)
-    redis.call("unlink", parent_key)
-end
-redis.call("expire", set_key, set_timeout)
-
-local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
-local has_root_span = redis.call("get", has_root_span_key) == "1" or is_root_span
-if has_root_span then
-    redis.call("setex", has_root_span_key, set_timeout, "1")
-end
-
-return {redirect_depth, span_key, set_key, has_root_span}
+return return_value

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -19,54 +19,63 @@ local num_spans = ARGV[1]
 local parent_span_id = ARGV[2]
 local set_timeout = tonumber(ARGV[3])
 
-local return_value = {}
+local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
+
+local set_span_id = parent_span_id
+local redirect_depth = 0
+
+for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
+    local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
+    redirect_depth = i
+    if not new_set_span or new_set_span == set_span_id then
+        break
+    end
+
+    set_span_id = new_set_span
+end
+
+local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
+local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
+
+local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
+local has_root_span = redis.call("get", has_root_span_key) == "1"
+
+for i = 4, num_spans + 3 do
+    local span_id = ARGV[i]
+    if span_id == parent_span_id then
+        has_root_span = true
+        break
+    end
+end
+
+if has_root_span then
+    redis.call("setex", has_root_span_key, set_timeout, "1")
+end
+
+local return_value = {redirect_depth, set_key, has_root_span}
 
 for i = 4, num_spans + 3 do
     local span_id = ARGV[i]
     local is_root_span = span_id == parent_span_id
 
     local span_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-    local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
-
-    local set_span_id = parent_span_id
-    local redirect_depth = 0
-
-    for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
-        local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
-        redirect_depth = i
-        if not new_set_span or new_set_span == set_span_id then
-            break
-        end
-
-        set_span_id = new_set_span
-    end
 
     redis.call("hset", main_redirect_key, span_id, set_span_id)
     redis.call("expire", main_redirect_key, set_timeout)
 
-    local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
     if not is_root_span and redis.call("scard", span_key) > 0 then
         redis.call("sunionstore", set_key, set_key, span_key)
         redis.call("unlink", span_key)
     end
 
-    local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
     if set_span_id ~= parent_span_id and redis.call("scard", parent_key) > 0 then
         redis.call("sunionstore", set_key, set_key, parent_key)
         redis.call("unlink", parent_key)
     end
-    redis.call("expire", set_key, set_timeout)
 
-    local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
-    local has_root_span = redis.call("get", has_root_span_key) == "1" or is_root_span
-    if has_root_span then
-        redis.call("setex", has_root_span_key, set_timeout, "1")
-    end
-
-    table.insert(return_value, redirect_depth)
     table.insert(return_value, span_key)
-    table.insert(return_value, set_key)
-    table.insert(return_value, has_root_span)
 end
+
+redis.call("expire", set_key, set_timeout)
 
 return return_value

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -218,7 +218,7 @@ class SpansBuffer:
 
                     is_root_span_count += sum(span.is_segment_span for span in subsegment)
                     shard = self.assigned_shards[
-                        int(project_and_trace.replace(":", ""), 16) % len(self.assigned_shards)
+                        int(project_and_trace.split(":")[1], 16) % len(self.assigned_shards)
                     ]
                     queue_keys.append(self._get_queue_key(shard))
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -205,23 +205,22 @@ class SpansBuffer:
 
             with self.client.pipeline(transaction=False) as p:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
-                    for span in subsegment:
-                        p.execute_command(
-                            "EVALSHA",
-                            add_buffer_sha,
-                            1,
-                            project_and_trace,
-                            "true" if span.is_segment_span else "false",
-                            span.span_id,
-                            parent_span_id,
-                            self.redis_ttl,
-                        )
+                    p.execute_command(
+                        "EVALSHA",
+                        add_buffer_sha,
+                        1,
+                        project_and_trace,
+                        len(subsegment),
+                        parent_span_id,
+                        self.redis_ttl,
+                        *[span.span_id for span in subsegment],
+                    )
 
-                        is_root_span_count += int(span.is_segment_span)
-                        shard = self.assigned_shards[
-                            int(span.trace_id, 16) % len(self.assigned_shards)
-                        ]
-                        queue_keys.append(self._get_queue_key(shard))
+                    is_root_span_count += sum(span.is_segment_span for span in subsegment)
+                    shard = self.assigned_shards[
+                        int(project_and_trace.replace(":", ""), 16) % len(self.assigned_shards)
+                    ]
+                    queue_keys.append(self._get_queue_key(shard))
 
                 results = p.execute()
 
@@ -231,31 +230,32 @@ class SpansBuffer:
 
             assert len(queue_keys) == len(results)
 
-            for queue_key, (redirect_depth, delete_item, add_item, has_root_span) in zip(
-                queue_keys, results
-            ):
-                min_redirect_depth = min(min_redirect_depth, redirect_depth)
-                max_redirect_depth = max(max_redirect_depth, redirect_depth)
+            for queue_key, result in zip(queue_keys, results):
+                for redirect_depth, delete_item, add_item, has_root_span in itertools.batched(
+                    result, 4
+                ):
+                    min_redirect_depth = min(min_redirect_depth, redirect_depth)
+                    max_redirect_depth = max(max_redirect_depth, redirect_depth)
 
-                delete_set = queue_deletes.setdefault(queue_key, set())
-                delete_set.add(delete_item)
-                # if we are going to add this item, we should not need to
-                # delete it from redis
-                delete_set.discard(add_item)
+                    delete_set = queue_deletes.setdefault(queue_key, set())
+                    delete_set.add(delete_item)
+                    # if we are going to add this item, we should not need to
+                    # delete it from redis
+                    delete_set.discard(add_item)
 
-                # if the currently processed span is a root span, OR the buffer
-                # already had a root span inside, use a different timeout than
-                # usual.
-                if has_root_span:
-                    has_root_span_count += 1
-                    offset = self.span_buffer_root_timeout_secs
-                else:
-                    offset = self.span_buffer_timeout_secs
+                    # if the currently processed span is a root span, OR the buffer
+                    # already had a root span inside, use a different timeout than
+                    # usual.
+                    if has_root_span:
+                        has_root_span_count += 1
+                        offset = self.span_buffer_root_timeout_secs
+                    else:
+                        offset = self.span_buffer_timeout_secs
 
-                zadd_items = queue_adds.setdefault(queue_key, {})
-                zadd_items[add_item] = now + offset
-                if delete_item != add_item:
-                    zadd_items.pop(delete_item, None)
+                    zadd_items = queue_adds.setdefault(queue_key, {})
+                    zadd_items[add_item] = now + offset
+                    if delete_item != add_item:
+                        zadd_items.pop(delete_item, None)
 
             with self.client.pipeline(transaction=False) as p:
                 for queue_key, adds in queue_adds.items():

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -212,6 +212,7 @@ class SpansBuffer:
                         project_and_trace,
                         len(subsegment),
                         parent_span_id,
+                        "true" if any(span.is_segment_span for span in subsegment) else "false",
                         self.redis_ttl,
                         *[span.span_id for span in subsegment],
                     )

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -231,9 +231,10 @@ class SpansBuffer:
             assert len(queue_keys) == len(results)
 
             for queue_key, result in zip(queue_keys, results):
-                for redirect_depth, delete_item, add_item, has_root_span in itertools.batched(
-                    result, 4
-                ):
+                redirect_depth, set_key, has_root_span, *span_keys = result
+                add_item = set_key
+
+                for delete_item in span_keys:
                     min_redirect_depth = min(min_redirect_depth, redirect_depth)
                     max_redirect_depth = max(max_redirect_depth, redirect_depth)
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -192,7 +192,7 @@ class SpansBuffer:
 
             with self.client.pipeline(transaction=False) as p:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
-                    set_key = f"span-buf:s:{{{project_and_trace}}}:{parent_span_id}"
+                    set_key = f"span-buf:s:{{{project_and_trace}}}:{parent_span_id}".encode("ascii")
                     p.sadd(set_key, *[span.payload for span in subsegment])
 
                 p.execute()


### PR DESCRIPTION
We recognized the add_buffer.lua script as a point of contention in the consumer. It issues a high number of Redis commands for every individual span, sometimes leading to duplicate SUNIONSTORE operations. 

While the command duration measured by Redis itself is fine even in the high-volume US environment, we notice much higher invocation latency from the consumer side. This leads us to believe that we simply issue too many of these script calls, combined with too much work inside the script.

Most of what the script does can be batched, since the consumer already groups spans by their parent node. Instead of resolving redirects and merging sets for every span individually, we can perform these operations once per subtree. This should greatly reduce the number of operations in Redis, similar to what we have seen when we introduced batching for push_payloads.

VIEPF-32
