### PR TITLE
chore(seer): billing fixes

### DIFF
--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -15,6 +15,7 @@ interface AiConfigResult {
   isAutofixSetupLoading: boolean;
   needsGenAiAcknowledgement: boolean;
   orgNeedsGenAiAcknowledgement: boolean;
+  refetchAutofixSetup: () => void;
 }
 
 export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
@@ -23,6 +24,7 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     data: autofixSetupData,
     isPending: isAutofixSetupLoading,
     hasAutofixQuota,
+    refetch: refetchAutofixSetup,
   } = useAutofixSetup({
     groupId: group.id,
   });
@@ -62,5 +64,6 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     areAiFeaturesAllowed,
     hasGithubIntegration,
     hasAutofixQuota,
+    refetchAutofixSetup,
   };
 };

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -272,7 +272,10 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
                 {aiConfig.hasAutofix && (
                   <Button
                     size="xs"
-                    onClick={reset}
+                    onClick={() => {
+                      reset();
+                      aiConfig.refetchAutofixSetup?.();
+                    }}
                     title={
                       autofixData?.last_triggered_at
                         ? tct('Last run at [date]', {

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -21,7 +21,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import StartTrialButton from 'getsentry/components/startTrialButton';
 import useSubscription from 'getsentry/hooks/useSubscription';
-import {BillingType} from 'getsentry/types';
+import {BillingType, OnDemandBudgetMode} from 'getsentry/types';
 import {getPotentialProductTrial} from 'getsentry/utils/billing';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 
@@ -52,6 +52,9 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const isTouchCustomer = subscription?.type === BillingType.INVOICED;
   const isSponsoredCustomer = Boolean(subscription?.isSponsored);
 
+  const isPerCategoryOnDemand =
+    subscription?.onDemandBudgets?.budgetMode === OnDemandBudgetMode.PER_CATEGORY;
+
   const userHasBillingAccess = organization.access.includes('org:billing');
 
   const autofixAcknowledgeMutation = useMutation({
@@ -78,6 +81,11 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
 
   function handleAddBudget() {
     if (!subscription) {
+      return;
+    }
+    if (isPerCategoryOnDemand) {
+      // Seer does not support per category on demand budgets, so we need to redirect to the checkout page to prompt the user to switch
+      navigate(`/settings/billing/checkout/?referrer=ai_setup_data_consent#step3`);
       return;
     }
     openOnDemandBudgetEditModal({


### PR DESCRIPTION
Two fixes:
- Start Over button refreshes setup check, which includes the billing quota check
- Add Budget button redirects to checkout step 3 for plans with per-category on-demand