### PR TITLE
feat(aci): Add helper to auto-annotate relevant IDs to logs

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_log_util.py
+++ b/tests/sentry/workflow_engine/processors/test_log_util.py
@@ -6,8 +6,154 @@ from unittest.mock import Mock
 from sentry.workflow_engine.processors.log_util import (
     _MAX_ITERATIONS_LOGGED,
     BatchPerformanceTracker,
+    log_extra_context,
     top_n_slowest,
+    with_log_context,
 )
+
+
+class TestLogExtraContextWithRealLogger(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.logger = logging.getLogger("test_real_logger")
+        self.logger.setLevel(logging.INFO)
+        self.records = []
+        self.handler = logging.Handler()
+        self.handler.emit = lambda record: self.records.append(record)
+        self.logger.addHandler(self.handler)
+
+    def tearDown(self):
+        super().tearDown()
+        self.logger.removeHandler(self.handler)
+
+    def test_real_logger_context(self):
+        """Verify that context is properly applied to real LogRecords."""
+        with log_extra_context(self.logger, project_id=123) as ctx:
+            self.logger.info("test message")
+            ctx.update(user_id=456)
+            self.logger.info("test message 2")
+
+        assert len(self.records) == 2
+
+        # First record should have project_id
+        first_record = self.records[0]
+        assert first_record.project_id == 123
+        assert not hasattr(first_record, "user_id")
+
+        # Second record should have both project_id and user_id
+        second_record = self.records[1]
+        assert second_record.project_id == 123
+        assert second_record.user_id == 456
+
+    def test_real_logger_extra_override(self):
+        """Verify that context doesn't override explicit extra values."""
+        with log_extra_context(self.logger, project_id=123) as ctx:
+            self.logger.info("test", extra={"project_id": 456})
+            ctx.update(user_id=789)
+            self.logger.info("test2", extra={"user_id": 0})
+
+        assert len(self.records) == 2
+
+        # First record should use explicit project_id
+        first_record = self.records[0]
+        assert first_record.project_id == 456
+
+        # Second record should use explicit user_id
+        second_record = self.records[1]
+        assert second_record.user_id == 0
+        assert second_record.project_id == 123  # Still from context
+
+    def test_nested_contexts(self):
+        """Verify that nested contexts work correctly with a real logger."""
+        with log_extra_context(self.logger, current=1):
+            self.logger.info("outer")
+            with log_extra_context(self.logger, current=2) as ctx2:
+                self.logger.info("inner")
+                ctx2.update(current=3)
+                self.logger.info("inner_updated")
+            self.logger.info("outer_again")
+        self.logger.info("outer_again_2")
+
+        assert len(self.records) == 5
+
+        first_record = self.records[0]
+        assert first_record.current == 1
+
+        second_record = self.records[1]
+        assert second_record.current == 2
+
+        third_record = self.records[2]
+        assert third_record.current == 3
+
+        # Fourth record should only have outer=1
+        fourth_record = self.records[3]
+        assert fourth_record.current == 1
+
+        # Fifth record shouldn't have current
+        fifth_record = self.records[4]
+        assert not hasattr(fifth_record, "current")
+
+    def test_with_log_context_decorator(self):
+        """Verify that the with_log_context decorator works correctly."""
+
+        @with_log_context(self.logger, initial=1)
+        def process_item(ctx, item_id: int) -> None:
+            self.logger.info("start", extra={"item_id": item_id})
+            ctx.update(updated=2)
+            self.logger.info("updated")
+            return None
+
+        process_item(123)
+
+        assert len(self.records) == 2
+
+        # First record should have initial=1 and item_id=123
+        first_record = self.records[0]
+        assert first_record.msg == "start"
+        assert first_record.initial == 1
+        assert first_record.item_id == 123
+
+        # Second record should have initial=1, updated=2, and item_id=123
+        second_record = self.records[1]
+        assert second_record.msg == "updated"
+        assert second_record.initial == 1
+        assert second_record.updated == 2
+
+    def test_with_log_context_decorator_nested(self):
+        """Verify that nested decorated functions work correctly."""
+
+        @with_log_context(self.logger, outer=1)
+        def outer_func(ctx, x: int) -> None:
+            self.logger.info("outer")
+            inner_func(x)
+            self.logger.info("outer_again")
+
+        @with_log_context(self.logger, inner=2)
+        def inner_func(ctx, x: int) -> None:
+            self.logger.info("inner")
+            ctx.update(inner_updated=3)
+            self.logger.info("inner_updated")
+
+        outer_func(123)
+
+        assert len(self.records) == 4
+
+        # First record should have outer=1
+        first_record = self.records[0]
+        assert first_record.outer == 1
+
+        # Second record should have inner=2
+        second_record = self.records[1]
+        assert second_record.inner == 2
+
+        # Third record should have inner=2 and inner_updated=3
+        third_record = self.records[2]
+        assert third_record.inner == 2
+        assert third_record.inner_updated == 3
+
+        # Fourth record should have outer=1
+        fourth_record = self.records[3]
+        assert fourth_record.outer == 1
 
 
 class TestBatchPerformanceTracker(unittest.TestCase):

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -100,11 +100,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_logger.info.assert_called_with(
             "workflow_engine.process_workflows.triggered_actions (batch)",
             extra={
-                "group_id": self.group.id,
-                "event_id": self.event.event_id,
                 "workflow_ids": [self.error_workflow.id],
                 "action_ids": [self.action.id],
-                "detector_type": self.error_detector.type,
             },
         )
 
@@ -240,8 +237,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_logger.exception.assert_called_once_with(
             "Detector not found for event",
             extra={
-                "event_id": self.event.event_id,
-                "group_id": self.group_event.group_id,
                 "detector_id": None,
             },
         )
@@ -257,7 +252,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
         mock_metrics.incr.assert_called_once_with("workflow_engine.process_workflows.error")
         mock_logger.exception.assert_called_once_with(
             "Missing environment for event",
-            extra={"event_id": self.event.event_id},
         )
 
     @patch("sentry.utils.metrics.incr")


### PR DESCRIPTION
When tracing execution through logs, it's very useful to be able to filter to a particular ID to see the flow of relevant messages.
Manually annotating IDs to every message is bothersome, so this adds a scoped helper that lets you pick what `extra` fields you want as they're available, and add them to all in-scope log messages from a particular logger.
The logger targeting is a bit of a weakness, but the alternative is weird given the way that python logger work.