### PR TITLE
feat(trace-eap-waterfall): Standalone spans detail panel loads indefnitely

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -376,7 +376,7 @@ function EAPSpanNodeDetails({
 
   const {
     data: eventTransaction,
-    isPending: isEventTransactionPending,
+    isLoading: isEventTransactionLoading,
     isError: isEventTransactionError,
   } = useTransaction({
     event_id: node.value.transaction_id,
@@ -388,7 +388,7 @@ function EAPSpanNodeDetails({
 
   const traceState = useTraceState();
 
-  if (isTraceItemPending || isEventTransactionPending) {
+  if (isTraceItemPending || isEventTransactionLoading) {
     return <LoadingIndicator />;
   }
 
@@ -403,8 +403,8 @@ function EAPSpanNodeDetails({
       ? 1
       : undefined;
 
-  const isTransaction = isEAPTransactionNode(node);
-  const profileMeta = getProfileMeta(eventTransaction) || '';
+  const isTransaction = isEAPTransactionNode(node) && !!eventTransaction;
+  const profileMeta = eventTransaction ? getProfileMeta(eventTransaction) || '' : '';
   const profileId =
     typeof profileMeta === 'string' ? profileMeta : profileMeta.profiler_id;
 


### PR DESCRIPTION
- Stand alone spans don't have `transaction_id`s. There `isPending` is always true.
- Using isLoading instead and only rendering the transaction specific sections if the data exists.
<img width="1242" alt="Screenshot 2025-06-04 at 3 43 27 PM" src="https://github.com/user-attachments/assets/98846735-7b71-486b-80be-dccdf8f8f1ef" />
