### PR TITLE
fix(nav): Update new stats & usage page with settings styles

### DIFF
--- a/static/app/views/organizationStats/header.tsx
+++ b/static/app/views/organizationStats/header.tsx
@@ -1,17 +1,74 @@
+import styled from '@emotion/styled';
+
 import {TabList} from 'sentry/components/core/tabs';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 import {makeStatsPathname} from 'sentry/views/organizationStats/pathname';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 type Props = {
   activeTab: 'stats' | 'issues' | 'health';
   organization: Organization;
 };
 
+function StatsHeaderTabs({organization}: Props) {
+  return (
+    <TabList hideBorder>
+      <TabList.Item
+        key="stats"
+        to={makeStatsPathname({
+          path: '/',
+          organization,
+        })}
+      >
+        {t('Usage')}
+      </TabList.Item>
+      <TabList.Item
+        key="issues"
+        to={makeStatsPathname({
+          path: '/issues/',
+          organization,
+        })}
+      >
+        {t('Issues')}
+      </TabList.Item>
+      <TabList.Item
+        key="health"
+        to={makeStatsPathname({
+          path: '/health/',
+          organization,
+        })}
+      >
+        {t('Health')}
+      </TabList.Item>
+    </TabList>
+  );
+}
+
 function StatsHeader({organization, activeTab}: Props) {
+  const prefersStackedNav = usePrefersStackedNav();
+
+  if (prefersStackedNav) {
+    return (
+      <SettingsPageHeader
+        title={t('Stats & Usage')}
+        subtitle={t(
+          'A view of the usage data that Sentry has received across your entire organization.'
+        )}
+        tabs={
+          <TabsContainer>
+            <StatsHeaderTabs organization={organization} activeTab={activeTab} />
+          </TabsContainer>
+        }
+      />
+    );
+  }
+
   return (
     <Layout.Header>
       <Layout.HeaderContent>
@@ -31,38 +88,15 @@ function StatsHeader({organization, activeTab}: Props) {
         )}
       </Layout.HeaderActions>
       <Layout.HeaderTabs value={activeTab}>
-        <TabList hideBorder>
-          <TabList.Item
-            key="stats"
-            to={makeStatsPathname({
-              path: '/',
-              organization,
-            })}
-          >
-            {t('Usage')}
-          </TabList.Item>
-          <TabList.Item
-            key="issues"
-            to={makeStatsPathname({
-              path: '/issues/',
-              organization,
-            })}
-          >
-            {t('Issues')}
-          </TabList.Item>
-          <TabList.Item
-            key="health"
-            to={makeStatsPathname({
-              path: '/health/',
-              organization,
-            })}
-          >
-            {t('Health')}
-          </TabList.Item>
-        </TabList>
+        <StatsHeaderTabs organization={organization} activeTab={activeTab} />
       </Layout.HeaderTabs>
     </Layout.Header>
   );
 }
+
+const TabsContainer = styled('div')`
+  border-bottom: 1px solid ${p => p.theme.border};
+  margin-bottom: ${space(2)};
+`;
 
 export default StatsHeader;

--- a/static/app/views/organizationStats/header.tsx
+++ b/static/app/views/organizationStats/header.tsx
@@ -61,7 +61,7 @@ function StatsHeader({organization, activeTab}: Props) {
           'A view of the usage data that Sentry has received across your entire organization.'
         )}
         tabs={
-          <TabsContainer>
+          <TabsContainer value={activeTab}>
             <StatsHeaderTabs organization={organization} activeTab={activeTab} />
           </TabsContainer>
         }
@@ -94,7 +94,7 @@ function StatsHeader({organization, activeTab}: Props) {
   );
 }
 
