### PR TITLE
feat(settings): Do not auto-save inbound filter configs

### DIFF
--- a/static/app/data/forms/inboundFilters.tsx
+++ b/static/app/data/forms/inboundFilters.tsx
@@ -22,6 +22,9 @@ const formGroups: JsonFormObject[] = [
       {
         name: 'filters:blacklisted_ips',
         type: 'string',
+        saveOnBlur: false,
+        saveMessage: t('Changing this filter will apply to all new events.'),
+        monospace: true,
         multiline: true,
         autosize: true,
         rows: 1,
@@ -48,6 +51,9 @@ export const customFilterFields: Field[] = [
   {
     name: 'filters:releases',
     type: 'string',
+    saveOnBlur: false,
+    saveMessage: t('Changing this filter will apply to all new events.'),
+    monospace: true,
     multiline: true,
     autosize: true,
     maxRows: 10,
@@ -67,6 +73,9 @@ export const customFilterFields: Field[] = [
   {
     name: 'filters:error_messages',
     type: 'string',
+    saveOnBlur: false,
+    saveMessage: t('Changing this filter will apply to all new events.'),
+    monospace: true,
     multiline: true,
     autosize: true,
     maxRows: 10,

--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -188,7 +188,7 @@ describe('ProjectFilters', function () {
       await screen.findByRole('textbox', {name: 'IP Addresses'}),
       'test\ntest2'
     );
-    await userEvent.tab();
+    await userEvent.click(await screen.findByRole('button', {name: 'Save'}));
 
     expect(mock.mock.calls[0][0]).toBe(PROJECT_URL);
     expect(mock.mock.calls[0][1].data.options['filters:blacklisted_ips']).toBe(
@@ -228,7 +228,7 @@ describe('ProjectFilters', function () {
       screen.getByRole('textbox', {name: 'Releases'}),
       'release\nrelease2'
     );
-    await userEvent.tab();
+    await userEvent.click(await screen.findByRole('button', {name: 'Save'}));
 
     expect(mock.mock.calls[0][0]).toBe(PROJECT_URL);
     expect(mock.mock.calls[0][1].data.options['filters:releases']).toBe(
@@ -239,7 +239,7 @@ describe('ProjectFilters', function () {
       screen.getByRole('textbox', {name: 'Error Message'}),
       'error\nerror2'
     );
-    await userEvent.tab();
+    await userEvent.click(await screen.findByRole('button', {name: 'Save'}));
 
     expect(mock.mock.calls[1][1].data.options['filters:error_messages']).toBe(
       'error\nerror2'


### PR DESCRIPTION
Part of [RTC-651: \[Sentry UI\] Consistently Confirm Destructive Actions](https://linear.app/getsentry/issue/RTC-651/sentry-ui-consistently-confirm-destructive-actions)