### PR TITLE
feat(codecov): create the TA aggregates endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -69,6 +69,9 @@ from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
 )
 from sentry.api.endpoints.trace_explorer_ai_setup import TraceExplorerAISetup
 from sentry.codecov.endpoints.TestResults.test_results import TestResultsEndpoint
+from sentry.codecov.endpoints.TestResultsAggregates.test_results_aggregates import (
+    TestResultsAggregatesEndpoint,
+)
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.data_secrecy.api.waive_data_secrecy import WaiveDataSecrecyEndpoint
@@ -3243,6 +3246,11 @@ PREVENT_URLS = [
         r"^owner/(?P<owner>[^\/]+)/repository/(?P<repository>[^\/]+)/test-results/$",
         TestResultsEndpoint.as_view(),
         name="sentry-api-0-test-results",
+    ),
+    re_path(
+        r"^owner/(?P<owner>[^\/]+)/repository/(?P<repository>[^\/]+)/test-results-aggregates/$",
+        TestResultsAggregatesEndpoint.as_view(),
+        name="sentry-api-0-test-results-aggregates",
     ),
 ]
 

--- a/src/sentry/codecov/endpoints/TestResults/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResults/serializers.py
@@ -73,6 +73,7 @@ class TestResultSerializer(serializers.Serializer):
                 "Error parsing GraphQL response",
                 extra={
                     "error": str(e),
+                    "endpoint": "test-results",
                     "response_keys": (
                         list(graphql_response.keys())
                         if isinstance(graphql_response, dict)

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,32 +11,7 @@ from sentry.codecov.base import CodecovEndpoint
 from sentry.codecov.client import CodecovApiClient
 from sentry.codecov.endpoints.TestResults.query import query
 from sentry.codecov.endpoints.TestResults.serializers import TestResultSerializer
-
-
-class OrderingDirection(Enum):
-    DESC = "DESC"
-    ASC = "ASC"
-
-
-class OrderingParameter(Enum):
-    AVG_DURATION = "AVG_DURATION"
-    FLAKE_RATE = "FLAKE_RATE"
-    FAILURE_RATE = "FAILURE_RATE"
-    COMMITS_WHERE_FAIL = "COMMITS_WHERE_FAIL"
-    UPDATED_AT = "UPDATED_AT"
-
-
-class TestResultsFilterParameter(Enum):
-    FLAKY_TESTS = "FLAKY_TESTS"
-    FAILED_TESTS = "FAILED_TESTS"
-    SLOWEST_TESTS = "SLOWEST_TESTS"
-    SKIPPED_TESTS = "SKIPPED_TESTS"
-
-
-class MeasurementInterval(Enum):
-    INTERVAL_30_DAY = "INTERVAL_30_DAY"
-    INTERVAL_7_DAY = "INTERVAL_7_DAY"
-    INTERVAL_1_DAY = "INTERVAL_1_DAY"
+from sentry.codecov.enums import MeasurementInterval, OrderingDirection, OrderingParameter
 
 
 @extend_schema(tags=["Prevent"])

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/query.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/query.py
@@ -1,0 +1,30 @@
+query = """query GetTestResultsAggregates(
+    $owner: String!
+    $repo: String!
+    $interval: MeasurementInterval
+) {
+    owner(username: $owner) {
+        repository: repository(name: $repo) {
+            __typename
+            ... on Repository {
+                testAnalytics {
+                    testResultsAggregates(interval: $interval) {
+                        totalDuration
+                        totalDurationPercentChange
+                        slowestTestsDuration
+                        slowestTestsDurationPercentChange
+                        totalSlowTests
+                        totalSlowTestsPercentChange
+                        totalFails
+                        totalFailsPercentChange
+                        totalSkips
+                        totalSkipsPercentChange
+                    }
+                }
+            }
+            ... on NotFoundError {
+                message
+            }
+        }
+    }
+}"""

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
@@ -1,0 +1,49 @@
+import logging
+
+import sentry_sdk
+from rest_framework import serializers
+
+logger = logging.getLogger(__name__)
+
+
+class TestResultAggregatesSerializer(serializers.Serializer):
+    """
+    Serializer for test results aggregates response
+    """
+
+    totalDuration = serializers.IntegerField()
+    totalDurationPercentChange = serializers.IntegerField()
+    slowestTestsDuration = serializers.IntegerField()
+    slowestTestsDurationPercentChange = serializers.IntegerField()
+    totalSlowTests = serializers.IntegerField()
+    totalSlowTestsPercentChange = serializers.IntegerField()
+    totalFails = serializers.IntegerField()
+    totalFailsPercentChange = serializers.IntegerField()
+    totalSkips = serializers.IntegerField()
+    totalSkipsPercentChange = serializers.IntegerField()
+
+    def to_representation(self, graphql_response):
+        """
+        Transform the GraphQL response to the serialized format
+        """
+        try:
+            response_data = graphql_response["data"]["owner"]["repository"]["testAnalytics"][
+                "testResultsAggregates"
+            ]
+
+            return super().to_representation(response_data)
+
+        except (KeyError, TypeError) as e:
+            sentry_sdk.capture_exception(e)
+            logger.exception(
+                "Error parsing GraphQL response",
+                extra={
+                    "error": str(e),
+                    "response_keys": (
+                        list(graphql_response.keys())
+                        if isinstance(graphql_response, dict)
+                        else None
+                    ),
+                },
+            )
+            raise

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
@@ -39,6 +39,7 @@ class TestResultAggregatesSerializer(serializers.Serializer):
                 "Error parsing GraphQL response",
                 extra={
                     "error": str(e),
+                    "endpoint": "test-results-aggregates",
                     "response_keys": (
                         list(graphql_response.keys())
                         if isinstance(graphql_response, dict)

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
@@ -1,0 +1,68 @@
+from enum import Enum
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.parameters import PreventParams
+from sentry.codecov.base import CodecovEndpoint
+from sentry.codecov.client import CodecovApiClient
+from sentry.codecov.endpoints.TestResultsAggregates.query import query
+from sentry.codecov.endpoints.TestResultsAggregates.serializers import (
+    TestResultAggregatesSerializer,
+)
+
+
+class MeasurementInterval(Enum):
+    INTERVAL_30_DAY = "INTERVAL_30_DAY"
+    INTERVAL_7_DAY = "INTERVAL_7_DAY"
+    INTERVAL_1_DAY = "INTERVAL_1_DAY"
+
+
+@extend_schema(tags=["Prevent"])
+@region_silo_endpoint
+class TestResultsAggregatesEndpoint(CodecovEndpoint):
+    owner = ApiOwner.CODECOV
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+
+    # Disable pagination requirement for this endpoint
+    def has_pagination(self, response):
+        return False
+
+    @extend_schema(
+        operation_id="Retrieve test results aggregates for a given repository and owner",
+        parameters=[
+            PreventParams.OWNER,
+            PreventParams.REPOSITORY,
+        ],
+        request=None,
+        responses={
+            200: TestResultAggregatesSerializer,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
+        """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
+
+        owner = "codecov"
+        repository = "gazebo"
+
+        variables = {
+            "owner": owner,
+            "repo": repository,
+            "interval": MeasurementInterval.INTERVAL_30_DAY.value,
+        }
+
+        client = CodecovApiClient(git_provider_org="codecov")
+        graphql_response = client.query(query=query, variables=variables)
+        test_results = TestResultAggregatesSerializer().to_representation(graphql_response.json())
+
+        return Response(test_results)

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,12 +13,7 @@ from sentry.codecov.endpoints.TestResultsAggregates.query import query
 from sentry.codecov.endpoints.TestResultsAggregates.serializers import (
     TestResultAggregatesSerializer,
 )
-
-
-class MeasurementInterval(Enum):
-    INTERVAL_30_DAY = "INTERVAL_30_DAY"
-    INTERVAL_7_DAY = "INTERVAL_7_DAY"
-    INTERVAL_1_DAY = "INTERVAL_1_DAY"
+from sentry.codecov.enums import MeasurementInterval
 
 
 @extend_schema(tags=["Prevent"])
@@ -31,12 +24,8 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
 
-    # Disable pagination requirement for this endpoint
-    def has_pagination(self, response):
-        return False
-
     @extend_schema(
-        operation_id="Retrieve test results aggregates for a given repository and owner",
+        operation_id="Retrieves aggregated test result metrics for a given repository and owner",
         parameters=[
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
@@ -50,7 +39,10 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
         },
     )
     def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
-        """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
+        """
+        Retrieves aggregated test result metrics for a given repository and owner.
+        Also accepts a query parameter to specify the time period for the metrics.
+        """
 
         owner = "codecov"
         repository = "gazebo"

--- a/src/sentry/codecov/enums.py
+++ b/src/sentry/codecov/enums.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+
+class OrderingDirection(Enum):
+    DESC = "DESC"
+    ASC = "ASC"
+
+
+class OrderingParameter(Enum):
+    AVG_DURATION = "AVG_DURATION"
+    FLAKE_RATE = "FLAKE_RATE"
+    FAILURE_RATE = "FAILURE_RATE"
+    COMMITS_WHERE_FAIL = "COMMITS_WHERE_FAIL"
+    UPDATED_AT = "UPDATED_AT"
+
+
+class TestResultsFilterParameter(Enum):
+    FLAKY_TESTS = "FLAKY_TESTS"
+    FAILED_TESTS = "FAILED_TESTS"
+    SLOWEST_TESTS = "SLOWEST_TESTS"
+    SKIPPED_TESTS = "SKIPPED_TESTS"
+
+
+class MeasurementInterval(Enum):
+    INTERVAL_30_DAY = "INTERVAL_30_DAY"
+    INTERVAL_7_DAY = "INTERVAL_7_DAY"
+    INTERVAL_1_DAY = "INTERVAL_1_DAY"

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -1,0 +1,75 @@
+from unittest.mock import Mock, patch
+
+from django.urls import reverse
+
+from sentry.testutils.cases import APITestCase
+
+
+class TestResultsAggregatesEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-test-results-aggregates"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def reverse_url(self, owner="testowner", repository="testrepo"):
+        """Custom reverse URL method to handle required URL parameters"""
+        return reverse(
+            self.endpoint,
+            kwargs={
+                "owner": owner,
+                "repository": repository,
+            },
+        )
+
+    @patch(
+        "sentry.codecov.endpoints.TestResultsAggregates.test_results_aggregates.CodecovApiClient"
+    )
+    def test_get_returns_mock_response(self, mock_codecov_client_class):
+        mock_graphql_response = {
+            "data": {
+                "owner": {
+                    "repository": {
+                        "__typename": "Repository",
+                        "testAnalytics": {
+                            "testResultsAggregates": {
+                                "totalDuration": 100,
+                                "totalDurationPercentChange": 10,
+                                "slowestTestsDuration": 100,
+                                "slowestTestsDurationPercentChange": 10,
+                                "totalSlowTests": 100,
+                                "totalSlowTestsPercentChange": 10,
+                                "totalFails": 100,
+                                "totalFailsPercentChange": 10,
+                                "totalSkips": 100,
+                                "totalSkipsPercentChange": 10,
+                            }
+                        },
+                    }
+                }
+            }
+        }
+
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        response = self.client.get(url)
+
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="codecov")
+        assert mock_codecov_client_instance.query.call_count == 1
+        assert response.status_code == 200
+
+        assert response.data["totalDuration"] == 100
+        assert response.data["totalDurationPercentChange"] == 10
+        assert response.data["slowestTestsDuration"] == 100
+        assert response.data["slowestTestsDurationPercentChange"] == 10
+        assert response.data["totalSlowTests"] == 100
+        assert response.data["totalSlowTestsPercentChange"] == 10
+        assert response.data["totalFails"] == 100
+        assert response.data["totalFailsPercentChange"] == 10
+        assert response.data["totalSkips"] == 100
+        assert response.data["totalSkipsPercentChange"] == 10


### PR DESCRIPTION
the equivalent of #91911 for test result aggregates
