### PR TITLE
ref(aci): Switch useFormField to use useSyncExternalStore

### DIFF
--- a/static/app/components/workflowEngine/form/control/priorityControl.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.tsx
@@ -8,7 +8,7 @@ import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import FormContext from 'sentry/components/forms/formContext';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
-import {useFormField} from 'sentry/components/workflowEngine/form/hooks';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {IconArrow, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';

--- a/static/app/components/workflowEngine/form/hooks.tsx
+++ b/static/app/components/workflowEngine/form/hooks.tsx
@@ -1,15 +1,17 @@
 import {useContext, useEffect, useState} from 'react';
 
 import FormContext from 'sentry/components/forms/formContext';
-import type FormModel from 'sentry/components/forms/model';
-import {MockModel} from 'sentry/components/forms/model';
-import type {FieldValue} from 'sentry/components/forms/types';
 
 export function useFormFields() {
   const context = useContext(FormContext);
-  const [model] = useState<FormModel>(() => context.form ?? (new MockModel({}) as any));
   const [_, forceUpdate] = useState({});
+
   useEffect(() => {
+    const model = context.form;
+    if (!model) {
+      return;
+    }
+
     const prevHook = model.options.onFieldChange;
     model.setFormOptions({
       onFieldChange: (id, value) => {
@@ -17,26 +19,11 @@ export function useFormFields() {
         prevHook?.(id, value);
       },
     });
-  }, [model]);
+  }, [context.form]);
 
-  return model.getData();
-}
+  if (!context.form) {
+    return {};
+  }
 
-export function useFormField<Value extends FieldValue = FieldValue>(field: string) {
-  const context = useContext(FormContext);
-  const [model] = useState<FormModel>(() => context.form ?? (new MockModel({}) as any));
-  const [value, setValue] = useState<Value | undefined>(() => model.getValue(field));
-  useEffect(() => {
-    const prevHook = model.options.onFieldChange;
-    model.setFormOptions({
-      onFieldChange: (id, newValue) => {
-        if (id === field) {
-          setValue(newValue as Value);
-        }
-        prevHook?.(id, newValue);
-      },
-    });
-  }, [model, field]);
-
-  return value;
+  return context.form.getData();
 }

--- a/static/app/components/workflowEngine/form/useFormField.spec.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.spec.tsx
@@ -49,4 +49,29 @@ describe('useFormField', function () {
     expect(typedResult.current).toBe(42);
     expect(typeof typedResult.current).toBe('number');
   });
+
+  it('handles fields that are added after subscription', function () {
+    // Start with a hook subscribed to a field that doesn't exist yet
+    const {result} = renderHook(() => useFormField('laterField'), {
+      wrapper: withFormContext,
+    });
+
+    // Initially should return empty string for non-existent field
+    expect(result.current).toBe('');
+
+    // Add the field later
+    act(() => {
+      model.setValue('laterField', 'newly added');
+    });
+
+    // Should now return the newly added field value
+    expect(result.current).toBe('newly added');
+
+    // Should continue to update when the field changes
+    act(() => {
+      model.setValue('laterField', 'updated value');
+    });
+
+    expect(result.current).toBe('updated value');
+  });
 });

--- a/static/app/components/workflowEngine/form/useFormField.spec.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.spec.tsx
@@ -74,4 +74,19 @@ describe('useFormField', function () {
 
     expect(result.current).toBe('updated value');
   });
+
+  it('handles fields that are removed after subscription', function () {
+    model.setInitialData({targetField: 'initial'});
+
+    const {result} = renderHook(() => useFormField('targetField'), {
+      wrapper: withFormContext,
+    });
+
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      model.removeField('targetField');
+    });
+    expect(result.current).toBe('');
+  });
 });

