### PR TITLE
fix(product-trials): Handle new navigation routes in product trials

### DIFF
--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -47,6 +47,7 @@ import {
 import type {EventType} from 'getsentry/components/addEventsCTA';
 import AddEventsCTA from 'getsentry/components/addEventsCTA';
 import ProductTrialAlert from 'getsentry/components/productTrial/productTrialAlert';
+import {getProductForPath} from 'getsentry/components/productTrial/productTrialPaths';
 import {makeLinkToOwnersAndBillingMembers} from 'getsentry/components/profiling/alerts';
 import withSubscription from 'getsentry/components/withSubscription';
 import ZendeskLink from 'getsentry/components/zendeskLink';
@@ -54,7 +55,6 @@ import {BILLED_DATA_CATEGORY_INFO} from 'getsentry/constants';
 import SubscriptionStore from 'getsentry/stores/subscriptionStore';
 import {
   type BilledDataCategoryInfo,
-  PlanTier,
   type Promotion,
   type PromotionClaimed,
   type Subscription,
@@ -1056,23 +1056,8 @@ class GSBanner extends Component<Props, State> {
 
   renderProductTrialAlerts() {
     const {subscription, organization, api} = this.props;
-    if (subscription.planTier === PlanTier.AM3) {
-      this.PATHS_FOR_PRODUCT_TRIALS['/performance/'] = {
-        product: DataCategory.SPANS,
-        categories: [DataCategory.SPANS],
-      };
-      this.PATHS_FOR_PRODUCT_TRIALS['/performance/database/'] = {
-        product: DataCategory.SPANS,
-        categories: [DataCategory.SPANS],
-      };
-      this.PATHS_FOR_PRODUCT_TRIALS['/profiling/'] = {
-        product: DataCategory.PROFILES,
-        categories: [DataCategory.PROFILE_DURATION, DataCategory.PROFILE_DURATION_UI],
-      };
-    }
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const productPath = this.PATHS_FOR_PRODUCT_TRIALS[window.location.pathname] || null;
 
+    const productPath = getProductForPath(subscription, window.location.pathname);
     if (!productPath) {
       return null;
     }

--- a/static/gsApp/components/productTrial/productTrialPaths.tsx
+++ b/static/gsApp/components/productTrial/productTrialPaths.tsx
@@ -1,0 +1,98 @@
+import {DataCategory} from 'sentry/types/core';
+
+import type {Subscription} from 'getsentry/types';
+import {PlanTier} from 'getsentry/types';
+
+type Product = {
+  categories: DataCategory[];
+  product: DataCategory;
+};
+
+type Path = string;
+
+const PATHS_FOR_PRODUCT_TRIALS: Record<Path, Product> = {
+  '/issues/': {
+    product: DataCategory.ERRORS,
+    categories: [DataCategory.ERRORS],
+  },
+  '/performance/': {
+    product: DataCategory.TRANSACTIONS,
+    categories: [DataCategory.TRANSACTIONS],
+  },
+  '/performance/database/': {
+    product: DataCategory.TRANSACTIONS,
+    categories: [DataCategory.TRANSACTIONS],
+  },
+  '/replays/': {
+    product: DataCategory.REPLAYS,
+    categories: [DataCategory.REPLAYS],
+  },
+  '/profiling/': {
+    product: DataCategory.PROFILES,
+    categories: [DataCategory.PROFILES, DataCategory.TRANSACTIONS],
+  },
+  '/insights/crons/': {
+    product: DataCategory.MONITOR_SEATS,
+    categories: [DataCategory.MONITOR_SEATS],
+  },
+  '/insights/uptime/': {
+    product: DataCategory.UPTIME,
+    categories: [DataCategory.UPTIME],
+  },
+  '/traces/': {
+    product: DataCategory.TRANSACTIONS,
+    categories: [DataCategory.TRANSACTIONS],
+  },
+  // TODO(Seer): add in-product links for Seer categories
+};
+
+const PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES: Record<Path, Product> = {
+  '/performance/': {
+    product: DataCategory.SPANS,
+    categories: [DataCategory.SPANS],
+  },
+  '/performance/database/': {
+    product: DataCategory.SPANS,
+    categories: [DataCategory.SPANS],
+  },
+  '/replays/': {
+    product: DataCategory.REPLAYS,
+    categories: [DataCategory.REPLAYS],
+  },
+  '/profiling/': {
+    product: DataCategory.PROFILES,
+    categories: [DataCategory.PROFILE_DURATION, DataCategory.PROFILE_DURATION_UI],
+  },
+  '/traces/': {
+    product: DataCategory.SPANS,
+    categories: [DataCategory.SPANS],
+  },
+};
+
+function normalizePath(path: string): string {
+  switch (path) {
+    case '/explore/traces/':
+      return '/traces/';
+    case '/explore/profiling/':
+      return '/profiling/';
+    case '/explore/replays/':
+      return '/replays/';
+    default:
+      return path;
+  }
+}
+
+export function getProductForPath(
+  subscription: Subscription,
+  path: string
+): Product | null {
+  path = normalizePath(path);
+
+  if (subscription.planTier === PlanTier.AM3) {
+    if (PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES.hasOwnProperty(path)) {
+      return PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES[path]!;
+    }
+  }
+
+  return PATHS_FOR_PRODUCT_TRIALS[path] || null;
+}


### PR DESCRIPTION
The new navigation uses different pathnames for some pages so make sure the new pathnames are properly handled.