### PR TITLE
ref(spans): Pin redis sharding to partition index

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -282,7 +282,7 @@ class SpansBuffer:
         :return: Dictionary of grouped spans. The key is a tuple of
             the `project_and_trace`, and the `parent_span_id`.
         """
-        trees: dict[tuple[str, str], list[Span]] = {}
+        trees: dict[tuple[int, str, str], list[Span]] = {}
         redirects: dict[str, dict[str, str]] = {}
 
         for span in spans:

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -80,7 +80,7 @@ from sentry.utils import metrics, redis
 
 # SegmentKey is an internal identifier used by the redis buffer that is also
 # directly used as raw redis key. the format is
-# "span-buf:s:{project_id:trace_id}:span_id", and the type is bytes because our
+# "span-buf:s:{partition}:project_id:trace_id:span_id", and the type is bytes because our
 # redis client is bytes.
 #
 # The segment ID in the Kafka protocol is only the span ID.
@@ -92,16 +92,17 @@ logger = logging.getLogger(__name__)
 
 
 def _segment_key_to_span_id(segment_key: SegmentKey) -> bytes:
-    return parse_segment_key(segment_key)[2]
+    return parse_segment_key(segment_key)[3]
 
 
-def parse_segment_key(segment_key: SegmentKey) -> tuple[bytes, bytes, bytes]:
+def parse_segment_key(segment_key: SegmentKey) -> tuple[int, bytes, bytes, bytes]:
     segment_key_parts = segment_key.split(b":")
-    project_id = segment_key_parts[2][1:]
-    trace_id = segment_key_parts[3][:-1]
-    span_id = segment_key_parts[4]
+    partition = int(segment_key_parts[2][1:-1])
+    project_id = segment_key_parts[3]
+    trace_id = segment_key_parts[4]
+    span_id = segment_key_parts[5]
 
-    return project_id, trace_id, span_id
+    return partition, project_id, trace_id, span_id
 
 
 def get_redis_client() -> RedisCluster[bytes] | StrictRedis[bytes]:
@@ -113,6 +114,7 @@ add_buffer_script = redis.load_redis_script("spans/add-buffer.lua")
 
 # NamedTuples are faster to construct than dataclasses
 class Span(NamedTuple):
+    partition: int
     trace_id: str
     span_id: str
     parent_span_id: str | None
@@ -153,8 +155,8 @@ class SpansBuffer:
     def __reduce__(self):
         return (SpansBuffer, (self.assigned_shards,))
 
-    def _get_span_key(self, project_and_trace: str, span_id: str) -> bytes:
-        return f"span-buf:s:{{{project_and_trace}}}:{span_id}".encode("ascii")
+    def _get_span_key(self, partition: int, project_and_trace: str, span_id: str) -> bytes:
+        return f"span-buf:s:{{{partition}}}:{project_and_trace}:{span_id}".encode("ascii")
 
     def process_spans(self, spans: Sequence[Span], now: int):
         """
@@ -176,8 +178,8 @@ class SpansBuffer:
             trees = self._group_by_parent(spans)
 
             with self.client.pipeline(transaction=False) as p:
-                for (project_and_trace, parent_span_id), subsegment in trees.items():
-                    set_key = self._get_span_key(project_and_trace, parent_span_id)
+                for (partition, project_and_trace, parent_span_id), subsegment in trees.items():
+                    set_key = self._get_span_key(partition, project_and_trace, parent_span_id)
                     p.sadd(set_key, *[span.payload for span in subsegment])
 
                 p.execute()
@@ -189,11 +191,12 @@ class SpansBuffer:
             add_buffer_sha = self._ensure_script()
 
             with self.client.pipeline(transaction=False) as p:
