### PR TITLE
fix(span-buffer): Do not use fork

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+import multiprocessing.context
 import threading
 import time
 from collections.abc import Callable
@@ -64,10 +65,10 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         # the restart, however.
         self.healthy_since.value = int(time.time())
 
-        make_process: Callable[..., multiprocessing.Process | threading.Thread]
+        make_process: Callable[..., multiprocessing.context.SpawnProcess | threading.Thread]
         if self.produce_to_pipe is None:
             initializer = _get_arroyo_subprocess_initializer(None)
-            make_process = multiprocessing.Process
+            make_process = multiprocessing.get_context("spawn").Process
         else:
             initializer = None
             make_process = threading.Thread


### PR DESCRIPTION

I was under the perception that Process used spawn on POSIX by default.
Apparently only on MacOS.

INC-1195