### PR TITLE
ref(platform-insights): Table refactoring

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/common.tsx
+++ b/static/app/views/insights/agentMonitoring/components/common.tsx
@@ -2,13 +2,6 @@ import styled from '@emotion/styled';
 
 import Link from 'sentry/components/links/link';
 import {space} from 'sentry/styles/space';
-/**
- * Used to force the cell to expand take as much width as possible in the table layout
- * otherwise grid editable will let the last column grow
- */
-export const CellExpander = styled('div')`
-  width: 100vw;
-`;
 
 export const GridEditableContainer = styled('div')`
   position: relative;

--- a/static/app/views/insights/agentMonitoring/components/headSortCell.tsx
+++ b/static/app/views/insights/agentMonitoring/components/headSortCell.tsx
@@ -1,6 +1,6 @@
 import {Fragment, memo} from 'react';
+import styled from '@emotion/styled';
 
-import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import type {QueryValue} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -35,30 +35,49 @@ export function useTableSortParams() {
 }
 
 export const HeadSortCell = memo(function HeadCell({
-  column,
+  sortKey,
   children,
+  align = 'left',
+  forceCellGrow = false,
+  cursorParamName = 'cursor',
 }: {
   children: React.ReactNode;
-  column: GridColumnHeader<string>;
+  sortKey: string;
+  align?: 'left' | 'right';
+  cursorParamName?: string;
+  forceCellGrow?: boolean;
 }) {
   const location = useLocation();
   const {sortField, sortOrder} = useTableSortParams();
   return (
     <SortLink
-      align={'left'}
-      direction={sortField === column.key ? sortOrder : undefined}
+      align={align}
+      direction={sortField === sortKey ? sortOrder : undefined}
       canSort
       preventScrollReset
       generateSortLink={() => ({
         ...location,
         query: {
           ...location.query,
-          field: column.key,
-          order:
-            sortField === column.key ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'desc',
+          [cursorParamName]: undefined,
+          field: sortKey,
+          order: sortField === sortKey ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'desc',
         },
       })}
-      title={<Fragment>{children}</Fragment>}
+      title={
+        <Fragment>
+          {forceCellGrow && <CellExpander />}
+          {children}
+        </Fragment>
+      }
     />
   );
 });
+
+/**
+ * Used to force the cell to expand take as much width as possible in the table layout
+ * otherwise grid editable will let the last column grow
+ */
+export const CellExpander = styled('div')`
+  width: 100vw;
+`;

--- a/static/app/views/insights/agentMonitoring/components/headSortCell.tsx
+++ b/static/app/views/insights/agentMonitoring/components/headSortCell.tsx
@@ -78,6 +78,6 @@ export const HeadSortCell = memo(function HeadCell({
  * Used to force the cell to expand take as much width as possible in the table layout
  * otherwise grid editable will let the last column grow
  */
-export const CellExpander = styled('div')`
+const CellExpander = styled('div')`
   width: 100vw;
 `;

