### PR TITLE
feat(settings): Add confirm delete to Seer repo removal

### DIFF
--- a/static/app/views/settings/projectSeer/autofixRepoItem.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepoItem.tsx
@@ -1,6 +1,7 @@
 import {type ChangeEvent, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
+import Confirm from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
@@ -14,7 +15,7 @@ import {
   IconCommit,
   IconDelete,
 } from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Repository} from 'sentry/types/integrations';
 
@@ -157,9 +158,16 @@ export function AutofixRepoItem({repo, onRemove, settings, onSettingsChange}: Pr
               </SettingsGroup>
             </div>
             <FormActions>
-              <Button size="sm" icon={<IconDelete />} onClick={onRemove}>
-                {t('Remove Repository')}
-              </Button>
+              <Confirm
+                onConfirm={onRemove}
+                message={tct('Are you sure you want to remove [repo] from Seer?', {
+                  repo: <strong>{repo.name}</strong>,
+                })}
+              >
+                <Button size="sm" icon={<IconDelete />}>
+                  {t('Remove Repository')}
+                </Button>
+              </Confirm>
               {isDirty && (
                 <ButtonBar gap={0.5}>
                   <Button size="sm" onClick={cancelChanges}>

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -229,6 +229,8 @@ describe('ProjectSeer', function () {
     await userEvent.click(repoItem);
     await userEvent.click(screen.getByRole('button', {name: 'Remove Repository'}));
 
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
+
     // Wait for the repo to disappear
     await waitFor(() => {
       expect(screen.queryByText('getsentry/sentry')).not.toBeInTheDocument();


### PR DESCRIPTION
Part of [RTC-651: \[Sentry UI\] Consistently Confirm Destructive Actions](https://linear.app/getsentry/issue/RTC-651/sentry-ui-consistently-confirm-destructive-actions)