### PR TITLE
fix(ACI): Account for status change messages in process_detectors logging and metrics

### DIFF
--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -4,7 +4,6 @@ import logging
 
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
-from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.utils import metrics
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.types import (
@@ -85,7 +84,7 @@ def process_detectors(
                         "detector_triggered",
                         extra=logger_extra,
                     )
-                elif isinstance(result.result, StatusChangeMessage):
+                else:
                     metrics.incr(
                         "workflow_engine.process_detector.resolved",
                         tags={"detector_type": detector.type},

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -4,6 +4,7 @@ import logging
 
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
+from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.utils import metrics
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.types import (
@@ -28,7 +29,7 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
     return detector
 
 
-def create_issue_occurrence_from_result(result: DetectorEvaluationResult):
+def create_issue_platform_payload(result: DetectorEvaluationResult):
     occurrence, status_change = None, None
 
     if isinstance(result.result, IssueOccurrence):
@@ -68,22 +69,32 @@ def process_detectors(
             return results
 
         for result in detector_results.values():
+            logger_extra = {
+                "detector": detector.id,
+                "detector_type": detector.type,
+                "evaluation_data": data_packet.packet,
+                "result": result,
+            }
             if result.result is not None:
-                create_issue_occurrence_from_result(result)
-                metrics.incr(
-                    "workflow_engine.process_detector.triggered",
-                    tags={"detector_type": detector.type},
-                )
-
-                logger.info(
-                    "detector_triggered",
-                    extra={
-                        "detector": detector.id,
-                        "detector_type": detector.type,
-                        "evaluation_data": data_packet.packet,
-                        "result": result,
-                    },
-                )
+                if isinstance(result.result, IssueOccurrence):
+                    metrics.incr(
+                        "workflow_engine.process_detector.triggered",
+                        tags={"detector_type": detector.type},
+                    )
+                    logger.info(
+                        "detector_triggered",
+                        extra=logger_extra,
+                    )
+                elif isinstance(result.result, StatusChangeMessage):
+                    metrics.incr(
+                        "workflow_engine.process_detector.resolved",
+                        tags={"detector_type": detector.type},
+                    )
+                    logger.info(
+                        "detector_resolved",
+                        extra=logger_extra,
+                    )
+                create_issue_platform_payload(result)
 
         if detector_results:
             results.append((detector, detector_results))

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -43,9 +43,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         ]
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
-    @mock.patch("sentry.workflow_engine.processors.detector.metrics")
-    @mock.patch("sentry.workflow_engine.processors.detector.logger")
-    def test_state_results(self, mock_logger, mock_metrics, mock_produce_occurrence_to_kafka):
+    def test_state_results(self, mock_produce_occurrence_to_kafka):
         detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
         data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {None: 6}})
         results = process_detectors(data_packet, [detector])
@@ -65,11 +63,11 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         )
 
         result = DetectorEvaluationResult(
-            group_key=None,
-            is_triggered=True,
-            priority=DetectorPriorityLevel.HIGH,
-            result=issue_occurrence,
-            event_data=expected_event_data,
+            None,
+            True,
+            DetectorPriorityLevel.HIGH,
+            issue_occurrence,
+            expected_event_data,
         )
         assert results == [
             (
@@ -83,44 +81,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             status_change=None,
             event_data=expected_event_data,
         )
-        mock_metrics.incr.assert_has_calls(
-            [
-                call(
-                    "workflow_engine.process_detector.triggered",
-                    tags={"detector_type": detector.type},
-                ),
-            ],
-        )
-        assert mock_logger.info.call_count == 1
-        assert mock_logger.info.call_args[0][0] == "detector_triggered"
-
-        data_packet = DataPacket("1", {"dedupe": 3, "group_vals": {None: 0}})
-        result = DetectorEvaluationResult(
-            group_key=None,
-            is_triggered=False,
-            priority=DetectorPriorityLevel.OK,
-            result=StatusChangeMessage(
-                fingerprint=["detector:1"],
-                project_id=self.project.id,
-                new_status=GroupStatus.RESOLVED,
-                new_substatus=None,
-                id=str(self.mock_uuid4.return_value),
-            ),
-            event_data=None,
-        )
-        results = process_detectors(data_packet, [detector])
-
-        assert results == [(detector, {result.group_key: result})]
-        mock_metrics.incr.assert_has_calls(
-            [
-                call(
-                    "workflow_engine.process_detector.resolved",
-                    tags={"detector_type": detector.type},
-                ),
-            ],
-        )
-        assert mock_logger.info.call_count == 2
-        assert mock_logger.info.call_args[0][0] == "detector_resolved"
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     def test_state_results_multi_group(self, mock_produce_occurrence_to_kafka):
@@ -234,17 +194,98 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
                 tags={"detector_type": detector.type},
             )
 
-    def test_sending_metric_with_results(self):
-        detector = self.create_detector(type=self.update_handler_type.slug)
-        data_packet = self.build_data_packet()
+    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
+    @mock.patch("sentry.workflow_engine.processors.detector.metrics")
+    @mock.patch("sentry.workflow_engine.processors.detector.logger")
+    def test_metrics_and_logs_fire(
+        self, mock_logger, mock_metrics, mock_produce_occurrence_to_kafka
+    ):
+        detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
+        data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {None: 6}})
+        results = process_detectors(data_packet, [detector])
 
-        with mock.patch("sentry.utils.metrics.incr") as mock_incr:
-            process_detectors(data_packet, [detector])
+        detector_occurrence, event_data = build_mock_occurrence_and_event(
+            detector.detector_handler, None, PriorityLevel.HIGH
+        )
 
