### PR TITLE
ref(ui): Remove header from debug repo remove confirm

### DIFF
--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/actions.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/actions.tsx
@@ -12,10 +12,9 @@ type Props = {
   hasFeature: boolean;
   onDelete: () => void;
   onEdit: () => void;
-  repositoryName: string;
 };
 
-function Actions({repositoryName, onEdit, onDelete, hasFeature, hasAccess}: Props) {
+function Actions({onEdit, onDelete, hasFeature, hasAccess}: Props) {
   const actionsDisabled = !hasAccess || !hasFeature;
 
   return (
@@ -51,7 +50,6 @@ function Actions({repositoryName, onEdit, onDelete, hasFeature, hasAccess}: Prop
           label: t('Delete'),
           onAction: () => {
             openConfirmModal({
-              header: <h6>{t('Delete %s?', repositoryName)}</h6>,
               message: (
                 <Fragment>
                   <TextBlock>

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/repository.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/repository.tsx
@@ -24,7 +24,6 @@ function Repository({repository, onDelete, onEdit, hasFeature, hasAccess}: Props
       </div>
       <div>
         <CustomRepositoryActions
-          repositoryName={repository.name}
           hasFeature={hasFeature}
           hasAccess={hasAccess}
           onDelete={() => onDelete(repository.id)}


### PR DESCRIPTION
We don't Typically use headers for these confirm messages