### PR TITLE
fix(taskscheduler): Add a flag for which schedules should be on taskscheduler

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1513,6 +1513,11 @@ TASKWORKER_SCHEDULES: ScheduleConfigMap = {
     },
 }
 
+TASKWORKER_CONTROL_SCHEDULES: ScheduleConfigMap = {}
+
+if SILO_MODE == "CONTROL":
+    TASKWORKER_SCHEDULES = TASKWORKER_CONTROL_SCHEDULES
+
 TASKWORKER_HIGH_THROUGHPUT_NAMESPACES = {
     "ingest.profiling",
     "ingest.transactions",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3408,13 +3408,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Flags for taskworker scheduler rollout
-register(
-    "taskworker.scheduler.rollout",
-    default=["sync_options_trial"],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.
 register("chunk-upload.no-compression", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3407,6 +3407,14 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Flags for taskworker scheduler rollout
+register(
+    "taskworker.scheduler.rollout",
+    default=["sync_options_trial"],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.
 register("chunk-upload.no-compression", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3408,6 +3408,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Flags for taskworker scheduler rollout
+register(
+    "taskworker.scheduler.rollout",
+    default=["sync_options_trial"],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Orgs for which compression should be disabled in the chunk upload endpoint.
 # This is intended to circumvent sporadic 503 errors reported by some customers.
 register("chunk-upload.no-compression", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -13,6 +13,7 @@ from django.utils import autoreload
 
 import sentry.taskworker.constants as taskworker_constants
 from sentry.bgtasks.api import managed_bgtasks
+from sentry.conf.server import TASKWORKER_SCHEDULES
 from sentry.runner.decorators import configuration, log_options
 from sentry.utils.kafka import run_processor_with_signals
 
@@ -266,10 +267,8 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 
     with managed_bgtasks(role="taskworker-scheduler"):
         runner = ScheduleRunner(taskregistry, run_storage)
-        enabled_schedules = set(options.get("taskworker.scheduler.rollout", []))
         for key, schedule_data in settings.TASKWORKER_SCHEDULES.items():
-            if key in enabled_schedules:
-                runner.add(key, schedule_data)
+            runner.add(key, schedule_data)
 
         runner.log_startup()
         while True:
@@ -488,7 +487,7 @@ def cron(**options: Any) -> None:
 
     old_schedule = app.conf.CELERYBEAT_SCHEDULE
     new_schedule = {}
-    task_schedules = set(options.get("taskworker.scheduler.rollout", []))
+    task_schedules = set(TASKWORKER_SCHEDULES.keys())
     for key, schedule_data in old_schedule.items():
         if key not in task_schedules:
             new_schedule[key] = schedule_data


### PR DESCRIPTION
This enables specific schedules to be run on either the taskscheduler or celerybeat.