### PR TITLE
fix(getting-started-docs): Link to auth tokens redirecting to main org settings

### DIFF
--- a/static/app/gettingStartedDocs/java/java.tsx
+++ b/static/app/gettingStartedDocs/java/java.tsx
@@ -200,7 +200,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           description: tct(
             'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
-              link: <Link to="/settings/auth-tokens/" />,
+              link: <Link to={`/settings/${params.organization.slug}/auth-tokens/`} />,
             }
           ),
           language: 'bash',

--- a/static/app/gettingStartedDocs/java/log4j2.tsx
+++ b/static/app/gettingStartedDocs/java/log4j2.tsx
@@ -221,7 +221,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           description: tct(
             'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
-              link: <Link to="/settings/auth-tokens/" />,
+              link: <Link to={`/settings/${params.organization.slug}/auth-tokens/`} />,
             }
           ),
           language: 'bash',

--- a/static/app/gettingStartedDocs/java/logback.tsx
+++ b/static/app/gettingStartedDocs/java/logback.tsx
@@ -226,7 +226,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           description: tct(
             'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
-              link: <Link to="/settings/auth-tokens/" />,
+              link: <Link to={`/settings/${params.organization.slug}/auth-tokens/`} />,
             }
           ),
           language: 'bash',

--- a/static/app/gettingStartedDocs/java/spring.tsx
+++ b/static/app/gettingStartedDocs/java/spring.tsx
@@ -238,7 +238,9 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
               {tct(
                 'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
                 {
-                  link: <Link to="/settings/auth-tokens/" />,
+                  link: (
+                    <Link to={`/settings/${params.organization.slug}/auth-tokens/`} />
+                  ),
                 }
               )}
             </p>

--- a/static/app/gettingStartedDocs/kotlin/kotlin.tsx
+++ b/static/app/gettingStartedDocs/kotlin/kotlin.tsx
@@ -162,7 +162,7 @@ const onboarding: OnboardingConfig<PlatformOptions> = {
           description: tct(
             'To see source context in Sentry, you have to generate an auth token by visiting the [link:Organization Tokens] settings. You can then set the token as an environment variable that is used by the build plugins.',
             {
-              link: <Link to="/settings/auth-tokens/" />,
+              link: <Link to={`/settings/${params.organization.slug}/auth-tokens/`} />,
             }
           ),
           language: 'bash',


### PR DESCRIPTION
Before


https://github.com/user-attachments/assets/64679faa-eaf6-4395-8352-7a8fbc2228fc



After



https://github.com/user-attachments/assets/7bbd6688-c514-43c0-8b66-0b8cb6202f70

