### PR TITLE
Reapply "fix(span-buffer): Do not use fork (#93026)"

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -67,7 +67,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         make_process: Callable[..., multiprocessing.context.SpawnProcess | threading.Thread]
         if self.produce_to_pipe is None:
             target = run_with_initialized_sentry(
-                "sentry.spans.consumers.process.flusher.main",
+                SpanFlusher.main,
                 # unpickling buffer will import sentry, so it needs to be
                 # pickled separately. at the same time, pickling
                 # synchronization primitives like multiprocessing.Value can
@@ -76,7 +76,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
             )
             make_process = self.mp_context.Process
         else:
-            target = partial(main, self.buffer)
+            target = partial(SpanFlusher.main, self.buffer)
             make_process = threading.Thread
 
         self.process = make_process(
@@ -262,6 +262,3 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
 
         if isinstance(self.process, multiprocessing.Process):
             self.process.terminate()
-
-
-main = SpanFlusher.main

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -1,5 +1,6 @@
 import logging
 import multiprocessing
+import multiprocessing.context
 import threading
 import time
 from collections.abc import Callable
@@ -62,10 +63,10 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         # the restart, however.
         self.healthy_since.value = int(time.time())
 
-        make_process: Callable[..., multiprocessing.Process | threading.Thread]
+        make_process: Callable[..., multiprocessing.context.SpawnProcess | threading.Thread]
         if self.produce_to_pipe is None:
             initializer = _get_arroyo_subprocess_initializer(None)
-            make_process = multiprocessing.Process
+            make_process = multiprocessing.get_context("spawn").Process
         else:
             initializer = None
             make_process = threading.Thread

--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -196,8 +196,11 @@ def run_task_with_multiprocessing(
 
 
 def _import_and_run(
-    initializer: Callable[[], None], main_fn_pickle: bytes, args_pickle: bytes, *additional_args
-):
+    initializer: Callable[[], None],
+    main_fn_pickle: bytes,
+    args_pickle: bytes,
+    *additional_args: Any,
+) -> None:
     initializer()
 
     # explicitly use pickle so that we can be sure arguments get unpickled
@@ -208,7 +211,7 @@ def _import_and_run(
     main_fn(*args, *additional_args)
 
 
-def run_with_initialized_sentry(main_fn: Callable[..., None], *args):
+def run_with_initialized_sentry(main_fn: Callable[..., None], *args: Any) -> Callable[..., None]:
     main_fn_pickle = pickle.dumps(main_fn)
     args_pickle = pickle.dumps(args)
     return partial(


### PR DESCRIPTION
the original PR was broken, but the error could only be reproduced if the sentry.conf.py was on a different path than `~/.sentry/sentry.conf.py`. otherwise the entire system still somehow worked due to hardcoded defaults in `sentry.runner.importer`.

