### PR TITLE
fix(crons): Show error message when crons update/create fails

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, useRef} from 'react';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -165,6 +166,13 @@ function Create(props: Props) {
                     })
                   )
                 }
+                onSubmitError={error => {
+                  if (error.status === 500) {
+                    addErrorMessage(
+                      t('An unknown error occurred when creating the cron monitor.')
+                    );
+                  }
+                }}
                 submitLabel={t('Create')}
               />
             ) : !hasMetricAlerts || alertType === AlertRuleType.ISSUE ? (

--- a/static/app/views/alerts/rules/crons/edit.tsx
+++ b/static/app/views/alerts/rules/crons/edit.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -82,6 +83,13 @@ export function CronRulesEdit({onChangeTitle, project, organization}: Props) {
         apiMethod="PUT"
         apiEndpoint={`/projects/${organization.slug}/${projectId}/monitors/${monitor.slug}/`}
         onSubmitSuccess={onSubmitSuccess}
+        onSubmitError={error => {
+          if (error.status === 500) {
+            addErrorMessage(
+              t('An unknown error occurred when updating the cron monitor.')
+            );
+          }
+        }}
       />
     </Layout.Main>
   );

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -68,6 +68,7 @@ type Props = {
   apiMethod: FormProps['apiMethod'];
   onSubmitSuccess: FormProps['onSubmitSuccess'];
   monitor?: Monitor;
+  onSubmitError?: FormProps['onSubmitError'];
   submitLabel?: string;
 };
 
@@ -175,6 +176,7 @@ function MonitorForm({
   apiEndpoint,
   apiMethod,
   onSubmitSuccess,
+  onSubmitError,
 }: Props) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -254,6 +256,7 @@ function MonitorForm({
             }
       }
       onSubmitSuccess={onSubmitSuccess}
+      onSubmitError={onSubmitError}
       submitLabel={submitLabel}
     >
       <StyledList symbol="colored-numeric">


### PR DESCRIPTION
If trying to create or edit a cron monitor fails, we will now show a toast indicating that the request has failed. 