### PR TITLE
feat(aci): Add connected automations to detector details

### DIFF
--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -5,7 +5,7 @@ import type {
   DataConditionHandlerGroupType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQueries, useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const makeAutomationsQueryKey = (orgSlug: string): ApiQueryKey => [
@@ -57,4 +57,16 @@ export function useAvailableActionsQuery() {
     staleTime: Infinity,
     retry: false,
   });
+}
+
+export function useDetectorQueriesByIds(automationIds: string[]) {
+  const org = useOrganization();
+
+  return useApiQueries<Automation>(
+    automationIds.map(id => makeAutomationQueryKey(org.slug, id)),
+    {
+      staleTime: 0,
+      retry: false,
+    }
+  );
 }

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -13,6 +13,7 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useDetectorQueriesByIds} from 'sentry/views/automations/hooks';
 import {useAutomationActions} from 'sentry/views/automations/hooks/utils';
@@ -59,7 +60,7 @@ export function ConnectedAutomationsList({
           : undefined,
       };
     })
-    .filter((x): x is ConnectedAutomationsData => x !== undefined);
+    .filter(defined);
 
   const isLoading = queries.some(query => query.isPending);
   const isError = queries.some(query => query.isError);

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import {Flex} from 'sentry/components/container/flex';
 import {Button} from 'sentry/components/core/button';
@@ -33,16 +33,15 @@ export function ConnectedAutomationsList({
 }: Props) {
   const organization = useOrganization();
   const canEdit = connectedAutomationIds && !!toggleConnected;
+  // TODO: There will eventually be a single api call to fetch a page of automations
   const queries = useDetectorQueriesByIds(automationIds);
   const [currentPage, setCurrentPage] = useState(0);
   const totalPages = Math.ceil(queries.length / AUTOMATIONS_PER_PAGE);
 
-  const handlePreviousPage = () => {
-    setCurrentPage(prev => Math.max(0, prev - 1));
-  };
-  const handleNextPage = () => {
-    setCurrentPage(prev => Math.min(totalPages - 1, prev + 1));
-  };
+  // Reset the page when the automationIds change
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [automationIds]);
 
   const data = queries
     .map((query): ConnectedAutomationsData | undefined => {
@@ -72,6 +71,13 @@ export function ConnectedAutomationsList({
   if (isLoading) {
     return <LoadingIndicator />;
   }
+
+  const handlePreviousPage = () => {
+    setCurrentPage(prev => Math.max(0, prev - 1));
+  };
+  const handleNextPage = () => {
+    setCurrentPage(prev => Math.min(totalPages - 1, prev + 1));
+  };
 
   const pagination = (
     <Flex justify="flex-end">

--- a/static/app/views/detectors/detail.tsx
+++ b/static/app/views/detectors/detail.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {DateTime} from 'sentry/components/dateTime';
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -83,7 +84,9 @@ export default function DetectorDetails() {
                 <IssuesList />
               </Section>
               <Section title={t('Connected Automations')}>
-                <ConnectedAutomationsList automations={[]} />
+                <ErrorBoundary mini>
+                  <ConnectedAutomationsList automationIds={detector.workflowIds} />
+                </ErrorBoundary>
               </Section>
             </DetailLayout.Main>
             <DetailLayout.Sidebar>


### PR DESCRIPTION
passes connected actions with in browser pagination. Currently makes N api calls since the api doesn't exist

![image](https://github.com/user-attachments/assets/f356f89f-6ba9-42bc-84d2-76e843ddb61d)
