### PR TITLE
inc(options): Log whenever options cache is set to 1.0

### DIFF
--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -277,6 +277,11 @@ class OptionsStore:
 
         cache_key = key.cache_key
 
+        if value == 1.0:
+            logger.warning(
+                "suspicious set_cache activity on %s = %s", key.cache_key, value, stack_info=True
+            )
+
         if key.ttl > 0:
             self._local_cache[cache_key] = _make_cache_value(key, value)
 


### PR DESCRIPTION
In INC-1195 we are dealing with a strange phenomenon where a few options
are being set to this (invalid) value by a ghost. Get a stacktrace to
see who did it.
