### PR TITLE
ref(source-maps): Add sentry.javascript.serverless to fallback list

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -644,6 +644,7 @@ def get_sdk_debug_id_support(event_data):
             "sentry.javascript.svelte",
             "sentry.javascript.sveltekit",
             "sentry.javascript.vue",
+            "sentry.javascript.serverless",
         ]
 
     if sdk_name not in official_sdks or sdk_name is None:


### PR DESCRIPTION
Should help with https://github.com/getsentry/sentry/issues/90285, though unclear if it will fix it

Part of [RTC-778: Source maps modal doesn't recognize official Sentry SDK](https://linear.app/getsentry/issue/RTC-778/source-maps-modal-doesnt-recognize-official-sentry-sdk)