### PR TITLE
fix(attachments): Fix issue where attachment name would overflow off card

### DIFF
--- a/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
@@ -82,8 +82,15 @@ export function ScreenshotCard({
   return (
     <StyledCard>
       <CardHeader>
-        <div>
-          <AttachmentName>{eventAttachment.name}</AttachmentName>
+        <ScreenshotInfo>
+          <AttachmentName
+            position="top"
+            title={eventAttachment.name}
+            showOnlyOnOverflow
+            skipWrapper
+          >
+            {eventAttachment.name}
+          </AttachmentName>
           <div>
             <DateTime date={eventAttachment.dateCreated} /> &middot;{' '}
             <Link
@@ -94,7 +101,7 @@ export function ScreenshotCard({
               </Tooltip>
             </Link>
           </div>
-        </div>
+        </ScreenshotInfo>
         <DropdownMenu
           items={[
             {
@@ -155,24 +162,33 @@ export function ScreenshotCard({
   );
 }
 
-const StyledCard = styled(Card)`
-  margin: 0;
+const ScreenshotInfo = styled('div')`
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 `;
 
-const AttachmentName = styled('div')`
-  font-weight: bold;
+const StyledCard = styled(Card)`
+  margin: 0;
+  padding: ${space(1)} ${space(1.5)};
+`;
+
+const AttachmentName = styled(Tooltip)`
+  display: flex;
   ${p => p.theme.overflowEllipsis};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 
 const CardHeader = styled('div')`
   display: flex;
   justify-content: space-between;
-  padding: ${space(1.5)} ${space(1.5)} ${space(1.5)} ${space(2)};
+  padding-bottom: ${space(1)};
+  flex-shrink: 0;
 `;
 
 const CardBody = styled('div')`
-  background: ${p => p.theme.gray100};
-  padding: ${space(1)} ${space(1.5)};
   max-height: 250px;
   min-height: 250px;
   overflow: hidden;
@@ -189,6 +205,7 @@ const StyledPanelBody = styled(PanelBody)`
   align-items: center;
   justify-content: center;
   flex: 1;
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const StyledLoadingIndicator = styled('div')`

--- a/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
@@ -170,12 +170,9 @@ const StyledCard = styled(Card)`
 `;
 
 const AttachmentName = styled('span')`
-  font-weight: ${p => p.theme.fontWeightBold};
   display: flex;
+  font-weight: ${p => p.theme.fontWeightBold};
   ${p => p.theme.overflowEllipsis};
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 `;
 
 const CardHeader = styled('div')`

--- a/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
@@ -117,6 +117,7 @@ export function ScreenshotCard({
                   confirmText: t('Delete'),
                 });
               },
+              priority: 'danger',
             },
           ]}
           position="bottom-end"

--- a/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
@@ -170,6 +170,7 @@ const StyledCard = styled(Card)`
 `;
 
 const AttachmentName = styled('span')`
+  font-weight: ${p => p.theme.fontWeightBold};
   display: flex;
   ${p => p.theme.overflowEllipsis};
   overflow: hidden;

--- a/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/screenshotCard.tsx
@@ -83,14 +83,9 @@ export function ScreenshotCard({
     <StyledCard>
       <CardHeader>
         <ScreenshotInfo>
-          <AttachmentName
-            position="top"
-            title={eventAttachment.name}
-            showOnlyOnOverflow
-            skipWrapper
-          >
-            {eventAttachment.name}
-          </AttachmentName>
+          <Tooltip title={eventAttachment.name} showOnlyOnOverflow skipWrapper>
+            <AttachmentName>{eventAttachment.name}</AttachmentName>
+          </Tooltip>
           <div>
             <DateTime date={eventAttachment.dateCreated} /> &middot;{' '}
             <Link
@@ -173,7 +168,7 @@ const StyledCard = styled(Card)`
   padding: ${space(1)} ${space(1.5)};
 `;
 
-const AttachmentName = styled(Tooltip)`
+const AttachmentName = styled('span')`
   display: flex;
   ${p => p.theme.overflowEllipsis};
   overflow: hidden;


### PR DESCRIPTION
fixes #92151

Fixes an issue where the event attachment name would overflow off the card and obscure the ellipsis menu. Also cleans up some styles. 

Before: 

![Screenshot 2025-06-05 at 1 13 32 PM](https://github.com/user-attachments/assets/d3288759-faa2-4dc6-a247-232de1a55175)

After: 

![Screenshot 2025-06-05 at 1 14 02 PM](https://github.com/user-attachments/assets/28b046c0-5e52-4bc5-9fcd-3ec6a962824d)
