### PR TITLE
fix(trace-eap-waterfall): Changing error.start_timestamp from iso_for…

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -110,7 +110,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             )
         elif event.get("event_type") == "error":
             timestamp = (
-                event["timestamp_ms"]
+                event["timestamp_ms"] / 1000.0
                 if "timestamp_ms" in event and event["timestamp_ms"] is not None
                 else event["timestamp"]
             )

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -36,13 +36,13 @@ class SerializedEvent(TypedDict):
     event_type: str
     project_id: int
     project_slug: str
-    start_timestamp: datetime
     transaction: str
 
 
 class SerializedIssue(SerializedEvent):
     issue_id: int
     level: str
+    start_timestamp: float
     end_timestamp: NotRequired[datetime]
 
 
@@ -58,6 +58,7 @@ class SerializedSpan(SerializedEvent):
     profile_id: str
     profiler_id: str
     sdk_name: str
+    start_timestamp: datetime
     is_transaction: bool
     transaction_id: str
 
@@ -110,9 +111,9 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             )
         elif event.get("event_type") == "error":
             timestamp = (
-                datetime.datetime.fromisoformat(event["timestamp_ms"]).timestamp()
+                datetime.fromisoformat(event["timestamp_ms"]).timestamp()
                 if "timestamp_ms" in event and event["timestamp_ms"] is not None
-                else event["timestamp"]
+                else datetime.fromisoformat(event["timestamp"]).timestamp()
             )
 
             return SerializedIssue(

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -14,10 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import (
-    handle_query_errors,
-    update_snuba_params_with_timestamp,
-)
+from sentry.api.utils import handle_query_errors, update_snuba_params_with_timestamp
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.organization import Organization
 from sentry.models.project import Project

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -110,7 +110,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             )
         elif event.get("event_type") == "error":
             timestamp = (
-                event["timestamp_ms"] / 1000.0
+                datetime.datetime.fromisoformat(event["timestamp_ms"]).timestamp()
                 if "timestamp_ms" in event and event["timestamp_ms"] is not None
                 else event["timestamp"]
             )

--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -16,7 +16,6 @@ from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import (
     handle_query_errors,
-    reformat_timestamp_ms_to_isoformat,
     update_snuba_params_with_timestamp,
 )
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -114,7 +113,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
             )
         elif event.get("event_type") == "error":
             timestamp = (
-                reformat_timestamp_ms_to_isoformat(event["timestamp_ms"])
+                event["timestamp_ms"]
                 if "timestamp_ms" in event and event["timestamp_ms"] is not None
                 else event["timestamp"]
             )

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from uuid import uuid4
 
 from django.urls import reverse
@@ -158,10 +157,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert error_event["project_slug"] == self.gen1_project.slug
         assert error_event["level"] == "error"
         assert error_event["issue_id"] == error.group_id
-        assert (
-            error_event["start_timestamp"]
-            == datetime.fromtimestamp(error_data["timestamp"]).astimezone().isoformat()
-        )
+        assert error_event["start_timestamp"] == error_data["timestamp"]
 
     def test_with_performance_issues(self):
         self.load_trace(is_eap=True)


### PR DESCRIPTION
- Mismatch in format, leads to broken waterfall timelines.
- Trying to fix this in the FE will lead to a bunch of redundant conditionals
<img width="1241" alt="Screenshot 2025-06-04 at 12 38 02 PM" src="https://github.com/user-attachments/assets/1ce4ea49-0220-47f2-82cd-84564b85857d" />
