### PR TITLE
ref(ui): cleanup featureBadge

### DIFF
--- a/static/app/components/core/badge/featureBadge.stories.tsx
+++ b/static/app/components/core/badge/featureBadge.stories.tsx
@@ -1,9 +1,4 @@
-import {Fragment} from 'react';
-
-import {
-  FeatureBadge,
-  type FeatureBadgeProps,
-} from 'sentry/components/core/badge/featureBadge';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import * as Storybook from 'sentry/stories';
 
 export default Storybook.story('FeatureBadge', story => {
@@ -14,22 +9,5 @@ export default Storybook.story('FeatureBadge', story => {
       <FeatureBadge type="new" />
       <FeatureBadge type="experimental" />
     </Storybook.SideBySide>
-  ));
-
-  story('Variants', () => (
-    <Fragment>
-      <Storybook.PropMatrix<FeatureBadgeProps>
-        render={props => (
-          <span>
-            Feature X
-            <FeatureBadge {...props} />
-          </span>
-        )}
-        propMatrix={{
-          type: ['alpha', 'beta', 'new', 'experimental'],
-        }}
-        selectedProps={['type', 'variant']}
-      />
-    </Fragment>
   ));
 });

--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -26,7 +26,6 @@ const labels: Record<FeatureBadgeProps['type'], string> = {
 export interface FeatureBadgeProps extends Omit<BadgeProps, 'children'> {
   type: 'alpha' | 'beta' | 'new' | 'experimental';
   tooltipProps?: Partial<TooltipProps>;
-  variant?: 'badge';
 }
 
 function InnerFeatureBadge({type, tooltipProps, ...props}: FeatureBadgeProps) {

--- a/static/app/components/core/badge/index.chonk.tsx
+++ b/static/app/components/core/badge/index.chonk.tsx
@@ -41,9 +41,6 @@ const StyledChonkBadge = chonkStyled('span')<ChonkBadgeProps>`
   height: 20px;
   font-weight: ${p => p.theme.fontWeightBold};
   padding: ${p => p.theme.space.micro} ${p => p.theme.space.mini};
-
-  // @TODO(jonasbadalic): this exists on the old badge, but should be removed
-  margin-left: ${p => p.theme.space.mini};
 `;
 
 function makeChonkBadgeTheme(

--- a/static/app/views/codecov/coverage/commits/commitWrapper.tsx
+++ b/static/app/views/codecov/coverage/commits/commitWrapper.tsx
@@ -16,7 +16,7 @@ export default function CommitDetailWrapper() {
         <Layout.HeaderContent>
           <HeaderContentBar>
             <Layout.Title>
-              Commit Page Wrapper <FeatureBadge type="new" variant="badge" />
+              Commit Page Wrapper <FeatureBadge type="new" />
             </Layout.Title>
           </HeaderContentBar>
         </Layout.HeaderContent>

--- a/static/app/views/codecov/coverage/coverageWrapper.tsx
+++ b/static/app/views/codecov/coverage/coverageWrapper.tsx
@@ -17,7 +17,7 @@ export default function CoveragePageWrapper() {
           <HeaderContentBar>
             <Layout.Title>
               {COVERAGE_PAGE_TITLE}
-              <FeatureBadge type="new" variant="badge" />
+              <FeatureBadge type="new" />
             </Layout.Title>
           </HeaderContentBar>
         </Layout.HeaderContent>

--- a/static/app/views/codecov/coverage/pulls/pullWrapper.tsx
+++ b/static/app/views/codecov/coverage/pulls/pullWrapper.tsx
@@ -16,7 +16,7 @@ export default function PullDetailWrapper() {
         <Layout.HeaderContent>
           <HeaderContentBar>
             <Layout.Title>
-              Pull Page Wrapper <FeatureBadge type="new" variant="badge" />
+              Pull Page Wrapper <FeatureBadge type="new" />
             </Layout.Title>
           </HeaderContentBar>
         </Layout.HeaderContent>

--- a/static/app/views/codecov/tests/testsWrapper.tsx
+++ b/static/app/views/codecov/tests/testsWrapper.tsx
@@ -17,7 +17,7 @@ export default function TestAnalyticsPageWrapper() {
           <HeaderContentBar>
             <Layout.Title>
               {TESTS_PAGE_TITLE}
-              <FeatureBadge type="new" variant="badge" />
+              <FeatureBadge type="new" />
             </Layout.Title>
           </HeaderContentBar>
         </Layout.HeaderContent>

--- a/static/app/views/codecov/tokens/tokensWrapper.tsx
+++ b/static/app/views/codecov/tokens/tokensWrapper.tsx
@@ -17,7 +17,7 @@ export default function TokensPageWrapper() {
           <HeaderContentBar>
             <Layout.Title>
               {TOKENS_PAGE_TITLE}
-              <FeatureBadge type="new" variant="badge" />
+              <FeatureBadge type="new" />
             </Layout.Title>
           </HeaderContentBar>
         </Layout.HeaderContent>


### PR DESCRIPTION
- `variant` didn’t do anything, and we also only had _one_ variant (`badge`)
- the `margin-left` breaks encapsulation and is bad when put into a `flex` layout, where items are already separated with `gap`. I’ve kept in in the old ui, but removed it for chonk.