### PR TITLE
fix(crons): Add tooltip to env label when overflow

### DIFF
--- a/static/app/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/monitorEnvironmentLabel.tsx
@@ -72,7 +72,9 @@ export default function MonitorEnvironmentLabel({monitorEnv}: Props) {
 
   return (
     <EnvWithStatus>
-      <MonitorEnvLabel color={color}>{name}</MonitorEnvLabel>
+      <Tooltip skipWrapper showOnlyOnOverflow title={name}>
+        <MonitorEnvLabel color={color}>{name}</MonitorEnvLabel>
+      </Tooltip>
       <Tooltip disabled={!label} title={label} skipWrapper>
         {icon}
       </Tooltip>


### PR DESCRIPTION
Fixes: [RTC-1011: Give cron environments in rows a tooltip if they overflow](https://linear.app/getsentry/issue/RTC-1011/give-cron-environments-in-rows-a-tooltip-if-they-overflow)