### PR TITLE
fix(crons/uptime): Reset cursor on zoom on details pages

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -151,6 +151,10 @@ interface GridLineOverlayProps {
    */
   labelPosition?: LabelPosition;
   /**
+   * Resets pagination cursor when zooming the timeline.
+   */
+  resetPaginationOnZoom?: boolean;
+  /**
    * Enable the timeline cursor
    */
   showCursor?: boolean;
@@ -169,6 +173,7 @@ export function GridLineOverlay({
   allowZoom,
   className,
   labelPosition = 'left-top',
+  resetPaginationOnZoom,
 }: GridLineOverlayProps) {
   const router = useRouter();
   const {periodStart, timelineWidth, dateLabelFormat, rollupConfig} = timeWindowConfig;
@@ -197,9 +202,9 @@ export function GridLineOverlay({
           end: dateFromPosition(endX).add(1, 'minute').startOf('minute').toDate(),
         },
         router,
-        {keepCursor: true}
+        {keepCursor: !resetPaginationOnZoom}
       ),
-    [dateFromPosition, router]
+    [dateFromPosition, resetPaginationOnZoom, router]
   );
 
   const {

--- a/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
@@ -45,7 +45,12 @@ export function DetailsTimeline({uptimeRule, onStatsLoaded}: Props) {
       <Header>
         <GridLineLabels timeWindowConfig={timeWindowConfig} />
       </Header>
-      <AlignedGridLineOverlay allowZoom showCursor timeWindowConfig={timeWindowConfig} />
+      <AlignedGridLineOverlay
+        allowZoom
+        resetPaginationOnZoom
+        showCursor
+        timeWindowConfig={timeWindowConfig}
+      />
       <OverviewRow
         uptimeRule={uptimeRule}
         timeWindowConfig={timeWindowConfig}

--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -120,6 +120,7 @@ export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
       <AlignedGridLineOverlay
         allowZoom
         showCursor
+        resetPaginationOnZoom
         timeWindowConfig={timeWindowConfig}
         additionalUi={<CronServiceIncidents timeWindowConfig={timeWindowConfig} />}
       />


### PR DESCRIPTION
Fixes: [RTC-1000: Zooming on cron timeline does not reset paging cursor on details page](https://linear.app/getsentry/issue/RTC-1000/zooming-on-cron-timeline-does-not-reset-paging-cursor-on-details-page)