### PR TITLE
feat(search bar): Enable replacement of raw search

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -54,6 +54,7 @@ interface SearchQueryBuilderContextData {
    */
   portalTarget?: HTMLElement | null;
   recentSearches?: SavedSearchType;
+  replaceRawSearchKeys?: string[];
 }
 
 export function useSearchQueryBuilder() {
@@ -90,6 +91,7 @@ export function SearchQueryBuilderProvider({
   searchSource,
   getFilterTokenWarning,
   portalTarget,
+  replaceRawSearchKeys,
 }: SearchQueryBuilderProps & {children: React.ReactNode}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
@@ -159,6 +161,7 @@ export function SearchQueryBuilderProvider({
       portalTarget,
       displaySeerResults,
       setDisplaySeerResults,
+      replaceRawSearchKeys,
     };
   }, [
     state,
@@ -182,6 +185,7 @@ export function SearchQueryBuilderProvider({
     parseQuery,
     displaySeerResults,
     setDisplaySeerResults,
+    replaceRawSearchKeys,
   ]);
 
   return (

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4353,7 +4353,8 @@ describe('SearchQueryBuilder', function () {
           {...defaultProps}
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
-        />
+        />,
+        {organization: {features: ['search-query-builder-raw-search-replacement']}}
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'randomValue');

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4378,7 +4378,8 @@ describe('SearchQueryBuilder', function () {
           {...defaultProps}
           initialQuery=""
           replaceRawSearchKeys={['span.description']}
-        />
+        />,
+        {organization: {features: ['search-query-builder-raw-search-replacement']}}
       );
 
       await userEvent.type(screen.getByRole('textbox'), 'random value');

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4370,5 +4370,29 @@ describe('SearchQueryBuilder', function () {
         screen.getByRole('row', {name: 'span.description:randomValue'})
       ).toBeInTheDocument();
     });
+
+    it('can handle values with spaces', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery=""
+          replaceRawSearchKeys={['span.description']}
+        />
+      );
+
+      await userEvent.type(screen.getByRole('textbox'), 'random value');
+
+      expect(
+        within(screen.getByRole('listbox')).getByText('span.description')
+      ).toBeInTheDocument();
+
+      await userEvent.click(
+        within(screen.getByRole('listbox')).getByText('span.description')
+      );
+
+      expect(
+        screen.getByRole('row', {name: 'span.description:"random value"'})
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4345,4 +4345,30 @@ describe('SearchQueryBuilder', function () {
       });
     });
   });
+
+  describe('replaceRawSearchKeys', function () {
+    it('should replace raw search keys with defined key:value', async function () {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery=""
+          replaceRawSearchKeys={['span.description']}
+        />
+      );
+
+      await userEvent.type(screen.getByRole('textbox'), 'randomValue');
+
+      expect(
+        within(screen.getByRole('listbox')).getByText('span.description')
+      ).toBeInTheDocument();
+
+      await userEvent.click(
+        within(screen.getByRole('listbox')).getByText('span.description')
+      );
+
+      expect(
+        screen.getByRole('row', {name: 'span.description:randomValue'})
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -116,6 +116,16 @@ export interface SearchQueryBuilderProps {
    */
   recentSearches?: SavedSearchType;
   /**
+   * When set, provided keys will override default raw search capabilities, while
+   * replacing it with options that include the provided keys, and the user's input
+   * as value.
+   *
+   * e.g. if `replaceRawSearchKeys` is set to `['span.description']`, the user will be
+   * able to type `randomValue` and the combobox will show `span.description:randomValue`
+   * as an option, and so on with any other provided keys.
+   */
+  replaceRawSearchKeys?: string[];
+  /**
    * When true, will trigger the `onSearch` callback when the query changes.
    */
   searchOnChange?: boolean;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -31,6 +31,11 @@ export interface FilterValueItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
+export interface RawSearchFilterValueItem extends SelectOptionWithKey<string> {
+  type: 'raw-search-filter-value';
+  value: string;
+}
+
 interface RecentFilterItem extends SelectOptionWithKey<string> {
   type: 'recent-filter';
   value: string;
@@ -42,7 +47,12 @@ export interface RecentQueryItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
-export type SearchKeyItem = KeySectionItem | KeyItem | RawSearchItem | FilterValueItem;
+export type SearchKeyItem =
+  | KeySectionItem
+  | KeyItem
+  | RawSearchItem
+  | FilterValueItem
+  | RawSearchFilterValueItem;
 
 export type FilterKeyItem =
   | KeyItem
@@ -50,7 +60,8 @@ export type FilterKeyItem =
   | KeySectionItem
   | RecentQueryItem
   | RawSearchItem
-  | FilterValueItem;
+  | FilterValueItem
+  | RawSearchFilterValueItem;
 
 export type Section = {
   label: ReactNode;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -7,6 +7,7 @@ import type {
   FilterValueItem,
   KeyItem,
   KeySectionItem,
+  RawSearchFilterValueItem,
   RawSearchItem,
   RecentQueryItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
@@ -140,6 +141,24 @@ export function createFilterValueItem(key: string, value: string): FilterValueIt
     showDetailsInOverlay: true,
     details: null,
     type: 'filter-value',
+  };
+}
+
+export function createRawSearchFilterValueItem(
+  key: string,
+  value: string
+): RawSearchFilterValueItem {
+  const filter = `${key}:${escapeFilterValue(value)}`;
+
+  return {
+    key: getEscapedKey(`${key}:${value}`),
+    label: <FormattedQuery query={filter} />,
+    value: filter,
+    textValue: filter,
+    hideCheck: true,
+    showDetailsInOverlay: true,
+    details: null,
+    type: 'raw-search-filter-value',
   };
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -429,6 +429,18 @@ function SearchQueryBuilderInputInternal({
             return;
           }
 
+          if (option.type === 'raw-search-filter-value' && option.textValue) {
+            dispatch({
+              type: 'UPDATE_FREE_TEXT',
+              tokens: [token],
+              text: option.textValue,
+              focusOverride: calculateNextFocusForInsertedToken(item),
+              shouldCommitQuery: true,
+            });
+            resetInputValue();
+            return;
+          }
+
           const value = option.value;
 
           dispatch({

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -212,10 +212,11 @@ export function useSortedFilterKeyItems({
         label: '',
         options:
           replaceRawSearchKeys?.map(key => {
-            return createRawSearchFilterValueItem(
-              key,
-              inputValue?.includes(' ') ? `"${inputValue}"` : inputValue
-            );
+            const value = inputValue?.includes(' ')
+              ? `"${inputValue.replace(/"/g, '')}"`
+              : inputValue;
+
+            return createRawSearchFilterValueItem(key, value);
           }) ?? [],
         type: 'section',
       };

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -9,6 +9,7 @@ import type {
 import {
   createFilterValueItem,
   createItem,
+  createRawSearchFilterValueItem,
   createRawSearchItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import type {FieldDefinitionGetter} from 'sentry/components/searchQueryBuilder/types';
@@ -206,21 +207,15 @@ export function useSortedFilterKeyItems({
         !replaceRawSearchKeys?.length;
 
       const rawSearchReplacements: KeySectionItem = {
-        key: 'raw-search',
-        value: 'raw-search',
+        key: 'key-items',
+        value: 'key-items',
         label: '',
         options:
           replaceRawSearchKeys?.map(key => {
-            try {
-              return createFilterValueItem(
-                key,
-                inputValue?.includes(' ') ? `"${inputValue}"` : inputValue
-              );
-            } catch (error) {
-              console.log('why no work');
-              console.error(error);
-              return '';
-            }
+            return createRawSearchFilterValueItem(
+              key,
+              inputValue?.includes(' ') ? `"${inputValue}"` : inputValue
+            );
           }) ?? [],
         type: 'section',
       };

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -17,6 +17,7 @@ import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {FieldKey} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type FilterKeySearchItem = {
   description: string;
@@ -135,6 +136,9 @@ export function useSortedFilterKeyItems({
     disallowFreeText,
     replaceRawSearchKeys,
   } = useSearchQueryBuilder();
+  const hasRawSearchReplacement = useOrganization().features.includes(
+    'search-query-builder-raw-search-replacement'
+  );
 
   const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);
 
@@ -204,7 +208,7 @@ export function useSortedFilterKeyItems({
         inputValue &&
         !isQuoted(inputValue) &&
         (!keyItems.length || inputValue.trim().includes(' ')) &&
-        !replaceRawSearchKeys?.length;
+        (!replaceRawSearchKeys?.length || !hasRawSearchReplacement);
 
       const rawSearchReplacements: KeySectionItem = {
         key: 'raw-search-filter-values',
@@ -226,7 +230,8 @@ export function useSortedFilterKeyItems({
         inputValue &&
         !isQuoted(inputValue) &&
         (!keyItems.length || inputValue.trim().includes(' ')) &&
-        !!replaceRawSearchKeys?.length;
+        !!replaceRawSearchKeys?.length &&
+        hasRawSearchReplacement;
 
       const keyItemsSection: KeySectionItem = {
         key: 'key-items',
@@ -250,15 +255,16 @@ export function useSortedFilterKeyItems({
 
     return keyItems;
   }, [
-    disallowFreeText,
-    filterKeySections,
-    filterKeys,
     filterValue,
+    search,
+    includeSuggestions,
+    filterKeySections,
     flatKeys,
     getFieldDefinition,
-    includeSuggestions,
+    filterKeys,
     inputValue,
-    search,
+    disallowFreeText,
     replaceRawSearchKeys,
+    hasRawSearchReplacement,
   ]);
 }

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -207,8 +207,8 @@ export function useSortedFilterKeyItems({
         !replaceRawSearchKeys?.length;
 
       const rawSearchReplacements: KeySectionItem = {
-        key: 'key-items',
-        value: 'key-items',
+        key: 'raw-search-filter-values',
+        value: 'raw-search-filter-values',
         label: '',
         options:
           replaceRawSearchKeys?.map(key => {

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -210,7 +210,18 @@ export function useSortedFilterKeyItems({
         value: 'raw-search',
         label: '',
         options:
-          replaceRawSearchKeys?.map(key => createFilterValueItem(key, inputValue)) ?? [],
+          replaceRawSearchKeys?.map(key => {
+            try {
+              return createFilterValueItem(
+                key,
+                inputValue?.includes(' ') ? `"${inputValue}"` : inputValue
+              );
+            } catch (error) {
+              console.log('why no work');
+              console.error(error);
+              return '';
+            }
+          }) ?? [],
         type: 'section',
       };
 

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -127,8 +127,13 @@ export function useSortedFilterKeyItems({
   includeSuggestions: boolean;
   inputValue: string;
 }): SearchKeyItem[] {
-  const {filterKeys, getFieldDefinition, filterKeySections, disallowFreeText} =
-    useSearchQueryBuilder();
+  const {
+    filterKeys,
+    getFieldDefinition,
+    filterKeySections,
+    disallowFreeText,
+    replaceRawSearchKeys,
+  } = useSearchQueryBuilder();
 
   const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);
 
@@ -197,7 +202,24 @@ export function useSortedFilterKeyItems({
         !disallowFreeText &&
         inputValue &&
         !isQuoted(inputValue) &&
-        (!keyItems.length || inputValue.trim().includes(' '));
+        (!keyItems.length || inputValue.trim().includes(' ')) &&
+        !replaceRawSearchKeys?.length;
+
+      const rawSearchReplacements: KeySectionItem = {
+        key: 'raw-search',
+        value: 'raw-search',
+        label: '',
+        options:
+          replaceRawSearchKeys?.map(key => createFilterValueItem(key, inputValue)) ?? [],
+        type: 'section',
+      };
+
+      const shouldReplaceRawSearch =
+        !disallowFreeText &&
+        inputValue &&
+        !isQuoted(inputValue) &&
+        (!keyItems.length || inputValue.trim().includes(' ')) &&
+        !!replaceRawSearchKeys?.length;
 
       const keyItemsSection: KeySectionItem = {
         key: 'key-items',
@@ -212,6 +234,7 @@ export function useSortedFilterKeyItems({
 
       return [
         ...(shouldShowAtTop && suggestedFiltersSection ? [suggestedFiltersSection] : []),
+        ...(shouldReplaceRawSearch ? [rawSearchReplacements] : []),
         ...(shouldIncludeRawSearch ? [rawSearchSection] : []),
         keyItemsSection,
         ...(!shouldShowAtTop && suggestedFiltersSection ? [suggestedFiltersSection] : []),
@@ -229,5 +252,6 @@ export function useSortedFilterKeyItems({
     includeSuggestions,
     inputValue,
     search,
+    replaceRawSearchKeys,
   ]);
 }

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -17,6 +17,7 @@ type TraceItemSearchQueryBuilderProps = {
   itemType: TraceItemDataset;
   numberAttributes: TagCollection;
   stringAttributes: TagCollection;
+  replaceRawSearchKeys?: string[];
 } & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
 const getFunctionTags = (supportedAggregates?: AggregationKey[]) => {
@@ -61,6 +62,7 @@ export function useSearchQueryBuilderProps({
   portalTarget,
   projects,
   supportedAggregates = [],
+  replaceRawSearchKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const organization = useOrganization();
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
@@ -111,6 +113,7 @@ export function useSearchQueryBuilderProps({
     recentSearches: itemTypeToRecentSearches(itemType),
     showUnsubmittedIndicator: true,
     portalTarget,
+    replaceRawSearchKeys,
   };
 }
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -204,6 +204,7 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
         mode === Mode.SAMPLES ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
       numberTags,
       stringTags,
+      replaceRawSearchKeys: ['span.description'],
     }),
     [fields, mode, query, setExplorePageParams, numberTags, stringTags, oldSearch]
   );


### PR DESCRIPTION
This PR updates the search query builder that enables overriding the default raw search ability, with being able to provide a list of filter keys and then when the user searches plain text it will provide options of the provided key(s), with the text input as the corresponding value.

Closes EXP-20


![Screenshot 2025-06-03 at 11 09 04](https://github.com/user-attachments/assets/eafb2b17-0fc3-4d10-a4c6-e696fb67fea6)
(note, the changes to the `spansTab` search builder only enables `span.description`)