### PR TITLE
ref(ui): Fix extraneous space in share modal

### DIFF
--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -133,7 +133,7 @@ export default function ShareIssueModal({
         <h4>{t('Share Issue')}</h4>
       </Header>
       <Body>
-        <ModalContent hasPublicShare={hasPublicShare}>
+        <ModalContent>
           <UrlContainer>
             <TextContainer>
               <StyledAutoSelectText ref={urlRef}>{issueUrl}</StyledAutoSelectText>
@@ -201,6 +201,7 @@ export default function ShareIssueModal({
                     {t('Share a link with anyone outside your organization')}
                   </SubText>
                 </div>
+                <div>{(!group || loading) && <LoadingIndicator mini />}</div>
                 <Switch
                   aria-label={isPublished ? t('Unpublish') : t('Publish')}
                   checked={isPublished}
@@ -208,11 +209,6 @@ export default function ShareIssueModal({
                   onChange={handlePublicShare}
                 />
               </SwitchWrapper>
-              {(!group || loading) && (
-                <LoadingContainer>
-                  <LoadingIndicator mini />
-                </LoadingContainer>
-              )}
               {group && !loading && isPublished && shareUrl && (
                 <Fragment>
                   <UrlContainer>
@@ -254,11 +250,10 @@ export default function ShareIssueModal({
   );
 }
 
-const ModalContent = styled('div')<{hasPublicShare: boolean}>`
+const ModalContent = styled('div')`
   display: flex;
   gap: ${space(1)};
   flex-direction: column;
-  min-height: ${p => (p.hasPublicShare ? '275px' : '')};
 `;
 
 const UrlContainer = styled('div')`
@@ -296,8 +291,8 @@ const StyledButtonBar = styled(ButtonBar)`
 `;
 
 const SwitchWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr max-content max-content;
   align-items: center;
   gap: ${space(2)};
 `;
@@ -310,11 +305,6 @@ const Title = styled('div')`
 const SubText = styled('p')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
-`;
-
-const LoadingContainer = styled('div')`
-  display: flex;
-  justify-content: center;
 `;
 
 const ReshareButton = styled(Button)`


### PR DESCRIPTION
<img alt="clipboard.png" width="687" src="https://i.imgur.com/pmCQRmN.png" />

There was extra space to allow for the public share link. Without this
the modal would jump around in size due to the loading indicator. I've
fixed this by just moving the loading indicator inline with the switch.

<img alt="clipboard.png" width="580" src="https://i.imgur.com/a5u9Jjx.png" />