### PR TITLE
:mag: nit(integrations): change default branch name to `main` for code mapping modal

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
@@ -214,7 +214,7 @@ describe('IntegrationCodeMappings', function () {
     renderGlobalModal();
 
     await userEvent.click(screen.getByRole('button', {name: 'Add Code Mapping'}));
-    expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue('master');
+    expect(screen.getByRole('textbox', {name: 'Branch'})).toHaveValue('main');
 
     await selectEvent.select(screen.getByText('Choose repo'), repos[1]!.name);
     await waitFor(() => {

--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.tsx
@@ -130,7 +130,7 @@ function RepositoryProjectPathConfigForm({
   }
 
   const initialData = {
-    defaultBranch: 'master',
+    defaultBranch: 'main',
     stackRoot: '',
     sourceRoot: '',
     repositoryId: existingConfig?.repoId,


### PR DESCRIPTION
https://sfconservancy.org/news/2020/jun/23/gitbranchname/

Git and Github has changed the default branch name from `master` to `main` - we should also change our default name as well - it also helps our wording to be more inclusive

<img width="625" alt="image" src="https://github.com/user-attachments/assets/803b2384-4376-45cb-b55e-a29334dd6ba1" />

closes ECO-677
