### PR TITLE
Add total allocated bytes to MemoryInfoContext

### DIFF
--- a/static/app/components/events/contexts/knownContext/memoryInfo.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/memoryInfo.spec.tsx
@@ -8,7 +8,6 @@ import {getMemoryInfoContext} from 'sentry/components/events/contexts/knownConte
 const MOCK_MEMORY_INFO_CONTEXT = {
   type: 'memory_info' as const,
   allocated_bytes: 1048576 * 1,
-  total_allocated_bytes: 1048576 * 1,
   fragmented_bytes: 1048576 * 2,
   heap_size_bytes: 1048576 * 3,
   high_memory_load_threshold_bytes: 1048576 * 4,
@@ -16,6 +15,7 @@ const MOCK_MEMORY_INFO_CONTEXT = {
   memory_load_bytes: 1048576 * 6,
   total_committed_bytes: 1048576 * 7,
   promoted_bytes: 1048576 * 8,
+  total_allocated_bytes: 1048576 * 9,
   pinned_objects_count: 150,
   pause_time_percentage: 25.5,
   index: 12,
@@ -41,7 +41,6 @@ describe('MemoryInfoContext', function () {
   it('returns values and according to the parameters', function () {
     expect(getMemoryInfoContext({data: MOCK_MEMORY_INFO_CONTEXT})).toEqual([
       {key: 'allocated_bytes', subject: 'Allocated Bytes', value: '1.0 MiB'},
-      {key: 'total_allocated_bytes', subject: 'Total Allocated Bytes', value: '1.0 MiB'},
       {key: 'fragmented_bytes', subject: 'Fragmented Bytes', value: '2.0 MiB'},
       {key: 'heap_size_bytes', subject: 'Heap Size Bytes', value: '3.0 MiB'},
       {
@@ -57,6 +56,7 @@ describe('MemoryInfoContext', function () {
       {key: 'memory_load_bytes', subject: 'Memory Load Bytes', value: '6.0 MiB'},
       {key: 'total_committed_bytes', subject: 'Total Committed Bytes', value: '7.0 MiB'},
       {key: 'promoted_bytes', subject: 'Promoted Bytes', value: '8.0 MiB'},
+      {key: 'total_allocated_bytes', subject: 'Total Allocated Bytes', value: '9.0 MiB'},
       {key: 'pinned_objects_count', subject: 'Pinned Objects Count', value: 150},
       {key: 'pause_time_percentage', subject: 'Pause Time Percentage', value: 25.5},
       {key: 'index', subject: 'Index', value: 12},

--- a/static/app/components/events/contexts/knownContext/memoryInfo.spec.tsx
+++ b/static/app/components/events/contexts/knownContext/memoryInfo.spec.tsx
@@ -8,6 +8,7 @@ import {getMemoryInfoContext} from 'sentry/components/events/contexts/knownConte
 const MOCK_MEMORY_INFO_CONTEXT = {
   type: 'memory_info' as const,
   allocated_bytes: 1048576 * 1,
+  total_allocated_bytes: 1048576 * 1,
   fragmented_bytes: 1048576 * 2,
   heap_size_bytes: 1048576 * 3,
   high_memory_load_threshold_bytes: 1048576 * 4,
@@ -40,6 +41,7 @@ describe('MemoryInfoContext', function () {
   it('returns values and according to the parameters', function () {
     expect(getMemoryInfoContext({data: MOCK_MEMORY_INFO_CONTEXT})).toEqual([
       {key: 'allocated_bytes', subject: 'Allocated Bytes', value: '1.0 MiB'},
+      {key: 'total_allocated_bytes', subject: 'Total Allocated Bytes', value: '1.0 MiB'},
       {key: 'fragmented_bytes', subject: 'Fragmented Bytes', value: '2.0 MiB'},
       {key: 'heap_size_bytes', subject: 'Heap Size Bytes', value: '3.0 MiB'},
       {

--- a/static/app/components/events/contexts/knownContext/memoryInfo.tsx
+++ b/static/app/components/events/contexts/knownContext/memoryInfo.tsx
@@ -26,6 +26,12 @@ export function getMemoryInfoContext({
           subject: t('Allocated Bytes'),
           value: data.allocated_bytes ? formatMemory(data.allocated_bytes) : undefined,
         };
+      case MemoryInfoContextKey.TOTAL_ALLOCATED_BYTES:
+        return {
+          key: ctxKey,
+          subject: t('Total Allocated Bytes'),
+          value: data.total_allocated_bytes ? formatMemory(data.total_allocated_bytes) : undefined,
+        };
       case MemoryInfoContextKey.FRAGMENTED_BYTES:
         return {
           key: ctxKey,

--- a/static/app/components/events/contexts/knownContext/memoryInfo.tsx
+++ b/static/app/components/events/contexts/knownContext/memoryInfo.tsx
@@ -30,7 +30,9 @@ export function getMemoryInfoContext({
         return {
           key: ctxKey,
           subject: t('Total Allocated Bytes'),
-          value: data.total_allocated_bytes ? formatMemory(data.total_allocated_bytes) : undefined,
+          value: data.total_allocated_bytes
+            ? formatMemory(data.total_allocated_bytes)
+            : undefined,
         };
       case MemoryInfoContextKey.FRAGMENTED_BYTES:
         return {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -548,6 +548,7 @@ export interface UnityContext {
 
 export enum MemoryInfoContextKey {
   ALLOCATED_BYTES = 'allocated_bytes',
+  TOTAL_ALLOCATED_BYTES = 'total_allocated_bytes',
   FRAGMENTED_BYTES = 'fragmented_bytes',
   HEAP_SIZE_BYTES = 'heap_size_bytes',
   HIGH_MEMORY_LOAD_THRESHOLD_BYTES = 'high_memory_load_threshold_bytes',
@@ -580,6 +581,7 @@ export interface MemoryInfoContext {
   [MemoryInfoContextKey.PAUSE_TIME_PERCENTAGE]?: number;
   [MemoryInfoContextKey.INDEX]?: number;
   [MemoryInfoContextKey.ALLOCATED_BYTES]?: number;
+  [MemoryInfoContextKey.TOTAL_ALLOCATED_BYTES]?: number;
   [MemoryInfoContextKey.FRAGMENTED_BYTES]?: number;
   [MemoryInfoContextKey.HEAP_SIZE_BYTES]?: number;
   [MemoryInfoContextKey.HIGH_MEMORY_LOAD_THRESHOLD_BYTES]?: number;


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds the `total_allocated_bytes` property added in https://github.com/getsentry/sentry-dotnet/pull/4243 to the static types.

cc @jamescrosswell

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
