### PR TITLE
fix(ui): align search box and search icon in pagerFilterBar

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -283,7 +283,7 @@ const ActionButton = styled(Button)`
 const PositionedSearchIconContainer = styled('div')`
   position: absolute;
   left: ${space(1.5)};
-  top: ${space(1)};
+  top: ${p => (p.theme.isChonk ? space(0.75) : space(1))};
 `;
 
 const SearchIcon = styled(IconSearch)`

--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -191,8 +191,9 @@ export function TokenizedQueryGrid({
 }
 
 const SearchQueryGridWrapper = styled('div')`
-  padding-top: ${p => (p.theme.isChonk ? space(0.5) : space(0.75))};
-  padding-bottom: ${p => (p.theme.isChonk ? space(0.5) : space(0.75))};
+  /* calc + 1px to account for the border */
+  padding-top: ${p => (p.theme.isChonk ? `calc(${space(0.5)} + 1px);` : space(0.75))};
+  padding-bottom: ${p => (p.theme.isChonk ? `calc(${space(0.5)} + 1px);` : space(0.75))};
   padding-left: 32px;
   padding-right: ${space(0.75)};
   display: flex;


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-06-05 at 15 19 36](https://github.com/user-attachments/assets/15a22282-0756-4a07-9c54-861063d6bee6) | ![Screenshot 2025-06-05 at 15 21 46](https://github.com/user-attachments/assets/127bc009-8563-4e75-9ed3-8d0054e3dec0) |
| ![Screenshot 2025-06-05 at 15 19 51](https://github.com/user-attachments/assets/f87869f1-8fab-4fad-be6a-99cbb3acf9f2) | ![Screenshot 2025-06-05 at 15 22 09](https://github.com/user-attachments/assets/1ba56917-64c7-4d59-b796-4a8b747063fc) | 