### PR TITLE
fix(ui): Correct anchor coloring in legacy box classes

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -226,14 +226,18 @@ const styles = (theme: Theme, isDark: boolean) => css`
             h6 {
               color: ${theme.headingColor};
             }
-
-            a {
-              color: ${theme.textColor};
-            }
           }
 
           .box-header {
             border-bottom-color: ${theme.border};
+
+            a {
+              color: ${theme.textColor};
+
+              &:hover {
+                color: ${theme.linkHoverColor};
+              }
+            }
           }
         }
         .loading .loading-indicator {


### PR DESCRIPTION
The color was only meant to apply to the header, butt it ended up
applying to all box-content.

Fixes: [RTC-260: \[New Organization Modal\] Links are not obvious in Dark Mode](https://linear.app/getsentry/issue/RTC-260/new-organization-modal-links-are-not-obvious-in-dark-mode)