### PR TITLE
feat(trace-eap-watefall): Using new trace-meta endpoint

### DIFF
--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -143,3 +143,12 @@ export type TraceMeta = {
   transaction_child_count_map: Record<string, number>;
   transactions: number;
 };
+
+export type EAPTraceMeta = {
+  errors: number;
+  logs: number;
+  performance_issues: number;
+  span_count: number;
+  span_count_map: Record<string, number>;
+  transaction_child_count_map: Record<string, number>;
+};

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -4,10 +4,15 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
 
 import {useTraceMeta} from './useTraceMeta';
+
+jest.mock('sentry/utils/useSyncedLocalStorageState', () => ({
+  useSyncedLocalStorageState: jest.fn(),
+}));
 
 const organization = OrganizationFixture();
 const queryClient = makeTestQueryClient();
@@ -29,6 +34,7 @@ const mockedReplayTraces: ReplayTrace[] = [
 
 describe('useTraceMeta', () => {
   beforeEach(function () {
+    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['non-eap', jest.fn()]);
     queryClient.clear();
     jest.clearAllMocks();
   });
@@ -112,6 +118,95 @@ describe('useTraceMeta', () => {
           op1: 2,
           op2: 1,
           op3: 1,
+        },
+      },
+      errors: [],
+      status: 'success',
+    });
+  });
+
+  it('EAP - Returns merged meta results', async () => {
+    const org = OrganizationFixture({
+      features: ['trace-spans-format'],
+    });
+
+    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['eap', jest.fn()]);
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug1/',
+      body: {
+        errors: 1,
+        logs: 1,
+        performance_issues: 1,
+        span_count: 1,
+        span_count_map: {
+          op1: 1,
+        },
+        transaction_child_count_map: [{'transaction.id': '1', count: 1}],
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug2/',
+      body: {
+        errors: 1,
+        logs: 1,
+        performance_issues: 1,
+        span_count: 1,
+        span_count_map: {
+          op1: 1,
+          op2: 1,
+        },
+        transaction_child_count_map: [{'transaction.id': '2', count: 2}],
+      },
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug3/',
+      body: {
+        errors: 1,
+        logs: 1,
+        performance_issues: 1,
+        span_count: 1,
+        span_count_map: {
+          op3: 1,
+        },
+        transaction_child_count_map: [{'transaction.id': '3', count: 1}],
+      },
+    });
+
+    const wrapper = ({children}: {children: React.ReactNode}) => (
+      <QueryClientProvider client={queryClient}>
+        <OrganizationContext value={org}>{children}</OrganizationContext>
+      </QueryClientProvider>
+    );
+
+    const {result} = renderHook(() => useTraceMeta(mockedReplayTraces), {wrapper});
+
+    expect(result.current).toEqual({
+      data: undefined,
+      errors: [],
+      status: 'pending',
+    });
+
+    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+
+    expect(result.current).toEqual({
+      data: {
+        errors: 3,
+        logs: 3,
+        performance_issues: 3,
+        span_count: 3,
+        span_count_map: {
+          op1: 2,
+          op2: 1,
+          op3: 1,
+        },
+        transaction_child_count_map: {
+          '1': 1,
+          '2': 2,
+          '3': 1,
         },
       },
       errors: [],

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -7,8 +7,8 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import getDuration from 'sentry/utils/duration/getDuration';
-import type {TraceMeta} from 'sentry/utils/performance/quickTrace/types';
 import type {OurLogsResponseItem} from 'sentry/views/explore/logs/types';
+import type {TraceMetaQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {RepresentativeTraceEvent} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
@@ -51,7 +51,7 @@ const SectionBody = styled('div')<{rightAlign?: boolean}>`
 
 interface MetaProps {
   logs: OurLogsResponseItem[] | undefined;
-  meta: TraceMeta | undefined;
+  meta: TraceMetaQueryResults['data'];
   organization: Organization;
   representativeEvent: RepresentativeTraceEvent;
   tree: TraceTree;
@@ -166,7 +166,11 @@ export function Meta(props: MetaProps) {
         <MetaSection
           rightAlignBody
           headingText={t('Logs')}
-          bodyText={props.logs?.length ?? 0}
+          bodyText={
+            props.meta && 'logs' in props.meta
+              ? props.meta.logs
+              : (props.logs?.length ?? 0)
+          }
         />
       ) : null}
     </MetaWrapper>


### PR DESCRIPTION
- The new `trace-meta` introduces the total logs count associated with a trace, and excludes unnecessary attrs like project and transactions count. 
- Currently `events-trace-meta` only goes up to the pagination limit on logs which is incorrect.
- Added test.
<img width="1236" alt="Screenshot 2025-06-08 at 7 15 00 PM" src="https://github.com/user-attachments/assets/8d8d45d8-ff32-4beb-9fbc-6bfa86dda04a" />
