### PR TITLE
docs: Document symbol source filter settings

### DIFF
--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -103,8 +103,8 @@ class FiltersSerializer(serializers.Serializer):
     ```
     """
 
-    filters = serializers.ListField(
-        child=serializers.ChoiceField(choices=VALID_FILE_TYPES),
+    filetypes = serializers.MultipleChoiceField(
+        choices=VALID_FILE_TYPES,
         required=False,
         help_text="The file types enabled for the source.",
     )

--- a/src/sentry/api/endpoints/project_symbol_sources.py
+++ b/src/sentry/api/endpoints/project_symbol_sources.py
@@ -22,6 +22,7 @@ from sentry.lang.native.sources import (
     REDACTED_SOURCE_SCHEMA,
     REDACTED_SOURCES_SCHEMA,
     VALID_CASINGS,
+    VALID_FILE_TYPES,
     VALID_LAYOUTS,
     InvalidSourcesError,
     backfill_source,
@@ -67,6 +68,56 @@ class LayoutSerializer(serializers.Serializer):
     )
 
 
+class FiltersSerializer(serializers.Serializer):
+    """
+    Filter settings for the source. This is optional for all sources.
+
+    **`filetypes`** ***(list)*** - A list of file types that can be found on this source. If this is left empty, all file types will be enabled. The options are:
+    - `pe` - Windows executable files
+    - `pdb` - Windows debug files
+    - `portablepdb` - .NET portable debug files
+    - `mach_code` - MacOS executable files
+    - `mach_debug` - MacOS debug files
+    - `elf_code` - ELF executable files
+    - `elf_debug` - ELF debug files
+    - `wasm_code` - WASM executable files
+    - `wasm_debug` - WASM debug files
+    - `breakpad` - Breakpad symbol files
+    - `sourcebundle` - Source code bundles
+    - `uuidmap` - Apple UUID mapping files
+    - `bcsymbolmap` - Apple bitcode symbol maps
+    - `il2cpp` - Unity IL2CPP mapping files
+    - `proguard` - ProGuard mapping files
+
+    **`path_patterns`** ***(list)*** - A list of glob patterns to check against the debug and code file paths of debug files. Only files that match one of these patterns will be requested from the source. If this is left empty, no path-based filtering takes place.
+
+    **`requires_checksum`** ***(boolean)*** - Whether this source requires a debug checksum to be sent with each request. Defaults to `false`.
+
+    ```json
+    {
+        "filters": {
+            "filetypes": ["pe", "pdb", "portablepdb"],
+            "path_patterns": ["*ffmpeg*"]
+        }
+    }
+    ```
+    """
+
+    filters = serializers.ListField(
+        child=serializers.ChoiceField(choices=VALID_FILE_TYPES),
+        required=False,
+        help_text="The file types enabled for the source.",
+    )
+    path_patterns = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="The debug and code file paths enabled for the source.",
+    )
+    requires_checksum = serializers.BooleanField(
+        required=False, help_text="Whether the source requires debug checksums."
+    )
+
+
 class SourceSerializer(serializers.Serializer):
     type = serializers.ChoiceField(
         choices=[
@@ -88,6 +139,7 @@ class SourceSerializer(serializers.Serializer):
     layout = LayoutSerializer(
         required=False,
     )
+    filters = FiltersSerializer(required=False)
     url = serializers.CharField(
         required=False,
         help_text="The source's URL. Optional for HTTP sources, invalid for all others.",


### PR DESCRIPTION
The filters part of the symbol source API was heretofore undocumented.

Closes INGEST-396.