### PR TITLE
fix(settings): Redirect to settings project list after proj deletion

### DIFF
--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -132,7 +132,7 @@ describe('projectGeneralSettings', function () {
       method: 'DELETE',
     });
 
-    render(<ProjectGeneralSettings onChangeSlug={mockOnChangeSlug} />, {
+    const {router} = render(<ProjectGeneralSettings onChangeSlug={mockOnChangeSlug} />, {
       organization,
       initialRouterConfig: {
         location: {
@@ -150,6 +150,7 @@ describe('projectGeneralSettings', function () {
 
     expect(deleteMock).toHaveBeenCalled();
     expect(removePageFiltersStorage).toHaveBeenCalledWith('org-slug');
+    expect(router.location.pathname).toBe('/settings/org-slug/projects/');
   });
 
   it('project admins can transfer project', async function () {

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -34,7 +34,6 @@ import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import recreateRoute from 'sentry/utils/recreateRoute';
-import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -52,6 +51,7 @@ type Props = {
 function ProjectGeneralSettings({onChangeSlug}: Props) {
   const form: Record<string, FieldValue> = {};
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const organization = useOrganization();
   const {projectId} = useParams<{projectId: string}>();
@@ -82,37 +82,27 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
     form[id] = value;
   };
 
-  const handleRemoveProject = () => {
+  const handleRemoveProject = async () => {
     removePageFiltersStorage(organization.slug);
 
     if (!project) {
       return;
     }
 
-    removeProject({
-      api,
-      orgSlug: organization.slug,
-      projectSlug: project.slug,
-      origin: 'settings',
-    })
-      .then(
-        () => {
-          addSuccessMessage(
-            tct('[project] was successfully removed', {project: project.slug})
-          );
-        },
-        err => {
-          addErrorMessage(tct('Error removing [project]', {project: project.slug}));
-          throw err;
-        }
-      )
-      .then(
-        () => {
-          // Need to hard reload because lots of components do not listen to Projects Store
-          window.location.assign('/');
-        },
-        (err: RequestError) => handleXhrErrorResponse('Unable to remove project', err)
-      );
+    try {
+      await removeProject({
+        api,
+        orgSlug: organization.slug,
+        projectSlug: project.slug,
+        origin: 'settings',
+      });
+    } catch (err) {
+      addErrorMessage(tct('Error removing [project]', {project: project.slug}));
+      throw err;
+    }
+
+    addSuccessMessage(tct('[project] was successfully removed', {project: project.slug}));
+    navigate(`/settings/${organization.slug}/projects/`);
   };
 
   const handleTransferProject = async () => {
@@ -283,7 +273,7 @@ function ProjectGeneralSettings({onChangeSlug}: Props) {
   // The <Form /> component applies its props to its children meaning the
   // hooked component would need to conform to the form settings applied in a
   // separate repository. This is not feasible to maintain and may introduce
-  // compatability errors if something changes in either repository. For that
+  // compatibility errors if something changes in either repository. For that
   // reason, the Form component is split in two, since the fields do not
   // depend on one another, allowing for the Hook to manage its own state.
   const formProps: FormProps = {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/91785
Fixes [RTC-964: \[Project Settings\] Redirect After Clicking Remove Project](https://linear.app/getsentry/issue/RTC-964/project-settings-redirect-after-clicking-remove-project)

Requires https://github.com/getsentry/sentry/pull/92851