### PR TITLE
ref(ui): Use a smaller select in the feature flag onboarding

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
@@ -250,6 +250,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
               {tct('I use a Feature Flag SDK from [sdkSelect]', {
                 sdkSelect: (
                   <CompactSelect
+                    size="xs"
                     triggerLabel={sdkProvider.label}
                     value={sdkProvider.value}
                     onChange={value => {


### PR DESCRIPTION
Matches the line-height of the radio options better

Before

<img alt="clipboard.png" width="943" src="https://i.imgur.com/fo45Zwo.png" />

After

<img alt="clipboard.png" width="1040" src="https://i.imgur.com/Qx70e1R.png" />