### PR TITLE
fix(agent-insights): Check for all ai descriptions

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -28,6 +28,9 @@ const AI_GENERATION_DESCRIPTIONS = [
 // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#execute-tool-span
 const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool', 'ai.toolCall'];
 
+const AI_OPS = [...AI_RUN_OPS, ...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS];
+const AI_DESCRIPTIONS = [...AI_RUN_DESCRIPTIONS, ...AI_GENERATION_DESCRIPTIONS];
+
 export const AI_MODEL_ID_ATTRIBUTE = 'ai.model.id' as EAPSpanProperty;
 export const AI_TOOL_NAME_ATTRIBUTE = 'ai.toolCall.name' as EAPSpanProperty;
 
@@ -46,8 +49,7 @@ export const legacyAttributeKeys = new Map<string, string[]>([
   ['gen_ai.usage.total_cost', ['ai.total_cost.used']],
 ]);
 
-// TODO: Remove once tool spans have their own op
-function mapMissingSpanOp({
+export function getIsAiSpan({
   op = 'default',
   description,
 }: {
@@ -55,19 +57,9 @@ function mapMissingSpanOp({
   op?: string;
 }) {
   if (op !== 'default') {
-    return op;
+    return AI_OPS.includes(op);
   }
-  if (description === 'ai.toolCall') {
-    return 'ai.toolCall';
-  }
-  return op;
-}
-
-const AI_OPS = [...AI_RUN_OPS, ...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS];
-
-export function getIsAiSpan({op, description}: {description?: string; op?: string}) {
-  const mappedOp = mapMissingSpanOp({op, description});
-  return AI_OPS.includes(mappedOp);
+  return AI_DESCRIPTIONS.includes(description ?? '');
 }
 
 export const getAgentRunsFilter = () => {


### PR DESCRIPTION
Include all ai span descriptions in the `getIsAiSpan` check.