### PR TITLE
chore(stats): Update copy for spike protection callout

### DIFF
--- a/static/gsApp/views/spikeProtection/spikeProtectionCallouts.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionCallouts.tsx
@@ -6,7 +6,7 @@ export function SpikeProtectionRangeLimitation() {
     <Alert.Container>
       <Alert type="warning">
         {t(
-          "To view this project's spike data on the chart, please select a time range between 30d and 6h"
+          "To view this project's spike data on the chart, please select a time range under 30d and above 6h"
         )}
       </Alert>
     </Alert.Container>

--- a/static/gsApp/views/spikeProtection/spikeProtectionCallouts.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionCallouts.tsx
@@ -6,7 +6,7 @@ export function SpikeProtectionRangeLimitation() {
     <Alert.Container>
       <Alert type="warning">
         {t(
-          "To view this project's spike data on the chart, please select a time range under 30d and above 6h"
+          "To view this project's spike data on the chart, please select a time range greater than or equal to 6h or less than 30d"
         )}
       </Alert>
     </Alert.Container>


### PR DESCRIPTION
fixes #82362

Updates the spike protection callout to better indicate that 30d is **non-inclusive**. 

Old: 
> "To view this project's spike data on the chart, please select a time range between 30d and 6h"

New: 
> "To view this project's spike data on the chart, please select a time range under 30d and above 6h"


I don't love the new copy either, but this is a significantly easier change then changing the backend to support this. Let me know if y'all can think of a better way to do this. 