### PR TITLE
ref(sdk): Use top-level `get_current_scope`

### DIFF
--- a/src/sentry/cache/base.py
+++ b/src/sentry/cache/base.py
@@ -46,7 +46,7 @@ class BaseCache(local):
         if not self.is_default_cache:
             return
 
-        scope = sentry_sdk.Scope.get_current_scope()
+        scope = sentry_sdk.get_current_scope()
         # Do not set this tag if we're in the global scope (which roughly
         # equates to having a transaction).
         if scope.transaction:

--- a/src/sentry/integrations/web/organization_integration_setup.py
+++ b/src/sentry/integrations/web/organization_integration_setup.py
@@ -21,7 +21,7 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
     csrf_protect = False
 
     def handle(self, request: HttpRequest, organization, provider_id) -> HttpResponseBase:
-        scope = sentry_sdk.Scope.get_current_scope()
+        scope = sentry_sdk.get_current_scope()
         scope.set_transaction_name(f"integration.{provider_id}", source=TransactionSource.VIEW)
 
         pipeline = IntegrationPipeline(

--- a/src/sentry/scim/endpoints/utils.py
+++ b/src/sentry/scim/endpoints/utils.py
@@ -25,7 +25,7 @@ ACCEPTED_FILTERED_KEYS = ["userName", "value", "displayName"]
 
 class SCIMApiError(APIException):
     def __init__(self, detail, status_code=400):
-        transaction = sentry_sdk.Scope.get_current_scope().transaction
+        transaction = sentry_sdk.get_current_scope().transaction
         if transaction is not None:
             transaction.set_tag("http.status_code", status_code)
         super().__init__({"schemas": [SCIM_API_ERROR], "detail": detail})

--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -248,7 +248,7 @@ class ThreadedExecutor(Executor):
             priority,
             (
                 sentry_sdk.Scope.get_isolation_scope(),
-                sentry_sdk.Scope.get_current_scope(),
+                sentry_sdk.get_current_scope(),
                 callable,
                 future,
             ),

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -584,7 +584,7 @@ def check_current_scope_transaction(
     Note: Ignores scope `transaction` values with `source = "custom"`, indicating a value which has
     been set maunually.
     """
-    scope = sentry_sdk.Scope.get_current_scope()
+    scope = sentry_sdk.get_current_scope()
     transaction_from_request = get_transaction_name_from_request(request)
 
     if (

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -490,7 +490,7 @@ def configure_sdk():
             LoggingIntegration(event_level=None, sentry_logs_level=logging.INFO),
             RustInfoIntegration(),
             RedisIntegration(),
-            ThreadingIntegration(propagate_hub=True),
+            ThreadingIntegration(),
         ],
         **sdk_options,
     )

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1091,7 +1091,7 @@ def _apply_cache_and_build_results(
     use_cache: bool | None = False,
 ) -> ResultSet:
     parent_api: str = "<missing>"
-    scope = sentry_sdk.Scope.get_current_scope()
+    scope = sentry_sdk.get_current_scope()
     if scope.transaction:
         parent_api = scope.transaction.name
 
@@ -1162,7 +1162,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     [
                         (
                             sentry_sdk.Scope.get_isolation_scope(),
-                            sentry_sdk.Scope.get_current_scope(),
+                            sentry_sdk.get_current_scope(),
                             snuba_request,
                         )
                         for snuba_request in snuba_requests_list
@@ -1175,7 +1175,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                 _snuba_query(
                     (
                         sentry_sdk.Scope.get_isolation_scope(),
-                        sentry_sdk.Scope.get_current_scope(),
+                        sentry_sdk.get_current_scope(),
                         snuba_requests_list[0],
                     )
                 )

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -123,7 +123,7 @@ def _make_rpc_requests(
     partial_request = partial(
         _make_rpc_request,
         thread_isolation_scope=sentry_sdk.Scope.get_isolation_scope(),
-        thread_current_scope=sentry_sdk.Scope.get_current_scope(),
+        thread_current_scope=sentry_sdk.get_current_scope(),
     )
     response = [
         result
@@ -253,9 +253,7 @@ def _make_rpc_request(
         else thread_isolation_scope
     )
     thread_current_scope = (
-        sentry_sdk.Scope.get_current_scope()
-        if thread_current_scope is None
-        else thread_current_scope
+        sentry_sdk.get_current_scope() if thread_current_scope is None else thread_current_scope
     )
     if SNUBA_INFO:
         from google.protobuf.json_format import MessageToJson

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -216,7 +216,7 @@ class CheckScopeTransactionTest(TestCase):
         mock_scope = Scope()
         mock_scope._transaction = "/dogs/{name}/"
 
-        with patch("sentry.utils.sdk.sentry_sdk.Scope.get_current_scope", return_value=mock_scope):
+        with patch("sentry.utils.sdk.sentry_sdk.get_current_scope", return_value=mock_scope):
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             assert mismatch is None
 
@@ -225,7 +225,7 @@ class CheckScopeTransactionTest(TestCase):
         mock_scope = Scope()
         mock_scope._transaction = "/tricks/{trick_name}/"
 
-        with patch("sentry.utils.sdk.sentry_sdk.Scope.get_current_scope", return_value=mock_scope):
+        with patch("sentry.utils.sdk.sentry_sdk.get_current_scope", return_value=mock_scope):
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             assert mismatch == {
                 "scope_transaction": "/tricks/{trick_name}/",


### PR DESCRIPTION
Using `sentry_sdk.Scope.get_current_scope` has been deprecated in favor of `sentry_sdk.get_current_scope`.

Going forward, we generally would like SDK users to stick to the top-level APIs.

Split off from #92011.

Stacked on:
  - #93016

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
