### PR TITLE
feat(seer): Add controls for seer scanner

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -93,6 +93,7 @@ export interface Organization extends OrganizationSummary {
   teamRoleList: TeamRole[];
   trustedRelays: Relay[];
   defaultAutofixAutomationTuning?: 'off' | 'low' | 'medium' | 'high' | 'always' | null;
+  defaultSeerScannerAutomation?: boolean;
   desiredSampleRate?: number | null;
   effectiveSampleRate?: number | null;
   extraOptions?: {

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -82,6 +82,7 @@ export type Project = {
   options?: Record<string, boolean | string>;
   securityToken?: string;
   securityTokenHeader?: string;
+  seerScannerAutomation?: boolean;
   sessionStats?: {
     currentCrashFreeRate: number | null;
     hasHealthData: boolean;

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -92,7 +92,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const needsAutomation =
     detailedProject?.data &&
     (detailedProject?.data?.autofixAutomationTuning === 'off' ||
-      detailedProject?.data?.autofixAutomationTuning === undefined) &&
+      detailedProject?.data?.autofixAutomationTuning === undefined ||
+      detailedProject?.data?.seerScannerAutomation === false ||
+      detailedProject?.data?.seerScannerAutomation === undefined) &&
     isAutomationAllowed;
   const needsFixabilityView =
     !views.some(view => view.query.includes(FieldKey.ISSUE_SEER_ACTIONABILITY)) &&

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -271,7 +271,7 @@ describe('ProjectSeer', function () {
 
     // Find the select menu
     const select = await screen.findByRole('textbox', {
-      name: /Automatically Analyze Incoming Issues/i,
+      name: /Automate Issue Fixes/i,
     });
 
     act(() => {
@@ -291,6 +291,48 @@ describe('ProjectSeer', function () {
       expect(projectPutRequest).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({data: {autofixAutomationTuning: 'high'}})
+      );
+    });
+  });
+
+  it('can update the project scanner automation setting', async function () {
+    const initialProject: Project = {
+      ...project,
+      seerScannerAutomation: false, // Start from off
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      method: 'GET',
+      body: initialProject,
+    });
+
+    const projectPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<ProjectSeer project={initialProject} />, {organization});
+
+    // Find the toggle for Automate Issue Scans
+    const toggle = await screen.findByRole('checkbox', {
+      name: /Automate Issue Scans/i,
+    });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).not.toBeChecked();
+
+    // Toggle it on
+    await userEvent.click(toggle);
+
+    // Form has saveOnBlur=true, so wait for the PUT request
+    await waitFor(() => {
+      expect(projectPutRequest).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(projectPutRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({data: {seerScannerAutomation: true}})
       );
     });
   });

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useCallback} from 'react';
+import {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback} from 'react';
+import React, {Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 import {useQueryClient} from '@tanstack/react-query';
 
@@ -40,20 +40,23 @@ const SeerSelectLabel = styled('div')`
   margin-bottom: ${space(0.5)};
 `;
 
+export const seerScannerAutomationField = {
+  name: 'seerScannerAutomation',
+  label: t('Automate Issue Scans'),
+  help: () =>
+    t(
+      'Seer can scan all new issues in your project, helping you focus on the most actionable and quick-to-fix ones, giving more context in Slack alerts, and enabling automatic Issue Fixes.'
+    ),
+  type: 'boolean',
+  saveOnBlur: true,
+} satisfies FieldObject;
+
 export const autofixAutomatingTuningField = {
   name: 'autofixAutomationTuning',
-  label: t('Automatically Analyze Incoming Issues'),
-  help: props =>
-    tct(
-      "Set how frequently Seer can automatically run on new issues, based on how actionable it thinks the issue is. Seer will find a root cause and solution, but won't automatically open PRs.[break][break][link:You can configure automation for other projects too.][break][break]Each run is charged at the [ratelink:standard billing rate] for Seer's Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
-      {
-        break: <br />,
-        link: <Link to={`/settings/${props.organization?.slug}/seer`} />,
-        ratelink: <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />,
-        spendlink: (
-          <Link to={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)} />
-        ),
-      }
+  label: t('Automate Issue Fixes'),
+  help: () =>
+    t(
+      "Seer can automatically find a root cause and solution for incoming issues, based on how actionable it thinks the issue is. It won't open PRs without your approval."
     ),
   type: 'choice',
   options: [
@@ -104,8 +107,8 @@ export const autofixAutomatingTuningField = {
 
 const seerFormGroups: JsonFormObject[] = [
   {
-    title: t('General'),
-    fields: [autofixAutomatingTuningField],
+    title: t('Automation'),
+    fields: [seerScannerAutomationField, autofixAutomatingTuningField],
   },
 ];
 
@@ -136,24 +139,61 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
         apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
         allowUndo
         initialData={{
+          seerScannerAutomation: project.seerScannerAutomation ?? false,
           autofixAutomationTuning: project.autofixAutomationTuning ?? 'off',
         }}
         onSubmitSuccess={handleSubmitSuccess}
         additionalFieldProps={{organization}}
       >
-        <JsonForm
-          forms={seerFormGroups}
-          disabled={!canWriteProject}
-          renderHeader={() =>
-            !canWriteProject && (
-              <Alert type="warning" system>
-                {t(
-                  'These settings can only be edited by users with the organization-level owner, manager, or team-level admin role.'
-                )}
-              </Alert>
-            )
-          }
-        />
+        {({model}) => {
+          const seerScannerAutomation = model.getValue('seerScannerAutomation');
+          const autofixAutomationTuning = model.getValue('autofixAutomationTuning');
+          const showWarning =
+            seerScannerAutomation === false && autofixAutomationTuning !== 'off';
+          return (
+            <JsonForm
+              forms={seerFormGroups}
+              disabled={!canWriteProject}
+              renderHeader={() => (
+                <Fragment>
+                  <Alert type="info" system>
+                    {tct(
+                      "Choose how Seer automates analysis of incoming issues. Automated scans and fixes are charged at the [link:standard billing rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.[break][break]You can also [bulklink:configure automation for other projects].",
+                      {
+                        link: (
+                          <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />
+                        ),
+                        spendlink: (
+                          <Link
+                            to={getPricingDocsLinkForEventType(
+                              DataCategoryExact.SEER_AUTOFIX
+                            )}
+                          />
+                        ),
+                        break: <br />,
+                        bulklink: <Link to={`/settings/${organization.slug}/seer`} />,
+                      }
+                    )}
+                  </Alert>
+                  {!canWriteProject && (
+                    <Alert type="warning" system>
+                      {t(
+                        'These settings can only be edited by users with the organization-level owner, manager, or team-level admin role.'
+                      )}
+                    </Alert>
+                  )}
+                  {showWarning && (
+                    <Alert type="warning" system showIcon>
+                      {t(
+                        'Automatic Issue Fixes will not be triggered until you enable automatic Issue Scans.'
+                      )}
+                    </Alert>
+                  )}
+                </Fragment>
+              )}
+            />
+          );
+        }}
       </Form>
     </Fragment>
   );

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -45,7 +45,7 @@ export const seerScannerAutomationField = {
   label: t('Automate Issue Scans'),
   help: () =>
     t(
-      'Seer can scan all new issues in your project, helping you focus on the most actionable and quick-to-fix ones, giving more context in Slack alerts, and enabling automatic Issue Fixes.'
+      'Seer will scan all new issues in your project, helping you focus on the most actionable and quick-to-fix ones, giving more context in Slack alerts, and enabling automatic Issue Fixes.'
     ),
   type: 'boolean',
   saveOnBlur: true,
@@ -56,7 +56,7 @@ export const autofixAutomatingTuningField = {
   label: t('Automate Issue Fixes'),
   help: () =>
     t(
-      "Seer can automatically find a root cause and solution for incoming issues, based on how actionable it thinks the issue is. It won't open PRs without your approval."
+      "Seer will automatically find a root cause and solution for incoming issues if it thinks the issue is actionable enough. It won't open PRs without your approval."
     ),
   type: 'choice',
   options: [
@@ -185,7 +185,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
                   {showWarning && (
                     <Alert type="warning" system showIcon>
                       {t(
-                        'Automatic Issue Fixes will not be triggered until you enable automatic Issue Scans.'
+                        'Automatic Issue Scans must be enabled for Issue Fixes to be triggered automatically.'
                       )}
                     </Alert>
                   )}

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -1,10 +1,16 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
+import {Alert} from 'sentry/components/core/alert';
+import Link from 'sentry/components/links/link';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {DataCategoryExact} from 'sentry/types/core';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
@@ -26,6 +32,17 @@ function SeerAutomationRoot() {
           'Seer can automatically find a root cause and solution for incoming issues.'
         )}
       />
+      <StyledAlert type="info">
+        {tct(
+          "Choose how Seer automates analysis of incoming issues across your projects. Automated scans and fixes are charged at the [link:standard billing rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
+          {
+            link: <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />,
+            spendlink: (
+              <Link to={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)} />
+            ),
+          }
+        )}
+      </StyledAlert>
       <ProjectPermissionAlert />
 
       <NoProjectMessage organization={organization}>
@@ -35,5 +52,9 @@ function SeerAutomationRoot() {
     </Fragment>
   );
 }
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(1)};
+`;
 
 export default SeerAutomationRoot;

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -9,7 +9,10 @@ import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
-import {autofixAutomatingTuningField} from 'sentry/views/settings/projectSeer';
+import {
+  autofixAutomatingTuningField,
+  seerScannerAutomationField,
+} from 'sentry/views/settings/projectSeer';
 
 const SeerSelectLabel = styled('div')`
   margin-bottom: ${space(0.5)};
@@ -20,22 +23,15 @@ export function SeerAutomationDefault() {
   const canWrite = hasEveryAccess(['org:write'], {organization});
 
   const orgDefaultScannerAutomation: FieldObject = {
+    ...seerScannerAutomationField,
     name: 'defaultSeerScannerAutomation',
     label: <SeerSelectLabel>{t('Default for Automatic Issue Scans')}</SeerSelectLabel>,
-    help: t(
-      'Seer can scan all new issues in your project, helping you focus on the most actionable and quick-to-fix ones, giving more context in Slack alerts, and enabling automatic Issue Fixes.'
-    ),
-    type: 'boolean',
-    saveOnBlur: true,
   };
 
   const orgDefaultAutomationTuning = {
     ...autofixAutomatingTuningField,
     name: 'defaultAutofixAutomationTuning',
     label: <SeerSelectLabel>{t('Default for Automatic Issue Fixes')}</SeerSelectLabel>,
-    help: t(
-      "Seer will find a root cause and solution for new issues that it thinks are actionable enough, but won't automatically open PRs."
-    ),
   } satisfies FieldObject;
 
   const seerFormGroups: JsonFormObject[] = [

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -1,15 +1,14 @@
+import React from 'react';
 import styled from '@emotion/styled';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
+import {Alert} from 'sentry/components/core/alert';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
-import Link from 'sentry/components/links/link';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {DataCategoryExact} from 'sentry/types/core';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import {autofixAutomatingTuningField} from 'sentry/views/settings/projectSeer';
 
 const SeerSelectLabel = styled('div')`
@@ -20,26 +19,29 @@ export function SeerAutomationDefault() {
   const organization = useOrganization();
   const canWrite = hasEveryAccess(['org:write'], {organization});
 
+  const orgDefaultScannerAutomation: FieldObject = {
+    name: 'defaultSeerScannerAutomation',
+    label: <SeerSelectLabel>{t('Default for Automatic Issue Scans')}</SeerSelectLabel>,
+    help: t(
+      'Seer can scan all new issues in your project, helping you focus on the most actionable and quick-to-fix ones, giving more context in Slack alerts, and enabling automatic Issue Fixes.'
+    ),
+    type: 'boolean',
+    saveOnBlur: true,
+  };
+
   const orgDefaultAutomationTuning = {
     ...autofixAutomatingTuningField,
     name: 'defaultAutofixAutomationTuning',
-    label: <SeerSelectLabel>{t('Default Automation for New Projects')}</SeerSelectLabel>,
-    help: tct(
-      "Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis.[break][break] Seer will find a root cause and solution for new issues that it thinks are actionable enough, but won't automatically open PRs.[break][break]Each run is charged at the [ratelink:standard billing rate] for Seer's Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
-      {
-        break: <br />,
-        ratelink: <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />,
-        spendlink: (
-          <Link to={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)} />
-        ),
-      }
+    label: <SeerSelectLabel>{t('Default for Automatic Issue Fixes')}</SeerSelectLabel>,
+    help: t(
+      "Seer will find a root cause and solution for new issues that it thinks are actionable enough, but won't automatically open PRs."
     ),
   } satisfies FieldObject;
 
   const seerFormGroups: JsonFormObject[] = [
     {
-      title: t('General'),
-      fields: [orgDefaultAutomationTuning],
+      title: t('Default Automation for New Projects'),
+      fields: [orgDefaultScannerAutomation, orgDefaultAutomationTuning],
     },
   ];
   return (
@@ -49,11 +51,44 @@ export function SeerAutomationDefault() {
       apiEndpoint={`/organizations/${organization.slug}/`}
       allowUndo
       initialData={{
+        defaultSeerScannerAutomation: organization.defaultSeerScannerAutomation ?? false,
         defaultAutofixAutomationTuning:
           organization.defaultAutofixAutomationTuning ?? 'off',
       }}
     >
-      <JsonForm forms={seerFormGroups} disabled={!canWrite} />
+      {({model}) => {
+        const defaultSeerScannerAutomation = model.getValue(
+          'defaultSeerScannerAutomation'
+        );
+        const defaultAutofixAutomationTuning = model.getValue(
+          'defaultAutofixAutomationTuning'
+        );
+        const showWarning =
+          defaultSeerScannerAutomation === false &&
+          defaultAutofixAutomationTuning !== 'off';
+        return (
+          <JsonForm
+            forms={seerFormGroups}
+            disabled={!canWrite}
+            renderHeader={() => (
+              <React.Fragment>
+                <Alert type="info" system>
+                  {t(
+                    'Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis.'
+                  )}
+                </Alert>
+                {showWarning && (
+                  <Alert type="warning" system showIcon>
+                    {t(
+                      'Automatic Issue Fixes will not be triggered until you enable automatic Issue Scans.'
+                    )}
+                  </Alert>
+                )}
+              </React.Fragment>
+            )}
+          />
+        );
+      }}
     </Form>
   );
 }

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -76,7 +76,7 @@ export function SeerAutomationDefault() {
                 {showWarning && (
                   <Alert type="warning" system showIcon>
                     {t(
-                      'Automatic Issue Fixes will not be triggered until you enable automatic Issue Scans.'
+                      'Automatic Issue Scans must be enabled for Issue Fixes to be triggered automatically.'
                     )}
                   </Alert>
                 )}

--- a/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
@@ -56,12 +56,26 @@ function ProjectSeerSetting({project, orgSlug}: {orgSlug: string; project: Proje
     return <div>Error</div>;
   }
 
+  const {autofixAutomationTuning = 'off', seerScannerAutomation = false} =
+    detailedProject.data;
+
   return (
     <SeerValue>
-      {getSeerLabel(detailedProject.data.autofixAutomationTuning ?? 'off')}
+      <span>
+        <Subheading>{t('Scans')}:</Subheading>{' '}
+        {seerScannerAutomation ? t('On') : t('Off')}
+      </span>
+      {' | '}
+      <span>
+        <Subheading>{t('Fixes')}:</Subheading> {getSeerLabel(autofixAutomationTuning)}
+      </span>
     </SeerValue>
   );
 }
+
+const Subheading = styled('span')`
+  font-weight: ${p => p.theme.fontWeightBold};
+`;
 
 const SeerSelectLabel = styled('div')`
   margin-bottom: ${space(0.5)};
@@ -174,24 +188,74 @@ export function SeerAutomationProjectList() {
     }
   }
 
+  async function updateProjectsSeerScanner(value: boolean) {
+    addLoadingMessage('Updating projects...', {duration: 30000});
+    try {
+      await Promise.all(
+        Array.from(selected).map(projectId => {
+          const project = projects.find(p => p.id === projectId);
+          if (!project) return Promise.resolve();
+          return api.requestPromise(`/projects/${organization.slug}/${project.slug}/`, {
+            method: 'PUT',
+            data: {seerScannerAutomation: value},
+          });
+        })
+      );
+      addSuccessMessage('Projects updated successfully');
+    } catch (err) {
+      addErrorMessage('Failed to update some projects');
+    } finally {
+      Array.from(selected).forEach(projectId => {
+        const project = projects.find(p => p.id === projectId);
+        if (!project) return;
+        queryClient.invalidateQueries({
+          queryKey: makeDetailedProjectQueryKey({
+            orgSlug: organization.slug,
+            projectSlug: project.slug,
+          }),
+        });
+      });
+    }
+  }
+
   const actionMenuItems = SEER_THRESHOLD_MAP.map(key => ({
     key,
     label: <SeerSelectLabel>{getSeerLabel(key)}</SeerSelectLabel>,
     onAction: () => updateProjectsSeerValue(key),
   }));
 
+  const scanMenuItems = [
+    {
+      key: 'on',
+      label: t('On'),
+      onAction: () => updateProjectsSeerScanner(true),
+    },
+    {
+      key: 'off',
+      label: t('Off'),
+      onAction: () => updateProjectsSeerScanner(false),
+    },
+  ];
+
   return (
     <Fragment>
       <Panel>
         <PanelHeader>
           {selected.size > 0 ? (
-            <ActionDropdownMenu
-              items={actionMenuItems}
-              triggerLabel={t('Set to')}
-              size="sm"
-            />
+            <Flex gap={space(1)} align="center">
+              <ActionDropdownMenu
+                items={scanMenuItems}
+                triggerLabel={t('Set Issue Scans to')}
+                size="sm"
+              />
+              <ActionDropdownMenu
+                items={actionMenuItems}
+                triggerLabel={t('Set Issue Fixes to')}
+                size="sm"
+              />
+            </Flex>
           ) : (
-            <div>{t('Current Project Settings')}</div>
+            <div>{t('Automation for Current Projects')}</div>
           )}
           <div style={{marginLeft: 'auto'}}>
             <Button size="sm" onClick={toggleSelectAll}>


### PR DESCRIPTION
Toggle to turn seer scanner off and on per project, and to change default for new projects.

<img width="1390" alt="Screenshot 2025-06-06 at 2 32 54 PM" src="https://github.com/user-attachments/assets/cb5ac0e9-d15b-40d1-943f-9b72999f5ed3" />
<img width="1399" alt="Screenshot 2025-06-06 at 3 30 05 PM" src="https://github.com/user-attachments/assets/ece4fd26-ba36-45dc-ad60-a5caefea66a7" />
<img width="556" alt="Screenshot 2025-06-06 at 3 33 15 PM" src="https://github.com/user-attachments/assets/d18e9c27-ac84-4d83-aeff-2ad2d61d942d" />
