### PR TITLE
enh(flutter-replay): improve message when no network details are found

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -3,6 +3,7 @@ import type {GridCellProps} from 'react-virtualized';
 import {AutoSizer, CellMeasurer, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import Placeholder from 'sentry/components/placeholder';
 import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -11,7 +12,7 @@ import {GridTable} from 'sentry/components/replays/virtualizedGrid/gridTable';
 import {OverflowHidden} from 'sentry/components/replays/virtualizedGrid/overflowHidden';
 import {SplitPanel} from 'sentry/components/replays/virtualizedGrid/splitPanel';
 import useDetailsSplit from 'sentry/components/replays/virtualizedGrid/useDetailsSplit';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
@@ -199,7 +200,19 @@ export default function NetworkList() {
                         unfilteredItems={networkFrames}
                         clearSearchTerm={clearSearchTerm}
                       >
-                        {t('No network requests recorded')}
+                        {replay?.getReplay()?.sdk.name?.includes('flutter')
+                          ? tct(
+                              'No network requests recorded. Make sure you are using either the [link1:Sentry Dio] or the [link2:Sentry HTTP] integration.',
+                              {
+                                link1: (
+                                  <ExternalLink href="https://docs.sentry.io/platforms/dart/integrations/dio/" />
+                                ),
+                                link2: (
+                                  <ExternalLink href="https://docs.sentry.io/platforms/dart/integrations/http-integration/" />
+                                ),
+                              }
+                            )
+                          : t('No network requests recorded')}
                       </NoRowRenderer>
                     )}
                     onScrollbarPresenceChange={onScrollbarPresenceChange}


### PR DESCRIPTION
Since Flutter requires more manual setup, we should call this out.

~also not sure where to add tests 🤔~

## Flutter Replay Without Network Requests 

![image](https://github.com/user-attachments/assets/9caa4a1a-d346-44b7-824c-888ea6526193)

## Other Replay (RN in this example) Without Network Requests

![image](https://github.com/user-attachments/assets/c1680c60-5a2e-4e64-a067-04fbd0f0bd71)
