### PR TITLE
style(replay/feedback): update compact select size in onboarding

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -284,6 +284,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
                   {tct('I use [platformSelect]', {
                     platformSelect: (
                       <CompactSelect
+                        size="xs"
                         triggerLabel={jsFramework.label}
                         value={jsFramework.value}
                         onChange={setJsFramework}

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -294,6 +294,7 @@ function OnboardingContent({
                   {tct('I use [platformSelect]', {
                     platformSelect: (
                       <CompactSelect
+                        size="xs"
                         triggerLabel={jsFramework.label}
                         value={jsFramework.value}
                         onChange={setJsFramework}


### PR DESCRIPTION
followup to https://github.com/getsentry/sentry/pull/92954

## feedback:
before:
<img width="352" alt="SCR-20250605-oesr" src="https://github.com/user-attachments/assets/de6cfa93-455b-4b9e-bb69-5b4253aba44f" />

after:
<img width="255" alt="SCR-20250605-oena" src="https://github.com/user-attachments/assets/dec010b7-2659-4481-bdc4-0497bde3bff9" />

## replay:
before:
<img width="303" alt="SCR-20250605-oevg" src="https://github.com/user-attachments/assets/ce069b77-ac2b-4ba4-9a1c-75106da63b40" />

after:
<img width="240" alt="SCR-20250605-oeyk" src="https://github.com/user-attachments/assets/1c4d58f9-5907-4371-b44d-bdee590b2e97" />
