### PR TITLE
fix(replay): Fix replay share at current timestamp button

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -5,7 +5,6 @@ import ArchivedReplayAlert from 'sentry/components/replays/alerts/archivedReplay
 import ReplayLoadingState from 'sentry/components/replays/player/replayLoadingState';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import type useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
-import ReplayDetailsProviders from 'sentry/views/replays/detail/body/replayDetailsProviders';
 import ReplaysLayout from 'sentry/views/replays/detail/layout';
 import ReplayDetailsError from 'sentry/views/replays/detail/replayDetailsError';
 
@@ -49,13 +48,11 @@ export default function ReplayDetailsPage({readerResult}: Props) {
       )}
     >
       {({replay}) => (
-        <ReplayDetailsProviders replay={replay} projectSlug={readerResult.projectSlug}>
-          <ReplaysLayout
-            isVideoReplay={replay.isVideoReplay()}
-            replayRecord={replay.getReplay()}
-            isLoading={false}
-          />
-        </ReplayDetailsProviders>
+        <ReplaysLayout
+          isVideoReplay={replay.isVideoReplay()}
+          replayRecord={replay.getReplay()}
+          isLoading={false}
+        />
       )}
     </ReplayLoadingState>
   );

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import FullViewport from 'sentry/components/layouts/fullViewport';
@@ -15,6 +16,7 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
+import ReplayDetailsProviders from 'sentry/views/replays/detail/body/replayDetailsProviders';
 import ReplayDetailsHeaderActions from 'sentry/views/replays/detail/header/replayDetailsHeaderActions';
 import ReplayDetailsMetadata from 'sentry/views/replays/detail/header/replayDetailsMetadata';
 import ReplayDetailsPageBreadcrumbs from 'sentry/views/replays/detail/header/replayDetailsPageBreadcrumbs';
@@ -56,16 +58,27 @@ export default function ReplayDetails({params: {replaySlug}}: Props) {
     ? `${replayRecord.user.display_name ?? t('Anonymous User')} — Session Replay — ${orgSlug}`
     : `Session Replay — ${orgSlug}`;
 
+  const content = (
+    <Fragment>
+      <Header>
+        <ReplayDetailsPageBreadcrumbs readerResult={readerResult} />
+        <ReplayDetailsHeaderActions readerResult={readerResult} />
+        <ReplayDetailsUserBadge readerResult={readerResult} />
+        <ReplayDetailsMetadata readerResult={readerResult} />
+      </Header>
+      <ReplayDetailsPage readerResult={readerResult} />
+    </Fragment>
+  );
   return (
     <SentryDocumentTitle title={title}>
       <FullViewport>
-        <Header>
-          <ReplayDetailsPageBreadcrumbs readerResult={readerResult} />
-          <ReplayDetailsHeaderActions readerResult={readerResult} />
-          <ReplayDetailsUserBadge readerResult={readerResult} />
-          <ReplayDetailsMetadata readerResult={readerResult} />
-        </Header>
-        <ReplayDetailsPage readerResult={readerResult} />
+        {replay ? (
+          <ReplayDetailsProviders replay={replay} projectSlug={readerResult.projectSlug}>
+            {content}
+          </ReplayDetailsProviders>
+        ) : (
+          content
+        )}
       </FullViewport>
     </SentryDocumentTitle>
   );


### PR DESCRIPTION
This broke from the changes in https://github.com/getsentry/sentry/pull/92230

What we need is to hoist the `<ReplayContext>` up so it wraps the header and main part of the page again.

Fixes #93032