### PR TITLE
ref(workflow engine): refactor `evaluate_data_conditions` to support non-boolean evaluation results

### DIFF
--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -98,8 +98,14 @@ def evaluate_data_conditions(
         return ProcessedDataConditionGroup(logic_result=True, condition_results=[])
 
     for condition, value in conditions_to_evaluate:
+        is_condition_triggered = False
         evaluation_result = condition.evaluate_value(value)
-        is_condition_triggered = evaluation_result is not None
+
+        if evaluation_result:
+            if isinstance(evaluation_result, bool):
+                is_condition_triggered = evaluation_result
+            else:
+                is_condition_triggered = True
 
         if is_condition_triggered:
             # Check for short-circuiting evaluations


### PR DESCRIPTION
This is necessary for evaluating the anomaly detection condition, which emits a detector priority level and not a boolean as its result.