### PR TITLE
fix(spans): Honor `max_flush_segments` with multiple partition assigments

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -65,14 +65,16 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
         committer = CommitOffsets(commit)
 
-        buffer = SpansBuffer(assigned_shards=[p.index for p in partitions])
+        buffer = SpansBuffer(
+            assigned_shards=[p.index for p in partitions],
+            max_flush_segments=self.max_flush_segments,
+        )
 
         # patch onto self just for testing
         flusher: ProcessingStrategy[FilteredPayload | int]
 
         flusher = self._flusher = SpanFlusher(
             buffer,
-            max_flush_segments=self.max_flush_segments,
             max_memory_percentage=self.max_memory_percentage,
             produce_to_pipe=self.produce_to_pipe,
             next_step=committer,

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -16,7 +16,10 @@ def test_backpressure(monkeypatch):
     # Flush very aggressively to make join() faster
     monkeypatch.setattr("time.sleep", lambda _: None)
 
-    buffer = SpansBuffer(assigned_shards=list(range(1)))
+    buffer = SpansBuffer(
+        assigned_shards=list(range(1)),
+        max_flush_segments=1,
+    )
 
     messages = []
 
@@ -26,7 +29,6 @@ def test_backpressure(monkeypatch):
 
     flusher = SpanFlusher(
         buffer,
-        max_flush_segments=1,
         max_memory_percentage=1.0,
         produce_to_pipe=append,
         next_step=Noop(),


### PR DESCRIPTION
The config param `max_flush_segments` should control the maximum number of
segments that are loaded from the cache in a single flush cycle. However, it was
applied once per assigned shard, which means the effective number was higher the
more partitions were assigned.

This PR changes this so that the number of segments is divided equally on the
shards. Since not all shards are utilized equally, this can lead in practice to
under-utilizing flusher capacity. Since large batches in the buffer have
negative impact on consumer performance, this is a desired effect.

We will evaluate this strategy and may pivot to spawning one dedicated flusher
process per shard instead.

Ref VIEPF-39

