### PR TITLE
chore(signup): increase signup form name characters to match db length

### DIFF
--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -146,7 +146,7 @@ class AuthenticationForm(forms.Form):
 class PasswordlessRegistrationForm(forms.ModelForm):
     name = forms.CharField(
         label=_("Name"),
-        max_length=30,
+        max_length=200,
         widget=forms.TextInput(attrs={"placeholder": "Jane Bloggs"}),
         required=True,
     )


### PR DESCRIPTION
`name` is 200 chars on the `User` model
https://github.com/getsentry/sentry/blob/156a527ff43218f9b0f47967580d03f670561ad7/src/sentry/users/models/user.py#L106

Closes https://github.com/getsentry/sentry/issues/74339