### PR TITLE
fix(manage): Correct malformed translate calls in manage/queue

### DIFF
--- a/static/app/views/admin/adminQueue.tsx
+++ b/static/app/views/admin/adminQueue.tsx
@@ -75,7 +75,7 @@ export default function AdminQueue() {
   return (
     <div>
       <Header>
-        <h3>t{'Queue Overview'}</h3>
+        <h3>{t('Queue Overview')}</h3>
 
         <ButtonBar merged>
           {TIME_WINDOWS.map(r => (
@@ -103,11 +103,11 @@ export default function AdminQueue() {
         </PanelBody>
       </Panel>
 
-      <h3>t{'Task Details'}</h3>
+      <h3>{t('Task Details')}</h3>
 
       <div>
         <div className="m-b-1">
-          <label>t{'Show details for task:'}</label>
+          <label>{t('Show details for task:')}</label>
           <Select
             name="task"
             onChange={({value}: any) => changeTask(value)}


### PR DESCRIPTION
Fixes: [RTC-989: Manage page has extraneous `t`'s](https://linear.app/getsentry/issue/RTC-989/manage-page-has-extraneous-ts)