### PR TITLE
fix(ourlog): Fix details row warning and cell shift

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -86,13 +86,14 @@ export const LogDetailTableBodyCell = styled(TableBodyCell)`
   }
 `;
 
-export const DetailsWrapper = styled('div')`
+export const DetailsWrapper = styled('tr')`
   align-items: center;
   background-color: ${p => p.theme.gray100};
   padding: ${space(1)} ${space(1)};
   flex-direction: column;
   white-space: nowrap;
   grid-column: 1 / -1;
+  display: grid;
   border-top: 1px solid ${p => p.theme.border};
   border-bottom: 1px solid ${p => p.theme.border};
   z-index: ${2 /* place above the grid resizing lines */};


### PR DESCRIPTION
### Summary

We previously had this as a 'div' but since it's a child of tbody it needs to be 'tr'. Also adding display:grid fixes the issue where items inside the detail wrapper cause the table grid to be re-arranged as the details wrapper becomes a subgrid.
