### PR TITLE
✨ feat(scm): add environment infomation to suspect commit prs

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -405,7 +405,6 @@ class GitHubPRCommentWorkflow(PRCommentWorkflow):
             [
                 self.get_merged_pr_single_issue_template(
                     title=issue.title,
-                    subtitle=self.format_comment_subtitle(issue.culprit or "unknown culprit"),
                     url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),
                     environment=self.get_environment_info(issue),
                 )

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -384,8 +384,6 @@ This pull request was deployed and Sentry observed the following issues:
 
 <sub>Did you find this useful? React with a 👍 or 👎</sub>"""
 
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url}){environment}"
-
 
 class GitHubPRCommentWorkflow(PRCommentWorkflow):
     organization_option_key = "sentry:github_pr_bot"
@@ -405,7 +403,7 @@ class GitHubPRCommentWorkflow(PRCommentWorkflow):
 
         issue_list = "\n".join(
             [
-                MERGED_PR_SINGLE_ISSUE_TEMPLATE.format(
+                self.get_merged_pr_single_issue_template(
                     title=issue.title,
                     subtitle=self.format_comment_subtitle(issue.culprit or "unknown culprit"),
                     url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -384,7 +384,7 @@ This pull request was deployed and Sentry observed the following issues:
 
 <sub>Did you find this useful? React with a 👍 or 👎</sub>"""
 
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url}){environment}"
 
 
 class GitHubPRCommentWorkflow(PRCommentWorkflow):
@@ -409,6 +409,7 @@ class GitHubPRCommentWorkflow(PRCommentWorkflow):
                     title=issue.title,
                     subtitle=self.format_comment_subtitle(issue.culprit or "unknown culprit"),
                     url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),
+                    environment=self.get_environment_info(issue),
                 )
                 for issue in issues
             ]

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -230,7 +230,7 @@ This merge request was deployed and Sentry observed the following issues:
 
 {issue_list}"""
 
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url}){environment}"
 
 
 class GitlabPRCommentWorkflow(PRCommentWorkflow):
@@ -257,6 +257,7 @@ class GitlabPRCommentWorkflow(PRCommentWorkflow):
                     title=issue.title,
                     subtitle=self.format_comment_subtitle(issue.culprit),
                     url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),
+                    environment=self.get_environment_info(issue),
                 )
                 for issue in issues
             ]

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -230,8 +230,6 @@ This merge request was deployed and Sentry observed the following issues:
 
 {issue_list}"""
 
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url}){environment}"
-
 
 class GitlabPRCommentWorkflow(PRCommentWorkflow):
     organization_option_key = "sentry:gitlab_pr_bot"
