### PR TITLE
build(ui): Switch to node-linker hoisted, fix HMR

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 lockfile=true
-shamefully-hoist=true
+node-linker=hoisted


### PR DESCRIPTION
shamfully hoist seems to include 2 versions of `rspack/core/hot/emitter.js` and the devserver is emitting on emitter1 and the other half of HMR is listening on emitter2 so HMR never fully happens.

[nodeLinker hoisted](https://pnpm.io/settings#nodelinker) as i understand it basically turns pnpm into Yarn Classic. I've not yet found another solution

note - the emitter that isn't quite hooking up https://github.com/web-infra-dev/rspack/blob/0b4cbecae7818079920f0ea77d44674faaec5557/packages/rspack/hot/dev-server.js#L65