### PR TITLE
feat(emerge-size): add FF to gate usage of new endpoint to just test orgs

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -272,6 +272,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:performance-spans-suspect-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Transaction alert deprecation
     manager.add("organizations:performance-transaction-deprecation-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod artifact assembly endpoint
+    manager.add("organizations:preprod-artifact-assemble", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -76,6 +77,11 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
         """
         Assembles a preprod artifact (mobile build, etc.) and stores it in the database.
         """
+        if not features.has(
+            "organizations:preprod-artifact-assemble", project.organization, actor=request.user
+        ):
+            return Response(status=404)
+
         with sentry_sdk.start_span(op="preprod_artifact.assemble"):
             data, error_message = validate_preprod_artifact_schema(request.body)
             if error_message:

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -16,6 +16,7 @@ from sentry.preprod.api.endpoints.organization_preprod_artifact_assemble import 
 from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import AssembleTask, ChunkFileState, set_assemble_status
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.features import Feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
@@ -147,6 +148,39 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             "sentry-api-0-assemble-preprod-artifact-files",
             args=[self.organization.slug, self.project.slug],
         )
+
+        # Enable the feature flag for all tests in this class
+        self.feature_context = Feature("organizations:preprod-artifact-assemble")
+        self.feature_context.__enter__()
+
+    def tearDown(self):
+        # Clean up the feature flag
+        self.feature_context.__exit__(None, None, None)
+        super().tearDown()
+
+    def test_feature_flag_disabled_returns_404(self):
+        """Test that endpoint returns 404 when feature flag is disabled."""
+        # Exit the current feature context to disable the flag
+        self.feature_context.__exit__(None, None, None)
+
+        try:
+            content = b"test content"
+            total_checksum = sha1(content).hexdigest()
+
+            # Should get 404 when feature flag is disabled
+            response = self.client.post(
+                self.url,
+                data={
+                    "checksum": total_checksum,
+                    "chunks": [],
+                },
+                HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            )
+            assert response.status_code == 404
+        finally:
+            # Re-enable the feature flag for any subsequent tests
+            self.feature_context = Feature("organizations:preprod-artifact-assemble")
+            self.feature_context.__enter__()
 
     def test_assemble_json_schema_integration(self):
         """Integration test for schema validation through the endpoint."""


### PR DESCRIPTION
https://github.com/getsentry/sentry-options-automator/pull/4076

use this feature flag to temporarily block access of this endpoint while in active development