### PR TITLE
:wrench: chore(integrations): remove sentry slack activity notif logs

### DIFF
--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -29,7 +29,6 @@ _TASK_QUEUED_METRIC = (
 )
 def send_activity_notifications_to_slack_threads(activity_id) -> None:
     log_params = {"activity_id": activity_id}
-    _default_logger.info("async processing for activity", extra=log_params)
 
     try:
         activity = Activity.objects.get(pk=activity_id)
@@ -40,7 +39,6 @@ def send_activity_notifications_to_slack_threads(activity_id) -> None:
     organization = Organization.objects.get_from_cache(id=activity.project.organization_id)
     log_params["organization_id"] = organization.id
 
-    _default_logger.info("attempting to send notifications", extra=log_params)
     slack_service = SlackService.default()
     try:
         slack_service.notify_all_threads_for_activity(activity=activity)
@@ -59,15 +57,13 @@ def send_activity_notifications_to_slack_threads(activity_id) -> None:
             sample_rate=1.0,
         )
 
-    _default_logger.info("task finished for sending notifications", extra=log_params)
-
 
 def activity_created_receiver(instance, created, **kwargs) -> None:
     """
     If an activity is created for an issue, this will trigger, and we can kick off an async process
     """
     log_params = {"activity_id": instance.id, "activity_object_created": created}
-    _default_logger.info("receiver for activity event", extra=log_params)
+
     if not created:
         _default_logger.info("instance is not created, skipping post processing", extra=log_params)
         return


### PR DESCRIPTION
these logs do nothing, we should be logging in failure states not success.

saves us ~$3k

contributes to ECO-692