-const TabsContainer = styled('div')`
+const TabsContainer = styled(Layout.HeaderTabs)`
   border-bottom: 1px solid ${p => p.theme.border};
   margin-bottom: ${space(2)};
 `;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -1,4 +1,5 @@
 import {Component} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
@@ -35,10 +36,12 @@ import type {Project} from 'sentry/types/project';
 import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
+import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 import HeaderTabs from 'sentry/views/organizationStats/header';
 import {getPerformanceBaseUrl} from 'sentry/views/performance/utils';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import type {ChartDataTransform} from './usageChart';
 import {CHART_OPTIONS_DATACATEGORY} from './usageChart';
@@ -365,6 +368,33 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
     const {organization} = this.props;
     const hasTeamInsights = organization.features.includes('team-insights');
     const showProfilingBanner = this.dataCategory === 'profiles';
+    const newLayout = prefersStackedNav(organization);
+
+    const HeaderContainer = newLayout ? SettingsPageHeader : Layout.Header;
+    const BodyContainer = newLayout ? NewLayoutBody : Body;
+
+    const header = newLayout ? (
+      <SettingsPageHeader
+        title={t('Stats & Usage')}
+        subtitle={t(
+          'A view of the usage data that Sentry has received across your entire organization.'
+        )}
+      />
+    ) : (
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <Layout.Title>{t('Organization Usage Stats')}</Layout.Title>
+          <HeadingSubtitle>
+            {tct(
+              'A view of the usage data that Sentry has received across your entire organization. [link: Read the docs].',
+              {
+                link: <ExternalLink href="https://docs.sentry.io/product/stats/" />,
+              }
+            )}
+          </HeadingSubtitle>
+        </Layout.HeaderContent>
+      </Layout.Header>
+    );
 
     return (
       <SentryDocumentTitle title={t('Usage Stats')} orgSlug={organization.slug}>
@@ -373,23 +403,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
             {hasTeamInsights ? (
               <HeaderTabs organization={organization} activeTab="stats" />
             ) : (
-              <Layout.Header>
-                <Layout.HeaderContent>
-                  <Layout.Title>{t('Organization Usage Stats')}</Layout.Title>
-                  <HeadingSubtitle>
-                    {tct(
-                      'A view of the usage data that Sentry has received across your entire organization. [link: Read the docs].',
-                      {
-                        link: (
-                          <ExternalLink href="https://docs.sentry.io/product/stats/" />
-                        ),
-                      }
-                    )}
-                  </HeadingSubtitle>
-                </Layout.HeaderContent>
-              </Layout.Header>
+              header
             )}
-            <Body>
+            <BodyContainer>
               <Layout.Main fullWidth>
                 <HookHeader organization={organization} />
                 <ControlsWrapper>
@@ -415,7 +431,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
                   />
                 </ErrorBoundary>
               </Layout.Main>
-            </Body>
+            </BodyContainer>
           </PageFiltersContainer>
         </NoProjectMessage>
       </SentryDocumentTitle>
@@ -459,6 +475,10 @@ const DropdownDataCategory = styled(CompactSelect)`
     border-radius: ${p => p.theme.borderRadius};
   }
 `;
+
+const NewLayoutHeader = styled('div')``;
+
+const NewLayoutBody = styled('div')``;
 
 const Body = styled(Layout.Body)`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -1,5 +1,4 @@
 import {Component} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
@@ -370,10 +369,8 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
     const showProfilingBanner = this.dataCategory === 'profiles';
     const newLayout = prefersStackedNav(organization);
 