-            mock_incr.assert_any_call(
-                "workflow_engine.process_detector.triggered",
-                tags={"detector_type": detector.type},
+        issue_occurrence, expected_event_data = self.detector_to_issue_occurrence(
+            detector_occurrence=detector_occurrence,
+            detector=detector,
+            group_key=None,
+            value=6,
+            priority=DetectorPriorityLevel.HIGH,
+            detection_time=datetime.now(UTC),
+            occurrence_id=str(self.mock_uuid4.return_value),
+        )
+
+        result = DetectorEvaluationResult(
+            group_key=None,
+            is_triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence,
+            event_data=expected_event_data,
+        )
+        assert results == [
+            (
+                detector,
+                {result.group_key: result},
             )
+        ]
+        mock_produce_occurrence_to_kafka.assert_called_once_with(
+            payload_type=PayloadType.OCCURRENCE,
+            occurrence=issue_occurrence,
+            status_change=None,
+            event_data=expected_event_data,
+        )
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "workflow_engine.process_detector.triggered",
+                    tags={"detector_type": detector.type},
+                ),
+            ],
+        )
+        assert mock_logger.info.call_count == 1
+        assert mock_logger.info.call_args[0][0] == "detector_triggered"
+
+    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
+    @mock.patch("sentry.workflow_engine.processors.detector.metrics")
+    @mock.patch("sentry.workflow_engine.processors.detector.logger")
+    def test_metrics_and_logs_resolve(
+        self, mock_logger, mock_metrics, mock_produce_occurrence_to_kafka
+    ):
+        detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
+        data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {None: 6}})
+        process_detectors(data_packet, [detector])
+
+        build_mock_occurrence_and_event(detector.detector_handler, None, PriorityLevel.HIGH)
+
+        data_packet = DataPacket("1", {"dedupe": 3, "group_vals": {None: 0}})
+        result = DetectorEvaluationResult(
+            group_key=None,
+            is_triggered=False,
+            priority=DetectorPriorityLevel.OK,
+            result=StatusChangeMessage(
+                fingerprint=["detector:1"],
+                project_id=self.project.id,
+                new_status=GroupStatus.RESOLVED,
+                new_substatus=None,
+                id=str(self.mock_uuid4.return_value),
+            ),
+            event_data=None,
+        )
+        results = process_detectors(data_packet, [detector])
+        assert results == [(detector, {result.group_key: result})]
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "workflow_engine.process_detector.resolved",
+                    tags={"detector_type": detector.type},
+                ),
+            ],
+        )
+        assert mock_logger.info.call_count == 2
+        assert mock_logger.info.call_args[0][0] == "detector_resolved"
 
     def test_doesnt_send_metric(self):
         detector = self.create_detector(type=self.no_handler_type.slug)
@@ -505,6 +546,7 @@ class TestEvaluate(BaseDetectorHandlerTest):
             detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
+
         assert handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}})) == {
             "val1": DetectorEvaluationResult(
                 group_key="val1",

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -486,8 +486,7 @@ class TestEvaluate(BaseDetectorHandlerTest):
             DetectorPriorityLevel.HIGH,
         )
 
-    @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
-    def test_above_below_threshold(self, mock_produce_occurrence_to_kafka):
+    def test_above_below_threshold(self):
         handler = self.build_handler()
         assert handler.evaluate(DataPacket("1", {"dedupe": 1, "group_vals": {"val1": 0}})) == {}
 
@@ -505,8 +504,7 @@ class TestEvaluate(BaseDetectorHandlerTest):
             detection_time=detection_time,
             occurrence_id=str(self.mock_uuid4.return_value),
         )
-        data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}})
-        result = {
+        assert handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}})) == {
             "val1": DetectorEvaluationResult(
                 group_key="val1",
                 is_triggered=True,
@@ -515,7 +513,6 @@ class TestEvaluate(BaseDetectorHandlerTest):
                 event_data=event_data,
             )
         }
-        assert handler.evaluate(data_packet) == result
         assert handler.evaluate(DataPacket("1", {"dedupe": 3, "group_vals": {"val1": 6}})) == {}
         assert handler.evaluate(DataPacket("1", {"dedupe": 4, "group_vals": {"val1": 0}})) == {
             "val1": DetectorEvaluationResult(

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -266,7 +266,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             is_triggered=False,
             priority=DetectorPriorityLevel.OK,
             result=StatusChangeMessage(
-                fingerprint=["detector:1"],
+                fingerprint=[f"detector:{detector.id}"],
                 project_id=self.project.id,
                 new_status=GroupStatus.RESOLVED,
                 new_substatus=None,

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -5,6 +5,7 @@ from unittest.mock import call
 
 from sentry.issues.producer import PayloadType
 from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.models.group import GroupStatus
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import DetectorStateData
@@ -101,7 +102,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             result=StatusChangeMessage(
                 fingerprint=["detector:1"],
                 project_id=self.project.id,
-                new_status=1,  # resolved, TODO import groupstatus enum
+                new_status=GroupStatus.RESOLVED,
                 new_substatus=None,
                 id=str(self.mock_uuid4.return_value),
             ),


### PR DESCRIPTION
If the handler evaluation result has a `StatusChangeMessage` we still have a `result` but the detector isn't actually triggered  (it's resolved) which was resulting in some misleading metrics and logs. I also renamed `create_issue_occurrence_from_result` to `create_issue_platform_payload` since we're not necessarily always creating an occurrence (as it could be a status change message). 