### PR TITLE
fix(ourlogs): More aggressive row loading and fix back to top hover

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -66,3 +66,5 @@ export const LOGS_INSTRUCTIONS_URL =
 export const LOGS_FILTER_KEY_SECTIONS: FilterKeySection[] = [LOGS_FILTERS];
 
 export const VIRTUAL_STREAMED_INTERVAL_MS = 333;
+
+export const LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD = 300; // Items from bottom of table to trigger table fetch.

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -67,4 +67,4 @@ export const LOGS_FILTER_KEY_SECTIONS: FilterKeySection[] = [LOGS_FILTERS];
 
 export const VIRTUAL_STREAMED_INTERVAL_MS = 333;
 
-export const LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD = 300; // Items from bottom of table to trigger table fetch.
+export const LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD = 100; // Items from bottom of table to trigger table fetch.

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -375,6 +375,12 @@ export const FloatingBackToTopContainer = styled('div')<{
   width: ${p => (p.tableWidth ? `${p.tableWidth}px` : '100%')};
   display: flex;
   justify-content: center;
+
+  pointer-events: none;
+
+  & > * {
+    pointer-events: auto;
+  }
 `;
 
 export const HoveringRowLoadingRendererContainer = styled('div')<{

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -44,6 +44,7 @@ import {
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {
+  getDynamicLogsNextFetchThreshold,
   getLogBodySearchTerms,
   getTableHeaderLabel,
   logsFieldAlignment,
@@ -58,7 +59,6 @@ type LogsTableProps = {
   stringAttributes?: TagCollection;
 };
 
-const LOGS_GRID_SCROLL_ITEM_THRESHOLD = 20; // Items from bottom of table to trigger table fetch.
 const LOGS_GRID_SCROLL_PIXEL_REVERSE_THRESHOLD = LOGS_GRID_BODY_ROW_HEIGHT * 2; // If you are less than this number of pixels from the top of the table while scrolling backward, fetch the previous page.
 const LOGS_OVERSCAN_AMOUNT = 50; // How many items to render beyond the visible area.
 
@@ -84,6 +84,7 @@ export function LogsInfiniteTable({
     fetchPreviousPage,
     isFetchingNextPage,
     isFetchingPreviousPage,
+    lastPageLength,
   } = infiniteLogsQueryResult;
 
   const tableRef = useRef<HTMLTableElement>(null);
@@ -171,7 +172,7 @@ export function LogsInfiniteTable({
       if (
         scrollDirection === 'forward' &&
         lastItemIndex &&
-        lastItemIndex >= data?.length - LOGS_GRID_SCROLL_ITEM_THRESHOLD
+        lastItemIndex >= data?.length - getDynamicLogsNextFetchThreshold(lastPageLength)
       ) {
         fetchNextPage();
       }
@@ -183,6 +184,7 @@ export function LogsInfiniteTable({
     isScrolling,
     fetchNextPage,
     fetchPreviousPage,
+    lastPageLength,
     scrollOffset,
     isFunctionScrolling,
   ]);

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -471,6 +471,7 @@ export function useInfiniteLogsQuery({
     hasPreviousPage,
     isFetchingNextPage,
     isFetchingPreviousPage,
+    lastPageLength: data?.pages?.[data.pages.length - 1]?.[0]?.data?.length ?? 0,
   };
 }
 

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -16,7 +16,10 @@ import {
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
-import {LogAttributesHumanLabel} from 'sentry/views/explore/logs/constants';
+import {
+  LogAttributesHumanLabel,
+  LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD,
+} from 'sentry/views/explore/logs/constants';
 import {
   type LogAttributeUnits,
   type LogRowItem,
@@ -228,4 +231,11 @@ export function logsPickableDays(organization: Organization): PickableDays {
       ...Object.fromEntries(relativeOptions),
     }),
   };
+}
+
+export function getDynamicLogsNextFetchThreshold(lastPageLength: number) {
+  if (lastPageLength > LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD * 2) {
+    return Math.floor(lastPageLength * 0.75); // Can be up to 750 on large pages.
+  }
+  return LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD;
 }

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -234,7 +234,7 @@ export function logsPickableDays(organization: Organization): PickableDays {
 }
 
 export function getDynamicLogsNextFetchThreshold(lastPageLength: number) {
-  if (lastPageLength * 0.75> LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD) {
+  if (lastPageLength * 0.75 > LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD) {
     return Math.floor(lastPageLength * 0.75); // Can be up to 750 on large pages.
   }
   return LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -234,7 +234,7 @@ export function logsPickableDays(organization: Organization): PickableDays {
 }
 
 export function getDynamicLogsNextFetchThreshold(lastPageLength: number) {
-  if (lastPageLength > LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD * 2) {
+  if (lastPageLength > LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD / 0.75) {
     return Math.floor(lastPageLength * 0.75); // Can be up to 750 on large pages.
   }
   return LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -234,7 +234,7 @@ export function logsPickableDays(organization: Organization): PickableDays {
 }
 
 export function getDynamicLogsNextFetchThreshold(lastPageLength: number) {
-  if (lastPageLength > LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD / 0.75) {
+  if (lastPageLength * 0.75> LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD) {
     return Math.floor(lastPageLength * 0.75); // Can be up to 750 on large pages.
   }
   return LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD;


### PR DESCRIPTION
### Summary
This addresses some feedback for infinite scrolling internally. 

Hovering the back to top button shouldn't block row highlight, and this will load a new page between 300 logs from the bottom up to 75% of the last loaded page (~750) since if you are scrolling quickly and have large pages they can take a bit longer to load. 
