### PR TITLE
fix(ui): remove overflow:hidden in feedbackListPage

### DIFF
--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -131,7 +131,6 @@ const Background = styled('div')`
 `;
 
 const LayoutGrid = styled('div')`
-  overflow: hidden;
   flex-grow: 1;
 
   display: grid;


### PR DESCRIPTION
chonk buttons exceed its container on purpose, but `overflow:hidden` cuts them off.

| before | after |
|--------|--------|
| ![image (35)](https://github.com/user-attachments/assets/6d524c9b-2834-43c2-a217-e5199da611c0) | ![Screenshot 2025-06-05 at 15 37 00](https://github.com/user-attachments/assets/a045bbc8-3efe-4912-b052-18450ea787d8) | 

note: I couldn’t see any issues without `overflow:hidden` in both themes, so I’ve generally removed it. This is the same approach as we took in:
- #92380