--- a/static/app/components/workflowEngine/form/useFormField.spec.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.spec.tsx
@@ -1,0 +1,52 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import FormContext from 'sentry/components/forms/formContext';
+import FormModel from 'sentry/components/forms/model';
+
+import {useFormField} from './useFormField';
+
+describe('useFormField', function () {
+  let model: FormModel;
+
+  const withFormContext = ({children}: {children: React.ReactNode}) => (
+    <FormContext value={{form: model}}>{children}</FormContext>
+  );
+
+  beforeEach(function () {
+    model = new FormModel();
+  });
+
+  it('returns field values and handles updates correctly', function () {
+    model.setInitialData({targetField: 'initial', otherField: 'other'});
+
+    const {result} = renderHook(() => useFormField('targetField'), {
+      wrapper: withFormContext,
+    });
+
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      model.setValue('otherField', 'changed');
+    });
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      model.setValue('targetField', 'changed');
+    });
+    expect(result.current).toBe('changed');
+  });
+
+  it('handles undefined values and type parameters', function () {
+    const {result: undefinedResult} = renderHook(() => useFormField('nonexistent'), {
+      wrapper: withFormContext,
+    });
+    expect(undefinedResult.current).toBe('');
+
+    model.setInitialData({numberField: 42});
+    const {result: typedResult} = renderHook(() => useFormField<number>('numberField'), {
+      wrapper: withFormContext,
+    });
+    expect(typedResult.current).toBe(42);
+    expect(typeof typedResult.current).toBe('number');
+  });
+});

--- a/static/app/components/workflowEngine/form/useFormField.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.tsx
@@ -13,12 +13,8 @@ export function useFormField<Value extends FieldValue = FieldValue>(
   const subscribe = useCallback(
     (callback: () => void) => {
       const form = context.form;
-      if (!form) {
-        return noop;
-      }
-
       // Check if the field exists
-      if (!form.fields.has(field)) {
+      if (!form?.fields.has(field)) {
         return noop;
       }
 

--- a/static/app/components/workflowEngine/form/useFormField.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.tsx
@@ -13,9 +13,20 @@ export function useFormField<Value extends FieldValue = FieldValue>(
   const subscribe = useCallback(
     (callback: () => void) => {
       const form = context.form;
+      if (!form) {
+        return noop;
+      }
+
       // Check if the field exists
       if (!form?.fields.has(field)) {
-        return noop;
+        // Allow field to be created later by subscribing to all fields
+        return observe(form.fields, () => {
+          // Only call callback if our specific field now exists
+          // This is less efficient than observing the specific field
+          if (form.fields.has(field)) {
+            callback();
+          }
+        });
       }
 
       // Use MobX observe for specific field watching

--- a/static/app/components/workflowEngine/form/useFormField.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.tsx
@@ -1,0 +1,43 @@
+import {useCallback, useContext, useSyncExternalStore} from 'react';
+import noop from 'lodash/noop';
+import {observe} from 'mobx';
+
+import FormContext from 'sentry/components/forms/formContext';
+import type {FieldValue} from 'sentry/components/forms/types';
+
+export function useFormField<Value extends FieldValue = FieldValue>(
+  field: string
+): Value | undefined {
+  const context = useContext(FormContext);
+
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const form = context.form;
+      if (!form) {
+        return noop;
+      }
+
+      // Check if the field exists
+      if (!form.fields.has(field)) {
+        return noop;
+      }
+
+      // Use MobX observe for specific field watching
+      const dispose = observe(form.fields, field, callback);
+
+      return dispose;
+    },
+    [context.form, field]
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (!context.form) {
+      return undefined;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    return context.form.getValue(field) as Value;
+  }, [context.form, field]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -9,7 +9,7 @@ import SentryProjectSelectorField from 'sentry/components/forms/fields/sentryPro
 import Form from 'sentry/components/forms/form';
 import FormModel from 'sentry/components/forms/model';
 import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {useFormField} from 'sentry/components/workflowEngine/form/hooks';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Environment} from 'sentry/types/project';

--- a/static/app/views/detectors/components/forms/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric.tsx
@@ -14,7 +14,7 @@ import Spinner from 'sentry/components/forms/spinner';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {FilterKeySection} from 'sentry/components/searchQueryBuilder/types';
 import PriorityControl from 'sentry/components/workflowEngine/form/control/priorityControl';
-import {useFormField} from 'sentry/components/workflowEngine/form/hooks';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {IconAdd} from 'sentry/icons';


### PR DESCRIPTION
Use mobx directly to observe the form field and return the current value instead of updating with an effect.

[useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore) is the recommended way of subscribing to external stores in react. 