### PR TITLE
fix(relocation) Treat '' as an empty set

### DIFF
--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -203,11 +203,7 @@ def parse_filter_arg(filter_arg: str | None) -> set[str] | None:
     if filter_arg is None:
         return None
 
-    filter_by = None
-    if filter_arg:
-        filter_by = {arg.strip() for arg in filter_arg.split(",") if not arg.isspace()}
-
-    return filter_by
+    return {arg.strip() for arg in filter_arg.split(",") if not arg.isspace()}
 
 
 def get_decryptor_from_flags(
@@ -928,7 +924,7 @@ def export() -> None:
     type=str,
     required=False,
     help="An optional comma-separated list of users to include. "
-    "If this option is not set, all encountered users are imported.",
+    "If this option is not set, all encountered users are exported.",
 )
 @click.option(
     "--filter-usernames-file",

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -590,6 +590,24 @@ class GoodImportExportCommandTests(TransactionTestCase):
                 export_args=["--filter-usernames-file", str(tmp_findings_file_path)],
             )
 
+    def test_export_user_scope_filter_usernames_empty(self):
+        # create a user that should not be in the export
+        self.create_user("admin@example.com", is_staff=True, is_superuser=True)
+        with TemporaryDirectory() as tmp_dir:
+            output = Path(tmp_dir).joinpath("output.tar")
+            filter_users = Path(tmp_dir).joinpath("filter-usernames.txt")
+            with open(filter_users, "w") as f:
+                f.write("")
+
+            rv = CliRunner().invoke(
+                export,
+                ["users", str(output), "--filter-usernames-file", str(filter_users)],
+            )
+            assert rv.exit_code == 0, rv.output
+            with open(output) as f:
+                contents = f.read()
+            assert contents.strip() == "[]"
+
 
 class GoodImportExportCommandEncryptionTests(TransactionTestCase):
     """


### PR DESCRIPTION
When an org is imported and that organization has no overlapping users with saas, the `filter-usernames` file will be empty. When an empty file is processed it should be interpreted as an empty set instead of None. With a None, all admin users are exported which causes import validation to fail.
