### PR TITLE
ref(api-tokens): Improve components / flows

### DIFF
--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useCallback, useState} from 'react';
 
 import ApiForm from 'sentry/components/forms/apiForm';
 import TextareaField from 'sentry/components/forms/fields/textareaField';
@@ -11,10 +11,9 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Permissions} from 'sentry/types/integrations';
 import type {NewInternalAppApiToken} from 'sentry/types/user';
-import {browserHistory} from 'sentry/utils/browserHistory';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
@@ -31,7 +30,8 @@ export default function ApiNewToken() {
     Organization: 'no-access',
     Alerts: 'no-access',
   });
-  const [newToken, setNewToken] = useState<NewInternalAppApiToken | null>(null);
+  const navigate = useNavigate();
+  const [hasNewToken, setHasnewToken] = useState(false);
   const [preview, setPreview] = useState<string>('');
 
   const getPreview = () => {
@@ -46,13 +46,10 @@ export default function ApiNewToken() {
     return previewString;
   };
 
-  const onCancel = () => {
-    browserHistory.push(normalizeUrl(API_INDEX_ROUTE));
-  };
-
-  const handleGoBack = () => {
-    browserHistory.push(normalizeUrl(API_INDEX_ROUTE));
-  };
+  const handleGoBack = useCallback(
+    () => navigate(normalizeUrl(API_INDEX_ROUTE)),
+    [navigate]
+  );
 
   return (
     <SentryDocumentTitle title={t('Create User Auth Token')}>
@@ -71,66 +68,58 @@ export default function ApiNewToken() {
             }
           )}
         </TextBlock>
-        {newToken === null ? (
-          <div>
-            <ApiForm
-              apiMethod="POST"
-              apiEndpoint="/api-tokens/"
-              initialData={{scopes: [], name: ''}}
-              onSubmitSuccess={setNewToken}
-              onCancel={onCancel}
-              footerStyle={{
-                marginTop: 0,
-                paddingRight: 20,
-              }}
-              submitDisabled={Object.values(permissions).every(
-                value => value === 'no-access'
-              )}
-              submitLabel={t('Create Token')}
-            >
-              <Panel>
-                <PanelHeader>{t('General')}</PanelHeader>
-                <PanelBody>
-                  <TextField
-                    name="name"
-                    label={t('Name')}
-                    help={t('A name to help you identify this token.')}
-                  />
-                </PanelBody>
-              </Panel>
-              <Panel>
-                <PanelHeader>{t('Permissions')}</PanelHeader>
-                <PanelBody>
-                  <PermissionSelection
-                    appPublished={false}
-                    permissions={permissions}
-                    onChange={p => {
-                      setPermissions(p);
-                      setPreview(getPreview());
-                    }}
-                  />
-                </PanelBody>
-                <TextareaField
-                  name="permissions-preview"
-                  label={t('Permissions Preview')}
-                  help={t('Your token will have the following scopes.')}
-                  rows={3}
-                  autosize
-                  placeholder={preview}
-                  disabled
-                />
-              </Panel>
-            </ApiForm>
-          </div>
-        ) : (
-          <NewTokenHandler
-            token={
-              getDynamicText({value: newToken.token, fixed: 'CI_AUTH_TOKEN'}) ||
-              'CI_AUTH_TOKEN'
-            }
-            handleGoBack={handleGoBack}
-          />
-        )}
+        <ApiForm
+          apiMethod="POST"
+          apiEndpoint="/api-tokens/"
+          initialData={{scopes: [], name: ''}}
+          onSubmitSuccess={(token: NewInternalAppApiToken) => {
+            setHasnewToken(true);
+            displayNewToken(token.token, handleGoBack);
+          }}
+          onCancel={handleGoBack}
+          footerStyle={{
+            marginTop: 0,
+            paddingRight: 20,
+          }}
+          submitDisabled={
+            !!hasNewToken ||
+            Object.values(permissions).every(value => value === 'no-access')
+          }
+          submitLabel={t('Create Token')}
+        >
+          <Panel>
+            <PanelHeader>{t('General')}</PanelHeader>
+            <PanelBody>
+              <TextField
+                name="name"
+                label={t('Name')}
+                help={t('A name to help you identify this token.')}
+              />
+            </PanelBody>
+          </Panel>
+          <Panel>
+            <PanelHeader>{t('Permissions')}</PanelHeader>
+            <PanelBody>
+              <PermissionSelection
+                appPublished={false}
+                permissions={permissions}
+                onChange={p => {
+                  setPermissions(p);
+                  setPreview(getPreview());
+                }}
+              />
+            </PanelBody>
+            <TextareaField
+              name="permissions-preview"
+              label={t('Permissions Preview')}
+              help={t('Your token will have the following scopes.')}
+              rows={3}
+              autosize
+              placeholder={preview}
+              disabled
+            />
+          </Panel>
+        </ApiForm>
       </div>
     </SentryDocumentTitle>
   );