--- a/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
@@ -19,7 +19,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {
-  CellExpander,
   CellLink,
   GridEditableContainer,
   LoadingOverlay,
@@ -124,8 +123,11 @@ export function ModelsTable() {
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
     return (
-      <HeadSortCell column={column}>
-        {column.key === 'model' && <CellExpander />}
+      <HeadSortCell
+        sortKey={column.key}
+        cursorParamName="modelsCursor"
+        forceCellGrow={column.key === 'model'}
+      >
         {column.name}
       </HeadSortCell>
     );

--- a/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
@@ -17,7 +17,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {
-  CellExpander,
   CellLink,
   GridEditableContainer,
   LoadingOverlay,
@@ -112,8 +111,11 @@ export function ToolsTable() {
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
     return (
-      <HeadSortCell column={column}>
-        {column.key === 'tool' && <CellExpander />}
+      <HeadSortCell
+        sortKey={column.key}
+        cursorParamName="toolsCursor"
+        forceCellGrow={column.key === 'tool'}
+      >
         {column.name}
       </HeadSortCell>
     );

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -73,8 +73,7 @@ export function TracesTable() {
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
     return (
-      <HeadSortCell column={column}>
-        {column.key === 'agentFlow' && <CellExpander />}
+      <HeadSortCell sortKey={column.key} forceCellGrow={column.key === 'agentFlow'}>
         {column.name}
       </HeadSortCell>
     );
@@ -158,14 +157,6 @@ const BodyCell = memo(function BodyCell({
       return null;
   }
 });
-
-/**
- * Used to force the cell to expand take as much width as possible in the table layout
- * otherwise grid editable will let the last column grow
- */
-const CellExpander = styled('div')`
-  width: 100vw;
-`;
 
 const GridEditableContainer = styled('div')`
   position: relative;

--- a/static/app/views/insights/pages/platform/shared/pagesTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pagesTable.tsx
@@ -1,80 +1,28 @@
-import {Fragment, memo, useCallback, useMemo, useState} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
 
-import {Tooltip} from 'sentry/components/core/tooltip';
-import GridEditable, {
+import {
   COL_WIDTH_UNDEFINED,
   type GridColumnHeader,
   type GridColumnOrder,
 } from 'sentry/components/gridEditable';
-import SortLink from 'sentry/components/gridEditable/sortLink';
-import Link from 'sentry/components/links/link';
-import type {CursorHandler} from 'sentry/components/pagination';
-import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import getDuration from 'sentry/utils/duration/getDuration';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
-import {formatPercentage} from 'sentry/utils/number/formatPercentage';
-import {type QueryValue} from 'sentry/utils/queryString';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
-import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
+import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
-import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
-import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
+import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
+import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
+import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
+import {TransactionCell} from 'sentry/views/insights/pages/platform/shared/table/TransactionCell';
+import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
 
-type SortableField =
-  | 'transaction'
-  | 'count()'
-  | 'failure_rate()'
-  | 'sum(span.duration)'
-  | 'avg(span.duration)'
-  | 'p95(span.duration)'
-  | 'performance_score(measurements.score.total)';
-
-interface TableData {
-  avgDuration: number;
-  errorRate: number;
-  p95: number;
-  page: string;
-  pageViews: number;
-  projectID: number;
-  spanOp: string;
-  totalTime: number;
-  'performance_score(measurements.score.total)'?: number;
-}
-
-const errorRateColorThreshold = {
-  error: 0.1,
-  warning: 0.05,
-} as const;
-
-const getP95Threshold = (_avg: number) => {
-  return {
-    error: 4000,
-    warning: 2500,
-  };
+const p95Threshold = {
+  error: 4000,
+  warning: 2500,
 };
 
-const getCellColor = (value: number, thresholds: Record<string, number>) => {
-  return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0] as
-    | 'errorText'
-    | 'warningText'
-    | undefined;
-};
-
-const getOrderBy = (field: string, order: 'asc' | 'desc') => {
-  return order === 'asc' ? field : `-${field}`;
-};
-
-const pageloadColumnOrder: Array<GridColumnOrder<SortableField>> = [
+const pageloadColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'transaction', name: t('Page'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Pageloads'), width: 122},
   {key: 'failure_rate()', name: t('Error Rate'), width: 122},
@@ -85,49 +33,13 @@ const pageloadColumnOrder: Array<GridColumnOrder<SortableField>> = [
   },
 ];
 
-const navigationColumnOrder: Array<GridColumnOrder<SortableField>> = [
+const navigationColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'transaction', name: t('Page'), width: COL_WIDTH_UNDEFINED},
   {key: 'count()', name: t('Navigations'), width: 132},
   {key: 'avg(span.duration)', name: t('Avg'), width: 90},
   {key: 'p95(span.duration)', name: t('P95'), width: 90},
   {key: 'sum(span.duration)', name: t('Time Spent'), width: 110},
 ];
-
-const pageloadKeys: SortableField[] = pageloadColumnOrder.map(col => col.key);
-const navigationKeys: SortableField[] = navigationColumnOrder.map(col => col.key);
-const allSortableKeys = new Set<SortableField>([...pageloadKeys, ...navigationKeys]);
-
-function isSortField(value: string): value is SortableField {
-  return allSortableKeys.has(value as SortableField);
-}
-
-function decodeSortField(value: QueryValue): SortableField {
-  if (typeof value === 'string' && isSortField(value)) {
-    return value;
-  }
-  return 'count()';
-}
-
-function isSortOrder(value: string): value is 'asc' | 'desc' {
-  return value === 'asc' || value === 'desc';
-}
-
-function decodeSortOrder(value: QueryValue): 'asc' | 'desc' {
-  if (typeof value === 'string' && isSortOrder(value)) {
-    return value;
-  }
-  return 'desc';
-}
-
-function useTableSortParams() {
-  const {field: sortField, order: sortOrder} = useLocationQuery({
-    fields: {
-      field: decodeSortField,
-      order: decodeSortOrder,
-    },
-  });
-  return {sortField, sortOrder};
-}
 
 interface PagesTableProps {
   spanOperationFilter: 'pageload' | 'navigation';
@@ -138,105 +50,62 @@ const CURSOR_PARAM_NAMES: Record<PagesTableProps['spanOperationFilter'], string>
   navigation: 'navigationCursor',
 };
 
-export function PagesTable({spanOperationFilter}: PagesTableProps) {
-  const location = useLocation();
-  const {query, setTransactionFilter} = useTransactionNameQuery();
-  const pageFilterChartParams = usePageFilterChartParams();
-  const {sortField, sortOrder} = useTableSortParams();
-  const currentCursorParamName = CURSOR_PARAM_NAMES[spanOperationFilter];
-  const navigate = useNavigate();
+const rightAlignColumns = new Set([
+  'count()',
+  'failure_rate()',
+  'sum(span.duration)',
+  'avg(span.duration)',
+  'p95(span.duration)',
+  'performance_score(measurements.score.total)',
+]);
 
-  const [columnOrder, setColumnOrder] = useState(() => {
+export function PagesTable({spanOperationFilter}: PagesTableProps) {
+  const currentCursorParamName = CURSOR_PARAM_NAMES[spanOperationFilter];
+
+  const getInitialColumnOrder = () => {
     if (spanOperationFilter === 'pageload') {
       return pageloadColumnOrder;
     }
     return navigationColumnOrder;
-  });
-
-  const handleCursor: CursorHandler = (cursor, pathname, transactionQuery) => {
-    navigate(
-      {
-        pathname,
-        search: qs.stringify({...transactionQuery, [currentCursorParamName]: cursor}),
-      },
-      {replace: true, preventScrollReset: true}
-    );
   };
 
-  const spansRequest = useEAPSpans(
-    {
-      ...pageFilterChartParams,
-      sorts: [
-        {
-          field: sortField,
-          kind: sortOrder,
-        },
-      ],
-      fields: [
-        'transaction',
-        'span.op',
-        'failure_rate()',
-        'count()',
-        'sum(span.duration)',
-        'avg(span.duration)',
-        'p95(span.duration)',
-        'performance_score(measurements.score.total)',
-        'project.id',
-      ],
-      limit: 10,
-      search: `span.op:[${spanOperationFilter}] ${query ? `${query}` : ''}`.trim(),
-      orderby: getOrderBy(sortField, sortOrder),
-      cursor:
-        typeof location.query[currentCursorParamName] === 'string'
-          ? location.query[currentCursorParamName]
-          : undefined,
-      keepPreviousData: true,
-    },
-    Referrer.PAGES_TABLE
-  );
-
-  const tableData = useMemo<TableData[]>(() => {
-    if (!spansRequest.data) {
-      return [];
-    }
-
-    return spansRequest.data.map(span => ({
-      page: span.transaction,
-      pageViews: span['count()'],
-      errorRate: span['failure_rate()'],
-      totalTime: span['sum(span.duration)'],
-      avgDuration: span['avg(span.duration)'],
-      p95: span['p95(span.duration)'],
-      spanOp: span['span.op'],
-      projectID: span['project.id'],
-      'performance_score(measurements.score.total)':
-        span['performance_score(measurements.score.total)'],
-    }));
-  }, [spansRequest.data]);
-
-  const handleResizeColumn = useCallback(
-    (columnIndex: number, nextColumn: GridColumnHeader<string>) => {
-      setColumnOrder(prev => {
-        const newColumnOrder = [...prev];
-        newColumnOrder[columnIndex] = {
-          ...newColumnOrder[columnIndex]!,
-          width: nextColumn.width,
-        };
-        return newColumnOrder;
-      });
-    },
-    []
-  );
+  const tableDataRequest = useTableData({
+    query: `span.op:[${spanOperationFilter}]`,
+    fields: [
+      'transaction',
+      'span.op',
+      'failure_rate()',
+      'count()',
+      'sum(span.duration)',
+      'avg(span.duration)',
+      'p95(span.duration)',
+      'performance_score(measurements.score.total)',
+      'project.id',
+    ],
+    cursorParamName: currentCursorParamName,
+    referrer: Referrer.PAGES_TABLE,
+  });
 
   const renderHeadCell = useCallback(
-    (column: GridColumnHeader<SortableField>) => {
-      return <HeadCell column={column} currentCursorParamName={currentCursorParamName} />;
+    (column: GridColumnHeader<string>) => {
+      return (
+        <HeadSortCell
+          sortKey={column.key}
+          align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
+          cursorParamName={currentCursorParamName}
+          forceCellGrow={column.key === 'transaction'}
+        >
+          {column.name}
+        </HeadSortCell>
+      );
     },
     [currentCursorParamName]
   );
 
+  type TableData = (typeof tableDataRequest.data)[number];
+
   const renderBodyCell = useCallback(
-    (column: GridColumnHeader<SortableField>, dataRow: TableData) => {
+    (column: GridColumnHeader<string>, dataRow: TableData) => {
       if (column.key === 'performance_score(measurements.score.total)') {
         const score = dataRow['performance_score(measurements.score.total)'];
         if (typeof score !== 'number') {
@@ -249,194 +118,62 @@ export function PagesTable({spanOperationFilter}: PagesTableProps) {
         );
       }
 
-      return (
-        <BodyCell
-          column={column}
-          dataRow={dataRow}
-          handleAddTransactionFilter={setTransactionFilter}
-        />
-      );
+      switch (column.key) {
+        case 'transaction': {
+          return (
+            <TransactionCell
+              transaction={dataRow.transaction}
+              column={column}
+              dataRow={dataRow}
+              targetView="frontend"
+              projectId={dataRow['project.id'].toString()}
+            />
+          );
+        }
+        case 'count()':
+          return <NumberCell value={dataRow['count()']} />;
+        case 'failure_rate()': {
+          return <ErrorRateCell errorRate={dataRow['failure_rate()']} />;
+        }
+        case 'sum(span.duration)':
+          return <DurationCell milliseconds={dataRow['sum(span.duration)']} />;
+        case 'avg(span.duration)': {
+          return <DurationCell milliseconds={dataRow['avg(span.duration)']} />;
+        }
+        case 'p95(span.duration)': {
+          return (
+            <DurationCell
+              milliseconds={dataRow['p95(span.duration)']}
+              thresholds={p95Threshold}
+            />
+          );
+        }
+        default:
+          return <div />;
+      }
     },
-    [setTransactionFilter]
+    []
   );
 
-  const pagesTablePageLinks = spansRequest.pageLinks;
+  const pagesTablePageLinks = tableDataRequest.pageLinks;
 
   return (
-    <Fragment>
-      <GridEditableContainer>
-        <GridEditable<TableData, SortableField>
-          isLoading={spansRequest.isPending}
-          error={spansRequest.error}
-          data={tableData}
-          columnOrder={columnOrder}
-          columnSortBy={[{key: sortField, order: sortOrder}]}
-          stickyHeader
-          grid={{
-            renderHeadCell,
-            renderBodyCell,
-            onResizeColumn: handleResizeColumn,
-          }}
-        />
-        {spansRequest.isPlaceholderData && <LoadingOverlay />}
-      </GridEditableContainer>
-      <Pagination pageLinks={pagesTablePageLinks} onCursor={handleCursor} />
-    </Fragment>
+    <PlatformInsightsTable
+      isLoading={tableDataRequest.isPending}
+      error={tableDataRequest.error}
+      data={tableDataRequest.data}
+      initialColumnOrder={getInitialColumnOrder}
+      stickyHeader
+      cursorParamName={currentCursorParamName}
+      pageLinks={pagesTablePageLinks}
+      isPlaceholderData={tableDataRequest.isPlaceholderData}
+      grid={{
+        renderHeadCell,
+        renderBodyCell,
+      }}
+    />
   );
 }
-
-const HeadCell = memo(function PagesTableHeadCell({
-  column,
-  currentCursorParamName,
-}: {
-  column: GridColumnHeader<SortableField>;
-  currentCursorParamName: string;
-}) {
-  const location = useLocation();
-  const {sortField, sortOrder} = useTableSortParams();
-
-  return (
-    <div style={{display: 'flex', alignItems: 'center'}}>
-      <SortLink
-        align="left"
-        title={
-          <Fragment>
-            {column.key === 'transaction' && <CellExpander />}
-            {column.name}
-          </Fragment>
-        }
-        direction={sortField === column.key ? sortOrder : undefined}
-        canSort
-        preventScrollReset
-        generateSortLink={() => {
-          const newQuery = {
-            ...location.query,
-            [currentCursorParamName]: undefined,
-            field: column.key,
-            order:
-              sortField === column.key ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'desc',
-          };
-          return {
-            pathname: location.pathname,
-            query: newQuery,
-          };
-        }}
-      />
-    </div>
-  );
-});
-
-const BodyCell = memo(function PagesBodyCell({
-  column,
-  dataRow,
-  handleAddTransactionFilter,
-}: {
-  column: GridColumnHeader<SortableField>;
-  dataRow: TableData;
-  handleAddTransactionFilter: (value: string) => void;
-}) {
-  const organization = useOrganization();
-
-  switch (column.key) {
-    case 'transaction': {
-      const target = transactionSummaryRouteWithQuery({
-        organization,
-        transaction: dataRow.page,
-        view: 'frontend',
-        projectID: dataRow.projectID.toString(),
-        query: {},
-      });
-
-      return (
-        <CellAction
-          column={{
-            ...column,
-            isSortable: false,
-            type: 'string',
-            column: {kind: 'field', field: 'transaction'},
-          }}
-          dataRow={dataRow as any}
-          allowActions={[Actions.ADD]}
-          handleCellAction={() => {
-            handleAddTransactionFilter(dataRow.page);
-          }}
-        >
-          <CellLink to={target}>
-            <Tooltip title={dataRow.page} showUnderline skipWrapper>
-              {dataRow.page}
-            </Tooltip>
-          </CellLink>
-        </CellAction>
-      );
-    }
-    case 'count()':
-      return <Count>{formatAbbreviatedNumber(dataRow.pageViews)}</Count>;
-    case 'failure_rate()': {
-      const thresholds = errorRateColorThreshold;
-      const color = getCellColor(dataRow.errorRate, thresholds);
-      return (
-        <ColoredValue color={color}>
-          {formatPercentage(dataRow.errorRate ?? 0)}
-        </ColoredValue>
-      );
-    }
-    case 'sum(span.duration)':
-      return <Duration>{getDuration(dataRow.totalTime / 1000, 2, true)}</Duration>;
-    case 'avg(span.duration)': {
-      return <Duration>{getDuration(dataRow.avgDuration / 1000, 2, true)}</Duration>;
-    }
-    case 'p95(span.duration)': {
-      const thresholds = getP95Threshold(dataRow.avgDuration);
-      const color = getCellColor(dataRow.p95, thresholds);
-      return (
-        <ColoredValue color={color}>
-          {getDuration(dataRow.p95 / 1000, 2, true)}
-        </ColoredValue>
-      );
-    }
-    default:
-      return <div />;
-  }
-});
-
-const GridEditableContainer = styled('div')`
-  position: relative;
-  margin-bottom: ${space(1)};
-`;
-
-const LoadingOverlay = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: ${p => p.theme.background};
-  opacity: 0.5;
-  z-index: 1;
-`;
-
-const CellLink = styled(Link)`
-  ${p => p.theme.overflowEllipsis}
-`;
-
-const Count = styled('div')`
-  text-align: right;
-`;
-
-const Duration = styled('div')`
-  text-align: right;
-`;
-
-const ColoredValue = styled('span')<{
-  color?: 'errorText' | 'warningText';
-}>`
-  color: ${p => (p.color ? p.theme[p.color] : 'inherit')};
-  text-align: right;
-  display: block;
-`;
-const CellExpander = styled('div')`
-  width: 100vw;
-`;
 
 const AlignRight = styled('div')`
   text-align: right;

--- a/static/app/views/insights/pages/platform/shared/pathsTable.tsx
+++ b/static/app/views/insights/pages/platform/shared/pathsTable.tsx
@@ -1,51 +1,25 @@
-import {Fragment, memo, useCallback, useMemo, useState} from 'react';
-import {css, useTheme} from '@emotion/react';
+import {useCallback} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
-import GridEditable, {
+import {
   COL_WIDTH_UNDEFINED,
   type GridColumnHeader,
   type GridColumnOrder,
 } from 'sentry/components/gridEditable';
-import SortLink from 'sentry/components/gridEditable/sortLink';
-import Link from 'sentry/components/links/link';
-import Pagination from 'sentry/components/pagination';
 import Placeholder from 'sentry/components/placeholder';
-import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
-import getDuration from 'sentry/utils/duration/getDuration';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
-import type {QueryValue} from 'sentry/utils/queryString';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
-import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
-import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
-import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
-
-interface TableData {
-  avg: number;
-  controller: string | undefined;
-  errorRate: number;
-  isControllerLoading: boolean;
-  method: string;
-  p95: number;
-  projectId: number;
-  requests: number;
-  sum: number;
-  transaction: string;
-  users: number;
-}
-
-const errorRateColorThreshold = {
-  error: 0.1,
-  warning: 0.05,
-} as const;
+import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
+import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
+import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
+import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
+import {TransactionCell} from 'sentry/views/insights/pages/platform/shared/table/TransactionCell';
+import {UserCell} from 'sentry/views/insights/pages/platform/shared/table/UserCell';
+import {useTableDataWithController} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
 
 const getP95Threshold = (avg: number) => {
   return {
@@ -53,16 +27,6 @@ const getP95Threshold = (avg: number) => {
     warning: avg * 2,
   };
 };
-
-const getCellColor = (value: number, thresholds: Record<string, number>) => {
-  return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0] as
-    | 'errorText'
-    | 'warningText'
-    | undefined;
-};
-
-const EMPTY_ARRAY: never[] = [];
-const PER_PAGE = 10;
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'http.request.method', name: t('Method'), width: 90},
@@ -75,53 +39,27 @@ const defaultColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'count_unique(user)', name: t('Users'), width: 90},
 ];
 
-function isSortField(value: string): value is string {
-  return defaultColumnOrder.some(column => column.key === value);
-}
-
-function decodeSortField(value: QueryValue): string {
-  if (typeof value === 'string' && isSortField(value)) {
-    return value;
-  }
-  return 'count()';
-}
-
-function isSortOrder(value: string): value is 'asc' | 'desc' {
-  return value === 'asc' || value === 'desc';
-}
-
-function decodeSortOrder(value: QueryValue): 'asc' | 'desc' {
-  if (typeof value === 'string' && isSortOrder(value)) {
-    return value;
-  }
-  return 'desc';
-}
-
-function useTableSortParams() {
-  const {field: sortField, order: sortOrder} = useLocationQuery({
-    fields: {
-      field: decodeSortField,
-      order: decodeSortOrder,
-    },
-  });
-  return {sortField, sortOrder};
-}
-
 interface PathsTableProps {
   showHttpMethodColumn?: boolean;
   showRouteController?: boolean;
   showUsersColumn?: boolean;
 }
 
+const rightAlignColumns = new Set([
+  'avg(span.duration)',
+  'count_unique(user)',
+  'count()',
+  'failure_rate()',
+  'p95(span.duration)',
+  'sum(span.duration)',
+]);
+
 export function PathsTable({
   showHttpMethodColumn = true,
   showUsersColumn = true,
   showRouteController = true,
 }: PathsTableProps) {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const {query, setTransactionFilter} = useTransactionNameQuery();
-  const [columnOrder, setColumnOrder] = useState(() => {
+  const getInitialColumnOrder = () => {
     let columns = [...defaultColumnOrder];
 
     if (!showHttpMethodColumn) {
@@ -133,331 +71,138 @@ export function PathsTable({
     }
 
     return columns;
+  };
+
+  const tableDataRequest = useTableDataWithController({
+    query: 'transaction.op:http.server is_transaction:True',
+    fields: [
+      'project.id',
+      'transaction',
+      'avg(span.duration)',
+      'p95(span.duration)',
+      'failure_rate()',
+      'count()',
+      'sum(span.duration)',
+      ...(showHttpMethodColumn ? ['http.request.method' as const] : []),
+      ...(showUsersColumn ? ['count_unique(user)' as const] : []),
+    ],
+    cursorParamName: 'pathsCursor',
+    fetchRouteController: showRouteController,
+    referrer: Referrer.PATHS_TABLE,
   });
-  const {sortField, sortOrder} = useTableSortParams();
-
-  const transactionsRequest = useEAPSpans(
-    {
-      search: `transaction.op:http.server is_transaction:True ${query}`,
-      sorts: [{field: sortField, kind: sortOrder}],
-      fields: [
-        'project.id',
-        'transaction',
-        'avg(span.duration)',
-        'p95(span.duration)',
-        'failure_rate()',
-        'count()',
-        'sum(span.duration)',
-        ...(showHttpMethodColumn ? ['http.request.method' as const] : []),
-        ...(showUsersColumn ? ['count_unique(user)' as const] : []),
-      ],
-      limit: PER_PAGE,
-      keepPreviousData: true,
-      cursor:
-        typeof location.query.pathsCursor === 'string'
-          ? location.query.pathsCursor
-          : undefined,
-    },
-    Referrer.PATHS_TABLE
-  );
-
-  // Get the list of transactions from the first request
-  const transactionPaths = useMemo(() => {
-    return transactionsRequest.data?.map(transactions => transactions.transaction) ?? [];
-  }, [transactionsRequest.data]);
-
-  // The controller name is available in the span.description field on the `span.op:http.route` span in the same transaction
-  const routeControllersRequest = useEAPSpans(
-    {
-      search: `transaction.op:http.server span.op:http.route transaction:[${
-        transactionPaths.map(transactions => `"${transactions}"`).join(',') || '""'
-      }]`,
-      fields: [
-        'span.description',
-        'transaction',
-        'http.request.method',
-        // We need an aggregation so we do not receive individual events
-        'count()',
-      ],
-      limit: PER_PAGE,
-      enabled:
-        showRouteController && !!transactionsRequest.data && transactionPaths.length > 0,
-    },
-    Referrer.PATHS_TABLE
-  );
-
-  const tableData = useMemo<TableData[]>(() => {
-    if (!transactionsRequest.data) {
-      return [];
-    }
-
-    // Create a mapping of transaction path to controller
-    const controllerMap = new Map(
-      routeControllersRequest.data?.map(item => [
-        item.transaction,
-        item['span.description'],
-      ])
-    );
-
-    return transactionsRequest.data.map(transaction => ({
-      method: transaction['http.request.method'],
-      transaction: transaction.transaction,
-      requests: transaction['count()'],
-      avg: transaction['avg(span.duration)'],
-      p95: transaction['p95(span.duration)'],
-      errorRate: transaction['failure_rate()'],
-      users: transaction['count_unique(user)'],
-      isControllerLoading: routeControllersRequest.isLoading,
-      controller: controllerMap.get(transaction.transaction),
-      projectId: transaction['project.id'],
-      sum: transaction['sum(span.duration)'],
-    }));
-  }, [
-    transactionsRequest.data,
-    routeControllersRequest.data,
-    routeControllersRequest.isLoading,
-  ]);
-
-  const handleResizeColumn = useCallback(
-    (columnIndex: number, nextColumn: GridColumnHeader<string>) => {
-      setColumnOrder(prev => {
-        const newColumnOrder = [...prev];
-        newColumnOrder[columnIndex] = {
-          ...newColumnOrder[columnIndex]!,
-          width: nextColumn.width,
-        };
-        return newColumnOrder;
-      });
-    },
-    []
-  );
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
-    return <HeadCell column={column} />;
+    return (
+      <HeadSortCell
+        sortKey={column.key}
+        align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
+        forceCellGrow={column.key === 'transaction'}
+        cursorParamName="pathsCursor"
+      >
+        {column.name}
+      </HeadSortCell>
+    );
   }, []);
 
   const renderBodyCell = useCallback(
-    (column: GridColumnOrder<string>, dataRow: TableData) => {
-      return (
-        <BodyCell
-          column={column}
-          dataRow={dataRow}
-          handleAddTransactionFilter={setTransactionFilter}
-        />
-      );
+    (
+      column: GridColumnOrder<string>,
+      dataRow: (typeof tableDataRequest.data)[number]
+    ) => {
+      switch (column.key) {
+        case 'http.request.method':
+          return dataRow['http.request.method'];
+        case 'transaction':
+          return (
+            <TransactionCell
+              transaction={dataRow.transaction}
+              column={column}
+              dataRow={dataRow}
+              projectId={dataRow['project.id'].toString()}
+              targetView="backend"
+              details={
+                <TransactionDetails
+                  isControllerLoading={dataRow.isControllerLoading}
+                  controller={dataRow.controller}
+                />
+              }
+            />
+          );
+        case 'count()':
+          return <NumberCell value={dataRow['count()']} />;
+        case 'failure_rate()':
+          return <ErrorRateCell errorRate={dataRow['failure_rate()']} />;
+        case 'avg(span.duration)':
+          return <DurationCell milliseconds={dataRow['avg(span.duration)']} />;
+        case 'p95(span.duration)':
+          return (
+            <DurationCell
+              milliseconds={dataRow['p95(span.duration)']}
+              thresholds={getP95Threshold(dataRow['avg(span.duration)'])}
+            />
+          );
+        case 'sum(span.duration)':
+          return <TimeSpentCell total={dataRow['sum(span.duration)']} />;
+        case 'count_unique(user)':
+          return <UserCell value={dataRow['count_unique(user)']} />;
+        default:
+          return <div />;
+      }
     },
-    [setTransactionFilter]
+    [tableDataRequest]
   );
 
   return (
-    <Fragment>
-      <GridEditableContainer>
-        <GridEditable
-          isLoading={transactionsRequest.isPending}
-          error={transactionsRequest.error}
-          data={tableData}
-          columnOrder={columnOrder}
-          columnSortBy={EMPTY_ARRAY}
-          stickyHeader
-          grid={{
-            renderBodyCell,
-            renderHeadCell,
-            onResizeColumn: handleResizeColumn,
-          }}
-        />
-        {transactionsRequest.isPlaceholderData && <LoadingOverlay />}
-      </GridEditableContainer>
-      <Pagination
-        pageLinks={transactionsRequest.pageLinks}
-        onCursor={(cursor, path, currentQuery) => {
-          navigate(
-            {
-              pathname: path,
-              query: {...currentQuery, pathsCursor: cursor},
-            },
-            {replace: true, preventScrollReset: true}
-          );
-        }}
-      />
-    </Fragment>
+    <PlatformInsightsTable
+      isLoading={tableDataRequest.isPending}
+      error={tableDataRequest.error}
+      data={tableDataRequest.data}
+      initialColumnOrder={getInitialColumnOrder}
+      stickyHeader
+      grid={{
+        renderBodyCell,
+        renderHeadCell,
+      }}
+      cursorParamName="pathsCursor"
+      pageLinks={tableDataRequest.pageLinks}
+      isPlaceholderData={tableDataRequest.isPlaceholderData}
+    />
   );
 }
 
-const HeadCell = memo(function HeadCell({column}: {column: GridColumnHeader<string>}) {
-  const location = useLocation();
-  const {sortField, sortOrder} = useTableSortParams();
-  return (
-    <SortLink
-      align={column.key === 'count_unique(user)' ? 'right' : 'left'}
-      direction={sortField === column.key ? sortOrder : undefined}
-      canSort
-      preventScrollReset
-      generateSortLink={() => ({
-        ...location,
-        query: {
-          ...location.query,
-          field: column.key,
-          order:
-            sortField === column.key ? (sortOrder === 'asc' ? 'desc' : 'asc') : 'desc',
-        },
-      })}
-      title={
-        <Fragment>
-          {column.key === 'transaction' && <CellExpander />}
-          {column.name}
-        </Fragment>
-      }
-    />
-  );
-});
-
-const BodyCell = memo(function BodyCell({
-  column,
-  dataRow,
-  handleAddTransactionFilter,
+function TransactionDetails({
+  isControllerLoading,
+  controller,
 }: {
-  column: GridColumnHeader<string>;
-  dataRow: TableData;
-  handleAddTransactionFilter: (value: string) => void;
+  isControllerLoading: boolean;
+  controller?: string;
 }) {
   const theme = useTheme();
-  const organization = useOrganization();
-  const p95Color = getCellColor(dataRow.p95, getP95Threshold(dataRow.avg));
-  const errorRateColor = getCellColor(dataRow.errorRate, errorRateColorThreshold);
 
-  switch (column.key) {
-    case 'http.request.method':
-      return dataRow.method;
-    case 'transaction':
-      return (
-        <CellAction
-          column={{
-            ...column,
-            isSortable: true,
-            type: 'string',
-            column: {kind: 'field', field: 'transaction'},
-          }}
-          dataRow={dataRow as any}
-          allowActions={[Actions.ADD]}
-          handleCellAction={() => handleAddTransactionFilter(dataRow.transaction)}
-        >
-          <PathCell>
-            <Tooltip
-              title={dataRow.transaction}
-              position="top"
-              maxWidth={400}
-              showOnlyOnOverflow
-              skipWrapper
-            >
-              <Link
-                css={css`
-                  ${theme.overflowEllipsis};
-                  min-width: 0px;
-                `}
-                to={transactionSummaryRouteWithQuery({
-                  organization,
-                  transaction: dataRow.transaction,
-                  view: 'backend',
-                  projectID: dataRow.projectId.toString(),
-                  query: {},
-                })}
-              >
-                {dataRow.transaction}
-              </Link>
-            </Tooltip>
-            {dataRow.isControllerLoading ? (
-              <Placeholder height={theme.fontSizeSmall} width="200px" />
-            ) : (
-              dataRow && (
-                <Tooltip
-                  title={dataRow.controller}
-                  position="top"
-                  maxWidth={400}
-                  showOnlyOnOverflow
-                  skipWrapper
-                >
-                  <ControllerText>{dataRow.controller}</ControllerText>
-                </Tooltip>
-              )
-            )}
-          </PathCell>
-        </CellAction>
-      );
-    case 'count()':
-      return formatAbbreviatedNumber(dataRow.requests);
-    case 'failure_rate()':
-      return (
-        <div style={{color: errorRateColor && theme[errorRateColor]}}>
-          {(dataRow.errorRate * 100).toFixed(2)}%
-        </div>
-      );
-    case 'avg(span.duration)':
-      return getDuration(dataRow.avg / 1000, 2, true, true);
-    case 'p95(span.duration)':
-      return (
-        <div style={{color: p95Color && theme[p95Color]}}>
-          {getDuration(dataRow.p95 / 1000, 2, true, true)}
-        </div>
-      );
-    case 'sum(span.duration)':
-      return getDuration(dataRow.sum / 1000, 2, true, true);
-    case 'count_unique(user)':
-      return (
-        <div
-          style={{
-            minWidth: '0',
-            display: 'flex',
-            alignItems: 'center',
-            gap: space(0.5),
-            justifyContent: 'flex-end',
-          }}
-        >
-          {formatAbbreviatedNumber(dataRow.users)}
-          <IconUser size="xs" />
-        </div>
-      );
-    default:
-      return null;
+  if (isControllerLoading) {
+    return <Placeholder height={theme.fontSizeSmall} width="200px" />;
   }
-});
 
-const PathCell = styled('div')`
-  overflow: hidden;
-  white-space: nowrap;
-  flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
-  gap: ${space(0.5)};
-  min-width: 0px;
-`;
+  if (!controller) {
+    return null;
+  }
 
-/**
- * Used to force the cell to expand take as much width as possible in the table layout
- * otherwise grid editable will let the last column grow
- */
-const CellExpander = styled('div')`
-  width: 100vw;
-`;
+  return (
+    <Tooltip
+      title={controller}
+      position="top"
+      maxWidth={400}
+      showOnlyOnOverflow
+      skipWrapper
+    >
+      <ControllerText>{controller}</ControllerText>
+    </Tooltip>
+  );
+}
 
 const ControllerText = styled('div')`
   ${p => p.theme.overflowEllipsis};
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   min-width: 0px;
-`;
-
-const GridEditableContainer = styled('div')`
-  position: relative;
-  margin-bottom: ${space(1)};
-`;
-
-const LoadingOverlay = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: ${p => p.theme.background};
-  opacity: 0.5;
-  z-index: 1;
 `;

--- a/static/app/views/insights/pages/platform/shared/table/DurationCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/DurationCell.tsx
@@ -1,0 +1,20 @@
+import Duration from 'sentry/components/duration';
+import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
+import type {CellThreshold} from 'sentry/views/insights/pages/platform/shared/table/ThresholdCell';
+import {ThresholdCell} from 'sentry/views/insights/pages/platform/shared/table/ThresholdCell';
+
+export function DurationCell({
+  milliseconds,
+  thresholds,
+}: {
+  milliseconds: number;
+  thresholds?: CellThreshold;
+}) {
+  return (
+    <ThresholdCell value={milliseconds} thresholds={thresholds}>
+      <TextAlignRight>
+        <Duration seconds={milliseconds / 1000} fixedDigits={2} abbreviation />
+      </TextAlignRight>
+    </ThresholdCell>
+  );
+}

--- a/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
@@ -1,0 +1,15 @@
+import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
+import {ThresholdCell} from 'sentry/views/insights/pages/platform/shared/table/ThresholdCell';
+
+const errorRateColorThreshold = {
+  error: 0.1,
+  warning: 0.05,
+} as const;
+
+export function ErrorRateCell({errorRate}: {errorRate: number}) {
+  return (
+    <ThresholdCell value={errorRate} thresholds={errorRateColorThreshold}>
+      <TextAlignRight>{(errorRate * 100).toFixed(2)}%</TextAlignRight>
+    </ThresholdCell>
+  );
+}

--- a/static/app/views/insights/pages/platform/shared/table/NumberCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/NumberCell.tsx
@@ -1,0 +1,6 @@
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
+
+export function NumberCell({value}: {value: number}) {
+  return <TextAlignRight>{formatAbbreviatedNumber(value)}</TextAlignRight>;
+}

--- a/static/app/views/insights/pages/platform/shared/table/ThresholdCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/ThresholdCell.tsx
@@ -1,0 +1,27 @@
+import {useTheme} from '@emotion/react';
+
+const getCellColor = (value?: number, thresholds?: Record<string, number>) => {
+  if (!value || !thresholds) {
+    return undefined;
+  }
+  return Object.entries(thresholds).find(([_, threshold]) => value >= threshold)?.[0] as
+    | 'errorText'
+    | 'warningText'
+    | undefined;
+};
+
+export type CellThreshold = Record<string, number>;
+
+export function ThresholdCell({
+  value,
+  thresholds,
+  children,
+}: {
+  children: React.ReactNode;
+  thresholds?: Record<string, number>;
+  value?: number;
+}) {
+  const theme = useTheme();
+  const color = getCellColor(value, thresholds);
+  return <div style={{color: color && theme[color]}}>{children}</div>;
+}

--- a/static/app/views/insights/pages/platform/shared/table/TransactionCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/TransactionCell.tsx
@@ -1,0 +1,79 @@
+import {Link} from 'react-router-dom';
+import styled from '@emotion/styled';
+
+import {Tooltip} from 'sentry/components/core/tooltip';
+import type {GridColumnOrder} from 'sentry/components/gridEditable';
+import {space} from 'sentry/styles/space';
+import useOrganization from 'sentry/utils/useOrganization';
+import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
+
+export function TransactionCell({
+  transaction,
+  projectId,
+  column,
+  dataRow,
+  details,
+  targetView,
+}: {
+  column: GridColumnOrder<string>;
+  dataRow: Record<string, any>;
+  projectId: string;
+  targetView: 'backend' | 'frontend';
+  transaction: string;
+  details?: React.ReactNode;
+}) {
+  const organization = useOrganization();
+  const {setTransactionFilter} = useTransactionNameQuery();
+
+  const transactionSummaryLink = transactionSummaryRouteWithQuery({
+    organization,
+    transaction,
+    view: targetView,
+    projectID: projectId,
+    query: {},
+  });
+
+  return (
+    <CellAction
+      column={{
+        ...column,
+        isSortable: true,
+        type: 'string',
+        column: {kind: 'field', field: 'transaction'},
+      }}
+      dataRow={dataRow as any}
+      allowActions={[Actions.ADD]}
+      handleCellAction={() => setTransactionFilter(transaction)}
+    >
+      <PathCell>
+        <Tooltip
+          title={transaction}
+          position="top"
+          maxWidth={400}
+          showOnlyOnOverflow
+          skipWrapper
+        >
+          <TransactionLink to={transactionSummaryLink}>{transaction}</TransactionLink>
+        </Tooltip>
+        {details}
+      </PathCell>
+    </CellAction>
+  );
+}
+
+const PathCell = styled('div')`
+  overflow: hidden;
+  white-space: nowrap;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: ${space(0.5)};
+  min-width: 0px;
+`;
+
+const TransactionLink = styled(Link)`
+  ${p => p.theme.overflowEllipsis};
+  min-width: 0px;
+`;

--- a/static/app/views/insights/pages/platform/shared/table/TransactionCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/TransactionCell.tsx
@@ -1,8 +1,8 @@
-import {Link} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {Tooltip} from 'sentry/components/core/tooltip';
 import type {GridColumnOrder} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
@@ -47,7 +47,7 @@ export function TransactionCell({
       allowActions={[Actions.ADD]}
       handleCellAction={() => setTransactionFilter(transaction)}
     >
-      <PathCell>
+      <CellWrapper>
         <Tooltip
           title={transaction}
           position="top"
@@ -58,12 +58,12 @@ export function TransactionCell({
           <TransactionLink to={transactionSummaryLink}>{transaction}</TransactionLink>
         </Tooltip>
         {details}
-      </PathCell>
+      </CellWrapper>
     </CellAction>
   );
 }
 
-const PathCell = styled('div')`
+const CellWrapper = styled('div')`
   overflow: hidden;
   white-space: nowrap;
   flex-direction: column;

--- a/static/app/views/insights/pages/platform/shared/table/UserCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/UserCell.tsx
@@ -1,0 +1,20 @@
+import {IconUser} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+
+export function UserCell({value}: {value: number}) {
+  return (
+    <div
+      style={{
+        minWidth: '0',
+        display: 'flex',
+        alignItems: 'center',
+        gap: space(0.5),
+        justifyContent: 'flex-end',
+      }}
+    >
+      {formatAbbreviatedNumber(value)}
+      <IconUser size="xs" />
+    </div>
+  );
+}

--- a/static/app/views/insights/pages/platform/shared/table/index.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/index.tsx
@@ -1,0 +1,101 @@
+import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
+
+import type {GridColumnHeader, GridColumnOrder} from 'sentry/components/gridEditable';
+import GridEditable from 'sentry/components/gridEditable';
+import type {CursorHandler} from 'sentry/components/pagination';
+import Pagination from 'sentry/components/pagination';
+import {space} from 'sentry/styles/space';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useTableSortParams} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+
+type ObjectKey = string | number;
+
+interface PlatformInsightsTableProps<
+  DataRow extends Record<string, any>,
+  ColumnKey extends ObjectKey = string,
+> extends Omit<
+    React.ComponentProps<typeof GridEditable<DataRow, ColumnKey>>,
+    'columnOrder' | 'columnSortBy'
+  > {
+  cursorParamName: string;
+  initialColumnOrder:
+    | Array<GridColumnOrder<ColumnKey>>
+    | (() => Array<GridColumnOrder<ColumnKey>>);
+  pageLinks: string | undefined;
+  isPlaceholderData?: boolean;
+}
+
+export function PlatformInsightsTable<
+  DataRow extends Record<string, any>,
+  ColumnKey extends ObjectKey = string,
+>({
+  cursorParamName,
+  pageLinks,
+  isPlaceholderData,
+  initialColumnOrder,
+  ...props
+}: PlatformInsightsTableProps<DataRow, ColumnKey>) {
+  const navigate = useNavigate();
+  const [columnOrder, setColumnOrder] = useState(initialColumnOrder);
+  const {sortField, sortOrder} = useTableSortParams();
+
+  const handleResizeColumn = useCallback(
+    (columnIndex: number, nextColumn: GridColumnHeader<ColumnKey>) => {
+      setColumnOrder(prev => {
+        const newColumnOrder = [...prev];
+        newColumnOrder[columnIndex] = {
+          ...newColumnOrder[columnIndex]!,
+          width: nextColumn.width,
+        };
+        return newColumnOrder;
+      });
+    },
+    []
+  );
+
+  const handleCursor = useCallback<CursorHandler>(
+    (cursor, pathname, previousQuery) => {
+      navigate(
+        {
+          pathname,
+          query: {...previousQuery, [cursorParamName]: cursor},
+        },
+        {replace: true, preventScrollReset: true}
+      );
+    },
+    [cursorParamName, navigate]
+  );
+
+  return (
+    <Fragment>
+      <GridEditableContainer>
+        <GridEditable
+          {...props}
+          grid={{...props.grid, onResizeColumn: handleResizeColumn}}
+          columnOrder={columnOrder}
+          columnSortBy={[{key: sortField as ColumnKey, order: sortOrder}]}
+          stickyHeader
+        />
+        {isPlaceholderData && <LoadingOverlay />}
+      </GridEditableContainer>
+      <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
+    </Fragment>
+  );
+}
+
+const GridEditableContainer = styled('div')`
+  position: relative;
+  margin-bottom: ${space(1)};
+`;
+
+const LoadingOverlay = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${p => p.theme.background};
+  opacity: 0.5;
+  z-index: 1;
+`;

--- a/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
@@ -1,0 +1,118 @@
+import {useMemo} from 'react';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {useTableSortParams} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import type {EAPSpanProperty} from 'sentry/views/insights/types';
+
+const PER_PAGE = 10;
+
+export function useTableData<Fields extends EAPSpanProperty>({
+  fields,
+  referrer,
+  query: baseQuery,
+  cursorParamName,
+}: {
+  cursorParamName: string;
+  fields: Fields[];
+  query: string;
+  referrer: string;
+}) {
+  const location = useLocation();
+  const {query} = useTransactionNameQuery();
+  const {sortField, sortOrder} = useTableSortParams();
+
+  return useEAPSpans(
+    {
+      search: `${baseQuery ?? ''} ${query}`.trim(),
+      sorts: [{field: sortField, kind: sortOrder}],
+      fields,
+      limit: PER_PAGE,
+      keepPreviousData: true,
+      cursor:
+        typeof location.query[cursorParamName] === 'string'
+          ? location.query[cursorParamName]
+          : undefined,
+    },
+    referrer
+  );
+}
+
+export function useTableDataWithController<Fields extends EAPSpanProperty>({
+  fields,
+  fetchRouteController,
+  referrer,
+  cursorParamName,
+  query,
+}: {
+  cursorParamName: string;
+  fetchRouteController: boolean;
+  fields: Fields[];
+  query: string;
+  referrer: string;
+}) {
+  const transactionsRequest = useTableData({
+    query,
+    fields: ['transaction', ...fields],
+    cursorParamName,
+    referrer,
+  });
+
+  // Get the list of transactions from the first request
+  const transactionPaths = useMemo(() => {
+    return transactionsRequest.data?.map(transactions => transactions.transaction) ?? [];
+  }, [transactionsRequest.data]);
+
+  // The controller name is available in the span.description field on the `span.op:http.route` span in the same transaction
+  const routeControllersRequest = useEAPSpans(
+    {
+      search: `transaction.op:http.server span.op:http.route transaction:[${
+        transactionPaths.map(transactions => `"${transactions}"`).join(',') || '""'
+      }]`,
+      fields: [
+        'span.description',
+        'transaction',
+        'http.request.method',
+        // We need an aggregation so we do not receive individual events
+        'count()',
+      ],
+      limit: PER_PAGE,
+      enabled:
+        fetchRouteController && !!transactionsRequest.data && transactionPaths.length > 0,
+    },
+    referrer
+  );
+
+  const tableData = useMemo(() => {
+    if (!transactionsRequest.data) {
+      return [];
+    }
+
+    // Create a mapping of transaction path to controller
+    const controllerMap = new Map(
+      routeControllersRequest.data?.map(item => [
+        item.transaction,
+        item['span.description'],
+      ])
+    );
+
+    return transactionsRequest.data.map(transaction => ({
+      ...transaction,
+      isControllerLoading: routeControllersRequest.isLoading,
+      controller: controllerMap.get(transaction.transaction),
+    }));
+  }, [
+    transactionsRequest.data,
+    routeControllersRequest.data,
+    routeControllersRequest.isLoading,
+  ]);
+
+  return {
+    data: tableData,
+    isPending: transactionsRequest.isPending,
+    error: transactionsRequest.error,
+    pageLinks: transactionsRequest.pageLinks,
+    isPlaceholderData: transactionsRequest.isPlaceholderData,
+  };
+}


### PR DESCRIPTION
Move common boilerplate for tables into base components as we are about to add two further tables.

- part of [TET-486: Add switch on top of the table](https://linear.app/getsentry/issue/TET-486/add-switch-on-top-of-the-table)