### PR TITLE
fix(autofix): Fix supported git provider check

### DIFF
--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -130,7 +130,10 @@ export const getCodeChangesIsLoading = (autofixData: AutofixData) => {
 };
 
 export const isSupportedAutofixProvider = (provider: string) => {
-  return provider.toLowerCase().includes('github');
+  return (
+    provider.toLowerCase() === 'github' ||
+    provider.toLowerCase() === 'integrations:github'
+  );
 };
 
 export interface AutofixProgressDetails {


### PR DESCRIPTION
Tighten supported provider check to only support github, not github enterprise.