### PR TITLE
feat: Add status field to fetch parallel & sequential hooks

### DIFF
--- a/static/app/utils/api/useFetchParallelPages.spec.tsx
+++ b/static/app/utils/api/useFetchParallelPages.spec.tsx
@@ -36,6 +36,7 @@ describe('useFetchParallelPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).not.toHaveBeenCalled();
   });
@@ -57,11 +58,13 @@ describe('useFetchParallelPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).not.toHaveBeenCalled();
 
     rerender({enabled: true, getQueryKey, hits: 13, perPage: 10});
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
     expect(getQueryKey).toHaveBeenCalled();
 
@@ -85,6 +88,7 @@ describe('useFetchParallelPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).not.toHaveBeenCalled();
   });
@@ -106,8 +110,11 @@ describe('useFetchParallelPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).toHaveBeenCalledTimes(1);
   });
 
@@ -128,8 +135,11 @@ describe('useFetchParallelPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).toHaveBeenCalledTimes(3);
   });
 
@@ -156,7 +166,8 @@ describe('useFetchParallelPages', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.pages).toEqual([
       'results starting at 0',
       'results starting at 10',
@@ -181,7 +192,8 @@ describe('useFetchParallelPages', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.isError).toBeFalsy();
   });
 
@@ -210,7 +222,8 @@ describe('useFetchParallelPages', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.getLastResponseHeader).toStrictEqual(expect.any(Function));
     expect(result.current.getLastResponseHeader?.('Link')).toBe('next: 0:20:0');
   });
