### PR TITLE
Open PR and add tests if confident

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -510,6 +510,22 @@ describe('EventTagsAndScreenshot', function () {
 
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/repos/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/releases/io.sentry.sample.iOS-Swift%407.2.3%2B390/',
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/releases/io.sentry.sample.iOS-Swift%407.2.3%2B390/deploys/',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/`,
+        body: project,
+      });
+      MockApiClient.addMockResponse({
         url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/`,
         body: flexibleScreenshotAttachments,
       });
@@ -520,7 +536,9 @@ describe('EventTagsAndScreenshot', function () {
       await assertTagsView();
 
       // Should show Screenshots section (plural) since we have 2 screenshot files
-      expect(await screen.findByRole('region', {name: 'Screenshots'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('region', {name: 'Screenshots'})
+      ).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
 
       // Should detect crash_screenshot.png as the first screenshot

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
@@ -51,7 +51,8 @@ export function ScreenshotDataSection({
   const screenshots =
     attachments?.filter(
       (attachment: EventAttachment) =>
-        attachment.name.includes('screenshot') && (attachment.name.endsWith('.jpg') || attachment.name.endsWith('.png'))
+        attachment.name.includes('screenshot') &&
+        (attachment.name.endsWith('.jpg') || attachment.name.endsWith('.png'))
     ) ?? [];
 
   const [screenshotInFocus, setScreenshotInFocus] = useState<number>(0);

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx
@@ -24,15 +24,6 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 
-const SCREENSHOT_NAMES = [
-  'screenshot.jpg',
-  'screenshot.png',
-  'screenshot-1.jpg',
-  'screenshot-1.png',
-  'screenshot-2.jpg',
-  'screenshot-2.png',
-];
-
 interface ScreenshotDataSectionProps {
   event: Event;
   projectSlug: Project['slug'];
@@ -58,7 +49,10 @@ export function ScreenshotDataSection({
   );
   const {mutate: deleteAttachment} = useDeleteEventAttachmentOptimistic();
   const screenshots =
-    attachments?.filter(({name}) => SCREENSHOT_NAMES.includes(name)) ?? [];
+    attachments?.filter(
+      (attachment: EventAttachment) =>
+        attachment.name.includes('screenshot') && (attachment.name.endsWith('.jpg') || attachment.name.endsWith('.png'))
+    ) ?? [];
 
   const [screenshotInFocus, setScreenshotInFocus] = useState<number>(0);
 


### PR DESCRIPTION
The screenshot widget in Issue Details was updated to improve file detection.

*   In `static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx`, the hardcoded `SCREENSHOT_NAMES` array was removed.
*   The logic was updated to flexibly identify screenshots by checking if an attachment's `name` includes "screenshot" and ends with `.jpg` or `.png`. This change addresses issue #92154, allowing files like `crash_screenshot.png` to be displayed.
*   A new test case was added to `static/app/components/events/eventTagsAndScreenshot/index.spec.tsx` to validate the updated detection logic, ensuring files with flexible naming patterns are correctly identified and navigable.
*   API mocks were added to the test to ensure proper functionality.
*   A new documentation file, `screenshot_detection_improvement.md`, was created to detail these changes.