### PR TITLE
fix(logs): Re-add UTC to time tooltip

### DIFF
--- a/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.spec.tsx
@@ -31,7 +31,29 @@ describe('TimestampTooltipBody', function () {
 
     expect(screen.getByText('Occurred')).toBeInTheDocument();
     expect(screen.getByText(/Jan 15, 2024.*10:45:30\.456 AM EST/)).toBeInTheDocument();
+    expect(screen.getByText(/Jan 15, 2024.*3:45:30\.456 PM UTC/)).toBeInTheDocument();
     expect(screen.getByText(/1705333530/)).toBeInTheDocument();
+  });
+
+  it('renders only timezone line when timezone is UTC', function () {
+    const user = UserFixture();
+    user.options.timezone = 'UTC';
+    ConfigStore.set('user', user);
+
+    const attributes = {
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1705333530456789012',
+    };
+
+    render(
+      <TimezoneProvider timezone="UTC">
+        <TimestampTooltipBody timestamp={timestamp} attributes={attributes} />
+      </TimezoneProvider>
+    );
+
+    expect(screen.getByText('Occurred')).toBeInTheDocument();
+    expect(screen.getByText(/Jan 15, 2024.*3:45:30\.456 PM UTC/)).toBeInTheDocument();
+    const allTimestampElements = screen.getAllByText(/Jan 15, 2024.*3:45:30\.456 PM UTC/);
+    expect(allTimestampElements).toHaveLength(1);
   });
 
   it('renders received time when observed timestamp is provided', function () {

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import AutoSelectText from 'sentry/components/autoSelectText';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';
+import {useTimezone} from 'sentry/components/timezoneProvider';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -22,6 +23,7 @@ function TimestampTooltipBody({
   attributes: Record<string, string | number | boolean>;
   timestamp: string | number;
 }) {
+  const currentTimezone = useTimezone();
   const preciseTimestamp = attributes[OurLogKnownFieldKey.TIMESTAMP_PRECISE];
   const preciseTimestampMs = preciseTimestamp
     ? Number(preciseTimestamp) / 1_000_000
@@ -35,6 +37,8 @@ function TimestampTooltipBody({
       : null;
   const observedTime = observedTimeMs ? new Date(observedTimeMs) : null;
 
+  const isUTC = currentTimezone === 'UTC';
+
   return (
     <DescriptionList>
       <dt>{t('Occurred')}</dt>
@@ -43,6 +47,11 @@ function TimestampTooltipBody({
           <AutoSelectText>
             <DateTime date={timestampToUse} seconds milliseconds timeZone />
           </AutoSelectText>
+          {!isUTC && (
+            <AutoSelectText>
+              <DateTime date={timestampToUse} seconds milliseconds timeZone utc />
+            </AutoSelectText>
+          )}
           <TimestampLabel>
             ({preciseTimestampMs ? String(preciseTimestampMs) : String(timestamp)})
           </TimestampLabel>


### PR DESCRIPTION
### Summary
UTC will appear below their local timezone, only showing one line if their timezone is in UTC already.


#### Screenshots
|![Screenshot 2025-06-09 at 2 33 02 PM](https://github.com/user-attachments/assets/86d12d91-724b-4665-958f-15edf2269181)|![Screenshot 2025-06-09 at 2 33 26 PM](https://github.com/user-attachments/assets/b43a9b62-b052-462b-9590-71633617b094)|
|-|-|