### PR TITLE
feat(dashboards): Add platform icons on starred dashboards sidebar

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -44,6 +44,7 @@ describe('add to dashboard modal', () => {
     dateCreated: '2020-01-01T00:00:00.000Z',
     widgetDisplay: [DisplayType.AREA],
     widgetPreview: [],
+    projects: [],
   };
   const testDashboard: DashboardDetails = {
     id: '1',

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -125,6 +125,7 @@ export type DashboardPermissions = {
  */
 export type DashboardListItem = {
   id: string;
+  projects: number[];
   title: string;
   widgetDisplay: DisplayType[];
   widgetPreview: WidgetPreview[];

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -1,16 +1,20 @@
 import {Fragment} from 'react';
 
 import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
+import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 export function DashboardsSecondaryNav() {
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/dashboards`;
+  const {projects} = useProjects();
 
   const {data: starredDashboards = []} = useApiQuery<DashboardListItem[]>(
     [
@@ -39,15 +43,25 @@ export function DashboardsSecondaryNav() {
         </SecondaryNav.Section>
         {starredDashboards.length > 0 ? (
           <SecondaryNav.Section id="dashboards-starred" title={t('Starred Dashboards')}>
-            {starredDashboards.map(dashboard => (
-              <SecondaryNav.Item
-                key={dashboard.id}
-                to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
-                analyticsItemName="dashboard_starred_item"
-              >
-                {dashboard.title}
-              </SecondaryNav.Item>
-            ))}
+            {starredDashboards.map(dashboard => {
+              const dashboardProjects = new Set(dashboard.projects.map(String));
+              const dashboardProjectPlatforms = projects
+                .filter(p => dashboardProjects.has(p.id))
+                .map(p => p.platform)
+                .filter(defined);
+              return (
+                <SecondaryNav.Item
+                  key={dashboard.id}
+                  to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+                  analyticsItemName="dashboard_starred_item"
+                  leadingItems={
+                    <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
+                  }
+                >
+                  {dashboard.title}
+                </SecondaryNav.Item>
+              );
+            })}
           </SecondaryNav.Section>
         ) : null}
       </SecondaryNav.Body>

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -1,10 +1,13 @@
 import {Fragment} from 'react';
+import * as Sentry from '@sentry/react';
 
+import ErrorBoundary from 'sentry/components/errorBoundary';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import ProjectIcon from 'sentry/views/nav/projectIcon';
@@ -15,6 +18,7 @@ export function DashboardsSecondaryNav() {
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/dashboards`;
   const {projects} = useProjects();
+  const user = useUser();
 
   const {data: starredDashboards = []} = useApiQuery<DashboardListItem[]>(
     [
@@ -43,25 +47,40 @@ export function DashboardsSecondaryNav() {
         </SecondaryNav.Section>
         {starredDashboards.length > 0 ? (
           <SecondaryNav.Section id="dashboards-starred" title={t('Starred Dashboards')}>
-            {starredDashboards.map(dashboard => {
-              const dashboardProjects = new Set(dashboard.projects.map(String));
-              const dashboardProjectPlatforms = projects
-                .filter(p => dashboardProjects.has(p.id))
-                .map(p => p.platform)
-                .filter(defined);
-              return (
-                <SecondaryNav.Item
-                  key={dashboard.id}
-                  to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
-                  analyticsItemName="dashboard_starred_item"
-                  leadingItems={
-                    <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
-                  }
-                >
-                  {dashboard.title}
-                </SecondaryNav.Item>
-              );
-            })}
+            <ErrorBoundary mini>
+              {starredDashboards.map(dashboard => {
+                const dashboardProjects = new Set(
+                  (dashboard?.projects ?? []).map(String)
+                );
+                if (!defined(dashboard?.projects)) {
+                  Sentry.setTag('organization', organization.id);
+                  Sentry.setTag('dashboard.id', dashboard.id);
+                  Sentry.setTag('user.id', user.id);
+                  Sentry.captureMessage(
+                    'dashboard.projects is undefined in starred sidebar',
+                    {
+                      level: 'warning',
+                    }
+                  );
+                }
+                const dashboardProjectPlatforms = projects
+                  .filter(p => dashboardProjects.has(p.id))
+                  .map(p => p.platform)
+                  .filter(defined);
+                return (
+                  <SecondaryNav.Item
+                    key={dashboard.id}
+                    to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+                    analyticsItemName="dashboard_starred_item"
+                    leadingItems={
+                      <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
+                    }
+                  >
+                    {dashboard.title}
+                  </SecondaryNav.Item>
+                );
+              })}
+            </ErrorBoundary>
           </SecondaryNav.Section>
         ) : null}
       </SecondaryNav.Body>

--- a/tests/js/fixtures/dashboard.ts
+++ b/tests/js/fixtures/dashboard.ts
@@ -28,6 +28,7 @@ export function DashboardListItemFixture(
     title: 'Dashboard',
     widgetDisplay: [],
     widgetPreview: [],
+    projects: [],
     ...params,
   };
 }


### PR DESCRIPTION
Take two of #92859. This time I added an error boundary around the sidebar component with some telemetry I can alert on if something's wrong with the API payload. I also added a null coalescing operator in case it's still undefined, although the backend shouldn't be sending it like that. This protects against all of the callsites where the issues were raised about this component.