### PR TITLE
ref: Remove `propagate_hub` to `ThreadingIntegration`

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -490,7 +490,7 @@ def configure_sdk():
             LoggingIntegration(event_level=None, sentry_logs_level=logging.INFO),
             RustInfoIntegration(),
             RedisIntegration(),
-            ThreadingIntegration(propagate_hub=True),
+            ThreadingIntegration(),
         ],
         **sdk_options,
     )


### PR DESCRIPTION
This parameter is deprecated as of Sentry SDK 2.0.0; the default value is now `True`, so passing this parameter is no longer needed.

Split off from #92011