### PR TITLE
fix(explore): Only allow unknown visualize field from current selection

### DIFF
--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -42,7 +42,6 @@ function useWrapper(yAxis: string) {
   return useVisualizeFields({
     numberTags,
     stringTags,
-    yAxes: [yAxis],
     parsedFunction: parseFunction(yAxis) ?? undefined,
   });
 }

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -36,7 +36,6 @@ export function VisualizeSection({query, index}: Props) {
   const options: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
     stringTags,
-    yAxes: query.yAxes,
     parsedFunction,
   });
 

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -282,7 +282,6 @@ function VisualizeSelector({
   const argumentOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
     stringTags,
-    yAxes: [],
     parsedFunction,
   });
 

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -140,10 +140,6 @@ function VisualizeDropdown({
   const {tags: stringTags} = useSpanTags('string');
   const {tags: numberTags} = useSpanTags('number');
 
-  const yAxes: string[] = useMemo(() => {
-    return visualizes.flatMap(visualize => visualize.yAxes);
-  }, [visualizes]);
-
   const parsedFunction = useMemo(() => parseFunction(yAxis), [yAxis]);
 
   const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
@@ -159,7 +155,6 @@ function VisualizeDropdown({
   const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
     stringTags,
-    yAxes,
     parsedFunction,
   });
 


### PR DESCRIPTION
Allowing unknown fields from other selections can cause some issues such as exposing unintentional fields. So limit it to just the current selection.