### PR TITLE
feat(seer): update provision subscription action

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
@@ -412,7 +412,7 @@ describe('provisionSubscriptionAction', function () {
       within(container).queryByText(/reserved cost-per-event accepted spans/i)
     ).not.toBeInTheDocument();
     expect(
-      within(container).queryByText(/reserved spans budget/i)
+      within(container).queryByText(/dynamic sampling arr/i)
     ).not.toBeInTheDocument();
     expect(within(container).getByLabelText('Reserved Spans')).toBeInTheDocument();
     expect(within(container).getByLabelText('Soft Cap Type Spans')).toBeInTheDocument();
@@ -432,9 +432,7 @@ describe('provisionSubscriptionAction', function () {
     expect(
       within(container).getByLabelText('Price for Accepted Spans')
     ).toBeInTheDocument();
-    expect(
-      within(container).queryByText('Reserved Spans Budget')
-    ).not.toBeInTheDocument();
+    expect(within(container).queryByText('Dynamic Sampling ARR')).not.toBeInTheDocument();
     expect(within(container).getByLabelText('Reserved Stored Spans')).toBeInTheDocument();
     expect(
       within(container).getByLabelText('Soft Cap Type Stored Spans')
@@ -446,7 +444,7 @@ describe('provisionSubscriptionAction', function () {
     await typeNumForField('Reserved Cost-Per-Event Accepted Spans', '1');
     await typeNumForField('Reserved Cost-Per-Event Stored Spans', '2');
     expect(
-      within(container).getByLabelText('Price for Accepted Spans (Reserved Spans Budget)')
+      within(container).getByLabelText('Price for Accepted Spans (Dynamic Sampling ARR)')
     ).toBeInTheDocument();
     expect(within(container).getByLabelText('Price for Stored Spans')).toHaveValue(0);
     expect(within(container).getByLabelText('Price for Stored Spans')).toBeDisabled();
@@ -1242,7 +1240,8 @@ describe('provisionSubscriptionAction', function () {
     await typeNumForField('Reserved Issue Fixes', '0');
     await typeNumForField('Reserved Issue Scans', '0');
     await typeNumForMatchingFields('Price for', '0', false);
-    await typeNumForField('Price for Accepted Spans (Reserved Spans Budget)', '12000'); // custom price for stored spans is auto-filled to 0
+    await typeNumForField('Price for Accepted Spans (Dynamic Sampling ARR)', '12000'); // custom price for stored spans is auto-filled to 0
+    await typeNumForField('Dynamic Sampling Budget', '12000');
     await typeNumForField('Price for PCSS', '500');
     await typeNumForField('Annual Contract Value', '12500');
 
@@ -1410,7 +1409,6 @@ describe('provisionSubscriptionAction', function () {
           reservedSpans: 10000000,
           reservedUptime: 250,
           retainOnDemandBudget: false,
-          seerBudget: 2400000,
           softCapTypeAttachments: null,
           softCapTypeErrors: null,
           softCapTypeMonitorSeats: null,

--- a/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
@@ -1359,9 +1359,10 @@ describe('provisionSubscriptionAction', function () {
     await typeNumForField('Reserved Cost-Per-Event Issue Fixes', '1');
     await typeNumForField('Reserved Cost-Per-Event Issue Scans', '0.5');
     await typeNumForMatchingFields('Price for', '0', false);
-    await typeNumForField('Price for Issue Fixes (Reserved Seer Budget)', '12000');
+    await typeNumForField('Price for Issue Fixes (Seer ARR)', '12000');
     await typeNumForField('Price for PCSS', '500');
     await typeNumForField('Annual Contract Value', '12500');
+    await typeNumForField('Seer Budget', '24000');
 
     const updateMock = MockApiClient.addMockResponse({
       url: `/customers/${mockOrg.slug}/provision-subscription/`,
@@ -1395,7 +1396,7 @@ describe('provisionSubscriptionAction', function () {
           plan: 'am3_business_ent',
           reservedAttachments: 1,
           reservedBudgets: [
-            {budget: 1200000, categories: ['seerAutofix', 'seerScanner']},
+            {budget: 2400000, categories: ['seerAutofix', 'seerScanner']},
           ],
           reservedCpeSeerAutofix: 100000000,
           reservedCpeSeerScanner: 50000000,
@@ -1409,6 +1410,7 @@ describe('provisionSubscriptionAction', function () {
           reservedSpans: 10000000,
           reservedUptime: 250,
           retainOnDemandBudget: false,
+          seerBudget: 2400000,
           softCapTypeAttachments: null,
           softCapTypeErrors: null,
           softCapTypeMonitorSeats: null,

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -950,6 +950,23 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                             </Fragment>
                           );
                         })}
+                      <StyledDollarsField
+                        label="Seer Budget"
+                        name="seerBudget"
+                        help="Monthly reserved budget for Seer"
+                        required={this.isSettingSeerBudget()}
+                        disabled={!this.isSettingSeerBudget()}
+                        value={data.seerBudget}
+                        onChange={v =>
+                          this.setState(state => ({
+                            ...state,
+                            data: {
+                              ...state.data,
+                              seerBudget: v,
+                            },
+                          }))
+                        }
+                      />
                     </Fragment>
                   )}
               </div>
@@ -1046,24 +1063,6 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                       data: {
                         ...state.data,
                         customPrice: v,
-                      },
-                    }))
-                  }
-                />
-
-                <StyledDollarsField
-                  label="Seer Budget"
-                  name="seerBudget"
-                  help="Monthly reserved budget for Seer"
-                  required={this.hasCompleteSeerBudget()}
-                  disabled={!this.hasCompleteSeerBudget()}
-                  value={data.seerBudget}
-                  onChange={v =>
-                    this.setState(state => ({
-                      ...state,
-                      data: {
-                        ...state.data,
-                        seerBudget: v,
                       },
                     }))
                   }


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-816/seer-admin-provisioning-fields

allows subscriptions to have different Seer ARR and reserved budget by adding new text input

<img width="588" alt="Screenshot 2025-06-04 at 9 03 40 AM" src="https://github.com/user-attachments/assets/57b84e88-3924-440a-8c6b-b41462cb0280" />

<img width="574" alt="Screenshot 2025-06-04 at 9 04 25 AM" src="https://github.com/user-attachments/assets/306a95f3-c9e5-4995-9d9e-d888e4a368da" />
