### PR TITLE
ref(security): Display Api Application / App Tokens for 5 minutes

### DIFF
--- a/src/sentry/api/serializers/models/apiapplication.py
+++ b/src/sentry/api/serializers/models/apiapplication.py
@@ -9,7 +9,7 @@ from sentry.models.apiapplication import ApiApplication
 @register(ApiApplication)
 class ApiApplicationSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
-        is_secret_visible = obj.date_added > timezone.now() - timedelta(days=1)
+        is_secret_visible = obj.date_added > timezone.now() - timedelta(minutes=5)
         return {
             "id": obj.client_id,
             "clientID": obj.client_id,

--- a/src/sentry/sentry_apps/api/serializers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app.py
@@ -145,7 +145,7 @@ class SentryAppSerializer(Serializer):
                 is_active_superuser(env.request) or is_active_staff(env.request)
             )
             if elevated_user or owner.id in user_org_ids:
-                is_secret_visible = obj.date_added > timezone.now() - timedelta(minutes=1)
+                is_secret_visible = obj.date_added > timezone.now() - timedelta(minutes=5)
 
                 owner_context = organization_service.get_organization_by_id(
                     id=owner.id, user_id=user.id

--- a/src/sentry/sentry_apps/api/serializers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app.py
@@ -145,7 +145,7 @@ class SentryAppSerializer(Serializer):
                 is_active_superuser(env.request) or is_active_staff(env.request)
             )
             if elevated_user or owner.id in user_org_ids:
-                is_secret_visible = obj.date_added > timezone.now() - timedelta(days=1)
+                is_secret_visible = obj.date_added > timezone.now() - timedelta(minutes=1)
 
                 owner_context = organization_service.get_organization_by_id(
                     id=owner.id, user_id=user.id

--- a/tests/sentry/sentry_apps/api/serializers/test_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/serializers/test_sentry_app.py
@@ -101,6 +101,6 @@ class SentryAppHiddenClientSecretSerializerTest(TestCase):
         assert result["clientSecret"] is not None
 
         now = datetime.now()
-        with freeze_time(now + timedelta(hours=25)):
+        with freeze_time(now + timedelta(minutes=10)):
             result = serialize(sentry_app, self.user, SentryAppSerializer(), access=acc)
             assert result["clientSecret"] is None


### PR DESCRIPTION
Fixes: [RTC-418: API Application's Client Secret stays visible](https://linear.app/getsentry/issue/RTC-418/api-applications-client-secret-stays-visible)