### PR TITLE
fix(release-health): Convert project IDs to slugs

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -91,6 +91,7 @@ import {
 } from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import type {GenericWidgetQueriesChildrenProps} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import IssueWidgetQueries from 'sentry/views/dashboards/widgetCard/issueWidgetQueries';
+import type {ReleaseWidgetQueriesProps} from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
 import ReleaseWidgetQueries from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import WidgetQueries from 'sentry/views/dashboards/widgetCard/widgetQueries';
@@ -627,7 +628,7 @@ function WidgetViewerModal(props: Props) {
     );
   };
 
-  const renderReleaseTable: ReleaseWidgetQueries['props']['children'] = ({
+  const renderReleaseTable: ReleaseWidgetQueriesProps['children'] = ({
     tableResults,
     loading,
     pageLinks,

--- a/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
@@ -64,7 +64,6 @@ export const FIELD_TO_METRICS_EXPRESSION = {
   'crash_free_rate(user)': SessionMetric.USER_CRASH_FREE_RATE,
   'crash_rate(session)': SessionMetric.SESSION_CRASH_RATE,
   'crash_rate(user)': SessionMetric.USER_CRASH_RATE,
-  project: 'project_id',
 };
 
 export const METRICS_EXPRESSION_TO_FIELD = invert(FIELD_TO_METRICS_EXPRESSION);

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -37,7 +37,7 @@ import type {
 } from './genericWidgetQueries';
 import GenericWidgetQueries from './genericWidgetQueries';
 
-type Props = {
+export interface ReleaseWidgetQueriesProps {
   api: Client;
   children: (props: GenericWidgetQueriesChildrenProps) => React.JSX.Element;
   organization: Organization;
@@ -52,7 +52,7 @@ type Props = {
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
   }) => void;
-};
+}
 
 type State = {
   loading: boolean;
@@ -145,7 +145,7 @@ export function requiresCustomReleaseSorting(query: WidgetQuery): boolean {
   return useMetricsAPI && rawOrderby === 'release';
 }
 
-class ReleaseWidgetQueries extends Component<Props, State> {
+class ReleaseWidgetQueries extends Component<ReleaseWidgetQueriesProps, State> {
   state: State = {
     loading: false,
     errorMessage: undefined,
@@ -160,7 +160,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Readonly<Props>): void {
+  componentDidUpdate(prevProps: Readonly<ReleaseWidgetQueriesProps>): void {
     if (
       !requiresCustomReleaseSorting(prevProps.widget.queries[0]!) &&
       requiresCustomReleaseSorting(this.props.widget.queries[0]!) &&

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -316,15 +316,6 @@ class ReleaseWidgetQueries extends Component<Props, State> {
       });
     }
 
-    widget.queries.forEach(query => {
-      query.columns = query.columns.map(column => {
-        if (column === 'project_id') {
-          return 'project';
-        }
-        return column;
-      });
-    });
-
     return widget;
   };
 


### PR DESCRIPTION
This is consistent with e.g. tables when a project column is added. Other datasets handle this project name properly, it seems like only the sessions data uses the project ID when requesting projects.

We should probably patch the backend but this is an immediate fix for the feedback.

Before (notice the ID in the legend and tooltip):
<img width="1065" alt="Screenshot 2025-06-06 at 3 52 54 PM" src="https://github.com/user-attachments/assets/f380b05d-e147-4b2d-9955-48f75b2eaeb7" />

After:
<img width="971" alt="Screenshot 2025-06-06 at 3 53 36 PM" src="https://github.com/user-attachments/assets/48c7ba5d-c2b3-428b-a30d-e3981e5910b0" />
