### PR TITLE
feat(search-bar): Prettify explicitly typed tags in aggregate params

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3643,7 +3643,7 @@ describe('SearchQueryBuilder', function () {
       const input = screen.getByPlaceholderText('bar');
       expect(input).toBeInTheDocument();
       expect(input).toHaveFocus();
-      // await userEvent.keyboard('bar');
+      await userEvent.keyboard('bar');
       expect(screen.getByRole('option', {name: 'bar'})).toBeInTheDocument();
     });
   });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -89,10 +89,12 @@ const FILTER_KEYS: TagCollection = {
   'tags[foo,string]': {
     key: 'tags[foo,string]',
     name: 'foo',
+    kind: FieldKind.TAG,
   },
   'tags[bar,number]': {
     key: 'tags[bar,number]',
     name: 'bar',
+    kind: FieldKind.MEASUREMENT,
   },
 };
 
@@ -3518,9 +3520,15 @@ describe('SearchQueryBuilder', function () {
   });
 
   describe('explicitly typed tags', function () {
+    const builderProps = {
+      ...defaultProps,
+      fieldDefinitionGetter: (key: string) =>
+        getFieldDefinition(key, 'span', defaultProps.filterKeys[key]?.kind),
+    };
+
     it('renders explicit string tag filter', async function () {
       render(
-        <SearchQueryBuilder {...defaultProps} initialQuery="tags[foo,string]:foo" />
+        <SearchQueryBuilder {...builderProps} initialQuery="tags[foo,string]:foo" />
       );
 
       expect(
@@ -3540,7 +3548,7 @@ describe('SearchQueryBuilder', function () {
 
     it('renders explicit number tag filter', async function () {
       render(
-        <SearchQueryBuilder {...defaultProps} initialQuery="tags[bar,number]:<=100" />
+        <SearchQueryBuilder {...builderProps} initialQuery="tags[bar,number]:<=100" />
       );
 
       expect(
@@ -3560,7 +3568,7 @@ describe('SearchQueryBuilder', function () {
 
     it('renders has explicit string tag filter', async function () {
       render(
-        <SearchQueryBuilder {...defaultProps} initialQuery="has:tags[foo,string]" />
+        <SearchQueryBuilder {...builderProps} initialQuery="has:tags[foo,string]" />
       );
 
       expect(
@@ -3579,7 +3587,7 @@ describe('SearchQueryBuilder', function () {
 
     it('renders has explicit number tag filter', async function () {
       render(
-        <SearchQueryBuilder {...defaultProps} initialQuery="has:tags[bar,number]" />
+        <SearchQueryBuilder {...builderProps} initialQuery="has:tags[bar,number]" />
       );
 
       expect(
@@ -3594,6 +3602,49 @@ describe('SearchQueryBuilder', function () {
       const option = screen.getByRole('option', {name: 'bar'});
       expect(option).toBeInTheDocument();
       expect(option).toHaveTextContent('bar');
+    });
+
+    it('renders aggregate filter with explicit string tag', async function () {
+      render(
+        <SearchQueryBuilder
+          {...builderProps}
+          initialQuery="count_unique(tags[foo,string]):5"
+        />
+      );
+
+      expect(
+        screen.getByRole('button', {name: 'Edit parameters for filter: count_unique'})
+      ).toHaveTextContent('foo');
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit parameters for filter: count_unique'})
+      );
+
+      const input = screen.getByPlaceholderText('foo');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveFocus();
+      await userEvent.keyboard('foo');
+      expect(screen.getByRole('option', {name: 'foo'})).toBeInTheDocument();
+    });
+
+    it('renders aggregate filter with explicit number tag', async function () {
+      render(
+        <SearchQueryBuilder {...builderProps} initialQuery="p95(tags[bar,number]):5" />
+      );
+
+      expect(
+        screen.getByRole('button', {name: 'Edit parameters for filter: p95'})
+      ).toHaveTextContent('bar');
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit parameters for filter: p95'})
+      );
+
+      const input = screen.getByPlaceholderText('bar');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveFocus();
+      // await userEvent.keyboard('bar');
+      expect(screen.getByRole('option', {name: 'bar'})).toBeInTheDocument();
     });
   });
 
@@ -3610,13 +3661,15 @@ describe('SearchQueryBuilder', function () {
       return key;
     }
 
+    const builderProps = {
+      ...defaultProps,
+      fieldDefinitionGetter: (key: string) =>
+        getFieldDefinition(key, 'span', defaultProps.filterKeys[key]?.kind),
+      getSuggestedFilterKey,
+    };
+
     it('replace string key with suggestion when autocompleting', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
-      );
+      render(<SearchQueryBuilder {...builderProps} />);
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('foo:{Escape}');
@@ -3627,12 +3680,7 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('replace number key with suggestion when autocompleting', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
-      );
+      render(<SearchQueryBuilder {...builderProps} />);
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('bar:{Escape}');
@@ -3644,11 +3692,7 @@ describe('SearchQueryBuilder', function () {
 
     it('replaces string key with suggestion on enter', async function () {
       render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          initialQuery="browser.name:firefox"
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
+        <SearchQueryBuilder {...builderProps} initialQuery="browser.name:firefox" />
       );
 
       await userEvent.click(
@@ -3663,11 +3707,7 @@ describe('SearchQueryBuilder', function () {
 
     it('replaces number key with suggestion on enter', async function () {
       render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          initialQuery="browser.name:firefox"
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
+        <SearchQueryBuilder {...builderProps} initialQuery="browser.name:firefox" />
       );
 
       await userEvent.click(
@@ -3681,12 +3721,7 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('replaces string key in has with suggestion on enter', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
-      );
+      render(<SearchQueryBuilder {...builderProps} />);
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('has:foo{Enter}{Escape}');
@@ -3698,12 +3733,7 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('replaces number key in has with suggestion on enter', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
-      );
+      render(<SearchQueryBuilder {...builderProps} />);
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('has:bar{Enter}{Escape}');
@@ -3715,12 +3745,7 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('replaces string key in has with suggestion on blur', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
-      );
+      render(<SearchQueryBuilder {...builderProps} />);
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('has:foo{Enter}');
@@ -3733,12 +3758,7 @@ describe('SearchQueryBuilder', function () {
     });
 
     it('replaces number key in has with suggestion on blur', async function () {
-      render(
-        <SearchQueryBuilder
-          {...defaultProps}
-          getSuggestedFilterKey={getSuggestedFilterKey}
-        />
-      );
+      render(<SearchQueryBuilder {...builderProps} />);
 
       await userEvent.click(getLastInput());
       await userEvent.keyboard('has:bar{Enter}');
@@ -3748,6 +3768,44 @@ describe('SearchQueryBuilder', function () {
         screen.getByRole('button', {name: 'Edit value for filter: has'})
       ).toHaveTextContent('bar');
       expect(screen.getByLabelText('has:tags[bar,number]')).toBeInTheDocument();
+    });
+
+    it('replaces aggregate param string key with suggestion on enter', async function () {
+      render(
+        <SearchQueryBuilder
+          {...builderProps}
+          initialQuery="count_unique(browser.name):>0"
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit parameters for filter: count_unique'})
+      );
+      await userEvent.keyboard('foo{Enter}{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit parameters for filter: count_unique'})
+      ).toHaveTextContent('foo');
+      expect(
+        screen.getByLabelText('count_unique(tags[foo,string]):>0')
+      ).toBeInTheDocument();
+    });
+
+    it('replaces aggregate param number key with suggestion on enter', async function () {
+      render(
+        <SearchQueryBuilder {...builderProps} initialQuery="avg(span.duration):>0" />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit parameters for filter: avg'})
+      );
+      await userEvent.keyboard('bar{Enter}{Escape}');
+
+      expect(
+        screen.getByRole('button', {name: 'Edit parameters for filter: avg'})
+      ).toHaveTextContent('bar');
+
+      expect(screen.getByLabelText('avg(tags[bar,number]):>0')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/aggregateKey.tsx
@@ -9,6 +9,7 @@ import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {SearchQueryBuilderParametersCombobox} from 'sentry/components/searchQueryBuilder/tokens/filter/parametersCombobox';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
+import {useAggregateParamVisual} from 'sentry/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import type {
   AggregateFilter,
@@ -28,7 +29,7 @@ type AggregateKeyProps = {
 
 export function AggregateKeyVisual({token}: {token: AggregateFilter}) {
   const fnName = getKeyName(token.key);
-  const fnParams = token.key.args?.text ?? '';
+  const fnParams = useAggregateParamVisual({token});
 
   return (
     <Fragment>

--- a/static/app/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual.tsx
@@ -1,0 +1,35 @@
+import {useMemo} from 'react';
+
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {getKeyLabel} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
+import type {AggregateFilter} from 'sentry/components/searchSyntax/parser';
+
+interface UseAggregateParamVisualOptions {
+  token: AggregateFilter;
+}
+
+export function useAggregateParamVisual({token}: UseAggregateParamVisualOptions) {
+  const {filterKeys, getFieldDefinition} = useSearchQueryBuilder();
+
+  return useMemo(() => {
+    const aggregateDefinition = getFieldDefinition(token.key.name.text);
+
+    const params =
+      token.key.args?.args?.map((arg, i) => {
+        const argumentKind = aggregateDefinition?.parameters?.[i]?.kind;
+
+        let argumentText = arg.value?.text ?? '';
+        if (argumentKind === 'column') {
+          const argumentKey = filterKeys[argumentText];
+          if (argumentKey) {
+            const argumentDefinition = getFieldDefinition(arg.value?.text ?? '');
+            argumentText = getKeyLabel(argumentKey, argumentDefinition);
+          }
+        }
+
+        return `${arg.separator}${argumentText}`;
+      }) ?? [];
+
+    return params.join('');
+  }, [token, filterKeys, getFieldDefinition]);
+}


### PR DESCRIPTION
Similiar to #91986 and #92071, this formats explicitly typed tags in aggregate params.

Closes EXP-295, EXP-296