### PR TITLE
🔧 chore(aci): remove `workflow_id` from `WorkflowEventData`

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -159,7 +159,6 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
 
         event_data = WorkflowEventData(
             event=test_event,
-            workflow_id=workflow.id,
         )
 
         for action_blob in actions:
@@ -168,6 +167,8 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                     [action_blob], skip_failures=False
                 )[0]
                 action.id = -1
+                # Annotate the action with the workflow id
+                setattr(action, "workflow_id", workflow.id)
             except Exception as e:
                 action_exceptions.append(str(e))
                 sentry_sdk.capture_exception(e)

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -135,22 +135,24 @@ class BaseIssueAlertHandler(ABC):
             "actions": [cls.build_rule_action_blob(action, detector.project.organization.id)],
         }
 
+        workflow_id = getattr(action, "workflow_id", None)
+
         label = detector.name
         # We need to pass the legacy rule id when the workflow-engine-ui-links feature flag is disabled
         # This is so we can build the old link to the rule
         if not features.has(
             "organizations:workflow-engine-ui-links", detector.project.organization
         ):
-            if job.workflow_id is None:
+            if workflow_id is None:
                 raise ValueError("Workflow ID is required when triggering an action")
 
             # If test event, just set the legacy rule id to -1
-            if job.workflow_id == -1:
+            if workflow_id == -1:
                 data["actions"][0]["legacy_rule_id"] = -1
             else:
                 try:
                     alert_rule_workflow = AlertRuleWorkflow.objects.get(
-                        workflow_id=job.workflow_id,
+                        workflow_id=workflow_id,
                     )
                 except AlertRuleWorkflow.DoesNotExist:
                     raise ValueError(
@@ -176,7 +178,7 @@ class BaseIssueAlertHandler(ABC):
 
         # In the new UI, we need this for to build the link to the new rule in the notification action
         else:
-            data["actions"][0]["workflow_id"] = job.workflow_id
+            data["actions"][0]["workflow_id"] = workflow_id
 
         rule = Rule(
             id=action.id,

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -107,7 +107,6 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project):
     workflow_id = -1
     workflow_event_data = WorkflowEventData(
         event=test_event,
-        workflow_id=workflow_id,
     )
 
     detector = Detector(
@@ -127,6 +126,9 @@ def test_fire_actions(actions: list[dict[str, Any]], project: Project):
             data=action_data.get("data", {}),
             config=action_data.get("config", {}),
         )
+
+        # Annotate the action with the workflow id
+        setattr(action, "workflow_id", workflow_id)
 
         # Test fire the action and collect any exceptions
         exceptions = test_fire_action(action, workflow_event_data, detector)

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -64,7 +64,6 @@ class WorkflowEventData:
     group_state: GroupState | None = None
     has_reappeared: bool | None = None
     has_escalated: bool | None = None
-    workflow_id: int | None = None
     workflow_env: Environment | None = None
 
 

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -85,9 +85,9 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
             data={"tags": "environment,user,my_tag"},
         )
         self.group, self.event, self.group_event = self.create_group_event()
-        self.event_data = WorkflowEventData(
-            event=self.group_event, workflow_env=self.environment, workflow_id=self.workflow.id
-        )
+        self.event_data = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
+
+        self.action.workflow_id = self.workflow.id
 
         class TestHandler(BaseIssueAlertHandler):
             @classmethod
@@ -112,15 +112,29 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
 
     def test_create_rule_instance_from_action_missing_workflow_id_raises_value_error(self):
         job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
+        action = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
+            data={"tags": "environment,user,my_tag"},
+        )
+
         with pytest.raises(ValueError):
-            self.handler.create_rule_instance_from_action(self.action, self.detector, job)
+            self.handler.create_rule_instance_from_action(action, self.detector, job)
 
     def test_create_rule_instance_from_action_missing_rule_raises_value_error(self):
         job = WorkflowEventData(event=self.group_event, workflow_env=self.environment)
         alert_rule = self.create_alert_rule(projects=[self.project], organization=self.organization)
         self.create_alert_rule_workflow(workflow=self.workflow, alert_rule_id=alert_rule.id)
+        action = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
+            data={"tags": "environment,user,my_tag"},
+        )
+
         with pytest.raises(ValueError):
-            self.handler.create_rule_instance_from_action(self.action, self.detector, job)
+            self.handler.create_rule_instance_from_action(action, self.detector, job)
 
     def test_create_rule_instance_from_action(self):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
@@ -180,9 +194,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
     def test_create_rule_instance_from_action_no_environment(self):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
         self.create_workflow()
-        job = WorkflowEventData(
-            event=self.group_event, workflow_env=None, workflow_id=self.workflow.id
-        )
+        job = WorkflowEventData(event=self.group_event, workflow_env=None)
         rule = self.handler.create_rule_instance_from_action(self.action, self.detector, job)
 
         assert isinstance(rule, Rule)
@@ -210,9 +222,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
     ):
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""
         self.create_workflow()
-        job = WorkflowEventData(
-            event=self.group_event, workflow_env=None, workflow_id=self.workflow.id
-        )
+        job = WorkflowEventData(event=self.group_event, workflow_env=None)
         rule = self.handler.create_rule_instance_from_action(self.action, self.detector, job)
 
         assert isinstance(rule, Rule)


### PR DESCRIPTION
continuing the work from https://github.com/getsentry/sentry/pull/92700

here, i remove the usage of `WorkflowEventData.workflow_id` and replacing it with the usage of annotating the `action` object