### PR TITLE
feat(taskworker): embed task metadata along activation

### DIFF
--- a/src/sentry/taskworker/client.py
+++ b/src/sentry/taskworker/client.py
@@ -1,3 +1,4 @@
+import dataclasses
 import hashlib
 import hmac
 import logging
@@ -60,6 +61,23 @@ if TYPE_CHECKING:
 else:
     InterceptorBase = grpc.UnaryUnaryClientInterceptor
     CallFuture = Any
+
+
+@dataclasses.dataclass
+class InflightTaskActivation:
+    activation: TaskActivation
+    host: str
+    receive_timestamp: float
+
+
+@dataclasses.dataclass
+class ProcessingResult:
+    """Result structure from child processess to parent"""
+
+    task_id: str
+    status: TaskActivationStatus.ValueType
+    host: str
+    receive_timestamp: float
 
 
 class RequestSignatureInterceptor(InterceptorBase):
@@ -127,7 +145,6 @@ class TaskworkerClient:
         self._host_to_stubs: dict[str, ConsumerServiceStub] = {
             self._cur_host: self._connect_to_host(self._cur_host)
         }
-        self._task_id_to_host: dict[str, str] = {}
 
         self._max_tasks_before_rebalance = max_tasks_before_rebalance
         self._num_tasks_before_rebalance = max_tasks_before_rebalance
@@ -209,7 +226,7 @@ class TaskworkerClient:
         self._num_tasks_before_rebalance -= 1
         return self._cur_host, self._host_to_stubs[self._cur_host]
 
-    def get_task(self, namespace: str | None = None) -> TaskActivation | None:
+    def get_task(self, namespace: str | None = None) -> InflightTaskActivation | None:
         """
         Fetch a pending task.
 
@@ -240,16 +257,16 @@ class TaskworkerClient:
                 "taskworker.client.get_task",
                 tags={"namespace": response.task.namespace},
             )
-            self._task_id_to_host[response.task.id] = host
-            return response.task
+            return InflightTaskActivation(
+                activation=response.task, host=host, receive_timestamp=time.monotonic()
+            )
         return None
 
     def update_task(
         self,
-        task_id: str,
-        status: TaskActivationStatus.ValueType,
+        processing_result: ProcessingResult,
         fetch_next_task: FetchNextTask | None = None,
-    ) -> TaskActivation | None:
+    ) -> InflightTaskActivation | None:
         """
         Update the status for a given task activation.
 
@@ -258,31 +275,26 @@ class TaskworkerClient:
         metrics.incr("taskworker.client.fetch_next", tags={"next": fetch_next_task is not None})
         self._clear_temporary_unavailable_hosts()
         request = SetTaskStatusRequest(
-            id=task_id,
-            status=status,
+            id=processing_result.task_id,
+            status=processing_result.status,
             fetch_next_task=fetch_next_task,
         )
 
-        host = self._task_id_to_host.get(task_id, None)
-        if host is None:
-            metrics.incr("taskworker.client.task_id_not_in_client")
-            return None
         try:
-            if host in self._temporary_unavailable_hosts:
+            if processing_result.host in self._temporary_unavailable_hosts:
                 metrics.incr("taskworker.client.skipping_update_due_to_unavailable_host")
-                raise HostTemporarilyUnavailable(f"Host: {host} is temporarily unavailable")
+                raise HostTemporarilyUnavailable(
+                    f"Host: {processing_result.host} is temporarily unavailable"
+                )
 
-            with metrics.timer("taskworker.update_task.rpc", tags={"host": host}):
-                response = self._host_to_stubs[host].SetTaskStatus(request)
-                del self._task_id_to_host[task_id]
+            with metrics.timer("taskworker.update_task.rpc", tags={"host": processing_result.host}):
+                response = self._host_to_stubs[processing_result.host].SetTaskStatus(request)
         except grpc.RpcError as err:
             metrics.incr(
                 "taskworker.client.rpc_error",
                 tags={"method": "SetTaskStatus", "status": err.code().name},
             )
             if err.code() == grpc.StatusCode.NOT_FOUND:
-                del self._task_id_to_host[task_id]
-
                 # The current broker is empty, switch.
                 self._num_tasks_before_rebalance = 0
 
@@ -293,8 +305,11 @@ class TaskworkerClient:
             raise
 
         self._num_consecutive_unavailable_errors = 0
-        self._temporary_unavailable_hosts.pop(host, None)
+        self._temporary_unavailable_hosts.pop(processing_result.host, None)
         if response.HasField("task"):
-            self._task_id_to_host[response.task.id] = host
-            return response.task
+            return InflightTaskActivation(
+                activation=response.task,
+                host=processing_result.host,
+                receive_timestamp=time.monotonic(),
+            )
         return None

--- a/src/sentry/taskworker/client/client.py
+++ b/src/sentry/taskworker/client/client.py
@@ -1,4 +1,3 @@
-import dataclasses
 import hashlib
 import hmac
 import logging
@@ -14,12 +13,12 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     FetchNextTask,
     GetTaskRequest,
     SetTaskStatusRequest,
-    TaskActivation,
-    TaskActivationStatus,
 )
 from sentry_protos.taskbroker.v1.taskbroker_pb2_grpc import ConsumerServiceStub
 
 from sentry import options
