### PR TITLE
fix(spans): After flusher hangs, debounce restarts

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -50,7 +50,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         self.redis_was_full = False
         self.current_drift = multiprocessing.Value("i", 0)
         self.backpressure_since = multiprocessing.Value("i", 0)
-        self.healthy_since = multiprocessing.Value("i", int(time.time()))
+        self.healthy_since = multiprocessing.Value("i", 0)
         self.process_restarts = 0
         self.produce_to_pipe = produce_to_pipe
 

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -51,6 +51,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         self.current_drift = multiprocessing.Value("i", 0)
         self.backpressure_since = multiprocessing.Value("i", 0)
         self.healthy_since = multiprocessing.Value("i", int(time.time()))
+        self.process_restarts = 0
         self.produce_to_pipe = produce_to_pipe
 
         self._create_process()
@@ -85,7 +86,6 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
             daemon=True,
         )
 
-        self.process_restarts = 0
         self.process.start()
 
     @staticmethod


### PR DESCRIPTION
Fixes two bugs with flusher restarts:

1. After a hang, it can take some time until the process starts and `healthy_since` is reset. This can create a race of flusher restarts. To avoid this, we reset `healthy_since` just before the restart.
2. `_create_process` unintentionally reset the restarts counter. This is moved to the initializer now.

Ref VIEPF-41