### PR TITLE
fix(seer): hide usage cards for developer plans

### DIFF
--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -202,6 +202,14 @@ function Overview({location, subscription, promotionData}: Props) {
           )
           .map(categoryHistory => {
             const category = categoryHistory.category;
+
+            // XXX: need to hide these categories for developer plans
+            if (
+              category === DataCategory.SEER_AUTOFIX ||
+              category === DataCategory.SEER_SCANNER
+            ) {
+              return null;
+            }
             // The usageData does not include details for seat-based categories.
             // For now we will handle the monitor category specially
             let monitor_usage: number | undefined = 0;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-868/hide-seer-ui-elements-for-developer-orgs