-                for (project_and_trace, parent_span_id), subsegment in trees.items():
+                for (partition, project_and_trace, parent_span_id), subsegment in trees.items():
                     p.execute_command(
                         "EVALSHA",
                         add_buffer_sha,
                         1,
+                        partition,
                         project_and_trace,
                         len(subsegment),
                         parent_span_id,
@@ -203,7 +206,7 @@ class SpansBuffer:
                     )
 
                     is_root_span_count += sum(span.is_segment_span for span in subsegment)
-                    result_meta.append((project_and_trace, parent_span_id))
+                    result_meta.append((partition, project_and_trace, parent_span_id))
 
                 results = p.execute()
 
@@ -213,14 +216,10 @@ class SpansBuffer:
 
             assert len(result_meta) == len(results)
 
-            for (project_and_trace, parent_span_id), result in zip(result_meta, results):
+            for (partition, project_and_trace, parent_span_id), result in zip(result_meta, results):
                 redirect_depth, set_key, has_root_span = result
 
-                shard = self.assigned_shards[
-                    int(project_and_trace.split(":")[1], 16) % len(self.assigned_shards)
-                ]
-                queue_key = self._get_queue_key(shard)
-
+                queue_key = self._get_queue_key(partition)
                 min_redirect_depth = min(min_redirect_depth, redirect_depth)
                 max_redirect_depth = max(max_redirect_depth, redirect_depth)
 
@@ -235,10 +234,11 @@ class SpansBuffer:
                 zadd_items = queue_adds.setdefault(queue_key, {})
                 zadd_items[set_key] = now + offset
 
-                subsegment_spans = trees[project_and_trace, parent_span_id]
+                subsegment_spans = trees[partition, project_and_trace, parent_span_id]
                 delete_set = queue_deletes.setdefault(queue_key, set())
                 delete_set.update(
-                    self._get_span_key(project_and_trace, span.span_id) for span in subsegment_spans
+                    self._get_span_key(partition, project_and_trace, span.span_id)
+                    for span in subsegment_spans
                 )
                 delete_set.discard(set_key)
 
@@ -271,7 +271,7 @@ class SpansBuffer:
     def _get_queue_key(self, shard: int) -> bytes:
         return f"span-buf:q:{shard}".encode("ascii")
 
