### PR TITLE
feat(insights): update series name when creating alert from published/processed chart

### DIFF
--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -54,6 +54,7 @@ export interface InsightsTimeSeriesWidgetProps
   visualizationType: 'line' | 'area' | 'bar';
   aliases?: Record<string, string>;
   description?: React.ReactNode;
+  extraActions?: React.ReactNode[];
   extraPlottables?: Plottable[];
   height?: string | number;
   interactiveTitle?: () => React.ReactNode;
@@ -69,6 +70,7 @@ export interface InsightsTimeSeriesWidgetProps
     groupBy?: SpanFields[];
     yAxis?: string[];
   };
+
   samples?: Samples;
   showLegend?: TimeSeriesWidgetVisualizationProps['showLegend'];
   showReleaseAs?: 'line' | 'bubble' | 'none';
@@ -204,6 +206,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
             {props.description && (
               <Widget.WidgetDescription description={props.description} />
             )}
+            {props.extraActions}
             {hasChartActionsEnabled && (
               <ChartActionDropdown
                 chartType={chartType}

--- a/static/app/views/insights/common/utils/useAlertsProject.tsx
+++ b/static/app/views/insights/common/utils/useAlertsProject.tsx
@@ -1,0 +1,18 @@
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+
+/**
+ * Alerts only support one project at a time, so we need to determine which project to use
+ * @returns
+ */
+export function useAlertsProject() {
+  const {projects} = useProjects();
+  const {selection} = usePageFilters();
+
+  const project =
+    projects.length === 1
+      ? projects[0]
+      : projects.find(p => p.id === `${selection.projects[0]}`);
+
+  return project;
+}

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -3,12 +3,21 @@ import {useTheme} from '@emotion/react';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {BaseChartActionDropdown} from 'sentry/views/insights/common/components/chartActionDropdown';
 // Our loadable chart widgets use this to render, so this import is ok
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {useTopNSpanMetricsSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {renameDiscoverSeries} from 'sentry/views/insights/common/utils/renameDiscoverSeries';
+import {useAlertsProject} from 'sentry/views/insights/common/utils/useAlertsProject';
 import type {Referrer} from 'sentry/views/insights/queues/referrers';
 import {FIELD_ALIASES} from 'sentry/views/insights/queues/settings';
 import type {SpanQueryFilters} from 'sentry/views/insights/types';
@@ -24,11 +33,16 @@ interface Props {
 
 export function ThroughputChart({id, error, destination, pageFilters, referrer}: Props) {
   const theme = useTheme();
+  const organization = useOrganization();
+  const project = useAlertsProject();
+  const {selection} = usePageFilters();
 
   const search = MutableSearch.fromQueryObject({
     'span.op': '[queue.publish, queue.process]',
   } satisfies SpanQueryFilters);
   const groupBy = SpanFields.SPAN_OP;
+  const yAxis = 'epm()';
+  const title = t('Published vs Processed');
 
   if (destination) {
     search.addFilterValue('messaging.destination.name', destination, false);
@@ -41,8 +55,8 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
   } = useTopNSpanMetricsSeries(
     {
       search,
-      yAxis: ['epm()'],
-      fields: ['epm()', groupBy],
+      yAxis: [yAxis],
+      fields: [yAxis, groupBy],
       topN: 2,
       transformAliasToInputFormat: true,
     },
@@ -60,11 +74,59 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
 
   const colors = theme.chart.getColorPalette(2);
 
+  const exploreUrl = getExploreUrl({
+    organization,
+    visualize: [
+      {
+        chartType: ChartType.LINE,
+        yAxes: [yAxis],
+      },
+    ],
+    mode: Mode.AGGREGATE,
+    title,
+    query: search?.formatString(),
+    sort: undefined,
+    groupBy: [groupBy],
+  });
+
+  const extraActions = [
+    <BaseChartActionDropdown
+      key="throughput-chart-action"
+      alertMenuOptions={[
+        {
+          key: 'publish',
+          label: FIELD_ALIASES['epm() span.op:queue.publish'],
+          to: getAlertsUrl({
+            project,
+            query: 'span.op:queue.publish',
+            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+            pageFilters: selection,
+            aggregate: yAxis,
+            organization,
+          }),
+        },
+        {
+          key: 'process',
+          label: FIELD_ALIASES['epm() span.op:queue.process'],
+          to: getAlertsUrl({
+            project,
+            query: 'span.op:queue.process',
+            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+            pageFilters: selection,
+            aggregate: yAxis,
+            organization,
+          }),
+        },
+      ]}
+      exploreUrl={exploreUrl}
+    />,
+  ];
+
   return (
     <InsightsLineChartWidget
       id={id}
-      queryInfo={{search, groupBy: [groupBy]}}
-      title={t('Published vs Processed')}
+      extraActions={extraActions}
+      title={title}
       series={[
         renameDiscoverSeries(
           {


### PR DESCRIPTION
Updates the `Create Alert For` dropdown for the `published vs processed` chart to match the series names and have option for both processed and published

This chart performed a unique query (uses topN on a single `yAxis`), which makes it harder to just pass in the series into the chart and it automatically determines the alerts url. To solve this
1. Created a `BaseChartActionDropdown` which accepts the raw alert urls to work in this case.
2.  Added a `extraActions` prop to the insights chart to handle more specialized cases like this
3. Create a `getAlertsProject` which returns a single project to alert on based on the global selection. Alerts have to have a single project selected (rn this just selects the first selected, but we could make this smarter based on what project has data for the current module)

Before
<img width="694" alt="image" src="https://github.com/user-attachments/assets/66e265ba-81c1-4128-8af9-d581590ceea3" />

After
<img width="602" alt="image" src="https://github.com/user-attachments/assets/3921d95a-c73f-4552-9a30-824f449b608e" />
