### PR TITLE
fix(aci): Report how many iteration durations were truncated

### DIFF
--- a/src/sentry/workflow_engine/processors/log_util.py
+++ b/src/sentry/workflow_engine/processors/log_util.py
@@ -93,8 +93,9 @@ class BatchPerformanceTracker:
             }
             if self._failure_key:
                 extra["failure_key"] = self._failure_key
-            if len(self._iteration_durations) > _MAX_ITERATIONS_LOGGED:
-                extra["durations_truncated"] = True
+            durations_truncated = max(0, len(self._iteration_durations) - _MAX_ITERATIONS_LOGGED)
+            if durations_truncated > 0:
+                extra["durations_truncated"] = durations_truncated
             self._logger.info(
                 self._name,
                 extra=extra,

--- a/tests/sentry/workflow_engine/processors/test_log_util.py
+++ b/tests/sentry/workflow_engine/processors/test_log_util.py
@@ -3,7 +3,11 @@ import unittest
 from datetime import timedelta
 from unittest.mock import Mock
 
-from sentry.workflow_engine.processors.log_util import BatchPerformanceTracker, top_n_slowest
+from sentry.workflow_engine.processors.log_util import (
+    _MAX_ITERATIONS_LOGGED,
+    BatchPerformanceTracker,
+    top_n_slowest,
+)
 
 
 class TestBatchPerformanceTracker(unittest.TestCase):
@@ -98,6 +102,18 @@ class TestBatchPerformanceTracker(unittest.TestCase):
         assert call_args["extra"]["total_duration"] == 200
         assert call_args["extra"]["durations"]["item1"] == 1
         assert call_args["extra"]["durations"]["item2"] == 199
+
+    def test_durations_truncated(self):
+        """Test that durations_truncated is set correctly when there are too many iterations."""
+        for i in range(_MAX_ITERATIONS_LOGGED + 100):
+            with self.tracker.track(f"item_{i}"):
+                self.time_func.return_value = i + 1
+
+        self.tracker.finalize()
+        self.logger.info.assert_called_once()
+        call_args = self.logger.info.call_args[1]
+        assert call_args["extra"]["durations_truncated"] == 100  # 300 - 200
+        assert len(call_args["extra"]["durations"]) == 200  # Should only keep top 200
 
 
 def test_top_n_slowest():


### PR DESCRIPTION
Knowing how many actual iterations were involved when it's too many to log is useful.
