### PR TITLE
ref(js): Remove custom styling on join request tag

### DIFF
--- a/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -60,12 +60,9 @@ function InviteRequestRow({
             </Description>
           )
         ) : (
-          <Tooltip
-            title={t('This user has asked to join your organization.')}
-            skipWrapper
-          >
-            <JoinRequestIndicator>{t('Join request')}</JoinRequestIndicator>
-          </Tooltip>
+          <Tag title={t('This user has asked to join your organization.')}>
+            {t('Join request')}
+          </Tag>
         )}
       </div>
 
@@ -157,10 +154,6 @@ function InviteRequestRow({
     </InviteModalHook>
   );
 }
-
-const JoinRequestIndicator = styled(Tag)`
-  text-transform: uppercase;
-`;
 
 const StyledPanelItem = styled(PanelItem)`
   display: grid;


### PR DESCRIPTION
Before

<img width="244" alt="image" src="https://github.com/user-attachments/assets/1162b94a-a9cc-4fb1-bd3a-2da8df42c526" />

After

<img alt="clipboard.png" width="205" src="https://i.imgur.com/Cn2jnXJ.png" />