### PR TITLE
fix(widget-builder): Change slideout + preview transition to start off screen

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -19,7 +19,7 @@ const OPEN_STYLES = {
 const COLLAPSED_STYLES = {
   bottom: {opacity: 0, x: 0, y: PANEL_HEIGHT},
   right: {opacity: 0, x: PANEL_WIDTH, y: 0},
-  left: {opacity: 0, x: -200, y: 0},
+  left: {opacity: 0, x: '-100%', y: 0},
 };
 
 type SlideOverPanelProps = {

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -323,9 +323,9 @@ export function WidgetPreviewContainer({
   };
 
   const animatedProps = {
-    initial: {opacity: 0, x: '50%', y: 0},
+    initial: {opacity: 0, x: '100%', y: 0},
     animate: {opacity: 1, x: 0, y: 0},
-    exit: {opacity: 0, x: '50%', y: 0},
+    exit: {opacity: 0, x: '100%', y: 0},
     transition: animationTransitionSettings,
   };
 


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/DAIN-351/janky-slideout-for-widget-builder

I've increased the initial x position on both the widget builder preview and slideout so that it looks like its coming from off the screen instead of it starting partially on the screen.