### PR TITLE
ref(symbolicator): only fetch gcp token if no private_key is configured

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -442,8 +442,6 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:user-feedback-event-link-ingestion-changes", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable view hierarchies options
     manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables GCP token fetching instead of providing credentials
-    manager.add("organizations:gcp-bearer-token-authentication", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=False)
     # Enable admin features on the new explore page
     manager.add("organizations:visibility-explore-admin", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable equations feature on the new explore page

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -574,11 +574,13 @@ def get_sources_for_project(project):
                 if other_source.get("type") == "alias":
                     yield from resolve_alias(other_source, organization)
                 else:
-                    yield fetch_token_for_gcp_source(other_source, organization)
+                    yield fetch_token_for_gcp_source_if_necessary(other_source, organization)
 
-    def fetch_token_for_gcp_source(source, organization):
-        if features.has("organizations:gcp-bearer-token-authentication", organization):
-            if source.get("type") == "gcs":
+    def fetch_token_for_gcp_source_if_necessary(source, organization):
+        if source.get("type") == "gcs":
+            if "client_email" in source and "private_key" in source:
+                return source
+            else:
                 client_email = source.get("client_email")
                 token = get_gcp_token(client_email)
                 # if target_credentials.token is None it means that the
@@ -609,7 +611,7 @@ def get_sources_for_project(project):
         if source.get("type") == "alias":
             sources.extend(resolve_alias(source, organization))
         else:
-            sources.append(fetch_token_for_gcp_source(source, organization))
+            sources.append(fetch_token_for_gcp_source_if_necessary(source, organization))
 
     return sources
 

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -27,16 +27,22 @@ SENTRY_BUILTIN_SOURCES_TEST = {
         "name": "aaa",
         "type": "gcs",
         "client_email": "application@project-id.iam.gserviceaccount.com",
-        "private_key": "FAKE_PRIVATE_KEY_STRING",
     },
     "bbb": {
         "id": "sentry:builtin-bbb",
         "name": "bbb",
         "type": "gcs",
         "client_email": "application@project-id.iam.gserviceaccount.com",
-        "private_key": "FAKE_PRIVATE_KEY_STRING",
     },
     "ccc": {"id": "sentry:builtin-ccc", "name": "ccc", "type": "alias", "sources": ["aaa", "bbb"]},
+    "ddd": {
+        "id": "sentry:builtin-ddd",
+        "name": "ddd",
+        "type": "gcs",
+        "client_email": "application@project-id.iam.gserviceaccount.com",
+        "private_key": "FAKE_PRIVATE_KEY_STRING",
+    },
+    "eee": {"id": "sentry:builtin-eee", "name": "eee", "type": "alias", "sources": ["ddd", "aaa"]},
 }
 
 
@@ -48,7 +54,6 @@ class TestGcpBearerAuthentication:
         mock_get_gcp_token.return_value = "ya29.TOKEN"
         features = {
             "organizations:symbol-sources": True,
-            "organizations:gcp-bearer-token-authentication": True,
         }
         default_project.update_option("sentry:builtin_symbol_sources", ["aaa", "bbb"])
 
@@ -67,7 +72,6 @@ class TestGcpBearerAuthentication:
         mock_get_gcp_token.return_value = "ya29.TOKEN"
         features = {
             "organizations:symbol-sources": True,
-            "organizations:gcp-bearer-token-authentication": True,
         }
         default_project.update_option("sentry:builtin_symbol_sources", ["ccc"])
 
@@ -90,6 +94,43 @@ class TestGcpBearerAuthentication:
             assert "client_email" not in sources[i]
             assert "private_key" not in sources[i]
             assert sources[i]["bearer_token"] == "ya29.TOKEN"
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    @patch("sentry.lang.native.sources.get_gcp_token")
+    @django_db_all
+    def test_source_with_private_key(self, mock_get_gcp_token, default_project):
+        mock_get_gcp_token.return_value = "ya29.TOKEN"
+        features = {
+            "organizations:symbol-sources": True,
+        }
+        default_project.update_option("sentry:builtin_symbol_sources", ["ddd"])
+
+        with Feature(features):
+            sources = get_sources_for_project(default_project)
+
+        assert sources[1]["name"] == "ddd"
+        assert sources[1]["client_email"] == "application@project-id.iam.gserviceaccount.com"
+        assert sources[1]["private_key"] == "FAKE_PRIVATE_KEY_STRING"
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    @patch("sentry.lang.native.sources.get_gcp_token")
+    @django_db_all
+    def test_mixed_sources(self, mock_get_gcp_token, default_project):
+        mock_get_gcp_token.return_value = "ya29.TOKEN"
+        features = {
+            "organizations:symbol-sources": True,
+        }
+        default_project.update_option("sentry:builtin_symbol_sources", ["eee"])
+
+        with Feature(features):
+            sources = get_sources_for_project(default_project)
+
+        assert sources[1]["name"] == "ddd"
+        assert "token" not in sources[1]
+        assert sources[1]["client_email"] == "application@project-id.iam.gserviceaccount.com"
+        assert sources[1]["private_key"] == "FAKE_PRIVATE_KEY_STRING"
+        assert sources[2]["name"] == "aaa"
+        assert sources[2]["bearer_token"] == "ya29.TOKEN"
 
 
 class TestIgnoredSourcesFiltering:

--- a/tests/sentry/lang/native/test_sources.py
+++ b/tests/sentry/lang/native/test_sources.py
@@ -116,6 +116,10 @@ class TestGcpBearerAuthentication:
     @patch("sentry.lang.native.sources.get_gcp_token")
     @django_db_all
     def test_mixed_sources(self, mock_get_gcp_token, default_project):
+        """
+        Tests the combination of sources where one uses credentials for authentication and the other one
+        uses pre-fetched token.
+        """
         mock_get_gcp_token.return_value = "ya29.TOKEN"
         features = {
             "organizations:symbol-sources": True,


### PR DESCRIPTION
This PR changes the order of operations for obtaining GCP token. Instead of attempting to fetch it in all cases, it will only try to obtain it if no `private_key` is defined.
This way we can ensure that previously configured projects work as before without having to unnecessary attempt to fetch the token.
By restoring the old behaviour for sources with `client_email` and `private_key`, it allows us to remove the feature flag.