### PR TITLE
fix(agents-insights): empty token usage widget

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -12,7 +12,9 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ModelName} from 'sentry/views/insights/agentMonitoring/components/modelName';
 import {
+  AI_INPUT_TOKENS_ATTRIBUTE_SUM,
   AI_MODEL_ID_ATTRIBUTE,
+  AI_OUTPUT_TOKENS_ATTRIBUTE_SUM,
   AI_TOKEN_USAGE_ATTRIBUTE_SUM,
   getAIGenerationsFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
@@ -45,7 +47,12 @@ export default function TokenUsageWidget() {
 
   const tokensRequest = useEAPSpans(
     {
-      fields: [AI_MODEL_ID_ATTRIBUTE, AI_TOKEN_USAGE_ATTRIBUTE_SUM],
+      fields: [
+        AI_MODEL_ID_ATTRIBUTE,
+        AI_TOKEN_USAGE_ATTRIBUTE_SUM,
+        AI_INPUT_TOKENS_ATTRIBUTE_SUM,
+        AI_OUTPUT_TOKENS_ATTRIBUTE_SUM,
+      ],
       sorts: [{field: AI_TOKEN_USAGE_ATTRIBUTE_SUM, kind: 'desc'}],
       search: fullQuery,
       limit: 3,
@@ -57,9 +64,14 @@ export default function TokenUsageWidget() {
     {
       ...pageFilterChartParams,
       search: fullQuery,
-      fields: [AI_MODEL_ID_ATTRIBUTE, AI_TOKEN_USAGE_ATTRIBUTE_SUM],
-      yAxis: [AI_TOKEN_USAGE_ATTRIBUTE_SUM],
-      sort: {field: AI_TOKEN_USAGE_ATTRIBUTE_SUM, kind: 'desc'},
+      fields: [
+        AI_MODEL_ID_ATTRIBUTE,
+        AI_TOKEN_USAGE_ATTRIBUTE_SUM,
+        AI_INPUT_TOKENS_ATTRIBUTE_SUM,
+        AI_OUTPUT_TOKENS_ATTRIBUTE_SUM,
+      ],
+      yAxis: [AI_INPUT_TOKENS_ATTRIBUTE_SUM],
+      sort: {field: AI_INPUT_TOKENS_ATTRIBUTE_SUM, kind: 'desc'},
       topN: 3,
       enabled: !!tokensRequest.data,
     },
@@ -117,7 +129,10 @@ export default function TokenUsageWidget() {
               <ModelName modelId={modelId} />
             </ModelText>
             <span>
-              {formatAbbreviatedNumber(item[AI_TOKEN_USAGE_ATTRIBUTE_SUM] || 0)}
+              {formatAbbreviatedNumber(
+                Number(item[AI_INPUT_TOKENS_ATTRIBUTE_SUM] || 0) +
+                  Number(item[AI_OUTPUT_TOKENS_ATTRIBUTE_SUM] || 0)
+              )}
             </span>
           </Fragment>
         );


### PR DESCRIPTION
Displaying input + output tokens instead of total tokes, as they are sometimes not available
