### PR TITLE
fix(aci): Simplify logic to create open period for new issues

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -89,7 +89,11 @@ from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.models.grouplink import GroupLink
-from sentry.models.groupopenperiod import create_open_period, has_initial_open_period
+from sentry.models.groupopenperiod import (
+    GroupOpenPeriod,
+    create_open_period,
+    has_initial_open_period,
+)
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.organization import Organization
@@ -1513,7 +1517,13 @@ def _create_group(
             logger.exception("Error after unsticking project counter")
             raise
 
-    create_open_period(group, group.first_seen)
+    if features.has("organizations:issue-open-periods", project.organization):
+        GroupOpenPeriod.objects.create(
+            group=group,
+            project_id=project.id,
+            date_started=group.first_seen,
+            date_ended=None,
+        )
     return group
 
 


### PR DESCRIPTION
Calling `GroupOpenPeriod.objects.create` directly instead of the helper. This was the original way we were creating open periods, which used to work. The refactor in https://github.com/getsentry/sentry/pull/92489 introduced a bug where the initial open periods aren't always created.