+from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
+from sentry.taskworker.client.processing_result import ProcessingResult
 from sentry.taskworker.constants import (
     DEFAULT_CONSECUTIVE_UNAVAILABLE_ERRORS,
     DEFAULT_REBALANCE_AFTER,
@@ -61,23 +60,6 @@ if TYPE_CHECKING:
 else:
     InterceptorBase = grpc.UnaryUnaryClientInterceptor
     CallFuture = Any
-
-
-@dataclasses.dataclass
-class InflightTaskActivation:
-    activation: TaskActivation
-    host: str
-    receive_timestamp: float
-
-
-@dataclasses.dataclass
-class ProcessingResult:
-    """Result structure from child processess to parent"""
-
-    task_id: str
-    status: TaskActivationStatus.ValueType
-    host: str
-    receive_timestamp: float
 
 
 class RequestSignatureInterceptor(InterceptorBase):

--- a/src/sentry/taskworker/client/inflight_task_activation.py
+++ b/src/sentry/taskworker/client/inflight_task_activation.py
@@ -1,0 +1,10 @@
+import dataclasses
+
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
+
+
+@dataclasses.dataclass
+class InflightTaskActivation:
+    activation: TaskActivation
+    host: str
+    receive_timestamp: float

--- a/src/sentry/taskworker/client/processing_result.py
+++ b/src/sentry/taskworker/client/processing_result.py
@@ -1,0 +1,13 @@
+import dataclasses
+
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivationStatus
+
+
+@dataclasses.dataclass
+class ProcessingResult:
+    """Result structure from child processess to parent"""
+
+    task_id: str
+    status: TaskActivationStatus.ValueType
+    host: str
+    receive_timestamp: float

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -15,12 +15,9 @@ import grpc
 from django.conf import settings
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import FetchNextTask
 
-from sentry.taskworker.client import (
-    HostTemporarilyUnavailable,
-    InflightTaskActivation,
-    ProcessingResult,
-    TaskworkerClient,
-)
+from sentry.taskworker.client.client import HostTemporarilyUnavailable, TaskworkerClient
+from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
+from sentry.taskworker.client.processing_result import ProcessingResult
 from sentry.taskworker.constants import DEFAULT_REBALANCE_AFTER, DEFAULT_WORKER_QUEUE_SIZE
 from sentry.taskworker.workerchild import child_process
 from sentry.utils import metrics

--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -13,11 +13,16 @@ from typing import Any
 
 import grpc
 from django.conf import settings
-from sentry_protos.taskbroker.v1.taskbroker_pb2 import FetchNextTask, TaskActivation
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import FetchNextTask
 
-from sentry.taskworker.client import HostTemporarilyUnavailable, TaskworkerClient
+from sentry.taskworker.client import (
+    HostTemporarilyUnavailable,
+    InflightTaskActivation,
+    ProcessingResult,
+    TaskworkerClient,
+)
 from sentry.taskworker.constants import DEFAULT_REBALANCE_AFTER, DEFAULT_WORKER_QUEUE_SIZE
-from sentry.taskworker.workerchild import ProcessingResult, child_process
+from sentry.taskworker.workerchild import child_process
 from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.taskworker.worker")
@@ -63,7 +68,7 @@ class TaskWorker:
             raise ValueError(f"Invalid process type: {process_type}")
         self._process_type = process_type
 
-        self._child_tasks: multiprocessing.Queue[TaskActivation] = self.mp_context.Queue(
+        self._child_tasks: multiprocessing.Queue[InflightTaskActivation] = self.mp_context.Queue(
             maxsize=child_tasks_queue_maxsize
         )
         self._processed_tasks: multiprocessing.Queue[ProcessingResult] = self.mp_context.Queue(
@@ -71,7 +76,6 @@ class TaskWorker:
         )
         self._children: list[BaseProcess] = []
         self._shutdown_event = self.mp_context.Event()
-        self._task_receive_timing: dict[str, float] = {}
         self._result_thread: threading.Thread | None = None
         self._spawn_children_thread: threading.Thread | None = None
 
@@ -144,11 +148,11 @@ class TaskWorker:
         if self._child_tasks.full():
             return False
 
-        task = self.fetch_task()
-        if task:
+        inflight = self.fetch_task()
+        if inflight:
             try:
                 start_time = time.monotonic()
-                self._child_tasks.put(task)
+                self._child_tasks.put(inflight)
                 metrics.distribution(
                     "taskworker.worker.child_task.put.duration",
                     time.monotonic() - start_time,
@@ -157,7 +161,10 @@ class TaskWorker:
             except queue.Full:
                 logger.warning(
                     "taskworker.add_task.child_task_queue_full",
-                    extra={"task_id": task.id, "processing_pool": self._processing_pool_name},
+                    extra={
+                        "task_id": inflight.activation.id,
+                        "processing_pool": self._processing_pool_name,
+                    },
                 )
             return True
         else:
@@ -199,29 +206,26 @@ class TaskWorker:
         Run in a thread to avoid blocking the process, and during shutdown/
         See `start_result_thread`
         """
-        task_received = self._task_receive_timing.pop(result.task_id, None)
-        if task_received is not None:
-            metrics.distribution(
-                "taskworker.worker.complete_duration",
-                time.monotonic() - task_received,
-                tags={"processing_pool": self._processing_pool_name},
-            )
+        metrics.distribution(
+            "taskworker.worker.complete_duration",
+            time.monotonic() - result.receive_timestamp,
+            tags={"processing_pool": self._processing_pool_name},
+        )
 
         if fetch:
             fetch_next = None
             if not self._child_tasks.full():
                 fetch_next = FetchNextTask(namespace=self._namespace)
 
-            next_task = self._send_update_task(result, fetch_next)
-            if next_task:
-                self._task_receive_timing[next_task.id] = time.monotonic()
+            next = self._send_update_task(result, fetch_next)
+            if next:
                 try:
-                    self._child_tasks.put(next_task)
+                    self._child_tasks.put(next)
                 except queue.Full:
                     logger.warning(
                         "taskworker.send_result.child_task_queue_full",
                         extra={
-                            "task_id": next_task.id,
+                            "task_id": next.activation.id,
                             "processing_pool": self._processing_pool_name,
                         },
                     )
@@ -232,7 +236,7 @@ class TaskWorker:
 
     def _send_update_task(
         self, result: ProcessingResult, fetch_next: FetchNextTask | None
-    ) -> TaskActivation | None:
+    ) -> InflightTaskActivation | None:
         """
         Do the RPC call to this worker's taskbroker, and handle errors
         """
@@ -247,11 +251,7 @@ class TaskWorker:
         # Use the shutdown_event as a sleep mechanism
         self._shutdown_event.wait(self._setstatus_backoff_seconds)
         try:
-            next_task = self.client.update_task(
-                task_id=result.task_id,
-                status=result.status,
-                fetch_next_task=fetch_next,
-            )
+            next_task = self.client.update_task(result, fetch_next)
             self._setstatus_backoff_seconds = 0
             return next_task
         except grpc.RpcError as e:
@@ -301,7 +301,7 @@ class TaskWorker:
         self._spawn_children_thread = threading.Thread(target=spawn_children_thread)
         self._spawn_children_thread.start()
 
-    def fetch_task(self) -> TaskActivation | None:
+    def fetch_task(self) -> InflightTaskActivation | None:
         # Use the shutdown_event as a sleep mechanism
         self._shutdown_event.wait(self._gettask_backoff_seconds)
         try:
@@ -329,5 +329,4 @@ class TaskWorker:
             return None
 
         self._gettask_backoff_seconds = 0
-        self._task_receive_timing[activation.id] = time.monotonic()
         return activation

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import dataclasses
 import logging
 import queue
 import signal
@@ -24,6 +23,8 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.crons import MonitorStatus, capture_checkin
 
+from sentry.taskworker.client import InflightTaskActivation, ProcessingResult
+
 logger = logging.getLogger("sentry.taskworker.worker")
 
 AT_MOST_ONCE_TIMEOUT = 60 * 60 * 24  # 1 day
@@ -31,14 +32,6 @@ AT_MOST_ONCE_TIMEOUT = 60 * 60 * 24  # 1 day
 
 class ProcessingDeadlineExceeded(BaseException):
     pass
-
-
-@dataclasses.dataclass
-class ProcessingResult:
-    """Result structure from child processess to parent"""
-
-    task_id: str
-    status: TaskActivationStatus.ValueType
 
 
 def child_worker_init(process_type: str) -> None:
@@ -95,7 +88,7 @@ def status_name(status: TaskActivationStatus.ValueType) -> str:
 
 
 def child_process(
-    child_tasks: queue.Queue[TaskActivation],
+    child_tasks: queue.Queue[InflightTaskActivation],
     processed_tasks: queue.Queue[ProcessingResult],
     shutdown_event: Event,
     max_task_count: int | None,
@@ -139,7 +132,7 @@ def child_process(
         return namespace.get(activation.taskname)
 
     def run_worker(
-        child_tasks: queue.Queue[TaskActivation],
+        child_tasks: queue.Queue[InflightTaskActivation],
         processed_tasks: queue.Queue[ProcessingResult],
         shutdown_event: Event,
         max_task_count: int | None,
@@ -178,7 +171,7 @@ def child_process(
                 break
 
             try:
-                activation = child_tasks.get(timeout=1.0)
+                inflight = child_tasks.get(timeout=1.0)
             except queue.Empty:
                 metrics.incr(
                     "taskworker.worker.child_task_queue_empty",
@@ -186,29 +179,38 @@ def child_process(
                 )
                 continue
 
-            task_func = _get_known_task(activation)
+            task_func = _get_known_task(inflight.activation)
             if not task_func:
                 metrics.incr(
                     "taskworker.worker.unknown_task",
                     tags={
-                        "namespace": activation.namespace,
-                        "taskname": activation.taskname,
+                        "namespace": inflight.activation.namespace,
+                        "taskname": inflight.activation.taskname,
                         "processing_pool": processing_pool_name,
                     },
                 )
                 processed_tasks.put(
-                    ProcessingResult(task_id=activation.id, status=TASK_ACTIVATION_STATUS_FAILURE)
+                    ProcessingResult(
+                        task_id=inflight.activation.id,
+                        status=TASK_ACTIVATION_STATUS_FAILURE,
+                        host=inflight.host,
+                        receive_timestamp=inflight.receive_timestamp,
+                    )
                 )
                 continue
 
             if task_func.at_most_once:
-                key = get_at_most_once_key(activation.namespace, activation.taskname, activation.id)
+                key = get_at_most_once_key(
+                    inflight.activation.namespace,
+                    inflight.activation.taskname,
+                    inflight.activation.id,
+                )
                 if cache.add(key, "1", timeout=AT_MOST_ONCE_TIMEOUT):  # The key didn't exist
                     metrics.incr(
                         "taskworker.task.at_most_once.executed",
                         tags={
-                            "namespace": activation.namespace,
-                            "taskname": activation.taskname,
+                            "namespace": inflight.activation.namespace,
+                            "taskname": inflight.activation.taskname,
                             "processing_pool": processing_pool_name,
                         },
                     )
@@ -216,46 +218,46 @@ def child_process(
                     metrics.incr(
                         "taskworker.worker.at_most_once.skipped",
                         tags={
-                            "namespace": activation.namespace,
-                            "taskname": activation.taskname,
+                            "namespace": inflight.activation.namespace,
+                            "taskname": inflight.activation.taskname,
                             "processing_pool": processing_pool_name,
                         },
                     )
                     continue
 
-            set_current_task(activation)
+            set_current_task(inflight.activation)
 
             next_state = TASK_ACTIVATION_STATUS_FAILURE
             # Use time.time() so we can measure against activation.received_at
             execution_start_time = time.time()
             try:
-                with timeout_alarm(activation.processing_deadline_duration, handle_alarm):
-                    _execute_activation(task_func, activation)
+                with timeout_alarm(inflight.activation.processing_deadline_duration, handle_alarm):
+                    _execute_activation(task_func, inflight.activation)
                 next_state = TASK_ACTIVATION_STATUS_COMPLETE
             except ProcessingDeadlineExceeded as err:
                 with sentry_sdk.isolation_scope() as scope:
                     scope.fingerprint = [
                         "taskworker.processing_deadline_exceeded",
-                        activation.namespace,
-                        activation.taskname,
+                        inflight.activation.namespace,
+                        inflight.activation.taskname,
                     ]
                     sentry_sdk.capture_exception(err)
                 metrics.incr(
                     "taskworker.worker.processing_deadline_exceeded",
                     tags={
                         "processing_pool": processing_pool_name,
-                        "namespace": activation.namespace,
-                        "taskname": activation.taskname,
+                        "namespace": inflight.activation.namespace,
+                        "taskname": inflight.activation.taskname,
                     },
                 )
                 next_state = TASK_ACTIVATION_STATUS_FAILURE
             except Exception as err:
-                if task_func.should_retry(activation.retry_state, err):
+                if task_func.should_retry(inflight.activation.retry_state, err):
                     logger.info(
                         "taskworker.task.retry",
                         extra={
-                            "namespace": activation.namespace,
-                            "taskname": activation.taskname,
+                            "namespace": inflight.activation.namespace,
+                            "taskname": inflight.activation.taskname,
                             "processing_pool": processing_pool_name,
                         },
                     )
@@ -275,10 +277,17 @@ def child_process(
                     "processing_pool": processing_pool_name,
                 },
             ):
-                processed_tasks.put(ProcessingResult(task_id=activation.id, status=next_state))
+                processed_tasks.put(
+                    ProcessingResult(
+                        task_id=inflight.activation.id,
+                        status=next_state,
+                        host=inflight.host,
+                        receive_timestamp=inflight.receive_timestamp,
+                    )
+                )
 
             record_task_execution(
-                activation,
+                inflight.activation,
                 next_state,
                 execution_start_time,
                 execution_complete_time,

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -23,7 +23,8 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 from sentry_sdk.consts import OP, SPANDATA, SPANSTATUS
 from sentry_sdk.crons import MonitorStatus, capture_checkin
 
-from sentry.taskworker.client import InflightTaskActivation, ProcessingResult
+from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
+from sentry.taskworker.client.processing_result import ProcessingResult
 
 logger = logging.getLogger("sentry.taskworker.worker")
 

--- a/tests/sentry/taskworker/test_client.py
+++ b/tests/sentry/taskworker/test_client.py
@@ -17,7 +17,7 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
     TaskActivation,
 )
 
-from sentry.taskworker.client import HostTemporarilyUnavailable, TaskworkerClient
+from sentry.taskworker.client import HostTemporarilyUnavailable, ProcessingResult, TaskworkerClient
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
@@ -126,8 +126,9 @@ def test_get_task_ok():
         result = client.get_task()
 
         assert result
-        assert result.id
-        assert result.namespace == "testing"
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id
+        assert result.activation.namespace == "testing"
 
 
 @django_db_all
@@ -159,8 +160,9 @@ def test_get_task_with_interceptor():
         result = client.get_task()
 
         assert result
-        assert result.id
-        assert result.namespace == "testing"
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id
+        assert result.activation.namespace == "testing"
 
 
 @django_db_all
@@ -185,8 +187,9 @@ def test_get_task_with_namespace():
         result = client.get_task(namespace="testing")
 
         assert result
-        assert result.id
-        assert result.namespace == "testing"
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id
+        assert result.activation.namespace == "testing"
 
 
 @django_db_all
@@ -237,13 +240,15 @@ def test_update_task_ok_with_next():
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
         client = TaskworkerClient("localhost:50051", 1)
-        client._task_id_to_host = {"abc123": "localhost-0:50051"}
         assert set(client._host_to_stubs.keys()) == {"localhost-0:50051"}
         result = client.update_task(
-            "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
+            ProcessingResult("abc123", TASK_ACTIVATION_STATUS_RETRY, "localhost-0:50051", 0),
+            FetchNextTask(namespace=None),
         )
+
         assert result
-        assert result.id == "abc123"
+        assert result.host == "localhost-0:50051"
+        assert result.activation.id == "abc123"
 
 
 @django_db_all
@@ -265,13 +270,18 @@ def test_update_task_ok_with_next_namespace():
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
         client = TaskworkerClient("localhost:50051", 1)
-        client._task_id_to_host = {"abc123": "localhost-0:50051"}
         result = client.update_task(
-            "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace="testing")
+            ProcessingResult(
+                task_id="id",
+                status=TASK_ACTIVATION_STATUS_RETRY,
+                host="localhost-0:50051",
+                receive_timestamp=0,
+            ),
+            FetchNextTask(namespace="testing"),
         )
         assert result
-        assert result.id == "abc123"
-        assert result.namespace == "testing"
+        assert result.activation.id == "abc123"
+        assert result.activation.namespace == "testing"
 
 
 @django_db_all
@@ -284,7 +294,13 @@ def test_update_task_ok_no_next():
         mock_channel.return_value = channel
         client = TaskworkerClient("localhost:50051", 1)
         result = client.update_task(
-            "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
+            ProcessingResult(
+                task_id="abc123",
+                status=TASK_ACTIVATION_STATUS_RETRY,
+                host="localhost-0:50051",
+                receive_timestamp=0,
+            ),
+            FetchNextTask(namespace=None),
         )
         assert result is None
 
@@ -299,9 +315,14 @@ def test_update_task_not_found():
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
         client = TaskworkerClient("localhost:50051", 1)
-        client._task_id_to_host = {"abc123": "localhost-0:50051"}
         result = client.update_task(
-            "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
+            ProcessingResult(
+                task_id="abc123",
+                status=TASK_ACTIVATION_STATUS_RETRY,
+                host="localhost-0:50051",
+                receive_timestamp=0,
+            ),
+            FetchNextTask(namespace=None),
         )
         assert result is None
 
@@ -316,13 +337,17 @@ def test_update_task_unavailable_retain_task_to_host():
     with patch("sentry.taskworker.client.grpc.insecure_channel") as mock_channel:
         mock_channel.return_value = channel
         client = TaskworkerClient("localhost:50051", 1)
-        client._task_id_to_host = {"abc123": "localhost-0:50051"}
         with pytest.raises(MockGrpcError) as err:
             client.update_task(
-                "abc123", TASK_ACTIVATION_STATUS_RETRY, FetchNextTask(namespace=None)
+                ProcessingResult(
+                    task_id="abc123",
+                    status=TASK_ACTIVATION_STATUS_RETRY,
+                    host="localhost-0:50051",
+                    receive_timestamp=0,
+                ),
+                FetchNextTask(namespace=None),
             )
         assert "broker down" in str(err.value)
-        assert client._task_id_to_host == {"abc123": "localhost-0:50051"}
 
 
 @django_db_all
@@ -413,41 +438,38 @@ def test_client_loadbalance():
             )
 
             task_0 = client.get_task()
-            assert task_0 is not None and task_0.id == "0"
+            assert task_0 is not None and task_0.activation.id == "0"
             task_1 = client.get_task()
-            assert task_1 is not None and task_1.id == "1"
+            assert task_1 is not None and task_1.activation.id == "1"
             task_2 = client.get_task()
-            assert task_2 is not None and task_2.id == "2"
+            assert task_2 is not None and task_2.activation.id == "2"
             task_3 = client.get_task()
-            assert task_3 is not None and task_3.id == "3"
+            assert task_3 is not None and task_3.activation.id == "3"
 
-            assert client._task_id_to_host == {
-                "0": "localhost-0:50051",
-                "1": "localhost-1:50051",
-                "2": "localhost-2:50051",
-                "3": "localhost-3:50051",
-            }
-
-            client.update_task(task_0.id, TASK_ACTIVATION_STATUS_COMPLETE, None)
-            assert client._task_id_to_host == {
-                "1": "localhost-1:50051",
-                "2": "localhost-2:50051",
-                "3": "localhost-3:50051",
-            }
-
-            client.update_task(task_1.id, TASK_ACTIVATION_STATUS_COMPLETE, None)
-            assert client._task_id_to_host == {
-                "2": "localhost-2:50051",
-                "3": "localhost-3:50051",
-            }
-
-            client.update_task(task_2.id, TASK_ACTIVATION_STATUS_COMPLETE, None)
-            assert client._task_id_to_host == {
-                "3": "localhost-3:50051",
-            }
-
-            client.update_task(task_3.id, TASK_ACTIVATION_STATUS_COMPLETE, None)
-            assert client._task_id_to_host == {}
+            client.update_task(
+                ProcessingResult(
+                    task_0.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_0.host, 0
+                ),
+                None,
+            )
+            client.update_task(
+                ProcessingResult(
+                    task_1.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_1.host, 0
+                ),
+                None,
+            )
+            client.update_task(
+                ProcessingResult(
+                    task_2.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_2.host, 0
+                ),
+                None,
+            )
+            client.update_task(
+                ProcessingResult(
+                    task_3.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_3.host, 0
+                ),
+                None,
+            )
 
 
 @django_db_all
@@ -510,24 +532,20 @@ def test_client_loadbalance_on_notfound():
 
             # Fetch again, this time from channel_1
             task_1 = client.get_task()
-            assert task_1 and task_1.id == "1"
+            assert task_1 and task_1.activation.id == "1"
 
-            assert client._task_id_to_host == {
-                "1": "localhost-1:50051",
-            }
-
-            res = client.update_task(task_1.id, TASK_ACTIVATION_STATUS_COMPLETE, None)
+            res = client.update_task(
+                ProcessingResult(
+                    task_1.activation.id, TASK_ACTIVATION_STATUS_COMPLETE, task_1.host, 0
+                ),
+                None,
+            )
             assert res is None
-            assert client._task_id_to_host == {}
 
             # Because SetStatus on channel_1 returned notfound the client
             # should switch brokers.
             task_2 = client.get_task()
-            assert task_2 and task_2.id == "2"
-
-            assert client._task_id_to_host == {
-                "2": "localhost-2:50051",
-            }
+            assert task_2 and task_2.activation.id == "2"
 
 
 @django_db_all
@@ -589,7 +607,7 @@ def test_client_loadbalance_on_unavailable():
 
             # Should rebalance to the second host and receive task
             task = client.get_task()
-            assert task and task.id == "1"
+            assert task and task.activation.id == "1"
             assert client._num_consecutive_unavailable_errors == 0
 
 
@@ -680,7 +698,7 @@ def test_client_reset_errors_after_success():
         assert client._num_consecutive_unavailable_errors == 1
 
         task = client.get_task()
-        assert task and task.id == "1"
+        assert task and task.activation.id == "1"
         assert client._num_consecutive_unavailable_errors == 0
 
         with pytest.raises(grpc.RpcError, match="host is unavailable"):
@@ -736,9 +754,8 @@ def test_client_update_task_host_unavailable():
 
         # Get a task to establish the host mapping
         task = client.get_task()
-        assert task and task.id == "1"
-        assert "1" in client._task_id_to_host
-        host = client._task_id_to_host["1"]
+        assert task and task.activation.id == "1"
+        host = task.host
 
         # Make the host temporarily unavailable
         for _ in range(3):
@@ -752,9 +769,11 @@ def test_client_update_task_host_unavailable():
             HostTemporarilyUnavailable, match=f"Host: {host} is temporarily unavailable"
         ):
             client.update_task(
-                task_id="1", status=TASK_ACTIVATION_STATUS_COMPLETE, fetch_next_task=None
+                ProcessingResult(
+                    task_id="1",
+                    status=TASK_ACTIVATION_STATUS_COMPLETE,
+                    host=host,
+                    receive_timestamp=0,
+                ),
+                fetch_next_task=None,
             )
-
-        # Task get skipped, but still be in the mapping since we didn't process it
-        assert "1" in client._task_id_to_host
-        assert client._task_id_to_host["1"] == host

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -16,7 +16,8 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 from sentry_sdk.crons import MonitorStatus
 from usageaccountant import UsageUnit
 
-from sentry.taskworker.client import InflightTaskActivation, ProcessingResult
+from sentry.taskworker.client.inflight_task_activation import InflightTaskActivation
+from sentry.taskworker.client.processing_result import ProcessingResult
 from sentry.taskworker.state import current_task
 from sentry.taskworker.worker import TaskWorker
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded, child_process

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -16,81 +16,106 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
 from sentry_sdk.crons import MonitorStatus
 from usageaccountant import UsageUnit
 
+from sentry.taskworker.client import InflightTaskActivation, ProcessingResult
 from sentry.taskworker.state import current_task
 from sentry.taskworker.worker import TaskWorker
-from sentry.taskworker.workerchild import (
-    ProcessingDeadlineExceeded,
-    ProcessingResult,
-    child_process,
-)
+from sentry.taskworker.workerchild import ProcessingDeadlineExceeded, child_process
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.utils.redis import redis_clusters
 
-SIMPLE_TASK = TaskActivation(
-    id="111",
-    taskname="examples.simple_task",
-    namespace="examples",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-)
-
-RETRY_TASK = TaskActivation(
-    id="222",
-    taskname="examples.retry_task",
-    namespace="examples",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-)
-
-FAIL_TASK = TaskActivation(
-    id="333",
-    taskname="examples.fail_task",
-    namespace="examples",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-)
-
-UNDEFINED_TASK = TaskActivation(
-    id="444",
-    taskname="total.rubbish",
-    namespace="lolnope",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-)
-
-AT_MOST_ONCE_TASK = TaskActivation(
-    id="555",
-    taskname="examples.at_most_once",
-    namespace="examples",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-)
-
-RETRY_STATE_TASK = TaskActivation(
-    id="654",
-    taskname="examples.retry_state",
-    namespace="examples",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-    retry_state=RetryState(
-        # no more attempts left
-        attempts=1,
-        max_attempts=2,
-        on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
+SIMPLE_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="111",
+        taskname="examples.simple_task",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
     ),
 )
 
-SCHEDULED_TASK = TaskActivation(
-    id="111",
-    taskname="examples.simple_task",
-    namespace="examples",
-    parameters='{"args": [], "kwargs": {}}',
-    processing_deadline_duration=2,
-    headers={
-        "sentry-monitor-slug": "simple-task",
-        "sentry-monitor-check-in-id": "abc123",
-    },
+RETRY_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="222",
+        taskname="examples.retry_task",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+    ),
+)
+
+FAIL_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="333",
+        taskname="examples.fail_task",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+    ),
+)
+
+UNDEFINED_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="444",
+        taskname="total.rubbish",
+        namespace="lolnope",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+    ),
+)
+
+AT_MOST_ONCE_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="555",
+        taskname="examples.at_most_once",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+    ),
+)
+
+RETRY_STATE_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="654",
+        taskname="examples.retry_state",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+        retry_state=RetryState(
+            # no more attempts left
+            attempts=1,
+            max_attempts=2,
+            on_attempts_exceeded=ON_ATTEMPTS_EXCEEDED_DISCARD,
+        ),
+    ),
+)
+
+SCHEDULED_TASK = InflightTaskActivation(
+    host="localhost:50051",
+    receive_timestamp=0,
+    activation=TaskActivation(
+        id="111",
+        taskname="examples.simple_task",
+        namespace="examples",
+        parameters='{"args": [], "kwargs": {}}',
+        processing_deadline_duration=2,
+        headers={
+            "sentry-monitor-slug": "simple-task",
+            "sentry-monitor-check-in-id": "abc123",
+        },
+    ),
 )
 
 
@@ -114,7 +139,7 @@ class TestTaskWorker(TestCase):
             mock_get.assert_called_once()
 
         assert task
-        assert task.id == SIMPLE_TASK.id
+        assert task.activation.id == SIMPLE_TASK.activation.id
 
     def test_fetch_no_task(self) -> None:
         taskworker = TaskWorker(
@@ -150,9 +175,13 @@ class TestTaskWorker(TestCase):
 
             taskworker.shutdown()
             assert mock_client.get_task.called
-            mock_client.update_task.assert_called_with(
-                task_id=SIMPLE_TASK.id, status=TASK_ACTIVATION_STATUS_COMPLETE, fetch_next_task=None
+            assert mock_client.update_task.call_count == 1
+            assert mock_client.update_task.call_args.args[0].host == "localhost:50051"
+            assert mock_client.update_task.call_args.args[0].task_id == SIMPLE_TASK.activation.id
+            assert (
+                mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
+            assert mock_client.update_task.call_args.args[1] is None
 
     def test_run_once_with_next_task(self) -> None:
         # Cover the scenario where update_task returns the next task which should
@@ -186,9 +215,12 @@ class TestTaskWorker(TestCase):
             taskworker.shutdown()
             assert mock_client.get_task.called
             assert mock_client.update_task.call_count == 2
-            mock_client.update_task.assert_called_with(
-                task_id=SIMPLE_TASK.id, status=TASK_ACTIVATION_STATUS_COMPLETE, fetch_next_task=None
+            assert mock_client.update_task.call_args.args[0].host == "localhost:50051"
+            assert mock_client.update_task.call_args.args[0].task_id == SIMPLE_TASK.activation.id
+            assert (
+                mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
+            assert mock_client.update_task.call_args.args[1] is None
 
     def test_run_once_with_update_failure(self) -> None:
         # Cover the scenario where update_task fails a few times in a row
@@ -264,11 +296,15 @@ class TestTaskWorker(TestCase):
             assert mock_client.get_task.called
             assert mock_client.update_task.call_count == 1
             # status is complete, as retry_state task handles the NoRetriesRemainingError
-            mock_client.update_task.assert_called_with(
-                task_id=RETRY_STATE_TASK.id,
-                status=TASK_ACTIVATION_STATUS_COMPLETE,
-                fetch_next_task=None,
+            assert mock_client.update_task.call_args.args[0].host == "localhost:50051"
+            assert (
+                mock_client.update_task.call_args.args[0].task_id == RETRY_STATE_TASK.activation.id
             )
+            assert (
+                mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
+            )
+            assert mock_client.update_task.call_args.args[1] is None
+
             redis = redis_clusters.get("default")
             assert current_task() is None, "should clear current task on completion"
             assert redis.get("no-retries-remaining"), "key should exist if except block was hit"
@@ -278,7 +314,7 @@ class TestTaskWorker(TestCase):
 @pytest.mark.django_db
 @mock.patch("sentry.taskworker.workerchild.capture_checkin")
 def test_child_process_complete(mock_capture_checkin) -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -294,21 +330,25 @@ def test_child_process_complete(mock_capture_checkin) -> None:
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == SIMPLE_TASK.id
+    assert result.task_id == SIMPLE_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
     assert mock_capture_checkin.call_count == 0
 
 
 @pytest.mark.django_db
 def test_child_process_remove_start_time_kwargs() -> None:
-    activation = TaskActivation(
-        id="6789",
-        taskname="examples.will_retry",
-        namespace="examples",
-        parameters='{"args": ["stuff"], "kwargs": {"__start_time": 123}}',
-        processing_deadline_duration=100000,
+    activation = InflightTaskActivation(
+        host="localhost:50051",
+        receive_timestamp=0,
+        activation=TaskActivation(
+            id="6789",
+            taskname="examples.will_retry",
+            namespace="examples",
+            parameters='{"args": ["stuff"], "kwargs": {"__start_time": 123}}',
+            processing_deadline_duration=100000,
+        ),
     )
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -324,14 +364,14 @@ def test_child_process_remove_start_time_kwargs() -> None:
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == activation.id
+    assert result.task_id == activation.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
 
 @pytest.mark.django_db
 @mock.patch("sentry.usage_accountant.record")
 def test_child_process_complete_record_usage(mock_record: mock.Mock) -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -349,7 +389,7 @@ def test_child_process_complete_record_usage(mock_record: mock.Mock) -> None:
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == SIMPLE_TASK.id
+    assert result.task_id == SIMPLE_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
     assert mock_record.call_count == 1
@@ -363,7 +403,7 @@ def test_child_process_complete_record_usage(mock_record: mock.Mock) -> None:
 
 @pytest.mark.django_db
 def test_child_process_retry_task() -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -379,13 +419,13 @@ def test_child_process_retry_task() -> None:
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == RETRY_TASK.id
+    assert result.task_id == RETRY_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_RETRY
 
 
 @pytest.mark.django_db
 def test_child_process_failure_task() -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -401,13 +441,13 @@ def test_child_process_failure_task() -> None:
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == FAIL_TASK.id
+    assert result.task_id == FAIL_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_FAILURE
 
 
 @pytest.mark.django_db
 def test_child_process_shutdown() -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
     shutdown.set()
@@ -429,7 +469,7 @@ def test_child_process_shutdown() -> None:
 
 @pytest.mark.django_db
 def test_child_process_unknown_task() -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -445,17 +485,17 @@ def test_child_process_unknown_task() -> None:
     )
 
     result = processed.get()
-    assert result.task_id == UNDEFINED_TASK.id
+    assert result.task_id == UNDEFINED_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_FAILURE
 
     result = processed.get()
-    assert result.task_id == SIMPLE_TASK.id
+    assert result.task_id == SIMPLE_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
 
 @pytest.mark.django_db
 def test_child_process_at_most_once() -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -473,18 +513,18 @@ def test_child_process_at_most_once() -> None:
 
     assert todo.empty()
     result = processed.get(block=False)
-    assert result.task_id == AT_MOST_ONCE_TASK.id
+    assert result.task_id == AT_MOST_ONCE_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
     result = processed.get(block=False)
-    assert result.task_id == SIMPLE_TASK.id
+    assert result.task_id == SIMPLE_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
 
 @pytest.mark.django_db
 @mock.patch("sentry.taskworker.workerchild.capture_checkin")
 def test_child_process_record_checkin(mock_capture_checkin: mock.Mock) -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
@@ -500,7 +540,7 @@ def test_child_process_record_checkin(mock_capture_checkin: mock.Mock) -> None:
 
     assert todo.empty()
     result = processed.get()
-    assert result.task_id == SIMPLE_TASK.id
+    assert result.task_id == SIMPLE_TASK.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_COMPLETE
 
     assert mock_capture_checkin.call_count == 1
@@ -515,16 +555,20 @@ def test_child_process_record_checkin(mock_capture_checkin: mock.Mock) -> None:
 @pytest.mark.django_db
 @mock.patch("sentry.taskworker.workerchild.sentry_sdk.capture_exception")
 def test_child_process_terminate_task(mock_capture: mock.Mock) -> None:
-    todo: queue.Queue[TaskActivation] = queue.Queue()
+    todo: queue.Queue[InflightTaskActivation] = queue.Queue()
     processed: queue.Queue[ProcessingResult] = queue.Queue()
     shutdown = Event()
 
-    sleepy = TaskActivation(
-        id="111",
-        taskname="examples.timed",
-        namespace="examples",
-        parameters='{"args": [3], "kwargs": {}}',
-        processing_deadline_duration=1,
+    sleepy = InflightTaskActivation(
+        host="localhost:50051",
+        receive_timestamp=0,
+        activation=TaskActivation(
+            id="111",
+            taskname="examples.timed",
+            namespace="examples",
+            parameters='{"args": [3], "kwargs": {}}',
+            processing_deadline_duration=1,
+        ),
     )
 
     todo.put(sleepy)
@@ -539,7 +583,7 @@ def test_child_process_terminate_task(mock_capture: mock.Mock) -> None:
 
     assert todo.empty()
     result = processed.get(block=False)
-    assert result.task_id == sleepy.id
+    assert result.task_id == sleepy.activation.id
     assert result.status == TASK_ACTIVATION_STATUS_FAILURE
     assert mock_capture.call_count == 1
     assert type(mock_capture.call_args.args[0]) is ProcessingDeadlineExceeded


### PR DESCRIPTION
This PR enriches task activation with additional metadata like broker IP and receive timestamp. 

Within task workers, we currently store a map of task → host pairs. This map is updated when tasks are received by a worker, and then used to ensure that results are published back to the same broker. When we send the result of a task to the broker, the task → host pair is evicted from the map.

It is possible for a worker to receive the same task twice during broker restarts, we are unable to publish results to the broker upon the second status update.

An easy solution would be to keep a counter in the map that tracks the number of times a task exists within the pipeline, but we already have 2 of these task → xyz mapping in the client, another being latency metrics and are planning to add more.