### PR TITLE
ref(spans): Remove deprecated CLI params

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -426,20 +426,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "process-spans": {
         "topic": Topic.INGEST_SPANS,
         "strategy_factory": "sentry.spans.consumers.process.factory.ProcessSpansStrategyFactory",
-        "click_options": [
-            click.Option(
-                ["--max-flush-segments", "max_flush_segments"],
-                type=int,
-                default=500,
-                help="DEPRECATED. Use option `spans.buffer.max-flush-segments` instead.",
-            ),
-            click.Option(
-                ["--max-memory-percentage", "max_memory_percentage"],
-                default=1.0,
-                help="DEPRECATED. Use option `spans.buffer.max-memory-percentage` instead.",
-            ),
-            *multiprocessing_options(default_max_batch_size=100),
-        ],
+        "click_options": multiprocessing_options(default_max_batch_size=100),
     },
     "process-segments": {
         "topic": Topic.BUFFERED_SEGMENTS,

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -38,8 +38,6 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         input_block_size: int | None,
         output_block_size: int | None,
         produce_to_pipe: Callable[[KafkaPayload], None] | None = None,
-        max_memory_percentage: float = -1,  # DEPRECATED
-        max_flush_segments: int = -1,  # DEPRECATED
     ):
         super().__init__()
 


### PR DESCRIPTION
Requires https://github.com/getsentry/ops/pull/15782
Closes VIEPF-44

