### PR TITLE
fix(ourlogs): Fix gradient for light mode

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -386,15 +386,15 @@ export const HoveringRowLoadingRendererContainer = styled('div')<{
   right: 0;
   margin: 0 auto;
   z-index: 1;
-  margin-top: ${p => (p.position === 'top' ? `${p.headerHeight}px` : '0px')};
+  margin-top: ${p => (p.position === 'top' ? `${p.headerHeight + 1}px` : '0px')};
   display: flex;
   background: linear-gradient(
     to ${p => (p.position === 'top' ? 'bottom' : 'top')},
-    rgb(from ${p => p.theme.black} r g b / 80%),
+    rgb(from ${p => p.theme.backgroundTertiary} r g b / 90%),
     rgb(from ${p => p.theme.backgroundSecondary} r g b / 0%)
   );
   align-items: center;
   justify-content: center;
-  height: ${p => p.rowHeight * 2}px;
+  height: ${p => p.rowHeight * 3}px;
   ${p => (p.position === 'top' ? 'top: 0px;' : 'bottom: 0px;')}
 `;

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -390,7 +390,7 @@ export const HoveringRowLoadingRendererContainer = styled('div')<{
   display: flex;
   background: linear-gradient(
     to ${p => (p.position === 'top' ? 'bottom' : 'top')},
-    rgb(from ${p => p.theme.backgroundTertiary} r g b / 90%),
+    rgb(from ${p => p.theme.backgroundTertiary} r g b / 75%),
     rgb(from ${p => p.theme.backgroundSecondary} r g b / 0%)
   );
   align-items: center;


### PR DESCRIPTION
### Summary
Shows a better gradient in light mode instead of a black line

#### Screenshots
|Light|Dark|
|-|-|
|![Screenshot 2025-06-04 at 10 00 29 AM](https://github.com/user-attachments/assets/14a9dd7f-db5f-4b37-aaae-992629f26fed)|![Screenshot 2025-06-04 at 10 00 46 AM](https://github.com/user-attachments/assets/45ca1e53-20e0-4ef3-9358-6ec30ba50e96)|
|![Screenshot 2025-06-04 at 10 04 21 AM](https://github.com/user-attachments/assets/568c371b-0e26-4f91-9700-a0e805b23a00)|![Screenshot 2025-06-04 at 10 04 14 AM](https://github.com/user-attachments/assets/95372373-d359-4fc1-82a5-02e7705d20cc)|
