### PR TITLE
ref(ui): update instances of yarn dev-ui to pnpm

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -730,7 +730,7 @@ export function resolveHostname(path: string, hostname?: string): string {
     hostname = '';
   }
 
-  // When running as yarn dev-ui we can't spread requests across domains because
+  // When running as pnpm dev-ui we can't spread requests across domains because
   // of CORS. Instead we extract the subdomain from the hostname
   // and prepend the URL with `/region/$name` so that webpack-devserver proxy
   // can route requests to the regions.

--- a/static/app/utils/resolveRoute.tsx
+++ b/static/app/utils/resolveRoute.tsx
@@ -5,7 +5,7 @@ import {extractSlug} from 'sentry/utils/extractSlug';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
 /**
- * In yarn dev-ui mode we proxy API calls to sentry.io.
+ * In pnpm dev-ui mode we proxy API calls to sentry.io.
  * However, browser URLs are in the form of acme.dev.getsentry.net.
  * In order to not redirect to production we swap domains.
  */


### PR DESCRIPTION
since we moved over to `pnpm`, `yarn dev-ui` no longer works and we have to do `pnpm dev-ui`.