### PR TITLE
fix(checkout): Don't prepopulate products based on trial

### DIFF
--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -53,6 +53,7 @@ import {
   isAmPlan,
   isBizPlanFamily,
   isNewPayingCustomer,
+  isTrialPlan,
 } from 'getsentry/utils/billing';
 import {getCompletedOrActivePromotion} from 'getsentry/utils/promotions';
 import {showSubscriptionDiscount} from 'getsentry/utils/promotionUtils';
@@ -473,17 +474,20 @@ class AMCheckout extends Component<Props, State> {
       };
     }
 
-    subscription.reservedBudgets?.forEach(budget => {
-      if (
-        Object.values(SelectableProduct).includes(
-          budget.apiName as string as SelectableProduct
-        )
-      ) {
-        data.selectedProducts[budget.apiName as string as SelectableProduct] = {
-          enabled: budget.reservedBudget > 0,
-        };
-      }
-    });
+    if (!isTrialPlan(subscription.plan)) {
+      // don't prepopulate selected products from trial state
+      subscription.reservedBudgets?.forEach(budget => {
+        if (
+          Object.values(SelectableProduct).includes(
+            budget.apiName as string as SelectableProduct
+          )
+        ) {
+          data.selectedProducts[budget.apiName as string as SelectableProduct] = {
+            enabled: budget.reservedBudget > 0,
+          };
+        }
+      });
+    }
 
     return this.getValidData(initialPlan, data);
   }

--- a/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
@@ -18,6 +18,7 @@ describe('ProductSelect', function () {
 
   beforeEach(function () {
     organization.features = ['seer-billing'];
+    subscription.reservedBudgets = [];
     SubscriptionStore.set(organization.slug, subscription);
 
     MockApiClient.addMockResponse({
@@ -159,8 +160,27 @@ describe('ProductSelect', function () {
     expect(await screen.findByTestId('product-option-seer')).toHaveTextContent(
       'Added to plan'
     );
+  });
 
-    subscription.reservedBudgets = []; // clear
+  it('does not render with product selected based on current subscription if plan is trial', async function () {
+    const trialSubscription = SubscriptionFixture({organization, plan: 'am3_t'});
+    trialSubscription.reservedBudgets = [SeerReservedBudgetFixture({id: '2'})];
+    SubscriptionStore.set(organization.slug, trialSubscription);
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM3}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByTestId('product-option-seer')).toHaveTextContent(
+      'Add for $20/mo'
+    );
   });
 
   it('can enable and disable products', async function () {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-873/checkout-should-not-prepopulate-with-seer-added-on-trial