### PR TITLE
fix(seer): don't skip pre-backfill

### DIFF
--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -1004,6 +1004,40 @@ describe('AM2 Checkout', function () {
     expect(screen.getByTestId('errors-volume-item')).toBeInTheDocument();
   });
 
+  it('does not skip step 1 for business plan pre-backfill', async function () {
+    const launchOrg = OrganizationFixture({features: ['seer-billing']});
+    const am2BizSubscription = SubscriptionFixture({
+      organization: launchOrg,
+      plan: 'am2_business',
+      planTier: 'am2',
+      categories: {
+        errors: MetricHistoryFixture({reserved: 100_000}),
+        transactions: MetricHistoryFixture({reserved: 20_000_000}),
+        attachments: MetricHistoryFixture({reserved: 1}),
+        monitorSeats: MetricHistoryFixture({reserved: 1}),
+        profileDuration: MetricHistoryFixture({reserved: 1}),
+        replays: MetricHistoryFixture({reserved: 10_000}),
+      },
+      onDemandMaxSpend: 2000,
+    });
+
+    SubscriptionStore.set(launchOrg.slug, am2BizSubscription);
+
+    render(
+      <AMCheckout
+        {...RouteComponentPropsFixture()}
+        params={params}
+        api={api}
+        onToggleLegacy={jest.fn()}
+        checkoutTier={PlanTier.AM2}
+      />,
+      {organization: launchOrg}
+    );
+    await screen.findByText('Choose Your Plan');
+    expect(screen.getByTestId('body-choose-your-plan')).toBeInTheDocument();
+    expect(screen.queryByTestId('errors-volume-item')).not.toBeInTheDocument();
+  });
+
   it('skips step 1 for business plan with seer', async function () {
     const seerOrg = OrganizationFixture({features: ['seer-billing']});
     const seerSubscription = SubscriptionWithSeerFixture({

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -131,16 +131,23 @@ class AMCheckout extends Component<Props, State> {
       isBizPlanFamily(props.subscription.planDetails) &&
       props.checkoutTier === props.subscription.planTier
     ) {
-      const selectedAll = props.subscription.reservedBudgets?.every(budget => {
-        if (
-          Object.values(SelectableProduct).includes(
-            budget.apiName as string as SelectableProduct
-          )
-        ) {
-          return budget.reservedBudget > 0;
-        }
-        return !props.organization.features.includes(budget.billingFlag || '');
-      });
+      // TODO(billing): cleanup condition after backfill
+      const selectedAll = props.organization.features.includes('seer-billing')
+        ? props.subscription.reservedBudgets &&
+          props.subscription.reservedBudgets.length > 0
+          ? props.subscription.reservedBudgets.every(budget => {
+              if (
+                Object.values(SelectableProduct).includes(
+                  budget.apiName as string as SelectableProduct
+                )
+              ) {
+                return budget.reservedBudget > 0;
+              }
+              return !props.organization.features.includes(budget.billingFlag || '');
+            })
+          : false // don't skip before backfill
+        : true; // skip if seer hasn't launched
+
       if (selectedAll) {
         step = 2;
       }


### PR DESCRIPTION
If the org has `seer-billing`, then we should check if `subscription.reservedBudgets` is an empty list or not. If it is an empty list, then we haven't backfilled this org AND they haven't bought Seer yet. Therefore, we should avoid skipping the first step.