### PR TITLE
fix(eap-trace-watefall): Fixing orphan error timelines

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -108,6 +108,12 @@ export class TraceTreeNode<T extends TraceTree.NodeValue = TraceTree.NodeValue> 
       ];
     } else if (value && 'timestamp' in value && typeof value.timestamp === 'number') {
       this.space = [value.timestamp * 1e3, 0];
+    } else if (
+      value &&
+      'start_timestamp' in value &&
+      typeof value.start_timestamp === 'number'
+    ) {
+      this.space = [value.start_timestamp * 1e3, 0];
     }
 
     if (value) {


### PR DESCRIPTION
- eap orphan errors were receiving `iso_formatted:string` timestamps, which is inconsistent with the rest of the eap events
- BE change to fix this: https://github.com/getsentry/sentry/pull/92853
- This PR is the FE followup, using the correctly formatted `number` timestamps

Before: 
<img width="1238" alt="Screenshot 2025-06-08 at 5 11 13 PM" src="https://github.com/user-attachments/assets/675b236b-4701-4dad-b240-79572b2a0c59" />

After (matches the non-eap trace):
<img width="1235" alt="Screenshot 2025-06-08 at 5 12 58 PM" src="https://github.com/user-attachments/assets/18f6ca4e-619d-4324-a19b-2b4659d25e06" />
