### PR TITLE
feat(settings): Add confirm delete for removing API Application

### DIFF
--- a/static/app/views/settings/account/apiApplications/row.tsx
+++ b/static/app/views/settings/account/apiApplications/row.tsx
@@ -6,6 +6,7 @@ import {
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
+import ConfirmDelete from 'sentry/components/confirmDelete';
 import {Button} from 'sentry/components/core/button';
 import Link from 'sentry/components/links/link';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -58,13 +59,17 @@ function Row({app, onRemove}: Props) {
         </ClientId>
       </ApplicationNameWrapper>
 
-      <Button
-        aria-label={t('Remove')}
-        onClick={handleRemove}
-        disabled={isLoading}
-        size="sm"
-        icon={<IconDelete size="sm" />}
-      />
+      <ConfirmDelete
+        message={t(
+          'Removing this API Application will break existing usages of the application!'
+        )}
+        confirmInput={app.name}
+        onConfirm={handleRemove}
+      >
+        <Button disabled={isLoading} size="sm" icon={<IconDelete />}>
+          {t('Remove')}
+        </Button>
+      </ConfirmDelete>
     </StyledPanelItem>
   );
 }

--- a/tests/acceptance/test_api.py
+++ b/tests/acceptance/test_api.py
@@ -1,3 +1,4 @@
+from sentry.models.apiapplication import ApiApplication
 from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.silo import no_silo_test
 
@@ -25,8 +26,13 @@ class ApiApplicationTest(AcceptanceTestCase):
         self.browser.click_when_visible('[data-test-id="toast-success"]')
         self.browser.wait_until_not('[data-test-id="toast-success"]')
 
+        app = ApiApplication.objects.first()
+        assert app
+
         self.browser.get(self.path)
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.click_when_visible('[aria-label="Remove"]')
+        self.browser.element("input[name='confirm-text']").send_keys(app.name)
+        self.browser.click_when_visible('[aria-label="Confirm"]')
         self.browser.wait_until_not('[data-test-id="toast-loading"]')
         self.browser.wait_until_test_id("empty-message")


### PR DESCRIPTION
Part of [RTC-651: \[Sentry UI\] Consistently Confirm Destructive Actions](https://linear.app/getsentry/issue/RTC-651/sentry-ui-consistently-confirm-destructive-actions)