### PR TITLE
fix(nav): Ensure that discover is displayed for free saas users

### DIFF
--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -60,7 +60,10 @@ export function ExploreSecondaryNav() {
               {t('Logs')}
             </SecondaryNav.Item>
           </Feature>
-          <Feature features="discover-basic">
+          <Feature
+            features="discover-basic"
+            hookName="feature-disabled:discover2-sidebar-item"
+          >
             <SecondaryNav.Item
               to={`${baseUrl}/discover/homepage/`}
               activeTo={`${baseUrl}/discover/`}
@@ -69,7 +72,10 @@ export function ExploreSecondaryNav() {
               {t('Discover')}
             </SecondaryNav.Item>
           </Feature>
-          <Feature features="profiling">
+          <Feature
+            features="profiling"
+            hookName="feature-disabled:profiling-sidebar-item"
+          >
             <SecondaryNav.Item
               to={`${baseUrl}/profiling/`}
               analyticsItemName="explore_profiles"
@@ -77,7 +83,10 @@ export function ExploreSecondaryNav() {
               {t('Profiles')}
             </SecondaryNav.Item>
           </Feature>
-          <Feature features="session-replay-ui">
+          <Feature
+            features="session-replay-ui"
+            hookName="feature-disabled:replay-sidebar-item"
+          >
             <SecondaryNav.Item
               to={`${baseUrl}/replays/`}
               analyticsItemName="explore_replays"


### PR DESCRIPTION
These `hookName` props were necessary (at least for discover) because it shows the element anyway if in SaaS.