### PR TITLE
fix(issue-details): Add syntax highlighting to other "db" spans

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -240,7 +240,7 @@ describe('SpanEvidenceKeyValueList', () => {
         screen.getByTestId('span-evidence-key-value-list.repeating-spans-2')
       ).toHaveTextContent('SELECT * FROM books');
       expect(screen.getByTestId('span-evidence-key-value-list.')).toHaveTextContent(
-        'db.sql.active_record - SELECT * FROM books WHERE id = %s'
+        'SELECT * FROM books WHERE id = %s'
       );
 
       expect(screen.queryByRole('cell', {name: 'Parameter'})).not.toBeInTheDocument();

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -559,7 +559,7 @@ function getSpanEvidenceValue(span: Span | null) {
     return span.op;
   }
 
-  if (span.op === 'db' && span.description) {
+  if (span.op && span.op.startsWith('db') && span.description) {
     return (
       <NoPaddingClippedBox clipHeight={200}>
         <StyledCodeSnippet language="sql">


### PR DESCRIPTION
we have a bunch of different `span.op` values that all start with "db" where we should highlight, not just the ones that are exactly "db"