### PR TITLE
chore(autofix): Set user-watching flag in get state endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -66,7 +66,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         if not access_check_cache_value:
             check_repo_access = True
 
-        autofix_state = get_autofix_state(group_id=group.id, check_repo_access=check_repo_access)
+        autofix_state = get_autofix_state(
+            group_id=group.id, check_repo_access=check_repo_access, is_user_fetching=True
+        )
 
         if check_repo_access:
             cache.set(access_check_cache_key, True, timeout=60)  # 1 minute timeout

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -66,8 +66,12 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         if not access_check_cache_value:
             check_repo_access = True
 
+        is_user_watching = request.GET.get("isUserWatching", False)
+
         autofix_state = get_autofix_state(
-            group_id=group.id, check_repo_access=check_repo_access, is_user_fetching=True
+            group_id=group.id,
+            check_repo_access=check_repo_access,
+            is_user_fetching=is_user_watching,
         )
 
         if check_repo_access:

--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -20,6 +20,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
 from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,14 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
+            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60, concurrent_limit=100),
+        }
+    }
 
     def get(self, request: Request, group: Group) -> Response:
         """

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -85,7 +85,11 @@ def get_autofix_repos_from_project_code_mappings(project: Project) -> list[dict]
 
 
 def get_autofix_state(
-    *, group_id: int | None = None, run_id: int | None = None, check_repo_access: bool = False
+    *,
+    group_id: int | None = None,
+    run_id: int | None = None,
+    check_repo_access: bool = False,
+    is_user_fetching: bool = False,
 ) -> AutofixState | None:
     path = "/v1/automation/autofix/state"
     body = orjson.dumps(
@@ -93,6 +97,7 @@ def get_autofix_state(
             "group_id": group_id,
             "run_id": run_id,
             "check_repo_access": check_repo_access,
+            "is_user_fetching": is_user_fetching,
         }
     )
 

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -526,7 +526,12 @@ function CreatePRsButton({
       );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       setHasClicked(true);
     },
     onError: () => {
@@ -604,7 +609,12 @@ function CreateBranchButton({
       );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Failed to push to branches.'));

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -217,7 +217,12 @@ function useUpdateHunk({groupId, runId}: {groupId: string; runId: string}) {
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when updating changes.'));

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -86,7 +86,12 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when sending your comment.'));
@@ -122,7 +127,12 @@ function useCloseCommentThread({groupId, runId}: {groupId: string; runId: string
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when resolving the thread.'));

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -595,7 +595,12 @@ export function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: 
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       addSuccessMessage(t('Rethinking this...'));
     },
     onError: () => {

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -239,7 +239,12 @@ export function AutofixOutputStream({
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       addSuccessMessage('Thanks for the input.');
     },
     onError: () => {

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -94,6 +94,12 @@ function useSelectSolution({groupId, runId}: {groupId: string; runId: string}) {
           };
         }
       );
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       addSuccessMessage('On it.');
     },
     onError: () => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -47,9 +47,13 @@ export function SeerSectionCtaButton({
   };
 
   const openButtonRef = useRef<HTMLButtonElement>(null);
+  const isDrawerOpenRef = useRef(false);
 
   const {isPending: isAutofixPending} = useAutofixData({groupId: group.id});
-  const {autofixData} = useAiAutofix(group, event, {isSidebar: true, pollInterval: 1500});
+  const {autofixData} = useAiAutofix(group, event, {
+    isSidebar: !isDrawerOpenRef.current,
+    pollInterval: 1500,
+  });
 
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
@@ -57,7 +61,11 @@ export function SeerSectionCtaButton({
     event,
     buttonRef: openButtonRef,
   });
-  const isDrawerOpenRef = useRef(false);
+
+  // Keep isDrawerOpenRef in sync with the Seer drawer state (based on URL query)
+  useEffect(() => {
+    isDrawerOpenRef.current = !!location.query.seerDrawer;
+  }, [location.query.seerDrawer]);
 
   // Keep track of previous steps to detect state transitions and notify the user
   const prevStepsRef = useRef<AutofixStep[] | null>(null);
@@ -115,22 +123,8 @@ export function SeerSectionCtaButton({
 
   // Update drawer state when opening
   const handleOpenDrawer = () => {
-    isDrawerOpenRef.current = true;
     openSeerDrawer();
   };
-
-  // Listen for drawer close events
-  useEffect(() => {
-    const handleClickOutside = () => {
-      isDrawerOpenRef.current = false;
-    };
-
-    document.addEventListener('click', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
 
   const showCtaButton =
     aiConfig.needsGenAiAcknowledgement ||

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -50,7 +50,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "profile" not in response.data["autofix"]["request"]
         assert "issue_summary" not in response.data["autofix"]["request"]
 
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
     def test_ai_autofix_get_endpoint_without_autofix(
@@ -65,7 +67,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert response.data["autofix"] is None
 
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
     @patch("sentry.api.endpoints.group_ai_autofix.get_sorted_code_mapping_configs")
@@ -650,7 +654,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache miss should trigger repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=True
+            group_id=self.group.id, check_repo_access=True, is_user_fetching=True
         )
 
         # Verify the cache was set with a 60-second timeout
@@ -681,7 +685,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache hit should skip repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=False
+            group_id=self.group.id, check_repo_access=False, is_user_fetching=True
         )
 
         # Verify the cache was not set again
@@ -713,7 +717,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Verify first request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)
 
         # Reset mocks for second request
@@ -728,7 +734,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Verify second request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=False)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=False, is_user_fetching=True
+        )
         mock_cache.set.assert_not_called()
 
         # Reset mocks for third request
@@ -743,5 +751,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         # Verify third request behavior - should be like the first request
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
-        mock_get_autofix_state.assert_called_once_with(group_id=group.id, check_repo_access=True)
+        mock_get_autofix_state.assert_called_once_with(
+            group_id=group.id, check_repo_access=True, is_user_fetching=True
+        )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -51,7 +51,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "issue_summary" not in response.data["autofix"]["request"]
 
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
@@ -68,7 +68,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["autofix"] is None
 
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
 
     @patch("sentry.api.endpoints.group_ai_autofix.get_autofix_state")
@@ -654,7 +654,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache miss should trigger repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=True, is_user_fetching=True
+            group_id=self.group.id, check_repo_access=True, is_user_fetching=False
         )
 
         # Verify the cache was set with a 60-second timeout
@@ -685,7 +685,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify cache behavior - cache hit should skip repo access check
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{self.group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=self.group.id, check_repo_access=False, is_user_fetching=True
+            group_id=self.group.id, check_repo_access=False, is_user_fetching=False
         )
 
         # Verify the cache was not set again
@@ -718,7 +718,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify first request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)
 
@@ -735,7 +735,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify second request behavior
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=False, is_user_fetching=True
+            group_id=group.id, check_repo_access=False, is_user_fetching=False
         )
         mock_cache.set.assert_not_called()
 
@@ -752,6 +752,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         # Verify third request behavior - should be like the first request
         mock_cache.get.assert_called_once_with(f"autofix_access_check:{group.id}")
         mock_get_autofix_state.assert_called_once_with(
-            group_id=group.id, check_repo_access=True, is_user_fetching=True
+            group_id=group.id, check_repo_access=True, is_user_fetching=False
         )
         mock_cache.set.assert_called_once_with(f"autofix_access_check:{group.id}", True, timeout=60)

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -123,7 +123,7 @@ class TestGetAutofixState(TestCase):
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=b'{"group_id":123,"run_id":null,"check_repo_access":false}',
+            data=b'{"group_id":123,"run_id":null,"check_repo_access":false,"is_user_fetching":false}',
             headers={"content-type": "application/json;charset=utf-8"},
         )
 
@@ -154,7 +154,7 @@ class TestGetAutofixState(TestCase):
 
         mock_post.assert_called_once_with(
             f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/state",
-            data=b'{"group_id":null,"run_id":456,"check_repo_access":false}',
+            data=b'{"group_id":null,"run_id":456,"check_repo_access":false,"is_user_fetching":false}',
             headers={"content-type": "application/json;charset=utf-8"},
         )
 


### PR DESCRIPTION
- sets user watching flag with using get state endpoint
- update invalidated queries to maintain functionality
- remove toast notifications when drawer is open