### PR TITLE
ref: Use `set_client` to change DSN

### DIFF
--- a/src/sentry/runner/main.py
+++ b/src/sentry/runner/main.py
@@ -135,7 +135,8 @@ def main() -> None:
             func(**kwargs)
         except Exception as e:
             # This reports errors sentry-devservices
-            with sentry_sdk.init(dsn=os.environ["SENTRY_DEVSERVICES_DSN"]):
+            with sentry_sdk.new_scope() as scope:
+                scope.set_client(sentry_sdk.Client(dsn=os.environ["SENTRY_DEVSERVICES_DSN"]))
                 if os.environ.get("USER"):
                     sentry_sdk.set_user({"username": os.environ.get("USER")})
                 sentry_sdk.capture_exception(e)


### PR DESCRIPTION
`with sentry_sdk.init` is deprecated and will be removed in Sentry SDK 3.0.

Split off from #92011

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
