### PR TITLE
feat(search): Focus on arguments when filtering on aggregate

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -113,6 +113,7 @@ type UpdateAggregateArgsAction = {
   token: AggregateFilter;
   type: 'UPDATE_AGGREGATE_ARGS';
   value: string;
+  focusOverride?: FocusOverride;
 };
 
 export type QueryBuilderActions =
@@ -472,11 +473,14 @@ function updateAggregateArgs(
   }
 ): QueryBuilderState {
   const fieldDefinition = getFieldDefinition(getKeyName(action.token.key));
+  const focusOverride =
+    action.focusOverride === undefined ? state.focusOverride : action.focusOverride;
 
   if (!fieldDefinition?.parameterDependentValueType) {
     return {
       ...state,
       query: replaceQueryToken(state.query, getArgsToken(action.token), action.value),
+      focusOverride,
     };
   }
 
@@ -489,6 +493,7 @@ function updateAggregateArgs(
     return {
       ...state,
       query: replaceQueryToken(state.query, getArgsToken(action.token), action.value),
+      focusOverride,
     };
   }
 
@@ -500,6 +505,7 @@ function updateAggregateArgs(
       {token: getArgsToken(action.token), replacement: action.value},
       {token: action.token.value, replacement: newValue},
     ]),
+    focusOverride,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3273,6 +3273,38 @@ describe('SearchQueryBuilder', function () {
         expect(screen.getByLabelText('count():>100')).toBeInTheDocument();
         expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
       });
+
+      it('focuses on the filter value after only argument is specified', async function () {
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />);
+
+        await userEvent.click(getLastInput());
+        await userEvent.keyboard('p95(');
+        expect(
+          screen.getByLabelText('p95(transaction.duration):>300ms')
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText('Edit function parameters')).toHaveFocus();
+        await userEvent.keyboard('transaction');
+        await userEvent.click(screen.getByRole('option', {name: 'transaction.duration'}));
+        expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
+      });
+
+      it('focuses on the filter value after all arguments is specified', async function () {
+        render(<SearchQueryBuilder {...aggregateDefaultProps} />);
+
+        await userEvent.click(getLastInput());
+        await userEvent.keyboard('count_if(');
+        expect(
+          screen.getByLabelText('count_if(transaction.duration,greater,300ms):>100')
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText('Edit function parameters')).toHaveFocus();
+        await userEvent.keyboard('transaction');
+        await userEvent.click(screen.getByRole('option', {name: 'transaction.duration'}));
+        expect(screen.getByLabelText('Edit function parameters')).toHaveFocus();
+        await userEvent.keyboard(',');
+        await userEvent.click(screen.getByRole('option', {name: 'greater'}));
+        await userEvent.keyboard(',100{Enter}');
+        expect(screen.getByLabelText('Edit filter value')).toHaveFocus();
+      });
     });
   });
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -84,6 +84,7 @@ export function AggregateKey({
         </UnfocusedText>
         <Parameters>
           <SearchQueryBuilderParametersCombobox
+            state={state}
             token={token}
             onDelete={() => {
               filterRef.current?.focus();

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -36,6 +36,7 @@ import {
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {FieldDefinition} from 'sentry/utils/fields';
 import {FieldKind, FieldValueType} from 'sentry/utils/fields';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -129,12 +130,19 @@ function countPreviousItemsOfType({
   }, 0);
 }
 
-function calculateNextFocusForFilter(state: ListState<ParseResultToken>): FocusOverride {
+function calculateNextFocusForFilter(
+  state: ListState<ParseResultToken>,
+  definition: FieldDefinition | null
+): FocusOverride {
   const numPreviousFilterItems = countPreviousItemsOfType({state, type: Token.FILTER});
+  const part =
+    definition && definition.kind === FieldKind.FUNCTION && definition.parameters?.length
+      ? 'key'
+      : 'value';
 
   return {
     itemKey: `${Token.FILTER}:${numPreviousFilterItems}`,
-    part: 'value',
+    part,
   };
 }
 
@@ -432,7 +440,7 @@ function SearchQueryBuilderInputInternal({
               value,
               getFieldDefinition
             ),
-            focusOverride: calculateNextFocusForFilter(state),
+            focusOverride: calculateNextFocusForFilter(state, getFieldDefinition(value)),
             shouldCommitQuery: false,
           });
           resetInputValue();
@@ -527,7 +535,10 @@ function SearchQueryBuilderInputInternal({
                     filterValue,
                     getFieldDefinition
                   ),
-                  focusOverride: calculateNextFocusForFilter(state),
+                  focusOverride: calculateNextFocusForFilter(
+                    state,
+                    getFieldDefinition(filterValue)
+                  ),
                   shouldCommitQuery: false,
                 });
                 resetInputValue();
@@ -564,7 +575,10 @@ function SearchQueryBuilderInputInternal({
                 filterKey,
                 getFieldDefinition
               ),
-              focusOverride: calculateNextFocusForFilter(state),
+              focusOverride: calculateNextFocusForFilter(
+                state,
+                getFieldDefinition(filterKey)
+              ),
               shouldCommitQuery: false,
             });
             resetInputValue();


### PR DESCRIPTION
When typing in an aggregate filter, the focus jumps to the filter value. So to change the arguments, you have to

1. type in `p50(`
2. cursor jumps to the value
3. click on `transaction.duration`
4. change it to what you want
5. cursor jumps to the end of the token
6. click on the filter value
7. change it to what you want

This change makes it so that it focuses on the desired component immediately.
