### PR TITLE
feat(screenshot): Loosen restrictions on Screenshot widget

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -24,7 +24,8 @@ export function EventTagsAndScreenshot({projectSlug, event, isShare = false}: Pr
   );
   const screenshots =
     attachments?.filter(
-      ({name}) => name.endsWith('screenshot.jpg') || name.endsWith('screenshot.png')
+      ({name}) =>
+        name.includes('screenshot') && (name.endsWith('.jpg') || name.endsWith('.png'))
     ) ?? [];
 
   if (!tags.length && (isShare || !screenshots.length)) {

--- a/static/app/components/events/eventTagsAndScreenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {useFetchEventAttachments} from 'sentry/actionCreators/events';
 import {ScreenshotDataSection} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection';
-import {SCREENSHOT_NAMES} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/utils';
 import {DataSection} from 'sentry/components/events/styles';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -24,7 +23,9 @@ export function EventTagsAndScreenshot({projectSlug, event, isShare = false}: Pr
     {enabled: !isShare}
   );
   const screenshots =
-    attachments?.filter(({name}) => SCREENSHOT_NAMES.includes(name)) ?? [];
+    attachments?.filter(
+      ({name}) => name.endsWith('screenshot.jpg') || name.endsWith('screenshot.png')
+    ) ?? [];
 
   if (!tags.length && (isShare || !screenshots.length)) {
     return null;

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/utils.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/utils.tsx
@@ -1,8 +1,0 @@
-export const SCREENSHOT_NAMES = [
-  'screenshot.jpg',
-  'screenshot.png',
-  'screenshot-1.jpg',
-  'screenshot-1.png',
-  'screenshot-2.jpg',
-  'screenshot-2.png',
-];

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -15,7 +15,6 @@ import {
 import ScreenshotModal, {
   modalCss,
 } from 'sentry/components/events/eventTagsAndScreenshot/screenshot/modal';
-import {SCREENSHOT_NAMES} from 'sentry/components/events/eventTagsAndScreenshot/screenshot/utils';
 import {getRuntimeLabelAndTooltip} from 'sentry/components/events/highlights/util';
 import {Text} from 'sentry/components/replays/virtualizedGrid/bodyCell';
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
@@ -51,7 +50,9 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
     projectSlug,
     eventId: event.id,
   });
-  const screenshot = attachments.find(({name}) => SCREENSHOT_NAMES.includes(name));
+  const screenshot = attachments.find(
+    ({name}) => name.endsWith('screenshot.jpg') || name.endsWith('screenshot.png')
+  );
   // Hide device for non-native platforms since it's mostly duplicate of the client_os or os context
   const shouldDisplayDevice =
     isMobilePlatform(projectPlatform) || isNativePlatform(projectPlatform);

--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -51,7 +51,8 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
     eventId: event.id,
   });
   const screenshot = attachments.find(
-    ({name}) => name.endsWith('screenshot.jpg') || name.endsWith('screenshot.png')
+    ({name}) =>
+      name.includes('screenshot') && (name.endsWith('.jpg') || name.endsWith('.png'))
   );
   // Hide device for non-native platforms since it's mostly duplicate of the client_os or os context
   const shouldDisplayDevice =


### PR DESCRIPTION
This expands the criteria to show the Screenshots component when at least one attachment ends with `screenshot.png` or `screenshot.jpg`.

This is a follow-up to #91602.

This widget:
<img width="164" alt="image" src="https://github.com/user-attachments/assets/37bafd95-0464-4604-b0f8-46e6479ce29a" />
