### PR TITLE
fix(forms): Do not duplicate handleInput calls

### DIFF
--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -196,7 +196,6 @@ function RangeSlider({
             step={step}
             disabled={disabled}
             onChange={(_, e) => handleInput(e)}
-            onInput={handleInput}
             onMouseUp={handleBlur}
             onKeyUp={handleBlur}
             value={sliderValue}


### PR DESCRIPTION
onChange is already mapped to onInput, don't duplicate these as we end
up calling handleInput twice

Part of https://github.com/getsentry/sentry/issues/70234
Part of [RTC-52: Editing Project Key Rate Limit Window Creates 2 Audit Log Entries](https://linear.app/getsentry/issue/RTC-52/editing-project-key-rate-limit-window-creates-2-audit-log-entries)
