### PR TITLE
ref(grouping): Log event info with exception group filtering errors

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -412,7 +412,7 @@ def get_grouping_variants_for_event(
 
     # Run all of the event-data-based grouping strategies. Any which apply will create grouping
     # components, which will then be grouped into variants by variant type (system, app, default).
-    context = GroupingContext(config or load_default_grouping_config())
+    context = GroupingContext(config or load_default_grouping_config(), event)
     strategy_component_variants: dict[str, ComponentVariant] = _get_variants_from_strategies(
         event, context
     )

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -95,10 +95,11 @@ def strategy(
 
 
 class GroupingContext:
-    def __init__(self, strategy_config: StrategyConfiguration):
+    def __init__(self, strategy_config: StrategyConfiguration, event: Event):
         # The initial context is essentially the grouping config options
         self._stack = [strategy_config.initial_context]
         self.config = strategy_config
+        self.event = event
         self.push()
         self["variant"] = None
 

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -626,7 +626,12 @@ def chained_exception(
         # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
         # TODO: Except we do, as it turns out. See https://github.com/getsentry/sentry/issues/73592.
         logging.exception(
-            "Failed to filter exceptions for exception groups. Continuing with original list."
+            "Failed to filter exceptions for exception groups. Continuing with original list.",
+            extra={
+                "event_id": context.event.event_id,
+                "project_id": context.event.project.id,
+                "org_id": context.event.project.organization.id,
+            },
         )
         exceptions = all_exceptions
 


### PR DESCRIPTION
When we're processing exception groups during our grouping calculations, sometimes we get errors when trying to filter those groups (which we do in order to avoid including duplicates and container errors just there to tie meaningful errors together). It's hard to debug these errors without seeing the data that's triggering them, though. This PR therefore adds information about the event being processed to the error we capture, so that we can go find it and have some example repro cases with which to work. In order to make event info available in the depths of the grouping machinery (where these errors occur), this also adds an `event` attribute to the `GroupingContext` class.