### PR TITLE
ref(crons): Include item_ts and start_time in debug log

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -435,7 +435,12 @@ def _process_checkin(item: CheckinItem, txn: Transaction | Span) -> None:
         clock_time = item.ts.replace(second=0, microsecond=0, tzinfo=UTC)
         logger.info(
             "monitors.consumer.sentry_clock_pulse_debug_entry",
-            extra={"clock_time": clock_time, **params},
+            extra={
+                "clock_time": clock_time,
+                "item_ts": item.ts,
+                "start_time": start_time,
+                **params,
+            },
         )
 
     project = Project.objects.get_from_cache(id=project_id)


### PR DESCRIPTION
We're seeing check-ins definitely come in out of order:

![clipboard.png](https://i.imgur.com/2baHM3t.png)

By a magnitude of seconds even (wall clock time).

- I would like to validate that the item timing is out of order as well
  (it MUST be, given we should be guaranteed the Kafka messages have
  ordered timestamps).

- I would also like to validate that the start_time is either ALSO out
  of order (indicating relay is receiving these totally out of order) OR
  that it is correctly ordered, implying there's some delay in relay
  processing our messages before placing them into Kafka.