### PR TITLE
ref(span-buffer): Crash consumer if flusher is hanging

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2696,6 +2696,11 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "standalone-spans.buffer.flusher.max_unhealthy_seconds",
+    default=10,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "indexed-spans.agg-span-waterfall.enable",
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 import rapidjson
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Message, Partition, Topic, Value
@@ -7,6 +8,7 @@ from arroyo.types import Message, Partition, Topic, Value
 from sentry.spans.consumers.process.factory import ProcessSpansStrategyFactory
 
 
+@pytest.mark.django_db
 def test_basic(monkeypatch):
     # Flush very aggressively to make test pass instantly
     monkeypatch.setattr("time.sleep", lambda _: None)


### PR DESCRIPTION
There seem to be instances where the flusher is somehow locking up and
no longer reporting metrics, without being killed. In that instance we
should hard-crash the consumer. Right now if the flusher hangs up, it
will not even signal backpressure (because it can't, because it's locked up)

Ref VIEPF-38
