### PR TITLE
fix(detectors): Update `sentry performance detect` command

### DIFF
--- a/src/sentry/runner/commands/performance.py
+++ b/src/sentry/runner/commands/performance.py
@@ -9,7 +9,6 @@ from django.template.defaultfilters import pluralize
 
 from sentry.runner.decorators import configuration
 from sentry.utils import json
-from sentry.utils.performance_issues.base import PerformanceDetector
 
 
 @click.group()
@@ -22,7 +21,10 @@ def performance() -> None:
 @performance.command()
 @click.argument("path", type=click.Path(exists=True, path_type=str, file_okay=True, dir_okay=True))
 @click.option(
-    "-d", "--detector", "detector_class", help="Limit detection to only one detector class"
+    "-d",
+    "--detector",
+    "detector_class",
+    help="Limit detection to only one detector class. Pass in the detector class name, i.e. NPlusOneAPICallsDetector ",
 )
 @click.option("-v", "--verbose", count=True)
 @configuration
@@ -33,6 +35,7 @@ def detect(path: str, detector_class: str | None, verbose: int) -> None:
     path to a JSON event data file or directory containing JSON event data files or folders of JSON event data files.
     """
     from sentry.utils.performance_issues import performance_detection
+    from sentry.utils.performance_issues.base import PerformanceDetector
 
     if detector_class:
         detector_classes = [performance_detection.__dict__[detector_class]]

--- a/src/sentry/runner/commands/performance.py
+++ b/src/sentry/runner/commands/performance.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from inspect import isclass
+
+import os
 
 import click
 from django.template.defaultfilters import pluralize
@@ -17,60 +18,69 @@ def performance() -> None:
 
 
 @performance.command()
-@click.argument("filename", type=click.Path(exists=True))
+@click.argument("path", type=click.Path(exists=True, path_type=str, file_okay=True, dir_okay=True))
 @click.option(
     "-d", "--detector", "detector_class", help="Limit detection to only one detector class"
 )
 @click.option("-v", "--verbose", count=True)
 @configuration
-def detect(filename: str, detector_class: str | None, verbose: int) -> None:
+def detect(path: str, detector_class: str | None, verbose: int) -> None:
     """
-    Runs performance problem detection on event data in the supplied filename
-    using default detector settings with every detector. Filename should be a
-    path to a JSON event data file.
+    Runs performance problem detection on event data in the supplied filename or directory
+    using default detector settings with every detector. Path should be a
+    path to a JSON event data file or directory containing JSON event data files or folders of JSON event data files.
     """
-    from sentry.utils.performance_issues import performance_detection
-    from sentry.utils.performance_issues.base import PerformanceDetector
+    from sentry.utils.performance_issues.performance_detection import (
+        DETECTOR_CLASSES,
+        get_detection_settings,
+        run_detector_on_data,
+    )
 
     if detector_class:
-        detector_classes = [performance_detection.__dict__[detector_class]]
+        detector_classes = [cls for cls in DETECTOR_CLASSES if cls.type.value == detector_class]
     else:
-        detector_classes = [
-            cls
-            for _, cls in performance_detection.__dict__.items()
-            if isclass(cls) and issubclass(cls, PerformanceDetector) and cls != PerformanceDetector
-        ]
+        detector_classes = DETECTOR_CLASSES
 
-    settings = performance_detection.get_detection_settings()
+    settings = get_detection_settings()
 
-    with open(filename) as file:
-        data = json.loads(file.read())
-        if verbose > 1:
-            click.echo(f"Event ID: {data['event_id']}")
-
-        detectors = [cls(settings, data) for cls in detector_classes]
-
-        for detector in detectors:
-            if verbose > 0:
-                click.echo(f"Detecting using {detector.__class__.__name__}")
-
-            performance_detection.run_detector_on_data(detector, data)
-
+    def run_detector_on_file(filepath: str) -> None:
+        if not filepath.endswith(".json"):
+            return
+        with open(filepath) as file:
+            data = json.loads(file.read())
             if verbose > 1:
-                if len(detector.stored_problems) == 0:
-                    click.echo("No problems detected")
-                else:
-                    click.echo(
-                        f"Found {len(detector.stored_problems)} {pluralize(len(detector.stored_problems), 'problem,problems')}"
-                    )
+                click.echo(f"Event ID: {data['event_id']}")
 
-            for problem in detector.stored_problems.values():
-                try:
-                    click.echo(problem.to_dict())
-                except AttributeError:
-                    click.echo(problem)
+            detectors = [cls(settings, data) for cls in detector_classes]
 
-            click.echo("\n")
+            for detector in detectors:
+                if verbose > 0:
+                    click.echo(f"Detecting using {detector.__class__.__name__}")
+
+                run_detector_on_data(detector, data)
+
+                if verbose > 1:
+                    if len(detector.stored_problems) == 0:
+                        click.echo("No problems detected")
+                    else:
+                        click.echo(
+                            f"Found {len(detector.stored_problems)} {pluralize(len(detector.stored_problems), 'problem,problems')}"
+                        )
+
+                for problem in detector.stored_problems.values():
+                    try:
+                        click.echo(problem.to_dict())
+                    except AttributeError:
+                        click.echo(problem)
+
+                click.echo("\n")
+
+    if os.path.isdir(path):
+        for root, _, files in os.walk(path):
+            for file in files:
+                run_detector_on_file(os.path.join(root, file))
+    else:
+        run_detector_on_file(path)
 
 
 @performance.command()

--- a/src/sentry/runner/commands/performance.py
+++ b/src/sentry/runner/commands/performance.py
@@ -48,8 +48,6 @@ def detect(path: str, detector_class: str | None, verbose: int) -> None:
 
     settings = performance_detection.get_detection_settings()
 
-    settings = performance_detection.get_detection_settings()
-
     def run_detector_on_file(filepath: str) -> None:
         if not filepath.endswith(".json"):
             return


### PR DESCRIPTION
this pr makes a few updates to the `sentry performance detect` command. 
1) makes it more clear on how to use the `--detector` argument
2) allows you to run it against a folder of files 

an example use case is you create a new detector and want to run it against our folder of event fixtures (primarily used for tests). This can be useful when creating a new detector because it allows the detector to run against a variety of events containing different data. or if you have multiple files you want to run it against, now you can do them all at once. 