### PR TITLE
fix(replay): Fix replay breadcrumb colors to be self-consistent between the Timeline and Breadcrumb tab

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,5 +1,6 @@
 import type {CSSProperties, ReactNode} from 'react';
 import {isValidElement, useCallback, useEffect, useRef} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
@@ -81,7 +82,9 @@ function BreadcrumbItem({
   updateDimensions,
   allowShowSnippet,
 }: Props) {
-  const {color, description, title, icon} = getFrameDetails(frame);
+  const theme = useTheme();
+  const {colorGraphicsToken, description, title, icon} = getFrameDetails(frame);
+  const colorHex = theme.tokens.graphics[colorGraphicsToken];
   const {replay} = useReplayContext();
   const organization = useOrganization();
   const {data: extraction, isPending} = useExtractDomNodes({
@@ -214,7 +217,7 @@ function BreadcrumbItem({
       ref={ref}
       icon={icon}
       title={title}
-      colorConfig={{title: color, icon: color, iconBorder: color}}
+      colorConfig={{title: colorHex, icon: colorHex, iconBorder: colorHex}}
       timestamp={
         <ReplayTimestamp>
           <TimestampButton

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -61,6 +61,12 @@ const EventColumn = styled(Timeline.Col)`
   }
 `;
 
+type GraphicsKey = keyof Theme['tokens']['graphics'];
+type GraphicsKeyTrio =
+  | [GraphicsKey]
+  | [GraphicsKey, GraphicsKey]
+  | [GraphicsKey, GraphicsKey, GraphicsKey];
+
 function Event({
   frames,
   markerWidth,
@@ -107,26 +113,25 @@ function Event({
   const firstFrame = frames.at(0);
 
   // We want to show the full variety of colors available.
-  const uniqueColors = uniq(frames.map(frame => getFrameDetails(frame).color));
+  const uniqueColorTokens = uniq(
+    frames.map(frame => getFrameDetails(frame).colorGraphicsToken)
+  );
 
   // We just need to stack up to 3 times
-  const frameCount = Math.min(uniqueColors.length, 3);
+  const frameCount = Math.min(uniqueColorTokens.length, 3);
 
   // Sort the frame colors by color priority
-  // Priority order: red300, yellow300, green300, purple300, gray300
-  const sortedUniqueColors = uniqueColors.sort(function (x, y) {
-    const colorOrder: string[] = [
-      theme.tokens.graphics.danger,
-      theme.tokens.graphics.warning,
-      theme.tokens.graphics.success,
-      theme.tokens.graphics.accent,
-      theme.tokens.graphics.muted,
-    ];
-    function getColorPos(c: string) {
-      return colorOrder.indexOf(c);
-    }
-    return getColorPos(x) - getColorPos(y);
-  });
+  const colorOrder = [
+    'danger',
+    'warning',
+    'success',
+    'accent',
+    'muted',
+  ] as readonly GraphicsKey[];
+  const getColorPos = (c: GraphicsKey) => colorOrder.indexOf(c);
+  const sortedUniqueColorTokens = uniqueColorTokens
+    .toSorted((x, y) => getColorPos(x) - getColorPos(y))
+    .slice(0, 3) as GraphicsKeyTrio;
 
   return (
     <IconPosition style={{marginLeft: `${markerWidth / 2}px`}}>
@@ -137,7 +142,7 @@ function Event({
         isHoverable
       >
         <IconNode
-          colors={sortedUniqueColors}
+          colorTokens={sortedUniqueColorTokens}
           frameCount={frameCount}
           onClick={() => {
             if (firstFrame) {
@@ -156,17 +161,17 @@ const IconPosition = styled('div')`
 `;
 
 const getBackgroundGradient = ({
-  colors,
+  colorTokens,
   frameCount,
   theme,
 }: {
-  colors: Array<keyof Theme['tokens']['graphics']>;
+  colorTokens: GraphicsKeyTrio;
   frameCount: number;
   theme: Theme;
 }) => {
-  const c0 = theme.tokens.graphics[colors[0]!] ?? colors[0]!;
-  const c1 = theme.tokens.graphics[colors[1]!] ?? colors[1]! ?? c0;
-  const c2 = theme.tokens.graphics[colors[2]!] ?? colors[2]! ?? c1;
+  const c0 = theme.tokens.graphics[colorTokens[0]];
+  const c1 = colorTokens[1] ? theme.tokens.graphics[colorTokens[1]] : c0;
+  const c2 = colorTokens[2] ? theme.tokens.graphics[colorTokens[2]] : c1;
 
   if (frameCount === 1) {
     return `background: ${c0};`;
@@ -192,7 +197,7 @@ const getBackgroundGradient = ({
 };
 
 const IconNode = styled('button')<{
-  colors: Array<keyof Theme['tokens']['graphics']>;
+  colorTokens: GraphicsKeyTrio;
   frameCount: number;
 }>`
   padding: 0;

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -33,6 +33,8 @@ import {explodeSlug} from 'sentry/utils';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {
   BreadcrumbFrame,
+  ClickFrame,
+  ConsoleFrame,
   DeviceBatteryFrame,
   DeviceConnectivityFrame,
   DeviceOrientationFrame,
@@ -41,8 +43,11 @@ import type {
   MultiClickFrame,
   MutationFrame,
   NavFrame,
+  NavigationFrame,
   RawBreadcrumbFrame,
   ReplayFrame,
+  RequestFrame,
+  ResourceFrame,
   ScrollFrame,
   SlowClickFrame,
   SwipeFrame,
@@ -61,7 +66,7 @@ import stripURLOrigin from 'sentry/utils/url/stripURLOrigin';
 import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings';
 
 interface Details {
-  color: keyof Theme['tokens']['graphics'];
+  colorGraphicsToken: keyof Theme['tokens']['graphics'];
   description: ReactNode;
   icon: ReactNode;
   tabKey: TabKey;
@@ -77,28 +82,28 @@ const DEVICE_CONNECTIVITY_MESSAGE: Record<string, string> = {
 
 const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
   'replay.init': (frame: BreadcrumbFrame) => ({
-    color: 'muted',
+    colorGraphicsToken: 'muted',
     description: stripURLOrigin(frame.message ?? ''),
     tabKey: TabKey.CONSOLE,
     title: 'Replay Start',
     icon: <IconInfo size="xs" />,
   }),
   navigation: (frame: NavFrame) => ({
-    color: 'success',
+    colorGraphicsToken: 'success',
     description: stripURLOrigin(frame.data.to),
     tabKey: TabKey.NETWORK,
     title: 'Navigation',
     icon: <IconLocation size="xs" />,
   }),
   feedback: (frame: FeedbackFrame) => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: frame.data.projectSlug,
     tabKey: TabKey.BREADCRUMBS,
     title: defaultTitle(frame),
     icon: <IconMegaphone size="xs" />,
   }),
   issue: (frame: ErrorFrame) => ({
-    color: 'danger',
+    colorGraphicsToken: 'danger',
     description: frame.message,
     tabKey: TabKey.ERRORS,
     title: <CrumbErrorTitle frame={frame} />,
@@ -108,7 +113,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     const node = frame.data.node;
     if (isDeadClick(frame)) {
       return {
-        color: isDeadRageClick(frame) ? 'danger' : 'warning',
+        colorGraphicsToken: isDeadRageClick(frame) ? 'danger' : 'warning',
         description: tct(
           'Click on [selector] did not cause a visible effect within [timeout] ms',
           {
@@ -122,7 +127,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
       };
     }
     return {
-      color: 'warning',
+      colorGraphicsToken: 'warning',
       description: tct(
         'Click on [selector] took [duration] ms to have a visible effect',
         {
@@ -138,7 +143,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
   'ui.multiClick': (frame: MultiClickFrame) => {
     if (isRageClick(frame)) {
       return {
-        color: 'danger',
+        colorGraphicsToken: 'danger',
         description: tct('Rage clicked [clickCount] times on [selector]', {
           clickCount: frame.data.clickCount,
           selector: stringifyNodeAttributes(frame.data.node),
@@ -150,7 +155,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     }
 
     return {
-      color: 'warning',
+      colorGraphicsToken: 'warning',
       description: tct('[clickCount] clicks on [selector]', {
         clickCount: frame.data.clickCount,
         selector: stringifyNodeAttributes(frame.data.node),
@@ -161,7 +166,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     };
   },
   'replay.mutations': (frame: MutationFrame) => ({
-    color: 'warning',
+    colorGraphicsToken: 'warning',
     description: frame.data.limit
       ? tct(
           'Significant mutations detected [count]. Replay is now stopped to prevent poor performance for your customer. [link]',
@@ -190,7 +195,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     icon: <IconWarning size="xs" />,
   }),
   'replay.hydrate-error': () => ({
-    color: 'danger',
+    colorGraphicsToken: 'danger',
     description: t(
       'There was a conflict between the server rendered html and the first client render.'
     ),
@@ -198,106 +203,106 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     title: 'Hydration Error',
     icon: <IconFire size="xs" />,
   }),
-  'ui.click': frame => ({
-    color: 'accent',
+  'ui.click': (frame: ClickFrame) => ({
+    colorGraphicsToken: 'accent',
     description: <SelectorList frame={frame} />,
     tabKey: TabKey.BREADCRUMBS,
     title: 'User Click',
     icon: <IconCursorArrow size="xs" />,
   }),
   'ui.swipe': (frame: SwipeFrame) => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: frame.data,
     tabKey: TabKey.BREADCRUMBS,
     title: 'User Swipe',
     icon: <IconTap size="xs" />,
   }),
   'ui.scroll': (frame: ScrollFrame) => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: frame.data,
     tabKey: TabKey.BREADCRUMBS,
     title: 'User Scroll',
     icon: <IconTap size="xs" />,
   }),
   'ui.tap': (frame: TapFrame) => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: frame.message,
     tabKey: TabKey.BREADCRUMBS,
     title: 'User Tap',
     icon: <IconTap size="xs" />,
   }),
   'ui.input': () => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: t('User Action'),
     tabKey: TabKey.BREADCRUMBS,
     title: 'User Input',
     icon: <IconInput size="xs" />,
   }),
   'ui.keyDown': () => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: t('User Action'),
     tabKey: TabKey.BREADCRUMBS,
     title: 'User KeyDown',
     icon: <IconKeyDown size="xs" />,
   }),
   'ui.blur': () => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: t('The user is preoccupied with another browser, tab, or window'),
     tabKey: TabKey.BREADCRUMBS,
     title: 'Window Blur',
     icon: <IconFocus isFocused={false} size="xs" />,
   }),
   'ui.focus': () => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: t('The user is currently focused on your application,'),
     tabKey: TabKey.BREADCRUMBS,
     title: 'Window Focus',
     icon: <IconFocus size="xs" />,
   }),
   'app.foreground': () => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: t('The user is currently focused on your application'),
     tabKey: TabKey.BREADCRUMBS,
     title: 'App in Foreground',
     icon: <IconFocus size="xs" />,
   }),
   'app.background': () => ({
-    color: 'accent',
+    colorGraphicsToken: 'accent',
     description: t('The user is preoccupied with another app or activity'),
     tabKey: TabKey.BREADCRUMBS,
     title: 'App in Background',
     icon: <IconFocus isFocused={false} size="xs" />,
   }),
-  console: frame => ({
-    color: 'muted',
+  console: (frame: ConsoleFrame) => ({
+    colorGraphicsToken: 'muted',
     description: frame.message ?? '',
     tabKey: TabKey.CONSOLE,
     title: 'Console',
     icon: <IconFix size="xs" />,
   }),
-  'navigation.navigate': frame => ({
-    color: 'success',
+  'navigation.navigate': (frame: NavigationFrame) => ({
+    colorGraphicsToken: 'success',
     description: stripURLOrigin(frame.description),
     tabKey: TabKey.NETWORK,
     title: 'Page Load',
     icon: <IconLocation size="xs" />,
   }),
-  'navigation.reload': frame => ({
-    color: 'success',
+  'navigation.reload': (frame: NavigationFrame) => ({
+    colorGraphicsToken: 'success',
     description: stripURLOrigin(frame.description),
     tabKey: TabKey.NETWORK,
     title: 'Reload',
     icon: <IconLocation size="xs" />,
   }),
-  'navigation.back_forward': frame => ({
-    color: 'success',
+  'navigation.back_forward': (frame: NavigationFrame) => ({
+    colorGraphicsToken: 'success',
     description: stripURLOrigin(frame.description),
     tabKey: TabKey.NETWORK,
     title: 'Navigate Back/Forward',
     icon: <IconLocation size="xs" />,
   }),
-  'navigation.push': frame => ({
-    color: 'success',
+  'navigation.push': (frame: NavigationFrame) => ({
+    colorGraphicsToken: 'success',
     description: stripURLOrigin(frame.description),
     tabKey: TabKey.NETWORK,
     title: 'Navigation',
@@ -307,7 +312,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     switch (frame.data.rating) {
       case 'good':
         return {
-          color: 'success',
+          colorGraphicsToken: 'success',
           description: tct('[value][unit] (Good)', {
             value: frame.data.value.toFixed(2),
             unit: isCLSFrame(frame) ? '' : 'ms',
@@ -318,7 +323,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
         };
       case 'needs-improvement':
         return {
-          color: 'warning',
+          colorGraphicsToken: 'warning',
           description: tct('[value][unit] (Meh)', {
             value: frame.data.value.toFixed(2),
             unit: isCLSFrame(frame) ? '' : 'ms',
@@ -329,7 +334,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
         };
       default:
         return {
-          color: 'danger',
+          colorGraphicsToken: 'danger',
           description: tct('[value][unit] (Poor)', {
             value: frame.data.value.toFixed(2),
             unit: isCLSFrame(frame) ? '' : 'ms',
@@ -341,91 +346,91 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     }
   },
   memory: () => ({
-    color: 'muted',
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.MEMORY,
     title: 'Memory',
     icon: <IconInfo size="xs" />,
   }),
   paint: () => ({
-    color: 'muted',
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: 'Paint',
     icon: <IconInfo size="xs" />,
   }),
-  'resource.css': frame => ({
-    color: 'muted',
+  'resource.css': (frame: ResourceFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.fetch': frame => ({
-    color: 'muted',
+  'resource.fetch': (frame: RequestFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.iframe': frame => ({
-    color: 'muted',
+  'resource.iframe': (frame: ResourceFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.img': frame => ({
-    color: 'muted',
+  'resource.img': (frame: ResourceFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.link': frame => ({
-    color: 'muted',
+  'resource.link': (frame: ResourceFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.other': frame => ({
-    color: 'muted',
+  'resource.other': (frame: ResourceFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.script': frame => ({
-    color: 'muted',
+  'resource.script': (frame: ResourceFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.xhr': frame => ({
-    color: 'muted',
+  'resource.xhr': (frame: RequestFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
-  'resource.http': frame => ({
-    color: 'muted',
+  'resource.http': (frame: RequestFrame) => ({
+    colorGraphicsToken: 'muted',
     description: undefined,
     tabKey: TabKey.NETWORK,
     title: frame.description,
     icon: <IconSort size="xs" rotated />,
   }),
   'device.connectivity': (frame: DeviceConnectivityFrame) => ({
-    color: 'promotion',
+    colorGraphicsToken: 'promotion',
     description: DEVICE_CONNECTIVITY_MESSAGE[frame.data.state],
     tabKey: TabKey.BREADCRUMBS,
     title: 'Device Connectivity',
     icon: <IconWifi size="xs" />,
   }),
   'device.battery': (frame: DeviceBatteryFrame) => ({
-    color: 'promotion',
+    colorGraphicsToken: 'promotion',
     description: tct('Device was at [percent]% battery and [charging]', {
       percent: frame.data.level,
       charging: frame.data.charging ? 'charging' : 'not charging',
@@ -435,7 +440,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
     icon: <IconLightning size="xs" />,
   }),
   'device.orientation': (frame: DeviceOrientationFrame) => ({
-    color: 'promotion',
+    colorGraphicsToken: 'promotion',
     description: tct('Device orientation was changed to [orientation]', {
       orientation: frame.data.position,
     }),
@@ -446,7 +451,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame: any) => Details> = {
 };
 
 const MAPPER_DEFAULT = (frame: any): Details => ({
-  color: 'muted',
+  colorGraphicsToken: 'muted',
   description: frame.message ?? frame.data ?? '',
   tabKey: TabKey.BREADCRUMBS,
   title: toTitleCase(defaultTitle(frame)),


### PR DESCRIPTION
Before the breadcrumb colors and timeline colors were different in some cases, because passing a color `token` is not the same as passing an actual hex code `#000000`. `<ReplayTimelineEvents>` seemed happy with graphics tokens, but `<StyledTimelineItem>` didn't know about those yet.

Now `getFrameDetails()` returns `colorGraphicsToken` (a rename, to make values more obvious) because it's the source of truth for colors of replay breadcrumbs. We flip that token into a hex code inside breadcrumbItem.tsx to make things work.

Notice **before** that User Clicks were not properly colored. Now they are consistent in the timeline and breadcrumb list.
| | Old UI | UI 2 |
| --- | --- | --- |
| Before | ![SCR-20250603-kqwz](https://github.com/user-attachments/assets/13be8802-378c-4fdb-ad38-417e1343533f) | ![SCR-20250603-kqys](https://github.com/user-attachments/assets/a29a06cd-f606-4d86-a2d1-196653995b47)
| After | ![SCR-20250603-koyr](https://github.com/user-attachments/assets/7458a177-985a-4d0b-aa77-ce20387a0153) | ![SCR-20250603-kovm](https://github.com/user-attachments/assets/423da9c0-0c25-472b-978f-3d8aa0ff1be5)
