### PR TITLE
fix(replay): Fix canvas replays appearing blank

### DIFF
--- a/static/app/components/replays/canvasReplayerPlugin.tsx
+++ b/static/app/components/replays/canvasReplayerPlugin.tsx
@@ -19,8 +19,12 @@ type CanvasEventWithTime = eventWithTime & {
   type: EventType.IncrementalSnapshot;
 };
 
+function isElement(node: Node): node is Element {
+  return node.nodeType === Node.ELEMENT_NODE;
+}
+
 function isCanvasElement(node: Node): node is HTMLCanvasElement {
-  return node instanceof HTMLCanvasElement;
+  return isElement(node) && node.tagName === 'CANVAS';
 }
 
 function isCanvasMutationEvent(e: eventWithTime): e is CanvasEventWithTime {
@@ -179,6 +183,7 @@ export function CanvasReplayerPlugin(events: eventWithTime[]): ReplayPlugin {
    */
   function cloneCanvas(id: number, node: Node) {
     if (!isCanvasElement(node)) {
+      Sentry.logger.warn('Replay: node is not a canvas element');
       return null;
     }
     const cloneNode = node.cloneNode();


### PR DESCRIPTION
Fixes an issue where canvas replays are blank unless you scrub through the replay.

Regressed in https://github.com/getsentry/sentry/pull/91725