### PR TITLE
ref: simplify tabs interface

### DIFF
--- a/static/app/components/core/tabs/index.stories.tsx
+++ b/static/app/components/core/tabs/index.stories.tsx
@@ -168,12 +168,12 @@ export default Storybook.story('Tabs', story => {
       </div>
       <div>
         <p>
-          Use <Storybook.JSXNode name="TabList" props={{disabledKeys: Array}} /> to
+          Use <Storybook.JSXNode name="TabList.Item" props={{disabled: true}} /> to
           disable individual <Storybook.JSXNode name="TabList.Item" /> children.
         </p>
         <Storybook.SizingWindow>
           <Tabs>
-            <TabList disabledKeys={['two']}>
+            <TabList>
               {TABS.map(tab => (
                 <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
               ))}
@@ -207,7 +207,9 @@ export default Storybook.story('Tabs', story => {
           <Tabs>
             <TabList variant={'floating'} hideBorder>
               {TABS.map(tab => (
-                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+                <TabList.Item disabled={tab.disabled} key={tab.key}>
+                  {tab.label}
+                </TabList.Item>
               ))}
             </TabList>
             <TabPanels>

--- a/static/app/components/core/tabs/index.stories.tsx
+++ b/static/app/components/core/tabs/index.stories.tsx
@@ -175,7 +175,9 @@ export default Storybook.story('Tabs', story => {
           <Tabs>
             <TabList>
               {TABS.map(tab => (
-                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
+                <TabList.Item disabled={tab.key === 'three'} key={tab.key}>
+                  {tab.label}
+                </TabList.Item>
               ))}
             </TabList>
             <TabPanels>
@@ -207,9 +209,7 @@ export default Storybook.story('Tabs', story => {
           <Tabs>
             <TabList variant={'floating'} hideBorder>
               {TABS.map(tab => (
-                <TabList.Item disabled={tab.disabled} key={tab.key}>
-                  {tab.label}
-                </TabList.Item>
+                <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
               ))}
             </TabList>
             <TabPanels>

--- a/static/app/components/core/tabs/item.tsx
+++ b/static/app/components/core/tabs/item.tsx
@@ -9,4 +9,5 @@ export interface TabListItemProps extends ItemProps<any> {
   to?: LocationDescriptor;
 }
 
-export const Item = _Item as (props: TabListItemProps) => React.JSX.Element;
+export const TabListItem = _Item as (props: TabListItemProps) => React.JSX.Element;
+export const TabPanelItem = _Item as (props: ItemProps<any>) => React.JSX.Element;

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -19,7 +19,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {TabsContext} from './index';
 import type {TabListItemProps} from './item';
-import {Item} from './item';
+import {TabListItem} from './item';
 import {type BaseTabProps, Tab} from './tab';
 import {tabsShouldForwardProp} from './utils';
 
@@ -122,23 +122,20 @@ function OverflowMenu({state, overflowMenuItems, disabled}: any) {
   );
 }
 
-export interface TabListProps
-  extends AriaTabListOptions<TabListItemProps>,
-    TabListStateOptions<TabListItemProps> {
-  className?: string;
+export interface TabListProps {
+  children: TabListStateOptions<TabListItemProps>['children'];
   hideBorder?: boolean;
   outerWrapStyles?: React.CSSProperties;
   variant?: BaseTabProps['variant'];
 }
 
-interface BaseTabListProps extends TabListProps {
+interface BaseTabListProps extends AriaTabListOptions<TabListItemProps>, TabListProps {
   items: TabListItemProps[];
   variant?: BaseTabProps['variant'];
 }
 
 function BaseTabList({
   hideBorder = false,
-  className,
   outerWrapStyles,
   variant = 'flat',
   ...props
@@ -222,7 +219,6 @@ function BaseTabList({
         {...tabListProps}
         orientation={orientation}
         hideBorder={hideBorder}
-        className={className}
         ref={tabListRef}
         variant={variant}
       >
@@ -252,25 +248,26 @@ function BaseTabList({
   );
 }
 
-const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
+const collectionFactory = (nodes: Iterable<Node<TabListItemProps>>) =>
+  new ListCollection(nodes);
 
 /**
  * To be used as a direct child of the `<Tabs />` component. See example usage
  * in tabs.stories.js
  */
-export function TabList({items, variant, ...props}: TabListProps) {
+export function TabList({variant, ...props}: TabListProps) {
   /**
    * Initial, unfiltered list of tab items.
    */
-  const collection = useCollection({items, ...props}, collectionFactory);
+  const collection = useCollection(props, collectionFactory);
 
-  const parsedItems = useMemo(
+  const parsedItems: TabListItemProps[] = useMemo(
     () => [...collection].map(({key, props: itemProps}) => ({key, ...itemProps})),
     [collection]
   );
 
   /**
-   * List of keys of disabled items (those with a `disbled` prop) to be passed
+   * List of keys of disabled items (those with a `disabled` prop) to be passed
    * into `BaseTabList`.
    */
   const disabledKeys = useMemo(
@@ -280,17 +277,17 @@ export function TabList({items, variant, ...props}: TabListProps) {
 
   return (
     <BaseTabList
+      {...props}
       items={parsedItems}
       disabledKeys={disabledKeys}
       variant={variant}
-      {...props}
     >
-      {item => <Item {...item} key={item.key} />}
+      {item => <TabListItem {...item} key={item.key} />}
     </BaseTabList>
   );
 }
 
-TabList.Item = Item;
+TabList.Item = TabListItem;
 
 const TabListOuterWrap = styled('div')`
   position: relative;

--- a/static/app/components/core/tabs/tabPanels.tsx
+++ b/static/app/components/core/tabs/tabPanels.tsx
@@ -13,7 +13,8 @@ import {TabsContext} from '.';
 
 const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
 
-interface TabPanelsProps extends AriaTabPanelProps, CollectionBase<any> {
+interface TabPanelsProps extends AriaTabPanelProps {
+  children: CollectionBase<unknown>['children'];
   className?: string;
 }
 

--- a/static/app/components/core/tabs/tabPanels.tsx
+++ b/static/app/components/core/tabs/tabPanels.tsx
@@ -7,7 +7,7 @@ import {ListCollection} from '@react-stately/list';
 import type {TabListState} from '@react-stately/tabs';
 import type {CollectionBase, Node, Orientation} from '@react-types/shared';
 
-import {Item} from './item';
+import {TabPanelItem} from './item';
 import {tabsShouldForwardProp} from './utils';
 import {TabsContext} from '.';
 
@@ -52,7 +52,7 @@ export function TabPanels(props: TabPanelsProps) {
   );
 }
 
-TabPanels.Item = Item;
+TabPanels.Item = TabPanelItem;
 
 interface TabPanelProps extends AriaTabPanelProps {
   state: TabListState<any>;


### PR DESCRIPTION
This PR simplifies how we use Tabs by removing props that didn’t do anything and weren’t used:

- `disabledKeys` on `TabList` was unused outside of stories, and we can already disable tabs by passing the `disabled` prop to the item itself, so this feels superfluous.
- `TabListItem` and `TabPanelItem` had the same props, even though they make no sense on the panel item. None of them had any effect, they were unused and it was confusing (e.g. where do I need to pass `disabled` it’s allowed everywhere?)
- `TabList` does not extend `TabListStateOptions` anymore. It had unused options like `isDisabled` or `items`, which could be passed instead of `children`. 