### PR TITLE
feat(aci): add remaining conditions to automation details conditions panel

### DIFF
--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -5,8 +5,11 @@ import TeamSelector from 'sentry/components/teamSelector';
 import AutomationBuilderSelectField, {
   selectControlStyles,
 } from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
+import useUserFromId from 'sentry/utils/useUserFromId';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 enum TargetType {
@@ -20,6 +23,29 @@ const TARGET_TYPE_CHOICES = [
   {value: TargetType.TEAM, label: 'Team'},
   {value: TargetType.MEMBER, label: 'Member'},
 ];
+
+export function AssignedToDetails({condition}: {condition: DataCondition}) {
+  const {target_type, target_identifier} = condition.comparison;
+
+  if (target_type === TargetType.TEAM) {
+    return <AssignedToTeam teamId={String(target_identifier)} />;
+  }
+  if (target_type === TargetType.MEMBER) {
+    return <AssignedToMember memberId={target_identifier} />;
+  }
+  return tct('Issue is unassigned', {});
+}
+
+function AssignedToTeam({teamId}: {teamId: string}) {
+  const {teams} = useTeamsById({ids: [teamId]});
+  const team = teams.find(tm => tm.id === teamId);
+  return t('Issue is assigned to team %s', `#${team?.slug ?? 'unknown'}`);
+}
+
+function AssignedToMember({memberId}: {memberId: number}) {
+  const {data: user} = useUserFromId({id: memberId});
+  return t('Issue is assigned to member %s', `${user?.email ?? 'unknown'}`);
+}
 
 export function AssignedToNode() {
   return tct('Issue is assigned to [targetType] [identifier]', {

--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -6,7 +6,7 @@ import AutomationBuilderSelectField, {
   selectControlStyles,
 } from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {t, tct} from 'sentry/locale';
-import {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import useUserFromId from 'sentry/utils/useUserFromId';

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -2,10 +2,8 @@ import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRo
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
-import {
-  DataCondition,
-  DataConditionType,
-} from 'sentry/types/workflowEngine/dataConditions';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {
   CountBranch,
   PercentBranch,

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -2,13 +2,67 @@ import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRo
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
-import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataCondition,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {
   CountBranch,
   PercentBranch,
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
-import {SubfiltersList} from 'sentry/views/automations/components/actionFilters/subfiltersList';
+import {
+  COMPARISON_INTERVAL_CHOICES,
+  INTERVAL_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  SubfilterDetailsList,
+  SubfiltersList,
+} from 'sentry/views/automations/components/actionFilters/subfiltersList';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function EventFrequencyCountDetails({condition}: {condition: DataCondition}) {
+  const hasSubfilters = condition.comparison.filters?.length > 0;
+  return (
+    <div>
+      {tct('Number of events in an issue is more than [value] [interval] [where]', {
+        value: condition.comparison.value,
+        interval:
+          INTERVAL_CHOICES.find(choice => choice.value === condition.comparison.interval)
+            ?.label || condition.comparison.interval,
+        where: hasSubfilters ? t('where') : null,
+      })}
+      {hasSubfilters && (
+        <SubfilterDetailsList subfilters={condition.comparison.filters} />
+      )}
+    </div>
+  );
+}
+
+export function EventFrequencyPercentDetails({condition}: {condition: DataCondition}) {
+  const hasSubfilters = condition.comparison.filters?.length > 0;
+  return (
+    <div>
+      {tct(
+        'Number of events in an issue is [value]% higher [interval] compared to [comparison_interval] [where]',
+        {
+          value: condition.comparison.value,
+          interval:
+            INTERVAL_CHOICES.find(
+              choice => choice.value === condition.comparison.interval
+            )?.label || condition.comparison.interval,
+          comparison_interval:
+            COMPARISON_INTERVAL_CHOICES.find(
+              choice => choice.value === condition.comparison.comparison_interval
+            )?.label || condition.comparison.comparison_interval,
+          where: hasSubfilters ? t('where') : null,
+        }
+      )}
+      {hasSubfilters && (
+        <SubfilterDetailsList subfilters={condition.comparison.filters} />
+      )}
+    </div>
+  );
+}
 
 export default function EventFrequencyNode() {
   const {condition} = useDataConditionNodeContext();

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -1,11 +1,51 @@
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {tct} from 'sentry/locale';
-import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataCondition,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {
   CountBranch,
   PercentBranch,
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
+import {
+  COMPARISON_INTERVAL_CHOICES,
+  INTERVAL_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function EventUniqueUserFrequencyCountDetails({
+  condition,
+}: {
+  condition: DataCondition;
+}) {
+  return tct('Number of users affected by an issue is more than [value] [interval]', {
+    value: condition.comparison.value,
+    interval:
+      INTERVAL_CHOICES.find(choice => choice.value === condition.comparison.interval)
+        ?.label || condition.comparison.interval,
+  });
+}
+
+export function EventUniqueUserFrequencyPercentDetails({
+  condition,
+}: {
+  condition: DataCondition;
+}) {
+  return tct(
+    'Number of users affected by an issue is [value]% higher [interval] compared to [comparison_interval]',
+    {
+      value: condition.comparison.value,
+      interval:
+        INTERVAL_CHOICES.find(choice => choice.value === condition.comparison.interval)
+          ?.label || condition.comparison.interval,
+      comparison_interval:
+        COMPARISON_INTERVAL_CHOICES.find(
+          choice => choice.value === condition.comparison.comparison_interval
+        )?.label || condition.comparison.comparison_interval,
+    }
+  );
+}
 
 export default function EventUniqueUserFrequencyNode() {
   return tct('Number of users affected by an issue is [select]', {

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -1,9 +1,7 @@
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {tct} from 'sentry/locale';
-import {
-  DataCondition,
-  DataConditionType,
-} from 'sentry/types/workflowEngine/dataConditions';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {
   CountBranch,
   PercentBranch,

--- a/static/app/views/automations/components/actionFilters/issueOccurrences.tsx
+++ b/static/app/views/automations/components/actionFilters/issueOccurrences.tsx
@@ -1,6 +1,13 @@
 import AutomationBuilderNumberField from 'sentry/components/workflowEngine/form/automationBuilderNumberField';
 import {tct} from 'sentry/locale';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function IssueOccurrencesDetails({condition}: {condition: DataCondition}) {
+  return tct('The issue has happened at least [value] times', {
+    value: condition.comparison.value,
+  });
+}
 
 export default function IssueOccurrencesNode() {
   return tct('The issue has happened at least [value] times', {

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -1,6 +1,7 @@
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {t, tct} from 'sentry/locale';
 import type {Environment} from 'sentry/types/project';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -10,6 +11,23 @@ import {
   type ModelAge,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function LatestAdoptedReleaseDetails({condition}: {condition: DataCondition}) {
+  return tct(
+    "The [releaseAgeType] adopted release associated with the event's issue is [ageComparison] the latest adopted release in [environment]",
+    {
+      releaseAgeType:
+        MODEL_AGE_CHOICES.find(
+          choice => choice.value === condition.comparison.release_age_type
+        )?.label || condition.comparison.release_age_type,
+      ageComparison:
+        AGE_COMPARISON_CHOICES.find(
+          choice => choice.value === condition.comparison.age_comparison
+        )?.label || condition.comparison.age_comparison,
+      environment: condition.comparison.environment,
+    }
+  );
+}
 
 export default function LatestAdoptedReleaseNode() {
   return tct(

--- a/static/app/views/automations/components/actionFilters/latestRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestRelease.tsx
@@ -1,0 +1,5 @@
+import {t} from 'sentry/locale';
+
+export function LatestReleaseNode() {
+  return t('The issue is the latest release');
+}

--- a/static/app/views/automations/components/actionFilters/level.tsx
+++ b/static/app/views/automations/components/actionFilters/level.tsx
@@ -1,5 +1,6 @@
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {tct} from 'sentry/locale';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
   type Level,
   LEVEL_CHOICES,
@@ -7,6 +8,17 @@ import {
   type MatchType,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function LevelDetails({condition}: {condition: DataCondition}) {
+  return tct("The event's level [match] [level]", {
+    match:
+      LEVEL_MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)
+        ?.label || condition.comparison.match,
+    level:
+      LEVEL_CHOICES.find(choice => choice.value === condition.comparison.level)?.label ||
+      condition.comparison.level,
+  });
+}
 
 export default function LevelNode() {
   return tct("The event's level [match] [level]", {

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -1,11 +1,46 @@
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {tct} from 'sentry/locale';
-import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataCondition,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 import {
   CountBranch,
   PercentBranch,
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
+import {
+  COMPARISON_INTERVAL_CHOICES,
+  INTERVAL_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function PercentSessionsCountDetails({condition}: {condition: DataCondition}) {
+  return tct(
+    'Percentage of sessions affected by an issue is more than [value] [interval]',
+    {
+      value: condition.comparison.value,
+      interval:
+        INTERVAL_CHOICES.find(choice => choice.value === condition.comparison.interval)
+          ?.label || condition.comparison.interval,
+    }
+  );
+}
+
+export function PercentSessionsPercentDetails({condition}: {condition: DataCondition}) {
+  return tct(
+    'Percentage of sessions affected by an issue is [value]% higher [interval] compared to [comparison_interval]',
+    {
+      value: condition.comparison.value,
+      interval:
+        INTERVAL_CHOICES.find(choice => choice.value === condition.comparison.interval)
+          ?.label || condition.comparison.interval,
+      comparison_interval:
+        COMPARISON_INTERVAL_CHOICES.find(
+          choice => choice.value === condition.comparison.comparison_interval
+        )?.label || condition.comparison.comparison_interval,
+    }
+  );
+}
 
 export default function PercentSessionsNode() {
   return tct('Percentage of sessions affected by an issue is [select]', {

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -1,9 +1,7 @@
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {tct} from 'sentry/locale';
-import {
-  DataCondition,
-  DataConditionType,
-} from 'sentry/types/workflowEngine/dataConditions';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {
   CountBranch,
   PercentBranch,

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -8,7 +8,7 @@ import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRo
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextButton';
 import {IconAdd, IconDelete} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import {
@@ -255,6 +255,30 @@ function ValueField() {
   );
 }
 
+export function SubfilterDetailsList({
+  subfilters,
+}: {
+  subfilters: Array<Record<string, any>>;
+}) {
+  return (
+    <DetailsListWrapper>
+      {subfilters.map((subfilter, index) => (
+        <div key={index}>
+          <SubfilterDetails subfilter={subfilter} />
+        </div>
+      ))}
+    </DetailsListWrapper>
+  );
+}
+
+function SubfilterDetails({subfilter}: {subfilter: Record<string, any>}) {
+  return tct('[item] [match] [value]', {
+    item: subfilter.attribute ?? subfilter.key,
+    match: subfilter.match === MatchType.EQUAL ? t('is') : t('is not'),
+    value: subfilter.value,
+  });
+}
+
 const RowWrapper = styled('div')`
   display: flex;
   align-items: center;
@@ -277,4 +301,11 @@ const StyledRowLine = styled(RowLine)`
       opacity: 1;
     }
   }
+`;
+
+const DetailsListWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  padding: ${space(1)} 0 0 ${space(2)};
 `;

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -1,11 +1,22 @@
 import AutomationBuilderInputField from 'sentry/components/workflowEngine/form/automationBuilderInputField';
 import AutomationBuilderSelectField from 'sentry/components/workflowEngine/form/automationBuilderSelectField';
 import {t, tct} from 'sentry/locale';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
   MATCH_CHOICES,
   type MatchType,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+export function TaggedEventDetails({condition}: {condition: DataCondition}) {
+  return tct("The event's [key] tag [match] [value]", {
+    key: condition.comparison.key,
+    match:
+      MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
+      condition.comparison.match,
+    value: condition.comparison.value,
+  });
+}
 
 export default function TaggedEventNode() {
   return tct("The event's [key] [match] [value]", {

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -1,7 +1,6 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/container/flex';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -21,18 +20,18 @@ type ConditionsPanelProps = {
 function ConditionsPanel({triggers, actionFilters}: ConditionsPanelProps) {
   return (
     <Panel>
-      <Flex column gap={space(1)}>
-        <div>
+      <ConditionGroupWrapper>
+        <ConditionGroupHeader>
           {tct('[when:When] any of the following occur', {
             when: <ConditionBadge />,
           })}
-        </div>
+        </ConditionGroupHeader>
         {triggers.conditions.map((trigger, index) => (
           <div key={index}>
             <DataConditionDetails condition={trigger} />
           </div>
         ))}
-      </Flex>
+      </ConditionGroupWrapper>
       {actionFilters.map((actionFilter, index) => (
         <div key={index}>
           <ActionFilter actionFilter={actionFilter} totalFilters={actionFilters.length} />
@@ -49,12 +48,12 @@ interface ActionFilterProps {
 
 function ActionFilter({actionFilter, totalFilters}: ActionFilterProps) {
   return (
-    <ActionFilterWrapper showDivider={totalFilters > 1}>
-      <div>
+    <ConditionGroupWrapper showDivider={totalFilters > 1}>
+      <ConditionGroupHeader>
         {tct('[if:If] any of these filters match', {
           if: <ConditionBadge />,
         })}
-      </div>
+      </ConditionGroupHeader>
       {actionFilter.conditions.length > 0
         ? actionFilter.conditions.map((filter, index) => (
             <div key={index}>
@@ -62,17 +61,17 @@ function ActionFilter({actionFilter, totalFilters}: ActionFilterProps) {
             </div>
           ))
         : t('Any event')}
-      <div>
+      <ConditionGroupHeader>
         {tct('[then:Then] perform these actions', {
           then: <ConditionBadge />,
         })}
-      </div>
+      </ConditionGroupHeader>
       {actionFilter.actions?.map((action, index) => (
         <div key={index}>
           <ActionDetails action={action} />
         </div>
       ))}
-    </ActionFilterWrapper>
+    </ConditionGroupWrapper>
   );
 }
 
@@ -108,10 +107,15 @@ const Panel = styled('div')`
   padding: ${space(1.5)};
 `;
 
-const ActionFilterWrapper = styled('div')<{showDivider?: boolean}>`
+const ConditionGroupHeader = styled('div')`
+  color: ${p => p.theme.textColor};
+`;
+
+const ConditionGroupWrapper = styled('div')<{showDivider?: boolean}>`
   display: flex;
   flex-direction: column;
   gap: ${space(1)};
+  color: ${p => p.theme.subText};
 
   ${p =>
     p.showDivider &&

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -8,20 +8,41 @@ import {
 import AgeComparisonNode, {
   AgeComparisonDetails,
 } from 'sentry/views/automations/components/actionFilters/ageComparison';
-import {AssignedToNode} from 'sentry/views/automations/components/actionFilters/assignedTo';
+import {
+  AssignedToDetails,
+  AssignedToNode,
+} from 'sentry/views/automations/components/actionFilters/assignedTo';
 import EventAttributeNode, {
   EventAttributeDetails,
 } from 'sentry/views/automations/components/actionFilters/eventAttribute';
-import EventFrequencyNode from 'sentry/views/automations/components/actionFilters/eventFrequency';
-import EventUniqueUserFrequencyNode from 'sentry/views/automations/components/actionFilters/eventUniqueUserFrequency';
-import IssueOccurrencesNode from 'sentry/views/automations/components/actionFilters/issueOccurrences';
+import EventFrequencyNode, {
+  EventFrequencyCountDetails,
+  EventFrequencyPercentDetails,
+} from 'sentry/views/automations/components/actionFilters/eventFrequency';
+import EventUniqueUserFrequencyNode, {
+  EventUniqueUserFrequencyCountDetails,
+  EventUniqueUserFrequencyPercentDetails,
+} from 'sentry/views/automations/components/actionFilters/eventUniqueUserFrequency';
+import IssueOccurrencesNode, {
+  IssueOccurrencesDetails,
+} from 'sentry/views/automations/components/actionFilters/issueOccurrences';
 import IssuePriorityNode, {
   IssuePriorityDetails,
 } from 'sentry/views/automations/components/actionFilters/issuePriority';
-import LatestAdoptedReleaseNode from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
-import LevelNode from 'sentry/views/automations/components/actionFilters/level';
-import PercentSessionsNode from 'sentry/views/automations/components/actionFilters/percentSessions';
-import TaggedEventNode from 'sentry/views/automations/components/actionFilters/taggedEvent';
+import LatestAdoptedReleaseNode, {
+  LatestAdoptedReleaseDetails,
+} from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
+import {LatestReleaseNode} from 'sentry/views/automations/components/actionFilters/latestRelease';
+import LevelNode, {
+  LevelDetails,
+} from 'sentry/views/automations/components/actionFilters/level';
+import PercentSessionsNode, {
+  PercentSessionsCountDetails,
+  PercentSessionsPercentDetails,
+} from 'sentry/views/automations/components/actionFilters/percentSessions';
+import TaggedEventNode, {
+  TaggedEventDetails,
+} from 'sentry/views/automations/components/actionFilters/taggedEvent';
 
 interface DataConditionNodeProps {
   condition: DataCondition;
@@ -94,6 +115,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Issue assignment'),
       dataCondition: <AssignedToNode />,
+      details: AssignedToDetails,
     },
   ],
   [
@@ -101,6 +123,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Issue frequency'),
       dataCondition: <IssueOccurrencesNode />,
+      details: IssueOccurrencesDetails,
     },
   ],
   [
@@ -116,13 +139,15 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Release age'),
       dataCondition: <LatestAdoptedReleaseNode />,
+      details: LatestAdoptedReleaseDetails,
     },
   ],
   [
     DataConditionType.LATEST_RELEASE,
     {
       label: t('Latest release'),
-      dataCondition: t('The issue is from the latest release'),
+      dataCondition: <LatestReleaseNode />,
+      details: LatestReleaseNode,
     },
   ],
   [
@@ -138,6 +163,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Tagged event'),
       dataCondition: <TaggedEventNode />,
+      details: TaggedEventDetails,
     },
   ],
   [
@@ -145,6 +171,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Event level'),
       dataCondition: <LevelNode />,
+      details: LevelDetails,
     },
   ],
   [
@@ -159,6 +186,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Number of events'),
       dataCondition: <EventFrequencyNode />,
+      details: EventFrequencyCountDetails,
     },
   ],
   [
@@ -166,6 +194,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Number of events'),
       dataCondition: <EventFrequencyNode />,
+      details: EventFrequencyPercentDetails,
     },
   ],
   [
@@ -180,6 +209,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Number of users affected'),
       dataCondition: <EventUniqueUserFrequencyNode />,
+      details: EventUniqueUserFrequencyCountDetails,
     },
   ],
   [
@@ -187,6 +217,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Number of users affected'),
       dataCondition: <EventUniqueUserFrequencyNode />,
+      details: EventUniqueUserFrequencyPercentDetails,
     },
   ],
   [
@@ -201,6 +232,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Percentage of sessions affected'),
       dataCondition: <PercentSessionsNode />,
+      details: PercentSessionsCountDetails,
     },
   ],
   [
@@ -208,6 +240,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     {
       label: t('Percentage of sessions affected'),
       dataCondition: <PercentSessionsNode />,
+      details: PercentSessionsPercentDetails,
     },
   ],
 ]);


### PR DESCRIPTION
added remaining conditions and updated styling (text color)

example:
<img width="383" alt="Screenshot 2025-06-04 at 11 27 11 AM" src="https://github.com/user-attachments/assets/bb085648-cc97-42d7-aae1-26653201d9a5" />


example with subfilters:
<img width="383" alt="Screenshot 2025-06-04 at 11 26 35 AM" src="https://github.com/user-attachments/assets/903b50cd-9df0-4ca7-b80c-11cefce79218" />
