### PR TITLE
:wrench: chore(aci): remove sentry sentry app slug identifier

### DIFF
--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -40,7 +40,6 @@ class SentryAppIdentifier(StrEnum):
     """
 
     SENTRY_APP_INSTALLATION_UUID = "sentry_app_installation_uuid"
-    SENTRY_APP_SLUG = "sentry_app_slug"
     SENTRY_APP_ID = "sentry_app_id"
 
 


### PR DESCRIPTION
this is an unused enum value