### PR TITLE
fix: HMR works with shamefully-hoist

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 lockfile=true
-node-linker=hoisted
+shamefully-hoist=true

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -467,7 +467,7 @@ const appConfig: Configuration = {
     preferAbsolute: true,
     modules: ['node_modules'],
     extensions: ['.js', '.tsx', '.ts', '.json', '.less'],
-    symlinks: false,
+    symlinks: true,
   },
   output: {
     crossOriginLoading: 'anonymous',


### PR DESCRIPTION
under shamefully-hoist the emitter is in node_modules at `@rspack/core/hot/emitter.js` where `@rspack/core -> ../.pnpm/@rspack+core@1.3.10_@swc+helpers@0.5.15/node_modules/@rspack/core`

with nodeLinker hoisted there are no symlinks to follow it's just `@rspack/core/hot/emitter.js`

the difference between a notworking `~/app.js`  and working one is this path that's passed to `__webpack_require__`, so i looked at how we configure module resolution - turns out we had disabled following symlinks 

note to test hmr: in `static/app/views/alerts/list/header.tsx` modify `{t('Alerts')}`