### PR TITLE
fix(ui): add missing line-height to chonk buttons

### DIFF
--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -56,6 +56,16 @@ export function DO_NOT_USE_getChonkButtonStyles(
 ): StrictCSSObject {
   const type = chonkPriorityToType(p.priority);
 
+  const buttonSizes = {
+    ...p.theme.form,
+    zero: {
+      height: '24px',
+      minHeight: '24px',
+      fontSize: '0.75rem',
+      lineHeight: '1rem',
+    },
+  } as const;
+
   return {
     position: 'relative',
     display: 'inline-flex',
@@ -74,16 +84,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
 
     background: 'none',
 
-    height:
-      p.size === 'md'
-        ? '36px'
-        : p.size === 'sm'
-          ? '32px'
-          : p.size === 'xs'
-            ? '28px'
-            : '24px',
-
-    fontSize: p.size === 'xs' || p.size === 'zero' ? '12px' : '14px',
+    ...buttonSizes[p.size],
 
     '&::before': {
       content: '""',


### PR DESCRIPTION
text in buttons always felt a bit off. Found out why today: `lineHeight` was missing:

| before | after |
|--------|--------|
| ![Screenshot 2025-06-05 at 16 04 26](https://github.com/user-attachments/assets/7d2efe2a-a763-43ea-921e-a14e1512f82b) | ![Screenshot 2025-06-05 at 16 04 32](https://github.com/user-attachments/assets/30d24bd6-7c97-4497-a892-4aa397c68030) |

This also fixes DE-127

| before | after |
|--------|--------|
| ![Screenshot 2025-06-05 at 16 11 13](https://github.com/user-attachments/assets/19cd80f3-1f5c-439a-9800-4312d2e183b6) | ![Screenshot 2025-06-05 at 16 11 18](https://github.com/user-attachments/assets/a66b2355-fde4-4159-a003-630f2cb6aa2f) | 