-    def _group_by_parent(self, spans: Sequence[Span]) -> dict[tuple[str, str], list[Span]]:
+    def _group_by_parent(self, spans: Sequence[Span]) -> dict[tuple[int, str, str], list[Span]]:
         """
         Groups partial trees of spans by their top-most parent span ID in the
         provided list. The result is a dictionary where the keys identify a
@@ -293,9 +293,9 @@ class SpansBuffer:
             while redirect := trace_redirects.get(parent):
                 parent = redirect
 
-            subsegment = trees.setdefault((project_and_trace, parent), [])
+            subsegment = trees.setdefault((span.partition, project_and_trace, parent), [])
             if parent != span.span_id:
-                subsegment.extend(trees.pop((project_and_trace, span.span_id), []))
+                subsegment.extend(trees.pop((span.partition, project_and_trace, span.span_id), []))
                 trace_redirects[span.span_id] = parent
             subsegment.append(span)
 
@@ -471,8 +471,12 @@ class SpansBuffer:
                     p.delete(hrs_key)
                     p.unlink(segment_key)
 
-                    project_id, trace_id, _ = parse_segment_key(segment_key)
-                    redirect_map_key = b"span-buf:sr:{%s:%s}" % (project_id, trace_id)
+                    partition, project_id, trace_id, _ = parse_segment_key(segment_key)
+                    redirect_map_key = b"span-buf:sr:{%d}:%s:%s" % (
+                        partition,
+                        project_id,
+                        trace_id,
+                    )
                     p.zrem(flushed_segment.queue_key, segment_key)
 
                     for span_batch in itertools.batched(flushed_segment.spans, 100):

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -110,7 +110,7 @@ def parse_segment_key(segment_key: SegmentKey) -> tuple[int | None, bytes, bytes
         trace_id = segment_key_parts[4]
         span_id = segment_key_parts[5]
     else:
-        raise ValueError("unsupported segment key format: %s" % segment_key)
+        raise ValueError("unsupported segment key format")
 
     return partition, project_id, trace_id, span_id
 

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -64,6 +64,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         committer = CommitOffsets(commit)
 
         buffer = SpansBuffer(assigned_shards=[p.index for p in partitions])
+        first_partition = next((p.index for p in partitions), 0)
 
         # patch onto self just for testing
         flusher: ProcessingStrategy[FilteredPayload | int]
@@ -75,7 +76,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
         if self.num_processes != 1:
             run_task = run_task_with_multiprocessing(
-                function=partial(process_batch, buffer),
+                function=partial(process_batch, buffer, first_partition),
                 next_step=flusher,
                 max_batch_size=self.max_batch_size,
                 max_batch_time=self.max_batch_time,
@@ -85,7 +86,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             )
         else:
             run_task = RunTask(
-                function=partial(process_batch, buffer),
+                function=partial(process_batch, buffer, first_partition),
                 next_step=flusher,
             )
 
@@ -119,7 +120,9 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
 
 def process_batch(
-    buffer: SpansBuffer, values: Message[ValuesBatch[tuple[int, KafkaPayload]]]
+    buffer: SpansBuffer,
+    first_partition: int,
+    values: Message[ValuesBatch[tuple[int, KafkaPayload]]],
 ) -> int:
     min_timestamp = None
     spans = []
@@ -130,10 +133,9 @@ def process_batch(
 
         val = rapidjson.loads(payload.value)
 
-        partition_id: int | None = None
-
+        partition_id: int = first_partition
         if len(value.committable) == 1:
-            partition_id = value.committable[next(iter(value.committable))]
+            partition_id = next(iter(value.committable)).index
 
         if killswitches.killswitch_matches_context(
             "spans.drop-in-buffer",
@@ -147,7 +149,7 @@ def process_batch(
             continue
 
         span = Span(
-            partition=partition_id if partition_id is not None else -1,  # TODO: Fallback OK?
+            partition=partition_id,
             trace_id=val["trace_id"],
             span_id=val["span_id"],
             parent_span_id=val.get("parent_span_id"),

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -130,7 +130,7 @@ def process_batch(
 
         val = rapidjson.loads(payload.value)
 
-        partition_id = None
+        partition_id: int | None = None
 
         if len(value.committable) == 1:
             partition_id = value.committable[next(iter(value.committable))]
@@ -147,6 +147,7 @@ def process_batch(
             continue
 
         span = Span(
+            partition=partition_id if partition_id is not None else -1,  # TODO: Fallback OK?
             trace_id=val["trace_id"],
             span_id=val["span_id"],
             parent_span_id=val.get("parent_span_id"),

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -39,6 +39,7 @@ def test_backpressure(monkeypatch):
 
         spans = [
             Span(
+                partition=0,
                 payload=_payload(b"a" * 16),
                 trace_id=trace_id,
                 span_id="a" * 16,
@@ -46,6 +47,7 @@ def test_backpressure(monkeypatch):
                 project_id=1,
             ),
             Span(
+                partition=0,
                 payload=_payload(b"d" * 16),
                 trace_id=trace_id,
                 span_id="d" * 16,
@@ -53,6 +55,7 @@ def test_backpressure(monkeypatch):
                 project_id=1,
             ),
             Span(
+                partition=0,
                 payload=_payload(b"c" * 16),
                 trace_id=trace_id,
                 span_id="c" * 16,
@@ -60,6 +63,7 @@ def test_backpressure(monkeypatch):
                 project_id=1,
             ),
             Span(
+                partition=0,
                 payload=_payload(b"b" * 16),
                 trace_id=trace_id,
                 span_id="b" * 16,

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -34,7 +34,7 @@ def shallow_permutations(spans: list[Span]) -> list[list[Span]]:
 
 
 def _segment_id(project_id: int, trace_id: str, span_id: str) -> SegmentKey:
-    return f"span-buf:s:{{{project_id}:{trace_id}}}:{span_id}".encode("ascii")
+    return f"span-buf:s:{{0}}:{project_id}:{trace_id}:{span_id}".encode("ascii")
 
 
 def _payload(span_id: bytes) -> bytes:
@@ -133,6 +133,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
         itertools.permutations(
             [
                 Span(
+                    partition=0,
                     payload=_payload(b"a" * 16),
                     trace_id="a" * 32,
                     span_id="a" * 16,
@@ -140,6 +141,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
@@ -147,6 +149,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
@@ -154,6 +157,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
@@ -198,6 +202,7 @@ def test_basic(buffer: SpansBuffer, spans):
         itertools.permutations(
             [
                 Span(
+                    partition=0,
                     payload=_payload(b"d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
@@ -206,6 +211,7 @@ def test_basic(buffer: SpansBuffer, spans):
                 ),
                 _SplitBatch(),
                 Span(
+                    partition=0,
                     payload=_payload(b"b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
@@ -213,6 +219,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"a" * 16),
                     trace_id="a" * 32,
                     span_id="a" * 16,
@@ -221,6 +228,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
@@ -264,6 +272,7 @@ def test_deep(buffer: SpansBuffer, spans):
         itertools.permutations(
             [
                 Span(
+                    partition=0,
                     payload=_payload(b"e" * 16),
                     trace_id="a" * 32,
                     span_id="e" * 16,
@@ -271,6 +280,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
@@ -278,6 +288,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
@@ -285,6 +296,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
@@ -292,6 +304,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"a" * 16),
                     trace_id="a" * 32,
                     span_id="a" * 16,
@@ -337,6 +350,7 @@ def test_deep2(buffer: SpansBuffer, spans):
         itertools.permutations(
             [
                 Span(
+                    partition=0,
                     payload=_payload(b"c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
@@ -344,6 +358,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
@@ -351,6 +366,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"e" * 16),
                     trace_id="a" * 32,
                     span_id="e" * 16,
@@ -358,6 +374,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     project_id=1,
                 ),
                 Span(
+                    partition=0,
                     payload=_payload(b"b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
@@ -409,6 +426,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
     shallow_permutations(
         [
             Span(
+                partition=0,
                 payload=_payload(b"c" * 16),
                 trace_id="a" * 32,
                 span_id="c" * 16,
@@ -417,6 +435,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 is_segment_span=True,
             ),
             Span(
+                partition=0,
                 payload=_payload(b"d" * 16),
                 trace_id="a" * 32,
                 span_id="d" * 16,
@@ -424,6 +443,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 project_id=1,
             ),
             Span(
+                partition=0,
                 payload=_payload(b"e" * 16),
                 trace_id="a" * 32,
                 span_id="e" * 16,
@@ -431,6 +451,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 project_id=1,
             ),
             Span(
+                partition=0,
                 payload=_payload(b"b" * 16),
                 trace_id="a" * 32,
                 span_id="b" * 16,
@@ -485,6 +506,7 @@ def test_parent_in_other_project_and_nested_is_segment_span(buffer: SpansBuffer,
 def test_flush_rebalance(buffer: SpansBuffer):
     spans = [
         Span(
+            partition=0,
             payload=_payload(b"a" * 16),
             trace_id="a" * 32,
             span_id="a" * 16,


### PR DESCRIPTION
We observe performance degradation of the `process-spans` consumer with an
increasing number of Redis shards. By using the partition index instead of the
trace ID as sharding key, we pin each partition to exactly one Redis shard,
which should reduce this effect.

The downside is that a single hot partition can no longer be spread across
multiple Redis shards. At the current time, we operate 4-8 partitions per shard,
so we do not expect that this becomes an issue in the short time.

If this proves successful, we should follow up with proper cellularization of
the buffer consumer.

Ref STREAM-155
See also #93209 