### PR TITLE
feat(dashboards): Add platform icons to starred sidebar items

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -44,6 +44,7 @@ describe('add to dashboard modal', () => {
     dateCreated: '2020-01-01T00:00:00.000Z',
     widgetDisplay: [DisplayType.AREA],
     widgetPreview: [],
+    projects: [],
   };
   const testDashboard: DashboardDetails = {
     id: '1',

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -125,6 +125,7 @@ export type DashboardPermissions = {
  */
 export type DashboardListItem = {
   id: string;
+  projects: number[];
   title: string;
   widgetDisplay: DisplayType[];
   widgetPreview: WidgetPreview[];

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -1,16 +1,20 @@
 import {Fragment} from 'react';
 
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
+import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 export function DashboardsSecondaryNav() {
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/dashboards`;
+  const {projects} = useProjects();
 
   const {data: starredDashboards = []} = useApiQuery<DashboardListItem[]>(
     [
@@ -39,15 +43,25 @@ export function DashboardsSecondaryNav() {
         </SecondaryNav.Section>
         {starredDashboards.length > 0 ? (
           <SecondaryNav.Section id="dashboards-starred" title={t('Starred Dashboards')}>
-            {starredDashboards.map(dashboard => (
-              <SecondaryNav.Item
-                key={dashboard.id}
-                to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
-                analyticsItemName="dashboard_starred_item"
-              >
-                {dashboard.title}
-              </SecondaryNav.Item>
-            ))}
+            {starredDashboards.map(dashboard => {
+              const dashboardProjects = new Set(dashboard.projects.map(String));
+              const dashboardProjectPlatforms = projects
+                .filter(p => dashboardProjects.has(p.id))
+                .map(p => p.platform)
+                .filter(defined);
+              return (
+                <SecondaryNav.Item
+                  key={dashboard.id}
+                  to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+                  analyticsItemName="dashboard_starred_item"
+                  leadingItems={
+                    <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
+                  }
+                >
+                  {dashboard.title}
+                </SecondaryNav.Item>
+              );
+            })}
           </SecondaryNav.Section>
         ) : null}
       </SecondaryNav.Body>

--- a/tests/js/fixtures/dashboard.ts
+++ b/tests/js/fixtures/dashboard.ts
@@ -28,6 +28,7 @@ export function DashboardListItemFixture(
     title: 'Dashboard',
     widgetDisplay: [],
     widgetPreview: [],
+    projects: [],
     ...params,
   };
 }


### PR DESCRIPTION
Since we store the project IDs on the dashboard object, use the `useProjects` hook to filter out for the platforms related to the starred dashboards in the sidebar.

<img width="198" alt="Screenshot 2025-06-04 at 1 53 02 PM" src="https://github.com/user-attachments/assets/26ead931-b6a0-4340-9a33-1f13f4757420" />
