### PR TITLE
ref(sdk): Migrate to `get_isolation_scope`

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -381,7 +381,7 @@ def merge_export_blobs(data_export_id, **kwargs):
 
 
 def _set_data_on_scope(data_export):
-    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
     if data_export.user_id:
         user = dict(id=data_export.user_id)
         scope.set_user(user)

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -596,7 +596,7 @@ class _RemoteSiloCall:
 
     def _raise_from_response_status_error(self, response: requests.Response) -> NoReturn:
         rpc_method = f"{self.service_name}.{self.method_name}"
-        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
         scope.set_tag("rpc_method", rpc_method)
         scope.set_tag("rpc_status_code", response.status_code)
 

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -147,7 +147,7 @@ class CompositeRuleStore:
 
         if self.MERGE_MAX_RULES < len(rules):
             set_span_attribute("discarded_rules", len(rules) - self.MERGE_MAX_RULES)
-            sentry_sdk.Scope.get_isolation_scope().set_context(
+            sentry_sdk.get_isolation_scope().set_context(
                 "clustering_rules_max",
                 {
                     "num_existing_rules": len(rules),

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -266,7 +266,7 @@ class CommitContextIntegration(ABC):
                 ),
                 extra={"organization_id": commit.organization_id, "merge_commit_sha": commit.key},
             )
-            scope = sentry_sdk.Scope.get_isolation_scope()
+            scope = sentry_sdk.get_isolation_scope()
             scope.set_tag("queue_comment_check.merge_commit_sha", commit.key)
             scope.set_tag("queue_comment_check.organization_id", commit.organization_id)
 

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -197,7 +197,7 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
                     "organization_id": repo.organization_id,
                 }
             )
-            scope = sentry_sdk.Scope.get_isolation_scope()
+            scope = sentry_sdk.get_isolation_scope()
             scope.set_tag("stacktrace_link.tried_version", False)
 
             def encode_url(url: str) -> str:

--- a/src/sentry/integrations/utils/scope.py
+++ b/src/sentry/integrations/utils/scope.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def clear_tags_and_context() -> None:
     """Clear certain tags and context since it should not be set."""
     reset_values = False
-    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     for tag in ["organization", "organization.slug"]:
         if tag in scope._tags:

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -124,7 +124,7 @@ class IntegrationClassification(BaseClassification):
 
         parser_class = self.integration_parsers.get(provider)
         if not parser_class:
