### PR TITLE
feat(trace-eap-waterfall): Reparenting http.server spans under pageload and browser.request spans

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -5,7 +5,7 @@ import {MissingInstrumentationNode} from './traceModels/missingInstrumentationNo
 import {ParentAutogroupNode} from './traceModels/parentAutogroupNode';
 import {SiblingAutogroupNode} from './traceModels/siblingAutogroupNode';
 import {CollapsedNode} from './traceModels/traceCollapsedNode';
-import type {TraceTree} from './traceModels/traceTree';
+import {TraceTree} from './traceModels/traceTree';
 import type {TraceTreeNode} from './traceModels/traceTreeNode';
 
 export function isMissingInstrumentationNode(
@@ -176,16 +176,22 @@ export function isJavascriptSDKEvent(value: TraceTree.NodeValue): boolean {
 export function isPageloadTransactionNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): boolean {
-  return isTransactionNode(node) && node.value['transaction.op'] === 'pageload';
+  return (
+    (isTransactionNode(node) && node.value['transaction.op'] === 'pageload') ||
+    (isEAPTransactionNode(node) && node.value.op === 'pageload')
+  );
 }
 
 export function isServerRequestHandlerTransactionNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): boolean {
-  return isTransactionNode(node) && node.value['transaction.op'] === 'http.server';
+  return (
+    (isTransactionNode(node) && node.value['transaction.op'] === 'http.server') ||
+    (isEAPTransactionNode(node) && node.value.op === 'http.server')
+  );
 }
 
-export function isBrowserRequestSpan(value: TraceTree.Span): boolean {
+export function isBrowserRequestSpan(value: TraceTree.Span | TraceTree.EAPSpan): boolean {
   return (
     // Adjust for SDK changes in https://github.com/getsentry/sentry-javascript/pull/13527
     value.op === 'browser.request' ||
@@ -196,12 +202,17 @@ export function isBrowserRequestSpan(value: TraceTree.Span): boolean {
 export function getPageloadTransactionChildCount(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): number {
-  if (!isTransactionNode(node)) {
+  if (!isTransactionNode(node) && !isEAPTransactionNode(node)) {
     return 0;
   }
   let count = 0;
-  for (const txn of node.value.children) {
-    if (txn && txn['transaction.op'] === 'pageload') {
+  for (const txn of TraceTree.VisibleChildren(node)) {
+    if (
+      txn &&
+      (isTransactionNode(txn)
+        ? txn.value['transaction.op'] === 'pageload'
+        : isEAPTransactionNode(txn) && txn.value.op === 'pageload')
+    ) {
       count++;
     }
   }

--- a/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.ssr.spec.tsx.snap
+++ b/static/app/views/performance/newTraceDetails/traceModels/__snapshots__/traceTree.ssr.spec.tsx.snap
@@ -9,6 +9,24 @@ trace root
 "
 `;
 
+exports[`server side rendering eap traces reparents pageload transaction as parent of server handler 1`] = `
+"
+eap trace root
+  pageload - span.description (eap-transaction)
+    http.server - span.description (eap-transaction)
+"
+`;
+
+exports[`server side rendering eap traces reparents server handler under browser request span 1`] = `
+"
+eap trace root
+  pageload - span.description (eap-transaction)
+    tls.connect - span.description
+    browser.request - browser
+      http.server - span.description (eap-transaction)
+"
+`;
+
 exports[`server side rendering reparents pageload transaction as parent of server handler 1`] = `
 "
 trace root


### PR DESCRIPTION
- This behaviour is enabled for the current nodestore/transaction based trace waterfall. 

On load:
<img width="561" alt="Screenshot 2025-06-05 at 12 01 29 AM" src="https://github.com/user-attachments/assets/616cf2b2-b6b8-45ef-a533-cf5fe9a700c4" />

On expansion:
<img width="461" alt="Screenshot 2025-06-05 at 12 05 31 AM" src="https://github.com/user-attachments/assets/f952ca58-e87e-41b2-93c9-a00fc5ec61df" />
