### PR TITLE
feat(projects): add redirect to issues for project chart bars

### DIFF
--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -40,8 +40,8 @@ import {
   displayCrashFreePercent,
 } from 'sentry/views/releases/utils';
 
-import Chart from './chart';
 import Deploys, {DeployRows, GetStarted, TextOverflow} from './deploys';
+import ProjectChart from './projectChart';
 
 type Props = {
   api: Client;
@@ -192,10 +192,11 @@ class ProjectCard extends Component<Props> {
           </CardHeader>
           <ChartContainer data-test-id="chart-container">
             {stats ? (
-              <Chart
+              <ProjectChart
                 firstEvent={hasFirstEvent}
                 stats={stats}
                 transactionStats={transactionStats}
+                project={project}
               />
             ) : (
               <Placeholder height="150px" />

--- a/static/app/views/projectsDashboard/projectChart.tsx
+++ b/static/app/views/projectsDashboard/projectChart.tsx
@@ -3,8 +3,11 @@ import {useTheme} from '@emotion/react';
 
 import BaseChart from 'sentry/components/charts/baseChart';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import NoEvents from './noEvents';
 
@@ -12,21 +15,32 @@ type BaseChartProps = React.ComponentProps<typeof BaseChart>;
 
 type Props = {
   firstEvent: boolean;
+  project: Project;
   stats: Project['stats'];
+  onBarClick?: (data: {seriesName: string; timestamp: number; value: number}) => void;
   transactionStats?: Project['transactionStats'];
 };
 
-function Chart({firstEvent, stats, transactionStats}: Props) {
+function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}: Props) {
   const series: BaseChartProps['series'] = [];
   const hasTransactions = transactionStats !== undefined;
+  const navigate = useNavigate();
+  const organization = useOrganization();
 
   const theme = useTheme();
 
   if (transactionStats) {
-    const transactionSeries = transactionStats.map(([timestamp, value]) => [
-      timestamp * 1000,
-      value,
-    ]);
+    const transactionSeries = transactionStats.map(([timestamp, value]) => ({
+      value: [timestamp * 1000, value],
+      onClick: onBarClick
+        ? () =>
+            onBarClick({
+              timestamp,
+              value,
+              seriesName: 'Transactions',
+            })
+        : undefined,
+    }));
 
     series.push({
       cursor: 'normal' as const,
@@ -51,10 +65,14 @@ function Chart({firstEvent, stats, transactionStats}: Props) {
 
   if (stats) {
     series.push({
-      cursor: 'normal' as const,
+      cursor: 'pointer' as const,
       name: t('Errors'),
       type: 'bar',
-      data: stats.map(([timestamp, value]) => [timestamp * 1000, value]),
+      data: stats.map(([timestamp, value]) => ({
+        value: [timestamp * 1000, value],
+        onClick: () =>
+          navigate(constructErrorsLink(organization, project, timestamp * 1000)),
+      })),
       barMinHeight: 1,
       xAxisIndex: 0,
       yAxisIndex: 0,
@@ -167,4 +185,15 @@ function Chart({firstEvent, stats, transactionStats}: Props) {
   );
 }
 
-export default Chart;
+const constructErrorsLink = (
+  organization: Organization,
+  project: Project,
+  timestamp: number
+) => {
+  const start = new Date(timestamp);
+  const end = new Date(start);
+  end.setHours(end.getHours() + 1);
+  return `/organizations/${organization.slug}/issues/?project=${project.id}&start=${start.toISOString()}&end=${end.toISOString()}`;
+};
+
+export default ProjectChart;

--- a/static/app/views/projectsDashboard/projectChart.tsx
+++ b/static/app/views/projectsDashboard/projectChart.tsx
@@ -3,11 +3,10 @@ import {useTheme} from '@emotion/react';
 
 import BaseChart from 'sentry/components/charts/baseChart';
 import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
 
 import NoEvents from './noEvents';
 
@@ -25,7 +24,6 @@ function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}
   const series: BaseChartProps['series'] = [];
   const hasTransactions = transactionStats !== undefined;
   const navigate = useNavigate();
-  const organization = useOrganization();
 
   const theme = useTheme();
 
@@ -70,8 +68,7 @@ function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}
       type: 'bar',
       data: stats.map(([timestamp, value]) => ({
         value: [timestamp * 1000, value],
-        onClick: () =>
-          navigate(constructErrorsLink(organization, project, timestamp * 1000)),
+        onClick: () => navigate(constructErrorsLink(project, timestamp * 1000)),
       })),
       barMinHeight: 1,
       xAxisIndex: 0,
@@ -185,15 +182,13 @@ function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}
   );
 }
 
-const constructErrorsLink = (
-  organization: Organization,
-  project: Project,
-  timestamp: number
-) => {
+const constructErrorsLink = (project: Project, timestamp: number) => {
   const start = new Date(timestamp);
   const end = new Date(start);
   end.setHours(end.getHours() + 1);
-  return `/organizations/${organization.slug}/issues/?project=${project.id}&start=${start.toISOString()}&end=${end.toISOString()}`;
+  return normalizeUrl(
+    `/issues/?project=${project.id}&start=${start.toISOString()}&end=${end.toISOString()}`
+  );
 };
 
 export default ProjectChart;

--- a/static/app/views/projectsDashboard/projectChart.tsx
+++ b/static/app/views/projectsDashboard/projectChart.tsx
@@ -3,10 +3,12 @@ import {useTheme} from '@emotion/react';
 
 import BaseChart from 'sentry/components/charts/baseChart';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import NoEvents from './noEvents';
 
@@ -24,6 +26,7 @@ function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}
   const series: BaseChartProps['series'] = [];
   const hasTransactions = transactionStats !== undefined;
   const navigate = useNavigate();
+  const organization = useOrganization();
 
   const theme = useTheme();
 
@@ -68,7 +71,8 @@ function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}
       type: 'bar',
       data: stats.map(([timestamp, value]) => ({
         value: [timestamp * 1000, value],
-        onClick: () => navigate(constructErrorsLink(project, timestamp * 1000)),
+        onClick: () =>
+          navigate(constructErrorsLink(organization, project, timestamp * 1000)),
       })),
       barMinHeight: 1,
       xAxisIndex: 0,
@@ -182,12 +186,16 @@ function ProjectChart({firstEvent, stats, transactionStats, onBarClick, project}
   );
 }
 
-const constructErrorsLink = (project: Project, timestamp: number) => {
+const constructErrorsLink = (
+  organization: Organization,
+  project: Project,
+  timestamp: number
+) => {
   const start = new Date(timestamp);
   const end = new Date(start);
   end.setHours(end.getHours() + 1);
   return normalizeUrl(
-    `/issues/?project=${project.id}&start=${start.toISOString()}&end=${end.toISOString()}`
+    `/organizations/${organization.slug}/issues/?project=${project.id}&start=${start.toISOString()}&end=${end.toISOString()}`
   );
 };
 


### PR DESCRIPTION
closes #43847

Clicking on a bar in the projects chart now redirects you to the issue stream with the time range prefilled:


https://github.com/user-attachments/assets/928c0b80-86ac-4dd3-815b-049fe3686a14

