### PR TITLE
fix(aci): display monitor assignee (owner) and creator to monitor lists

### DIFF
--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
+import {IconSentry} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 
@@ -11,6 +12,7 @@ export type TitleCellProps = {
   link: string;
   name: string;
   className?: string;
+  createdBy?: string | null;
   details?: string[];
   disabled?: boolean;
   projectId?: string;
@@ -18,17 +20,21 @@ export type TitleCellProps = {
 
 export function TitleCell({
   name,
-  projectId: project_id,
+  createdBy,
+  projectId,
   details,
   link,
   disabled = false,
   className,
 }: TitleCellProps) {
-  const project = useProjectFromId({project_id});
+  const project = useProjectFromId({project_id: projectId});
   return (
     <TitleWrapper to={link} disabled={disabled} className={className}>
       <Name disabled={disabled}>
         <strong>{name}</strong>
+        {!createdBy && (
+          <IconSentry size="xs" color="subText" style={{alignSelf: 'center'}} />
+        )}
         {disabled && <span>&mdash; Disabled</span>}
       </Name>
       <DetailsWrapper>

--- a/static/app/types/workflowEngine/automations.tsx
+++ b/static/app/types/workflowEngine/automations.tsx
@@ -11,6 +11,7 @@ interface NewAutomation {
 }
 
 export interface Automation extends Readonly<NewAutomation> {
+  readonly createdBy: string;
   readonly dateCreated: string;
   readonly dateUpdated: string;
   readonly id: string;

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -1,10 +1,10 @@
 import type {Dispatch, SetStateAction} from 'react';
 
 import {Button} from 'sentry/components/core/button';
+import ActorBadge from 'sentry/components/idBadge/actorBadge';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
 import {TitleCell} from 'sentry/components/workflowEngine/gridCell/titleCell';
 import {TypeCell} from 'sentry/components/workflowEngine/gridCell/typeCell';
-import {UserCell} from 'sentry/components/workflowEngine/gridCell/userCell';
 import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
@@ -41,12 +41,13 @@ export default function ConnectedMonitorsList({
   const data = monitors.map(monitor => ({
     title: {
       name: monitor.name,
+      createdBy: monitor.createdBy,
       projectId: monitor.projectId,
       link: makeMonitorDetailsPathname(organization.slug, monitor.id),
     },
     type: monitor.type,
     lastIssue: undefined, // TODO: call API to get last issue
-    createdBy: monitor.createdBy,
+    owner: monitor.owner,
     connected: canEdit
       ? {
           isConnected: connectedIds?.has(monitor.id),
@@ -69,9 +70,9 @@ export default function ConnectedMonitorsList({
 }
 
 interface BaseMonitorsData {
-  createdBy: Detector['createdBy'];
   lastIssue: Group | undefined;
-  title: {link: string; name: string; projectId: string};
+  owner: Detector['owner'];
+  title: {createdBy: string | null; link: string; name: string; projectId: string};
   type: Detector['type'];
 }
 
@@ -79,7 +80,12 @@ const baseColumns = defineColumns<BaseMonitorsData>({
   title: {
     Header: () => t('Name'),
     Cell: ({value}) => (
-      <TitleCell name={value.name} projectId={value.projectId} link={value.link} />
+      <TitleCell
+        name={value.name}
+        createdBy={value.createdBy}
+        projectId={value.projectId}
+        link={value.link}
+      />
     ),
     width: '4fr',
   },
@@ -93,12 +99,24 @@ const baseColumns = defineColumns<BaseMonitorsData>({
     Cell: ({value}) => <IssueCell group={value} />,
     width: '1.5fr',
   },
-  createdBy: {
-    Header: () => t('Creator'),
-    Cell: ({value}) => (value ? <UserCell user={value} /> : null),
+  owner: {
+    Header: () => t('Assignee'),
+    Cell: ({value}) => <MonitorOwner owner={value} />,
     width: '1fr',
   },
 });
+
+function MonitorOwner({owner}: {owner: string | null}) {
+  if (!owner) {
+    return t('Unassigned');
+  }
+
+  const [ownerType, ownerId] = owner.split(':');
+  if (!ownerId || (ownerType !== 'user' && ownerType !== 'team')) {
+    return t('Unknown Owner');
+  }
+  return <ActorBadge actor={{id: ownerId, name: '', type: ownerType}} />;
+}
 
 interface ConnectedMonitorsData extends BaseMonitorsData {
   connected?: {

--- a/static/app/views/automations/detail.tsx
+++ b/static/app/views/automations/detail.tsx
@@ -22,6 +22,7 @@ import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import useUserFromId from 'sentry/utils/useUserFromId';
 import AutomationHistoryList from 'sentry/views/automations/components/automationHistoryList';
 import ConditionsPanel from 'sentry/views/automations/components/conditionsPanel';
 import ConnectedMonitorsList from 'sentry/views/automations/components/connectedMonitorsList';
@@ -40,6 +41,8 @@ export default function AutomationDetail() {
     isError,
     refetch,
   } = useAutomationQuery(params.automationId);
+
+  const {data: createdByUser} = useUserFromId({id: Number(automation?.createdBy)});
 
   const detectorsQuery = useDetectorQueriesByIds(automation?.detectorIds || []);
   const detectors = detectorsQuery
@@ -105,7 +108,10 @@ export default function AutomationDetail() {
                     keyName={t('Date created')}
                     value={<DateTime date={automation.dateCreated} dateOnly year />}
                   />
-                  <KeyValueTableRow keyName={t('Created by')} value="placeholder" />
+                  <KeyValueTableRow
+                    keyName={t('Created by')}
+                    value={createdByUser?.name || createdByUser?.email || t('Unknown')}
+                  />
                   <KeyValueTableRow
                     keyName={t('Last modified')}
                     value={<TimeSince date={automation.dateUpdated} />}

--- a/static/app/views/detectors/components/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListRow.tsx
@@ -31,6 +31,7 @@ export function DetectorListRow({
       <CellWrapper>
         <StyledTitleCell
           name={name}
+          createdBy={createdBy}
           projectId={projectId}
           link={link}
           disabled={disabled}


### PR DESCRIPTION
we want to display the sentry logo next to the name if the monitor was created by sentry (`createdBy = null`)

the right-most column should now display the monitor `owner`, which is the default assignee of any issues created by the monitor

<img width="869" alt="Screenshot 2025-06-09 at 4 01 36 PM" src="https://github.com/user-attachments/assets/59f128ea-d254-4e42-843c-bf44bcc67db2" />
