### PR TITLE
feat(tempest): Add playstation key to keys endpoint

### DIFF
--- a/src/sentry/api/serializers/models/project_key.py
+++ b/src/sentry/api/serializers/models/project_key.py
@@ -27,6 +27,7 @@ class DSN(TypedDict):
     unreal: str
     crons: str
     cdn: str
+    playstation: str
 
 
 class BrowserSDK(TypedDict):
@@ -94,6 +95,7 @@ class ProjectKeySerializer(Serializer):
                 "unreal": obj.unreal_endpoint,
                 "crons": obj.crons_endpoint,
                 "cdn": obj.js_sdk_loader_cdn_url,
+                "playstation": obj.playstation_endpoint,
             },
             "browserSdkVersion": get_selected_browser_sdk_version(obj),
             "browserSdk": {"choices": get_browser_sdk_version_choices(obj.project)},

--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -17,6 +17,7 @@ KEY_RATE_LIMIT = {
         "csp": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/csp-report/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "security": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/security/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "minidump": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/minidump/?sentry_key=a785682ddda719b7a8a4011110d75598",
+        "playstation": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/playstation/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "nel": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/nel/?sentry_key=a785682ddda719b7a8a4011110d75598",
         "unreal": "https://o4504765715316736.ingest.sentry.io/api/4505281256090153/unreal/a785682ddda719b7a8a4011110d75598/",
         "cdn": "https://js.sentry-cdn.com/a785682ddda719b7a8a4011110d75598.min.js",

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -260,6 +260,12 @@ class ProjectKey(Model):
         return f"{endpoint}/api/{self.project_id}/minidump/?sentry_key={self.public_key}"
 
     @property
+    def playstation_endpoint(self):
+        endpoint = self.get_endpoint()
+
+        return f"{endpoint}/api/{self.project_id}/playstation/?sentry_key={self.public_key}"
+
+    @property
     def unreal_endpoint(self):
         return f"{self.get_endpoint()}/api/{self.project_id}/unreal/{self.public_key}/"
 

--- a/tests/sentry/api/endpoints/test_project_keys.py
+++ b/tests/sentry/api/endpoints/test_project_keys.py
@@ -25,6 +25,21 @@ class ListProjectKeysTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]["public"] == key.public_key
 
+    def test_playstation_dsn(self):
+        project = self.create_project()
+        key = ProjectKey.objects.get_or_create(project=project)[0]
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-project-keys",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data[0]["dsn"]["playstation"] == key.playstation_endpoint
+
     def test_use_case(self):
         """Regular user can access user DSNs but not internal DSNs"""
         project = self.create_project()


### PR DESCRIPTION
Currently we are using string replace on frontend to create a playstation URL, but that should be constructed on the backend, so this PR introduces it.

There is a failing OpenAPI action, but that is expected according to our docs: https://develop.sentry.dev/backend/api/public/#build-process

Part of https://linear.app/getsentry/issue/TET-587/add-playstation-url-in-project-keys-endpoint-like-there-is-for