### PR TITLE
fix(ourlogs): Fix regular table chevron movement

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -207,7 +207,7 @@ export function LogsInfiniteTable({
 
   const tableStaticCSS = useMemo(() => {
     return {
-      '#log-table-row-chevron-button': {
+      '.log-table-row-chevron-button': {
         width: theme.isChonk ? '24px' : '18px',
         height: theme.isChonk ? '24px' : '18px',
         marginRight: '4px',
@@ -262,6 +262,7 @@ export function LogsInfiniteTable({
                   highlightTerms={highlightTerms}
                   sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                   key={virtualRow.key}
+                  canDeferRenderElements
                   onExpand={handleExpand}
                   onCollapse={handleCollapse}
                   isExpanded={expandedLogRows.has(dataRow[OurLogKnownFieldKey.ID])}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -67,6 +67,7 @@ type LogsRowProps = {
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  canDeferRenderElements?: boolean;
   isExpanded?: boolean;
   onCollapse?: (logItemId: string) => void;
   onExpand?: (logItemId: string) => void;
@@ -99,6 +100,7 @@ export const LogRowContent = memo(function LogRowContent({
   onExpand,
   onCollapse,
   onExpandHeight,
+  canDeferRenderElements,
 }: LogsRowProps) {
   const location = useLocation();
   const organization = useOrganization();
@@ -108,7 +110,18 @@ export const LogRowContent = memo(function LogRowContent({
   const isTableFrozen = useLogsIsTableFrozen();
   const blockRowExpanding = useLogsBlockRowExpanding();
   const measureRef = useRef<HTMLTableRowElement>(null);
-  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
+  const [shouldRenderHoverElements, _setShouldRenderHoverElements] = useState(
+    canDeferRenderElements ? false : true
+  );
+
+  const setShouldRenderHoverElements = useCallback(
+    (value: boolean) => {
+      if (canDeferRenderElements) {
+        _setShouldRenderHoverElements(value);
+      }
+    },
+    [canDeferRenderElements, _setShouldRenderHoverElements]
+  );
 
   function onPointerUp(event: SyntheticEvent) {
     if (event.target instanceof Element && isInsideButton(event.target)) {
@@ -233,7 +246,7 @@ export const LogRowContent = memo(function LogRowContent({
                 onClick={() => toggleExpanded()}
               />
             ) : (
-              <span id="log-table-row-chevron-button">{chevronIcon}</span>
+              <span className="log-table-row-chevron-button">{chevronIcon}</span>
             )}
             <SeverityCircleRenderer extra={rendererExtra} meta={meta} />
           </LogFirstCellContent>


### PR DESCRIPTION
### Summary
The css class isn't applied on the other side of the infinite table causing odd behaviour. We don't need the deferred rendering in the first place for the static table though.
