### PR TITLE
feat(ourlogs): Improve logs time tooltip

### DIFF
--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -26,6 +26,7 @@ export const AlwaysPresentLogFields: OurLogFieldKey[] = [
   OurLogKnownFieldKey.SEVERITY,
   OurLogKnownFieldKey.TIMESTAMP,
   OurLogKnownFieldKey.TIMESTAMP_PRECISE,
+  OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE,
 ] as const;
 
 const AlwaysHiddenLogFields: OurLogFieldKey[] = [

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -20,6 +20,7 @@ import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
 import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {stripLogParamsFromLocation} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import LogsTimestampTooltip from 'sentry/views/explore/logs/logsTimeTooltip';
 import {
   AlignedCellContent,
   ColoredLogCircle,
@@ -53,6 +54,7 @@ export interface RendererExtra extends RenderFunctionBaggage {
   logColors: ReturnType<typeof getLogColors>;
   projectSlug: string;
   align?: 'left' | 'center' | 'right';
+  shouldRenderHoverElements?: boolean;
   useFullSeverityText?: boolean;
   wrapBody?: true;
 }
@@ -124,7 +126,13 @@ function TimestampRenderer(props: LogFieldRendererProps) {
 
   return (
     <LogDate align={props.extra.align}>
-      <DateTime seconds milliseconds date={timestampToUse} />
+      <LogsTimestampTooltip
+        timestamp={props.item.value as string | number}
+        attributes={props.extra.attributes}
+        shouldRender={props.extra.shouldRenderHoverElements}
+      >
+        <DateTime seconds milliseconds date={timestampToUse} />
+      </LogsTimestampTooltip>
     </LogDate>
   );
 }

--- a/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
@@ -1,0 +1,96 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {TimezoneProvider} from 'sentry/components/timezoneProvider';
+import ConfigStore from 'sentry/stores/configStore';
+import {TimestampTooltipBody} from 'sentry/views/explore/logs/logsTimeTooltip';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+describe('TimestampTooltipBody', function () {
+  const timestamp = '2024-01-15T15:45:30.456Z';
+
+  beforeEach(() => {
+    ConfigStore.set('user', UserFixture());
+  });
+
+  it('renders basic precise timestamp', function () {
+    const user = UserFixture();
+    user.options.timezone = 'America/New_York';
+    ConfigStore.set('user', user);
+
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705333530456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimestampTooltipBody timestamp={timestamp} attributes={attributes} />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText('Occurred')).toBeInTheDocument();
+    expect(screen.getByText(/Jan 15, 2024.*10:45:30\.456 AM EST/)).toBeInTheDocument();
+    expect(screen.getByText(/1705333530/)).toBeInTheDocument();
+  });
+
+  it('renders received time when observed timestamp is provided', function () {
+    const user = UserFixture();
+    user.options.timezone = 'America/New_York';
+    ConfigStore.set('user', user);
+
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705333530456789012',
+      [OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE]: '1705333540456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimestampTooltipBody timestamp={timestamp} attributes={attributes} />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText('Occurred')).toBeInTheDocument();
+    expect(screen.getByText('Received')).toBeInTheDocument();
+  });
+
+  it('does not render received time when observed timestamp is not provided', function () {
+    const user = UserFixture();
+    user.options.timezone = 'America/New_York';
+    ConfigStore.set('user', user);
+
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705333530456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimestampTooltipBody timestamp={timestamp} attributes={attributes} />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText('Occurred')).toBeInTheDocument();
+    expect(screen.queryByText('Received')).not.toBeInTheDocument();
+  });
+
+  it('renders in 24h format when user preference is set', function () {
+    const user = UserFixture();
+    user.options.timezone = 'America/New_York';
+    user.options.clock24Hours = true;
+    ConfigStore.set('user', user);
+
+    const pmTimestamp = '2024-01-15T20:45:30.456Z';
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705351530456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="America/New_York">
+        <TimestampTooltipBody timestamp={pmTimestamp} attributes={attributes} />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText(/15:45:30\.456/)).toBeInTheDocument();
+    expect(screen.queryByText(/AM|PM/)).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -1,0 +1,116 @@
+import React, {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import AutoSelectText from 'sentry/components/autoSelectText';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {DateTime} from 'sentry/components/dateTime';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+type Props = {
+  attributes: Record<string, string | number | boolean>;
+  children: React.ReactNode;
+  timestamp: string | number;
+  shouldRender?: boolean;
+};
+
+function TimestampTooltipBody({
+  timestamp,
+  attributes,
+}: {
+  attributes: Record<string, string | number | boolean>;
+  timestamp: string | number;
+}) {
+  const preciseTimestamp = attributes[OurLogKnownFieldKey.TIMESTAMP_PRECISE];
+  const preciseTimestampMs = preciseTimestamp
+    ? Math.floor(Number(preciseTimestamp) / 1_000_000)
+    : null;
+  const timestampToUse = preciseTimestampMs ? new Date(preciseTimestampMs) : timestamp;
+
+  const observedTimeNanos = attributes[OurLogKnownFieldKey.OBSERVED_TIMESTAMP_PRECISE];
+  const observedTimeMs =
+    observedTimeNanos && typeof observedTimeNanos === 'string'
+      ? Math.floor(Number(observedTimeNanos) / 1_000_000)
+      : null;
+  const observedTime = observedTimeMs ? new Date(observedTimeMs) : null;
+
+  return (
+    <DescriptionList>
+      <dt>{t('Occurred')}</dt>
+      <dd>
+        <TimestampValues>
+          <AutoSelectText>
+            <DateTime date={timestampToUse} seconds milliseconds timeZone />
+          </AutoSelectText>
+          <TimestampRawValue>
+            {preciseTimestampMs ? String(preciseTimestampMs) : String(timestamp)}
+          </TimestampRawValue>
+        </TimestampValues>
+      </dd>
+
+      {observedTime && (
+        <Fragment>
+          <HorizontalRule />
+          <dt>{t('Received')}</dt>
+          <dd>
+            <TimestampValues>
+              <AutoSelectText>
+                <DateTime date={observedTime} seconds timeZone />
+              </AutoSelectText>
+            </TimestampValues>
+          </dd>
+        </Fragment>
+      )}
+    </DescriptionList>
+  );
+}
+
+export {TimestampTooltipBody};
+
+export default function LogsTimestampTooltip({
+  timestamp,
+  attributes,
+  children,
+  shouldRender = true,
+}: Props) {
+  if (!shouldRender) {
+    return <Fragment>{children}</Fragment>;
+  }
+
+  return (
+    <Tooltip
+      title={<TimestampTooltipBody timestamp={timestamp} attributes={attributes} />}
+      maxWidth={400}
+      isHoverable
+    >
+      {children}
+    </Tooltip>
+  );
+}
+
+const DescriptionList = styled('dl')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: ${space(0.75)} ${space(1)};
+  text-align: left;
+  margin: 0;
+`;
+
+const TimestampValues = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.25)};
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+const TimestampRawValue = styled('div')`
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+const HorizontalRule = styled('hr')`
+  grid-column: 1 / -1;
+  margin: ${space(0.5)} 0;
+  border: none;
+  border-top: 1px solid ${p => p.theme.border};
+`;

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -43,9 +43,7 @@ function TimestampTooltipBody({
           <AutoSelectText>
             <DateTime date={timestampToUse} seconds milliseconds timeZone />
           </AutoSelectText>
-          <TimestampRawValue>
-            {preciseTimestampMs ? String(preciseTimestampMs) : String(timestamp)}
-          </TimestampRawValue>
+          {preciseTimestampMs ? String(preciseTimestampMs) : String(timestamp)}
         </TimestampValues>
       </dd>
 
@@ -101,10 +99,6 @@ const TimestampValues = styled('div')`
   display: flex;
   flex-direction: column;
   gap: ${space(0.25)};
-  font-family: ${p => p.theme.text.familyMono};
-`;
-
-const TimestampRawValue = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
 `;
 

--- a/static/app/views/explore/logs/types.tsx
+++ b/static/app/views/explore/logs/types.tsx
@@ -25,6 +25,7 @@ export enum OurLogKnownFieldKey {
   SPAN_ID = 'span_id',
   TIMESTAMP = 'timestamp',
   TIMESTAMP_PRECISE = 'tags[sentry.timestamp_precise,number]',
+  OBSERVED_TIMESTAMP_PRECISE = 'sentry.observed_timestamp_nanos',
   CODE_FILE_PATH = 'code.file.path',
   CODE_LINE_NUMBER = 'tags[code.line.number,number]',
   CODE_FUNCTION_NAME = 'code.function.name',


### PR DESCRIPTION
### Summary 
This improves the tooltip to show timezone and also the received time if we have it (started including it in the last few days).

Received uses observed timestamp nanos, but those are precision[ limited to seconds](https://github.com/getsentry/relay/blob/34658b37b30bf9db1e82e7bbbfca7beff73efd86/relay-common/src/time.rs#L112)

#### Screenshots
![Screenshot 2025-06-06 at 3 22 33 PM](https://github.com/user-attachments/assets/31d9650b-4377-4888-8a15-a9f00c2e379a)


Closes LOGS-115
