### PR TITLE
chore(seer): Move seer automation task to dedicated queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1012,6 +1012,7 @@ CELERY_QUEUES_REGION = [
     Queue("integrations_slack_activity_notify", routing_key="integrations_slack_activity_notify"),
     Queue("demo_mode", routing_key="demo_mode"),
     Queue("release_registry", routing_key="release_registry"),
+    Queue("seer.seer_automation", routing_key="seer.seer_automation"),
 ]
 
 from celery.schedules import crontab

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -37,6 +37,7 @@ def check_autofix_status(run_id: int):
 
 @instrumented_task(
     name="sentry.tasks.autofix.start_seer_automation",
+    queue="seer.seer_automation",
     max_retries=1,
     time_limit=30,
     soft_time_limit=25,


### PR DESCRIPTION
Moves the seer automation task from post_process to its own queue