### PR TITLE
fix(alerts): Fix IS_IN condition removing all spaces

### DIFF
--- a/src/sentry/rules/match.py
+++ b/src/sentry/rules/match.py
@@ -92,11 +92,11 @@ def match_values(group_values: Iterable[Any], match_value: str, match_type: str)
         return not any(match_value in g_value for g_value in group_values_set)
 
     elif match_type == MatchType.IS_IN:
-        values_set = set(match_value.replace(" ", "").split(","))
+        values_set = {value.strip() for value in match_value.split(",")}
         return any(g_value in values_set for g_value in group_values)
 
     elif match_type == MatchType.NOT_IN:
-        values_set = set(match_value.replace(" ", "").split(","))
+        values_set = {value.strip() for value in match_value.split(",")}
         return not any(g_value in values_set for g_value in group_values)
 
     raise RuntimeError("Invalid Match")

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -971,6 +971,22 @@ class EventAttributeConditionTest(RuleTestCase):
         )
         self.assertDoesNotPass(rule, event)
 
+    def test_attr_is_in_with_spaces(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.IS_IN,
+                "attribute": "exception.value",
+                "value": "hello world, foo bar",
+            }
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={"match": MatchType.IS_IN, "attribute": "exception.value", "value": "foo bar"}
+        )
+        self.assertDoesNotPass(rule, event)
+
     def test_attr_not_in(self):
         event = self.get_event()
         rule = self.get_rule(
@@ -980,5 +996,21 @@ class EventAttributeConditionTest(RuleTestCase):
 
         rule = self.get_rule(
             data={"match": MatchType.NOT_IN, "attribute": "platform", "value": "python"}
+        )
+        self.assertPasses(rule, event)
+
+    def test_attr_not_in_with_spaces(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.NOT_IN,
+                "attribute": "exception.value",
+                "value": "hello world, foo bar",
+            }
+        )
+        self.assertDoesNotPass(rule, event)
+
+        rule = self.get_rule(
+            data={"match": MatchType.NOT_IN, "attribute": "exception.value", "value": "foo bar"}
         )
         self.assertPasses(rule, event)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/92719

The IS_IN condition was removing all spaces in the value (in order to support something like `foo, bar`), but it should have only been stripping them to support values with spaces like `foo bar`.

This is a simple fix that supports that use case, but just want to note that this is also a bit suboptimal. This doesn't support values with commas inside of them like `"value, 1", "value, 2"`. We should probably be using our search parser for this in the new ACI stuff.