### PR TITLE
feat(trace-eap-watefall): Hiding Take me to an example trace when eap…

### DIFF
--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -489,6 +489,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const [received, setReceived] = useState<boolean>(false);
   const showNewUi = organization.features.includes('tracing-onboarding-new-ui');
+  const isEAPTraceEnabled = organization.features.includes('trace-spans-format');
 
   const currentPlatform = project.platform
     ? platforms.find(p => p.id === project.platform)
@@ -756,7 +757,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
                 >
                   {t('Take me to traces')}
                 </Button>
-              ) : (
+              ) : isEAPTraceEnabled ? null : (
                 <SampleButton
                   triggerText={t('Take me to an example')}
                   loadingMessage={t('Processing sample trace...')}


### PR DESCRIPTION
… traces are enabled.

<img width="1273" alt="Screenshot 2025-06-10 at 12 32 56 PM" src="https://github.com/user-attachments/assets/670c5161-d9e5-40b2-b726-995ce7bf8474" />
