### PR TITLE
fix(dashboards-comparison): Use helper for widget url and rename sentry message

### DIFF
--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -16,6 +16,7 @@ from sentry.models.dashboard import Dashboard
 from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetQuery
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.organizations.absolute_url import generate_organization_url
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
 from sentry.search.events.types import SAMPLING_MODES, EventsResponse, SnubaParams
 from sentry.snuba import metrics_enhanced_performance, spans_rpc
@@ -183,6 +184,11 @@ def compare_tables_for_dashboard_widget_queries(
         logger.info("EAP query failed: %s", e)
         has_eap_error = True
 
+    widget_viewer_url = (
+        generate_organization_url(organization.slug)
+        + f"/dashboard/{dashboard.id}/widget/{widget.id}/"
+    )
+
     if has_metrics_error and has_eap_error:
         with sentry_sdk.isolation_scope() as scope:
             scope.set_tag("passed", False)
@@ -190,7 +196,7 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("widget_filter_query", query)
             scope.set_tag(
                 "widget_viewer_url",
-                f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
+                widget_viewer_url,
             )
             sentry_sdk.capture_message(
                 "dashboard_widget_comparison_done", level="info", scope=scope
@@ -210,7 +216,7 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("widget_filter_query", query)
             scope.set_tag(
                 "widget_viewer_url",
-                f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
+                widget_viewer_url,
             )
             sentry_sdk.capture_message(
                 "dashboard_widget_comparison_done", level="info", scope=scope
@@ -230,7 +236,7 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("widget_filter_query", query)
             scope.set_tag(
                 "widget_viewer_url",
-                f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
+                widget_viewer_url,
             )
             sentry_sdk.capture_message(
                 "dashboard_widget_comparison_done", level="info", scope=scope
@@ -251,7 +257,7 @@ def compare_tables_for_dashboard_widget_queries(
                 scope.set_tag("mismatches", mismatches)
                 scope.set_tag(
                     "widget_viewer_url",
-                    f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
+                    widget_viewer_url,
                 )
                 sentry_sdk.capture_message(
                     "dashboard_widget_comparison_done", level="info", scope=scope
@@ -272,7 +278,7 @@ def compare_tables_for_dashboard_widget_queries(
                 scope.set_tag("widget_filter_query", query)
                 scope.set_tag(
                     "widget_viewer_url",
-                    f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
+                    widget_viewer_url,
                 )
                 sentry_sdk.capture_message(
                     "dashboard_widget_comparison_done", level="info", scope=scope

--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -192,7 +192,9 @@ def compare_tables_for_dashboard_widget_queries(
                 "widget_viewer_url",
                 f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
             )
-            sentry_sdk.capture_message("dashboard_comparison_passed", level="info", scope=scope)
+            sentry_sdk.capture_message(
+                "dashboard_widget_comparison_done", level="info", scope=scope
+            )
         return {
             "passed": False,
             "reason": CompareTableResult.BOTH_FAILED,
@@ -210,7 +212,9 @@ def compare_tables_for_dashboard_widget_queries(
                 "widget_viewer_url",
                 f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
             )
-            sentry_sdk.capture_message("dashboard_comparison_passed", level="info", scope=scope)
+            sentry_sdk.capture_message(
+                "dashboard_widget_comparison_done", level="info", scope=scope
+            )
         return {
             "passed": False,
             "reason": CompareTableResult.METRICS_FAILED,
@@ -228,7 +232,9 @@ def compare_tables_for_dashboard_widget_queries(
                 "widget_viewer_url",
                 f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
             )
-            sentry_sdk.capture_message("dashboard_comparison_passed", level="info", scope=scope)
+            sentry_sdk.capture_message(
+                "dashboard_widget_comparison_done", level="info", scope=scope
+            )
         return {
             "passed": False,
             "reason": CompareTableResult.EAP_FAILED,
@@ -247,7 +253,9 @@ def compare_tables_for_dashboard_widget_queries(
                     "widget_viewer_url",
                     f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
                 )
-                sentry_sdk.capture_message("dashboard_comparison_passed", level="info", scope=scope)
+                sentry_sdk.capture_message(
+                    "dashboard_widget_comparison_done", level="info", scope=scope
+                )
             return {
                 "passed": True,
                 "reason": CompareTableResult.PASSED,
@@ -266,7 +274,9 @@ def compare_tables_for_dashboard_widget_queries(
                     "widget_viewer_url",
                     f"{organization.slug}.sentry.io/dashboard/{dashboard.id}/widget/{widget.id}/",
                 )
-                sentry_sdk.capture_message("dashboard_comparison_passed", level="info", scope=scope)
+                sentry_sdk.capture_message(
+                    "dashboard_widget_comparison_done", level="info", scope=scope
+                )
             return {
                 "passed": False,
                 "reason": reason,


### PR DESCRIPTION
The widget url was not being created correctly for self hosted instances so i've used the organization url helper to make sure the org slug portion is being formatted correctly. Also the message title being sent to sentry wasn't making sense so i've changed it.
