### PR TITLE
feat(relay): UI settings for ingestion through trusted relays only

### DIFF
--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -4,6 +4,8 @@ import omit from 'lodash/omit';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/core/button';
+import Form from 'sentry/components/forms/form';
+import JsonForm from 'sentry/components/forms/jsonForm';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -68,6 +70,43 @@ export function RelayWrapper() {
         }
       />
       <OrganizationPermissionAlert />
+      <Form
+        saveOnBlur
+        initialData={organization}
+        apiMethod="PUT"
+        apiEndpoint={`/organizations/${organization.slug}/`}
+      >
+        <JsonForm
+          disabled={disabled}
+          forms={[
+            {
+              title: t('Data Authenticity'),
+              fields: [
+                {
+                  name: 'ingestThroughTrustedRelaysOnly',
+                  type: 'boolean',
+                  label: t('Ingest Through Trusted Relays Only'),
+                  help: t(
+                    'Require events to be ingested only through trusted relays. Direct submissions from SDKs or other sources will be rejected unless signed by a registered relay.'
+                  ),
+                  'aria-label': t(
+                    'Enable to require events to be ingested only through trusted relays'
+                  ),
+                  confirm: {
+                    isDangerous: true,
+                    true: t(
+                      'Enabling this can lead to data being rejected for ALL projects, are you sure you want to continue?'
+                    ),
+                  },
+                  visible: organization.features.includes(
+                    'ingest-through-trusted-relays-only'
+                  ),
+                },
+              ],
+            },
+          ]}
+        />
+      </Form>
       <TextBlock>
         {tct(
           'Sentry Relay offers enterprise-grade data security by providing a standalone service that acts as a middle layer between your application and sentry.io. Go to [link:Relay Documentation] for setup and details.',


### PR DESCRIPTION
Adds UI toggle for this setting
![image](https://github.com/user-attachments/assets/44534196-a7ba-4bf5-a761-2f3ce2f48bd9)

This settings is currently behind a feature flag, and it will be accessible only to organization admins, for others it will be visible, but disabled.

Part of [TET-541: UI Toggle to enable ingestion through trusted relays only](https://linear.app/getsentry/issue/TET-541/ui-toggle-to-enable-ingestion-through-trusted-relays-only)