### PR TITLE
ref(forms): Allow `null` as a form value

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -25,6 +25,7 @@ export type FieldValue =
   | boolean
   | Record<PropertyKey, unknown>
   | Choice
+  | null
   | undefined; // is undefined valid here?
 
 export type FormOptions = {


### PR DESCRIPTION
Undefined will end up not passing the value through the API response,
null is a valid value for fields to be set to at times.