### PR TITLE
perf(aci): Only call filter_recently_fired_actions once

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -445,9 +445,6 @@ def fire_actions_for_groups(
                     ):
                         action_filters.add(dcg)
 
-                # process action filters
-                filtered_actions = filter_recently_fired_actions(action_filters, event_data)
-
                 # process workflow_triggers
                 workflows = set(
                     Workflow.objects.filter(when_condition_group_id__in=workflow_triggers)
@@ -460,7 +457,9 @@ def fire_actions_for_groups(
                     threshold_seconds=1,
                 ):
                     workflows_actions = evaluate_workflows_action_filters(workflows, event_data)
-                filtered_actions = filtered_actions.union(workflows_actions)
+                filtered_actions = filter_recently_fired_actions(
+                    action_filters | workflows_actions, event_data
+                )
 
                 metrics.incr(
                     "workflow_engine.delayed_workflow.triggered_actions",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -7,7 +7,6 @@ from django.db import router, transaction
 from django.db.models import Q
 
 from sentry import buffer, features
-from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.utils import json, metrics
@@ -108,7 +107,7 @@ def evaluate_workflow_triggers(
 def evaluate_workflows_action_filters(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
-) -> BaseQuerySet[Action]:
+) -> set[DataConditionGroup]:
     filtered_action_groups: set[DataConditionGroup] = set()
 
     action_conditions = (
@@ -167,7 +166,7 @@ def evaluate_workflows_action_filters(
         },
     )
 
-    return filter_recently_fired_actions(filtered_action_groups, event_data)
+    return filtered_action_groups
 
 
 def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
@@ -261,7 +260,9 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
     with sentry_sdk.start_span(
         op="workflow_engine.process_workflows.evaluate_workflows_action_filters"
     ):
-        actions = evaluate_workflows_action_filters(triggered_workflows, event_data)
+        actions = filter_recently_fired_actions(
+            evaluate_workflows_action_filters(triggered_workflows, event_data), event_data
+        )
         metrics.incr(
             "workflow_engine.process_workflows.actions",
             amount=len(actions),

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -260,8 +260,8 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
     with sentry_sdk.start_span(
         op="workflow_engine.process_workflows.evaluate_workflows_action_filters"
     ):
-        actions = filter_recently_fired_actions(
-            evaluate_workflows_action_filters(triggered_workflows, event_data), event_data
+        actions_to_trigger = evaluate_workflows_action_filters(triggered_workflows, event_data), event_data
+        actions = filter_recently_fired_actions(actions_to_trigger, event_data)
         )
         metrics.incr(
             "workflow_engine.process_workflows.actions",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -260,9 +260,8 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
     with sentry_sdk.start_span(
         op="workflow_engine.process_workflows.evaluate_workflows_action_filters"
     ):
-        actions_to_trigger = evaluate_workflows_action_filters(triggered_workflows, event_data), event_data
+        actions_to_trigger = evaluate_workflows_action_filters(triggered_workflows, event_data)
         actions = filter_recently_fired_actions(actions_to_trigger, event_data)
-        )
         metrics.incr(
             "workflow_engine.process_workflows.actions",
             amount=len(actions),


### PR DESCRIPTION
Simplify data flow, better batching, slightly easier testing
