### PR TITLE
fix(aci): make icons inline in workflow details

### DIFF
--- a/static/app/components/workflowEngine/ui/actionMetadata.tsx
+++ b/static/app/components/workflowEngine/ui/actionMetadata.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
@@ -5,60 +7,65 @@ import {ActionType} from 'sentry/types/workflowEngine/actions';
 
 const ICON_SIZE = 20;
 
+const StyledPluginIcon = styled(PluginIcon)`
+  display: inline-block;
+  vertical-align: middle;
+`;
+
 export const ActionMetadata: Partial<
   Record<ActionType, {icon: React.ReactNode; name: string}>
 > = {
   [ActionType.AZURE_DEVOPS]: {
     name: t('Azure DevOps'),
-    icon: <PluginIcon pluginId="vsts" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="vsts" size={ICON_SIZE} />,
   },
   [ActionType.DISCORD]: {
     name: t('Discord'),
-    icon: <PluginIcon pluginId={'discord'} size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId={'discord'} size={ICON_SIZE} />,
   },
   [ActionType.EMAIL]: {name: t('Email'), icon: <IconMail size="md" />},
   [ActionType.GITHUB]: {
     name: t('GitHub'),
-    icon: <PluginIcon pluginId="github" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="github" size={ICON_SIZE} />,
   },
   [ActionType.GITHUB_ENTERPRISE]: {
     name: t('GitHub Enterprise'),
-    icon: <PluginIcon pluginId="github_enterprise" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="github_enterprise" size={ICON_SIZE} />,
   },
   [ActionType.JIRA]: {
     name: t('JIRA'),
-    icon: <PluginIcon pluginId="jira" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="jira" size={ICON_SIZE} />,
   },
   [ActionType.JIRA_SERVER]: {
     name: t('JIRA Server'),
-    icon: <PluginIcon pluginId="jira_server" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="jira_server" size={ICON_SIZE} />,
   },
   [ActionType.MSTEAMS]: {
     name: t('Teams'),
-    icon: <PluginIcon pluginId="msteams" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="msteams" size={ICON_SIZE} />,
   },
   [ActionType.OPSGENIE]: {
     name: t('Opsgenie'),
-    icon: <PluginIcon pluginId="opsgenie" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="opsgenie" size={ICON_SIZE} />,
   },
   [ActionType.PAGERDUTY]: {
     name: t('Pagerduty'),
-    icon: <PluginIcon pluginId="pagerduty" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="pagerduty" size={ICON_SIZE} />,
   },
   [ActionType.PLUGIN]: {
     name: t('Plugin'),
-    icon: <PluginIcon pluginId="placeholder" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="placeholder" size={ICON_SIZE} />,
   },
   [ActionType.SENTRY_APP]: {
     name: t('Sentry App'),
-    icon: <PluginIcon pluginId="sentry" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="sentry" size={ICON_SIZE} />,
   },
   [ActionType.SLACK]: {
     name: t('Slack'),
-    icon: <PluginIcon pluginId="slack" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="slack" size={ICON_SIZE} />,
   },
   [ActionType.WEBHOOK]: {
     name: t('Webhook'),
-    icon: <PluginIcon pluginId="webhooks" size={ICON_SIZE} />,
+    icon: <StyledPluginIcon pluginId="webhooks" size={ICON_SIZE} />,
   },
 };

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -70,15 +70,16 @@ const PLUGIN_ICONS = {
 
 export interface PluginIconProps extends React.RefAttributes<HTMLDivElement> {
   pluginId: keyof typeof PLUGIN_ICONS | (string & {});
+  className?: string;
   /**
    * @default 20
    */
   size?: number;
 }
 
-export function PluginIcon({pluginId, size = 20, ref}: PluginIconProps) {
+export function PluginIcon({pluginId, size = 20, ref, className}: PluginIconProps) {
   return (
-    <StyledPluginIconContainer size={size}>
+    <StyledPluginIconContainer size={size} className={className}>
       <StyledPluginIcon size={size} pluginSrc={getPluginIconSource(pluginId)} ref={ref} />
     </StyledPluginIconContainer>
   );

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -3,15 +3,18 @@ import {
   OptionalRowLine,
   RowLine,
 } from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
+import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
 import {BannerLink, InfoBanner} from 'sentry/components/workflowEngine/ui/infoBanner';
 import {t, tct} from 'sentry/locale';
-import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import {space} from 'sentry/styles/space';
-import type {Action, ActionHandler} from 'sentry/types/workflowEngine/actions';
+import {
+  type Action,
+  type ActionHandler,
+  ActionType,
+} from 'sentry/types/workflowEngine/actions';
 import {IntegrationField} from 'sentry/views/automations/components/actions/integrationField';
 import {TagsField} from 'sentry/views/automations/components/actions/tagsField';
 import {TargetDisplayField} from 'sentry/views/automations/components/actions/targetDisplayField';
-import {ICON_SIZE} from 'sentry/views/automations/components/automationBuilderRow';
 
 export function DiscordDetails({
   action,
@@ -28,7 +31,7 @@ export function DiscordDetails({
   return tct(
     'Send a [logo] Discord message to [server] server, to channel with ID or URL [channel][tags]',
     {
-      logo: <PluginIcon pluginId="discord" size={ICON_SIZE} />,
+      logo: ActionMetadata[ActionType.DISCORD]?.icon,
       server: integrationName,
       channel: String(action.config.target_identifier),
       tags: action.data.tags ? `, and in the message show tags [${tags}]` : null,
@@ -41,7 +44,7 @@ export function DiscordNode() {
     <Flex column gap={space(1)} flex="1">
       <RowLine>
         {tct('Send a [logo] Discord message to [server] server, to [channel]', {
-          logo: <PluginIcon pluginId="discord" size={ICON_SIZE} />,
+          logo: ActionMetadata[ActionType.DISCORD]?.icon,
           server: <IntegrationField />,
           channel: <TargetDisplayField placeholder={t('channel ID or URL')} />,
         })}

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -32,7 +32,7 @@ export function SlackDetails({
       logo: ActionMetadata[ActionType.SLACK]?.icon,
       workspace: integrationName,
       channel: action.config.target_display
-        ? `#${action.config.target_display}`
+        ? `${action.config.target_display}`
         : action.config.target_identifier,
       tagsAndNotes: SlackTagsAndNotes(action),
     }

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -52,5 +52,3 @@ const DeleteButton = styled(Button)`
   right: ${space(0.75)};
   opacity: 0;
 `;
-
-export const ICON_SIZE = 24;

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -1,7 +1,6 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/container/flex';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {t, tct} from 'sentry/locale';
@@ -122,11 +121,7 @@ function ActionDetails({action, handler}: ActionDetailsProps) {
     return <span>{node?.label}</span>;
   }
 
-  return (
-    <Flex wrap="wrap" gap={space(1)} flex={1}>
-      <Component action={action} handler={handler} />
-    </Flex>
-  );
+  return <Component action={action} handler={handler} />;
 }
 
 const Panel = styled('div')`


### PR DESCRIPTION
before
<img width="320" alt="Screenshot 2025-06-10 at 9 52 34 AM" src="https://github.com/user-attachments/assets/526e9f3e-0390-477e-a1f0-e0943c0b1f1a" />

after
<img width="299" alt="Screenshot 2025-06-10 at 9 52 17 AM" src="https://github.com/user-attachments/assets/93db8448-b49a-46c8-8528-b8be033ad300" />
