### PR TITLE
feat(laravel-insights): Add commands and jobs table

### DIFF
--- a/static/app/utils/analytics/laravelInsightsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/laravelInsightsAnalyticsEvents.tsx
@@ -1,7 +1,7 @@
 export type LaravelInsightsEventParameters = {
   'laravel-insights.page-view': Record<string, unknown>;
-  'laravel-insights.ui_toggle': {
-    isEnabled: boolean;
+  'laravel-insights.table_view_change': {
+    view: string;
   };
 };
 
@@ -10,5 +10,5 @@ export const laravelInsightsEventMap: Record<
   string
 > = {
   'laravel-insights.page-view': 'Laravel Insights: Page View',
-  'laravel-insights.ui_toggle': 'Laravel Insights: UI Toggle',
+  'laravel-insights.table_view_change': 'Laravel Insights: Table View Change',
 };

--- a/static/app/views/insights/pages/platform/laravel/commandsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/commandsTable.tsx
@@ -1,0 +1,130 @@
+import {useCallback} from 'react';
+
+import {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+  type GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
+import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
+import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
+import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
+import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
+import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+
+const defaultColumnOrder: Array<GridColumnOrder<string>> = [
+  {key: 'command', name: t('Command Name'), width: COL_WIDTH_UNDEFINED},
+  {key: 'count()', name: t('Invocations'), width: 136},
+  {key: 'failure_rate()', name: t('Error Rate'), width: 124},
+  {key: 'avg(span.duration)', name: t('AVG'), width: 90},
+  {key: 'p95(span.duration)', name: t('P95'), width: 90},
+  {key: 'sum(span.duration)', name: t('Time Spent'), width: 120},
+];
+
+const rightAlignColumns = new Set([
+  'count()',
+  'failure_rate()',
+  'sum(span.duration)',
+  'avg(span.duration)',
+  'p95(span.duration)',
+]);
+
+export function CommandsTable() {
+  const tableDataRequest = useTableData({
+    query: 'span.op:console.command*',
+    fields: [
+      'command',
+      'project.id',
+      'count()',
+      'failure_rate()',
+      'avg(span.duration)',
+      'p95(span.duration)',
+      'sum(span.duration)',
+    ],
+    cursorParamName: 'jobsCursor',
+    referrer: Referrer.PATHS_TABLE,
+  });
+
+  const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
+    return (
+      <HeadSortCell
+        sortKey={column.key}
+        align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
+        forceCellGrow={column.key === 'command'}
+        cursorParamName="commandsCursor"
+      >
+        {column.name}
+      </HeadSortCell>
+    );
+  }, []);
+
+  const renderBodyCell = useCallback(
+    (
+      column: GridColumnOrder<string>,
+      dataRow: (typeof tableDataRequest.data)[number]
+    ) => {
+      switch (column.key) {
+        case 'command':
+          return <CommandCell command={dataRow.command} />;
+        case 'failure_rate()':
+          return <ErrorRateCell errorRate={dataRow['failure_rate()']} />;
+        case 'avg(span.duration)':
+        case 'p95(span.duration)':
+          return <DurationCell milliseconds={dataRow[column.key]} />;
+        case 'count()':
+          return <NumberCell value={dataRow['count()']} />;
+        case 'sum(span.duration)':
+          return <TimeSpentCell total={dataRow['sum(span.duration)']} />;
+        default:
+          return <div />;
+      }
+    },
+    [tableDataRequest]
+  );
+
+  return (
+    <PlatformInsightsTable
+      isLoading={tableDataRequest.isPending}
+      error={tableDataRequest.error}
+      data={tableDataRequest.data}
+      initialColumnOrder={defaultColumnOrder}
+      stickyHeader
+      grid={{
+        renderBodyCell,
+        renderHeadCell,
+      }}
+      cursorParamName="commandsCursor"
+      pageLinks={tableDataRequest.pageLinks}
+      isPlaceholderData={tableDataRequest.isPlaceholderData}
+    />
+  );
+}
+
+function CommandCell({command}: {command: string}) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const link = getExploreUrl({
+    organization,
+    selection,
+    mode: Mode.SAMPLES,
+    visualize: [
+      {
+        chartType: ChartType.BAR,
+        yAxes: ['count(span.duration)'],
+      },
+    ],
+    query: `span.op:console.command* command:${command}`,
+    sort: `-count(span.duration)`,
+  });
+  return <Link to={link}>{command}</Link>;
+}

