### PR TITLE
fix(releases): Fix Release Health banner

### DIFF
--- a/static/app/utils/useProjects.tsx
+++ b/static/app/utils/useProjects.tsx
@@ -158,7 +158,7 @@ function useProjects({limit, slugs, orgId: propOrgId}: Options = {}) {
   const organization = useOrganization({allowNull: true});
   const store = useLegacyStore(ProjectsStore);
 
-  const orgId = propOrgId ?? organization?.slug ?? organization?.slug;
+  const orgId = propOrgId ?? organization?.slug;
 
   const storeSlugs = new Set(store.projects.map(t => t.slug));
   const slugsToLoad = slugs?.filter(slug => !storeSlugs.has(slug)) ?? [];

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -88,6 +88,11 @@ describe('ReleasesList', () => {
       url: '/organizations/org-slug/projects/',
       body: [],
     });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${projects[0]!.slug}/`,
+      body: [],
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/releases/list/releaseHealthCTA.tsx
+++ b/static/app/views/releases/list/releaseHealthCTA.tsx
@@ -51,7 +51,7 @@ export default function ReleaseHealthCTA({
   const projectCanHaveReleases =
     project.platform && releaseHealth.includes(project.platform);
 
-  if (project.hasSessions !== false || !projectCanHaveReleases) {
+  if (project.hasSessions || !projectCanHaveReleases) {
     return null;
   }
 

--- a/static/app/views/releases/list/releaseHealthCTA.tsx
+++ b/static/app/views/releases/list/releaseHealthCTA.tsx
@@ -8,10 +8,10 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import type {AvatarProject, Project} from 'sentry/types/project';
+import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import Projects from 'sentry/utils/projects';
+import {useApiQuery} from 'sentry/utils/queryClient';
 
 interface Props {
   organization: Organization;
@@ -26,6 +26,15 @@ export default function ReleaseHealthCTA({
   selectedProject,
   selection,
 }: Props) {
+  const {
+    data: project,
+    isPending,
+    isError,
+  } = useApiQuery<Project>([`/projects/${organization.slug}/${selectedProject?.slug}/`], {
+    enabled: Boolean(selectedProject) && releases.length > 0,
+    staleTime: 1_000, // 1 second
+  });
+
   const trackAddReleaseHealth = useCallback(() => {
     if (organization.id && selection.projects[0]) {
       trackAnalytics('releases_list.click_add_release_health', {
@@ -35,43 +44,35 @@ export default function ReleaseHealthCTA({
     }
   }, [organization, selection]);
 
-  if (!selectedProject || selectedProject?.hasSessions !== false || !releases?.length) {
+  if (isPending || isError) {
+    return null;
+  }
+
+  const projectCanHaveReleases =
+    project.platform && releaseHealth.includes(project.platform);
+
+  if (project.hasSessions !== false || !projectCanHaveReleases) {
     return null;
   }
 
   return (
-    <Projects orgId={organization.slug} slugs={[selectedProject.slug]}>
-      {({projects, initiallyLoaded, fetchError}) => {
-        const project: AvatarProject | undefined =
-          projects?.length === 1 ? projects.at(0) : undefined;
-        const projectCanHaveReleases =
-          project?.platform && releaseHealth.includes(project.platform);
-
-        if (!initiallyLoaded || fetchError || !projectCanHaveReleases) {
-          return null;
-        }
-
-        return (
-          <Alert.Container>
-            <Alert type="info" showIcon>
-              <AlertText>
-                <div>
-                  {t(
-                    'To track user adoption, crash rates, session data and more, add Release Health to your current setup.'
-                  )}
-                </div>
-                <ExternalLink
-                  href="https://docs.sentry.io/product/releases/setup/#release-health"
-                  onClick={trackAddReleaseHealth}
-                >
-                  {t('Add Release Health')}
-                </ExternalLink>
-              </AlertText>
-            </Alert>
-          </Alert.Container>
-        );
-      }}
-    </Projects>
+    <Alert.Container>
+      <Alert type="info" showIcon>
+        <AlertText>
+          <div>
+            {t(
+              'To track user adoption, crash rates, session data and more, add Release Health to your current setup.'
+            )}
+          </div>
+          <ExternalLink
+            href="https://docs.sentry.io/product/releases/setup/#release-health"
+            onClick={trackAddReleaseHealth}
+          >
+            {t('Add Release Health')}
+          </ExternalLink>
+        </AlertText>
+      </Alert>
+    </Alert.Container>
   );
 }
 


### PR DESCRIPTION
I think the problem is that we had a cached project, so `hasSessions` can be `false` when it shouldn't be (anymore).

This re-fetches the project before we run the logic.
We'll show the banner if:
- there's a selected project
- AND there are some releases
- AND we fetch the project without errors
- AND the project does not have sessions
- AND the project platform can have releases


Fixes #86684