### PR TITLE
:mag: nit: remove expensive github access token log

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -195,7 +195,6 @@ class GithubProxyClient(IntegrationProxyClient):
         if should_refresh:
             access_token = self._refresh_access_token()
 
-        logger.info("token.access_token", extra=logger_extra)
         return access_token
 
     @control_silo_function


### PR DESCRIPTION
we don't use this log and based on my math, deleting this log will save us ~$4.5k

data from [here](https://console.cloud.google.com/monitoring/dashboards/builder/2fac5642-c4b9-4359-8f84-fb9065a40cbe;duration=P1D?invt=Abzq3g&project=internal-sentry&pageState=(%22eventTypes%22:(%22selected%22:%5B%22CLOUD_ALERTING_ALERT%22,%22SERVICE_HEALTH_INCIDENT%22%5D))&rapt=AEjHL4NL5TS0_HZRIGGC_2egzRlxKZeImiELNSwRDfxXfNQQK4cOqTRpTFVtft8OU7vUwd3dNvnbTsF2fvAcTLuuObMcjhsxVKQ9VKqesD5qpM3kuqYnWG0&inv=1)


contributes to ECO-692
