### PR TITLE
ref: make is_active_supseruser preserve Request type

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -15,7 +15,7 @@ import ipaddress
 import logging
 from collections.abc import Container
 from datetime import datetime, timedelta, timezone
-from typing import Any, TypeIs
+from typing import Any, TypeIs, overload
 
 import orjson
 from django.conf import settings
@@ -25,6 +25,7 @@ from django.http import HttpRequest
 from django.utils import timezone as django_timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework import serializers, status
+from rest_framework.request import Request
 
 from sentry import options
 from sentry.api.exceptions import DataSecrecyError, SentryAPIException
@@ -34,7 +35,7 @@ from sentry.auth.system import is_system_auth
 from sentry.data_secrecy.data_secrecy_logic import should_allow_superuser_access
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcUserOrganizationContext
-from sentry.types.request import _HttpRequestWithUser
+from sentry.types.request import _HttpRequestWithUser, _RequestWithUser
 from sentry.users.models.user import User
 from sentry.utils import metrics
 from sentry.utils.auth import has_completed_sso
@@ -140,7 +141,15 @@ def superuser_has_permission(
     return request.method == "GET" or request.method == "OPTIONS"
 
 
-def is_active_superuser(request: HttpRequest) -> TypeIs[_HttpRequestWithUser]:
+@overload
+def is_active_superuser(request: Request) -> TypeIs[_RequestWithUser]: ...
+
+
+@overload
+def is_active_superuser(request: HttpRequest) -> TypeIs[_HttpRequestWithUser]: ...
+
+
+def is_active_superuser(request: HttpRequest) -> bool:
     if is_system_auth(getattr(request, "auth", None)):
         return True
     su = getattr(request, "superuser", None) or Superuser(request)

--- a/src/sentry/types/request.py
+++ b/src/sentry/types/request.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from django.http.request import HttpRequest
+from rest_framework.request import Request
 
 from sentry.users.models.user import User
 
 
 class _HttpRequestWithUser(HttpRequest):
+    """typing-only: for use in TypeIs to narrow to non-AnonymousUser"""
+
+    user: User
+
+
+class _RequestWithUser(Request):
     """typing-only: for use in TypeIs to narrow to non-AnonymousUser"""
 
     user: User


### PR DESCRIPTION
mypy  1.16 notices that the `TypeIs` I wrote here is unsound when passed `Request` as it ends up with incompatible `user: ...` annotations

<!-- Describe your PR here. -->