### PR TITLE
fix(nav): Add default gap on the secondary nav item component

### DIFF
--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -424,6 +424,7 @@ const StyledNavItem = styled(Link)<ItemProps>`
   font-weight: ${p => p.theme.fontWeightNormal};
   line-height: 177.75%;
   border-radius: ${p => p.theme.borderRadius};
+  gap: ${space(0.75)};
 
   &:focus-visible {
     box-shadow: 0 0 0 2px ${p => p.theme.focusBorder};

--- a/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSavedQueryNavItems.tsx
@@ -128,7 +128,6 @@ const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
   align-items: center;
   padding-right: ${space(0.5)};
   position: relative;
-  gap: 0;
 
   :not(:hover) {
     [data-drag-icon] {
@@ -175,7 +174,6 @@ const LeadingItemsWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-right: ${space(0.75)};
 `;
 
 const TruncatedTitle = styled('div')`

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -1,10 +1,8 @@
 import {Fragment, useMemo} from 'react';
-import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -157,7 +155,7 @@ export function InsightsSecondaryNav() {
                     : undefined
                 }
                 leadingItems={
-                  <StyledProjectIcon
+                  <ProjectIcon
                     projectPlatforms={project.platform ? [project.platform] : ['default']}
                   />
                 }
@@ -172,7 +170,3 @@ export function InsightsSecondaryNav() {
     </Fragment>
   );
 }
-
-const StyledProjectIcon = styled(ProjectIcon)`
-  margin-right: ${space(0.75)};
-`;

--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewItem.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewItem.tsx
@@ -221,13 +221,11 @@ const StyledInteractionStateLayer = styled(InteractionStateLayer)`
 const TrailingItemsWrapper = styled('div')`
   display: flex;
   align-items: center;
-  margin-left: ${space(0.5)};
 `;
 
 const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
   position: relative;
   padding-right: ${space(0.5)};
-  gap: 0;
 
   /* Hide the project icon on hover in favor of the drag handle */
   :hover {
@@ -269,7 +267,6 @@ const LeadingItemsWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-right: ${space(0.75)};
 `;
 
 const GrabHandleWrapper = styled(motion.div)`


### PR DESCRIPTION
Seeing this in prod:

![CleanShot 2025-06-04 at 12 47 57@2x](https://github.com/user-attachments/assets/ac331df3-de28-4678-b089-802f764607d8)

Diagnosing the issue, we have been handling the gap manually up until now. It makes more sense to add it at the component level between leading/trailing items. The chonk version already does this, which is how the dashboards addition didn't get caught.