### PR TITLE
fix(codemappings): avoid double quoting in codemappings

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any
 from urllib.parse import quote as urlquote
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 import sentry_sdk
 
@@ -202,9 +202,13 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
 
             def encode_url(url: str) -> str:
                 parsed = urlparse(url)
+                # Decode the path first to avoid double-encoding
+                decoded_path = unquote(parsed.path)
+                # Encode only unencoded elements
+                encoded_path = urlquote(decoded_path, safe="/")
                 # Encode elements of the filepath like square brackets
                 # Preserve path separators and query params etc.
-                return urlunparse(parsed._replace(path=urlquote(parsed.path, safe="/")))
+                return urlunparse(parsed._replace(path=encoded_path))
 
             if version:
                 scope.set_tag("stacktrace_link.tried_version", True)


### PR DESCRIPTION
If the incoming filepath already includes encoded elements, we shouldn't double encode them in codemappings.

Fixes RTC-929