@@ -253,9 +251,9 @@ class GitlabPRCommentWorkflow(PRCommentWorkflow):
 
         issue_list = "\n".join(
             [
-                MERGED_PR_SINGLE_ISSUE_TEMPLATE.format(
+                self.get_merged_pr_single_issue_template(
                     title=issue.title,
-                    subtitle=self.format_comment_subtitle(issue.culprit),
+                    subtitle=self.format_comment_subtitle(issue.culprit or "unknown culprit"),
                     url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),
                     environment=self.get_environment_info(issue),
                 )

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -253,7 +253,6 @@ class GitlabPRCommentWorkflow(PRCommentWorkflow):
             [
                 self.get_merged_pr_single_issue_template(
                     title=issue.title,
-                    subtitle=self.format_comment_subtitle(issue.culprit or "unknown culprit"),
                     url=self.format_comment_url(issue.get_absolute_url(), self.referrer_id),
                     environment=self.get_environment_info(issue),
                 )

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -570,6 +570,18 @@ class PRCommentWorkflow(ABC):
         )
         return raw_snql_query(request, referrer=self.referrer.value)["data"]
 
+    def get_environment_info(self, issue: Group) -> str:
+        try:
+            recommended_event = issue.get_recommended_event()
+            if recommended_event:
+                environment = recommended_event.get_environment()
+                if environment and environment.name:
+                    return f" Environment: *({environment.name})*"
+        except Exception:
+            # If anything goes wrong, just continue without environment info
+            pass
+        return ""
+
 
 class OpenPRCommentWorkflow(ABC):
     def __init__(self, integration: CommitContextIntegration):

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -580,9 +580,12 @@ class PRCommentWorkflow(ABC):
                 environment = recommended_event.get_environment()
                 if environment and environment.name:
                     return f" Environment: *({environment.name})*"
-        except Exception:
+        except Exception as e:
             # If anything goes wrong, just continue without environment info
-            pass
+            logger.info(
+                "get_environment_info.no-environment",
+                extra={"issue_id": issue.id, "error": e},
+            )
         return ""
 
     @staticmethod

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -139,6 +139,9 @@ class PullRequestFile:
     patch: str
 
 
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url}){environment}"
+
+
 class CommitContextIntegration(ABC):
     """
     Base class for integrations that include commit context features: suspect commits, suspect PR comments
@@ -581,6 +584,17 @@ class PRCommentWorkflow(ABC):
             # If anything goes wrong, just continue without environment info
             pass
         return ""
+
+    @staticmethod
+    def get_merged_pr_single_issue_template(
+        title: str, subtitle: str, url: str, environment: str
+    ) -> str:
+        return MERGED_PR_SINGLE_ISSUE_TEMPLATE.format(
+            title=title,
+            subtitle=subtitle,
+            url=url,
+            environment=environment,
+        )
 
 
 class OpenPRCommentWorkflow(ABC):

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -139,7 +139,9 @@ class PullRequestFile:
     patch: str
 
 
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url}){environment}"
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = (
+    "‼️ **{title}** `{subtitle}`\n - [View Issue]({url}){environment}\n"
+)
 
 
 class CommitContextIntegration(ABC):
@@ -579,7 +581,7 @@ class PRCommentWorkflow(ABC):
             if recommended_event:
                 environment = recommended_event.get_environment()
                 if environment and environment.name:
-                    return f" Environment: *({environment.name})*"
+                    return f"\n - Environment: `{environment.name}`"
         except Exception as e:
             # If anything goes wrong, just continue without environment info
             logger.info(

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -42,6 +42,10 @@ from sentry.utils.cache import cache
 
 pytestmark = [requires_snuba]
 
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = (
+    "‼️ **{title}** `{subtitle}` \n - [View Issue]({url}){environment}\n"
+)
+
 
 class GithubCommentTestCase(IntegrationTestCase):
     provider = GitHubIntegrationProvider
@@ -369,9 +373,17 @@ class TestGetCommentBody(GithubCommentTestCase):
         expected_comment = f"""## Suspect Issues
 This pull request was deployed and Sentry observed the following issues:
 
-- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/foo/issues/{ev1.group.id}/?referrer=github-pr-bot) Environment: *(dev)*
-- ‼️ **issue 2** `issue2` [View Issue](http://testserver/organizations/foo/issues/{ev2.group.id}/?referrer=github-pr-bot)
-- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/foo/issues/{ev3.group.id}/?referrer=github-pr-bot) Environment: *(prod)*
+‼️ **issue 1** `issue1`
+ - [View Issue](http://testserver/organizations/foo/issues/{ev1.group.id}/?referrer=github-pr-bot)
+ - Environment: `dev`
+
+‼️ **issue 2** `issue2`
+ - [View Issue](http://testserver/organizations/foo/issues/{ev2.group.id}/?referrer=github-pr-bot)
+
+‼️ **issue 3** `issue3`
+ - [View Issue](http://testserver/organizations/foo/issues/{ev3.group.id}/?referrer=github-pr-bot)
+ - Environment: `prod`
+
 
 <sub>Did you find this useful? React with a 👍 or 👎</sub>"""
         assert formatted_comment == expected_comment
@@ -407,7 +419,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         github_comment_workflow(self.pr.id, self.project.id)
 
         assert (
-            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n- \\u203c\\ufe0f **{titles[0]}** `{culprits[0]}` [View Issue](http://testserver/organizations/foo/issues/{groups[0]}/?referrer=github-pr-bot)\\n- \\u203c\\ufe0f **{titles[1]}** `{culprits[1]}` [View Issue](http://testserver/organizations/foobar/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
+            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n\\u203c\\ufe0f **{titles[0]}** `{culprits[0]}` [View Issue](http://testserver/organizations/foo/issues/{groups[0]}/?referrer=github-pr-bot)\\n\\u203c\\ufe0f **{titles[1]}** `{culprits[1]}` [View Issue](http://testserver/organizations/foobar/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
             in responses.calls[0].request.body
         )
         pull_request_comment_query = PullRequestComment.objects.all()
@@ -453,7 +465,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         github_comment_workflow(self.pr.id, self.project.id)
 
         assert (
-            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n- \\u203c\\ufe0f **issue 1** `issue1` [View Issue](http://testserver/organizations/foo/issues/{groups[0]}/?referrer=github-pr-bot)\\n- \\u203c\\ufe0f **issue 2** `issue2` [View Issue](http://testserver/organizations/foobar/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
+            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n\\u203c\\ufe0f **issue 1** `issue1` [View Issue](http://testserver/organizations/foo/issues/{groups[0]}/?referrer=github-pr-bot)\\n\\u203c\\ufe0f **issue 2** `issue2` [View Issue](http://testserver/organizations/foobar/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
             in responses.calls[0].request.body
         )
         pull_request_comment.refresh_from_db()

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -338,7 +338,12 @@ class TestTop5IssuesByCount(GithubCommentTestCase, SnubaTestCase):
 class TestGetCommentBody(GithubCommentTestCase):
     def test_simple(self):
         ev1 = self.store_event(
-            data={"message": "issue 1", "culprit": "issue1", "fingerprint": ["group-1"]},
+            data={
+                "message": "issue 1",
+                "culprit": "issue1",
+                "fingerprint": ["group-1"],
+                "environment": "dev",
+            },
             project_id=self.project.id,
         )
         assert ev1.group is not None
@@ -348,7 +353,12 @@ class TestGetCommentBody(GithubCommentTestCase):
         )
         assert ev2.group is not None
         ev3 = self.store_event(
-            data={"message": "issue 3", "culprit": "issue3", "fingerprint": ["group-3"]},
+            data={
+                "message": "issue 3",
+                "culprit": "issue3",
+                "fingerprint": ["group-3"],
+                "environment": "prod",
+            },
             project_id=self.project.id,
         )
         assert ev3.group is not None
@@ -359,9 +369,9 @@ class TestGetCommentBody(GithubCommentTestCase):
         expected_comment = f"""## Suspect Issues
 This pull request was deployed and Sentry observed the following issues:
 
-- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/foo/issues/{ev1.group.id}/?referrer=github-pr-bot)
+- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/foo/issues/{ev1.group.id}/?referrer=github-pr-bot) Environment: *(dev)*
 - ‼️ **issue 2** `issue2` [View Issue](http://testserver/organizations/foo/issues/{ev2.group.id}/?referrer=github-pr-bot)
-- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/foo/issues/{ev3.group.id}/?referrer=github-pr-bot)
+- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/foo/issues/{ev3.group.id}/?referrer=github-pr-bot) Environment: *(prod)*
 
 <sub>Did you find this useful? React with a 👍 or 👎</sub>"""
         assert formatted_comment == expected_comment

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -42,10 +42,6 @@ from sentry.utils.cache import cache
 
 pytestmark = [requires_snuba]
 
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = (
-    "‼️ **{title}** `{subtitle}` \n - [View Issue]({url}){environment}\n"
-)
-
 
 class GithubCommentTestCase(IntegrationTestCase):
     provider = GitHubIntegrationProvider
@@ -373,16 +369,11 @@ class TestGetCommentBody(GithubCommentTestCase):
         expected_comment = f"""## Suspect Issues
 This pull request was deployed and Sentry observed the following issues:
 
-‼️ **issue 1** `issue1`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/?referrer=github-pr-bot)
- - Environment: `dev`
+* ‼️ [**issue 1**](http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/?referrer=github-pr-bot) in `dev`
 
-‼️ **issue 2** `issue2`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/?referrer=github-pr-bot)
+* ‼️ [**issue 2**](http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/?referrer=github-pr-bot)
 
