### PR TITLE
fix(detectors): Fix bug with empty string and keyword in SQL Injection Detector

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
@@ -20,7 +20,8 @@
     "method": "GET",
     "query_string": [
       ["username", "hello"],
-      ["sort", "username"]
+      ["sort", "username"],
+      ["empty", ""]
     ]
   },
   "spans": [

--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
@@ -21,7 +21,8 @@
     "query_string": [
       ["username", "hello"],
       ["sort", "username"],
-      ["empty", ""]
+      ["empty", ""],
+      ["single", "u"]
     ]
   },
   "spans": [

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -87,7 +87,7 @@ class SQLInjectionDetector(PerformanceDetector):
                 continue
             if query_key == query_value:
                 continue
-            if query_value.upper() in SQL_KEYWORDS:
+            if query_value.upper() in SQL_KEYWORDS or query_key.upper() in SQL_KEYWORDS:
                 continue
             valid_parameters.append(query_pair)
 

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -83,7 +83,8 @@ class SQLInjectionDetector(PerformanceDetector):
             query_value = query_pair[1]
             query_key = query_pair[0]
 
-            if not isinstance(query_value, str) or not query_value:
+            # Filters out empty strings or single character strings
+            if not isinstance(query_value, str) or not query_value or len(query_value) == 1:
                 continue
             if query_key == query_value:
                 continue

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -83,7 +83,7 @@ class SQLInjectionDetector(PerformanceDetector):
             query_value = query_pair[1]
             query_key = query_pair[0]
 
-            if not isinstance(query_value, str):
+            if not isinstance(query_value, str) or not query_value:
                 continue
             if query_key == query_value:
                 continue

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -84,7 +84,12 @@ class SQLInjectionDetector(PerformanceDetector):
             query_key = query_pair[0]
 
             # Filters out empty strings or single character strings
-            if not isinstance(query_value, str) or not query_value or len(query_value) == 1:
+            if (
+                not isinstance(query_value, str)
+                or not isinstance(query_key, str)
+                or not query_value
+                or len(query_value) == 1
+            ):
                 continue
             if query_key == query_value:
                 continue


### PR DESCRIPTION
adds a few additional checks to the sql injection detector: 
1) adds a check for an empty string
2) checks if the key is a SQL keyword, now that we are checking if the key is also in the description. 
3) checks if the value is 1 character - can cause false positives if it's a single letter or number