### PR TITLE
feat(trace-eap-waterfall): EAP transaction spans should represent trace

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/utils.tsx
@@ -4,6 +4,7 @@ import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {
   isEAPTraceNode,
+  isEAPTransaction,
   isTraceNode,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -49,18 +50,29 @@ export const getRepresentativeTraceEvent = (
     throw new TypeError('Not trace node');
   }
 
-  let firstRootEvent: TraceTree.TraceEvent | null = null;
+  let rootEvent: TraceTree.TraceEvent | null = null;
   let candidateEvent: TraceTree.TraceEvent | null = null;
   let firstEvent: TraceTree.TraceEvent | null = null;
 
-  const events = isTraceNode(traceNode)
-    ? [...traceNode.value.transactions, ...traceNode.value.orphan_errors]
-    : traceNode.value;
+  const isEAP = isEAPTraceNode(traceNode);
+  const events = isEAP
+    ? traceNode.value
+    : [...traceNode.value.transactions, ...traceNode.value.orphan_errors];
   for (const event of events) {
-    // If we find a root transaction, we can stop looking and use it for the title.
-    if (!firstRootEvent && isRootEvent(event)) {
-      firstRootEvent = event;
-      break;
+    if (isRootEvent(event)) {
+      rootEvent = event;
+
+      if (!isEAP) {
+        // For non-EAP traces, we return the first root event.
+        break;
+      }
+
+      if (isEAPTransaction(event)) {
+        // If we find a root EAP transaction, we can stop looking and use it for the title.
+        break;
+      }
+      // Otherwise we keep looking for a root eap transaction. If we don't find one, we use other roots, like standalone spans.
+      continue;
     } else if (
       // If we haven't found a root transaction, but we found a candidate transaction
       // with an op that we care about, we can use it for the title. We keep looking for
@@ -84,7 +96,7 @@ export const getRepresentativeTraceEvent = (
   }
 
   return {
-    event: firstRootEvent ?? candidateEvent ?? firstEvent,
+    event: rootEvent ?? candidateEvent ?? firstEvent,
     type: 'trace',
   };
 };


### PR DESCRIPTION
In the img below both the inp span and the eap span with `is_transaction:true` are roots.
In such a scenario, we want the latter to represent the trace (i.e. used in the header and we use its attrs as the trace level attrs
<img width="1231" alt="Screenshot 2025-06-05 at 4 34 14 PM" src="https://github.com/user-attachments/assets/65784cc0-b12c-460b-967f-c26b64986e12" />
