### PR TITLE
feat(dashboards): Expose projects in list endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -117,6 +117,8 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         else:
             dashboards = Dashboard.objects.filter(organization_id=organization.id)
 
+        dashboards = dashboards.prefetch_related("projects")
+
         query = request.GET.get("query")
         if query:
             dashboards = dashboards.filter(title__icontains=query)

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -117,8 +117,6 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         else:
             dashboards = Dashboard.objects.filter(organization_id=organization.id)
 
-        dashboards = dashboards.prefetch_related("projects")
-
         query = request.GET.get("query")
         if query:
             dashboards = dashboards.filter(title__icontains=query)

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -206,6 +206,7 @@ class _Widget(TypedDict):
     created_by: dict[str, Any] | None
     permissions: NotRequired[dict[str, Any]]
     is_favorited: NotRequired[bool]
+    projects: list[int]
 
 
 class DashboardListSerializer(Serializer):
@@ -226,7 +227,14 @@ class DashboardListSerializer(Serializer):
         permissions = DashboardPermissions.objects.filter(dashboard_id__in=item_dict.keys())
 
         result: dict[int, _Widget]
-        result = defaultdict(lambda: {"widget_display": [], "widget_preview": [], "created_by": {}})
+        result = defaultdict(
+            lambda: {
+                "widget_display": [],
+                "widget_preview": [],
+                "created_by": {},
+                "projects": [],
+            }
+        )
         for widget in widgets:
             dashboard = item_dict[widget.dashboard_id]
             display_type = DashboardWidgetDisplayTypes.get_type_name(widget.display_type)

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -190,6 +190,7 @@ class DashboardListResponse(TypedDict):
     widgetPreview: list[dict[str, str]]
     permissions: DashboardPermissionsResponse | None
     isFavorited: bool
+    projects: list[int]
 
 
 class _WidgetPreview(TypedDict):
@@ -274,6 +275,7 @@ class DashboardListSerializer(Serializer):
             "widgetPreview": attrs.get("widget_preview", []),
             "permissions": attrs.get("permissions", None),
             "isFavorited": attrs.get("is_favorited", False),
+            "projects": list(obj.projects.values_list("id", flat=True)),
         }
 
 

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -80,6 +80,7 @@ DASHBOARDS_OBJECT = [
         "id": "1",
         "title": "Dashboard",
         "dateCreated": "2024-06-20T14:38:03.498574Z",
+        "projects": [1],
         "createdBy": {
             "id": "1",
             "name": "Admin",
@@ -112,6 +113,7 @@ DASHBOARDS_OBJECT = [
         "id": "2",
         "title": "Dashboard",
         "dateCreated": "2024-06-20T14:38:03.498574Z",
+        "projects": [],
         "createdBy": {
             "id": "1",
             "name": "Admin",

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -183,6 +183,7 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
             "createdBy": "",
             "permissions": {"isEditableByEveryone": True, "teamsWithEditAccess": []},
             "isFavorited": False,
+            "projects": [],
             "widgets": [
                 {
                     "title": "Number of Errors",

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1493,3 +1493,20 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         queries = widgets[0].dashboardwidgetquery_set.all()
         assert len(queries) == 1
         self.assert_serialized_widget_query(data["widgets"][0]["queries"][0], queries[0])
+
+    def test_response_includes_project_ids(self):
+        project = self.create_project()
+        self.dashboard.projects.add(project)
+        self.dashboard.save()
+
+        response = self.do_request("get", self.url)
+        assert response.status_code == 200, response.content
+
+        overview_dashboard = response.data[0]
+        assert overview_dashboard["projects"] == []
+
+        current_dashboard = response.data[1]
+        assert current_dashboard["projects"] == [project.id]
+
+        starred_dashboard = response.data[2]
+        assert starred_dashboard["projects"] == []


### PR DESCRIPTION
Expose the project IDs on a dashboard so we can render the platform icons next to dashboard titles in the starred section in the sidebar.