### PR TITLE
perf(aci): Don't load GroupAssignee.team unnecessarily

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -53,6 +53,6 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
         target_id = comparison.get("target_identifier")
 
         if target_type == AssigneeTargetType.TEAM:
-            return any(assignee.team and assignee.team_id == target_id for assignee in assignees)
+            return any(assignee.team_id and assignee.team_id == target_id for assignee in assignees)
         elif target_type == AssigneeTargetType.MEMBER:
             return any(assignee.user_id and assignee.user_id == target_id for assignee in assignees)


### PR DESCRIPTION
We only need the ID,  no need to fetch the actual Team.
This is a cheap query, but a common one in tasks that care about team assignee; avoiding it can
remove dozens of queries per task in some cases.