### PR TITLE
ref(spans): Polish buffer flush restarts and streamline metrics

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -471,7 +471,7 @@ class SpansBuffer:
                 # partitioned by trace_id so multiple consumers are writing
                 # over each other. The consequence is duplicated segments,
                 # worst-case.
-                metrics.incr("sentry.spans.buffer.empty_segments")
+                metrics.incr("spans.buffer.empty_segments")
 
         return payloads
 


### PR DESCRIPTION
When the flusher process crashes, it is automatically restarted by the consumer for a configurable number of times. After this, the consumer crashes and restarts. We now apply the same behavior for hangs of the flusher process.

Additionally, this PR renames all remaining metrics that have the redundant `sentry.` prefix.

Ref VIEPF-41