### PR TITLE
feat(trace-eap-waterfall): Adding support for sibling autogroup in eap traces

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.autogrouping.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.autogrouping.spec.tsx.snap
@@ -193,6 +193,70 @@ trace root
 "
 `;
 
+exports[`autogrouping sibling autogrouping eap traces collapsing sibling autogroup removes its children 1`] = `
+"
+eap trace root
+  http.server - redis
+    sibling autogroup (db: 5)
+      db - redis
+      db - redis
+      db - redis
+      db - redis
+      db - redis
+"
+`;
+
+exports[`autogrouping sibling autogrouping eap traces collapsing sibling autogroup removes its children 2`] = `
+"
+eap trace root
+  http.server - redis
+    sibling autogroup (db: 5)
+"
+`;
+
+exports[`autogrouping sibling autogrouping eap traces does not autogroup if count is less 5 1`] = `
+"
+eap trace root
+  http.server - redis
+    db - redis
+    db - redis
+    db - redis
+"
+`;
+
+exports[`autogrouping sibling autogrouping eap traces expanding sibling autogroup renders its children 1`] = `
+"
+eap trace root
+  http.server - redis
+    sibling autogroup (db: 5)
+      db - redis
+      db - redis
+      db - redis
+      db - redis
+      db - redis
+"
+`;
+
+exports[`autogrouping sibling autogrouping eap traces groups spans with the same op and description 1`] = `
+"
+eap trace root
+  http.server - redis
+    sibling autogroup (db: 5)
+"
+`;
+
+exports[`autogrouping sibling autogrouping eap traces removes sibling autogroup 1`] = `
+"
+eap trace root
+  http.server - redis
+    db - redis
+    db - redis
+    db - redis
+    db - redis
+    db - redis
+"
+`;
+
 exports[`autogrouping sibling autogrouping expanding sibling autogroup renders its children 1`] = `
 "
 trace root

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.autogrouping.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.autogrouping.spec.tsx
@@ -57,6 +57,56 @@ const siblingAutogroupSpans = [
   }),
 ];
 
