### PR TITLE
feat(aci): Batch of minor logging fixes

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -50,7 +50,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     get_slow_conditions_for_groups,
 )
 from sentry.workflow_engine.processors.detector import get_detector_by_event
-from sentry.workflow_engine.processors.log_util import track_batch_performance
+from sentry.workflow_engine.processors.log_util import log_if_slow, track_batch_performance
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
     evaluate_workflows_action_filters,
@@ -422,7 +422,7 @@ def fire_actions_for_groups(
     )
 
     with track_batch_performance(
-        "workflow_engine.delayed_workflow.group_to_groupevent.loop",
+        "workflow_engine.delayed_workflow.fire_actions_for_groups.loop",
         logger,
         threshold=timedelta(seconds=40),
     ) as tracker:
@@ -453,9 +453,14 @@ def fire_actions_for_groups(
                     Workflow.objects.filter(when_condition_group_id__in=workflow_triggers)
                 )
 
-                filtered_actions = filtered_actions.union(
-                    evaluate_workflows_action_filters(workflows, event_data)
-                )
+                with log_if_slow(
+                    logger,
+                    "workflow_engine.delayed_workflow.slow_evaluate_workflows_action_filters",
+                    extra={"group_id": group.id, "event_data": event_data},
+                    threshold_seconds=1,
+                ):
+                    workflows_actions = evaluate_workflows_action_filters(workflows, event_data)
+                filtered_actions = filtered_actions.union(workflows_actions)
 
                 metrics.incr(
                     "workflow_engine.delayed_workflow.triggered_actions",

--- a/src/sentry/workflow_engine/processors/log_util.py
+++ b/src/sentry/workflow_engine/processors/log_util.py
@@ -14,7 +14,7 @@ def top_n_slowest(durations: dict[str, float], n: int) -> dict[str, float]:
 
 
 # To keep logs reasonable, we only report up to this many individual iteration times.
-_MAX_ITERATIONS_LOGGED = 200
+_MAX_ITERATIONS_LOGGED = 20
 
 
 # NOTE: You should be using Sentry's built-in performance tracking instead of this.

--- a/tests/sentry/workflow_engine/processors/test_log_util.py
+++ b/tests/sentry/workflow_engine/processors/test_log_util.py
@@ -112,8 +112,8 @@ class TestBatchPerformanceTracker(unittest.TestCase):
         self.tracker.finalize()
         self.logger.info.assert_called_once()
         call_args = self.logger.info.call_args[1]
-        assert call_args["extra"]["durations_truncated"] == 100  # 300 - 200
-        assert len(call_args["extra"]["durations"]) == 200  # Should only keep top 200
+        assert call_args["extra"]["durations_truncated"] == 100
+        assert len(call_args["extra"]["durations"]) == _MAX_ITERATIONS_LOGGED
 
 
 def test_top_n_slowest():


### PR DESCRIPTION
* Add back log_if_slow call that was lost in a weird merge.
* Shorten explicitly reported batch duration list from 200 -> 20; they're generally logged unordered, so having 200 to look at for a slow one is actually not useful. 20 is more than enough to get a sense of the distribution without being big in logs. 
* Fix loop log event to not be misleading.
