### PR TITLE
ref(span-buffer): Crash consumer if flusher is hanging (reapply)

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2704,7 +2704,7 @@ register(
 )
 register(
     "standalone-spans.buffer.flusher.max_unhealthy_seconds",
-    default=10,
+    default=60,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2703,6 +2703,11 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "standalone-spans.buffer.flusher.max_unhealthy_seconds",
+    default=10,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "indexed-spans.agg-span-waterfall.enable",
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -53,7 +53,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         self.redis_was_full = False
         self.current_drift = multiprocessing.Value("i", 0)
         self.backpressure_since = multiprocessing.Value("i", 0)
-        self.healthy_since = multiprocessing.Value("i", 0)
+        self.healthy_since = multiprocessing.Value("i", int(time.time()))
         self.produce_to_pipe = produce_to_pipe
 
         self._create_process()

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 import rapidjson
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Message, Partition, Topic, Value
@@ -7,6 +8,7 @@ from arroyo.types import Message, Partition, Topic, Value
 from sentry.spans.consumers.process.factory import ProcessSpansStrategyFactory
 
 
+@pytest.mark.django_db
 def test_basic(monkeypatch):
     # Flush very aggressively to make test pass instantly
     monkeypatch.setattr("time.sleep", lambda _: None)


### PR DESCRIPTION
- **Reapply "ref(span-buffer): Crash consumer if flusher is hanging (#92854)"**
- **fix**

The original PR had to be reverted because it would immediately trigger a crash because the flusher is hanging. The issue cannot be reproduced locally or in the sandbox, but if i had to guess it's because of this mistake.