### PR TITLE
test: Remove redundant assertions

### DIFF
--- a/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
+++ b/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
@@ -238,7 +238,6 @@ class IntegrationPlatformEndpointTest(TestCase):
         response = self.endpoint._handle_sentry_app_exception(error)
 
         assert response.status_code == 400
-        assert response.data == error.to_public_dict()
         assert response.exception is True
         assert response.data == {"detail": error.message}
 
@@ -253,7 +252,6 @@ class IntegrationPlatformEndpointTest(TestCase):
         response = self.endpoint._handle_sentry_app_exception(error)
 
         assert response.status_code == 400
-        assert response.data == error.to_public_dict()
         assert response.exception is True
         assert response.data == {"detail": error.message, "context": public_context}
 
@@ -265,7 +263,6 @@ class IntegrationPlatformEndpointTest(TestCase):
         response = self.endpoint._handle_sentry_app_exception(error)
 
         assert response.status_code == 500
-        assert response.data == error.to_public_dict()
         assert response.data == {
             "detail": f"An issue occured during the integration platform process. Sentry error ID: {None}"
         }


### PR DESCRIPTION
These assertions are redundant. We already assert that `response.data` has the correct contents in all three tests. If we want to check `error.to_public_dict()`'s value, we should do so in a separate unit test.

Hopefully unblocks #92011