### PR TITLE
fix(insights): laravel and nextJs should have same date restrictions as generic overview

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -20,7 +20,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
@@ -272,18 +271,8 @@ function EAPBackendOverviewPage() {
 }
 
 function BackendOverviewPageWithProviders() {
-  const organization = useOrganization();
-  const isLaravelPageAvailable = useIsLaravelInsightsAvailable();
-  const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
-
-  const {maxPickableDays} = limitMaxPickableDays(organization);
-
   return (
-    <DomainOverviewPageProviders
-      maxPickableDays={
-        isLaravelPageAvailable || isNextJsPageEnabled ? maxPickableDays : undefined
-      }
-    >
+    <DomainOverviewPageProviders>
       <BackendOverviewPage />
     </DomainOverviewPageProviders>
   );

--- a/static/app/views/insights/pages/domainOverviewPageProviders.tsx
+++ b/static/app/views/insights/pages/domainOverviewPageProviders.tsx
@@ -6,19 +6,13 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 
-export function DomainOverviewPageProviders({
-  children,
-  maxPickableDays,
-}: {
-  children: React.ReactNode;
-  maxPickableDays?: number;
-}) {
+export function DomainOverviewPageProviders({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
   const location = useLocation();
 
   return (
     <NoProjectMessage organization={organization}>
-      <PageFiltersContainer maxPickableDays={maxPickableDays}>
+      <PageFiltersContainer>
         <SentryDocumentTitle title={OVERVIEW_PAGE_TITLE} orgSlug={organization.slug}>
           <MEPSettingProvider location={location}>{children}</MEPSettingProvider>
         </SentryDocumentTitle>

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -24,7 +24,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
@@ -279,14 +278,11 @@ function EAPOverviewPage() {
 }
 
 function FrontendOverviewPageWithProviders() {
-  const organization = useOrganization();
   const [isNextJsPageEnabled] = useIsNextJsInsightsEnabled();
   const useEap = useInsightsEap();
 
-  const {maxPickableDays} = limitMaxPickableDays(organization);
-
   return (
-    <DomainOverviewPageProviders maxPickableDays={maxPickableDays}>
+    <DomainOverviewPageProviders>
       {isNextJsPageEnabled ? (
         <NextJsOverviewPage performanceType="frontend" />
       ) : useEap ? (

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -274,6 +274,7 @@ function EAPMobileOverviewPage() {
 
 function MobileOverviewPageWithProviders() {
   const useEap = useInsightsEap();
+
   return (
     <DomainOverviewPageProviders>
       {useEap ? <EAPMobileOverviewPage /> : <OldMobileOverviewPage />}

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -274,7 +274,6 @@ function EAPMobileOverviewPage() {
 
 function MobileOverviewPageWithProviders() {
   const useEap = useInsightsEap();
-
   return (
     <DomainOverviewPageProviders>
       {useEap ? <EAPMobileOverviewPage /> : <OldMobileOverviewPage />}

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -12,7 +12,6 @@ import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
@@ -49,7 +48,6 @@ export function PlatformLandingPageLayout({
   const location = useLocation();
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
-  const datePageFilterProps = limitMaxPickableDays(organization);
 
   const showOnboarding = onboardingProject !== undefined;
 
@@ -89,7 +87,7 @@ export function PlatformLandingPageLayout({
                 <PageFilterBar condensed>
                   <ProjectPageFilter resetParamsOnChange={['starred']} />
                   <EnvironmentPageFilter />
-                  <DatePageFilter {...datePageFilterProps} />
+                  <DatePageFilter />
                 </PageFilterBar>
                 {!showOnboarding && (
                   <StyledTransactionNameSearchBar


### PR DESCRIPTION
The laraval and nextjs page pickable days should match the generic insight overview page (not explore). This is 30 days for the free account and 90 days for paid (this restrictions is automatically applied under the hood by the `header-selection-items` hook)