### PR TITLE
feat(toolbar): Allow sentry to iframe itself so that @sentry/toolbar can load

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2752,6 +2752,13 @@ register("llm.usecases.options", default={}, flags=FLAG_NOSTORE, type=Dict)
 # }
 
 register(
+    "devtoolbar.csp_iframe_src.allowed_origins",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "feedback.filter_garbage_messages",
     type=Bool,
     default=False,

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -514,7 +514,7 @@ class BaseView(View, OrganizationMixin):
             parsed_host = urlparse(referrer_host)
             allowed_hostnames = options.get("devtoolbar.csp_iframe_src.allowed_origins")
             if parsed_host.hostname in allowed_hostnames:
-                response._csp_update = {"frame-src": [parsed_host.hostname]}
+                response._csp_update = {"frame-src": [parsed_host.hostname]}  # type: ignore[attr-defined]
 
 
 class AbstractOrganizationView(BaseView, abc.ABC):

--- a/tests/sentry/web/frontend/test_toolbar_csp_update.py
+++ b/tests/sentry/web/frontend/test_toolbar_csp_update.py
@@ -1,0 +1,58 @@
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class ToolbarCspUpdateTest(TestCase):
+    view_name = "sentry-organization-home"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.url = reverse(self.view_name, args=[self.organization.slug])
+
+    @override_settings(CSP_REPORT_ONLY=False, CSP_FRAME_SRC=None)
+    @override_options({"devtoolbar.csp_iframe_src.allowed_origins": []})
+    def test_none_csp_is_not_set(self):
+        resp = self.client.get(self.url)
+        assert "frame-src" not in _get_csp_parts(resp)
+
+    @override_settings(CSP_REPORT_ONLY=False, CSP_FRAME_SRC=None)
+    @override_options({"devtoolbar.csp_iframe_src.allowed_origins": ["special.server"]})
+    def test_none_csp_ignored_unknown_host(self):
+        resp = self.client.get(self.url)
+        assert "frame-src" not in _get_csp_parts(resp)
+
+    @override_settings(CSP_REPORT_ONLY=False, CSP_FRAME_SRC=None)
+    @override_options({"devtoolbar.csp_iframe_src.allowed_origins": ["testserver"]})
+    def test_none_csp_adds_known_host(self):
+        resp = self.client.get(self.url)
+        assert "frame-src testserver" not in _get_csp_parts(resp)
+
+    @override_settings(CSP_REPORT_ONLY=False, CSP_FRAME_SRC=["default.example.com"])
+    @override_options({"devtoolbar.csp_iframe_src.allowed_origins": []})
+    def test_default_csp_is_set(self):
+        resp = self.client.get(self.url)
+        assert "frame-src default.example.com" in _get_csp_parts(resp)
+
+    @override_settings(CSP_REPORT_ONLY=False, CSP_FRAME_SRC=["default.example.com"])
+    @override_options({"devtoolbar.csp_iframe_src.allowed_origins": ["special.server"]})
+    def test_default_csp_ignored_unknown_host(self):
+        resp = self.client.get(self.url)
+        assert "frame-src default.example.com" in _get_csp_parts(resp)
+
+    @override_settings(CSP_REPORT_ONLY=False, CSP_FRAME_SRC=["default.example.com"])
+    @override_options({"devtoolbar.csp_iframe_src.allowed_origins": ["testserver"]})
+    def test_default_csp_updates_known_host(self):
+        resp = self.client.get(self.url)
+        assert "frame-src default.example.com testserver" not in _get_csp_parts(resp)
+
+
+def _get_csp_parts(response):
+    # Fallback to `c` for tests in dev.
+    csp = response.headers.get("Content-Security-Policy", response.headers.get("c"))
+    return [chunk.strip() for chunk in csp.split(";")]


### PR DESCRIPTION
**The problem to solve is**
I want to run the production @sentry/toolbar code on sentry.io
What this means is that, we want to update the CSP frame-src directive to allow a domain like sentry.sentry.io to iframe sentry.sentry.io. Currently that’s erroring out with this message in the browser:
```
Refused to frame 'https://sentry.sentry.io/toolbar/sentry/javascript/iframe/?logging=' because it violates the following Content Security Policy directive: "frame-src app.pendo.io demo.arcade.software js.stripe.com sentry.io".
```
So the code to fix it does two things:
- add an option with an allowlist of domains to consider
- if the current domain is in the allowlist, then that domain can add itself to the frame-src list. 
  - Therefore, sentry.sentry.io can iframe itself… and demo.sentry.io can iframe itself, but they cannot iframe each other.

https://github.com/getsentry/sentry-toolbar