### PR TITLE
fix(issues): Ensure screenshot modal only shows screenshots

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
@@ -66,7 +66,16 @@ describe('ScreenshotModal', function () {
 
   it('renders with previous and next buttons when passed attachments', async function () {
     const eventAttachment = EventAttachmentFixture();
-    const attachments = [eventAttachment, EventAttachmentFixture({id: '2'})];
+    const attachments = [
+      eventAttachment,
+      EventAttachmentFixture({id: '2'}),
+      EventAttachmentFixture({name: 'other-image.png'}),
+      EventAttachmentFixture({
+        name: 'textfile.txt',
+        mimetype: 'text/plain',
+        headers: {'Content-Type': 'text/plain'},
+      }),
+    ];
 
     render(
       <ScreenshotModal


### PR DESCRIPTION
Fixes: [RTC-1001: Make the Screenshot carousel to only iterate over screenshots](https://linear.app/getsentry/issue/RTC-1001/make-the-screenshot-carousel-to-only-iterate-over-screenshots)