### PR TITLE
feat(tempest): Add endpoint for Tempest outbound IPs

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -374,6 +374,7 @@ from sentry.sentry_apps.api.endpoints.sentry_internal_app_tokens import (
 )
 from sentry.tempest.endpoints.tempest_credentials import TempestCredentialsEndpoint
 from sentry.tempest.endpoints.tempest_credentials_details import TempestCredentialsDetailsEndpoint
+from sentry.tempest.endpoints.tempest_ips import TempestIpsEndpoint
 from sentry.uptime.endpoints.organiation_uptime_alert_index import (
     OrganizationUptimeAlertIndexEndpoint,
 )
@@ -3447,6 +3448,12 @@ urlpatterns = [
         r"^uptime-ips/$",
         UptimeIpsEndpoint.as_view(),
         name="sentry-api-0-uptime-ips",
+    ),
+    # Tempest public IP address list
+    re_path(
+        r"^tempest-ips/$",
+        TempestIpsEndpoint.as_view(),
+        name="sentry-api-0-tempest-ips",
     ),
     # Secret Scanning
     re_path(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2983,6 +2983,15 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Configures the list of public IP addresses that are returned from the
+# `tempest-ips` API. This provides a way to configure and retrieve
+# IP addresses for Tempest purposes without code changes.
+register(
+    "tempest.tempest-ips-api-response",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "releases.no_snuba_for_release_creation",

--- a/src/sentry/tempest/endpoints/tempest_ips.py
+++ b/src/sentry/tempest/endpoints/tempest_ips.py
@@ -1,0 +1,21 @@
+from django.http.response import HttpResponse
+from rest_framework.request import Request
+
+from sentry import options
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+
+
+@region_silo_endpoint
+class TempestIpsEndpoint(Endpoint):
+    owner = ApiOwner.GDX
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    # Disable authentication and permission requirements.
+    permission_classes = ()
+
+    def get(self, _request: Request) -> HttpResponse:
+        ips: list[str] = list(options.get("tempest.tempest-ips-api-response"))
+        return HttpResponse("\n".join(ips), content_type="text/plain")

--- a/tests/sentry/tempest/endpoints/test_tempest_ips.py
+++ b/tests/sentry/tempest/endpoints/test_tempest_ips.py
@@ -1,0 +1,16 @@
+from ipaddress import ip_address
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
+
+
+class TempestIpsEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-tempest-ips"
+
+    @override_options({"tempest.tempest-ips-api-response": ["10.0.0.1", "10.0.0.2"]})
+    def test_simple(self):
+        response = self.get_success_response()
+
+        # Validate that we get back IP addresses
+        for ip in response.content.decode().split("\n"):
+            ip_address(ip)


### PR DESCRIPTION
Adds an endpoint which serves Tempest outbound IPs, similar how it is done with Uptime IPs in: https://github.com/getsentry/sentry/pull/84822

Part of [TET-570: PlayStation onboarding: Use IP address endpoint to populate the onboarding instructions](https://linear.app/getsentry/issue/TET-570/playstation-onboarding-use-ip-address-endpoint-to-populate-the)