### PR TITLE
fix(uptime): Make body null when form method is get, head, or options

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -45,6 +45,8 @@ interface Props {
 
 const HTTP_METHOD_OPTIONS = ['GET', 'POST', 'HEAD', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'];
 
+const HTTP_METHODS_WITHOUT_BODY = new Set<string>(['GET', 'HEAD', 'OPTIONS']);
+
 const MINUTE = 60;
 
 const VALID_INTERVALS_SEC = [
@@ -84,7 +86,7 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
   const [formModel] = useState(() => new FormModel());
 
   const [isBodyVisible, setIsBodyVisible] = useState<boolean>(
-    !(initialData.method === 'GET' || initialData.method === 'HEAD')
+    !HTTP_METHODS_WITHOUT_BODY.has(initialData.method)
   );
   const [knownEnvironments, setEnvironments] = useState<string[]>([]);
   const [newEnvironment, setNewEnvironment] = useState<string | undefined>(undefined);
@@ -248,8 +250,8 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
                 value: option,
                 label: option,
               }))}
-              onChange={(value: any) => {
-                if (value === 'GET' || value === 'HEAD') {
+              onChange={value => {
+                if (HTTP_METHODS_WITHOUT_BODY.has(value)) {
                   setIsBodyVisible(false);
                   formModel.setValue('body', null as any);
                 } else {

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -79,10 +79,13 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
 
   const initialData = rule
     ? getFormDataFromRule(rule)
-    : {projectSlug: project.slug, method: 'GET', headers: []};
+    : {projectSlug: project.slug, method: 'GET', headers: [], body: null};
 
   const [formModel] = useState(() => new FormModel());
 
+  const [isBodyVisible, setIsBodyVisible] = useState<boolean>(
+    !(initialData.method === 'GET' || initialData.method === 'HEAD')
+  );
   const [knownEnvironments, setEnvironments] = useState<string[]>([]);
   const [newEnvironment, setNewEnvironment] = useState<string | undefined>(undefined);
   const environments = [newEnvironment, ...knownEnvironments].filter(Boolean);
@@ -245,6 +248,15 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
                 value: option,
                 label: option,
               }))}
+              onChange={(value: any) => {
+                if (value === 'GET' || value === 'HEAD') {
+                  setIsBodyVisible(false);
+                  formModel.setValue('body', null as any);
+                } else {
+                  setIsBodyVisible(true);
+                }
+                formModel.setValue('method', value);
+              }}
               flexibleControlStateSize
               required
             />
@@ -256,9 +268,7 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
             <TextareaField
               name="body"
               label={t('Body')}
-              visible={({model}: any) =>
-                !['GET', 'HEAD'].includes(model.getValue('method'))
-              }
+              visible={isBodyVisible}
               rows={4}
               maxRows={15}
               autosize


### PR DESCRIPTION
A fix for https://github.com/getsentry/sentry/issues/84934.  Body can be string or null, this makes body null when form method is get, head, or options.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
