### PR TITLE
feat(uptime):add-config-defaults

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -59,10 +59,6 @@ describe('Uptime Alert Form', function () {
 
     await userEvent.click(screen.getByRole('checkbox', {name: 'Allow Sampling'}));
 
-    const name = input('Uptime rule name');
-    await userEvent.clear(name);
-    await userEvent.type(name, 'New Uptime Rule');
-
     await selectEvent.select(input('Owner'), 'Foo Bar');
 
     const updateMock = MockApiClient.addMockResponse({
@@ -77,7 +73,7 @@ describe('Uptime Alert Form', function () {
       expect.objectContaining({
         data: expect.objectContaining({
           environment: 'prod',
-          name: 'New Uptime Rule',
+          name: 'Uptime Check for example.com',
           owner: 'user:1',
           url: 'http://example.com',
           method: 'POST',

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -123,7 +123,7 @@ export function UptimeAlertForm({project, handleDelete, rule, organization}: Pro
   useEffect(
     () =>
       autorun(() => {
-        const projectSlug = formModel.getValue('projectSlug');
+        const projectSlug = formModel.getValue<string>('projectSlug');
         const selectedProject = projects.find(p => p.slug === projectSlug);
         const apiEndpoint = rule
           ? `/projects/${organization.slug}/${projectSlug}/uptime/${rule.id}/`


### PR DESCRIPTION
Adding some default suggestions for config of Uptime Monitors, to reduce required clicks and friction for developers to create new monitors