### PR TITLE
fix(replay): Fix mobile replays that have multiple pages of segments

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -524,14 +524,18 @@ export function Provider({
   // Initialize replayer for Video Replays
   useEffect(() => {
     const instance =
-      isVideoReplay && rootEl && !replayerRef.current && initVideoRoot(rootEl);
+      isVideoReplay &&
+      rootEl &&
+      !replay?.isFetching() &&
+      !replayerRef.current &&
+      initVideoRoot(rootEl);
 
     return () => {
       if (instance && !rootEl) {
         instance.destroy();
       }
     };
-  }, [rootEl, isVideoReplay, initVideoRoot, videoEvents]);
+  }, [rootEl, isVideoReplay, initVideoRoot, videoEvents, replay]);
 
   // For non-video (e.g. rrweb) replays, initialize the player
   useEffect(() => {


### PR DESCRIPTION
This fixes an issue with mobile replays that have multiple pages of segments. The video replayer could get initialized with an out-of-order page of segments and does not get updated when the other pages are fetched successfully. The replayer now waits until replay reader is finished fetching before it initializes.