-‼️ **issue 3** `issue3`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/?referrer=github-pr-bot)
- - Environment: `prod`
+* ‼️ [**issue 3**](http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/?referrer=github-pr-bot) in `prod`
 
 
 <sub>Did you find this useful? React with a 👍 or 👎</sub>"""
@@ -406,7 +397,6 @@ class TestCommentWorkflow(GithubCommentTestCase):
         group_objs = Group.objects.order_by("id").all()
         groups = [g.id for g in group_objs]
         titles = [g.title for g in group_objs]
-        culprits = [g.culprit for g in group_objs]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
 
         responses.add(
@@ -419,7 +409,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         github_comment_workflow(self.pr.id, self.project.id)
 
         assert (
-            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n\\u203c\\ufe0f **{titles[0]}** `{culprits[0]}`\\n - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{groups[0]}/?referrer=github-pr-bot)\\n\\n\\u203c\\ufe0f **{titles[1]}** `{culprits[1]}`\\n - [View Issue](http://testserver/organizations/{self.another_organization.slug}/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
+            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n* \\u203c\\ufe0f [**{titles[0]}**](http://testserver/organizations/foo/issues/{groups[0]}/?referrer=github-pr-bot)\\n\\n* \\u203c\\ufe0f [**{titles[1]}**](http://testserver/organizations/foobar/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
             in responses.calls[0].request.body
         )
         pull_request_comment_query = PullRequestComment.objects.all()
@@ -438,7 +428,6 @@ class TestCommentWorkflow(GithubCommentTestCase):
         group_objs = Group.objects.order_by("id").all()
         groups = [g.id for g in group_objs]
         titles = [g.title for g in group_objs]
-        culprits = [g.culprit for g in group_objs]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
         pull_request_comment = PullRequestComment.objects.create(
             external_id=1,
@@ -468,7 +457,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         github_comment_workflow(self.pr.id, self.project.id)
 
         assert (
-            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n\\u203c\\ufe0f **{titles[0]}** `{culprits[0]}`\\n - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{groups[0]}/?referrer=github-pr-bot)\\n\\n\\u203c\\ufe0f **{titles[1]}** `{culprits[1]}`\\n - [View Issue](http://testserver/organizations/{self.another_organization.slug}/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
+            f'"body": "## Suspect Issues\\nThis pull request was deployed and Sentry observed the following issues:\\n\\n* \\u203c\\ufe0f [**{titles[0]}**](http://testserver/organizations/foo/issues/{groups[0]}/?referrer=github-pr-bot)\\n\\n* \\u203c\\ufe0f [**{titles[1]}**](http://testserver/organizations/foobar/issues/{groups[1]}/?referrer=github-pr-bot)\\n\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e</sub>"'.encode()
             in responses.calls[0].request.body
         )
         pull_request_comment.refresh_from_db()

--- a/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
@@ -330,9 +330,9 @@ class TestGetCommentBody(GitlabCommentTestCase):
         expected_comment = f"""## Suspect Issues
 This merge request was deployed and Sentry observed the following issues:
 
-- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/baz/issues/{ev1.group.id}/?referrer=gitlab-pr-bot) Environment: *(dev)*
+- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/baz/issues/{ev1.group.id}/?referrer=gitlab-pr-bot) Environment: `dev`
 - ‼️ **issue 2** `issue2` [View Issue](http://testserver/organizations/baz/issues/{ev2.group.id}/?referrer=gitlab-pr-bot)
-- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/baz/issues/{ev3.group.id}/?referrer=gitlab-pr-bot) Environment: *(prod)*"""
+- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/baz/issues/{ev3.group.id}/?referrer=gitlab-pr-bot) Environment: `prod`"""
         assert formatted_comment == expected_comment
 
 

--- a/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
@@ -299,7 +299,12 @@ class TestTop5IssuesByCount(SnubaTestCase, GitlabCommentTestCase):
 class TestGetCommentBody(GitlabCommentTestCase):
     def test_simple(self):
         ev1 = self.store_event(
-            data={"message": "issue 1", "culprit": "issue1", "fingerprint": ["group-1"]},
+            data={
+                "message": "issue 1",
+                "culprit": "issue1",
+                "fingerprint": ["group-1"],
+                "environment": "dev",
+            },
             project_id=self.project.id,
         )
         assert ev1.group is not None
@@ -309,7 +314,12 @@ class TestGetCommentBody(GitlabCommentTestCase):
         )
         assert ev2.group is not None
         ev3 = self.store_event(
-            data={"message": "issue 3", "culprit": "issue3", "fingerprint": ["group-3"]},
+            data={
+                "message": "issue 3",
+                "culprit": "issue3",
+                "fingerprint": ["group-3"],
+                "environment": "prod",
+            },
             project_id=self.project.id,
         )
         assert ev3.group is not None
