### PR TITLE
feat(ui): Do not auto-save security token / header

### DIFF
--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -165,6 +165,8 @@ export const fields = {
     help: t(
       'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended'
     ),
+    saveOnBlur: false,
+    saveMessage: t('Ensure you update usages of your security token.'),
     setValue: value => getDynamicText({value, fixed: '__SECURITY_TOKEN__'}),
   },
   securityTokenHeader: {
@@ -175,6 +177,8 @@ export const fields = {
     help: t(
       'Outbound requests matching Allowed Domains will have the header "{token_header}: {token}" appended'
     ),
+    saveOnBlur: false,
+    saveMessage: t('Ensure you update usages of the security token header.'),
   },
   verifySSL: {
     name: 'verifySSL',


### PR DESCRIPTION
Part of [RTC-651: \[Sentry UI\] Consistently Confirm Destructive Actions](https://linear.app/getsentry/issue/RTC-651/sentry-ui-consistently-confirm-destructive-actions)