### PR TITLE
chore(explore): Expose semver attributes to search

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useMemo} from 'react';
 
 import {fetchSpanFieldValues} from 'sentry/actionCreators/tags';
+import {STATIC_SEMVER_TAGS} from 'sentry/components/events/searchBarFieldConstants';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {CallbackSearchState} from 'sentry/components/searchQueryBuilder/types';
@@ -26,6 +27,7 @@ import {
 import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
+import {SpanIndexedField} from 'sentry/views/insights/types';
 import {
   useSpanFieldCustomTags,
   useSpanFieldSupportedTags,
@@ -214,16 +216,29 @@ export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderPr
 
 export function useEAPSpanSearchQueryBuilderProps(props: EAPSpanSearchQueryBuilderProps) {
   const {numberTags, stringTags, ...rest} = props;
+
+  const numberAttributes = numberTags;
+  const stringAttributes = useMemo(() => {
+    if (stringTags.hasOwnProperty(SpanIndexedField.RELEASE)) {
+      return {
+        ...stringTags,
+        ...STATIC_SEMVER_TAGS,
+      };
+    }
+    return stringTags;
+  }, [stringTags]);
+
   return useSearchQueryBuilderProps({
     itemType: TraceItemDataset.SPANS,
-    numberAttributes: numberTags,
-    stringAttributes: stringTags,
+    numberAttributes,
+    stringAttributes,
     ...rest,
   });
 }
 
 export function EAPSpanSearchQueryBuilder(props: EAPSpanSearchQueryBuilderProps) {
   const {numberTags, stringTags, ...rest} = props;
+
   return (
     <TraceItemSearchQueryBuilder
       itemType={TraceItemDataset.SPANS}


### PR DESCRIPTION
Semver attributes are filterable but not queryable. This is because they're looked up in postgres and not directly stored in clickhouse. This exposes them to the search bar so they can be filtered on but not available elsewhere.