### PR TITLE
fix(ui): Correct unicode escape in terminal component

### DIFF
--- a/static/app/views/settings/organizationRelay/modals/add/terminal.tsx
+++ b/static/app/views/settings/organizationRelay/modals/add/terminal.tsx
@@ -16,7 +16,7 @@ export default Terminal;
 const StyledCodeSnippet = styled(CodeSnippet)`
   padding-left: ${space(2)};
   &:before {
-    content: '\u0024';
+    content: '\0024';
     position: absolute;
     padding-top: ${space(1)};
     color: var(--prism-comment);


### PR DESCRIPTION
Fixes: [RTC-990: Terminal component rendering overlapping unicode descriptor](https://linear.app/getsentry/issue/RTC-990/terminal-component-rendering-overlapping-unicode-descriptor)