### PR TITLE
feat(autofix): Track if autofix state is fetched through endpoint or elsewhere

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -66,7 +66,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         if not access_check_cache_value:
             check_repo_access = True
 
-        autofix_state = get_autofix_state(group_id=group.id, check_repo_access=check_repo_access)
+        autofix_state = get_autofix_state(
+            group_id=group.id, check_repo_access=check_repo_access, is_user_fetching=True
+        )
 
         if check_repo_access:
             cache.set(access_check_cache_key, True, timeout=60)  # 1 minute timeout

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -71,7 +71,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         autofix_state = get_autofix_state(
             group_id=group.id,
             check_repo_access=check_repo_access,
-            is_user_fetching=is_user_watching,
+            is_user_fetching=bool(is_user_watching),
         )
 
         if check_repo_access:

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -66,8 +66,12 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         if not access_check_cache_value:
             check_repo_access = True
 
+        is_user_watching = request.GET.get("isUserWatching", False)
+
         autofix_state = get_autofix_state(
-            group_id=group.id, check_repo_access=check_repo_access, is_user_fetching=True
+            group_id=group.id,
+            check_repo_access=check_repo_access,
+            is_user_fetching=is_user_watching,
         )
 
         if check_repo_access:

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -20,6 +20,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,14 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
+            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60, concurrent_limit=100),
+        }
+    }
 
     def get(self, request: Request, group: Group) -> Response:
         """

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -85,7 +85,11 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
 
 def get_autofix_state(
-    *, group_id: int | None = None, run_id: int | None = None, check_repo_access: bool = False
+    *,
+    group_id: int | None = None,
+    run_id: int | None = None,
+    check_repo_access: bool = False,
+    is_user_fetching: bool = False,
 ) -> AutofixState | None:
     path = "/v1/automation/autofix/state"
     body = orjson.dumps(
@@ -93,6 +97,7 @@ def get_autofix_state(
             "group_id": group_id,
             "run_id": run_id,
             "check_repo_access": check_repo_access,
+            "is_user_fetching": is_user_fetching,
         }
     )
 

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -50,7 +50,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "profile" not in response.data["autofix"]["request"]
         assert "issue_summary" not in response.data["autofix"]["request"]
 
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
     def test_ai_autofix_get_endpoint_without_autofix(
@@ -65,7 +67,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["autofix"] is None
 
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
     @patch("sentry.api.endpoints.group_ai_autofix.get_sorted_code_mapping_configs")
@@ -650,7 +654,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache miss should trigger repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=True
+            group_id=self.group.id, check_repo_access=True, is_user_fetching=True
         )
 
         # Verify the cache was set with a 60-second timeout
@@ -681,7 +685,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache hit should skip repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=False
+            group_id=self.group.id, check_repo_access=False, is_user_fetching=True
         )
 
         # Verify the cache was not set again
@@ -713,7 +717,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Verify first request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)
 
         # Reset mocks for second request
@@ -728,7 +734,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Verify second request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=False)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=False, is_user_fetching=True
+        )
         mock_cache.set.assert_not_called()
 
         # Reset mocks for third request
@@ -743,5 +751,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Verify third request behavior - should be like the first request
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -51,7 +51,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "issue_summary" not in response.data["autofix"]["request"]
 
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
@@ -68,7 +68,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is None
 
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
@@ -654,7 +654,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache miss should trigger repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=True, is_user_fetching=True
+            group_id=self.group.id, check_repo_access=True, is_user_fetching=False
         )
 
         # Verify the cache was set with a 60-second timeout
@@ -685,7 +685,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache hit should skip repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=False, is_user_fetching=True
+            group_id=self.group.id, check_repo_access=False, is_user_fetching=False
         )
 
         # Verify the cache was not set again
@@ -718,7 +718,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify first request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)
 
@@ -735,7 +735,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify second request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=False, is_user_fetching=True
+            group_id=group.id, check_repo_access=False, is_user_fetching=False
         )
         mock_cache.set.assert_not_called()
 
@@ -752,6 +752,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify third request behavior - should be like the first request
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -123,7 +123,7 @@ class TestGetAutofixState(TestCase):
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=b'{"group_id":123,"run_id":null,"check_repo_access":false}',
+            data=b'{"group_id":123,"run_id":null,"check_repo_access":false,"is_user_fetching":false}',
             headers={"content-type": "application/json;charset=utf-8"},
         )
 
@@ -154,7 +154,7 @@ class TestGetAutofixState(TestCase):
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=b'{"group_id":null,"run_id":456,"check_repo_access":false}',
+            data=b'{"group_id":null,"run_id":456,"check_repo_access":false,"is_user_fetching":false}',
             headers={"content-type": "application/json;charset=utf-8"},
         )
 


### PR DESCRIPTION
Tracking if a user is viewing the state or the state is just being accessed by the sentry backend. Will be used for stopping automated runs if the user is looking at it.

Frontend PR to set flag: https://github.com/getsentry/sentry/pull/93168