### PR TITLE
fix(ui): Remove extra padding on left of ConfirmDelete

### DIFF
--- a/static/app/components/confirmDelete.tsx
+++ b/static/app/components/confirmDelete.tsx
@@ -28,6 +28,7 @@ function ConfirmDelete({message, confirmInput, ...props}: Props) {
           <FieldGroup
             flexibleControlStateSize
             inline={false}
+            stacked
             label={t(
               'Please enter %s to confirm the deletion',
               <code>{confirmInput}</code>


### PR DESCRIPTION
Fixes: [RTC-993: `ConfirmDelete` has extraneous left side padding on the confirm input](https://linear.app/getsentry/issue/RTC-993/confirmdelete-has-extraneous-left-side-padding-on-the-confirm-input)