-            scope = sentry_sdk.Scope.get_isolation_scope()
+            scope = sentry_sdk.get_isolation_scope()
             scope.set_tag("provider", provider)
             scope.set_tag("path", request.path)
             sentry_sdk.capture_exception(

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -79,7 +79,7 @@ def process_message(message: Message[KafkaPayload]) -> ProcessedRecordingMessage
 
 
 def commit_message(message: Message[ProcessedRecordingMessage]) -> None:
-    isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
+    isolation_scope = sentry_sdk.get_isolation_scope().fork()
     with sentry_sdk.scope.use_isolation_scope(isolation_scope):
         with sentry_sdk.start_transaction(
             name="replays.consumer.recording_buffered.commit_message",

--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -93,7 +93,7 @@ class RecordingIngestMessage:
 
 def ingest_recording(message_bytes: bytes) -> None:
     """Ingest non-chunked recording messages."""
-    isolation_scope = sentry_sdk.Scope.get_isolation_scope().fork()
+    isolation_scope = sentry_sdk.get_isolation_scope().fork()
 
     with sentry_sdk.scope.use_isolation_scope(isolation_scope):
         with sentry_sdk.start_transaction(

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -372,7 +372,7 @@ def buffered_delete_old_primary_hash(
             old_primary_hashes.add(old_primary_hash)
             reprocessing_store.add_hash(project_id, group_id, old_primary_hash)
 
-    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
     scope.set_tag("project_id", project_id)
     scope.set_tag("old_group_id", group_id)
     scope.set_tag("old_primary_hash", old_primary_hash)

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -530,7 +530,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         """
         update_role = False
 
-        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
 
         if "sentryOrgRole" in request.data and request.data["sentryOrgRole"]:
             role = request.data["sentryOrgRole"].lower()

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_authorizations.py
@@ -40,7 +40,7 @@ class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
     }
 
     def post(self, request: Request, installation: SentryAppInstallation) -> Response:
-        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
 
         scope.set_tag("organization", installation.organization_id)
         scope.set_tag("sentry_app_id", installation.sentry_app.id)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -231,7 +231,7 @@ class BaseApiClient:
         )
 
         if self.integration_type:
-            sentry_sdk.Scope.get_isolation_scope().set_tag(self.integration_type, self.name)
+            sentry_sdk.get_isolation_scope().set_tag(self.integration_type, self.name)
 
         request = Request(
             method=method.upper(),

--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -247,7 +247,7 @@ class ThreadedExecutor(Executor):
         task = PriorityTask(
             priority,
             (
-                sentry_sdk.Scope.get_isolation_scope(),
+                sentry_sdk.get_isolation_scope(),
                 sentry_sdk.get_current_scope(),
                 callable,
                 future,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1161,7 +1161,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
                     _snuba_query,
                     [
                         (
-                            sentry_sdk.Scope.get_isolation_scope(),
+                            sentry_sdk.get_isolation_scope(),
                             sentry_sdk.get_current_scope(),
                             snuba_request,
                         )
@@ -1174,7 +1174,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
             query_results = [
                 _snuba_query(
                     (
-                        sentry_sdk.Scope.get_isolation_scope(),
+                        sentry_sdk.get_isolation_scope(),
                         sentry_sdk.get_current_scope(),
                         snuba_requests_list[0],
                     )

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -122,7 +122,7 @@ def _make_rpc_requests(
     # Sets the thread parameters once so we're not doing it in the map repeatedly
     partial_request = partial(
         _make_rpc_request,
-        thread_isolation_scope=sentry_sdk.Scope.get_isolation_scope(),
+        thread_isolation_scope=sentry_sdk.get_isolation_scope(),
         thread_current_scope=sentry_sdk.get_current_scope(),
     )
     response = [
@@ -248,7 +248,7 @@ def _make_rpc_request(
     thread_current_scope: sentry_sdk.Scope | None = None,
 ) -> BaseHTTPResponse:
     thread_isolation_scope = (
-        sentry_sdk.Scope.get_isolation_scope()
+        sentry_sdk.get_isolation_scope()
         if thread_isolation_scope is None
         else thread_isolation_scope
     )

--- a/src/sentry/web/frontend/csrf_failure.py
+++ b/src/sentry/web/frontend/csrf_failure.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def view(request: HttpRequest, reason: str = "") -> HttpResponse:
     context = {"no_referer": reason == REASON_NO_REFERER}
     extras = {"reason": reason, "referer": request.META.get("HTTP_REFERER")}
-    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     # Emit a sentry request that the incoming request is rejected by the CSRF protection.
     if hasattr(request, "user") and request.user.is_authenticated:

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -108,7 +108,7 @@ def test_bind_organization_context(default_organization):
 
     bind_organization_context(default_organization)
 
-    scope = sentry_sdk.Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
     assert scope._tags["organization"] == default_organization.id
     assert scope._tags["organization.slug"] == default_organization.slug
     assert scope._contexts["organization"] == {
@@ -130,7 +130,7 @@ def test_bind_organization_context_with_callback(default_organization):
     with override_settings(SENTRY_ORGANIZATION_CONTEXT_HELPER=add_context):
         bind_organization_context(default_organization)
 
-        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
         assert scope._tags["organization.test"] == "1"
 
 
@@ -146,5 +146,5 @@ def test_bind_organization_context_with_callback_error(default_organization):
     with override_settings(SENTRY_ORGANIZATION_CONTEXT_HELPER=add_context):
         bind_organization_context(default_organization)
 
-        scope = sentry_sdk.Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
         assert scope._tags["organization"] == default_organization.id


### PR DESCRIPTION
Migrate calls of `sentry_sdk.Scope.get_isolation_scope` to `sentry_sdk.get_isolation_scope`. Calls where `Scope` is first imported and then where `Scope.get_isolation_scope` is called are left as-is; we will address those separately.

Split off from #92011.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
