### PR TITLE
fix(eap-spans): `file_extension` test should be deterministic

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5502,6 +5502,7 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "field": [
                     "file_extension",
                 ],
+                "orderby": "file_extension",
                 "project": self.project.id,
                 "dataset": self.dataset,
             }


### PR DESCRIPTION
Need to add `orderby`