### PR TITLE
perf(aci): Use index better in latest release querying

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -440,7 +440,7 @@ def _run_latest_release_query(
     extra_conditions = ""
     if environments:
         env_join = "INNER JOIN sentry_releaseprojectenvironment srpe on srpe.release_id = sr.id"
-        env_where = "AND srpe.environment_id in %s"
+        env_where = "AND srpe.environment_id in %s AND srpe.project_id in %s"
         adopted_table_alias = "srpe"
     else:
         adopted_table_alias = "srp"
@@ -473,6 +473,7 @@ def _run_latest_release_query(
     query_args: list[int | tuple[int, ...]] = [organization_id, tuple(project_ids)]
     if environments:
         query_args.append(tuple(e.id for e in environments))
+        query_args.append(tuple(project_ids))
     cursor.execute(query, query_args)
     return [row[0] for row in cursor.fetchall()]
 


### PR DESCRIPTION
We're regularly seeing >20s queries for latest release. This seems to largely be due to inefficiencies in managing and filtering the joins.
There may be other approaches, but including the project IDs when filtering sentry_releaseprojectenvironment allows us to hit the index on (project_id, release_id, environment_id) and results in a much more reasonable looking plan and much faster execution (subsecond rather than 30s+) on Redash.
