### PR TITLE
fix(insights): fixes webvitals timeseries query on eap using invalid low interval

### DIFF
--- a/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -4,6 +4,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useDefaultWebVitalsQuery} from 'sentry/views/insights/browser/webVitals/utils/useDefaultQuery';
 import {useMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
@@ -19,6 +20,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
 }: Props) => {
   const pageFilters = usePageFilters();
   const defaultQuery = useDefaultWebVitalsQuery();
+  const useEap = useInsightsEap();
   const search = new MutableSearch([]);
 
   if (transaction) {
@@ -31,10 +33,12 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
     search.addDisjunctionFilterValues(SpanIndexedField.USER_GEO_SUBREGION, subregions);
   }
 
+  const interval = useEap ? 'spans-low' : 'low';
+
   const result = useMetricsSeries(
     {
       search: [defaultQuery, search.formatString()].join(' ').trim(),
-      interval: getInterval(pageFilters.selection.datetime, 'low'),
+      interval: getInterval(pageFilters.selection.datetime, interval),
       yAxis: [
         'p75(measurements.lcp)',
         'p75(measurements.fcp)',


### PR DESCRIPTION
EAP queries only supports a subset of intervals. Updates the webvitals timeseries query to use `spans-low` interval ladder.