### PR TITLE
feat(tempest): Dynamically fetch ip addresses

### DIFF
--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -4,9 +4,11 @@ import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
 import {Button} from 'sentry/components/core/button';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeInteger} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -14,6 +16,20 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 export default function EmptyState() {
   const navigate = useNavigate();
   const location = useLocation();
+
+  const {data: ipAddresses, isPending} = useApiQuery<string>(
+    [
+      '/tempest-ips/',
+      {
+        headers: {
+          Accept: 'text/html, text/plain, */*',
+        },
+      },
+    ],
+    {
+      staleTime: Infinity,
+    }
+  );
 
   return (
     <div>
@@ -57,20 +73,13 @@ export default function EmptyState() {
                 {t(
                   'Allow list our Outbound IP addresses as they will be the once used for making the requests using the provided credentials'
                 )}
-                <CodeSnippetWrapper>
-                  <OnboardingCodeSnippet>
-                    {`
-35.184.238.160/32
-104.155.159.182/32
-104.155.149.19/32
-130.211.230.102/32
-34.141.31.19/32
-34.141.4.162/32
-35.234.78.236/32
-213.164.1.114
-                    `}
-                  </OnboardingCodeSnippet>
-                </CodeSnippetWrapper>
+                {isPending ? (
+                  <LoadingIndicator size={16} />
+                ) : (
+                  <CodeSnippetWrapper>
+                    <OnboardingCodeSnippet>{ipAddresses || ''}</OnboardingCodeSnippet>
+                  </CodeSnippetWrapper>
+                )}
               </DescriptionWrapper>
 
               <GuidedSteps.StepButtons />
@@ -84,11 +93,11 @@ export default function EmptyState() {
               <DescriptionWrapper>
                 <p>
                   {t(
-                    'You can toggle “Attach Dumps” in which case Sentry will add the prosperodumps as an attachment to the issues.'
+                    'You can toggle "Attach Dumps" in which case Sentry will add the prosperodumps as an attachment to the issues.'
                   )}
                   <br />
                   {t(
-                    'You can toggle “Attach Screenshots” in which case Sentry will add the crash screenshot, if available, as an attachment to the issues. These screenshots are not PII stripped.'
+                    'You can toggle "Attach Screenshots" in which case Sentry will add the crash screenshot, if available, as an attachment to the issues. These screenshots are not PII stripped.'
                   )}
                 </p>
                 <p>


### PR DESCRIPTION
So far outbound ip addresses were hardcoded on the frontend, which means that for every change we would need to re-deploy the whole UI.

Now we fetch it dynamically from the API as a single source of truth 

Closes [TET-570: PlayStation onboarding: Use IP address endpoint to populate the onboarding instructions](https://linear.app/getsentry/issue/TET-570/playstation-onboarding-use-ip-address-endpoint-to-populate-the)