### PR TITLE
fix(ui): Use consistent wording for API tokens

### DIFF
--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -38,7 +38,7 @@ describe('ApiTokenRow', () => {
     render(<ApiTokenRow onRemove={cb} token={ApiTokenFixture()} canEdit />);
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Revoke'}));
     await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
     expect(cb).toHaveBeenCalled();
   });

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -64,7 +64,7 @@ function ApiTokenRow({
           }
         >
           <Button size="sm" icon={<IconSubtract isCircled />}>
-            {t('Remove')}
+            {t('Revoke')}
           </Button>
         </Confirm>
       </Actions>

--- a/static/app/views/settings/account/apiTokens.spec.tsx
+++ b/static/app/views/settings/account/apiTokens.spec.tsx
@@ -75,7 +75,7 @@ describe('ApiTokens', function () {
 
     render(<ApiTokens />);
     renderGlobalModal();
-    const removeButton = await screen.findByRole('button', {name: 'Remove'});
+    const removeButton = await screen.findByRole('button', {name: 'Revoke'});
     expect(removeButton).toBeInTheDocument();
     expect(deleteTokenMock).not.toHaveBeenCalled();
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -431,7 +431,7 @@ describe('Sentry Application Details', function () {
       renderComponent();
       renderGlobalModal();
       await screen.findByRole('button', {name: 'Save Changes'});
-      await userEvent.click(screen.getByRole('button', {name: 'Remove'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Revoke'}));
       // Confirm modal
       await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
       expect(

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -85,7 +85,7 @@ describe('User Details', function () {
 
       expect(await screen.findByText('test-username')).toBeInTheDocument();
       expect(screen.getByText('test-email@gmail.com')).toBeInTheDocument();
-      expect(screen.getByText('Remove')).toBeInTheDocument();
+      expect(screen.getByText('Revoke')).toBeInTheDocument();
     });
   });
 });

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -107,7 +107,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
         self.load_page(url)
 
-        self.browser.click('[aria-label="Remove"]')
+        self.browser.click('[aria-label="Revoke"]')
         self.browser.click('[data-test-id="confirm-button"]')
         self.browser.wait_until(".ref-success")
 


### PR DESCRIPTION
In other parts of the app we say 'revoke' when removing API tokens.