### PR TITLE
fix(emerge): use the same cache key for redis when doing file write

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -61,7 +61,7 @@ def assemble_preprod_artifact(
 
         assemble_result = assemble_file(
             task=AssembleTask.PREPROD_ARTIFACT,
-            org_or_project=organization,
+            org_or_project=project,
             name=f"preprod-artifact-{uuid.uuid4().hex}",
             checksum=checksum,
             chunks=chunks,

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -56,7 +56,7 @@ def assemble_preprod_artifact(
         bind_organization_context(organization)
 
         set_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, org_id, checksum, ChunkFileState.ASSEMBLING
+            AssembleTask.PREPROD_ARTIFACT, project_id, checksum, ChunkFileState.ASSEMBLING
         )
 
         assemble_result = assemble_file(
@@ -123,10 +123,10 @@ def assemble_preprod_artifact(
         )
         set_assemble_status(
             AssembleTask.PREPROD_ARTIFACT,
-            org_id,
+            project_id,
             checksum,
             ChunkFileState.ERROR,
             detail=str(e),
         )
     else:
-        set_assemble_status(AssembleTask.PREPROD_ARTIFACT, org_id, checksum, ChunkFileState.OK)
+        set_assemble_status(AssembleTask.PREPROD_ARTIFACT, project_id, checksum, ChunkFileState.OK)

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -149,25 +149,21 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             args=[self.organization.slug, self.project.slug],
         )
 
-        # Enable the feature flag for all tests in this class
         self.feature_context = Feature("organizations:preprod-artifact-assemble")
         self.feature_context.__enter__()
 
     def tearDown(self):
-        # Clean up the feature flag
         self.feature_context.__exit__(None, None, None)
         super().tearDown()
 
     def test_feature_flag_disabled_returns_404(self):
         """Test that endpoint returns 404 when feature flag is disabled."""
-        # Exit the current feature context to disable the flag
         self.feature_context.__exit__(None, None, None)
 
         try:
             content = b"test content"
             total_checksum = sha1(content).hexdigest()
 
-            # Should get 404 when feature flag is disabled
             response = self.client.post(
                 self.url,
                 data={
@@ -178,19 +174,16 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             )
             assert response.status_code == 404
         finally:
-            # Re-enable the feature flag for any subsequent tests
             self.feature_context = Feature("organizations:preprod-artifact-assemble")
             self.feature_context.__enter__()
 
     def test_assemble_json_schema_integration(self):
         """Integration test for schema validation through the endpoint."""
-        # Test invalid JSON
         response = self.client.post(
             self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
         )
         assert response.status_code == 400
 
-        # Test valid minimal JSON
         checksum = sha1(b"1").hexdigest()
         response = self.client.post(
             self.url,
@@ -306,7 +299,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
     def test_assemble_json_schema_optional_fields(self):
         checksum = sha1(b"test content").hexdigest()
 
-        # Test with all optional fields
         response = self.client.post(
             self.url,
             data={
@@ -391,7 +383,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         content = b"test content for missing chunks"
         total_checksum = sha1(content).hexdigest()
 
-        # Try to upload with all the checksums missing
         response = self.client.post(
             self.url,
             data={
@@ -405,11 +396,9 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.data["state"] == ChunkFileState.NOT_FOUND
         assert set(response.data["missingChunks"]) == {total_checksum}
 
-        # Store the blobs into the database
         blob = FileBlob.from_file(ContentFile(content))
         FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
 
-        # Make the request again after the file has been uploaded
         response = self.client.post(
             self.url,
             data={
@@ -441,7 +430,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.data["state"] == ChunkFileState.CREATED
 
     def test_assemble_with_pending_deletion_project(self):
-        # Create a project with pending deletion status
         self.project.status = ObjectStatus.PENDING_DELETION
         self.project.save()
 
@@ -459,7 +447,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
-        # Should return 404 since the project is pending deletion
         assert response.status_code == 404
 
     def test_assemble_org_auth_token(self):
@@ -470,7 +457,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         blob = FileBlob.from_file(ContentFile(content))
         FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
 
-        # right org, wrong permission level
         with assume_test_silo_mode(SiloMode.CONTROL):
             bad_token_str = generate_token(self.organization.slug, "")
             OrgAuthToken.objects.create(
@@ -491,7 +477,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
         assert response.status_code == 403
 
-        # wrong org, right permission level
         with assume_test_silo_mode(SiloMode.CONTROL):
             bad_org_token_str = generate_token(self.organization.slug, "")
             OrgAuthToken.objects.create(
@@ -512,7 +497,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
         assert response.status_code == 403
 
-        # right org, right permission level
         with assume_test_silo_mode(SiloMode.CONTROL):
             good_token_str = generate_token(self.organization.slug, "")
             OrgAuthToken.objects.create(
@@ -535,14 +519,12 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             )
         assert response.status_code == 200
 
-        # Make sure org token usage was updated
         with assume_test_silo_mode(SiloMode.CONTROL):
             org_token = OrgAuthToken.objects.get(token_hashed=hash_token(good_token_str))
         assert org_token.date_last_used is not None
         assert org_token.project_last_used_id == self.project.id
 
     def test_poll_request(self):
-        # Test poll request (no chunks provided)
         checksum = sha1(b"test poll").hexdigest()
 
         response = self.client.post(
@@ -561,7 +543,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
     def test_check_existing_assembly_status(self):
         checksum = sha1(b"test existing status").hexdigest()
 
-        # Set a status manually
         set_assemble_status(
             AssembleTask.PREPROD_ARTIFACT, self.project.id, checksum, ChunkFileState.OK
         )
@@ -592,16 +573,13 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         content = b"test integration content"
         total_checksum = sha1(content).hexdigest()
 
-        # Create blob and ownership
         blob = FileBlob.from_file(ContentFile(content))
         FileBlobOwner.objects.get_or_create(organization_id=self.organization.id, blob=blob)
 
-        # Step 1: Simulate what the real task does - sets status with project_id scope
         set_assemble_status(
             AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum, ChunkFileState.OK
         )
 
-        # Step 2: Poll the API endpoint to see if it can read the status
         response = self.client.post(
             self.url,
             data={
@@ -612,12 +590,10 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         )
 
         assert response.status_code == 200
-        # This should now work because both task and API use project_id scope
         assert response.data["state"] == ChunkFileState.OK
         assert response.data["missingChunks"] == []
 
     def test_permission_required(self):
-        # Test without any authorization
         content = b"test permission content"
         total_checksum = sha1(content).hexdigest()
 

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -29,7 +29,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.OK
         assert details is None
@@ -70,7 +70,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.OK
 
@@ -96,7 +96,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.OK
 
@@ -121,7 +121,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, wrong_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, wrong_checksum
         )
         assert status == ChunkFileState.ERROR
         assert "Reported checksum mismatch" in details
@@ -138,7 +138,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
         assert "Not all chunks available for assembling" in details
@@ -149,17 +149,16 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         total_checksum = sha1(content).hexdigest()
 
         blob = FileBlob.from_file_with_organization(fileobj, self.organization)
-        nonexistent_org_id = 99999
 
         assemble_preprod_artifact(
-            org_id=nonexistent_org_id,
+            org_id=self.organization.id,
             project_id=self.project.id,
             checksum=total_checksum,
             chunks=[blob.checksum],
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, nonexistent_org_id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
         assert details is not None
@@ -180,7 +179,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
         assert details is not None
@@ -206,7 +205,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         )
 
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.OK
 
@@ -256,7 +255,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
 
         # Check that the task failed
         status, details = get_assemble_status(
-            AssembleTask.PREPROD_ARTIFACT, self.organization.id, total_checksum
+            AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum
         )
         assert status == ChunkFileState.ERROR
         assert "Simulated failure" in details

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -87,7 +87,7 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
         assert artifact.build_configuration is None
         assert artifact.extras is None
 
-        delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)
+        delete_assemble_status(AssembleTask.PREPROD_ARTIFACT, self.project.id, total_checksum)  # type: ignore[unreachable]
 
     def test_assemble_preprod_artifact_generates_filename(self):
         content = b"test preprod artifact with generated filename"


### PR DESCRIPTION
typo from creating the endpoint previously