### PR TITLE
feat(agents-monitoring): add other series

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -65,7 +65,7 @@ export default function LLMGenerationsWidget() {
     Referrer.QUERIES_CHART // TODO: add referrer
   );
 
-  const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');
+  const timeSeries = timeSeriesRequest.data;
 
   const isLoading = timeSeriesRequest.isLoading || generationsRequest.isLoading;
   const error = timeSeriesRequest.error || generationsRequest.error;
@@ -91,7 +91,7 @@ export default function LLMGenerationsWidget() {
         plottables: timeSeries.map(
           (ts, index) =>
             new Bars(convertSeriesToTimeseries(ts), {
-              color: colorPalette[index],
+              color: ts.seriesName === 'Other' ? theme.gray200 : colorPalette[index],
               alias: ts.seriesName,
               stack: 'stack',
             })
@@ -116,7 +116,7 @@ export default function LLMGenerationsWidget() {
             <ModelText>
               <ModelName modelId={modelId} />
             </ModelText>
-            <span>{item['count(span.duration)']}</span>
+            <span>{item['count()']}</span>
           </Fragment>
         );
       })}

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -66,7 +66,7 @@ export default function TokenUsageWidget() {
     Referrer.QUERIES_CHART // TODO: add referrer
   );
 
-  const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');
+  const timeSeries = timeSeriesRequest.data;
 
   const isLoading = timeSeriesRequest.isLoading || tokensRequest.isLoading;
   const error = timeSeriesRequest.error || tokensRequest.error;
@@ -91,7 +91,7 @@ export default function TokenUsageWidget() {
         plottables: timeSeries.map(
           (ts, index) =>
             new Bars(convertSeriesToTimeseries(ts), {
-              color: colorPalette[index],
+              color: ts.seriesName === 'Other' ? theme.gray200 : colorPalette[index],
               alias: ts.seriesName,
               stack: 'stack',
             })

--- a/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
@@ -64,7 +64,7 @@ export default function ToolUsageWidget() {
     Referrer.QUERIES_CHART // TODO: add referrer
   );
 
-  const timeSeries = timeSeriesRequest.data.filter(ts => ts.seriesName !== 'Other');
+  const timeSeries = timeSeriesRequest.data;
 
   const isLoading = timeSeriesRequest.isLoading || toolsRequest.isLoading;
   const error = timeSeriesRequest.error || toolsRequest.error;
@@ -88,7 +88,7 @@ export default function ToolUsageWidget() {
         plottables: timeSeries.map(
           (ts, index) =>
             new Bars(convertSeriesToTimeseries(ts), {
-              color: colorPalette[index],
+              color: ts.seriesName === 'Other' ? theme.gray200 : colorPalette[index],
               alias: ts.seriesName,
               stack: 'stack',
             })
@@ -111,7 +111,7 @@ export default function ToolUsageWidget() {
           <div>
             <ToolText>{item[AI_TOOL_NAME_ATTRIBUTE]}</ToolText>
           </div>
-          <span>{item['count(span.duration)']}</span>
+          <span>{item['count()']}</span>
         </Fragment>
       ))}
     </WidgetFooterTable>


### PR DESCRIPTION
Removes filtering of the 'Other' timeseries for LLM, Tool calls and Token usage widgets
<img width="485" alt="image" src="https://github.com/user-attachments/assets/cfd824fe-c0d2-4c22-9296-8782b850b1e4" />
