### PR TITLE
chore(ui2): update spacing scale

### DIFF
--- a/static/app/components/core/alert/index.chonk.tsx
+++ b/static/app/components/core/alert/index.chonk.tsx
@@ -152,7 +152,7 @@ export const TrailingItems = chonkStyled('div')<ChonkAlertProps>`
 export const Message = chonkStyled('div')`
   line-height: ${p => p.theme.text.lineHeightBody};
   place-content: center;
-  padding-block: ${p => p.theme.space.mini};
+  padding-block: ${p => p.theme.space.xs};
 `;
 
 export const IconWrapper = chonkStyled('div')<{type: AlertProps['type']}>`

--- a/static/app/components/core/badge/index.chonk.tsx
+++ b/static/app/components/core/badge/index.chonk.tsx
@@ -40,7 +40,7 @@ const StyledChonkBadge = chonkStyled('span')<ChonkBadgeProps>`
   line-height: initial;
   height: 20px;
   font-weight: ${p => p.theme.fontWeightBold};
-  padding: ${p => p.theme.space.micro} ${p => p.theme.space.mini};
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.xs};
 `;
 
 function makeChonkBadgeTheme(

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -308,7 +308,7 @@ function getChonkButtonSizeTheme(
     case 'zero':
       return {
         borderRadius: theme.radius.sm,
-        padding: `${theme.space.mini} ${theme.space.sm}`,
+        padding: `${theme.space.xs} ${theme.space.sm}`,
       };
     default:
       return {};

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -554,13 +554,21 @@ function generateChonkTokens(colorScheme: typeof lightColors) {
 }
 
 const space = {
-  nano: '1px',
-  micro: '2px',
-  mini: '4px',
+  none: '0px',
+  '2xs': '2px',
+  xs: '4px',
   sm: '6px',
   md: '8px',
   lg: '12px',
   xl: '16px',
+  '2xl': '24px',
+  '3xl': '32px',
+  '4xl': '48px',
+  '5xl': '64px',
+  '6xl': '80px',
+  '7xl': '96px',
+  '8xl': '112px',
+  '9xl': '128px',
 } as const;
 
 const radius = {


### PR DESCRIPTION
Updates our `space` scale to reflect the new structure of the design system scale.

No visual changes here, just a syntax update!

**Before**
We had `nano`, `micro`, and `mini` tokens at the lower end of the scale

**After**
We're using standardized _shirt size_ scales, so `2xs` and `xs` have replaced the previous tokens. `nano` has been removed. `none` has been added. The scale has also been expanded above `xl` to `9xl`