### PR TITLE
bug(aci): Fail delayed_workflow when Snuba querying fails

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -535,7 +535,7 @@ class TestGetSnubaResults(BaseWorkflowTest):
         mock_handler.intervals = {"1h": ("fake", timedelta(seconds=1))}
 
         unique_query = UniqueConditionQuery(
-            handler=lambda: mock_handler,
+            handler=lambda: mock_handler,  # type: ignore[arg-type]
             interval="1h",
             environment_id=None,
         )

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 from dataclasses import asdict
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+
+import pytest
 
 from sentry import buffer
 from sentry.eventstore.models import Event
@@ -18,6 +20,7 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.redis import mock_redis_buffer
 from sentry.utils import json
 from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
+    BaseEventFrequencyQueryHandler,
     EventFrequencyQueryHandler,
     EventUniqueUserFrequencyQueryHandler,
     QueryResult,
@@ -521,6 +524,26 @@ class TestGetSnubaResults(BaseWorkflowTest):
             count_query: {group_id: 4},
             offset_percent_query: {group_id: 1},
         }
+
+    def test_get_condition_group_results_exception_propagation(self) -> None:
+        """
+        When we get an exception from the handler, we should propagate it.
+        We don't want to proceed with partial data.
+        """
+        mock_handler = Mock(spec=BaseEventFrequencyQueryHandler)
+        mock_handler.get_rate_bulk.side_effect = ValueError("Escaping exception")
+        mock_handler.intervals = {"1h": ("fake", timedelta(seconds=1))}
+
+        unique_query = UniqueConditionQuery(
+            handler=lambda: mock_handler,
+            interval="1h",
+            environment_id=None,
+        )
+
+        condition_groups = {unique_query: {1}}  # One group ID to query
+
+        with pytest.raises(ValueError, match="Escaping exception"):
+            get_condition_group_results(condition_groups)
 
 
 class TestGetGroupsToFire(TestDelayedWorkflowBase):


### PR DESCRIPTION
Continuing with partial data is less correct than retrying the task.
