### PR TITLE
feat(settings): Add confirm to deleting email

### DIFF
--- a/static/app/views/settings/account/accountEmails.spec.tsx
+++ b/static/app/views/settings/account/accountEmails.spec.tsx
@@ -1,6 +1,11 @@
 import {AccountEmailsFixture} from 'sentry-fixture/accountEmails';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
 import AccountEmails from 'sentry/views/settings/account/accountEmails';
 
@@ -29,11 +34,14 @@ describe('AccountEmails', function () {
     });
 
     render(<AccountEmails />);
+    renderGlobalModal();
     expect(mock).not.toHaveBeenCalled();
 
     await userEvent.click(
       (await screen.findAllByRole('button', {name: 'Remove email'}))[0]!
     );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
 
     expect(mock).toHaveBeenCalledWith(
       ENDPOINT,

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {RequestOptions} from 'sentry/api';
+import Confirm from 'sentry/components/confirm';
 import {AlertLink} from 'sentry/components/core/alert/alertLink';
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Button} from 'sentry/components/core/button';
@@ -19,7 +20,7 @@ import PanelItem from 'sentry/components/panels/panelItem';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import accountEmailsFields from 'sentry/data/forms/accountEmails';
 import {IconDelete, IconStack} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {UserEmail} from 'sentry/types/user';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
@@ -211,14 +212,21 @@ function EmailRow({
           </Button>
         )}
         {!hideRemove && !isPrimary && (
-          <Button
-            aria-label={t('Remove email')}
-            data-test-id="remove"
+          <Confirm
+            onConfirm={() => onRemove(email)}
             priority="danger"
-            size="sm"
-            icon={<IconDelete />}
-            onClick={() => onRemove(email)}
-          />
+            message={tct('Are you sure you want to remove [email]?', {
+              email: <strong>{email}</strong>,
+            })}
+          >
+            <Button
+              aria-label={t('Remove email')}
+              data-test-id="remove"
+              priority="danger"
+              size="sm"
+              icon={<IconDelete />}
+            />
+          </Confirm>
         )}
       </ButtonBar>
     </EmailItem>


### PR DESCRIPTION
Part of [RTC-651: \[Sentry UI\] Consistently Confirm Destructive Actions](https://linear.app/getsentry/issue/RTC-651/sentry-ui-consistently-confirm-destructive-actions)