### PR TITLE
feat(search-bar): Enable contains functionality on op change

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -1,0 +1,309 @@
+import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
+
+import {addWildcardToToken, removeWildcardFromToken} from './useQueryBuilderState';
+
+describe('addWildcardToToken', function () {
+  const testCases = [
+    // --- contains ---
+    {
+      input: {
+        token: {text: 'firefox', quoted: false},
+        isContains: true,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '*firefox*',
+    },
+    {
+      input: {
+        token: {text: '"firefox"', quoted: true},
+        isContains: true,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '"*firefox*"',
+    },
+    {
+      input: {
+        token: {text: '*firefox', quoted: false},
+        isContains: true,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '*firefox*',
+    },
+    {
+      input: {
+        token: {text: 'firefox*', quoted: false},
+        isContains: true,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '*firefox*',
+    },
+    {
+      input: {
+        token: {text: '"e m"', quoted: true},
+        isContains: true,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '"*e m*"',
+    },
+    // --- starts with ---
+    {
+      input: {
+        token: {text: 'firefox', quoted: false},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: 'firefox*',
+    },
+    {
+      input: {
+        token: {text: '"firefox"', quoted: true},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: '"firefox*"',
+    },
+    {
+      input: {
+        token: {text: '*firefox', quoted: false},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: '*firefox*',
+    },
+    {
+      input: {
+        token: {text: 'firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: 'firefox*',
+    },
+    {
+      input: {
+        token: {text: '"e m"', quoted: true},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: '"e m*"',
+    },
+    // --- ends with ---
+    {
+      input: {
+        token: {text: 'firefox', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '*firefox',
+    },
+    {
+      input: {
+        token: {text: '"firefox"', quoted: true},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '"*firefox"',
+    },
+    {
+      input: {
+        token: {text: '*firefox', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '*firefox',
+    },
+    {
+      input: {
+        token: {text: 'firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '*firefox*',
+    },
+    {
+      input: {
+        token: {text: '"e m"', quoted: true},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '"*e m"',
+    },
+  ];
+
+  it.each(testCases)('should add wildcard to token', function ({input, expected}) {
+    const result = addWildcardToToken(
+      input.token as TokenResult<Token.VALUE_TEXT>,
+      input.isContains,
+      input.isStartsWith,
+      input.isEndsWith
+    );
+    expect(result).toBe(expected);
+  });
+});
+
+describe('removeWildcardFromToken', function () {
+  const testCases = [
+    // --- contains ---
+    {
+      input: {
+        token: {text: '*firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: 'firefox',
+    },
+    {
+      input: {
+        token: {text: '"*firefox*"', quoted: true},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '"firefox"',
+    },
+    {
+      input: {
+        token: {text: '*firefox', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: 'firefox',
+    },
+    {
+      input: {
+        token: {text: 'firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: 'firefox',
+    },
+    {
+      input: {
+        token: {text: '"*e m*"', quoted: true},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: false,
+      },
+      expected: '"e m"',
+    },
+    // --- starts with ---
+    {
+      input: {
+        token: {text: '*firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: 'firefox*',
+    },
+    {
+      input: {
+        token: {text: '"*firefox*"', quoted: true},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: '"firefox*"',
+    },
+    {
+      input: {
+        token: {text: '*firefox', quoted: false},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: 'firefox',
+    },
+    {
+      input: {
+        token: {text: 'firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: 'firefox*',
+    },
+    {
+      input: {
+        token: {text: '"*e m*"', quoted: true},
+        isContains: false,
+        isStartsWith: true,
+        isEndsWith: false,
+      },
+      expected: '"e m*"',
+    },
+    // --- ends with ---
+    {
+      input: {
+        token: {text: '*firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '*firefox',
+    },
+    {
+      input: {
+        token: {text: '"*firefox*"', quoted: true},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '"*firefox"',
+    },
+    {
+      input: {
+        token: {text: '*firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '*firefox',
+    },
+    {
+      input: {
+        token: {text: '*firefox*', quoted: false},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '*firefox',
+    },
+    {
+      input: {
+        token: {text: '"*e m*"', quoted: true},
+        isContains: false,
+        isStartsWith: false,
+        isEndsWith: true,
+      },
+      expected: '"*e m"',
+    },
+  ];
+
+  it.each(testCases)('should remove wildcard from token', function ({input, expected}) {
+    const result = removeWildcardFromToken(
+      input.token as TokenResult<Token.VALUE_TEXT>,
+      input.isContains,
+      input.isStartsWith,
+      input.isEndsWith
+    );
+    expect(result).toBe(expected);
+  });
+});

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -7,7 +7,7 @@ describe('addWildcardToToken', function () {
     // --- contains ---
     {
       input: {
-        token: {text: 'firefox', quoted: false},
+        token: {value: 'firefox'},
         isContains: true,
         isStartsWith: false,
         isEndsWith: false,
@@ -16,16 +16,7 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: '"firefox"', quoted: true},
-        isContains: true,
-        isStartsWith: false,
-        isEndsWith: false,
-      },
-      expected: '"*firefox*"',
-    },
-    {
-      input: {
-        token: {text: '*firefox', quoted: false},
+        token: {value: '*firefox'},
         isContains: true,
         isStartsWith: false,
         isEndsWith: false,
@@ -34,7 +25,7 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: 'firefox*', quoted: false},
+        token: {value: 'firefox*'},
         isContains: true,
         isStartsWith: false,
         isEndsWith: false,
@@ -43,17 +34,17 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: '"e m"', quoted: true},
+        token: {value: 'e m'},
         isContains: true,
         isStartsWith: false,
         isEndsWith: false,
       },
-      expected: '"*e m*"',
+      expected: '*e m*',
     },
     // --- starts with ---
     {
       input: {
-        token: {text: 'firefox', quoted: false},
+        token: {value: 'firefox'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
@@ -62,16 +53,7 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: '"firefox"', quoted: true},
-        isContains: false,
-        isStartsWith: true,
-        isEndsWith: false,
-      },
-      expected: '"firefox*"',
-    },
-    {
-      input: {
-        token: {text: '*firefox', quoted: false},
+        token: {value: '*firefox'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
@@ -80,7 +62,7 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: 'firefox*', quoted: false},
+        token: {value: 'firefox*'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
@@ -89,17 +71,17 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: '"e m"', quoted: true},
+        token: {value: 'e m'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
       },
-      expected: '"e m*"',
+      expected: 'e m*',
     },
     // --- ends with ---
     {
       input: {
-        token: {text: 'firefox', quoted: false},
+        token: {value: 'firefox'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
@@ -108,16 +90,7 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: '"firefox"', quoted: true},
-        isContains: false,
-        isStartsWith: false,
-        isEndsWith: true,
-      },
-      expected: '"*firefox"',
-    },
-    {
-      input: {
-        token: {text: '*firefox', quoted: false},
+        token: {value: '*firefox'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
@@ -126,7 +99,7 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: 'firefox*', quoted: false},
+        token: {value: 'firefox*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
@@ -135,12 +108,12 @@ describe('addWildcardToToken', function () {
     },
     {
       input: {
-        token: {text: '"e m"', quoted: true},
+        token: {value: 'e m'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
       },
-      expected: '"*e m"',
+      expected: '*e m',
     },
   ];
 
@@ -160,7 +133,7 @@ describe('removeWildcardFromToken', function () {
     // --- contains ---
     {
       input: {
-        token: {text: '*firefox*', quoted: false},
+        token: {value: '*firefox*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: false,
@@ -169,16 +142,7 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '"*firefox*"', quoted: true},
-        isContains: false,
-        isStartsWith: false,
-        isEndsWith: false,
-      },
-      expected: '"firefox"',
-    },
-    {
-      input: {
-        token: {text: '*firefox', quoted: false},
+        token: {value: '*firefox'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: false,
@@ -187,7 +151,7 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: 'firefox*', quoted: false},
+        token: {value: 'firefox*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: false,
@@ -196,17 +160,17 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '"*e m*"', quoted: true},
+        token: {value: '*e m*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: false,
       },
-      expected: '"e m"',
+      expected: 'e m',
     },
     // --- starts with ---
     {
       input: {
-        token: {text: '*firefox*', quoted: false},
+        token: {value: '*firefox*'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
@@ -215,16 +179,7 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '"*firefox*"', quoted: true},
-        isContains: false,
-        isStartsWith: true,
-        isEndsWith: false,
-      },
-      expected: '"firefox*"',
-    },
-    {
-      input: {
-        token: {text: '*firefox', quoted: false},
+        token: {value: '*firefox'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
@@ -233,7 +188,7 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: 'firefox*', quoted: false},
+        token: {value: 'firefox*'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
@@ -242,17 +197,17 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '"*e m*"', quoted: true},
+        token: {value: '*e m*'},
         isContains: false,
         isStartsWith: true,
         isEndsWith: false,
       },
-      expected: '"e m*"',
+      expected: 'e m*',
     },
     // --- ends with ---
     {
       input: {
-        token: {text: '*firefox*', quoted: false},
+        token: {value: '*firefox*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
@@ -261,16 +216,7 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '"*firefox*"', quoted: true},
-        isContains: false,
-        isStartsWith: false,
-        isEndsWith: true,
-      },
-      expected: '"*firefox"',
-    },
-    {
-      input: {
-        token: {text: '*firefox*', quoted: false},
+        token: {value: '*firefox*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
@@ -279,7 +225,7 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '*firefox*', quoted: false},
+        token: {value: '*firefox*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
@@ -288,12 +234,12 @@ describe('removeWildcardFromToken', function () {
     },
     {
       input: {
-        token: {text: '"*e m*"', quoted: true},
+        token: {value: '*e m*'},
         isContains: false,
         isStartsWith: false,
         isEndsWith: true,
       },
-      expected: '"*e m"',
+      expected: '*e m',
     },
   ];
 

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -164,7 +164,6 @@ function deleteQueryTokens(
   };
 }
 
-/** Exported for testing purposes only */
 export function addWildcardToToken(
   token: TokenResult<Token.VALUE_TEXT>,
   isContains: boolean,
@@ -190,7 +189,6 @@ export function addWildcardToToken(
   return newTokenText;
 }
 
-/** Exported for testing purposes only */
 export function removeWildcardFromToken(
   token: TokenResult<Token.VALUE_TEXT>,
   isContains: boolean,

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -170,23 +170,16 @@ export function addWildcardToToken(
   isStartsWith: boolean,
   isEndsWith: boolean
 ) {
-  const addToFront = isContains || isEndsWith;
-  const addToBack = isContains || isStartsWith;
-
-  let newTokenText = token.text;
-  if (addToFront && token.quoted && !token.text.slice(1).startsWith('*')) {
-    newTokenText = `"*${newTokenText.slice(1)}`;
-  } else if (addToFront && !token.quoted && !token.text.startsWith('*')) {
-    newTokenText = `*${newTokenText}`;
+  let newTokenValue = token.value;
+  if ((isContains || isEndsWith) && !token.value.startsWith('*')) {
+    newTokenValue = `*${newTokenValue}`;
   }
 
-  if (addToBack && token.quoted && !token.text.slice(0, -1).endsWith('*')) {
-    newTokenText = `${newTokenText.slice(0, -1)}*"`;
-  } else if (addToBack && !token.quoted && !token.text.endsWith('*')) {
-    newTokenText = `${newTokenText}*`;
+  if ((isContains || isStartsWith) && !token.value.endsWith('*')) {
+    newTokenValue = `${newTokenValue}*`;
   }
 
-  return newTokenText;
+  return newTokenValue;
 }
 
 export function removeWildcardFromToken(
@@ -195,23 +188,16 @@ export function removeWildcardFromToken(
   isStartsWith: boolean,
   isEndsWith: boolean
 ) {
-  const removeFromFront = !isEndsWith && !isContains;
-  const removeFromBack = !isStartsWith && !isContains;
-
-  let newTokenText = token.text;
-  if (removeFromFront && token.quoted && token.text.slice(1).startsWith('*')) {
-    newTokenText = `"${newTokenText.slice(2)}`;
-  } else if (removeFromFront && !token.quoted && token.text.startsWith('*')) {
-    newTokenText = newTokenText.slice(1);
+  let newTokenValue = token.value;
+  if (!isEndsWith && !isContains && token.value.startsWith('*')) {
+    newTokenValue = newTokenValue.slice(1);
   }
 
-  if (removeFromBack && token.quoted && token.text.slice(0, -1).endsWith('*')) {
-    newTokenText = `${newTokenText.slice(0, -2)}"`;
-  } else if (removeFromBack && !token.quoted && token.text.endsWith('*')) {
-    newTokenText = newTokenText.slice(0, -1);
+  if (!isStartsWith && !isContains && token.value.endsWith('*')) {
+    newTokenValue = newTokenValue.slice(0, -1);
   }
 
-  return newTokenText;
+  return newTokenValue;
 }
 
 function modifyFilterOperatorQuery(
@@ -245,35 +231,33 @@ function modifyFilterOperatorQuery(
   const isEndsWith = newOperator === WildcardOperators.ENDS_WITH;
 
   if (hasWildcardOperators && newToken.value.type === Token.VALUE_TEXT) {
-    newToken.value.text = addWildcardToToken(
+    newToken.value.value = addWildcardToToken(
       newToken.value,
       isContains,
       isStartsWith,
       isEndsWith
     );
-    newToken.value.text = removeWildcardFromToken(
+    newToken.value.value = removeWildcardFromToken(
       newToken.value,
       isContains,
       isStartsWith,
       isEndsWith
     );
-    newToken.value.value = newToken.value.text;
   } else if (hasWildcardOperators && newToken.value.type === Token.VALUE_TEXT_LIST) {
     newToken.value.items.forEach(item => {
       if (!item.value) return;
-      item.value.text = addWildcardToToken(
+      item.value.value = addWildcardToToken(
         item.value,
         isContains,
         isStartsWith,
         isEndsWith
       );
-      item.value.text = removeWildcardFromToken(
+      item.value.value = removeWildcardFromToken(
         item.value,
         isContains,
         isStartsWith,
         isEndsWith
       );
-      item.value.value = item.value.text;
     });
   }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3827,4 +3827,382 @@ describe('SearchQueryBuilder', function () {
       expect(screen.getByLabelText('avg(tags[bar,number]):>0')).toBeInTheDocument();
     });
   });
+
+  describe('wildcard operators', function () {
+    describe('selecting contains', function () {
+      describe('single value', function () {
+        it('wraps the value in wildcards', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:firefox"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'contains'}));
+
+          // Token should be wrapped in wildcards
+          expect(
+            screen.getByRole('row', {name: 'browser.name:*firefox*'})
+          ).toBeInTheDocument();
+
+          // Should now have "contains" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('contains')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              'browser.name:*firefox*',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('multiple values', function () {
+        it('wraps the values in wildcards', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:[firefox,chrome]"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'contains'}));
+
+          // Token should be wrapped in wildcards
+          expect(
+            screen.getByRole('row', {name: 'browser.name:[*firefox*,*chrome*]'})
+          ).toBeInTheDocument();
+
+          // Should now have "contains" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('contains')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              'browser.name:[*firefox*,*chrome*]',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('selecting does not contain', function () {
+      describe('single value', function () {
+        it('wraps the value in wildcards', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:firefox"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'does not contain'}));
+
+          // Token should be modified to be wrapped in wildcards and negated
+          expect(
+            screen.getByRole('row', {name: '!browser.name:*firefox*'})
+          ).toBeInTheDocument();
+
+          // Should now have "does not contain" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('does not contain')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              '!browser.name:*firefox*',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('multiple values', function () {
+        it('wraps the values in wildcards', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:[firefox,chrome]"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'does not contain'}));
+
+          // Token should be wrapped in wildcards and negated
+          expect(
+            screen.getByRole('row', {name: '!browser.name:[*firefox*,*chrome*]'})
+          ).toBeInTheDocument();
+
+          // Should now have "does not contain" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('does not contain')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              '!browser.name:[*firefox*,*chrome*]',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('selecting starts with', function () {
+      describe('single value', function () {
+        it('adds trailing wildcard', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:firefox"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'starts with'}));
+
+          // Token should have trailing wildcard
+          expect(
+            screen.getByRole('row', {name: 'browser.name:firefox*'})
+          ).toBeInTheDocument();
+
+          // Should now have "starts with" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('starts with')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              'browser.name:firefox*',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('multiple values', function () {
+        it('adds trailing wildcard to each value', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:[firefox,chrome]"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'starts with'}));
+
+          // Token should have trailing wildcard on each value
+          expect(
+            screen.getByRole('row', {name: 'browser.name:[firefox*,chrome*]'})
+          ).toBeInTheDocument();
+
+          // Should now have "starts with" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('starts with')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              'browser.name:[firefox*,chrome*]',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('selecting ends with', function () {
+      describe('single value', function () {
+        it('adds leading wildcard', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:firefox"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'ends with'}));
+
+          // Token should have leading wildcard
+          expect(
+            screen.getByRole('row', {name: 'browser.name:*firefox'})
+          ).toBeInTheDocument();
+
+          // Should now have "ends with" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('ends with')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              'browser.name:*firefox',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('multiple values', function () {
+        it('adds leading wildcard to each value', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:[firefox,chrome]"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('is')
+          ).toBeInTheDocument();
+
+          await userEvent.click(
+            screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+          );
+          await userEvent.click(screen.getByRole('option', {name: 'ends with'}));
+
+          // Token should have leading wildcard on each value
+          expect(
+            screen.getByRole('row', {name: 'browser.name:[*firefox,*chrome]'})
+          ).toBeInTheDocument();
+
+          // Should now have "ends with" label
+          expect(
+            within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).getByText('ends with')
+          ).toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalledWith(
+              'browser.name:[*firefox,*chrome]',
+              expect.anything()
+            );
+          });
+
+          expect(mockOnChange).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -100,10 +100,12 @@ export function getValidOpsForFilter(
     allValidTypes.flatMap(type => filterTypeConfig[type].validOps)
   );
 
-  const isTextFilter =
-    filterToken.filter === FilterType.TEXT || filterToken.filter === FilterType.TEXT_IN;
   // Special case for text, add contains operator
-  if (isTextFilter && fieldDefinition?.allowWildcard !== false && hasWildcardOperators) {
+  if (
+    hasWildcardOperators &&
+    fieldDefinition?.allowWildcard !== false &&
+    (filterToken.filter === FilterType.TEXT || filterToken.filter === FilterType.TEXT_IN)
+  ) {
     validOps.add(WildcardOperators.CONTAINS);
     validOps.add(WildcardOperators.DOES_NOT_CONTAIN);
     validOps.add(WildcardOperators.STARTS_WITH);

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 
-import {type ParseResult, TermOperator} from 'sentry/components/searchSyntax/parser';
+import type {ParseResult, TermOperator} from 'sentry/components/searchSyntax/parser';
 import type {FieldDefinition} from 'sentry/utils/fields';
 
 export type FilterKeySection = {
@@ -38,8 +38,10 @@ export enum WildcardOperators {
   ENDS_WITH = 'ends with',
 }
 
-export function isTermOperator(op: SearchQueryBuilderOperators): op is TermOperator {
-  return typeof op === 'string' && Object.values(TermOperator).includes(op as any);
+export function isWildcardOperator(
+  op: SearchQueryBuilderOperators
+): op is WildcardOperators {
+  return typeof op === 'string' && Object.values(WildcardOperators).includes(op as any);
 }
 
 export type SearchQueryBuilderOperators = TermOperator | WildcardOperators;

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -358,7 +358,12 @@ export function stringifyToken(token: TokenResult<Token>): string {
       return token.value;
     case Token.VALUE_TEXT_LIST: {
       const textListItems = token.items
-        .map(item => item.value?.text ?? '')
+        .map(item => {
+          if (item.value?.value) {
+            return item.value.quoted ? `"${item.value.value}"` : item.value.value;
+          }
+          return '';
+        })
         .filter(text => text.length > 0);
       return `[${textListItems.join(',')}]`;
     }


### PR DESCRIPTION
Adding in operator change functionality that will add in or remove wildcards from filter values. 

These changes handle all of the cases for: contains, does not contain, starts with, and ends with, for single values, multuple values, and quoted values.