### PR TITLE
feat(logs): Hide meta attributes for trace items

### DIFF
--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -114,6 +114,9 @@ LOGS_PRIVATE_ATTRIBUTES: set[str] = {
     if definition.private
 }
 
+# For dynamic internal attributes (eg. meta information for attributes) we match by the beginning of the key.
+LOGS_PRIVATE_ATTRIBUTE_PREFIXES: set[str] = {"_meta.sentry"}
+
 LOGS_REPLACEMENT_ATTRIBUTES: set[str] = {
     definition.replacement
     for definition in OURLOG_ATTRIBUTE_DEFINITIONS.values()

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -115,7 +115,7 @@ LOGS_PRIVATE_ATTRIBUTES: set[str] = {
 }
 
 # For dynamic internal attributes (eg. meta information for attributes) we match by the beginning of the key.
-LOGS_PRIVATE_ATTRIBUTE_PREFIXES: set[str] = {"_meta.sentry"}
+LOGS_PRIVATE_ATTRIBUTE_PREFIXES: set[str] = {"sentry._meta"}
 
 LOGS_REPLACEMENT_ATTRIBUTES: set[str] = {
     definition.replacement

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -559,7 +559,7 @@ SPANS_PRIVATE_ATTRIBUTES: set[str] = {
 }
 
 # For dynamic internal attributes (eg. meta information for attributes) we match by the beginning of the key.
-SPANS_PRIVATE_ATTRIBUTE_PREFIXES: set[str] = {"_meta.sentry"}
+SPANS_PRIVATE_ATTRIBUTE_PREFIXES: set[str] = {"sentry._meta"}
 
 SPANS_REPLACEMENT_ATTRIBUTES: set[str] = {
     definition.replacement

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -558,6 +558,9 @@ SPANS_PRIVATE_ATTRIBUTES: set[str] = {
     if definition.private
 }
 
+# For dynamic internal attributes (eg. meta information for attributes) we match by the beginning of the key.
+SPANS_PRIVATE_ATTRIBUTE_PREFIXES: set[str] = {"_meta.sentry"}
+
 SPANS_REPLACEMENT_ATTRIBUTES: set[str] = {
     definition.replacement
     for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -16,6 +16,7 @@ from sentry.search.eap.constants import SAMPLING_MODE_MAP
 from sentry.search.eap.ourlogs.attributes import (
     LOGS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
     LOGS_INTERNAL_TO_SECONDARY_ALIASES_MAPPING,
+    LOGS_PRIVATE_ATTRIBUTE_PREFIXES,
     LOGS_PRIVATE_ATTRIBUTES,
     LOGS_REPLACEMENT_ATTRIBUTES,
     LOGS_REPLACEMENT_MAP,
@@ -23,6 +24,7 @@ from sentry.search.eap.ourlogs.attributes import (
 from sentry.search.eap.spans.attributes import (
     SPAN_INTERNAL_TO_SECONDARY_ALIASES_MAPPING,
     SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS,
+    SPANS_PRIVATE_ATTRIBUTE_PREFIXES,
     SPANS_PRIVATE_ATTRIBUTES,
     SPANS_REPLACEMENT_ATTRIBUTES,
     SPANS_REPLACEMENT_MAP,
@@ -128,6 +130,11 @@ PRIVATE_ATTRIBUTES: dict[SupportedTraceItemType, set[str]] = {
     SupportedTraceItemType.LOGS: LOGS_PRIVATE_ATTRIBUTES,
 }
 
+PRIVATE_ATTRIBUTE_PREFIXES: dict[SupportedTraceItemType, set[str]] = {
+    SupportedTraceItemType.SPANS: SPANS_PRIVATE_ATTRIBUTE_PREFIXES,
+    SupportedTraceItemType.LOGS: LOGS_PRIVATE_ATTRIBUTE_PREFIXES,
+}
+
 SENTRY_CONVENTIONS_REPLACEMENT_ATTRIBUTES: dict[SupportedTraceItemType, set[str]] = {
     SupportedTraceItemType.SPANS: SPANS_REPLACEMENT_ATTRIBUTES,
     SupportedTraceItemType.LOGS: LOGS_REPLACEMENT_ATTRIBUTES,
@@ -162,7 +169,10 @@ def get_secondary_aliases(
 
 
 def can_expose_attribute(attribute: str, item_type: SupportedTraceItemType) -> bool:
-    return attribute not in PRIVATE_ATTRIBUTES.get(item_type, {})
+    return attribute not in PRIVATE_ATTRIBUTES.get(item_type, {}) and not any(
+        attribute.lower().startswith(prefix.lower())
+        for prefix in PRIVATE_ATTRIBUTE_PREFIXES.get(item_type, {})
+    )
 
 
 def handle_downsample_meta(meta: DownsampledStorageMeta) -> bool:


### PR DESCRIPTION
### Summary
We have to add meta information for attributes (eg. appending pii scrubbing reasons in Relay when a log gets filtered), and since attributes is the only storage of data for trace items, attributes is where we'll have to store it. This was stored in `_meta` on events previously, hence the name.

These meta fields should never appear in autocompletes, schema hints etcs. (not exposed) but should still be returned when requesting trace items in trace item details. We may in the future also consider also returning them in the events endpoint but that will double all attribute requests on /events to show filter reasons in a table.

Refs LOGS-81

