### PR TITLE
chore(plugins): undeprecate Heroku

### DIFF
--- a/src/sentry/plugins/__init__.py
+++ b/src/sentry/plugins/__init__.py
@@ -17,6 +17,5 @@ HIDDEN_PLUGINS = (
     "splunk",
     "segment",
     "victorops",
-    "heroku",
     "sessionstack",
 )


### PR DESCRIPTION
This is reverting a part of what I did in https://github.com/getsentry/sentry/pull/91550/
It turned out Heroku plugin is needed for Heroku partnership and people keep creating new projects with it. I have to bring back add to project button so people are unblocked while we find another solution.

I didn't bring back all the code, just these two views.

<img width="916" alt="Screenshot 2025-06-05 at 12 28 38 PM" src="https://github.com/user-attachments/assets/49911c91-17e9-4b7d-bca9-bb5c859a538b" />
<img width="910" alt="Screenshot 2025-06-05 at 12 28 46 PM" src="https://github.com/user-attachments/assets/c4efe14b-7faf-4039-b2bb-b8bd91623f1a" />
