### PR TITLE
feat(insights): update cache and web vitals charts to be compatible with open in explore

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
@@ -95,7 +95,9 @@ export function WebVitalStatusLineChart({
           error={timeseriesError}
           series={[webVitalSeries]}
           extraPlottables={extraPlottables}
-          search={search}
+          queryInfo={{
+            search,
+          }}
           height={250}
         />
       )}

--- a/static/app/views/insights/cache/components/charts/hitMissChart.tsx
+++ b/static/app/views/insights/cache/components/charts/hitMissChart.tsx
@@ -7,7 +7,7 @@ import {Referrer} from 'sentry/views/insights/cache/referrers';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
-import {SpanFunction} from 'sentry/views/insights/types';
+import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
 type Props = {
   search: MutableSearch;
@@ -27,9 +27,16 @@ export function CacheHitMissChart({search}: Props) {
     Referrer.SAMPLES_CACHE_HIT_MISS_CHART
   );
 
+  // explore/alerts doesn't support `cache_miss_rate`, so this is used as a comparable query
+  const queryInfo = {
+    yAxis: [`${SpanFunction.COUNT}()`],
+    search,
+    groupBy: [SpanFields.CACHE_HIT],
+  };
+
   return (
     <InsightsLineChartWidget
-      search={search}
+      queryInfo={queryInfo}
       title={DataTitles[`cache_miss_rate()`]}
       series={[data[`cache_miss_rate()`]]}
       showLegend="never"

--- a/static/app/views/insights/cache/components/charts/hitMissChart.tsx
+++ b/static/app/views/insights/cache/components/charts/hitMissChart.tsx
@@ -29,7 +29,7 @@ export function CacheHitMissChart({search}: Props) {
 
   // explore/alerts doesn't support `cache_miss_rate`, so this is used as a comparable query
   const queryInfo = {
-    yAxis: [`${SpanFunction.COUNT}()`],
+    yAxis: [`${SpanFunction.COUNT}(span.duration)`],
     search,
     groupBy: [SpanFields.CACHE_HIT],
   };

--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -34,7 +34,7 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
 
   return (
     <InsightsLineChartWidget
-      search={search}
+      queryInfo={{search}}
       showLegend="never"
       title={t('Average Transaction Duration')}
       isLoading={isPending}

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -43,7 +43,7 @@ import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDisco
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {INGESTION_DELAY} from 'sentry/views/insights/settings';
-import {type SpanFields} from 'sentry/views/insights/types';
+import type {SpanFields} from 'sentry/views/insights/types';
 
 export interface InsightsTimeSeriesWidgetProps
   extends WidgetTitleProps,
@@ -55,14 +55,21 @@ export interface InsightsTimeSeriesWidgetProps
   aliases?: Record<string, string>;
   description?: React.ReactNode;
   extraPlottables?: Plottable[];
-  groupBy?: SpanFields[];
   height?: string | number;
   interactiveTitle?: () => React.ReactNode;
   legendSelection?: LegendSelection | undefined;
   onLegendSelectionChange?: ((selection: LegendSelection) => void) | undefined;
   pageFilters?: PageFilters;
+  /**
+   * Query info to be used for the open in explore and create alert actions,
+   * yAxis should only be provided if it's expected to be different when opening in explore
+   */
+  queryInfo?: {
+    search: MutableSearch;
+    groupBy?: SpanFields[];
+    yAxis?: string[];
+  };
   samples?: Samples;
-  search?: MutableSearch;
   showLegend?: TimeSeriesWidgetVisualizationProps['showLegend'];
   showReleaseAs?: 'line' | 'bubble' | 'none';
   stacked?: boolean;
@@ -84,7 +91,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
     })) ?? [];
 
   const hasChartActionsEnabled =
-    organization.features.includes('insights-chart-actions') && useEap;
+    organization.features.includes('insights-chart-actions') && useEap && props.queryInfo;
   const yAxes = new Set<string>();
   const plottables = [
     ...(props.series.filter(Boolean) ?? []).map(serie => {
@@ -175,7 +182,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
     chartType = ChartType.BAR;
   }
 
-  const yAxisArray = [...yAxes];
+  const yAxisArray = props.queryInfo?.yAxis || [...yAxes];
 
   return (
     <ChartContainer height={props.height}>
@@ -201,9 +208,9 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
               <ChartActionDropdown
                 chartType={chartType}
                 yAxes={yAxisArray}
-                groupBy={props.groupBy}
+                groupBy={props.queryInfo?.groupBy}
                 title={props.title}
-                search={props.search}
+                search={props.queryInfo?.search}
                 aliases={props.aliases}
               />
             )}

--- a/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
@@ -23,7 +23,7 @@ export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps
 
   // explore/alerts doesn't support `cache_miss_rate`, so this is used as a comparable query
   const queryInfo = {
-    yAxis: [`${COUNT}()`],
+    yAxis: [`${COUNT}(span.duration)`],
     search,
     groupBy: [SpanFields.CACHE_HIT],
   };

--- a/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheMissRateChartWidget.tsx
@@ -5,9 +5,9 @@ import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/i
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
-import {SpanFunction} from 'sentry/views/insights/types';
+import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
-const {CACHE_MISS_RATE} = SpanFunction;
+const {CACHE_MISS_RATE, COUNT} = SpanFunction;
 
 export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps) {
   const search = MutableSearch.fromQueryObject(BASE_FILTERS);
@@ -21,10 +21,17 @@ export default function CacheMissRateChartWidget(props: LoadableChartWidgetProps
     props.pageFilters
   );
 
+  // explore/alerts doesn't support `cache_miss_rate`, so this is used as a comparable query
+  const queryInfo = {
+    yAxis: [`${COUNT}()`],
+    search,
+    groupBy: [SpanFields.CACHE_HIT],
+  };
+
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={queryInfo}
       id="cacheMissRateChartWidget"
       title={DataTitles[`${CACHE_MISS_RATE}()`]}
       series={[data[`${CACHE_MISS_RATE}()`]]}

--- a/static/app/views/insights/common/components/widgets/cacheThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/cacheThroughputChartWidget.tsx
@@ -21,7 +21,7 @@ export default function CacheThroughputChartWidget(props: LoadableChartWidgetPro
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="cacheThroughputChartWidget"
       title={getThroughputChartTitle('cache.get_item')}
       series={[data['epm()']]}

--- a/static/app/views/insights/common/components/widgets/databaseLandingDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseLandingDurationChartWidget.tsx
@@ -17,7 +17,7 @@ export default function DatabaseLandingDurationChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="databaseLandingDurationChartWidget"
       title={getDurationChartTitle('db')}
       series={[data[`${DEFAULT_DURATION_AGGREGATE}(span.self_time)`]]}

--- a/static/app/views/insights/common/components/widgets/databaseLandingThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseLandingThroughputChartWidget.tsx
@@ -16,7 +16,7 @@ export default function DatabaseLandingThroughputChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="databaseLandingThroughputChartWidget"
       title={getThroughputChartTitle('db')}
       series={[data['epm()']]}

--- a/static/app/views/insights/common/components/widgets/databaseSummaryDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseSummaryDurationChartWidget.tsx
@@ -29,7 +29,7 @@ export default function DatabaseSummaryDurationChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="databaseSummaryDurationChartWidget"
       title={getDurationChartTitle('db')}
       series={[data[`${DEFAULT_DURATION_AGGREGATE}(${SpanMetricsField.SPAN_SELF_TIME})`]]}

--- a/static/app/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget.tsx
@@ -28,7 +28,7 @@ export default function DatabaseSummaryThroughputChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="databaseSummaryThroughputChartWidget"
       title={getThroughputChartTitle('db')}
       series={[data['epm()']]}

--- a/static/app/views/insights/common/components/widgets/httpDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDurationChartWidget.tsx
@@ -26,7 +26,7 @@ export default function HttpDurationChartWidget(props: LoadableChartWidgetProps)
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="httpDurationChartWidget"
       title={getDurationChartTitle('http')}
       series={[durationData['avg(span.self_time)']]}

--- a/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
@@ -28,7 +28,7 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
     <InsightsLineChartWidget
       {...props}
       id="httpResponseCodesChartWidget"
-      search={search}
+      queryInfo={{search}}
       title={DataTitles.unsuccessfulHTTPCodes}
       series={[
         responseCodeData[`http_response_rate(3)`],

--- a/static/app/views/insights/common/components/widgets/httpThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpThroughputChartWidget.tsx
@@ -26,7 +26,7 @@ export default function HttpThroughputChartWidget(props: LoadableChartWidgetProp
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="httpThroughputChartWidget"
       title={getThroughputChartTitle('http')}
       series={[throughputData['epm()']]}

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -112,7 +112,6 @@ export default function PerformanceScoreBreakdownChartWidget(
   return (
     <InsightsTimeSeriesWidget
       {...props}
-      search={search}
       id="performanceScoreBreakdownChartWidget"
       title={t('Score Breakdown')}
       height="100%"

--- a/static/app/views/insights/common/components/widgets/resourceLandingDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceLandingDurationChartWidget.tsx
@@ -22,7 +22,7 @@ export default function ResourceLandingDurationChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="resourceLandingDurationChartWidget"
       title={getDurationChartTitle('resource')}
       series={[data[`avg(${SPAN_SELF_TIME})`]]}

--- a/static/app/views/insights/common/components/widgets/resourceLandingThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceLandingThroughputChartWidget.tsx
@@ -19,7 +19,7 @@ export default function ResourceLandingThroughputChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="resourceLandingThroughputChartWidget"
       title={getThroughputChartTitle('resource')}
       series={[data['epm()']]}

--- a/static/app/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryAverageSizeChartWidget.tsx
@@ -39,7 +39,7 @@ export default function ResourceSummaryAverageSizeChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="resourceSummaryAverageSizeChartWidget"
       title={t('Average %s Size', DATA_TYPE)}
       series={[

--- a/static/app/views/insights/common/components/widgets/resourceSummaryDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryDurationChartWidget.tsx
@@ -25,7 +25,7 @@ export default function ResourceSummaryDurationChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="resourceSummaryDurationChartWidget"
       title={getDurationChartTitle('resource')}
       series={[data?.[`avg(${SPAN_SELF_TIME})`]]}

--- a/static/app/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/resourceSummaryThroughputChartWidget.tsx
@@ -23,7 +23,7 @@ export default function ResourceSummaryThroughputChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
-      search={search}
+      queryInfo={{search}}
       id="resourceSummaryThroughputChartWidget"
       title={getThroughputChartTitle('resource')}
       series={[data?.[`epm()`]]}

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -172,7 +172,7 @@ function DurationChart({
 
   return (
     <InsightsLineChartWidget
-      search={search}
+      queryInfo={{search}}
       showLegend="never"
       title={t('Average Duration')}
       isLoading={isPending}

--- a/static/app/views/insights/constants.tsx
+++ b/static/app/views/insights/constants.tsx
@@ -74,6 +74,12 @@ export const STARFISH_AGGREGATION_FIELDS: Record<
     kind: FieldKind.FUNCTION,
     valueType: FieldValueType.NUMBER,
   },
+  [SpanFunction.COUNT]: {
+    desc: t('Count of spans'),
+    defaultOutputType: 'integer',
+    kind: FieldKind.FUNCTION,
+    valueType: FieldValueType.NUMBER,
+  },
 };
 
 const RELEASE_FILTERS: FilterKeySection = {

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -50,8 +50,7 @@ export function ResponseCodeCountChart({
 
   return (
     <InsightsLineChartWidget
-      search={search}
-      groupBy={groupBy}
+      queryInfo={{search, groupBy}}
       title={t('Top 5 Response Codes')}
       series={seriesWithMeta}
       isLoading={isLoading}

--- a/static/app/views/insights/http/components/httpSamplesPanel.tsx
+++ b/static/app/views/insights/http/components/httpSamplesPanel.tsx
@@ -419,7 +419,7 @@ export function HTTPSamplesPanel() {
                 <ModuleLayout.Full>
                   <InsightsLineChartWidget
                     showLegend="never"
-                    search={search}
+                    queryInfo={{search}}
                     title={getDurationChartTitle('http')}
                     isLoading={isDurationDataFetching}
                     error={durationError}

--- a/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/startDurationWidget.tsx
@@ -111,7 +111,7 @@ function StartDurationWidget({additionalFilters}: Props) {
       series={sortedSeries}
       isLoading={isSeriesLoading}
       error={seriesError}
-      search={search}
+      queryInfo={{search, groupBy: [groupBy]}}
       showReleaseAs="none"
       showLegend="always"
       height={220}

--- a/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenCharts.tsx
@@ -26,6 +26,7 @@ import {
   CHART_TITLES,
   YAXIS_COLUMNS,
 } from 'sentry/views/insights/mobile/screenload/constants';
+import {SpanFields} from 'sentry/views/insights/types';
 
 enum YAxis {
   WARM_START = 0,
@@ -82,6 +83,7 @@ export function ScreenCharts({additionalFilters}: Props) {
   ]);
 
   const search = new MutableSearch(queryString);
+  const groupBy = SpanFields.RELEASE;
 
   const {
     data: releaseSeriesArray,
@@ -89,7 +91,7 @@ export function ScreenCharts({additionalFilters}: Props) {
     error: seriesError,
   } = useTopNMetricsMultiSeries(
     {
-      fields: ['release'],
+      fields: [groupBy],
       topN: 2,
       yAxis: [
         'avg(measurements.time_to_initial_display)',
@@ -190,7 +192,7 @@ export function ScreenCharts({additionalFilters}: Props) {
         <ChartContainer>
           <ScreensBarChart search={search} type="ttid" chartHeight={150} />
           <InsightsLineChartWidget
-            search={search}
+            queryInfo={{search, groupBy: [groupBy]}}
             title={t('Average TTID')}
             series={seriesMap['avg(measurements.time_to_initial_display)']}
             isLoading={isSeriesLoading}
@@ -201,7 +203,7 @@ export function ScreenCharts({additionalFilters}: Props) {
             height={'100%'}
           />
           <InsightsLineChartWidget
-            search={search}
+            queryInfo={{search, groupBy: [groupBy]}}
             title={CHART_TITLES[YAxis.COUNT]}
             series={seriesMap['count()']}
             isLoading={isSeriesLoading}
@@ -213,7 +215,7 @@ export function ScreenCharts({additionalFilters}: Props) {
           />
           <ScreensBarChart search={search} type="ttfd" chartHeight={150} />
           <InsightsLineChartWidget
-            search={search}
+            queryInfo={{search, groupBy: [groupBy]}}
             title={t('Average TTFD')}
             series={seriesMap['avg(measurements.time_to_full_display)']}
             isLoading={isSeriesLoading}

--- a/static/app/views/insights/queues/charts/latencyChart.tsx
+++ b/static/app/views/insights/queues/charts/latencyChart.tsx
@@ -68,7 +68,7 @@ export function LatencyChart({id, error, destination, referrer, pageFilters}: Pr
   return (
     <InsightsAreaChartWidget
       id={id}
-      search={search}
+      queryInfo={{search}}
       title={t('Average Duration')}
       series={[messageReceiveLatencySeries, data['avg(span.duration)']]}
       aliases={FIELD_ALIASES}

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -63,8 +63,7 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
   return (
     <InsightsLineChartWidget
       id={id}
-      search={search}
-      groupBy={[groupBy]}
+      queryInfo={{search, groupBy: [groupBy]}}
       title={t('Published vs Processed')}
       series={[
         renameDiscoverSeries(

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.tsx
@@ -313,7 +313,7 @@ export function MessageSpanSamplesPanel() {
             <ModuleLayout.Full>
               <InsightsLineChartWidget
                 showLegend="never"
-                search={timeseriesFilters}
+                queryInfo={{search: timeseriesFilters}}
                 title={getDurationChartTitle('queue')}
                 isLoading={isDurationDataFetching}
                 error={durationError}

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -312,7 +312,7 @@ export type EAPSpanResponse = {
     [Property in SpanFields as `count_if(${Property},${string})`]: number;
   };
 
-export type EAPSpanProperty = keyof EAPSpanResponse;
+export type EAPSpanProperty = keyof EAPSpanResponse; // TODO: rename this to `SpanProperty` when we remove `useInsightsEap`
 
 export enum SpanIndexedField {
   ENVIRONMENT = 'environment',
@@ -503,6 +503,7 @@ export enum SpanFunction {
   SPS = 'sps',
   EPM = 'epm',
   TPM = 'tpm',
+  COUNT = 'count',
   TIME_SPENT_PERCENTAGE = 'time_spent_percentage',
   HTTP_RESPONSE_COUNT = 'http_response_count',
   HTTP_RESPONSE_RATE = 'http_response_rate',


### PR DESCRIPTION
Couple of changes here! they are small so I bundled into one PR
1. Refactor `insightsTimeSeriesWidget`
a. Takes in `queryInfo` instead of separate props for `search` and `groupBy`
b. Does not render open in explore/create alert if `queryInfo` is missing
c. `queryInfo` takes in `yAxis` in case we need a seperate yAxis for opening in explore vs what the chart actually shows
2. Remove `open in explore`/`create alert` in web vitals module (not compatible with each)
3. Update cache miss rate charts to have a comparable query when opening in explore (`cache_miss_rate` is not supported so we can't do it directly)
