### PR TITLE
fix(detectors): Additional SQL Injection Detector improvements 

### DIFF
--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -44,6 +45,9 @@ SQL_KEYWORDS = [
     "ANY",
     "SOME",
     "EXISTS",
+    "DESC",
+    "ASC",
+    "NULL",
 ]
 
 
@@ -88,7 +92,7 @@ class SQLInjectionDetector(PerformanceDetector):
                 not isinstance(query_value, str)
                 or not isinstance(query_key, str)
                 or not query_value
-                or len(query_value) == 1
+                or len(query_value) < 3
             ):
                 continue
             if query_key == query_value:
@@ -111,7 +115,7 @@ class SQLInjectionDetector(PerformanceDetector):
         for parameter in self.request_parameters:
             value = parameter[1]
             key = parameter[0]
-            if key in description and value in description:
+            if re.search(f"\\b{key}\\b", description) and re.search(f"\\b{value}\\b", description):
                 description = description.replace(value, "?")
                 vulnerable_parameters.append(key)
 

--- a/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/sql_injection_detector.py
@@ -115,7 +115,9 @@ class SQLInjectionDetector(PerformanceDetector):
         for parameter in self.request_parameters:
             value = parameter[1]
             key = parameter[0]
-            if re.search(f"\\b{key}\\b", description) and re.search(f"\\b{value}\\b", description):
+            if re.search(f"\\b{re.escape(key)}\\b", description) and re.search(
+                f"\\b{re.escape(value)}\\b", description
+            ):
                 description = description.replace(value, "?")
                 vulnerable_parameters.append(key)
 


### PR DESCRIPTION
this pr adds a few additional improvements to the SQL Injection Detector:
- Increases the minimum character count to 3
- Adds a few additional keywords to not match on 
- adds word boundaries during lookup. this won't be perfect but should help narrow down where further improvements are needed