### PR TITLE
ref(span-buffer): Make flusher backpressure more aggressive

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -122,7 +122,8 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
                 now = int(time.time()) + current_drift.value
                 flushed_segments = buffer.flush_segments(now=now, max_segments=max_flush_segments)
 
-                if len(flushed_segments) >= max_flush_segments * len(buffer.assigned_shards):
+                # Check backpressure flag set by buffer
+                if buffer.any_shard_at_limit:
                     if backpressure_since.value == 0:
                         backpressure_since.value = int(time.time())
                 else:


### PR DESCRIPTION
We see that when only some shards backlog, the flusher backpressure just
never kicks in.

VIEFP-38
