### PR TITLE
fix(crons): Specify checkinId on Go quickstart

### DIFF
--- a/static/app/views/insights/crons/components/quickStartEntries.tsx
+++ b/static/app/views/insights/crons/components/quickStartEntries.tsx
@@ -608,6 +608,7 @@ checkinId := sentry.CaptureCheckIn(
 // 🟢 Notify Sentry your job has completed successfully:
 sentry.CaptureCheckIn(
   &sentry.CheckIn{
+    ID:          *checkinId,
     MonitorSlug: "<monitor-slug>",
     Status:      sentry.CheckInStatusOK,
   },


### PR DESCRIPTION
Sentry's GO SDK automatically allocates a UUID for each check in sent, therefore if you do not specify the checkinId a new check in record is made in Sentry.

Closes #92822

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
