### PR TITLE
fix(insights): fixes perf score function calculating incorrectly when there is a groupby

### DIFF
--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -377,9 +377,6 @@ def performance_score(args: ResolvedArguments, settings: ResolverSettings) -> Co
     if ratio_attribute.name == "score.total":
         return total_performance_score(args, settings)
 
-    web_vital = score_attribute.name.split(".")[-1]
-    vital_count = get_count_of_vital(web_vital, settings)
-
     return Column.BinaryFormula(
         default_value_double=0.0,
         left=Column(
@@ -390,7 +387,7 @@ def performance_score(args: ResolvedArguments, settings: ResolverSettings) -> Co
             )
         ),
         op=Column.BinaryFormula.OP_MULTIPLY,
-        right=Column(literal=LiteralValue(val_double=1.0 if vital_count > 0 else 0.0)),
+        right=Column(literal=LiteralValue(val_double=1.0)),
     )
 
 

--- a/src/sentry/search/eap/spans/formulas.py
+++ b/src/sentry/search/eap/spans/formulas.py
@@ -397,22 +397,20 @@ def performance_score(args: ResolvedArguments, settings: ResolverSettings) -> Co
 def total_performance_score(
     _: ResolvedArguments, settings: ResolverSettings
 ) -> Column.BinaryFormula:
+    extrapolation_mode = settings["extrapolation_mode"]
     vitals = ["lcp", "fcp", "cls", "ttfb", "inp"]
     vital_score_columns: list[Column] = []
+    vital_weights: list[Column] = []
 
     performance_score_formulas: list[tuple[Column.BinaryFormula, str]] = []
-    total_weight = 0.0
     for vital in vitals:
         vital_score = f"score.{vital}"
         vital_score_key = AttributeKey(name=vital_score, type=AttributeKey.TYPE_DOUBLE)
         vital_performance_score = performance_score([vital_score_key], settings)
-        hasVitalCount = vital_performance_score.right.literal.val_double > 0
-        if hasVitalCount:
-            performance_score_formulas.append((vital_performance_score, vital))
-            total_weight += WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[vital]
+        performance_score_formulas.append((vital_performance_score, vital))
 
     for formula, vital in performance_score_formulas:
-        weight = WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[vital] / total_weight
+        weight = WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[vital]
         vital_score_columns.append(
             Column(
                 formula=Column.BinaryFormula(
@@ -420,6 +418,40 @@ def total_performance_score(
                     left=Column(formula=formula),
                     op=Column.BinaryFormula.OP_MULTIPLY,
                     right=Column(literal=LiteralValue(val_double=weight)),
+                )
+            )
+        )
+        vital_score_ratio_key = AttributeKey(
+            name=f"score.ratio.{vital}", type=AttributeKey.TYPE_DOUBLE
+        )
+        # Hack to return 1.0 if any span with the vital metric exists, otherwise 0.0
+        vital_exists_formula = Column.BinaryFormula(
+            default_value_double=0.0,
+            left=Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT,
+                    key=vital_score_ratio_key,
+                    extrapolation_mode=extrapolation_mode,
+                )
+            ),
+            op=Column.BinaryFormula.OP_DIVIDE,
+            right=Column(
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT,
+                    key=vital_score_ratio_key,
+                    extrapolation_mode=extrapolation_mode,
+                )
+            ),
+        )
+        vital_weights.append(
+            Column(
+                formula=Column.BinaryFormula(
+                    default_value_double=0.0,
+                    left=Column(
+                        literal=LiteralValue(val_double=WEB_VITALS_PERFORMANCE_SCORE_WEIGHTS[vital])
+                    ),
+                    op=Column.BinaryFormula.OP_MULTIPLY,
+                    right=Column(formula=vital_exists_formula),
                 )
             )
         )
