### PR TITLE
chore(aci): cleanup data condition + action node components

### DIFF
--- a/static/app/views/automations/components/actionFilters/ageComparison.tsx
+++ b/static/app/views/automations/components/actionFilters/ageComparison.tsx
@@ -37,7 +37,7 @@ export function AgeComparisonDetails({condition}: AgeComparisonDetailsProps) {
   });
 }
 
-export default function AgeComparisonNode() {
+export function AgeComparisonNode() {
   return tct('The issue is [comparisonType] [value] [time]', {
     comparisonType: <ComparisonField />,
     value: <ValueField />,

--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -19,7 +19,7 @@ export function EventAttributeDetails({condition}: {condition: DataCondition}) {
   });
 }
 
-export default function EventAttributeNode() {
+export function EventAttributeNode() {
   return tct("The event's [attribute] [match] [value]", {
     attribute: <AttributeField />,
     match: <MatchField />,

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -62,7 +62,7 @@ export function EventFrequencyPercentDetails({condition}: {condition: DataCondit
   );
 }
 
-export default function EventFrequencyNode() {
+export function EventFrequencyNode() {
   const {condition} = useDataConditionNodeContext();
   const hasSubfilters = condition.comparison.filters?.length > 0;
 

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -45,7 +45,7 @@ export function EventUniqueUserFrequencyPercentDetails({
   );
 }
 
-export default function EventUniqueUserFrequencyNode() {
+export function EventUniqueUserFrequencyNode() {
   return tct('Number of users affected by an issue is [select]', {
     select: <ComparisonTypeField />,
   });

--- a/static/app/views/automations/components/actionFilters/issueOccurrences.tsx
+++ b/static/app/views/automations/components/actionFilters/issueOccurrences.tsx
@@ -9,7 +9,7 @@ export function IssueOccurrencesDetails({condition}: {condition: DataCondition})
   });
 }
 
-export default function IssueOccurrencesNode() {
+export function IssueOccurrencesNode() {
   return tct('The issue has happened at least [value] times', {
     value: <ValueField />,
   });

--- a/static/app/views/automations/components/actionFilters/issuePriority.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriority.tsx
@@ -15,7 +15,7 @@ export function IssuePriorityDetails({condition}: {condition: DataCondition}) {
   });
 }
 
-export default function IssuePriorityNode() {
+export function IssuePriorityNode() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   return tct('Current issue priority is [level]', {
     level: (

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -29,7 +29,7 @@ export function LatestAdoptedReleaseDetails({condition}: {condition: DataConditi
   );
 }
 
-export default function LatestAdoptedReleaseNode() {
+export function LatestAdoptedReleaseNode() {
   return tct(
     "The [releaseAgeType] adopted release associated with the event's issue is [ageComparison] the latest adopted release in [environment]",
     {

--- a/static/app/views/automations/components/actionFilters/level.tsx
+++ b/static/app/views/automations/components/actionFilters/level.tsx
@@ -20,7 +20,7 @@ export function LevelDetails({condition}: {condition: DataCondition}) {
   });
 }
 
-export default function LevelNode() {
+export function LevelNode() {
   return tct("The event's level [match] [level]", {
     match: <MatchField />,
     level: <LevelField />,

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -40,7 +40,7 @@ export function PercentSessionsPercentDetails({condition}: {condition: DataCondi
   );
 }
 
-export default function PercentSessionsNode() {
+export function PercentSessionsNode() {
   return tct('Percentage of sessions affected by an issue is [select]', {
     select: <ComparisonTypeField />,
   });

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -18,7 +18,7 @@ export function TaggedEventDetails({condition}: {condition: DataCondition}) {
   });
 }
 
-export default function TaggedEventNode() {
+export function TaggedEventNode() {
   return tct("The event's [key] [match] [value]", {
     key: <KeyField />,
     match: <MatchField />,

--- a/static/app/views/automations/components/actionNodeList.tsx
+++ b/static/app/views/automations/components/actionNodeList.tsx
@@ -134,8 +134,8 @@ function Node() {
   const {action} = useActionNodeContext();
   const node = actionNodesMap.get(action.type);
 
-  const component = node?.action;
-  return component ? component : node?.label;
+  const Component = node?.action;
+  return Component ? <Component /> : node?.label;
 }
 
 const StyledSelectControl = styled(Select)`

--- a/static/app/views/automations/components/actionNodes.tsx
+++ b/static/app/views/automations/components/actionNodes.tsx
@@ -1,4 +1,5 @@
-import React, {createContext, useContext} from 'react';
+import type React from 'react';
+import {createContext, useContext} from 'react';
 
 import {t} from 'sentry/locale';
 import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
@@ -13,6 +14,7 @@ import {JiraServerNode} from 'sentry/views/automations/components/actions/jiraSe
 import {MSTeamsNode} from 'sentry/views/automations/components/actions/msTeams';
 import {OpsgenieNode} from 'sentry/views/automations/components/actions/opsgenie';
 import {PagerdutyNode} from 'sentry/views/automations/components/actions/pagerduty';
+import {PluginNode} from 'sentry/views/automations/components/actions/plugin';
 import {SentryAppNode} from 'sentry/views/automations/components/actions/sentryApp';
 import {SlackNode} from 'sentry/views/automations/components/actions/slack';
 import {WebhookNode} from 'sentry/views/automations/components/actions/webhook';
@@ -35,65 +37,65 @@ export function useActionNodeContext(): ActionNodeProps {
 }
 
 type ActionNode = {
-  action: React.ReactNode;
+  action: React.ComponentType<any>;
   details?: React.ComponentType<any>;
   label?: string;
 };
 
 export const actionNodesMap = new Map<ActionType, ActionNode>([
-  [ActionType.AZURE_DEVOPS, {label: t('Azure DevOps'), action: <AzureDevOpsNode />}],
-  [ActionType.EMAIL, {label: t('Notify on preferred channel'), action: <EmailNode />}],
+  [ActionType.AZURE_DEVOPS, {label: t('Azure DevOps'), action: AzureDevOpsNode}],
+  [ActionType.EMAIL, {label: t('Notify on preferred channel'), action: EmailNode}],
   [
     ActionType.DISCORD,
     {
       label: t('Discord'),
-      action: <DiscordNode />,
+      action: DiscordNode,
     },
   ],
-  [ActionType.GITHUB, {label: t('Github'), action: <GithubNode />}],
+  [ActionType.GITHUB, {label: t('Github'), action: GithubNode}],
   [
     ActionType.GITHUB_ENTERPRISE,
-    {label: t('Github Enterprise'), action: <GithubEnterpriseNode />},
+    {label: t('Github Enterprise'), action: GithubEnterpriseNode},
   ],
-  [ActionType.JIRA, {label: t('Jira'), action: <JiraNode />}],
-  [ActionType.JIRA_SERVER, {label: t('Jira Server'), action: <JiraServerNode />}],
+  [ActionType.JIRA, {label: t('Jira'), action: JiraNode}],
+  [ActionType.JIRA_SERVER, {label: t('Jira Server'), action: JiraServerNode}],
   [
     ActionType.MSTEAMS,
     {
       label: t('MS Teams'),
-      action: <MSTeamsNode />,
+      action: MSTeamsNode,
     },
   ],
-  [ActionType.OPSGENIE, {label: t('Opsgenie'), action: <OpsgenieNode />}],
+  [ActionType.OPSGENIE, {label: t('Opsgenie'), action: OpsgenieNode}],
   [
     ActionType.PAGERDUTY,
     {
       label: t('Pagerduty'),
-      action: <PagerdutyNode />,
+      action: PagerdutyNode,
     },
   ],
   [
     ActionType.PLUGIN,
     {
       label: t('Legacy integrations'),
-      action: t('Send a notification (for all legacy integrations)'),
+      action: PluginNode,
     },
   ],
   [
     ActionType.SENTRY_APP,
     {
-      action: <SentryAppNode />,
+      action: SentryAppNode,
     },
   ],
   [
     ActionType.SLACK,
     {
       label: t('Slack'),
-      action: <SlackNode />,
+      action: SlackNode,
     },
   ],
   [
     ActionType.WEBHOOK,
-    {label: t('Send a notification via an integration'), action: <WebhookNode />},
+    {label: t('Send a notification via an integration'), action: WebhookNode},
   ],
 ]);

--- a/static/app/views/automations/components/actions/plugin.tsx
+++ b/static/app/views/automations/components/actions/plugin.tsx
@@ -1,0 +1,5 @@
+import {t} from 'sentry/locale';
+
+export function PluginNode() {
+  return t('Send a notification (for all legacy integrations)');
+}

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -143,7 +143,7 @@ function Node() {
   const node = dataConditionNodesMap.get(condition.type);
 
   const Component = node?.dataCondition;
-  return Component ? Component : node?.label;
+  return Component ? <Component /> : node?.label;
 }
 
 const StyledSelectControl = styled(Select)`

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {createContext, useContext} from 'react';
 
 import {t} from 'sentry/locale';
@@ -5,43 +6,53 @@ import {
   type DataCondition,
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
-import AgeComparisonNode, {
+import {
   AgeComparisonDetails,
+  AgeComparisonNode,
 } from 'sentry/views/automations/components/actionFilters/ageComparison';
 import {
   AssignedToDetails,
   AssignedToNode,
 } from 'sentry/views/automations/components/actionFilters/assignedTo';
-import EventAttributeNode, {
+import {
   EventAttributeDetails,
+  EventAttributeNode,
 } from 'sentry/views/automations/components/actionFilters/eventAttribute';
-import EventFrequencyNode, {
+import {
   EventFrequencyCountDetails,
+  EventFrequencyNode,
   EventFrequencyPercentDetails,
 } from 'sentry/views/automations/components/actionFilters/eventFrequency';
-import EventUniqueUserFrequencyNode, {
+import {
   EventUniqueUserFrequencyCountDetails,
+  EventUniqueUserFrequencyNode,
   EventUniqueUserFrequencyPercentDetails,
 } from 'sentry/views/automations/components/actionFilters/eventUniqueUserFrequency';
-import IssueOccurrencesNode, {
+import {
   IssueOccurrencesDetails,
+  IssueOccurrencesNode,
 } from 'sentry/views/automations/components/actionFilters/issueOccurrences';
-import IssuePriorityNode, {
+import {
   IssuePriorityDetails,
+  IssuePriorityNode,
 } from 'sentry/views/automations/components/actionFilters/issuePriority';
-import LatestAdoptedReleaseNode, {
+import {
   LatestAdoptedReleaseDetails,
+  LatestAdoptedReleaseNode,
 } from 'sentry/views/automations/components/actionFilters/latestAdoptedRelease';
 import {LatestReleaseNode} from 'sentry/views/automations/components/actionFilters/latestRelease';
-import LevelNode, {
+import {
   LevelDetails,
+  LevelNode,
 } from 'sentry/views/automations/components/actionFilters/level';
-import PercentSessionsNode, {
+import {
   PercentSessionsCountDetails,
+  PercentSessionsNode,
   PercentSessionsPercentDetails,
 } from 'sentry/views/automations/components/actionFilters/percentSessions';
-import TaggedEventNode, {
+import {
   TaggedEventDetails,
+  TaggedEventNode,
 } from 'sentry/views/automations/components/actionFilters/taggedEvent';
 
 interface DataConditionNodeProps {
@@ -67,7 +78,7 @@ export function useDataConditionNodeContext(): DataConditionNodeProps {
 
 type DataConditionNode = {
   label: string;
-  dataCondition?: React.ReactNode;
+  dataCondition?: React.ComponentType<any>;
   details?: React.ComponentType<any>;
 };
 
@@ -106,7 +117,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.AGE_COMPARISON,
     {
       label: t('Issue age'),
-      dataCondition: <AgeComparisonNode />,
+      dataCondition: AgeComparisonNode,
       details: AgeComparisonDetails,
     },
   ],
@@ -114,7 +125,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.ASSIGNED_TO,
     {
       label: t('Issue assignment'),
-      dataCondition: <AssignedToNode />,
+      dataCondition: AssignedToNode,
       details: AssignedToDetails,
     },
   ],
@@ -122,7 +133,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.ISSUE_OCCURRENCES,
     {
       label: t('Issue frequency'),
-      dataCondition: <IssueOccurrencesNode />,
+      dataCondition: IssueOccurrencesNode,
       details: IssueOccurrencesDetails,
     },
   ],
@@ -130,7 +141,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.ISSUE_PRIORITY_EQUALS,
     {
       label: t('Issue priority'),
-      dataCondition: <IssuePriorityNode />,
+      dataCondition: IssuePriorityNode,
       details: IssuePriorityDetails,
     },
   ],
@@ -138,7 +149,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.LATEST_ADOPTED_RELEASE,
     {
       label: t('Release age'),
-      dataCondition: <LatestAdoptedReleaseNode />,
+      dataCondition: LatestAdoptedReleaseNode,
       details: LatestAdoptedReleaseDetails,
     },
   ],
@@ -146,7 +157,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.LATEST_RELEASE,
     {
       label: t('Latest release'),
-      dataCondition: <LatestReleaseNode />,
+      dataCondition: LatestReleaseNode,
       details: LatestReleaseNode,
     },
   ],
@@ -154,7 +165,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.EVENT_ATTRIBUTE,
     {
       label: t('Event attribute'),
-      dataCondition: <EventAttributeNode />,
+      dataCondition: EventAttributeNode,
       details: EventAttributeDetails,
     },
   ],
@@ -162,7 +173,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.TAGGED_EVENT,
     {
       label: t('Tagged event'),
-      dataCondition: <TaggedEventNode />,
+      dataCondition: TaggedEventNode,
       details: TaggedEventDetails,
     },
   ],
@@ -170,7 +181,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.LEVEL,
     {
       label: t('Event level'),
-      dataCondition: <LevelNode />,
+      dataCondition: LevelNode,
       details: LevelDetails,
     },
   ],
@@ -178,14 +189,14 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.EVENT_FREQUENCY,
     {
       label: t('Number of events'),
-      dataCondition: <EventFrequencyNode />,
+      dataCondition: EventFrequencyNode,
     },
   ],
   [
     DataConditionType.EVENT_FREQUENCY_COUNT,
     {
       label: t('Number of events'),
-      dataCondition: <EventFrequencyNode />,
+      dataCondition: EventFrequencyNode,
       details: EventFrequencyCountDetails,
     },
   ],
@@ -193,7 +204,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.EVENT_FREQUENCY_PERCENT,
     {
       label: t('Number of events'),
-      dataCondition: <EventFrequencyNode />,
+      dataCondition: EventFrequencyNode,
       details: EventFrequencyPercentDetails,
     },
   ],
@@ -201,14 +212,14 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
     {
       label: t('Number of users affected'),
-      dataCondition: <EventUniqueUserFrequencyNode />,
+      dataCondition: EventUniqueUserFrequencyNode,
     },
   ],
   [
     DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
     {
       label: t('Number of users affected'),
-      dataCondition: <EventUniqueUserFrequencyNode />,
+      dataCondition: EventUniqueUserFrequencyNode,
       details: EventUniqueUserFrequencyCountDetails,
     },
   ],
@@ -216,7 +227,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
     {
       label: t('Number of users affected'),
-      dataCondition: <EventUniqueUserFrequencyNode />,
+      dataCondition: EventUniqueUserFrequencyNode,
       details: EventUniqueUserFrequencyPercentDetails,
     },
   ],
@@ -224,14 +235,14 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.PERCENT_SESSIONS,
     {
       label: t('Percentage of sessions affected'),
-      dataCondition: <PercentSessionsNode />,
+      dataCondition: PercentSessionsNode,
     },
   ],
   [
     DataConditionType.PERCENT_SESSIONS_COUNT,
     {
       label: t('Percentage of sessions affected'),
-      dataCondition: <PercentSessionsNode />,
+      dataCondition: PercentSessionsNode,
       details: PercentSessionsCountDetails,
     },
   ],
@@ -239,7 +250,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     DataConditionType.PERCENT_SESSIONS_PERCENT,
     {
       label: t('Percentage of sessions affected'),
-      dataCondition: <PercentSessionsNode />,
+      dataCondition: PercentSessionsNode,
       details: PercentSessionsPercentDetails,
     },
   ],


### PR DESCRIPTION
removing default exports and fixing the data condition and action node maps so that components are not instantiated at load time (see comment [here](https://github.com/getsentry/sentry/pull/92175#discussion_r2110433492))