### PR TITLE
chore(ourlogs): Fix referrer for query

### DIFF
--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -123,7 +123,6 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
     },
     pageFiltersReady,
     eventView,
-    referrer,
   };
 
   const queryKey: ApiQueryKey = [

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -119,6 +119,7 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
       ...(limitToTraceId ? {traceId: limitToTraceId} : {}),
       cursor,
       per_page: limit ? limit : undefined,
+      referrer,
     },
     pageFiltersReady,
     eventView,


### PR DESCRIPTION
### Summary
This makes sure referrer is passed along since right now it all shows as trace-view.

