### PR TITLE
fix(explore): move failure rate function down the list

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -835,7 +835,6 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.COUNT, // DO NOT RE-ORDER: the first element is used as the default
   AggregationKey.COUNT_UNIQUE,
   AggregationKey.EPM,
-  AggregationKey.FAILURE_RATE,
   AggregationKey.AVG,
   AggregationKey.P50,
   AggregationKey.P75,
@@ -846,6 +845,7 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.SUM,
   AggregationKey.MIN,
   AggregationKey.MAX,
+  AggregationKey.FAILURE_RATE,
 ];
 
 const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {


### PR DESCRIPTION
Feedback from https://github.com/getsentry/sentry/pull/92848#discussion_r2128991235
Failure rate is likely be less common then most functions, so we can move it down the list.