### PR TITLE
ci: Run `enforce-license-compliance` on all PRs

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,7 +2,6 @@ name: Enforce License Compliance
 
 on:
   pull_request:
-    branches: [master, main]
 
 jobs:
   enforce-license-compliance:


### PR DESCRIPTION
Since this action is required, but only gets triggered on PRs against `master`/`main`, stacking PRs in `sentry` becomes quite difficult since the entire CI flow needs to be rerun after the parent PR is merged.

Running the action on all PRs will solve the problem.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
