### PR TITLE
fix(billing): Update calculateCategoryPrepaidUsage to consider reservedSpend

### DIFF
--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.spec.tsx
@@ -330,7 +330,7 @@ describe('mapReservedBudgetStatsToChart', () => {
       ],
       reserved: [
         {
-          value: ['Jan 1', 500_00],
+          value: ['Jan 1', 2000_00],
         },
         {
           value: ['Jan 2', 2000_00],
@@ -466,7 +466,7 @@ describe('mapReservedBudgetStatsToChart', () => {
       ],
       reserved: [
         {
-          value: ['Jan 1', 1000_00],
+          value: ['Jan 1', 2000_00],
         },
         {
           value: ['Jan 2', 2000_00],
@@ -541,10 +541,10 @@ describe('mapReservedBudgetStatsToChart', () => {
       ],
       reserved: [
         {
-          value: ['Jan 1', 500_00],
+          value: ['Jan 1', 2000_00],
         },
         {
-          value: ['Jan 2', 1500_00],
+          value: ['Jan 2', 2000_00],
         },
       ],
     });
@@ -645,10 +645,10 @@ describe('mapReservedBudgetStatsToChart', () => {
       ],
       reserved: [
         {
-          value: ['Jan 1', 1000_00],
+          value: ['Jan 1', 4000_00],
         },
         {
-          value: ['Jan 2', 1000_00],
+          value: ['Jan 2', 4000_00],
         },
       ],
     });


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-801/on-demand-running-cost-not-calculated-correctly

The spend usage chart on the Subscription overview page does not consider reserved spend usage.

This pull request fixes that.