@@ -320,9 +330,9 @@ class TestGetCommentBody(GitlabCommentTestCase):
         expected_comment = f"""## Suspect Issues
 This merge request was deployed and Sentry observed the following issues:
 
-- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/baz/issues/{ev1.group.id}/?referrer=gitlab-pr-bot)
+- ‼️ **issue 1** `issue1` [View Issue](http://testserver/organizations/baz/issues/{ev1.group.id}/?referrer=gitlab-pr-bot) Environment: *(dev)*
 - ‼️ **issue 2** `issue2` [View Issue](http://testserver/organizations/baz/issues/{ev2.group.id}/?referrer=gitlab-pr-bot)
-- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/baz/issues/{ev3.group.id}/?referrer=gitlab-pr-bot)"""
+- ‼️ **issue 3** `issue3` [View Issue](http://testserver/organizations/baz/issues/{ev3.group.id}/?referrer=gitlab-pr-bot) Environment: *(prod)*"""
         assert formatted_comment == expected_comment
 
 

--- a/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
@@ -330,16 +330,11 @@ class TestGetCommentBody(GitlabCommentTestCase):
         expected_comment = f"""## Suspect Issues
 This merge request was deployed and Sentry observed the following issues:
 
-‼️ **{ev1.group.title}** `{ev1.group.culprit}`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/?referrer=gitlab-pr-bot)
- - Environment: `dev`
+* ‼️ [**{ev1.group.title}**](http://testserver/organizations/{self.organization.slug}/issues/{ev1.group.id}/?referrer=gitlab-pr-bot) in `dev`
 
-‼️ **{ev2.group.title}** `{ev2.group.culprit}`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/?referrer=gitlab-pr-bot)
+* ‼️ [**{ev2.group.title}**](http://testserver/organizations/{self.organization.slug}/issues/{ev2.group.id}/?referrer=gitlab-pr-bot)
 
-‼️ **{ev3.group.title}** `{ev3.group.culprit}`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/?referrer=gitlab-pr-bot)
- - Environment: `prod`
+* ‼️ [**{ev3.group.title}**](http://testserver/organizations/{self.organization.slug}/issues/{ev3.group.id}/?referrer=gitlab-pr-bot) in `prod`
 """
         assert formatted_comment == expected_comment
 
@@ -361,7 +356,6 @@ class TestCommentWorkflow(GitlabCommentTestCase):
         group_objs = Group.objects.order_by("id").all()
         groups = [g.id for g in group_objs]
         titles = [g.title for g in group_objs]
-        culprits = [g.culprit for g in group_objs]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
 
         responses.add(
@@ -378,11 +372,9 @@ class TestCommentWorkflow(GitlabCommentTestCase):
 ## Suspect Issues
 This merge request was deployed and Sentry observed the following issues:
 
-‼️ **{titles[0]}** `{culprits[0]}`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{groups[0]}/?referrer=gitlab-pr-bot)
+* ‼️ [**{titles[0]}**](http://testserver/organizations/{self.organization.slug}/issues/{groups[0]}/?referrer=gitlab-pr-bot)
 
-‼️ **{titles[1]}** `{culprits[1]}`
- - [View Issue](http://testserver/organizations/{self.another_organization.slug}/issues/{groups[1]}/?referrer=gitlab-pr-bot)
+* ‼️ [**{titles[1]}**](http://testserver/organizations/{self.another_organization.slug}/issues/{groups[1]}/?referrer=gitlab-pr-bot)
 """
         }
 
@@ -402,7 +394,6 @@ This merge request was deployed and Sentry observed the following issues:
         group_objs = Group.objects.order_by("id").all()
         groups = [g.id for g in group_objs]
         titles = [g.title for g in group_objs]
-        culprits = [g.culprit for g in group_objs]
         mock_issues.return_value = [{"group_id": id, "event_count": 10} for id in groups]
         pull_request_comment = PullRequestComment.objects.create(
             external_id=1,
@@ -436,11 +427,9 @@ This merge request was deployed and Sentry observed the following issues:
 ## Suspect Issues
 This merge request was deployed and Sentry observed the following issues:
 
-‼️ **{titles[0]}** `{culprits[0]}`
- - [View Issue](http://testserver/organizations/{self.organization.slug}/issues/{groups[0]}/?referrer=gitlab-pr-bot)
+* ‼️ [**{titles[0]}**](http://testserver/organizations/{self.organization.slug}/issues/{groups[0]}/?referrer=gitlab-pr-bot)
 
-‼️ **{titles[1]}** `{culprits[1]}`
- - [View Issue](http://testserver/organizations/{self.another_organization.slug}/issues/{groups[1]}/?referrer=gitlab-pr-bot)
+* ‼️ [**{titles[1]}**](http://testserver/organizations/{self.another_organization.slug}/issues/{groups[1]}/?referrer=gitlab-pr-bot)
 """
         }
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/cdc9e712-ed04-478e-8762-e2548825315b)




This pr adds environment information to pr comments. 

there isn't a clean way to fetch the environment for a group since there can be many environments associated for a group, but when we open the issue details page, it defaults to opening the `recommended_event` (which will also be the `latest_event` for low frequency groups. 

this made it an ideal candidate to grab the event for, then fetch its environment and show it in the pr comment. this should address the main pain point since errors in dev will be relatively new and be the recommended event

closes ECO-94