### PR TITLE
chore(sentry-apps): Allow Sentry App tokens to appear on group activity payload

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -4,6 +4,9 @@ from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.pullrequest import PullRequest
+from sentry.sentry_apps.api.serializers.sentry_app_avatar import SentryAppAvatarSerializer
+from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.app.model import RpcSentryApp
 from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -25,6 +28,22 @@ class ActivitySerializer(Serializer):
                 filter={"user_ids": user_ids}, as_user=serialize_generic_user(user)
             )
         users = {u["id"]: u for u in user_list}
+
+        # If an activity is created by the proxy user of a Sentry App, attach it to the payload
+        sentry_apps_list: list[RpcSentryApp] = []
+        if user_ids:
+            sentry_apps_list = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=user_ids)
+        # Minimal Sentry App serialization to keep the payload minimal
+        sentry_apps = {
+            str(app.proxy_user_id): {
+                "id": str(app.id),
+                "name": app.name,
+                "slug": app.slug,
+                "avatars": serialize(app.avatars, user, serializer=SentryAppAvatarSerializer()),
+            }
+            for app in sentry_apps_list
+            if app.proxy_user_id
+        }
 
         commit_ids = {
             i.data["commit"]
@@ -85,6 +104,7 @@ class ActivitySerializer(Serializer):
         return {
             item: {
                 "user": users.get(str(item.user_id)) if item.user_id else None,
+                "sentry_app": sentry_apps.get(str(item.user_id)) if item.user_id else None,
                 "source": (
                     groups.get(item.data["source_id"])
                     if item.type == ActivityType.UNMERGE_DESTINATION.value
@@ -121,6 +141,7 @@ class ActivitySerializer(Serializer):
         return {
             "id": str(obj.id),
             "user": attrs["user"],
+            "sentry_app": attrs["sentry_app"],
             "type": obj.get_type_display(),
             "data": data,
             "dateCreated": obj.datetime,

--- a/src/sentry/sentry_apps/api/serializers/sentry_app_avatar.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_avatar.py
@@ -2,6 +2,7 @@ from typing import TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
+from sentry.sentry_apps.services.app.model import RpcSentryAppAvatar
 
 
 class SentryAppAvatarSerializerResponse(TypedDict):
@@ -15,11 +16,11 @@ class SentryAppAvatarSerializerResponse(TypedDict):
 @register(SentryAppAvatar)
 class SentryAppAvatarSerializer(Serializer):
     def serialize(
-        self, obj: SentryAppAvatar, attrs, user, **kwargs
+        self, obj: SentryAppAvatar | RpcSentryAppAvatar, attrs, user, **kwargs
     ) -> SentryAppAvatarSerializerResponse:
         return {
             "avatarType": obj.get_avatar_type_display(),
-            "avatarUuid": obj.ident,
+            "avatarUuid": obj.ident or "",
             "avatarUrl": obj.absolute_url(),
             "color": obj.color,
             "photoType": obj.get_avatar_photo_type(),

--- a/src/sentry/sentry_apps/services/app/serial.py
+++ b/src/sentry/sentry_apps/services/app/serial.py
@@ -2,6 +2,7 @@ from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_apps.models.sentry_app import SentryApp
+from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.services.app import (
@@ -10,6 +11,7 @@ from sentry.sentry_apps.services.app import (
     RpcSentryAppComponent,
     RpcSentryAppInstallation,
 )
+from sentry.sentry_apps.services.app.model import RpcSentryAppAvatar
 
 
 def serialize_api_application(api_app: ApiApplication | None) -> RpcApiApplication | None:
@@ -22,7 +24,11 @@ def serialize_api_application(api_app: ApiApplication | None) -> RpcApiApplicati
     )
 
 
-def serialize_sentry_app(app: SentryApp) -> RpcSentryApp:
+def serialize_sentry_app(
+    app: SentryApp, avatars: list[SentryAppAvatar] | None = None
+) -> RpcSentryApp:
+    if avatars is None:
+        avatars = []
     return RpcSentryApp(
         id=app.id,
         scope_list=app.scope_list,
@@ -42,6 +48,7 @@ def serialize_sentry_app(app: SentryApp) -> RpcSentryApp:
         is_publish_request_inprogress=app.status == SentryAppStatus.PUBLISH_REQUEST_INPROGRESS,
         status=SentryAppStatus.as_str(app.status),
         metadata=app.metadata,
+        avatars=[serialize_sentry_app_avatar(avatar) for avatar in avatars],
     )
 
 
@@ -77,4 +84,14 @@ def serialize_sentry_app_component(component: SentryAppComponent) -> RpcSentryAp
         sentry_app_id=component.sentry_app_id,
         type=component.type,
         app_schema=component.schema,
+    )
+
+
+def serialize_sentry_app_avatar(avatar: SentryAppAvatar) -> RpcSentryAppAvatar:
+    return RpcSentryAppAvatar(
+        id=avatar.id,
+        ident=avatar.ident,
+        sentry_app_id=avatar.sentry_app_id,
+        avatar_type=avatar.avatar_type,
+        color=avatar.color,
     )

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -89,6 +89,11 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_sentry_apps_by_proxy_users(self, *, proxy_user_ids: list[int]) -> list[RpcSentryApp]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_installation_by_id(self, *, id: int) -> RpcSentryAppInstallation | None:
         pass
 

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -3,8 +3,11 @@ from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import GroupStatus
 from sentry.models.pullrequest import PullRequest
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
+from sentry.users.models.user import User
 
 
 class GroupActivityTestCase(TestCase):
@@ -150,3 +153,53 @@ class GroupActivityTestCase(TestCase):
         serialized = serialize(act)
 
         assert "firstSeen" not in serialized["data"]["source"]
+
+    def test_get_activities_for_group_proxy_user(self):
+        project = self.create_project(name="test_activities_group")
+        group = self.create_group(project)
+        user = self.create_user()
+        data = serialize(
+            Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.NOTE,
+                data={"text": "A human sent this message"},
+                user=user,
+            )
+        )
+        # Regular users, have a new empty key
+        assert data["user"]["name"] == user.username
+        assert data["sentry_app"] is None
+
+        sentry_app = self.create_sentry_app(name="test_sentry_app")
+        default_avatar = self.create_sentry_app_avatar(sentry_app=sentry_app)
+        upload_avatar = self.create_sentry_app_avatar(sentry_app=sentry_app)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            proxy_user = User.objects.get(id=sentry_app.proxy_user_id)
+            upload_avatar.avatar_type = 1  # an upload
+            upload_avatar.color = True  # a logo
+            upload_avatar.save()
+
+        data = serialize(
+            Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.NOTE,
+                data={"text": "My app sent this message"},
+                user=proxy_user,
+            )
+        )
+        assert data["user"]["name"] == proxy_user.username
+        assert data["sentry_app"]["name"] == sentry_app.name
+        assert {
+            "avatarType": "default",
+            "avatarUuid": default_avatar.ident,
+            "avatarUrl": f"http://testserver/sentry-app-avatar/{default_avatar.ident}/",
+            "color": False,
+            "photoType": "icon",
+        } in data["sentry_app"]["avatars"]
+        assert {
+            "avatarType": "upload",
+            "avatarUuid": upload_avatar.ident,
+            "avatarUrl": f"http://testserver/sentry-app-avatar/{upload_avatar.ident}/",
+            "color": True,
+            "photoType": "logo",
+        } in data["sentry_app"]["avatars"]

--- a/tests/sentry/sentry_apps/api/serializers/test_sentry_app_avatar.py
+++ b/tests/sentry/sentry_apps/api/serializers/test_sentry_app_avatar.py
@@ -1,0 +1,29 @@
+from sentry.api.serializers import serialize
+from sentry.sentry_apps.api.serializers.sentry_app_avatar import SentryAppAvatarSerializer
+from sentry.sentry_apps.services.app.serial import serialize_sentry_app_avatar
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class SentryAppSerializerTest(TestCase):
+    def setUp(self):
+        self.sentry_app = self.create_sentry_app(organization=self.organization)
+        self.avatar = self.create_sentry_app_avatar(sentry_app=self.sentry_app)
+
+    def test_avatar(self):
+        serial_avatar = serialize(self.avatar, None)
+        assert serial_avatar["avatarType"] == self.avatar.get_avatar_type_display()
+        assert serial_avatar["avatarUuid"] == self.avatar.ident
+        assert serial_avatar["avatarUrl"] == self.avatar.absolute_url()
+        assert serial_avatar["color"] == self.avatar.color
+        assert serial_avatar["photoType"] == self.avatar.get_avatar_photo_type().value
+
+    def test_rpc_avatar(self):
+        rpc_avatar = serialize_sentry_app_avatar(self.avatar)
+        serial_rpc_avatar = serialize(rpc_avatar, None, SentryAppAvatarSerializer())
+        assert serial_rpc_avatar["avatarType"] == self.avatar.get_avatar_type_display()
+        assert serial_rpc_avatar["avatarUuid"] == self.avatar.ident
+        assert serial_rpc_avatar["avatarUrl"] == self.avatar.absolute_url()
+        assert serial_rpc_avatar["color"] == self.avatar.color
+        assert serial_rpc_avatar["photoType"] == self.avatar.get_avatar_photo_type().value

--- a/tests/sentry/sentry_apps/services/test_model.py
+++ b/tests/sentry/sentry_apps/services/test_model.py
@@ -1,7 +1,33 @@
-from sentry.sentry_apps.services.app.serial import serialize_sentry_app_installation
+from sentry.sentry_apps.services.app.serial import (
+    serialize_sentry_app_avatar,
+    serialize_sentry_app_installation,
+)
 from sentry.sentry_apps.services.app.service import app_service
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import control_silo_test, region_silo_test
+
+
+@control_silo_test
+class TestSentryAppAvatar(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sentry_app = self.create_sentry_app(organization=self.organization)
+        self.avatar = self.create_sentry_app_avatar(sentry_app=self.sentry_app)
+
+    def test_rpc_avatar_properties(self):
+        rpc_avatar = serialize_sentry_app_avatar(self.avatar)
+        assert rpc_avatar.id == self.avatar.id
+        assert rpc_avatar.ident == self.avatar.ident
+        assert rpc_avatar.sentry_app_id == self.avatar.sentry_app_id
+        assert rpc_avatar.avatar_type == self.avatar.avatar_type
+        assert rpc_avatar.color == self.avatar.color
+        assert rpc_avatar.AVATAR_TYPES == self.avatar.AVATAR_TYPES
+        assert rpc_avatar.url_path == self.avatar.url_path
+        assert rpc_avatar.FILE_TYPE == self.avatar.FILE_TYPE
+        assert rpc_avatar.get_avatar_type_display() == self.avatar.get_avatar_type_display()
+        assert rpc_avatar.get_cache_key(20) == self.avatar.get_cache_key(20)
+        assert rpc_avatar.get_avatar_photo_type() == self.avatar.get_avatar_photo_type()
+        assert rpc_avatar.absolute_url() == self.avatar.absolute_url()
 
 
 @region_silo_test


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/93612

In the event a token issued from a sentry app is used to create an activity, we attribute it to the proxy user instead of a sentry app. 

<img width="512" alt="image" src="https://github.com/user-attachments/assets/de959330-bc0a-4476-803e-3c33e28d0764" />

To get the sentry app to appear (and minimize API/RPC calls) I added a new rpc method that will return the sentry app, and its avatars (everything the FE will need) to properly render the source of the activity.


Thinking about this more, I would rather read `is_sentry_app` off of the user property, so I will modify the RPC method to do that instead of using all user_ids.