### PR TITLE
fix(detectors): Add extra condition to sql injection detector 

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
@@ -18,7 +18,10 @@
   "request": {
     "url": "http://localhost:3001/vulnerable-login",
     "method": "GET",
-    "query_string": [["username", "hello"]]
+    "query_string": [
+      ["username", "hello"],
+      ["sort", "username"]
+    ]
   },
   "spans": [
     {
@@ -138,13 +141,13 @@
       "parent_span_id": "91fa92ff0205967d",
       "trace_id": "375a86eca09a4a4e91903838dd771f50",
       "status": "ok",
-      "description": "SELECT * FROM users WHERE username = 'hello'",
+      "description": "SELECT * FROM users WHERE username = 'hello' ORDER BY username ASC",
       "origin": "auto.db.otel.mysql2",
       "data": {
         "db.system": "mysql",
         "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",
         "db.name": "injection_test",
-        "db.statement": "SELECT * FROM users WHERE username = 'hello'",
+        "db.statement": "SELECT * FROM users WHERE username = 'hello' ORDER BY username ASC",
         "db.user": "root",
         "net.peer.name": "localhost",
         "net.peer.port": 3306,

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -105,7 +105,7 @@ class SQLInjectionDetector(PerformanceDetector):
         for parameter in self.request_parameters:
             value = parameter[1]
             key = parameter[0]
-            if value in description:
+            if key in description and value in description:
                 description = description.replace(value, "?")
                 vulnerable_parameters.append(key)
 
@@ -128,7 +128,7 @@ class SQLInjectionDetector(PerformanceDetector):
                 "parent_span_ids": [],
                 "offender_span_ids": spans_involved,
                 "transaction_name": self._event.get("transaction", ""),
-                "vulnerable_parameters": vulnerable_parameters,
+                "vulnerable_parameters": list(set(vulnerable_parameters)),
                 "request_url": self.request_url,
             },
             evidence_display=[

--- a/tests/sentry/utils/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/utils/performance_issues/test_sql_injection_detector.py
@@ -33,9 +33,9 @@ class SQLInjectionDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
         assert problem.type == DBQueryInjectionVulnerabilityGroupType
-        assert problem.fingerprint == "1-1020-841b1fd77bae6e89b3570a2ab0bf43d3c8cfbac6"
+        assert problem.fingerprint == "1-1020-d9460b7b6c17b64a51f0390b53390cb1b4c39662"
         assert problem.op == "db"
-        assert problem.desc == "SELECT * FROM users WHERE username = '?'"
+        assert problem.desc == "SELECT * FROM users WHERE username = '?' ORDER BY username ASC"
         assert problem.evidence_data is not None
         assert problem.evidence_data["vulnerable_parameters"] == ["username"]
         assert problem.evidence_data["request_url"] == "http://localhost:3001/vulnerable-login"


### PR DESCRIPTION
this pr adds an extra condition to check to see if the key of the query param/body is in the description. `sort` was a pretty common false positive appearing in our org's requests because it would find a column name that was being sorted by.

also updates the vulnerable parameters to not show repeats. 