### PR TITLE
feat(explore): Add failure rate to explore/alerts/dashboards

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -835,6 +835,7 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
   AggregationKey.COUNT_UNIQUE,
   AggregationKey.EPM,
+  AggregationKey.FAILURE_RATE,
   AggregationKey.AVG,
   AggregationKey.P50,
   AggregationKey.P75,
@@ -1031,6 +1032,12 @@ const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
     ],
   },
 };
+
+export const NO_ARGUMENT_SPAN_AGGREGATES: AggregationKey[] = Object.entries(
+  SPAN_AGGREGATION_FIELDS
+)
+  .filter(([_, field]) => field.parameters?.length === 0)
+  .map(([key]) => key as AggregationKey);
 
 export const MEASUREMENT_FIELDS: Record<WebVital | MobileVital, FieldDefinition> = {
   [WebVital.FP]: {

--- a/static/app/views/alerts/rules/metric/eapField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.spec.tsx
@@ -76,6 +76,35 @@ describe('EAPField', () => {
     expect(inputs[1]).toBeDisabled();
   });
 
+  it('renders failure_rate with argument disabled', () => {
+    render(
+      <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <EAPField aggregate={'failure_rate()'} onChange={() => {}} />
+      </SpanTagsProvider>
+    );
+    expect(fieldsMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/trace-items/attributes/`,
+      expect.objectContaining({
+        query: expect.objectContaining({attributeType: 'number'}),
+      })
+    );
+    expect(fieldsMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/trace-items/attributes/`,
+      expect.objectContaining({
+        query: expect.objectContaining({attributeType: 'string'}),
+      })
+    );
+    expect(screen.getByText('failure_rate')).toBeInTheDocument();
+    expect(screen.getByText('spans')).toBeInTheDocument();
+
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(2);
+    // this corresponds to the `count` input
+    expect(inputs[0]).toBeEnabled();
+    // this corresponds to the `spans` input
+    expect(inputs[1]).toBeDisabled();
+  });
+
   it('should call onChange with the new aggregate string when switching aggregates', async () => {
     const onChange = jest.fn();
     render(

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -10,6 +10,7 @@ import {parseFunction} from 'sentry/utils/discover/fields';
 import {
   AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  NO_ARGUMENT_SPAN_AGGREGATES,
   prettifyTagKey,
 } from 'sentry/utils/fields';
 import {
@@ -67,7 +68,10 @@ function EAPField({aggregate, onChange}: Props) {
       return [true, {label: t('spans'), value: DEFAULT_VISUALIZATION_FIELD}];
     }
 
-    if (aggregation === AggregationKey.EPM || aggregation === AggregationKey.EPS) {
+    if (
+      aggregation &&
+      NO_ARGUMENT_SPAN_AGGREGATES.includes(aggregation as AggregationKey)
+    ) {
       return [true, {label: t('spans'), value: ''}];
     }
 

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -21,7 +21,11 @@ import {
   doDiscoverQuery,
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {AggregationKey, ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {
+  AggregationKey,
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  NO_ARGUMENT_SPAN_AGGREGATES,
+} from 'sentry/utils/fields';
 import type {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {
@@ -86,7 +90,7 @@ const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce(
           },
         ],
       };
-    } else if (aggregate === AggregationKey.EPM || aggregate === AggregationKey.EPS) {
+    } else if (NO_ARGUMENT_SPAN_AGGREGATES.includes(aggregate as AggregationKey)) {
       acc[aggregate] = {
         isSortable: true,
         outputType: null,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -1558,6 +1558,35 @@ describe('Visualize', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('disables changing visualize fields for failure_rate', async function () {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.LINE,
+              yAxis: ['failure_rate()'],
+            },
+          }),
+        }),
+
+        deprecatedRouterMocks: true,
+      }
+    );
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toBeEnabled();
+    expect(
+      screen.queryByRole('button', {name: 'Column Selection'})
+    ).not.toBeInTheDocument();
+  });
+
   it('changes to epm() when using epm', async function () {
     render(
       <WidgetBuilderProvider>
@@ -1594,6 +1623,47 @@ describe('Visualize', () => {
     await userEvent.click(screen.getByRole('option', {name: 'epm'}));
     expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
       'epm'
+    );
+    expect(
+      screen.queryByRole('button', {name: 'Column Selection'})
+    ).not.toBeInTheDocument();
+  });
+  it('changes to failure_rate() when using failure_rate', async function () {
+    render(
+      <WidgetBuilderProvider>
+        <Visualize />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+
+        router: RouterFixture({
+          location: LocationFixture({
+            query: {
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.LINE,
+              yAxis: ['avg(span.self_time)'],
+            },
+          }),
+        }),
+
+        deprecatedRouterMocks: true,
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: 'Aggregate Selection'})
+    ).toBeEnabled();
+
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'avg'
+    );
+    expect(screen.getByRole('button', {name: 'Column Selection'})).toHaveTextContent(
+      'span.self_time'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Aggregate Selection'}));
+    await userEvent.click(screen.getByRole('option', {name: 'failure_rate'}));
+    expect(screen.getByRole('button', {name: 'Aggregate Selection'})).toHaveTextContent(
+      'failure_rate'
     );
     expect(
       screen.queryByRole('button', {name: 'Column Selection'})

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -8,6 +8,7 @@ import {
   AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
   ALLOWED_EXPLORE_VISUALIZE_FIELDS,
+  NO_ARGUMENT_SPAN_AGGREGATES,
 } from 'sentry/utils/fields';
 import {decodeList} from 'sentry/utils/queryString';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -164,15 +165,14 @@ export function updateVisualizeAggregate({
     return `${newAggregate}(${SpanIndexedField.SPAN_OP})`;
   }
 
-  if (newAggregate === AggregationKey.EPM || newAggregate === AggregationKey.EPS) {
+  if (NO_ARGUMENT_SPAN_AGGREGATES.includes(newAggregate as AggregationKey)) {
     return `${newAggregate}()`;
   }
 
   // switching away from count_unique means we need to reset the field
   if (
     oldAggregate === AggregationKey.COUNT_UNIQUE ||
-    oldAggregate === AggregationKey.EPM ||
-    oldAggregate === AggregationKey.EPS
+    NO_ARGUMENT_SPAN_AGGREGATES.includes(oldAggregate as AggregationKey)
   ) {
     return `${newAggregate}(${DEFAULT_VISUALIZATION_FIELD})`;
   }

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -6,7 +6,12 @@ import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {
+  AggregationKey,
+  FieldKind,
+  NO_ARGUMENT_SPAN_AGGREGATES,
+  prettifyTagKey,
+} from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -39,10 +44,7 @@ export function useVisualizeFields({
       return [FieldKind.MEASUREMENT, countTags];
     }
 
-    if (
-      parsedFunction?.name === AggregationKey.EPM ||
-      parsedFunction?.name === AggregationKey.EPS
-    ) {
+    if (NO_ARGUMENT_SPAN_AGGREGATES.includes(parsedFunction?.name as AggregationKey)) {
       const countTags: TagCollection = {
         '': {
           name: t('spans'),

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -270,6 +270,96 @@ describe('MultiQueryModeContent', function () {
     ]);
   });
 
+  it('changes to failure_rate() when using failure_rate', async function () {
+    let queries: any;
+    function Component() {
+      queries = useReadQueriesFromLocation();
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>
+    );
+
+    const section = await screen.findByTestId('section-visualize-0');
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'failure_rate'}));
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['failure_rate()'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+  });
+
+  it('disables changing fields for failure_rate', async function () {
+    function Component() {
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>
+    );
+
+    const section = await screen.findByTestId('section-visualize-0');
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'failure_rate'}));
+    expect(within(section).getByRole('button', {name: 'spans'})).toBeDisabled();
+  });
+
   it('defaults count_unique argument to span.op', async function () {
     let queries: any;
     function Component() {


### PR DESCRIPTION
pretty much a copy of https://github.com/getsentry/sentry/pull/92227
but for failure rate.

Failure rate has been updated to be generic to any type of span (looks for `span.status`) so it is acceptable to add it explore

Closes EXP-268
Closes #91136