### PR TITLE
feat(dashboards): Patch updates to filters do not invalidate sidebar

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1255,7 +1255,7 @@ class DashboardDetail extends Component<Props, State> {
                                     },
                                   });
                                 }}
-                                onSave={() => {
+                                onSave={async () => {
                                   const newModifiedDashboard = {
                                     ...cloneDashboard(modifiedDashboard ?? dashboard),
                                     ...getCurrentPageFilters(location),
@@ -1265,7 +1265,7 @@ class DashboardDetail extends Component<Props, State> {
                                   };
                                   this.setState({isSavingDashboardFilters: true});
                                   addLoadingMessage(t('Saving dashboard filters'));
-                                  updateDashboard(
+                                  await updateDashboard(
                                     api,
                                     organization.slug,
                                     newModifiedDashboard

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -21,6 +21,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/detail';
+import {useInvalidateStarredDashboards} from 'sentry/views/dashboards/hooks/useInvalidateStarredDashboards';
 
 import ReleasesSelectControl from './releasesSelectControl';
 import type {DashboardFilters, DashboardPermissions} from './types';
@@ -36,7 +37,7 @@ type FiltersBarProps = {
   dashboardCreator?: User;
   dashboardPermissions?: DashboardPermissions;
   onCancel?: () => void;
-  onSave?: () => void;
+  onSave?: () => Promise<void>;
   shouldBusySaveButton?: boolean;
 };
 
@@ -64,6 +65,8 @@ export default function FiltersBar({
     dashboardPermissions,
     dashboardCreator
   );
+
+  const invalidateStarredDashboards = useInvalidateStarredDashboards();
 
   const selectedReleases =
     (defined(location.query?.[DashboardFilterKeys.RELEASE])
@@ -124,7 +127,10 @@ export default function FiltersBar({
                 !hasEditAccess && t('You do not have permission to edit this dashboard')
               }
               priority="primary"
-              onClick={onSave}
+              onClick={async () => {
+                await onSave?.();
+                invalidateStarredDashboards();
+              }}
               disabled={!hasEditAccess}
               busy={shouldBusySaveButton}
             >

--- a/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
@@ -1,0 +1,20 @@
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+
+export function useGetStarredDashboards() {
+  const organization = useOrganization();
+  return useApiQuery<DashboardListItem[]>(
+    [
+      `/organizations/${organization.slug}/dashboards/`,
+      {
+        query: {
+          filter: 'onlyFavorites',
+        },
+      },
+    ],
+    {
+      staleTime: Infinity,
+    }
+  );
+}

--- a/static/app/views/dashboards/hooks/useInvalidateStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useInvalidateStarredDashboards.tsx
@@ -1,0 +1,18 @@
+import {useCallback} from 'react';
+
+import {useQueryClient} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useInvalidateStarredDashboards() {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+
+  return useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        `/organizations/${organization.slug}/dashboards/`,
+        {query: {filter: 'onlyFavorites'}},
+      ],
+    });
+  }, [queryClient, organization.slug]);
+}

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -4,11 +4,10 @@ import * as Sentry from '@sentry/react';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
-import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
-import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
@@ -20,19 +19,7 @@ export function DashboardsSecondaryNav() {
   const {projects} = useProjects();
   const user = useUser();
 
-  const {data: starredDashboards = []} = useApiQuery<DashboardListItem[]>(
-    [
-      `/organizations/${organization.slug}/dashboards/`,
-      {
-        query: {
-          filter: 'onlyFavorites',
-        },
-      },
-    ],
-    {
-      staleTime: Infinity,
-    }
-  );
+  const {data: starredDashboards = []} = useGetStarredDashboards();
 
   return (
     <Fragment>


### PR DESCRIPTION
The sidebar should invalidate when the filters get saved because the projects may change. We need to await the save call so we call invalidate at the right time.