-    const HeaderContainer = newLayout ? SettingsPageHeader : Layout.Header;
-    const BodyContainer = newLayout ? NewLayoutBody : Body;
-
-    const header = newLayout ? (
+    const BodyWrapper = newLayout ? NewLayoutBody : Body;
+    const noTeamInsightsHeader = newLayout ? (
       <SettingsPageHeader
         title={t('Stats & Usage')}
         subtitle={t(
@@ -403,9 +400,9 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
             {hasTeamInsights ? (
               <HeaderTabs organization={organization} activeTab="stats" />
             ) : (
-              header
+              noTeamInsightsHeader
             )}
-            <BodyContainer>
+            <BodyWrapper>
               <Layout.Main fullWidth>
                 <HookHeader organization={organization} />
                 <ControlsWrapper>
@@ -431,7 +428,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
                   />
                 </ErrorBoundary>
               </Layout.Main>
-            </BodyContainer>
+            </BodyWrapper>
           </PageFiltersContainer>
         </NoProjectMessage>
       </SentryDocumentTitle>
@@ -475,8 +472,6 @@ const DropdownDataCategory = styled(CompactSelect)`
     border-radius: ${p => p.theme.borderRadius};
   }
 `;
-
-const NewLayoutHeader = styled('div')``;
 
 const NewLayoutBody = styled('div')``;
 

--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -13,6 +13,7 @@ import localStorage from 'sentry/utils/localStorage';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 import Header from 'sentry/views/organizationStats/header';
 
 import TeamStatsControls from './controls';
@@ -28,6 +29,7 @@ type Props = RouteComponentProps;
 function TeamStatsHealth({location, router}: Props) {
   const organization = useOrganization();
   const {teams, isLoading, isError} = useUserTeams();
+  const prefersStackedNav = usePrefersStackedNav();
 
   useRouteAnalyticsEventNames('team_insights.viewed', 'Team Insights: Viewed');
 
@@ -57,12 +59,14 @@ function TeamStatsHealth({location, router}: Props) {
     return <LoadingError />;
   }
 
+  const BodyWrapper = prefersStackedNav ? NewLayoutBody : Body;
+
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Project Health')} orgSlug={organization.slug} />
       <Header organization={organization} activeTab="health" />
 
-      <Body>
+      <BodyWrapper>
         <TeamStatsControls
           location={location}
           router={router}
@@ -135,7 +139,7 @@ function TeamStatsHealth({location, router}: Props) {
             </DescriptionCard>
           </Layout.Main>
         )}
-      </Body>
+      </BodyWrapper>
     </Fragment>
   );
 }
@@ -147,3 +151,5 @@ const Body = styled(Layout.Body)`
     display: block;
   }
 `;
+
+const NewLayoutBody = styled('div')``;

--- a/static/app/views/organizationStats/teamInsights/issues.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.tsx
@@ -13,6 +13,7 @@ import localStorage from 'sentry/utils/localStorage';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 import Header from 'sentry/views/organizationStats/header';
 
 import TeamStatsControls from './controls';
@@ -28,6 +29,7 @@ type Props = RouteComponentProps;
 function TeamStatsIssues({location, router}: Props) {
   const organization = useOrganization();
   const {teams, isLoading, isError} = useUserTeams();
+  const prefersStackedNav = usePrefersStackedNav();
 
   useRouteAnalyticsEventNames('team_insights.viewed', 'Team Insights: Viewed');
 
@@ -58,12 +60,14 @@ function TeamStatsIssues({location, router}: Props) {
     return <LoadingError />;
   }
 
+  const BodyWrapper = prefersStackedNav ? NewLayoutBody : Body;
+
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Team Issues')} orgSlug={organization.slug} />
       <Header organization={organization} activeTab="issues" />
 
-      <Body>
+      <BodyWrapper>
         <TeamStatsControls
           showEnvironment
           location={location}
@@ -159,7 +163,7 @@ function TeamStatsIssues({location, router}: Props) {
             </DescriptionCard>
           </Layout.Main>
         )}
-      </Body>
+      </BodyWrapper>
     </Fragment>
   );
 }
@@ -171,3 +175,5 @@ const Body = styled(Layout.Body)`
     display: block;
   }
 `;
+
+const NewLayoutBody = styled('div')``;

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -190,15 +190,6 @@ const Content = styled('div')`
   ${Layout.Page} {
     padding: 0;
   }
-
-  /**
-   * Components which use Layout.Header will provide their own padding.
-   * TODO: Refactor existing components to use Layout.Header and Layout.Body,
-   * then remove the padding from this component.
-   */
-  &:has(${Layout.Header}) {
-    padding: 0;
-  }
 `;
 
 export default SettingsLayout;


### PR DESCRIPTION
When viewed with the new navigation, the stats & usage page should use similar styles that other settings pages do. Settings pages use their own header component and don't really support the Layout components.

Before:

![CleanShot 2025-06-03 at 11 53 30@2x](https://github.com/user-attachments/assets/22cb7ebc-9491-41d1-8755-ebc5f6de8ee3)

After:

![CleanShot 2025-06-03 at 11 52 51@2x](https://github.com/user-attachments/assets/2c9dadf0-8726-4207-8dcc-e84440e305c8)
