### PR TITLE
fix(replay): Return valid JSON when segment data is unavailable

### DIFF
--- a/src/sentry/replays/usecases/reader.py
+++ b/src/sentry/replays/usecases/reader.py
@@ -262,8 +262,8 @@ def download_segments(segments: list[RecordingSegmentStorageMeta]) -> Iterator[b
             yield b"[]"
         else:
             yield result[1]
-            if i < len(segments) - 1:
-                yield b","
+        if i < len(segments) - 1:
+            yield b","
     yield b"]"
 
 


### PR DESCRIPTION
Currently returns `[[][]]`.  Will now return `[[],[]]`.