### PR TITLE
feat(autofix): Change polling and queries to set user watching flag

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -526,7 +526,12 @@ function CreatePRsButton({
       );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       setHasClicked(true);
     },
     onError: () => {
@@ -604,7 +609,12 @@ function CreateBranchButton({
       );
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Failed to push to branches.'));

--- a/static/app/components/events/autofix/autofixDiff.tsx
+++ b/static/app/components/events/autofix/autofixDiff.tsx
@@ -217,7 +217,12 @@ function useUpdateHunk({groupId, runId}: {groupId: string; runId: string}) {
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when updating changes.'));

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -86,7 +86,12 @@ function useCommentThread({groupId, runId}: {groupId: string; runId: string}) {
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when sending your comment.'));
@@ -122,7 +127,12 @@ function useCloseCommentThread({groupId, runId}: {groupId: string; runId: string
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
     },
     onError: () => {
       addErrorMessage(t('Something went wrong when resolving the thread.'));

--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -595,7 +595,12 @@ export function useUpdateInsightCard({groupId, runId}: {groupId: string; runId: 
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       addSuccessMessage(t('Rethinking this...'));
     },
     onError: () => {

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -239,7 +239,12 @@ export function AutofixOutputStream({
       );
     },
     onSuccess: _ => {
-      queryClient.invalidateQueries({queryKey: makeAutofixQueryKey(orgSlug, groupId)});
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       addSuccessMessage('Thanks for the input.');
     },
     onError: () => {

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -94,6 +94,12 @@ function useSelectSolution({groupId, runId}: {groupId: string; runId: string}) {
           };
         }
       );
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, true),
+      });
+      queryClient.invalidateQueries({
+        queryKey: makeAutofixQueryKey(orgSlug, groupId, false),
+      });
       addSuccessMessage('On it.');
     },
     onError: () => {

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -142,7 +142,7 @@ const isPolling = (
 };
 
 export const useAutofixRepos = (groupId: string) => {
-  const {data} = useAutofixData({groupId});
+  const {data} = useAutofixData({groupId, isUserWatching: true});
 
   return useMemo(() => {
     const repos = data?.request?.repos ?? [];
@@ -159,11 +159,17 @@ export const useAutofixRepos = (groupId: string) => {
   }, [data]);
 };
 
-export const useAutofixData = ({groupId}: {groupId: string}) => {
+export const useAutofixData = ({
+  groupId,
+  isUserWatching = false,
+}: {
+  groupId: string;
+  isUserWatching: boolean;
+}) => {
   const orgSlug = useOrganization().slug;
 
   const {data, isPending} = useApiQuery<AutofixResponse>(
-    makeAutofixQueryKey(orgSlug, groupId),
+    makeAutofixQueryKey(orgSlug, groupId, isUserWatching),
     {
       staleTime: Infinity,
       enabled: false,

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -164,7 +164,7 @@ export const useAutofixData = ({
   isUserWatching = false,
 }: {
   groupId: string;
-  isUserWatching: boolean;
+  isUserWatching?: boolean;
 }) => {
   const orgSlug = useOrganization().slug;
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -47,9 +47,13 @@ export function SeerSectionCtaButton({
   };
 
   const openButtonRef = useRef<HTMLButtonElement>(null);
+  const isDrawerOpenRef = useRef(false);
 
   const {isPending: isAutofixPending} = useAutofixData({groupId: group.id});
-  const {autofixData} = useAiAutofix(group, event, {isSidebar: true, pollInterval: 1500});
+  const {autofixData} = useAiAutofix(group, event, {
+    isSidebar: !isDrawerOpenRef.current,
+    pollInterval: 1500,
+  });
 
   const {openSeerDrawer} = useOpenSeerDrawer({
     group,
@@ -57,7 +61,11 @@ export function SeerSectionCtaButton({
     event,
     buttonRef: openButtonRef,
   });
-  const isDrawerOpenRef = useRef(false);
+
+  // Keep isDrawerOpenRef in sync with the Seer drawer state (based on URL query)
+  useEffect(() => {
+    isDrawerOpenRef.current = !!location.query.seerDrawer;
+  }, [location.query.seerDrawer]);
 
   // Keep track of previous steps to detect state transitions and notify the user
   const prevStepsRef = useRef<AutofixStep[] | null>(null);
@@ -115,22 +123,8 @@ export function SeerSectionCtaButton({
 
   // Update drawer state when opening
   const handleOpenDrawer = () => {
-    isDrawerOpenRef.current = true;
     openSeerDrawer();
   };
-
-  // Listen for drawer close events
-  useEffect(() => {
-    const handleClickOutside = () => {
-      isDrawerOpenRef.current = false;
-    };
-
-    document.addEventListener('click', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, []);
 
   const showCtaButton =
     aiConfig.needsGenAiAcknowledgement ||


### PR DESCRIPTION
Sets user-watching flag in get state endpoint based on whether or not the drawer is open. Updates query invalidation accordingly.

Also removes toast notifications for step completion when the drawer is open.