### PR TITLE
fix(nav): Settings nav preview should always show org settings

### DIFF
--- a/static/app/views/nav/secondary/sections/settings/settingsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/settings/settingsSecondaryNav.tsx
@@ -1,14 +1,17 @@
 import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {PrimaryNavGroup} from 'sentry/views/nav/types';
+import {useActiveNavGroup} from 'sentry/views/nav/useActiveNavGroup';
 import OrganizationSettingsNavigation from 'sentry/views/settings/organization/organizationSettingsNavigation';
 import ProjectSettingsNavigation from 'sentry/views/settings/project/projectSettingsNavigation';
 
 export function SettingsSecondaryNav() {
   const organization = useOrganization();
   const params = useParams();
-
-  const isProjectSettings = defined(params.projectId);
+  const activeNavGroup = useActiveNavGroup();
+  const isProjectSettings =
+    defined(params.projectId) && activeNavGroup === PrimaryNavGroup.SETTINGS;
 
   return isProjectSettings ? (
     <ProjectSettingsNavigation organization={organization} />


### PR DESCRIPTION
Fixes an issue where, if you were on the project details page, hovering over the settings nav item would preview project settings instead of org settings.