### PR TITLE
Streamline Uptime Monitor Creation

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -126,7 +126,8 @@ function Create(props: Props) {
       : 'issues';
   }
 
-  const title = t('New Alert Rule');
+  const title =
+    alertType === AlertRuleType.UPTIME ? t('Create Uptime Monitor') : t('New Alert Rule');
 
   return (
     <Fragment>


### PR DESCRIPTION
Uptime Monitor are created as an alert type. But the creation process is unique from a UI POV. This PR just updates a few things to hopefully make it easier for more users to create additional uptime monitors.

- Title: New Alert Rule -> Create Uptime Monitor
- default env selection when only one
- have use URL and metho, move the rest below in some small font advanced config collapsed panel
- establish ownership: let's remove clicks so they can click create rule
  - suggest a name, similar to what we do for projects

*assist from cursor*

![image](https://github.com/user-attachments/assets/d81adc9d-292c-4ad8-99cb-56ffdb5f143b)
