### PR TITLE
feat(billing): Add Seer copy to on-demand modal

### DIFF
--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -168,6 +168,13 @@ class OnDemandBudgetEdit extends Component<Props> {
             organization={organization}
             subscription={subscription}
           />
+          <Alert.Container>
+            <Alert type="warning" showIcon>
+              {t(
+                "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
+              )}
+            </Alert>
+          </Alert.Container>
         </InputFields>
       );
     }
@@ -278,13 +285,6 @@ class OnDemandBudgetEdit extends Component<Props> {
                     )}
                   </Description>
                   {this.renderInputFields(OnDemandBudgetMode.PER_CATEGORY)}
-                  <Alert.Container>
-                    <Alert type="warning" showIcon>
-                      {t(
-                        "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
-                      )}
-                    </Alert>
-                  </Alert.Container>
                 </BudgetDetails>
               </BudgetContainer>
             </div>

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -168,13 +168,15 @@ class OnDemandBudgetEdit extends Component<Props> {
             organization={organization}
             subscription={subscription}
           />
-          <Alert.Container>
-            <Alert type="warning" showIcon>
-              {t(
-                "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
-              )}
-            </Alert>
-          </Alert.Container>
+          {organization.features.includes('seer-billing') && (
+            <Alert.Container>
+              <Alert type="warning" showIcon>
+                {t(
+                  "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
+                )}
+              </Alert>
+            </Alert.Container>
+          )}
         </InputFields>
       );
     }

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -1,8 +1,8 @@
-import {Component, Fragment} from 'react';
+import React, {Component, Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import Color from 'color';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Input} from 'sentry/components/core/input';
 import {Radio} from 'sentry/components/core/radio';
@@ -10,7 +10,6 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelItem from 'sentry/components/panels/panelItem';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
-import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategoryExact} from 'sentry/types/core';
@@ -279,12 +278,13 @@ class OnDemandBudgetEdit extends Component<Props> {
                     )}
                   </Description>
                   {this.renderInputFields(OnDemandBudgetMode.PER_CATEGORY)}
-                  <SeerUsageNote>
-                    <IconWarning size="sm" />
-                    {t(
-                      "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
-                    )}
-                  </SeerUsageNote>
+                  <Alert.Container>
+                    <Alert type="warning" showIcon>
+                      {t(
+                        "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
+                      )}
+                    </Alert>
+                  </Alert.Container>
                 </BudgetDetails>
               </BudgetContainer>
             </div>
@@ -388,15 +388,6 @@ const InputDiv = styled('div')`
   gap: ${space(0.5)};
   align-items: center;
   padding: ${space(1)} 0;
-`;
-
-const SeerUsageNote = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
-  margin-top: ${space(1)};
-  padding: ${space(1)};
-  border-radius: ${p => p.theme.borderRadius};
-  background: ${p => Color(p.theme.yellow100).alpha(0.05).toString()};
 `;
 
 export default OnDemandBudgetEdit;

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -1,6 +1,7 @@
 import {Component, Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import Color from 'color';
 
 import {Tag} from 'sentry/components/core/badge/tag';
 import {Input} from 'sentry/components/core/input';
@@ -9,6 +10,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelItem from 'sentry/components/panels/panelItem';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
+import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DataCategoryExact} from 'sentry/types/core';
@@ -277,6 +279,12 @@ class OnDemandBudgetEdit extends Component<Props> {
                     )}
                   </Description>
                   {this.renderInputFields(OnDemandBudgetMode.PER_CATEGORY)}
+                  <SeerUsageNote>
+                    <IconWarning size="sm" />
+                    {t(
+                      "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
+                    )}
+                  </SeerUsageNote>
                 </BudgetDetails>
               </BudgetContainer>
             </div>
@@ -380,6 +388,15 @@ const InputDiv = styled('div')`
   gap: ${space(0.5)};
   align-items: center;
   padding: ${space(1)} 0;
+`;
+
+const SeerUsageNote = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  margin-top: ${space(1)};
+  padding: ${space(1)};
+  border-radius: ${p => p.theme.borderRadius};
+  background: ${p => Color(p.theme.yellow100).alpha(0.05).toString()};
 `;
 
 export default OnDemandBudgetEdit;

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -1,4 +1,4 @@
-import React, {Component, Fragment} from 'react';
+import {Component, Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -606,7 +606,7 @@ describe('OnDemandBudgets', () => {
     ).toBeInTheDocument();
   });
 
-  it('always displays warning alert in per-category section', () => {
+  it('always displays Seer warning alert in per-category section', () => {
     const subscription = SubscriptionFixture({
       plan: 'am1_business',
       planTier: PlanTier.AM1,
@@ -673,60 +673,5 @@ describe('OnDemandBudgets', () => {
         "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
       )
     ).toBeInTheDocument();
-  });
-
-  it('does not display warning alert for pay-as-you-go plans', () => {
-    const subscription = SubscriptionFixture({
-      plan: 'am3_business',
-      planTier: PlanTier.AM3,
-      isFree: false,
-      isTrial: false,
-      supportsOnDemand: true,
-      planDetails: {
-        ...PlanDetailsLookupFixture('am3_business')!,
-        budgetTerm: 'pay-as-you-go',
-      },
-      organization,
-      onDemandBudgets: {
-        enabled: true,
-        budgetMode: OnDemandBudgetMode.SHARED,
-        sharedMaxBudget: 5000,
-        onDemandSpendUsed: 0,
-      },
-    });
-
-    const activePlan = subscription.planDetails;
-
-    const onDemandBudget = {
-      budgetMode: OnDemandBudgetMode.SHARED as const,
-      sharedMaxBudget: 5000,
-    };
-
-    render(
-      <OnDemandBudgetEdit
-        {...defaultProps}
-        subscription={subscription}
-        activePlan={activePlan}
-        onDemandBudget={onDemandBudget}
-      />
-    );
-
-    // Check that the warning alert is NOT displayed for pay-as-you-go plans
-    expect(
-      screen.queryByText(
-        "Additional Seer usage is only available through a shared on-demand budget. To ensure you'll have access to additional Seer usage, set up a shared on-demand budget instead."
-      )
-    ).not.toBeInTheDocument();
-
-    // Verify that pay-as-you-go UI is rendered instead
-    expect(
-      screen.getByText(
-        /This budget ensures continued monitoring after you've used up your reserved event volume/
-      )
-    ).toBeInTheDocument();
-
-    // Verify that the radio buttons are NOT displayed (different UI for pay-as-you-go)
-    expect(screen.queryByTestId('shared-budget-radio')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('per-category-budget-radio')).not.toBeInTheDocument();
   });
 });

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgets.spec.tsx
@@ -607,6 +607,7 @@ describe('OnDemandBudgets', () => {
   });
 
   it('always displays Seer warning alert in per-category section', () => {
+    organization.features = ['seer-billing'];
     const subscription = SubscriptionFixture({
       plan: 'am1_business',
       planTier: PlanTier.AM1,


### PR DESCRIPTION
Closes: https://linear.app/getsentry/issue/BIL-869/copy-for-per-category-od-modal

Displays a warning message describing the on-demand budget limitations for to the Seer product suite.

**Expanded view**

<img width="642" alt="Screenshot 2025-06-09 at 12 33 13 PM" src="https://github.com/user-attachments/assets/ca686f6e-7600-46ae-81f3-d483f02a8a8c" />

