### PR TITLE
chore(search-bar) Concat multiple wildcards to single wildcard

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -419,6 +419,9 @@ function modifyFilterValue(
     return modifyFilterValueDate(query, token, newValue);
   }
 
+  // stop the user from entering multiple wildcards by themselves
+  newValue = newValue.replace(/\*\*+/g, '*');
+
   return replaceQueryToken(query, token.value, newValue);
 }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1665,6 +1665,34 @@ describe('SearchQueryBuilder', function () {
       const listBox = screen.getByRole('checkbox', {name: 'Toggle randomValue'});
       expect(listBox).toBeChecked();
     });
+
+    it('strips multiple wildcards into a single wildcard', async function () {
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          onChange={mockOnChange}
+          initialQuery="browser.name:Firefox"
+        />
+      );
+
+      // Click into filter value (button to edit will no longer exist)
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+      ).not.toBeInTheDocument();
+
+      await userEvent.type(
+        screen.getByRole('combobox'),
+        '****random****Value*****{enter}'
+      );
+      expect(mockOnChange).toHaveBeenCalledWith(
+        'browser.name:[Firefox,*random*Value*]',
+        expect.anything()
+      );
+    });
   });
 
   describe('filter types', function () {


### PR DESCRIPTION
Small PR adding in some code to replace values that have multiple asterisks into a single asterisk, as having multiple asterisk's doesn't affect the search results.

Closes EXP-263