--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -10,7 +10,7 @@ import {
 import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
 
 describe('ApiTokenRow', () => {
-  it('renders link when can edit', () => {
+  it('renders', () => {
     render(
       <ApiTokenRow
         onRemove={() => {}}
@@ -18,30 +18,32 @@ describe('ApiTokenRow', () => {
         canEdit
       />
     );
-    screen.getByRole('link', {name: /token1/i});
+
+    screen.getByText(/token1/);
+    expect(screen.getByRole('button', {name: 'Edit'})).toBeInTheDocument();
   });
 
-  it('renders text when cannot edit', () => {
+  it('no button when not editable', () => {
     render(
       <ApiTokenRow
         onRemove={() => {}}
         token={ApiTokenFixture({id: '1', name: 'token1'})}
       />
     );
-    screen.getByText(/token1/);
+    expect(screen.queryByRole('button', {name: 'Edit'})).not.toBeInTheDocument();
   });
 
-  it('calls onRemove callback when trash can is clicked', async () => {
+  it('calls onRemove callback when remove is clicked', async () => {
     const cb = jest.fn();
     render(<ApiTokenRow onRemove={cb} token={ApiTokenFixture()} canEdit />);
     renderGlobalModal();
 
-    await userEvent.click(screen.getByLabelText('Remove'));
-    await userEvent.click(screen.getByLabelText('Confirm'));
+    await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
     expect(cb).toHaveBeenCalled();
   });
 
-  it('uses NewTokenHandler when lastTokenCharacters field is found', () => {
+  it('displays token preview lastTokenCharacters field is found', () => {
     const token = ApiTokenFixture();
     token.tokenLastCharacters = 'a1b2c3d4';
 

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -1,13 +1,13 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Confirm from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {DateTime} from 'sentry/components/dateTime';
-import Link from 'sentry/components/links/link';
-import PanelItem from 'sentry/components/panels/panelItem';
 import {IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {InternalAppApiToken} from 'sentry/types/user';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {tokenPreview} from 'sentry/views/settings/organizationAuthTokens';
@@ -28,137 +28,62 @@ function ApiTokenRow({
   onRemoveConfirmMessage,
 }: Props) {
   return (
-    <StyledPanelItem>
-      <Controls>
-        {canEdit ? (
-          <LinkWrapper name={token.name}>
-            <Link to={`/settings/account/api/auth-tokens/${token.id}/`}>
-              {token.name ? token.name : 'Token created on '}
-              <DateTime
-                date={getDynamicText({
-                  value: token.dateCreated,
-                  fixed: new Date(1508208080000), // National Pasta Day
-                })}
-                hidden={!!token.name}
-              />
-            </Link>
-          </LinkWrapper>
-        ) : (
-          <p>{token.name ? token.name : ''}</p>
+    <Fragment>
+      <div>
+        {token.name}
+        <TokenPreview aria-label={t('Token preview')}>
+          {tokenPreview(
+            getDynamicText({
+              value: token.tokenLastCharacters,
+              fixed: 'ABCD',
+            }),
+            tokenPrefix
+          )}
+        </TokenPreview>
+      </div>
+      <div>
+        <DateTime date={token.dateCreated} />
+      </div>
+      <div>
+        <ScopeList>{token.scopes.join(', ')}</ScopeList>
+      </div>
+      <Actions gap={1}>
+        {canEdit && (
+          <LinkButton size="sm" to={`/settings/account/api/auth-tokens/${token.id}/`}>
+            {t('Edit')}
+          </LinkButton>
         )}
-        <ButtonWrapper>
-          <Confirm
-            onConfirm={() => onRemove(token)}
-            message={
-              onRemoveConfirmMessage ||
-              t(
-                'Are you sure you want to revoke %s token? It will not be usable anymore, and this cannot be undone.',
-                tokenPreview(token.tokenLastCharacters, tokenPrefix)
-              )
-            }
-          >
-            <Button
-              data-test-id="token-delete"
-              icon={<IconSubtract isCircled size="xs" />}
-            >
-              {t('Remove')}
-            </Button>
-          </Confirm>
-        </ButtonWrapper>
-      </Controls>
-
-      <Details>
-        <TokenWrapper>
-          <Heading>{t('Token')}</Heading>
-          <TokenPreview aria-label={t('Token preview')}>
-            {tokenPreview(
-              getDynamicText({
-                value: token.tokenLastCharacters,
-                fixed: 'ABCD',
-              }),
-              tokenPrefix
-            )}
-          </TokenPreview>
-        </TokenWrapper>
-        <ScopesWrapper>
-          <Heading>{t('Scopes')}</Heading>
-          <ScopeList>{token.scopes.join(', ')}</ScopeList>
-        </ScopesWrapper>
-        <div>
-          <Heading>{t('Created')}</Heading>
-          <Time>
-            <DateTime
-              date={getDynamicText({
-                value: token.dateCreated,
-                fixed: new Date(1508208080000), // National Pasta Day
-              })}
-            />
-          </Time>
-        </div>
-      </Details>
-    </StyledPanelItem>
+        <Confirm
+          onConfirm={() => onRemove(token)}
+          message={
+            onRemoveConfirmMessage ||
+            t(
+              'Are you sure you want to revoke %s token? It will not be usable anymore, and this cannot be undone.',
+              tokenPreview(token.tokenLastCharacters, tokenPrefix)
+            )
+          }
+        >
+          <Button size="sm" icon={<IconSubtract isCircled />}>
+            {t('Remove')}
+          </Button>
+        </Confirm>
+      </Actions>
+    </Fragment>
   );
 }
 
-const StyledPanelItem = styled(PanelItem)`
-  flex-direction: column;
-  padding: ${space(2)};
-`;
-
-const Controls = styled('div')`
-  display: flex;
-  align-items: center;
-  margin-bottom: ${space(1)};
-`;
-
-const Details = styled('div')`
-  display: flex;
-  margin-top: ${space(1)};
-`;
-
-const TokenWrapper = styled('div')`
-  flex: 1;
-  margin-right: ${space(1)};
-`;
-
-const ScopesWrapper = styled('div')`
-  flex: 2;
-  margin-right: ${space(4)};
-`;
-
 const ScopeList = styled('div')`
+  font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
-  line-height: 1.4;
+  max-width: 400px;
 `;
 
-const Time = styled('time')`
-  font-size: ${p => p.theme.fontSizeRelativeSmall};
-  line-height: 1.4;
-`;
-
-const Heading = styled('div')`
-  font-size: ${p => p.theme.fontSizeMedium};
-  text-transform: uppercase;
-  color: ${p => p.theme.subText};
-  margin-bottom: ${space(1)};
+const Actions = styled(ButtonBar)`
+  justify-content: flex-end;
 `;
 
 const TokenPreview = styled('div')`
   color: ${p => p.theme.subText};
-`;
-
-const LinkWrapper = styled('div')<{name: string}>`
-  font-style: ${p => (p.name ? 'normal' : 'italic')};
-`;
-
-const ButtonWrapper = styled('div')`
-  margin-left: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  justify-content: flex-end;
-  font-size: ${p => p.theme.fontSizeSmall};
-  gap: ${space(1)};
 `;
 
 export default ApiTokenRow;

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -4,13 +4,10 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import EmptyMessage from 'sentry/components/emptyMessage';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
+import {PanelTable} from 'sentry/components/panels/panelTable';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {InternalAppApiToken} from 'sentry/types/user';
@@ -125,21 +122,15 @@ function ApiTokens() {
           }
         )}
       </TextBlock>
-      <Panel>
-        <PanelHeader>{t('Auth Token')}</PanelHeader>
-
-        <PanelBody>
-          {isEmpty && (
-            <EmptyMessage>
-              {t("You haven't created any authentication tokens yet.")}
-            </EmptyMessage>
-          )}
-
-          {tokenList?.map(token => (
-            <ApiTokenRow key={token.id} token={token} onRemove={deleteToken} canEdit />
-          ))}
-        </PanelBody>
-      </Panel>
+      <PanelTable
+        headers={[t('Token'), t('Created On'), t('Scopes'), '']}
+        isEmpty={isEmpty}
+        emptyMessage={t("You haven't created any authentication tokens yet.")}
+      >
+        {tokenList?.map(token => (
+          <ApiTokenRow key={token.id} token={token} onRemove={deleteToken} canEdit />
+        ))}
+      </PanelTable>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/settings/components/newTokenHandler.spec.tsx
+++ b/static/app/views/settings/components/newTokenHandler.spec.tsx
@@ -1,12 +1,20 @@
 import {ApiTokenFixture} from 'sentry-fixture/apiToken';
 
-import {render} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
+import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 
-describe('NewTokenHandler', () => {
-  it('renders', () => {
-    const callback = () => {};
-    render(<NewTokenHandler token={ApiTokenFixture().token} handleGoBack={callback} />);
+describe('displayNewToken', function () {
+  it('renders', async function () {
+    renderGlobalModal();
+
+    const callback = jest.fn();
+    const token = ApiTokenFixture();
+
+    act(() => displayNewToken(token.token, callback));
+
+    expect(screen.getByLabelText('Generated token')).toHaveValue(token.token);
+    await userEvent.click(screen.getByRole('button', {name: "I've saved it"}));
+    expect(callback).toHaveBeenCalled();
   });
 });

--- a/static/app/views/settings/components/newTokenHandler.tsx
+++ b/static/app/views/settings/components/newTokenHandler.tsx
@@ -1,68 +1,30 @@
-import type {MouseEventHandler} from 'react';
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
+import {openModal} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
-import FieldGroup from 'sentry/components/forms/fieldGroup';
-import PanelItem from 'sentry/components/panels/panelItem';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
-function NewTokenHandler({
-  token,
-  handleGoBack,
-}: {
-  handleGoBack: MouseEventHandler;
-  token: string;
-}) {
-  return (
-    <div>
-      <Alert.Container>
-        <Alert type="warning" showIcon system>
-          {t("Please copy this token to a safe place — it won't be shown again!")}
-        </Alert>
-      </Alert.Container>
-
-      <PanelItem>
-        <InputWrapper>
-          <FieldGroupNoPadding
-            label={t('Token')}
-            help={t('You can only view this token when it was created.')}
-            inline
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('Generated token')}>{token}</TextCopyInput>
-          </FieldGroupNoPadding>
-        </InputWrapper>
-      </PanelItem>
-
-      <PanelItem>
-        <ButtonWrapper>
-          <Button onClick={handleGoBack} priority="primary">
-            {t('Done')}
+export function displayNewToken(token: string, onClose: () => void) {
+  openModal(
+    ({Body, Footer, closeModal}) => (
+      <Fragment>
+        <Body>
+          <Alert.Container>
+            <Alert type="warning">
+              {t("Please copy this token to a safe place — it won't be shown again!")}
+            </Alert>
+          </Alert.Container>
+          <TextCopyInput aria-label={t('Generated token')}>{token}</TextCopyInput>
+        </Body>
+        <Footer>
+          <Button onClick={closeModal} priority="primary">
+            {t("I've saved it")}
           </Button>
-        </ButtonWrapper>
-      </PanelItem>
-    </div>
+        </Footer>
+      </Fragment>
+    ),
+    {closeEvents: 'none', onClose}
   );
 }
-
-const InputWrapper = styled('div')`
-  flex: 1;
-`;
-
-const FieldGroupNoPadding = styled(FieldGroup)`
-  padding: 0;
-`;
-
-const ButtonWrapper = styled('div')`
-  margin-left: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-size: ${p => p.theme.fontSizeSmall};
-  gap: ${space(1)};
-`;
-
-export default NewTokenHandler;

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.spec.tsx
@@ -1,4 +1,9 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {OrgAuthToken} from 'sentry/types/user';
@@ -9,6 +14,7 @@ describe('OrganizationAuthTokensNewAuthToken', function () {
 
   it('can create token', async function () {
     render(<OrganizationAuthTokensNewAuthToken />);
+    renderGlobalModal();
 
     const generatedToken: OrgAuthToken & {token: string} = {
       id: '1',
@@ -30,8 +36,7 @@ describe('OrganizationAuthTokensNewAuthToken', function () {
     await userEvent.type(screen.getByLabelText('Name'), 'My Token');
     await userEvent.click(screen.getByRole('button', {name: 'Create Auth Token'}));
 
-    expect(screen.getByLabelText('Generated token')).toHaveValue('sntrys_XXXXXXX');
-    expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+    expect(await screen.findByLabelText('Generated token')).toHaveValue('sntrys_XXXXXXX');
 
     expect(mock).toHaveBeenCalledWith(
       ENDPOINT,

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -17,14 +17,13 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {OrgAuthToken} from 'sentry/types/user';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
+import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {makeFetchOrgAuthTokensForOrgQueryKey} from 'sentry/views/settings/organizationAuthTokens';
@@ -132,7 +131,6 @@ function AuthTokenCreateForm({
 export default function OrganizationAuthTokensNewAuthToken() {
   const organization = useOrganization();
   const navigate = useNavigate();
-  const [newToken, setNewToken] = useState<OrgAuthTokenWithToken | null>(null);
 
   const handleGoBack = useCallback(
     () => navigate(`/settings/${organization.slug}/auth-tokens/`),
@@ -146,7 +144,7 @@ export default function OrganizationAuthTokensNewAuthToken() {
 
       <TextBlock>
         {t(
-          'Organization Auth Tokens can be used in many places to interact with Sentry programatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
+          'Organization Auth Tokens can be used in many places to interact with Sentry programmatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
         )}
       </TextBlock>
       <TextBlock>
@@ -161,17 +159,10 @@ export default function OrganizationAuthTokensNewAuthToken() {
         <PanelHeader>{t('Create New Auth Token')}</PanelHeader>
 
         <PanelBody>
-          {newToken ? (
-            <NewTokenHandler
-              token={getDynamicText({value: newToken.token, fixed: 'ORG_AUTH_TOKEN'})}
-              handleGoBack={handleGoBack}
-            />
-          ) : (
-            <AuthTokenCreateForm
-              organization={organization}
-              onCreatedToken={setNewToken}
-            />
-          )}
+          <AuthTokenCreateForm
+            organization={organization}
+            onCreatedToken={token => displayNewToken(token.token, handleGoBack)}
+          />
         </PanelBody>
       </Panel>
     </div>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -296,7 +296,6 @@ describe('Sentry Application Details', function () {
       renderComponent();
 
       await screen.findByRole('button', {name: 'Save Changes'});
-      expect(screen.getByText('Tokens')).toBeInTheDocument();
       expect(screen.getByLabelText('Token preview')).toHaveTextContent('oken');
     });
 
@@ -406,6 +405,8 @@ describe('Sentry Application Details', function () {
       });
 
       renderComponent();
+      renderGlobalModal();
+
       await screen.findByRole('button', {name: 'Save Changes'});
       expect(screen.queryByLabelText('Generated token')).not.toBeInTheDocument();
       expect(screen.getAllByLabelText('Token preview')).toHaveLength(1);
@@ -433,7 +434,9 @@ describe('Sentry Application Details', function () {
       await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
       // Confirm modal
       await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
-      expect(await screen.findByText('No tokens created yet.')).toBeInTheDocument();
+      expect(
+        await screen.findByText("You haven't created any authentication tokens yet.")
+      ).toBeInTheDocument();
     });
 
     it('removing webhookURL unsets isAlertable and changes webhookDisabled to true', async () => {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -29,6 +29,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
+import {PanelTable} from 'sentry/components/panels/panelTable';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {SENTRY_APP_PERMISSIONS} from 'sentry/constants';
 import {
@@ -56,7 +57,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
-import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
+import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionsObserver from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 
@@ -268,6 +269,14 @@ export default function SentryApplicationDetails(props: Props) {
     const token = await addSentryAppToken(api, app);
     const updatedNewTokens = newTokens.concat(token);
     setNewTokens(updatedNewTokens);
+    displayNewToken(token.token, () => handleFinishNewToken(token));
+  };
+
+  const handleFinishNewToken = (newToken: NewInternalAppApiToken) => {
+    const updatedNewTokens = newTokens.filter(token => token.id !== newToken.id);
+    const updatedTokens = tokens.concat(newToken as InternalAppApiToken);
+    setApiQueryData(queryClient, SENTRY_APP_API_TOKENS_QUERY_KEY, updatedTokens);
+    setNewTokens(updatedNewTokens);
   };
 
   const onRemoveToken = async (token: InternalAppApiToken) => {
@@ -277,13 +286,6 @@ export default function SentryApplicationDetails(props: Props) {
     const updatedTokens = tokens.filter(tok => tok.id !== token.id);
     await removeSentryAppToken(api, app, token.id);
     setApiQueryData(queryClient, SENTRY_APP_API_TOKENS_QUERY_KEY, updatedTokens);
-  };
-
-  const handleFinishNewToken = (newToken: NewInternalAppApiToken) => {
-    const updatedNewTokens = newTokens.filter(token => token.id !== newToken.id);
-    const updatedTokens = tokens.concat(newToken as InternalAppApiToken);
-    setApiQueryData(queryClient, SENTRY_APP_API_TOKENS_QUERY_KEY, updatedTokens);
-    setNewTokens(updatedNewTokens);
   };
 
   const renderTokens = () => {
@@ -303,16 +305,6 @@ export default function SentryApplicationDetails(props: Props) {
         onRemove={onRemoveToken}
       />
     ));
-    tokensToDisplay.push(
-      ...newTokens.map(newToken => (
-        <NewTokenHandler
-          data-test-id="new-api-token"
-          key={newToken.id}
-          token={getDynamicText({value: newToken.token, fixed: 'ORG_AUTH_TOKEN'})}
-          handleGoBack={() => handleFinishNewToken(newToken)}
-        />
-      ))
-    );
 
     return tokensToDisplay;
   };
@@ -484,10 +476,12 @@ export default function SentryApplicationDetails(props: Props) {
           </Observer>
 
           {app && app.status === 'internal' && (
-            <Panel>
-              {hasTokenAccess() ? (
-                <PanelHeader hasButtons>
-                  {t('Tokens')}
+            <PanelTable
+              headers={[
+                t('Token'),
+                t('Created On'),
+                t('Scopes'),
+                <AddTokenHeader key="token-add">
                   <Button
                     size="xs"
                     icon={<IconAdd isCircled />}
@@ -496,12 +490,13 @@ export default function SentryApplicationDetails(props: Props) {
                   >
                     {t('New Token')}
                   </Button>
-                </PanelHeader>
-              ) : (
-                <PanelHeader>{t('Tokens')}</PanelHeader>
-              )}
-              <PanelBody>{renderTokens()}</PanelBody>
-            </Panel>
+                </AddTokenHeader>,
+              ]}
+              isEmpty={tokens.length === 0}
+              emptyMessage={t("You haven't created any authentication tokens yet.")}
+            >
+              {renderTokens()}
+            </PanelTable>
           )}
 
           {app && (
@@ -598,4 +593,10 @@ const ClientSecret = styled('div')`
   justify-content: right;
   align-items: center;
   margin-right: 0;
+`;
+
+const AddTokenHeader = styled('div')`
+  margin: -${space(1)} 0;
+  display: flex;
+  justify-content: flex-end;
 `;

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -5,6 +5,7 @@ import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
+import {PanelTable} from 'sentry/components/panels/panelTable';
 import {IconNot} from 'sentry/icons';
 import type {UserIdentityConfig} from 'sentry/types/auth';
 import {UserIdentityCategory, UserIdentityStatus} from 'sentry/types/auth';
@@ -168,7 +169,7 @@ function UserOverview({
         )}
         <h6>Auth Tokens</h6>
         {tokens.length ? (
-          <ApiTokenList>
+          <PanelTable headers={['Token', 'Created On', 'Scopes', '']}>
             {tokens.map(token => (
               <ApiTokenRow
                 key={token.id}
@@ -179,7 +180,7 @@ function UserOverview({
                 }
               />
             ))}
-          </ApiTokenList>
+          </PanelTable>
         ) : (
           <p>
             <em>
@@ -198,7 +199,3 @@ const ButtonWrapper = styled('div')`
 `;
 
 export default UserOverview;
-
-const ApiTokenList = styled('div')`
-  flex-direction: column;
-`;

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -107,12 +107,13 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
         self.load_page(url)
 
-        self.browser.click('[data-test-id="token-delete"]')
+        self.browser.click('[aria-label="Remove"]')
         self.browser.click('[data-test-id="confirm-button"]')
         self.browser.wait_until(".ref-success")
 
         assert self.browser.find_element(
-            by=By.XPATH, value="//div[contains(text(), 'No tokens created yet.')]"
+            by=By.XPATH,
+            value='//p[contains(text(), "You haven\'t created any authentication tokens yet.")]',
         )
 
     def test_add_tokens_internal_app(self):


### PR DESCRIPTION
This rebuilds 3 API token tables that use the ApiTokenRow. Here are some
before and afters:

**Before**

- User tokens
  <img alt="clipboard.png" width="1427" src="https://i.imgur.com/mooKhas.png" />

- Integration
  <img alt="clipboard.png" width="1406" src="https://i.imgur.com/faaj4yY.png" />

- Create new token
  <img alt="clipboard.png" width="1420" src="https://i.imgur.com/eRGk6kl.png" />
  <img alt="clipboard.png" width="1424" src="https://i.imgur.com/QYmvibm.png" />

**After**

- User tokens
  <img alt="clipboard.png" width="1419" src="https://i.imgur.com/I0PY1Re.png" />

- Integrations
  <img alt="clipboard.png" width="1399" src="https://i.imgur.com/BevE0KE.png" />

- Create new token
  All 3 share this modal
  <img alt="clipboard.png" width="653" src="https://i.imgur.com/COg9zLQ.png" />