@@ -432,7 +464,13 @@ def total_performance_score(
     if len(vital_score_columns) == 1:
         return vital_score_columns[0].formula
 
-    return operate_multiple_columns(vital_score_columns, Column.BinaryFormula.OP_ADD)
+    return Column.BinaryFormula(
+        left=Column(
+            formula=operate_multiple_columns(vital_score_columns, Column.BinaryFormula.OP_ADD)
+        ),
+        op=Column.BinaryFormula.OP_DIVIDE,
+        right=Column(formula=operate_multiple_columns(vital_weights, Column.BinaryFormula.OP_ADD)),
+    )
 
 
 def http_response_rate(args: ResolvedArguments, settings: ResolverSettings) -> Column.BinaryFormula:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3521,6 +3521,159 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
 
         assert meta["dataset"] == self.dataset
 
+    def test_total_performance_score_missing_vital(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.lcp": {"value": 0.0},
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.lcp": {"value": 0.02},
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.lcp": {"value": 0.04},
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.cls": {"value": 0.08},
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.inp": {"value": 0.5},
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.fcp": {"value": 0.08},
+                        }
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "performance_score(measurements.score.lcp)",
+                    "performance_score(measurements.score.cls)",
+                    "performance_score(measurements.score.ttfb)",
+                    "performance_score(measurements.score.fcp)",
+                    "performance_score(measurements.score.inp)",
+                    "performance_score(measurements.score.total)",
+                ],
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data[0]["performance_score(measurements.score.lcp)"] == 0.02
+        assert data[0]["performance_score(measurements.score.cls)"] == 0.08
+        assert data[0]["performance_score(measurements.score.ttfb)"] == 0.0
+        assert data[0]["performance_score(measurements.score.fcp)"] == 0.08
+        assert data[0]["performance_score(measurements.score.inp)"] == 0.5
+        self.assertAlmostEqual(data[0]["performance_score(measurements.score.total)"], 0.20)
+
+        assert meta["dataset"] == self.dataset
+
+    def test_total_performance_score_multiple_transactions(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.lcp": {"value": 0.8},
+                        },
+                        "sentry_tags": {"transaction": "foo_transaction"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "measurements": {
+                            "score.ratio.cls": {"value": 0.7},
+                        },
+                        "sentry_tags": {"transaction": "bar_transaction"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=True,
+        )
+
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "performance_score(measurements.score.total)",
+                    "performance_score(measurements.score.lcp)",
+                    "performance_score(measurements.score.cls)",
+                    "performance_score(measurements.score.fcp)",
+                    "opportunity_score(measurements.score.total)",
+                    "opportunity_score(measurements.score.lcp)",
+                    "opportunity_score(measurements.score.cls)",
+                    "opportunity_score(measurements.score.fcp)",
+                ],
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data[0]["transaction"] == "foo_transaction"
+        self.assertAlmostEqual(data[0]["performance_score(measurements.score.total)"], 0.8)
+        assert data[0]["performance_score(measurements.score.lcp)"] == 0.8
+        assert data[0]["performance_score(measurements.score.cls)"] == 0.0
+        assert data[0]["performance_score(measurements.score.fcp)"] == 0.0
+        self.assertAlmostEqual(
+            data[0]["opportunity_score(measurements.score.total)"], 0.13333333333333333
+        )
+        self.assertAlmostEqual(data[0]["opportunity_score(measurements.score.lcp)"], 0.2)
+        assert data[0]["opportunity_score(measurements.score.cls)"] == 0.0
+        assert data[0]["opportunity_score(measurements.score.fcp)"] == 0.0
+        assert data[1]["transaction"] == "bar_transaction"
+        self.assertAlmostEqual(data[1]["performance_score(measurements.score.total)"], 0.7)
+        assert data[1]["performance_score(measurements.score.lcp)"] == 0.0
+        assert data[1]["performance_score(measurements.score.cls)"] == 0.7
+        assert data[1]["performance_score(measurements.score.fcp)"] == 0.0
+        self.assertAlmostEqual(data[1]["opportunity_score(measurements.score.total)"], 0.1)
+        assert data[1]["opportunity_score(measurements.score.lcp)"] == 0.0
+        self.assertAlmostEqual(data[1]["opportunity_score(measurements.score.cls)"], 0.3)
+        assert data[1]["opportunity_score(measurements.score.fcp)"] == 0.0
+
+        assert meta["dataset"] == self.dataset
+
     def test_division(self):
         self.store_spans(
             [

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -3644,6 +3644,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 ],
                 "project": self.project.id,
                 "dataset": self.dataset,
+                "orderby": "-transaction",
             }
         )
 


### PR DESCRIPTION
When querying for `performance_score(...)`, we used to do a secondary query under the hood to determine if any vitals are missing. This is useful for scaling up performance scores when a vital component is missing, to fill in the gap in weight. However, when using a group by such as `transaction`, this secondary query doesn't filter for the respective `transaction` for each row, causing the result `performance_score` to be off.

Updates the `performance_score(...)` function to no longer do a secondary query and moves the weight scaling logic inside of the formula itself. This change involves a bit a of hack to divide `FUNCTION_COUNT` by itself to return `1.0` when a vital exists, defaulting to `0.0` when it does not exist.