### PR TITLE
ref(settings): Rename auth tokens and merge nav sections

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -154,7 +154,7 @@ export default function SidebarDropdown({orientation, collapsed, hideOrgLinks}: 
                       {t('User settings')}
                     </SidebarMenuItem>
                     <SidebarMenuItem to="/settings/account/api/">
-                      {t('User auth tokens')}
+                      {t('Personal Tokens')}
                     </SidebarMenuItem>
                     {hasOrganization && (
                       <Hook

--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -198,7 +198,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       configurations: [
         {
           description: tct(
-            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Auth Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
+            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
               link: <Link to="/settings/auth-tokens/" />,
             }

--- a/static/app/gettingStartedDocs/java/log4j2.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.tsx
@@ -219,7 +219,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       configurations: [
         {
           description: tct(
-            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Auth Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
+            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
               link: <Link to="/settings/auth-tokens/" />,
             }

--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -224,7 +224,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       configurations: [
         {
           description: tct(
-            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Auth Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
+            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
               link: <Link to="/settings/auth-tokens/" />,
             }

--- a/static/app/gettingStartedDocs/java/spring-boot.tsx
+++ b/static/app/gettingStartedDocs/java/spring-boot.tsx
@@ -192,7 +192,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       configurations: [
         {
           description: tct(
-            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Auth Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
+            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
               link: <Link to="/settings/auth-tokens/" />,
             }

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -236,7 +236,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           description: (
             <p>
               {tct(
-                'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Auth Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
+                'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
                 {
                   link: <Link to="/settings/auth-tokens/" />,
                 }

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -160,7 +160,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
       configurations: [
         {
           description: tct(
-            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Auth Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
+            'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
               link: <Link to="/settings/auth-tokens/" />,
             }

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -415,18 +415,18 @@ function buildRoutes() {
       />
       <Route path="api/" name={t('API')}>
         <IndexRedirect to="auth-tokens/" />
-        <Route path="auth-tokens/" name={t('User Auth Tokens')}>
+        <Route path="auth-tokens/" name={t('Personal Tokens')}>
           <IndexRoute
             component={make(() => import('sentry/views/settings/account/apiTokens'))}
           />
           <Route
             path="new-token/"
-            name={t('Create New Token')}
+            name={t('Create Personal Token')}
             component={make(() => import('sentry/views/settings/account/apiNewToken'))}
           />
           <Route
             path=":tokenId/"
-            name={t('Edit User Auth Token')}
+            name={t('Edit Personal Token')}
             component={make(
               () => import('sentry/views/settings/account/apiTokenDetails')
             )}
@@ -983,20 +983,20 @@ function buildRoutes() {
           )}
         />
       </Route>
-      <Route path="auth-tokens/" name={t('Auth Tokens')}>
+      <Route path="auth-tokens/" name={t('Organization Tokens')}>
         <IndexRoute
           component={make(() => import('sentry/views/settings/organizationAuthTokens'))}
         />
         <Route
           path="new-token/"
-          name={t('Create New Auth Token')}
+          name={t('Create New Organization Token')}
           component={make(
             () => import('sentry/views/settings/organizationAuthTokens/newAuthToken')
           )}
         />
         <Route
           path=":tokenId/"
-          name={t('Edit Auth Token')}
+          name={t('Edit Organization Token')}
           component={make(
             () => import('sentry/views/settings/organizationAuthTokens/authTokenDetails')
           )}

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -10,7 +10,7 @@ import type SelectorItems from 'sentry/components/timeRangeSelector/selectorItem
 import type {TitleableModuleNames} from 'sentry/views/insights/common/components/modulePageProviders';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
-import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
+import type {NavigationSection} from 'sentry/views/settings/types';
 
 import type {Integration, IntegrationProvider} from './integrations';
 import type {
@@ -284,7 +284,6 @@ type OnboardingHooks = {
  * Settings navigation hooks.
  */
 type SettingsHooks = {
-  'settings:api-navigation-config': SettingsItemsHook;
   'settings:organization-navigation': OrganizationSettingsHook;
   'settings:organization-navigation-config': SettingsConfigHook;
 };
@@ -454,11 +453,6 @@ type OrganizationSettingsHook = (organization: Organization) => React.ReactEleme
  * Provides additional setting configurations
  */
 type SettingsConfigHook = (organization: Organization) => NavigationSection;
-
-/**
- * Provides additional setting navigation items
- */
-type SettingsItemsHook = (organization?: Organization) => NavigationItem[];
 
 /**
  * Each sidebar label is wrapped with this hook, to allow sidebar item

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -52,12 +52,12 @@ export default function ApiNewToken() {
   );
 
   return (
-    <SentryDocumentTitle title={t('Create User Auth Token')}>
+    <SentryDocumentTitle title={t('Create New Personal Token')}>
       <div>
-        <SettingsPageHeader title={t('Create New User Auth Token')} />
+        <SettingsPageHeader title={t('Create New Personal Token')} />
         <TextBlock>
           {t(
-            "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
+            "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
           )}
         </TextBlock>
         <TextBlock>

--- a/static/app/views/settings/account/apiTokenDetails.tsx
+++ b/static/app/views/settings/account/apiTokenDetails.tsx
@@ -116,8 +116,8 @@ function ApiTokenDetails({params}: Props) {
 
   return (
     <div>
-      <SentryDocumentTitle title={t('Edit User Auth Token')} />
-      <SettingsPageHeader title={t('Edit User Auth Token')} />
+      <SentryDocumentTitle title={t('Edit Personal Token')} />
+      <SettingsPageHeader title={t('Edit Personal Token')} />
 
       <TextBlock>
         {t(
@@ -133,12 +133,12 @@ function ApiTokenDetails({params}: Props) {
         )}
       </TextBlock>
       <Panel>
-        <PanelHeader>{t('User Auth Token Details')}</PanelHeader>
+        <PanelHeader>{t('Personal Token Details')}</PanelHeader>
 
         <PanelBody>
           {isError && (
             <LoadingError
-              message={t('Failed to load user auth token.')}
+              message={t('Failed to load personal token.')}
               onRetry={refetchToken}
             />
           )}

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -24,7 +24,7 @@ import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-const PAGE_TITLE = t('User Auth Tokens');
+const PAGE_TITLE = t('Personal Tokens');
 const API_TOKEN_QUERY_KEY = ['/api-tokens/'] as const;
 
 function ApiTokens() {
@@ -111,7 +111,7 @@ function ApiTokens() {
       <SettingsPageHeader title={PAGE_TITLE} action={action} />
       <TextBlock>
         {t(
-          "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
+          "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
         )}
       </TextBlock>
       <TextBlock>

--- a/static/app/views/settings/account/navigationConfiguration.tsx
+++ b/static/app/views/settings/account/navigationConfiguration.tsx
@@ -1,5 +1,4 @@
 import {t} from 'sentry/locale';
-import HookStore from 'sentry/stores/hookStore';
 import type {Organization} from 'sentry/types/organization';
 import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 import {getUserOrgNavigationConfiguration} from 'sentry/views/settings/organization/userOrgNavigationConfiguration';
@@ -13,7 +12,7 @@ type ConfigParams = {
 
 function getConfiguration({organization}: ConfigParams): NavigationSection[] {
   if (organization && prefersStackedNav(organization)) {
-    return getUserOrgNavigationConfiguration({organization});
+    return getUserOrgNavigationConfiguration();
   }
 
   return [
@@ -84,14 +83,11 @@ function getConfiguration({organization}: ConfigParams): NavigationSection[] {
         },
         {
           path: `${pathPrefix}/api/auth-tokens/`,
-          title: t('User Auth Tokens'),
+          title: t('Personal Tokens'),
           description: t(
-            "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
+            "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
           ),
         },
-        ...HookStore.get('settings:api-navigation-config').flatMap(cb =>
-          cb(organization)
-        ),
       ],
     },
   ];

--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -17,7 +17,7 @@ export function getOrganizationNavigationConfiguration({
   organization: incomingOrganization,
 }: ConfigParams): NavigationSection[] {
   if (incomingOrganization && prefersStackedNav(incomingOrganization)) {
-    return getUserOrgNavigationConfiguration({organization: incomingOrganization});
+    return getUserOrgNavigationConfiguration();
   }
 
   return [
@@ -162,8 +162,8 @@ export function getOrganizationNavigationConfiguration({
       items: [
         {
           path: `${organizationSettingsPathPrefix}/auth-tokens/`,
-          title: t('Auth Tokens'),
-          description: t('Manage organization auth tokens'),
+          title: t('Organization Tokens'),
+          description: t('Manage organization tokens'),
           id: 'auth-tokens',
         },
         {

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -1,18 +1,12 @@
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {t} from 'sentry/locale';
-import HookStore from 'sentry/stores/hookStore';
-import type {Organization} from 'sentry/types/organization';
 import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 import type {NavigationSection} from 'sentry/views/settings/types';
 
 const organizationSettingsPathPrefix = '/settings/:orgId';
 const userSettingsPathPrefix = '/settings/account';
 
-export function getUserOrgNavigationConfiguration({
-  organization: incomingOrganization,
-}: {
-  organization: Organization;
-}): NavigationSection[] {
+export function getUserOrgNavigationConfiguration(): NavigationSection[] {
   return [
     {
       id: 'settings-account',
@@ -191,9 +185,16 @@ export function getUserOrgNavigationConfiguration({
       items: [
         {
           path: `${organizationSettingsPathPrefix}/auth-tokens/`,
-          title: t('Auth Tokens'),
-          description: t('Manage organization auth tokens'),
+          title: t('Organization Tokens'),
+          description: t('Manage organization tokens'),
           id: 'auth-tokens',
+        },
+        {
+          path: `${userSettingsPathPrefix}/api/auth-tokens/`,
+          title: t('Personal Tokens'),
+          description: t(
+            "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
+          ),
         },
         {
           path: `${organizationSettingsPathPrefix}/developer-settings/`,
@@ -201,27 +202,11 @@ export function getUserOrgNavigationConfiguration({
           description: t('Manage custom integrations'),
           id: 'developer-settings',
         },
-      ],
-    },
-    {
-      id: 'settings-api',
-      name: t('API'),
-      items: [
         {
           path: `${userSettingsPathPrefix}/api/applications/`,
           title: t('Applications'),
           description: t('Add and configure OAuth2 applications'),
         },
-        {
-          path: `${userSettingsPathPrefix}/api/auth-tokens/`,
-          title: t('User Auth Tokens'),
-          description: t(
-            "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
-          ),
-        },
-        ...HookStore.get('settings:api-navigation-config').flatMap(cb =>
-          cb(incomingOrganization)
-        ),
       ],
     },
   ];

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -75,7 +75,7 @@ function OrganizationApiKeysList({
       <AlertLink.Container>
         <AlertLink to="/settings/account/api/auth-tokens/" type="info">
           {tct(
-            'Until Sentry supports OAuth, you might want to switch to using [tokens:User Auth Tokens] instead.',
+            'Until Sentry supports OAuth, you might want to switch to using [tokens:Personal Tokens] instead.',
             {
               tokens: <u />,
             }

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -199,8 +199,8 @@ function OrganizationAuthTokensDetails({params, organization}: Props) {
 
   return (
     <div>
-      <SentryDocumentTitle title={t('Edit Auth Token')} />
-      <SettingsPageHeader title={t('Edit Auth Token')} />
+      <SentryDocumentTitle title={t('Edit Organization Token')} />
+      <SettingsPageHeader title={t('Edit Organization Token')} />
 
       <TextBlock>
         {t(
@@ -216,12 +216,12 @@ function OrganizationAuthTokensDetails({params, organization}: Props) {
         )}
       </TextBlock>
       <Panel>
-        <PanelHeader>{t('Auth Token Details')}</PanelHeader>
+        <PanelHeader>{t('Organization Token Details')}</PanelHeader>
 
         <PanelBody>
           {isError && (
             <LoadingError
-              message={t('Failed to load auth token.')}
+              message={t('Failed to load organization token.')}
               onRetry={refetchToken}
             />
           )}

--- a/static/app/views/settings/organizationAuthTokens/index.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.spec.tsx
@@ -143,7 +143,7 @@ describe('OrganizationAuthTokensIndex', function () {
     render(<OrganizationAuthTokensIndex {...defaultProps} />);
 
     expect(await screen.findByTestId('loading-error')).toHaveTextContent(
-      'Failed to load auth tokens for the organization.'
+      'Failed to load organization tokens.'
     );
     expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument();

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -192,7 +192,7 @@ export function OrganizationAuthTokensIndex({
               ) : undefined
             }
             emptyMessage={t("You haven't created any authentication tokens yet.")}
-            headers={[t('Auth token'), t('Created'), t('Last access'), '']}
+            headers={[t('Token'), t('Created'), t('Last access'), '']}
           >
             {!isError && !isPending && !!tokenList?.length && (
               <TokenList

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -160,12 +160,15 @@ export function OrganizationAuthTokensIndex({
     <Access access={['org:write']}>
       {({hasAccess}) => (
         <Fragment>
-          <SentryDocumentTitle title={t('Auth Tokens')} orgSlug={organization.slug} />
-          <SettingsPageHeader title={t('Auth Tokens')} action={createNewToken} />
+          <SentryDocumentTitle
+            title={t('Organization Tokens')}
+            orgSlug={organization.slug}
+          />
+          <SettingsPageHeader title={t('Organization Tokens')} action={createNewToken} />
 
           <TextBlock>
             {t(
-              'Organization Auth Tokens can be used in many places to interact with Sentry programatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
+              'Organization Tokens can be used in many places to interact with Sentry programatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
             )}
           </TextBlock>
           <TextBlock>
@@ -183,7 +186,7 @@ export function OrganizationAuthTokensIndex({
             loader={
               isError ? (
                 <LoadingError
-                  message={t('Failed to load auth tokens for the organization.')}
+                  message={t('Failed to load organization tokens.')}
                   onRetry={refetchTokenList}
                 />
               ) : undefined

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.spec.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.spec.tsx
@@ -34,7 +34,7 @@ describe('OrganizationAuthTokensNewAuthToken', function () {
     expect(screen.queryByLabelText('Generated token')).not.toBeInTheDocument();
 
     await userEvent.type(screen.getByLabelText('Name'), 'My Token');
-    await userEvent.click(screen.getByRole('button', {name: 'Create Auth Token'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create Token'}));
 
     expect(await screen.findByLabelText('Generated token')).toHaveValue('sntrys_XXXXXXX');
 
@@ -63,12 +63,12 @@ describe('OrganizationAuthTokensNewAuthToken', function () {
     expect(screen.queryByLabelText('Generated token')).not.toBeInTheDocument();
 
     await userEvent.type(screen.getByLabelText('Name'), 'My Token');
-    await userEvent.click(screen.getByRole('button', {name: 'Create Auth Token'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create Token'}));
 
     expect(screen.queryByLabelText('Generated token')).not.toBeInTheDocument();
 
     expect(indicators.addErrorMessage).toHaveBeenCalledWith(
-      'Failed to create a new auth token.'
+      'Failed to create a new organization token.'
     );
 
     expect(mock).toHaveBeenCalledWith(
@@ -96,7 +96,7 @@ describe('OrganizationAuthTokensNewAuthToken', function () {
     expect(screen.queryByLabelText('Generated token')).not.toBeInTheDocument();
 
     await userEvent.type(screen.getByLabelText('Name'), 'My Token');
-    await userEvent.click(screen.getByRole('button', {name: 'Create Auth Token'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Create Token'}));
 
     expect(screen.queryByLabelText('Generated token')).not.toBeInTheDocument();
 

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -72,7 +72,7 @@ function AuthTokenCreateForm({
     },
 
     onSuccess: (token: OrgAuthTokenWithToken) => {
-      addSuccessMessage(t('Created auth token.'));
+      addSuccessMessage(t('Created organization token.'));
 
       queryClient.invalidateQueries({
         queryKey: makeFetchOrgAuthTokensForOrgQueryKey({orgSlug: organization.slug}),
@@ -89,7 +89,7 @@ function AuthTokenCreateForm({
           ? t(
               'You have to configure `system.url-prefix` in your Sentry instance in order to generate tokens.'
             )
-          : t('Failed to create a new auth token.');
+          : t('Failed to create a new organization token.');
       handleXhrErrorResponse(message, error);
       addErrorMessage(message);
     },
@@ -104,7 +104,7 @@ function AuthTokenCreateForm({
         submitToken({name});
       }}
       onCancel={handleGoBack}
-      submitLabel={t('Create Auth Token')}
+      submitLabel={t('Create Token')}
       requireChanges
       submitDisabled={isPending}
     >
@@ -117,7 +117,7 @@ function AuthTokenCreateForm({
 
       <FieldGroup
         label={t('Scopes')}
-        help={t('Organization auth tokens currently have a limited set of scopes.')}
+        help={t('Organization tokens currently have a limited set of scopes.')}
       >
         <div>
           <div>org:ci</div>
@@ -139,12 +139,12 @@ export default function OrganizationAuthTokensNewAuthToken() {
 
   return (
     <div>
-      <SentryDocumentTitle title={t('Create New Auth Token')} />
-      <SettingsPageHeader title={t('Create New Auth Token')} />
+      <SentryDocumentTitle title={t('Create New Organization Token')} />
+      <SettingsPageHeader title={t('Create New Organization Token')} />
 
       <TextBlock>
         {t(
-          'Organization Auth Tokens can be used in many places to interact with Sentry programmatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
+          'Organization tokens can be used in many places to interact with Sentry programmatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
         )}
       </TextBlock>
       <TextBlock>
@@ -156,7 +156,7 @@ export default function OrganizationAuthTokensNewAuthToken() {
         )}
       </TextBlock>
       <Panel>
-        <PanelHeader>{t('Create New Auth Token')}</PanelHeader>
+        <PanelHeader>{t('Create New Organization Token')}</PanelHeader>
 
         <PanelBody>
           <AuthTokenCreateForm

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -228,12 +228,12 @@ function SettingsIndex(props: SettingsIndexProps) {
           {organizationSettingsUrl && (
             <li>
               <HomeLink to={`${organizationSettingsUrl}auth-tokens/`}>
-                {t('Organization Auth Tokens')}
+                {t('Organization Tokens')}
               </HomeLink>
             </li>
           )}
           <li>
-            <HomeLink to={LINKS.API}>{t('User Auth Tokens')}</HomeLink>
+            <HomeLink to={LINKS.API}>{t('Personal Tokens')}</HomeLink>
           </li>
           {organizationSettingsUrl && (
             <li>


### PR DESCRIPTION
Rename `Auth Token` and `User Auth Token` to `Organization Token` and `Personal Token` respectively.
Merge the nav section `API` into `Developer Settings`.

Before
<img width="205" alt="Screenshot 2025-06-04 at 07 04 04" src="https://github.com/user-attachments/assets/b288603e-a3a5-4807-a196-3d448c4284ff" />


After
<img width="205" alt="Screenshot 2025-06-04 at 07 03 53" src="https://github.com/user-attachments/assets/be1ff6a4-e67a-413a-ac86-475c5dc401bf" />


- closes [TET-556: Merge sections and rename Auth Tokens and User Auth Tokens](https://linear.app/getsentry/issue/TET-556/merge-sections-and-rename-auth-tokens-and-user-auth-tokens)
- docs update in https://github.com/getsentry/sentry-docs/pull/13914

