### PR TITLE
feat(devserver): Enable span buffer by default

### DIFF
--- a/config/relay/config.yml
+++ b/config/relay/config.yml
@@ -18,4 +18,5 @@ processing:
   topics:
     metrics_transactions: ingest-performance-metrics
     metrics_sessions: ingest-metrics
+    spans: ingest-spans
   redis: redis://sentry_redis:6379

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2406,7 +2406,7 @@ SENTRY_USE_PROFILING = False
 SENTRY_USE_SPANS = False
 
 # This flag activates spans consumer in the sentry backend in development environment
-SENTRY_USE_SPANS_BUFFER = False
+SENTRY_USE_SPANS_BUFFER = True
 
 # This flag activates consuming issue platform occurrence data in the development environment
 SENTRY_USE_ISSUE_OCCURRENCE = False


### PR DESCRIPTION
Sets `SENTRY_USE_SPANS_BUFFER = True`, which enables the span buffer by default for local development. This includes two more changes:
1. Relay is configured to produce to `ingest-spans`
2. The span pipeline now produces trace items for spans

This can be used to test standalone span ingestion, buffering, and trace items for spans in the local environment. Note that you still have to **set `SENTRY_USE_RELAY = True` in your sentry.conf.py** to enable ingestion.

VIEPF-37