### PR TITLE
perf(aci): Track condition evaluation speed

### DIFF
--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -1,5 +1,6 @@
 import logging
 import operator
+import time
 from enum import StrEnum
 from typing import Any, TypeVar, cast
 
@@ -102,6 +103,12 @@ LEGACY_CONDITIONS = [
 
 T = TypeVar("T")
 
+# Threshold at which we consider a fast condition's evaluation time to
+# be long enough to be worth logging. Our systems are designed on the
+# assumption that fast conditions should be fast, and if they aren't,
+# it's worth investigating.
+FAST_CONDITION_TOO_SLOW_THRESHOLD_SECONDS = 1
+
 
 @region_silo_model
 class DataCondition(DefaultFieldsModel):
@@ -193,8 +200,14 @@ class DataCondition(DefaultFieldsModel):
             )
             return None
 
+        should_be_fast = not is_slow_condition(self)
+        start_time = time.time()
         try:
-            result = handler.evaluate_value(value, self.comparison)
+            with metrics.timer(
+                "workflow_engine.data_condition.evaluation_duration_seconds",
+                tags={"type": self.type, "speed_category": "fast" if should_be_fast else "slow"},
+            ):
+                result = handler.evaluate_value(value, self.comparison)
         except DataConditionEvaluationException as e:
             metrics.incr("workflow_engine.data_condition.evaluation_error")
             logger.info(
@@ -208,6 +221,19 @@ class DataCondition(DefaultFieldsModel):
                 },
             )
             return None
+        finally:
+            duration = time.time() - start_time
+            if should_be_fast and duration >= FAST_CONDITION_TOO_SLOW_THRESHOLD_SECONDS:
+                logger.error(
+                    "Fast condition evaluation too slow; took %s seconds",
+                    duration,
+                    extra={
+                        "condition_id": self.id,
+                        "duration": duration,
+                        "type": self.type,
+                        "comparison": self.comparison,
+                    },
+                )
 
         if isinstance(result, bool):
             return self.get_condition_result() if result else None

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -205,7 +205,7 @@ class DataCondition(DefaultFieldsModel):
         start_time = time.time()
         try:
             with metrics.timer(
-                "workflow_engine.data_condition.evaluation_duration_seconds",
+                "workflow_engine.data_condition.evaluation_duration",
                 tags={"type": self.type, "speed_category": "fast" if should_be_fast else "slow"},
             ):
                 result = handler.evaluate_value(value, self.comparison)

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -1,6 +1,7 @@
 import logging
 import operator
 import time
+from datetime import timedelta
 from enum import StrEnum
 from typing import Any, TypeVar, cast
 
@@ -107,7 +108,7 @@ T = TypeVar("T")
 # be long enough to be worth logging. Our systems are designed on the
 # assumption that fast conditions should be fast, and if they aren't,
 # it's worth investigating.
-FAST_CONDITION_TOO_SLOW_THRESHOLD_SECONDS = 1
+FAST_CONDITION_TOO_SLOW_THRESHOLD = timedelta(milliseconds=500)
 
 
 @region_silo_model
@@ -223,7 +224,7 @@ class DataCondition(DefaultFieldsModel):
             return None
         finally:
             duration = time.time() - start_time
-            if should_be_fast and duration >= FAST_CONDITION_TOO_SLOW_THRESHOLD_SECONDS:
+            if should_be_fast and duration >= FAST_CONDITION_TOO_SLOW_THRESHOLD.total_seconds():
                 logger.error(
                     "Fast condition evaluation too slow; took %s seconds",
                     duration,
@@ -231,6 +232,7 @@ class DataCondition(DefaultFieldsModel):
                         "condition_id": self.id,
                         "duration": duration,
                         "type": self.type,
+                        "value": value,
                         "comparison": self.comparison,
                     },
                 )


### PR DESCRIPTION
We classify Conditions as 'fast' and 'slow' and design around these speed assumptions; we should track how long they typically take, and log any 'fast' condition that is taking too long to aid in investigations.