### PR TITLE
fix(search): Fix errant selection after cmd+a and typing

### DIFF
--- a/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
+++ b/static/app/components/searchQueryBuilder/selectionKeyHandler.tsx
@@ -131,13 +131,14 @@ export function SelectionKeyHandler({ref, state, undo}: SelectionKeyHandlerProps
             return;
           }
 
-          // If th key pressed will generate a symbol, replace the selection with it
+          // If the key pressed will generate a symbol, replace the selection with it
           if (/^.$/u.test(e.key)) {
             dispatch({
               type: 'REPLACE_TOKENS_WITH_TEXT',
               text: e.key,
               tokens: selectedTokens,
             });
+            state.selectionManager.clearSelection();
             e.preventDefault();
             e.stopPropagation();
           }


### PR DESCRIPTION
Can reproduce by:

- Selecting all tokens with cmd+a
- Typing a character

The selection will stay over everything, which means that the text will have a gray background.

Not sure how this was working before, but we just need to clear the selection in this case.