### PR TITLE
fix(ACI): Increment metric once per rule

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -409,6 +409,7 @@ class SubscriptionProcessor:
         fired_incident_triggers = []
         with transaction.atomic(router.db_for_write(AlertRule)):
             # Triggers is the threshold - NOT an instance of a trigger
+            trigger_logger_counter = 0
             for trigger in self.triggers:
                 if potential_anomalies:
                     # NOTE: There should only be one anomaly in the list
@@ -470,11 +471,15 @@ class SubscriptionProcessor:
                             "incidents.alert_rules.threshold.alert",
                             tags={"detection_type": self.alert_rule.detection_type},
                         )
-                        if features.has(
-                            "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                            self.subscription.project.organization,
+                        if (
+                            features.has(
+                                "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                                self.subscription.project.organization,
+                            )
+                            and trigger_logger_counter < 1
                         ):
                             metrics.incr("dual_processing.alert_rules.fire")
+                            trigger_logger_counter += 1
                         # triggering a threshold will create an incident and set the status to active
                         incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
                         if incident_trigger is not None:

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -409,7 +409,7 @@ class SubscriptionProcessor:
         fired_incident_triggers = []
         with transaction.atomic(router.db_for_write(AlertRule)):
             # Triggers is the threshold - NOT an instance of a trigger
-            trigger_logger_counter = 0
+            metrics_incremented = False
             for trigger in self.triggers:
                 if potential_anomalies:
                     # NOTE: There should only be one anomaly in the list
@@ -476,10 +476,10 @@ class SubscriptionProcessor:
                                 "organizations:workflow-engine-metric-alert-dual-processing-logs",
                                 self.subscription.project.organization,
                             )
-                            and trigger_logger_counter < 1
+                            and not metrics_incremented
                         ):
                             metrics.incr("dual_processing.alert_rules.fire")
-                            trigger_logger_counter += 1
+                            metrics_incremented = True
                         # triggering a threshold will create an incident and set the status to active
                         incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
                         if incident_trigger is not None:

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1066,11 +1066,30 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
+    @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
-    def test_alert_metrics(self, mock_metrics):
+    @patch("sentry.incidents.subscription_processor.logger")
+    def test_alert_metrics_logging(self, mock_logger, mock_metrics):
+        """
+        Test that we are logging when we enter workflow engine at the same rate as we store a metric for firing an alert
+        """
         rule = self.rule
         trigger = self.trigger
+        # create a warning trigger
+        create_alert_rule_trigger(self.rule, WARNING_TRIGGER_LABEL, trigger.alert_threshold - 1)
         self.send_update(rule, trigger.alert_threshold + 1)
+        logger_extra = {
+            "results": [],
+            "num_results": 0,
+            "value": trigger.alert_threshold + 1,
+            "rule_id": rule.id,
+        }
+        assert mock_logger.info.call_count == 1
+        mock_logger.info.assert_called_with(
+            "dual processing results for alert rule",
+            extra=logger_extra,
+        )
+        # assert that we only create a metric for `dual_processing.alert_rules.fire` once despite having 2 triggers
         mock_metrics.incr.assert_has_calls(
             [
                 call(
@@ -1079,6 +1098,11 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 ),
                 call(
                     "dual_processing.alert_rules.fire",
+                ),
+                call("incidents.alert_rules.trigger", tags={"type": "fire"}),
+                call(
+                    "incidents.alert_rules.threshold.alert",
+                    tags={"detection_type": "static"},
                 ),
                 call("incidents.alert_rules.trigger", tags={"type": "fire"}),
             ],


### PR DESCRIPTION
We are seeing instances in [this Datadog dashboard](https://app.datadoghq.com/dashboard/ccd-cnh-4c7/workflow-engine?fromUser=false&fullscreen_end_ts=1749073392429&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1748986992429&fullscreen_widget=2078657708111834&refresh_mode=sliding&tpl_var_data_source_type%5B0%5D=snuba_query_subscription&tpl_var_detector_type%5B0%5D=metric_issue&from_ts=1748974292364&to_ts=1749060692364&live=true) of us entering into the dual processing entry point about half as frequently as we are seeing rules fire. One possible explanation for this is because we loop over the alert rule's triggers and increment the metric each time the threshold is met. This PR makes sure that we only increment it once per rule.