--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -1,19 +1,51 @@
 import {useEffect} from 'react';
+import styled from '@emotion/styled';
 
+import {SegmentedControl} from 'sentry/components/core/segmentedControl';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import OverviewApiLatencyChartWidget from 'sentry/views/insights/common/components/widgets/overviewApiLatencyChartWidget';
 import OverviewCacheMissChartWidget from 'sentry/views/insights/common/components/widgets/overviewCacheMissChartWidget';
 import OverviewJobsChartWidget from 'sentry/views/insights/common/components/widgets/overviewJobsChartWidget';
 import OverviewRequestsChartWidget from 'sentry/views/insights/common/components/widgets/overviewRequestsChartWidget';
 import OverviewSlowQueriesChartWidget from 'sentry/views/insights/common/components/widgets/overviewSlowQueriesChartWidget';
+import {CommandsTable} from 'sentry/views/insights/pages/platform/laravel/commandsTable';
+import {JobsTable} from 'sentry/views/insights/pages/platform/laravel/jobsTable';
 import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWidget';
 import {PlatformLandingPageLayout} from 'sentry/views/insights/pages/platform/shared/layout';
 import {PathsTable} from 'sentry/views/insights/pages/platform/shared/pathsTable';
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
 
+enum TableType {
+  PATHS = 'paths',
+  COMMANDS = 'commands',
+  JOBS = 'jobs',
+}
+
+function isTableType(value: any): value is TableType {
+  return Object.values(TableType).includes(value as TableType);
+}
+
+const decodeTableType = (value: any): TableType => {
+  if (isTableType(value)) {
+    return value;
+  }
+  return TableType.PATHS;
+};
+
+const TableControl = SegmentedControl<TableType>;
+const TableControlItem = SegmentedControl.Item<TableType>;
+
 export function LaravelOverviewPage() {
   const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const currentView = decodeTableType(location.query.view);
 
   useEffect(() => {
     trackAnalytics('laravel-insights.page-view', {
@@ -21,6 +53,31 @@ export function LaravelOverviewPage() {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  function handleViewChange(view: TableType) {
+    trackAnalytics('laravel-insights.table_view_change', {
+      organization,
+      view,
+    });
+
+    navigate(
+      {
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          // Reset cursors when view changes
+          pathsCursor: undefined,
+          commandsCursor: undefined,
+          jobsCursor: undefined,
+          view,
+        },
+      },
+      {
+        replace: true,
+        preventScrollReset: true,
+      }
+    );
+  }
 
   return (
     <PlatformLandingPageLayout performanceType={'backend'}>
@@ -44,7 +101,20 @@ export function LaravelOverviewPage() {
           <OverviewCacheMissChartWidget />
         </WidgetGrid.Position6>
       </WidgetGrid>
-      <PathsTable />
+      <ControlsWrapper>
+        <TableControl value={currentView} onChange={handleViewChange} size="sm">
+          <TableControlItem key={TableType.PATHS}>{t('Paths')}</TableControlItem>
+          <TableControlItem key={TableType.COMMANDS}>{t('Commands')}</TableControlItem>
+          <TableControlItem key={TableType.JOBS}>{t('Jobs')}</TableControlItem>
+        </TableControl>
+      </ControlsWrapper>
+      {currentView === TableType.JOBS && <JobsTable />}
+      {currentView === TableType.PATHS && <PathsTable />}
+      {currentView === TableType.COMMANDS && <CommandsTable />}
     </PlatformLandingPageLayout>
   );
 }
+
+const ControlsWrapper = styled('div')`
+  padding: ${space(2)} 0;
+`;

--- a/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
+++ b/static/app/views/insights/pages/platform/laravel/jobsTable.tsx
@@ -1,0 +1,132 @@
+import {useCallback} from 'react';
+
+import {
+  COL_WIDTH_UNDEFINED,
+  type GridColumnHeader,
+  type GridColumnOrder,
+} from 'sentry/components/gridEditable';
+import Link from 'sentry/components/links/link';
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
+import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
+import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
+import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
+import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
+import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
+import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
+import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
+import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/useTableData';
+
+const defaultColumnOrder: Array<GridColumnOrder<string>> = [
+  {key: 'messaging.destination.name', name: t('Job Name'), width: COL_WIDTH_UNDEFINED},
+  {key: 'count()', name: t('Processed'), width: 124},
+  {key: 'failure_rate()', name: t('Error Rate'), width: 124},
+  {
+    key: 'avg(messaging.message.receive.latency)',
+    name: t('Avg Time in Queue'),
+    width: 164,
+  },
+  {
+    key: 'avg_if(span.duration,span.op,queue.process)',
+    name: t('Avg Processing Time'),
+    width: 184,
+  },
+  {key: 'sum(span.duration)', name: t('Time Spent'), width: 120},
+];
+
+const rightAlignColumns = new Set([
+  'count()',
+  'failure_rate()',
+  'sum(span.duration)',
+  'avg(messaging.message.receive.latency)',
+  'avg_if(span.duration,span.op,queue.process)',
+]);
+
+export function JobsTable() {
+  const tableDataRequest = useTableData({
+    query: 'span.op:queue.process',
+    fields: [
+      'count()',
+      'messaging.destination.name',
+      'avg(messaging.message.receive.latency)',
+      'avg_if(span.duration,span.op,queue.process)',
+      'failure_rate()',
+      'sum(span.duration)',
+    ],
+    cursorParamName: 'jobsCursor',
+    referrer: Referrer.PATHS_TABLE,
+  });
+
+  const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
+    return (
+      <HeadSortCell
+        sortKey={column.key}
+        align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
+        forceCellGrow={column.key === 'messaging.destination.name'}
+        cursorParamName="jobsCursor"
+      >
+        {column.name}
+      </HeadSortCell>
+    );
+  }, []);
+
+  const renderBodyCell = useCallback(
+    (
+      column: GridColumnOrder<string>,
+      dataRow: (typeof tableDataRequest.data)[number]
+    ) => {
+      switch (column.key) {
+        case 'messaging.destination.name':
+          return <DestinationCell destination={dataRow['messaging.destination.name']} />;
+        case 'failure_rate()':
+          return <ErrorRateCell errorRate={dataRow['failure_rate()']} />;
+        case 'avg(messaging.message.receive.latency)':
+        case 'avg_if(span.duration,span.op,queue.process)':
+          return <DurationCell milliseconds={dataRow[column.key]} />;
+        case 'count()':
+          return <NumberCell value={dataRow['count()']} />;
+        case 'sum(span.duration)':
+          return <TimeSpentCell total={dataRow['sum(span.duration)']} />;
+        default:
+          return <div />;
+      }
+    },
+    [tableDataRequest]
+  );
+
+  return (
+    <PlatformInsightsTable
+      isLoading={tableDataRequest.isPending}
+      error={tableDataRequest.error}
+      data={tableDataRequest.data}
+      initialColumnOrder={defaultColumnOrder}
+      stickyHeader
+      grid={{
+        renderBodyCell,
+        renderHeadCell,
+      }}
+      cursorParamName="jobsCursor"
+      pageLinks={tableDataRequest.pageLinks}
+      isPlaceholderData={tableDataRequest.isPlaceholderData}
+    />
+  );
+}
+
+function DestinationCell({destination}: {destination: string}) {
+  const moduleURL = useModuleURL('queue');
+  const {query} = useLocation();
+  return (
+    <Link
+      to={{
+        pathname: `${moduleURL}/destination/`,
+        query: {
+          ...query,
+          destination,
+        },
+      }}
+    >
+      {destination}
+    </Link>
+  );
+}

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -160,6 +160,7 @@ type SpanStringFields =
   | 'project'
   | 'http.request.method'
   | 'messaging.destination.name'
+  | 'command'
   | 'user'
   | 'user.display'
   | 'user.id'


### PR DESCRIPTION
Add jobs and commands table to the laravel insights page.

https://github.com/user-attachments/assets/6ad4be1b-d191-4859-b07f-ca25091d226f

- closes [TET-486: Add switch on top of the table](https://linear.app/getsentry/issue/TET-486/add-switch-on-top-of-the-table)