### PR TITLE
:wrench: chore(logs): remove integration client http response log

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -219,6 +219,9 @@ class DiscordClient(ApiClient):
             sample_rate=1.0,
         )
 
+        if options.get("integrations.http-response.logs"):
+            self.logger.info("handled discord error", extra=log_params)
+
     def _handle_success(
         self,
         log_params: dict[str, Any],

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -221,11 +221,15 @@ class DiscordClient(ApiClient):
 
     def _handle_success(
         self,
+        log_params: dict[str, Any],
     ) -> None:
         metrics.incr(
             self._METRICS_SUCCESS_KEY,
             sample_rate=1.0,
         )
+
+        if options.get("integrations.http-response.logs"):
+            self.logger.info("handled discord success", extra=log_params)
 
     def send_message(self, channel_id: str, message: dict[str, object]) -> None:
         """

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -166,7 +166,7 @@ class DiscordClient(ApiClient):
             code_to_use = code if isinstance(code, int) else None
             self._handle_failure(code=code_to_use, log_params=log_params, resp=resp)
         else:
-            self._handle_success(log_params=log_params)
+            self._handle_success()
 
     def _handle_failure(
         self,
@@ -218,17 +218,14 @@ class DiscordClient(ApiClient):
             metrics_key,
             sample_rate=1.0,
         )
-        self.logger.info("handled discord error", extra=log_params)
 
     def _handle_success(
         self,
-        log_params: dict[str, Any],
     ) -> None:
         metrics.incr(
             self._METRICS_SUCCESS_KEY,
             sample_rate=1.0,
         )
-        self.logger.info("handled discord success", extra=log_params)
 
     def send_message(self, channel_id: str, message: dict[str, object]) -> None:
         """

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -219,9 +219,6 @@ class DiscordClient(ApiClient):
             sample_rate=1.0,
         )
 
-        if options.get("integrations.http-response.logs"):
-            self.logger.info("handled discord error", extra=log_params)
-
     def _handle_success(
         self,
         log_params: dict[str, Any],
@@ -230,9 +227,6 @@ class DiscordClient(ApiClient):
             self._METRICS_SUCCESS_KEY,
             sample_rate=1.0,
         )
-
-        if options.get("integrations.http-response.logs"):
-            self.logger.info("handled discord success", extra=log_params)
 
     def send_message(self, channel_id: str, message: dict[str, object]) -> None:
         """

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -166,7 +166,7 @@ class DiscordClient(ApiClient):
             code_to_use = code if isinstance(code, int) else None
             self._handle_failure(code=code_to_use, log_params=log_params, resp=resp)
         else:
-            self._handle_success()
+            self._handle_success(log_params=log_params)
 
     def _handle_failure(
         self,

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -6,6 +6,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.integrations.base import is_response_error, is_response_success
@@ -32,6 +33,15 @@ def track_response_data(response: SlackResponse, method: str, error: str | None 
         sample_rate=1.0,
         tags={"ok": is_ok, "status": code},
     )
+
+    if options.get("integrations.http-response.logs"):
+        extra = {
+            "integration": "slack",
+            "status_string": str(code),
+            "error": error,
+            "method": method,
+        }
+        logger.info("integration.http_response", extra=extra)
 
 
 def is_response_fatal(response: SlackResponse) -> bool:

--- a/src/sentry/integrations/slack/sdk_client.py
+++ b/src/sentry/integrations/slack/sdk_client.py
@@ -33,14 +33,6 @@ def track_response_data(response: SlackResponse, method: str, error: str | None 
         tags={"ok": is_ok, "status": code},
     )
 
-    extra = {
-        "integration": "slack",
-        "status_string": str(code),
-        "error": error,
-        "method": method,
-    }
-    logger.info("integration.http_response", extra=extra)
-
 
 def is_response_fatal(response: SlackResponse) -> bool:
     if not response.get("ok"):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -812,6 +812,9 @@ register("store.allow-s4s-ddm-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MO
 # Mock out integrations and services for tests
 register("mocks.jira", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Enable logging of HTTP response codes for integrations
+register("integrations.http-response.logs", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Record statistics about event payloads and their compressibility
 register(
     "store.nodestore-stats-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -98,17 +98,6 @@ class BaseApiClient:
             tags={self.integration_type: self.name, "status": code},
         )
 
-        log_params = {
-            **(extra or {}),
-            "status_string": str(code),
-            "error": str(error)[:256] if error else None,
-        }
-        if self.integration_type:
-            log_params[self.integration_type] = self.name
-
-        log_params.update(getattr(self, "logging_context", None) or {})
-        self.logger.info("%s.http_response", self.integration_type, extra=log_params)
-
     def get_cache_prefix(self) -> str:
         return f"{self.integration_type}.{self.name}.client:"
 

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -1,9 +1,10 @@
 import errno
 import os
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 import responses
+from django.test import TestCase
 from requests import Response
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 from requests.sessions import Session


### PR DESCRIPTION
saving us ~$8k

we can use an opt-in process if we actually need these logs to debug.

contributes to ECO-692