### PR TITLE
feat(span-buffer): Add killswitch for dropping spans

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -217,6 +217,16 @@ ALL_KILLSWITCH_OPTIONS = {
             "project_id": "A project ID to filter events by.",
         },
     ),
+    "standalone-spans.drop-in-buffer": KillswitchInfo(
+        description="""
+        Drop spans.
+        """,
+        fields={
+            "org_id": "An org ID to filter spans by.",
+            "trace_id": "A trace ID.",
+            "partition_id": "A kafka partition index.",
+        },
+    ),
 }
 
 

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -223,7 +223,7 @@ ALL_KILLSWITCH_OPTIONS = {
         """,
         fields={
             "org_id": "An org ID to filter spans by.",
-            "project_id": "An project ID.",
+            "project_id": "A project ID.",
             "trace_id": "A trace ID.",
             "partition_id": "A kafka partition index.",
         },

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -223,6 +223,7 @@ ALL_KILLSWITCH_OPTIONS = {
         """,
         fields={
             "org_id": "An org ID to filter spans by.",
+            "project_id": "An project ID.",
             "trace_id": "A trace ID.",
             "partition_id": "A kafka partition index.",
         },

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2708,6 +2708,12 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "standalone-spans.drop-in-buffer",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "indexed-spans.agg-span-waterfall.enable",
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -144,6 +144,7 @@ def process_batch(
             "standalone-spans.drop-in-buffer",
             {
                 "org_id": val.get("organization_id"),
+                "project_id": val.get("project_id"),
                 "trace_id": val.get("trace_id"),
                 "partition_id": partition_id,
             },

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -12,6 +12,7 @@ from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import Commit, FilteredPayload, Message, Partition
 
+from sentry import killswitches
 from sentry.spans.buffer import Span, SpansBuffer
 from sentry.spans.consumers.process.flusher import SpanFlusher
 from sentry.utils.arroyo import MultiprocessingPool, run_task_with_multiprocessing
@@ -133,6 +134,22 @@ def process_batch(
             min_timestamp = timestamp
 
         val = rapidjson.loads(payload.value)
+
+        partition_id = None
+
+        if len(value.committable) == 1:
+            partition_id = value.committable[next(iter(value.committable))]
+
+        if killswitches.killswitch_matches_context(
+            "standalone-spans.drop-in-buffer",
+            {
+                "org_id": val.get("organization_id"),
+                "trace_id": val.get("trace_id"),
+                "partition_id": partition_id,
+            },
+        ):
+            continue
+
         span = Span(
             trace_id=val["trace_id"],
             span_id=val["span_id"],


### PR DESCRIPTION
Relay already protects the buffer, but if data is already in the topic
we need to have a solution as well. We could advance offsets manually
via script-runner, but this is probably better and more fine-grained.
