### PR TITLE
perf(aci): Avoid unnecessary Workflow.when_condition_group loads

### DIFF
--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -99,12 +99,12 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             process_data_condition_group,
         )
 
-        if self.when_condition_group is None:
+        if self.when_condition_group_id is None:
             return True, []
 
         workflow_event_data = replace(event_data, workflow_env=self.environment)
         group_evaluation, remaining_conditions = process_data_condition_group(
-            self.when_condition_group.id, workflow_event_data
+            self.when_condition_group_id, workflow_event_data
         )
         return group_evaluation.logic_result, remaining_conditions
 


### PR DESCRIPTION
`evaluate_workflow_triggers` calls `evaluate_trigger_conditions` on a list of workflows; 
`evaluate_trigger_conditions` calls `process_data_condition_group` with the `when_condition_group` ID when it is set, and within there it is loaded from cache.
We only need the ID, so only using it avoids an unnecessary query per Workflow.

