### PR TITLE
feat(seer): Add seer scanner settings

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -46,6 +46,7 @@ from sentry.constants import (
     ATTACHMENTS_ROLE_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
     DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+    DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     GITHUB_COMMENT_BOT_DEFAULT,
     GITLAB_COMMENT_BOT_DEFAULT,
@@ -236,6 +237,12 @@ ORG_OPTIONS = (
         DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
     ),
     (
+        "defaultSeerScannerAutomation",
+        "sentry:default_seer_scanner_automation",
+        bool,
+        DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
+    ),
+    (
         "ingestThroughTrustedRelaysOnly",
         "sentry:ingest-through-trusted-relays-only",
         bool,
@@ -308,6 +315,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         required=False,
         help_text="The default automation tuning setting for new projects.",
     )
+    defaultSeerScannerAutomation = serializers.BooleanField(required=False)
     ingestThroughTrustedRelaysOnly = serializers.BooleanField(required=False)
 
     @cached_property
@@ -435,6 +443,17 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_defaultAutofixAutomationTuning(self, value):
+        organization = self.context["organization"]
+        request = self.context["request"]
+        if not features.has(
+            "organizations:trigger-autofix-on-issue-summary", organization, actor=request.user
+        ):
+            raise serializers.ValidationError(
+                "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
+            )
+        return value
+
+    def validate_defaultSeerScannerAutomation(self, value):
         organization = self.context["organization"]
         request = self.context["request"]
         if not features.has(
@@ -678,6 +697,7 @@ def post_org_pending_deletion(
         "apdexThreshold",
         "genAIConsent",
         "defaultAutofixAutomationTuning",
+        "defaultSeerScannerAutomation",
         "ingestThroughTrustedRelaysOnly",
     ]
 )
@@ -1052,6 +1072,11 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     organization.update_option(
                         "sentry:default_autofix_automation_tuning",
                         serializer.validated_data["defaultAutofixAutomationTuning"],
+                    )
+                if is_org_mode and "defaultSeerScannerAutomation" in changed_data:
+                    organization.update_option(
+                        "sentry:default_seer_scanner_automation",
+                        serializer.validated_data["defaultSeerScannerAutomation"],
                     )
 
             if was_pending_deletion:

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -31,6 +31,7 @@ from sentry.models.team import Team
 from sentry.seer.similarity.utils import (
     project_is_seer_eligible,
     set_default_project_autofix_automation_tuning,
+    set_default_project_seer_scanner_automation,
 )
 from sentry.signals import project_created
 from sentry.utils.snowflake import MaxSnowflakeRetryError
@@ -50,6 +51,7 @@ def apply_default_project_settings(organization: Organization, project: Project)
         project.update_option("sentry:similarity_backfill_completed", int(time.time()))
 
     set_default_project_autofix_automation_tuning(organization, project)
+    set_default_project_seer_scanner_automation(organization, project)
 
 
 class ProjectPostSerializer(serializers.Serializer):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -35,6 +35,7 @@ from sentry.constants import (
     DATA_CONSENT_DEFAULT,
     DEBUG_FILES_ROLE_DEFAULT,
     DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+    DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     GITHUB_COMMENT_BOT_DEFAULT,
     GITLAB_COMMENT_BOT_DEFAULT,
@@ -560,6 +561,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     rollbackEnabled: bool
     streamlineOnly: bool
     defaultAutofixAutomationTuning: str
+    defaultSeerScannerAutomation: bool
 
 
 class DetailedOrganizationSerializer(OrganizationSerializer):
@@ -712,6 +714,10 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             "defaultAutofixAutomationTuning": obj.get_option(
                 "sentry:default_autofix_automation_tuning",
                 DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
+            ),
+            "defaultSeerScannerAutomation": obj.get_option(
+                "sentry:default_seer_scanner_automation",
+                DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
             ),
             "streamlineOnly": obj.get_option("sentry:streamline_ui_only", None),
             "trustedRelays": [

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -952,6 +952,7 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
     tempestFetchScreenshots: NotRequired[bool]
     tempestFetchDumps: NotRequired[bool]
     autofixAutomationTuning: NotRequired[str]
+    seerScannerAutomation: NotRequired[bool]
 
 
 class DetailedProjectSerializer(ProjectWithTeamSerializer):
@@ -1102,6 +1103,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "isDynamicallySampled": sample_rate is not None and sample_rate < 1.0,
             "autofixAutomationTuning": self.get_value_with_default(
                 attrs, "sentry:autofix_automation_tuning"
+            ),
+            "seerScannerAutomation": self.get_value_with_default(
+                attrs, "sentry:seer_scanner_automation"
             ),
         }
 

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -324,6 +324,7 @@ class OrganizationExamples:
                 "gitlabOpenPRBot": True,
                 "aggregatedDataConsent": False,
                 "defaultAutofixAutomationTuning": "off",
+                "defaultSeerScannerAutomation": True,
                 "issueAlertsThreadFlag": True,
                 "metricAlertsThreadFlag": True,
                 "trustedRelays": [],

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -263,6 +263,7 @@ DETAILED_PROJECT = {
     "tempestFetchDumps": False,
     "isDynamicallySampled": True,
     "autofixAutomationTuning": "off",
+    "seerScannerAutomation": True,
     "highlightTags": [],
     "highlightContext": {},
     "highlightPreset": {"tags": [], "context": {}},

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -722,6 +722,7 @@ TARGET_SAMPLE_RATE_DEFAULT = 1.0
 SAMPLING_MODE_DEFAULT = "organization"
 ROLLBACK_ENABLED_DEFAULT = True
 DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT = "off"
+DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT = True
 INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT = False
 
 # `sentry:events_member_admin` - controls whether the 'member' role gets the event:admin scope

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -27,6 +27,9 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         return None
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
         return None
+    project = group.project
+    if not project.get_option("sentry:seer_scanner_automation"):
+        return
 
     timeout = options.get("alerts.issue_summary_timeout") or 5
 

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -29,7 +29,7 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         return None
     project = group.project
     if not project.get_option("sentry:seer_scanner_automation"):
-        return
+        return None
 
     timeout = options.get("alerts.issue_summary_timeout") or 5
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -66,6 +66,7 @@ OPTION_KEYS = frozenset(
         "sentry:transaction_name_cluster_rules",
         "sentry:uptime_autodetection",
         "sentry:autofix_automation_tuning",
+        "sentry:seer_scanner_automation",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -200,3 +200,6 @@ register(key="sentry:tempest_fetch_dumps", default=False)
 
 # Should autofix run automatically on new issues
 register(key="sentry:autofix_automation_tuning", default="off")
+
+# Should seer scanner run automatically on new issues
+register(key="sentry:seer_scanner_automation", default=True)

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -434,3 +434,15 @@ def set_default_project_autofix_automation_tuning(
         project.update_option(
             "sentry:default_autofix_automation_tuning", org_default_autofix_automation_tuning
         )
+
+
+def set_default_project_seer_scanner_automation(
+    organization: Organization, project: Project
+) -> None:
+    org_default_seer_scanner_automation = organization.get_option(
+        "sentry:default_seer_scanner_automation"
+    )
+    if org_default_seer_scanner_automation:
+        project.update_option(
+            "sentry:default_seer_scanner_automation", org_default_seer_scanner_automation
+        )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1590,6 +1590,10 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     if not seer_enabled:
         return
 
+    project = group.project
+    if not project.get_option("sentry:seer_scanner_automation"):
+        return
+
     start_seer_automation.delay(group.id)
 
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -1355,6 +1355,20 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         ]
         assert self.organization.get_option("sentry:default_autofix_automation_tuning") is None
 
+    @with_feature({"organizations:trigger-autofix-on-issue-summary": False})
+    def test_default_seer_scanner_automation_feature_disabled(self):
+        data = {"defaultSeerScannerAutomation": True}
+        response = self.get_error_response(self.organization.slug, status_code=400, **data)
+        assert response.data["defaultSeerScannerAutomation"] == [
+            "Organization does not have the trigger-autofix-on-issue-summary feature enabled."
+        ]
+
+    @with_feature({"organizations:trigger-autofix-on-issue-summary": True})
+    def test_default_seer_scanner_automation_feature_enabled(self):
+        data = {"defaultSeerScannerAutomation": True}
+        self.get_success_response(self.organization.slug, **data)
+        assert self.organization.get_option("sentry:default_seer_scanner_automation") is True
+
 
 class OrganizationDeleteTest(OrganizationDetailsTestBase):
     method = "delete"

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -818,6 +818,16 @@ class DetailedProjectSerializerTest(TestCase):
         result = serialize(self.project, self.user, DetailedProjectSerializer())
         assert result["autofixAutomationTuning"] == "high"
 
+    def test_seer_scanner_automation_flag(self):
+        # Default is "on"
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        assert result["seerScannerAutomation"] is True
+
+        # Update the value
+        self.project.update_option("sentry:seer_scanner_automation", False)
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        assert result["seerScannerAutomation"] is False
+
 
 class BulkFetchProjectLatestReleases(TestCase):
     @cached_property

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -990,6 +990,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
+        self.project.update_option("sentry:seer_scanner_automation", True)
 
         mock_summary = {
             "headline": "Custom AI Title",
@@ -1053,6 +1054,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
+        self.project.update_option("sentry:seer_scanner_automation", True)
 
         patch_path = "sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary"
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2568,6 +2568,31 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
 
         mock_start_seer_automation.assert_not_called()
 
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    def test_kick_off_seer_automation_without_scanner_on(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
+        event = self.create_event(
+            data={"message": "testing"},
+            project_id=self.project.id,
+        )
+        self.project.update_option("sentry:seer_scanner_automation", False)
+
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
+
+        mock_start_seer_automation.assert_not_called()
+
 
 class PostProcessGroupErrorTest(
     TestCase,


### PR DESCRIPTION
Adds two settings for Seer Scanner controls:
- a project option to turn it on or off, on by default
- an organization option controlling the default value for newly created projects, on by default

Will follow up with frontend controls