### PR TITLE
fix(spans): Align `hrs` key in the span buffer

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -41,7 +41,7 @@ end
 local set_key = string.format("span-buf:s:{%s}:%s:%s", partition, project_and_trace, set_span_id)
 local parent_key = string.format("span-buf:s:{%s}:%s:%s", partition, project_and_trace, parent_span_id)
 
-local has_root_span_key = string.format("span-buf:hrs:{%s}:%s", partition, set_key)
+local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
 has_root_span = has_root_span or redis.call("get", has_root_span_key) == "1"
 if has_root_span then
     redis.call("setex", has_root_span_key, set_timeout, "1")

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -477,8 +477,7 @@ class SpansBuffer:
         with metrics.timer("spans.buffer.done_flush_segments"):
             with self.client.pipeline(transaction=False) as p:
                 for segment_key, flushed_segment in segment_keys.items():
-                    hrs_key = b"span-buf:hrs:" + segment_key
-                    p.delete(hrs_key)
+                    p.delete(b"span-buf:hrs:" + segment_key)
                     p.unlink(segment_key)
                     p.zrem(flushed_segment.queue_key, segment_key)
 


### PR DESCRIPTION
The `hrs` key includes the entire span's set key, which already includes the
partition number as sharding key. With this, it is not necessary to
double-encode the partition.

This also re-aligns the lua script with cleanup in the buffer.

Ref STREAM-155