### PR TITLE
fix(onboarding): Show correct minidump url in onbaording

### DIFF
--- a/static/app/gettingStartedDocs/minidump/minidump.tsx
+++ b/static/app/gettingStartedDocs/minidump/minidump.tsx
@@ -16,7 +16,7 @@ type Params = DocsParams;
 
 const getCurlSnippet = (params: Params) => `
 curl -X POST \
-'${params.dsn.public}' \
+'${params.dsn.minidump}' \
 -F upload_file_minidump=@mini.dmp`;
 
 const onboarding: OnboardingConfig = {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-585/wrong-minidump-url 
closes [TET-594: Onboarding for `minidump` is broken (uses DSN instead of Minidump URL)](https://linear.app/getsentry/issue/TET-594/onboarding-for-minidump-is-broken-uses-dsn-instead-of-minidump-url)