### PR TITLE
fix(ourlogs): Fix colspan count

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -380,9 +380,11 @@ function LogRowDetails({
     );
   }
 
+  const colSpan = fields.length + 1; // Number of dynamic fields + first cell which is always rendered.
+
   return (
     <DetailsWrapper ref={isPending ? undefined : ref}>
-      <LogDetailTableBodyCell colSpan={fields.length}>
+      <LogDetailTableBodyCell colSpan={colSpan}>
         {isPending && <LoadingIndicator />}
         {!isPending && data && (
           <Fragment>


### PR DESCRIPTION
### Summary
Colspan of the details should be the number of columns in the tables, which isn't === fields because of the default first column for expansion.

