### PR TITLE
fix(debug-symbols): Do not require private keys when editing source

### DIFF
--- a/static/app/components/modals/debugFileCustomRepository/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/utils.tsx
@@ -127,7 +127,7 @@ export function getFormFieldsAndInitialData(
           {
             name: 'secret_key',
             type: 'string',
-            required: true,
+            required: !secret_key,
             label: t('Secret Access Key'),
             placeholder:
               typeof secret_key === 'object'
@@ -173,7 +173,8 @@ export function getFormFieldsAndInitialData(
           {
             name: 'private_key',
             type: 'string',
-            required: true,
+            // Private key is only required if it's not already set
+            required: !private_key,
             multiline: true,
             autosize: true,
             maxRows: 5,


### PR DESCRIPTION
After 069d35fb74d7f10a87657b15e36bd1fdf453ca70 private keys and secrets
in the debug symbol custom repos were no longer returned as part of the
API responses. When editing the repos though, the form still required
you to fill them out.

This only requires them when not editing existing repos.

Fixes: [RTC-808: Replacing Private Key is mandatory when editing custom repositories.](https://linear.app/getsentry/issue/RTC-808/replacing-private-key-is-mandatory-when-editing-custom-repositories)
Fixes: https://github.com/getsentry/sentry/issues/90663