### PR TITLE
feat(taskworker) Add CI check for scheduled task parameters

### DIFF
--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -1,19 +1,43 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
 import pytest
 from celery.beat import ScheduleEntry
 from django.conf import settings
 
 from sentry.celery import app
+from sentry.dynamic_sampling.tasks.task_context import TaskContext
 
 app.loader.import_default_modules()
 
 
 # XXX(dcramer): this doesn't actually work as we'd expect, as if the task is imported
 # anywhere else before this code is run it will still show up as registered
-@pytest.mark.parametrize("name,entry", list(settings.CELERYBEAT_SCHEDULE.items()))
-def test_validate_celerybeat_schedule(name, entry):
-    entry = ScheduleEntry(name=name, app=app, **entry)
+@pytest.mark.parametrize("name,entry_data", list(settings.CELERYBEAT_SCHEDULE.items()))
+def test_validate_celerybeat_schedule(name: str, entry_data: dict[str, Any]) -> None:
+    entry = ScheduleEntry(name=name, app=app, **entry_data)
     assert entry.task in app.tasks
     mod_name = app.tasks[entry.task].__module__
     assert mod_name in settings.CELERY_IMPORTS, f"{mod_name} is missing from CELERY_IMPORTS"
     # Test that the schedules are valid. Throws a RuntimeError if one is invalid.
     entry.is_due()
+
+
+@pytest.mark.parametrize("name,entry_data", list(settings.CELERYBEAT_SCHEDULE.items()))
+def test_validate_scheduled_task_parameters(name: str, entry_data: dict[str, Any]) -> None:
+    entry = ScheduleEntry(name=name, app=app, **entry_data)
+    task = app.tasks[entry.task]
+    signature = inspect.signature(task)
+    for parameter in signature.parameters.values():
+        # Skip *args and **kwargs
+        if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
+            continue
+        # The dynamic sampling tasks splice in a TaskContext via a decorator :(
+        if parameter.annotation == TaskContext:
+            continue
+        if parameter.default == parameter.empty:
+            raise AssertionError(
+                f"Parameter `{parameter.name}` for task `{task.name}` must have a default value"
+            )

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -1,5 +1,6 @@
 import inspect
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from django.conf import settings
@@ -18,7 +19,7 @@ def test_import_paths():
 
 
 @pytest.mark.parametrize("name,config", list(settings.TASKWORKER_SCHEDULES.items()))
-def test_taskworker_schedule_type(name, config) -> None:
+def test_taskworker_schedule_type(name: str, config: dict[str, Any]) -> None:
     assert config["task"], f"schedule {name} is missing a task name"
     (namespace, taskname) = config["task"].split(":")
     assert taskregistry.get_task(namespace, taskname), f"task for {name} is not registered"
@@ -31,7 +32,7 @@ def test_taskworker_schedule_type(name, config) -> None:
 
 
 @pytest.mark.parametrize("config", list(settings.TASKWORKER_SCHEDULES.values()))
-def test_taskworker_schedule_parameters(config) -> None:
+def test_taskworker_schedule_parameters(config: dict[str, Any]) -> None:
     (namespace, taskname) = config["task"].split(":")
     task = taskregistry.get_task(namespace, taskname)
     signature = inspect.signature(task)

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -1,8 +1,11 @@
+import inspect
 from datetime import timedelta
 
+import pytest
 from django.conf import settings
 
 from sentry.conf.types.taskworker import crontab
+from sentry.dynamic_sampling.tasks.task_context import TaskContext
 from sentry.taskworker.registry import taskregistry
 
 
@@ -14,16 +17,33 @@ def test_import_paths():
             raise AssertionError(f"Unable to import {path} from TASKWORKER_IMPORTS")
 
 
-def test_taskworker_schedule() -> None:
-    for schedule_name, config in settings.TASKWORKER_SCHEDULES.items():
-        assert config["task"], f"schedule {schedule_name} is missing a task name"
-        (namespace, taskname) = config["task"].split(":")
-        assert taskregistry.get_task(
-            namespace, taskname
-        ), f"task for {schedule_name} is not registered"
+@pytest.mark.parametrize("name,config", list(settings.TASKWORKER_SCHEDULES.items()))
+def test_taskworker_schedule_type(name, config) -> None:
+    assert config["task"], f"schedule {name} is missing a task name"
+    (namespace, taskname) = config["task"].split(":")
+    assert taskregistry.get_task(namespace, taskname), f"task for {name} is not registered"
 
-        assert config["schedule"], f"Schedule {schedule_name} is missing a schedule"
-        schedule = config.get("schedule")
-        assert isinstance(
-            schedule, (timedelta, crontab)
-        ), f"Schedule {schedule_name} has a schedule of type {type(schedule)}"
+    assert config["schedule"], f"Schedule {name} is missing a schedule"
+    schedule = config.get("schedule")
+    assert isinstance(
+        schedule, (timedelta, crontab)
+    ), f"Schedule {name} has a schedule of type {type(schedule)}"
+
+
+@pytest.mark.parametrize("config", list(settings.TASKWORKER_SCHEDULES.values()))
+def test_taskworker_schedule_parameters(config) -> None:
+    (namespace, taskname) = config["task"].split(":")
+    task = taskregistry.get_task(namespace, taskname)
+    signature = inspect.signature(task)
+
+    for parameter in signature.parameters.values():
+        # Skip *args and **kwargs
+        if parameter.kind in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD):
+            continue
+        # The dynamic sampling tasks splice in a TaskContext via a decorator :(
+        if parameter.annotation == TaskContext:
+            continue
+        if parameter.default == parameter.empty:
+            raise AssertionError(
+                f"Parameter `{parameter.name}` for task `{task.name}` must have a default value."
+            )


### PR DESCRIPTION
Add a test to ensure that we don't introduce scheduled tasks that require parameters. All parameters must have default values as the task scheduler does not provide any parameters.

Fixes #91177