### PR TITLE
fix(issue-views): Fix `Save As` chevron color

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -135,7 +135,7 @@ function SegmentedIssueViewSaveButton({
               <DropdownTrigger
                 {...props}
                 disabled={!hasFeature || isSaving}
-                icon={<IconChevron direction="down" />}
+                icon={<IconChevron direction="down" color="gray300" />}
                 aria-label={t('More save options')}
                 priority={buttonPriority}
               />

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -135,7 +135,7 @@ function SegmentedIssueViewSaveButton({
               <DropdownTrigger
                 {...props}
                 disabled={!hasFeature || isSaving}
-                icon={<IconChevron direction="down" color="gray300" />}
+                icon={<IconChevron direction="down" color="subText" />}
                 aria-label={t('More save options')}
                 priority={buttonPriority}
               />


### PR DESCRIPTION
The chevron in the save as button was darker than the other chevrons in Issues.

Before:

![Screenshot 2025-06-09 at 11 06 37 AM](https://github.com/user-attachments/assets/a04744a5-1189-49fc-bdae-cfc7d269b9c7)

After: 

![Screenshot 2025-06-09 at 11 07 16 AM](https://github.com/user-attachments/assets/9f5f6e18-bafb-4d5b-aa2c-1c86119392d9)