+const siblingAutogroupEAPSpans = [
+  makeEAPSpan({
+    op: 'http.server',
+    description: 'redis',
+    event_id: '0000',
+    children: [
+      makeEAPSpan({
+        event_id: '0001',
+        op: 'db',
+        description: 'redis',
+        start_timestamp: start,
+        end_timestamp: start + 1,
+        parent_span_id: '0000',
+      }),
+      makeEAPSpan({
+        event_id: '0002',
+        op: 'db',
+        description: 'redis',
+        start_timestamp: start,
+        end_timestamp: start + 1,
+        parent_span_id: '0000',
+      }),
+      makeEAPSpan({
+        event_id: '0003',
+        op: 'db',
+        description: 'redis',
+        start_timestamp: start,
+        end_timestamp: start + 1,
+        parent_span_id: '0000',
+      }),
+      makeEAPSpan({
+        event_id: '0004',
+        op: 'db',
+        description: 'redis',
+        start_timestamp: start,
+        end_timestamp: start + 1,
+        parent_span_id: '0000',
+      }),
+      makeEAPSpan({
+        event_id: '0005',
+        op: 'db',
+        description: 'redis',
+        start_timestamp: start,
+        end_timestamp: start + 1,
+        parent_span_id: '0000',
+      }),
+    ],
+  }),
+];
+
 const parentAutogroupSpans = [
   makeSpan({op: 'db', description: 'redis', span_id: '0000'}),
   makeSpan({op: 'db', description: 'redis', span_id: '0001', parent_span_id: '0000'}),
@@ -538,5 +588,119 @@ describe('autogrouping', () => {
     it.todo(
       'collects errors, performance issues and profiles from sibling autogroup chain'
     );
+
+    describe('eap traces', () => {
+      it('groups spans with the same op and description', () => {
+        const tree = TraceTree.FromTrace(
+          makeEAPTrace(siblingAutogroupEAPSpans),
+          traceMetadata
+        );
+
+        TraceTree.AutogroupSiblingSpanNodes(tree.root);
+        expect(tree.build().serialize()).toMatchSnapshot();
+      });
+
+      it('does not autogroup if count is less 5', () => {
+        const tree = TraceTree.FromTrace(
+          makeEAPTrace([
+            makeEAPSpan({
+              op: 'http.server',
+              description: 'redis',
+              event_id: '0000',
+              children: [
+                makeEAPSpan({
+                  event_id: '0001',
+                  op: 'db',
+                  description: 'redis',
+                  start_timestamp: start,
+                  end_timestamp: start + 1,
+                  parent_span_id: '0000',
+                }),
+                makeEAPSpan({
+                  event_id: '0002',
+                  op: 'db',
+                  description: 'redis',
+                  start_timestamp: start,
+                  end_timestamp: start + 1,
+                  parent_span_id: '0000',
+                }),
+                makeEAPSpan({
+                  event_id: '0003',
+                  op: 'db',
+                  description: 'redis',
+                  start_timestamp: start,
+                  end_timestamp: start + 1,
+                  parent_span_id: '0000',
+                }),
+              ],
+            }),
+          ]),
+          traceMetadata
+        );
+
+        TraceTree.AutogroupSiblingSpanNodes(tree.root);
+
+        expect(tree.build().serialize()).toMatchSnapshot();
+      });
+
+      it('expanding sibling autogroup renders its children', () => {
+        const tree = TraceTree.FromTrace(
+          makeEAPTrace(siblingAutogroupEAPSpans),
+          traceMetadata
+        );
+
+        TraceTree.AutogroupSiblingSpanNodes(tree.root);
+
+        TraceTree.ForEachChild(tree.root, c => {
+          if (isSiblingAutogroupedNode(c)) {
+            tree.expand(c, true);
+          }
+        });
+
+        expect(tree.build().serialize()).toMatchSnapshot();
+      });
+
+      it('collapsing sibling autogroup removes its children', () => {
+        const tree = TraceTree.FromTrace(
+          makeEAPTrace(siblingAutogroupEAPSpans),
+          traceMetadata
+        );
+
+        TraceTree.AutogroupSiblingSpanNodes(tree.root);
+
+        TraceTree.ForEachChild(tree.root, c => {
+          if (isSiblingAutogroupedNode(c)) {
+            tree.expand(c, true);
+          }
+        });
+        expect(tree.build().serialize()).toMatchSnapshot();
+        TraceTree.ForEachChild(tree.root, c => {
+          if (isSiblingAutogroupedNode(c)) {
+            tree.expand(c, false);
+          }
+        });
+        expect(tree.build().serialize()).toMatchSnapshot();
+      });
+
+      it('removes sibling autogroup', () => {
+        const tree = TraceTree.FromTrace(
+          makeEAPTrace(siblingAutogroupEAPSpans),
+          traceMetadata
+        );
+
+        const snapshot = tree.build().serialize();
+
+        // Add sibling autogroup
+        TraceTree.AutogroupSiblingSpanNodes(tree.root);
+        expect(
+          TraceTree.Find(tree.root, c => isSiblingAutogroupedNode(c))
+        ).not.toBeNull();
+
+        // Remove it and assert that the tree is back to the original state
+        TraceTree.RemoveSiblingAutogroupNodes(tree.root);
+        expect(tree.build().serialize()).toEqual(snapshot);
+        expect(tree.build().serialize()).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -232,23 +232,21 @@ export declare namespace TraceTree {
     timestamp: number;
     type: 'missing_instrumentation';
   }
-  interface SiblingAutogroup extends Span {
+
+  interface BaseAutogroup {
+    op: string;
+    span_id: string;
+    description?: string;
+  }
+
+  interface SiblingAutogroup extends BaseAutogroup {
     autogrouped_by: {
       description: string;
       op: string;
     };
   }
 
-  interface ChildrenAutogroup {
-    autogrouped_by: {
-      op: string;
-    };
-    op: string;
-    span_id: string;
-    description?: string;
-  }
-
-  interface EAPChildrenAutogroup extends EAPSpan {
+  interface ChildrenAutogroup extends BaseAutogroup {
     autogrouped_by: {
       op: string;
     };
@@ -358,6 +356,25 @@ export class TraceTree extends TraceTreeEventDispatcher {
     t.type = 'error';
     t.build();
     return t;
+  }
+
+  static ApplyPreferences(
+    root: TraceTreeNode<TraceTree.NodeValue>,
+    options: {
+      preferences?: Pick<TracePreferencesState, 'autogroup' | 'missing_instrumentation'>;
+    }
+  ): void {
+    if (options?.preferences?.missing_instrumentation) {
+      TraceTree.DetectMissingInstrumentation(root);
+    }
+
+    if (options?.preferences?.autogroup.parent) {
+      TraceTree.AutogroupDirectChildrenSpanNodes(root);
+    }
+
+    if (options?.preferences?.autogroup.sibling) {
+      TraceTree.AutogroupSiblingSpanNodes(root);
+    }
   }
 
   static FromTrace(
@@ -578,13 +595,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
     tree.indicators.sort((a, b) => a.start - b.start);
 
     if (isEAPTraceNode(traceNode)) {
-      if (options?.preferences?.missing_instrumentation) {
-        TraceTree.DetectMissingInstrumentation(tree.root);
-      }
-
-      if (options?.preferences?.autogroup.parent) {
-        TraceTree.AutogroupDirectChildrenSpanNodes(tree.root);
-      }
+      TraceTree.ApplyPreferences(tree.root, options);
     }
 
     return tree;
@@ -1058,18 +1069,22 @@ export class TraceTree extends TraceTreeEventDispatcher {
 
       while (index < node.children.length) {
         // Skip until we find a span candidate
-        if (!isSpanNode(node.children[index]!)) {
+        if (!isSpanNode(node.children[index]!) && !isEAPSpanNode(node.children[index]!)) {
           index++;
           matchCount = 0;
           continue;
         }
 
-        const current = node.children[index] as TraceTreeNode<TraceTree.Span>;
-        const next = node.children[index + 1] as TraceTreeNode<TraceTree.Span>;
+        const current = node.children[index] as
+          | TraceTreeNode<TraceTree.Span>
+          | TraceTreeNode<TraceTree.EAPSpan>;
+        const next = node.children[index + 1] as
+          | TraceTreeNode<TraceTree.Span>
+          | TraceTreeNode<TraceTree.EAPSpan>;
 
         if (
           next &&
-          isSpanNode(next) &&
+          (isSpanNode(next) || isEAPSpanNode(next)) &&
           next.children.length === 0 &&
           current.children.length === 0 &&
           // skip `op: default` spans as `default` is added to op-less spans
@@ -1089,7 +1104,11 @@ export class TraceTree extends TraceTreeEventDispatcher {
           const autoGroupedNode = new SiblingAutogroupNode(
             node,
             {
-              ...current.value,
+              span_id: isEAPSpanNode(current)
+                ? current.value.event_id
+                : current.value.span_id,
+              op: current.value.op ?? '',
+              description: current.value.description ?? '',
               autogrouped_by: {
                 op: current.value.op ?? '',
                 description: current.value.description ?? '',
@@ -1795,15 +1814,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
           this.dispatch('trace timeline change', this.root.space);
         }
 
-        if (options.preferences.missing_instrumentation) {
-          TraceTree.DetectMissingInstrumentation(root);
-        }
-        if (options.preferences.autogroup.sibling) {
-          TraceTree.AutogroupSiblingSpanNodes(root);
-        }
-        if (options.preferences.autogroup.parent) {
-          TraceTree.AutogroupDirectChildrenSpanNodes(root);
-        }
+        TraceTree.ApplyPreferences(root, options);
 
         if (index !== -1) {
           this.list.splice(index + 1, 0, ...TraceTree.VisibleChildren(node));

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1108,7 +1108,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
                 ? current.value.event_id
                 : current.value.span_id,
               op: current.value.op ?? '',
-              description: current.value.description ?? '',
+              description: current.value.description,
               autogrouped_by: {
                 op: current.value.op ?? '',
                 description: current.value.description ?? '',

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -441,15 +441,10 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     if (query.fov && typeof query.fov === 'string') {
       viewManager.maybeInitializeTraceViewFromQS(query.fov);
     }
-    if (traceStateRef.current.preferences.missing_instrumentation) {
-      TraceTree.DetectMissingInstrumentation(props.tree.root);
-    }
-    if (traceStateRef.current.preferences.autogroup.sibling) {
-      TraceTree.AutogroupSiblingSpanNodes(props.tree.root);
-    }
-    if (traceStateRef.current.preferences.autogroup.parent) {
-      TraceTree.AutogroupDirectChildrenSpanNodes(props.tree.root);
-    }
+
+    TraceTree.ApplyPreferences(props.tree.root, {
+      preferences: traceStateRef.current.preferences,
+    });
 
     // Construct the visual representation of the tree
     props.tree.build();


### PR DESCRIPTION
- Autogrouping `>= 5` sibling spans with the same op and description
- Added tests.
- Example demo org trace for testing: [link](https://demo.dev.getsentry.net:7999/explore/traces/trace/ec36300b1c6b478fa51bb5d2c50ab973/?mode=samples&node=span-a97f140573066e08&pageEnd&pageStart&project=-1&source=traces&statsPeriod=24h&tab=waterfall&table=trace&timestamp=1748977852.977) 
<img width="1243" alt="Screenshot 2025-06-03 at 11 48 12 PM" src="https://github.com/user-attachments/assets/1a96643f-17c1-4bce-9e51-8aa71e574b7d" />
