### PR TITLE
:wrench: chore: change slack service activity notif to debug level

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -141,7 +141,7 @@ class SlackService:
         }
 
         if activity.group is None:
-            self._logger.info(
+            self._logger.debug(
                 "no group associated on the activity, nothing to do",
                 extra=log_params,
             )
@@ -156,7 +156,8 @@ class SlackService:
         )
 
         if activity.user_id is None and not uptime_resolved_notification:
-            self._logger.info(
+            # This is a machine/system update, so we don't need to send a notification
+            self._logger.debug(
                 "machine/system updates are ignored at this time, nothing to do",
                 extra=log_params,
             )

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -128,7 +128,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
 
         with mock.patch.object(self.service, "_logger") as mock_logger:
             self.service.notify_all_threads_for_activity(activity=self.activity)
-            mock_logger.info.assert_called_with(
+            mock_logger.debug.assert_called_with(
                 "no group associated on the activity, nothing to do",
                 extra={
                     "activity_id": self.activity.id,
@@ -141,7 +141,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
 
         with mock.patch.object(self.service, "_logger") as mock_logger:
             self.service.notify_all_threads_for_activity(activity=self.activity)
-            mock_logger.info.assert_called_with(
+            mock_logger.debug.assert_called_with(
                 "machine/system updates are ignored at this time, nothing to do",
                 extra={
                     "activity_id": self.activity.id,


### PR DESCRIPTION
i think these logs are worth having locally since i use it sometimes when debugging activity notifs locally, but not on prod

saves us $1k

contributes to ECO-692