@@ -242,10 +255,12 @@ describe('useFetchParallelPages', () => {
     });
 
     // No responses have resolved
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
 
     // Both responses have resolved
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.pages).toEqual([
       'results starting at 0',
       'results starting at 10',

--- a/static/app/utils/api/useFetchParallelPages.tsx
+++ b/static/app/utils/api/useFetchParallelPages.tsx
@@ -36,6 +36,7 @@ interface ResponsePage<Data> {
   getResponseHeader: ((header: string) => string | null) | undefined;
   isError: boolean;
   isFetching: boolean;
+  status: 'pending' | 'error' | 'success';
 }
 
 interface State<Data> {
@@ -44,6 +45,7 @@ interface State<Data> {
   isError: boolean;
   isFetching: boolean;
   pages: Data[];
+  status: 'pending' | 'error' | 'success';
 }
 
 /**
@@ -107,6 +109,7 @@ export default function useFetchParallelPages<Data>({
     pages: [],
     error: undefined,
     getLastResponseHeader: undefined,
+    status: 'pending',
     isError: false,
     isFetching: willFetch,
   });
@@ -120,6 +123,7 @@ export default function useFetchParallelPages<Data>({
               data: undefined,
               error: undefined,
               getResponseHeader: undefined,
+              status: 'pending',
               isError: false,
               isFetching: true,
             });
@@ -134,6 +138,7 @@ export default function useFetchParallelPages<Data>({
               data,
               error: undefined,
               getResponseHeader: resp?.getResponseHeader,
+              status: 'success',
               isError: false,
               isFetching: false,
             });
@@ -142,6 +147,7 @@ export default function useFetchParallelPages<Data>({
               data: undefined,
               error,
               getResponseHeader: undefined,
+              status: 'error',
               isError: true,
               isFetching: false,
             });
@@ -151,6 +157,11 @@ export default function useFetchParallelPages<Data>({
               pages: values.map(value => value.data).filter(defined),
               error: values.map(value => value.error).filter(defined),
               getLastResponseHeader: values.slice(-1)[0]?.getResponseHeader,
+              status: values.some(value => value.status === 'error')
+                ? 'error'
+                : values.some(value => value.status === 'pending')
+                  ? 'pending'
+                  : 'success',
               isError: values.map(value => value.isError).some(Boolean),
               isFetching: values.map(value => value.isFetching).some(Boolean),
             });
@@ -168,6 +179,7 @@ export default function useFetchParallelPages<Data>({
 
     setState(prev => ({
       ...prev,
+      status: 'pending',
       isFetching: true,
     }));
 

--- a/static/app/utils/api/useFetchSequentialPages.spec.tsx
+++ b/static/app/utils/api/useFetchSequentialPages.spec.tsx
@@ -53,15 +53,18 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).not.toHaveBeenCalled();
 
     rerender({enabled: true, getQueryKey, perPage: 10});
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
     expect(getQueryKey).toHaveBeenCalled();
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
   });
 
   it('should call the queryFn 1 times when the response has no pagination header', async () => {
@@ -80,8 +83,11 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).toHaveBeenCalledTimes(1);
   });
 
@@ -102,8 +108,11 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).toHaveBeenCalledTimes(1);
   });
 
@@ -131,8 +140,11 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
+    expect(result.current.status).toBe('pending');
     expect(result.current.isFetching).toBeTruthy();
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(getQueryKey).toHaveBeenCalledTimes(2);
   });
 
@@ -161,7 +173,8 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.pages).toEqual([
       'results starting at 0',
       'results starting at 10',
@@ -187,7 +200,8 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.isError).toBeTruthy();
     expect(result.current.error).toEqual(expect.objectContaining({status: 429}));
   });
@@ -221,7 +235,8 @@ describe('useFetchSequentialPages', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.isFetching).toBeFalsy();
     expect(result.current.getLastResponseHeader).toStrictEqual(expect.any(Function));
     expect(result.current.getLastResponseHeader?.('Link')).toBe(secondLinkHeader);
   });

--- a/static/app/utils/api/useFetchSequentialPages.tsx
+++ b/static/app/utils/api/useFetchSequentialPages.tsx
@@ -40,6 +40,7 @@ interface ResponsePage<Data> {
   getResponseHeader: ((header: string) => string | null) | undefined;
   isError: boolean;
   isFetching: boolean;
+  status: 'pending' | 'error' | 'success';
 }
 
 interface State<Data> {
@@ -48,6 +49,7 @@ interface State<Data> {
   isError: boolean;
   isFetching: boolean;
   pages: Data[];
+  status: 'pending' | 'error' | 'success';
 }
 
 /**
@@ -100,6 +102,7 @@ export default function useFetchSequentialPages<Data>({
     pages: [],
     error: undefined,
     getLastResponseHeader: undefined,
+    status: 'pending',
     isError: false,
     isFetching: enabled,
   });
@@ -128,6 +131,7 @@ export default function useFetchSequentialPages<Data>({
             data,
             error: undefined,
             getResponseHeader: resp?.getResponseHeader,
+            status: 'success',
             isError: false,
             isFetching: false,
           });
@@ -140,6 +144,7 @@ export default function useFetchSequentialPages<Data>({
           data: undefined,
           error,
           getResponseHeader: undefined,
+          status: 'error',
           isError: true,
           isFetching: false,
         });
@@ -149,6 +154,11 @@ export default function useFetchSequentialPages<Data>({
           pages: values.map(value => value.data).filter(defined),
           error: values.map(value => value.error).at(0),
           getLastResponseHeader: values.at(-1)?.getResponseHeader,
+          status: values.some(value => value.status === 'error')
+            ? 'error'
+            : values.some(value => value.status === 'pending')
+              ? 'pending'
+              : 'success',
           isError: values.map(value => value.isError).some(Boolean),
           isFetching: values.map(value => value.isFetching).every(Boolean),
         });
@@ -164,6 +174,7 @@ export default function useFetchSequentialPages<Data>({
 
     setState(prev => ({
       ...prev,
+      status: 'pending',
       isFetching: true,
     }));
 


### PR DESCRIPTION
This `status` field matches the field that react-query has. This is an improvement over the existing `isFetching` field, because we can tell if the query, overall is or isn't ready yet. `isFetching` only reveals if the network request is in-flight.

https://tanstack.com/query/latest/docs/framework/react/reference/useQuery
