### PR TITLE
feat: Add path and query params to test-results endpoint

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1062,20 +1062,18 @@ Available fields are:
         description="""The branch to search for results by. If not specified, the default branch is returned.
         """,
     )
-    TEST_RESULTS_ORDER_BY = OpenApiParameter(
-        name="orderBy",
+    TEST_RESULTS_FILTER_BY = OpenApiParameter(
+        name="filterBy",
         location="query",
         required=False,
         type=str,
-        description="""An optional field to order by, which must be one of the fields provided in `field`. Use `-`
-        for descending order.
+        description="""An optional field to filter by, which will constrain the results to only include tests that match the filter.
 
 Available fields are:
-- `AVG_DURATION`
-- `FLAKE_RATE`
-- `FAILURE_RATE`
-- `COMMITS_WHERE_FAIL`
-- `UPDATED_AT`
+- `FLAKY_TESTS`
+- `FAILED_TESTS`
+- `SLOWEST_TESTS`
+- `SKIPPED_TESTS`
         """,
     )
     TEST_RESULTS_SORT_BY = OpenApiParameter(
@@ -1087,10 +1085,11 @@ Available fields are:
         for descending order.
 
 Available fields are:
-- `FLAKY_TESTS`
-- `FAILED_TESTS`
-- `SLOWEST_TESTS`
-- `SKIPPED_TESTS`
+- `AVG_DURATION`
+- `FLAKE_RATE`
+- `FAILURE_RATE`
+- `COMMITS_WHERE_FAIL`
+- `UPDATED_AT`
         """,
     )
     FIRST = OpenApiParameter(

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1093,3 +1093,18 @@ Available fields are:
 - `SKIPPED_TESTS`
         """,
     )
+    FIRST = OpenApiParameter(
+        name="first",
+        location="query",
+        required=False,
+        type=int,
+        default=20,
+        description="""The number of results to return from the start of the list.""",
+    )
+    LAST = OpenApiParameter(
+        name="last",
+        location="query",
+        required=False,
+        type=int,
+        description="""The number of results to return from the end of the list.""",
+    )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1041,3 +1041,55 @@ class PreventParams:
         type=str,
         description="The name of the repository.",
     )
+    INTERVAL = OpenApiParameter(
+        name="interval",
+        location="query",
+        required=False,
+        type=str,
+        description="""The time interval to search for results by.
+
+Available fields are:
+- `INTERVAL_30_DAY`
+- `INTERVAL_7_DAY`
+- `INTERVAL_1_DAY`
+""",
+    )
+    BRANCH = OpenApiParameter(
+        name="branch",
+        location="query",
+        required=False,
+        type=str,
+        description="""The branch to search for results by. If not specified, the default branch is returned.
+        """,
+    )
+    TEST_RESULTS_ORDER_BY = OpenApiParameter(
+        name="orderBy",
+        location="query",
+        required=False,
+        type=str,
+        description="""An optional field to order by, which must be one of the fields provided in `field`. Use `-`
+        for descending order.
+
+Available fields are:
+- `AVG_DURATION`
+- `FLAKE_RATE`
+- `FAILURE_RATE`
+- `COMMITS_WHERE_FAIL`
+- `UPDATED_AT`
+        """,
+    )
+    TEST_RESULTS_SORT_BY = OpenApiParameter(
+        name="sortBy",
+        location="query",
+        required=False,
+        type=str,
+        description="""The property to sort results by. If not specified, all results are returned. Use `-`
+        for descending order.
+
+Available fields are:
+- `FLAKY_TESTS`
+- `FAILED_TESTS`
+- `SLOWEST_TESTS`
+- `SKIPPED_TESTS`
+        """,
+    )

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -97,6 +98,11 @@ class TestResultsEndpoint(CodecovEndpoint):
 
         if not first and not last:
             first = 20
+        if first and last:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"details": "Cannot specify both `first` and `last`"},
+            )
 
         variables = {
             "owner": owner_var,

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -62,6 +62,8 @@ class TestResultsEndpoint(CodecovEndpoint):
             PreventParams.TEST_RESULTS_ORDER_BY,
             PreventParams.INTERVAL,
             PreventParams.BRANCH,
+            PreventParams.FIRST,
+            PreventParams.LAST,
         ],
         request=None,
         responses={
@@ -87,6 +89,14 @@ class TestResultsEndpoint(CodecovEndpoint):
             direction = OrderingDirection.DESC.value
         else:
             direction = OrderingDirection.ASC.value
+
+        first = (
+            int(request.query_params.get("first")) if request.query_params.get("first") else None
+        )
+        last = int(request.query_params.get("last")) if request.query_params.get("last") else None
+
+        if not first and not last:
+            first = 20
 
         variables = {
             "owner": owner_var,
@@ -115,7 +125,8 @@ class TestResultsEndpoint(CodecovEndpoint):
                 "direction": direction,
                 "parameter": order_by,
             },
-            "first": 10,
+            "first": first,
+            "last": last,
         }
 
         client = CodecovApiClient(git_provider_org="codecov")

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -60,7 +60,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
             PreventParams.TEST_RESULTS_SORT_BY,
-            PreventParams.TEST_RESULTS_ORDER_BY,
+            PreventParams.TEST_RESULTS_FILTER_BY,
             PreventParams.INTERVAL,
             PreventParams.BRANCH,
             PreventParams.FIRST,
@@ -77,10 +77,10 @@ class TestResultsEndpoint(CodecovEndpoint):
     def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
         """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
 
-        order_by = request.query_params.get("orderBy", OrderingParameter.COMMITS_WHERE_FAIL.value)
+        sort_by = request.query_params.get("sortBy", OrderingParameter.COMMITS_WHERE_FAIL.value)
 
-        if order_by and order_by.startswith("-"):
-            order_by = order_by[1:]
+        if sort_by and sort_by.startswith("-"):
+            sort_by = sort_by[1:]
             direction = OrderingDirection.DESC.value
         else:
             direction = OrderingDirection.ASC.value
@@ -104,7 +104,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             "repo": repository,
             "filters": {
                 "branch": request.query_params.get("branch", "main"),
-                "parameter": request.query_params.get("sortBy"),
+                "parameter": request.query_params.get("filterBy"),
                 "interval": (
                     request.query_params.get("interval", MeasurementInterval.INTERVAL_30_DAY.value)
                 ),
@@ -114,7 +114,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             },
             "ordering": {
                 "direction": direction,
-                "parameter": order_by,
+                "parameter": sort_by,
             },
             "first": first,
             "last": last,

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -77,9 +77,6 @@ class TestResultsEndpoint(CodecovEndpoint):
     def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
         """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
 
-        owner_var = owner if owner else "codecov"
-        repository_var = repository if repository else "gazebo"
-
         order_by = request.query_params.get("orderBy", OrderingParameter.COMMITS_WHERE_FAIL.value)
 
         if order_by and order_by.startswith("-"):
@@ -103,8 +100,8 @@ class TestResultsEndpoint(CodecovEndpoint):
             )
 
         variables = {
-            "owner": owner_var,
-            "repo": repository_var,
+            "owner": owner,
+            "repo": repository,
             "filters": {
                 "branch": request.query_params.get("branch", "main"),
                 "parameter": request.query_params.get("sortBy"),

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -120,7 +120,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             "last": last,
         }
 
-        client = CodecovApiClient(git_provider_org="codecov")
+        client = CodecovApiClient(git_provider_org=owner)
         graphql_response = client.query(query=query, variables=variables)
 
         test_results = TestResultSerializer().to_representation(graphql_response.json())

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -85,16 +85,18 @@ class TestResultsEndpoint(CodecovEndpoint):
             if request.query_params.get("orderBy")
             else OrderingParameter.COMMITS_WHERE_FAIL.value
         )
-        if order_by.startswith("-"):
+
+        if order_by and order_by.startswith("-"):
             order_by = order_by[1:]
             direction = OrderingDirection.DESC.value
         else:
             direction = OrderingDirection.ASC.value
 
-        first = (
-            int(request.query_params.get("first")) if request.query_params.get("first") else None
-        )
-        last = int(request.query_params.get("last")) if request.query_params.get("last") else None
+        first_param = request.query_params.get("first")
+        last_param = request.query_params.get("last")
+
+        first = int(first_param) if first_param else None
+        last = int(last_param) if last_param else None
 
         if not first and not last:
             first = 20

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -80,11 +80,7 @@ class TestResultsEndpoint(CodecovEndpoint):
         owner_var = owner if owner else "codecov"
         repository_var = repository if repository else "gazebo"
 
-        order_by = (
-            request.query_params.get("orderBy")
-            if request.query_params.get("orderBy")
-            else OrderingParameter.COMMITS_WHERE_FAIL.value
-        )
+        order_by = request.query_params.get("orderBy", OrderingParameter.COMMITS_WHERE_FAIL.value)
 
         if order_by and order_by.startswith("-"):
             order_by = order_by[1:]
@@ -110,20 +106,10 @@ class TestResultsEndpoint(CodecovEndpoint):
             "owner": owner_var,
             "repo": repository_var,
             "filters": {
-                "branch": (
-                    request.query_params.get("branch")
-                    if request.query_params.get("branch")
-                    else "main"
-                ),
-                "parameter": (
-                    request.query_params.get("sortBy")
-                    if request.query_params.get("sortBy")
-                    else None
-                ),
+                "branch": request.query_params.get("branch", "main"),
+                "parameter": request.query_params.get("sortBy"),
                 "interval": (
-                    request.query_params.get("interval")
-                    if request.query_params.get("interval")
-                    else MeasurementInterval.INTERVAL_30_DAY.value
+                    request.query_params.get("interval", MeasurementInterval.INTERVAL_30_DAY.value)
                 ),
                 "flags": None,
                 "term": None,

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -91,13 +91,14 @@ class TestResultsEndpoint(CodecovEndpoint):
         first = int(first_param) if first_param else None
         last = int(last_param) if last_param else None
 
-        if not first and not last:
-            first = 20
         if first and last:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"details": "Cannot specify both `first` and `last`"},
             )
+
+        if not first and not last:
+            first = 20
 
         variables = {
             "owner": owner,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3701,7 +3701,7 @@ MARKETO_FORM_ID = os.getenv("MARKETO_FORM_ID")
 # Base URL for Codecov API. Override if developing against a local instance
 # of Codecov.
 # Stage: "https://stage-api.codecov.dev/"
-CODECOV_API_BASE_URL = "https://stage-api.codecov.dev/"
+CODECOV_API_BASE_URL = "https://api.codecov.io"
 
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3701,7 +3701,7 @@ MARKETO_FORM_ID = os.getenv("MARKETO_FORM_ID")
 # Base URL for Codecov API. Override if developing against a local instance
 # of Codecov.
 # Stage: "https://stage-api.codecov.dev/"
-CODECOV_API_BASE_URL = "https://api.codecov.io"
+CODECOV_API_BASE_URL = "https://stage-api.codecov.dev/"
 
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -83,7 +83,7 @@ class TestResultsEndpointTest(APITestCase):
         url = self.reverse_url()
         response = self.client.get(url)
 
-        mock_codecov_client_class.assert_called_once_with(git_provider_org="codecov")
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
 
         # Verify the correct variables are passed to the GraphQL query
         expected_variables = {

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -26,7 +26,7 @@ class TestResultsEndpointTest(APITestCase):
         )
 
     @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
-    def test_get_returns_mock_response(self, mock_codecov_client_class):
+    def test_get_returns_mock_response_with_default_variables(self, mock_codecov_client_class):
         mock_graphql_response = {
             "data": {
                 "owner": {
@@ -84,11 +84,33 @@ class TestResultsEndpointTest(APITestCase):
         response = self.client.get(url)
 
         mock_codecov_client_class.assert_called_once_with(git_provider_org="codecov")
-        assert mock_codecov_client_instance.query.call_count == 1
+
+        # Verify the correct variables are passed to the GraphQL query
+        expected_variables = {
+            "owner": "testowner",
+            "repo": "testrepo",
+            "filters": {
+                "branch": "main",
+                "parameter": None,
+                "interval": "INTERVAL_30_DAY",
+                "flags": None,
+                "term": None,
+                "test_suites": None,
+            },
+            "ordering": {
+                "direction": "ASC",
+                "parameter": "COMMITS_WHERE_FAIL",
+            },
+            "first": 20,
+            "last": None,
+        }
+
+        mock_codecov_client_instance.query.assert_called_once()
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+
         assert response.status_code == 200
-
         assert len(response.data["results"]) == 2
-
         assert response.data["pageInfo"]["endCursor"] == "cursor123"
         assert response.data["pageInfo"]["hasNextPage"] is False
         assert response.data["totalCount"] == 2
@@ -99,3 +121,122 @@ class TestResultsEndpointTest(APITestCase):
         assert (
             response_keys == serializer_fields
         ), f"Response keys {response_keys} don't match serializer fields {serializer_fields}"
+
+    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
+    def test_get_with_query_parameters(self, mock_codecov_client_class):
+        mock_graphql_response = {
+            "data": {
+                "owner": {
+                    "repository": {
+                        "__typename": "Repository",
+                        "testAnalytics": {
+                            "testResults": {
+                                "edges": [],
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "totalCount": 0,
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        query_params = {
+            "branch": "develop",
+            "sortBy": "FLAKY_TESTS",
+            "orderBy": "-AVG_DURATION",
+            "interval": "INTERVAL_7_DAY",
+            "first": "10",
+        }
+        response = self.client.get(url, query_params)
+
+        # Verify the correct variables are passed with custom query parameters
+        expected_variables = {
+            "owner": "testowner",
+            "repo": "testrepo",
+            "filters": {
+                "branch": "develop",
+                "parameter": "FLAKY_TESTS",
+                "interval": "INTERVAL_7_DAY",
+                "flags": None,
+                "term": None,
+                "test_suites": None,
+            },
+            "ordering": {
+                "direction": "DESC",
+                "parameter": "AVG_DURATION",
+            },
+            "first": 10,
+            "last": None,
+        }
+
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+        assert response.status_code == 200
+
+    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
+    def test_get_with_last_parameter(self, mock_codecov_client_class):
+        mock_graphql_response = {
+            "data": {
+                "owner": {
+                    "repository": {
+                        "__typename": "Repository",
+                        "testAnalytics": {
+                            "testResults": {
+                                "edges": [],
+                                "pageInfo": {"endCursor": None, "hasNextPage": False},
+                                "totalCount": 0,
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        query_params = {"last": "5"}
+        response = self.client.get(url, query_params)
+
+        # Verify the correct variables are passed with last parameter
+        expected_variables = {
+            "owner": "testowner",
+            "repo": "testrepo",
+            "filters": {
+                "branch": "main",
+                "parameter": None,
+                "interval": "INTERVAL_30_DAY",
+                "flags": None,
+                "term": None,
+                "test_suites": None,
+            },
+            "ordering": {
+                "direction": "ASC",
+                "parameter": "COMMITS_WHERE_FAIL",
+            },
+            "first": None,
+            "last": 5,
+        }
+
+        call_args = mock_codecov_client_instance.query.call_args
+        assert call_args[1]["variables"] == expected_variables
+        assert response.status_code == 200
+
+    def test_get_with_both_first_and_last_returns_bad_request(self):
+        """Test that providing both first and last parameters returns a 400 Bad Request error"""
+        url = self.reverse_url()
+        query_params = {"first": "10", "last": "5"}
+        response = self.client.get(url, query_params)
+
+        assert response.status_code == 400
+        assert response.data == {"details": "Cannot specify both `first` and `last`"}

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -149,8 +149,8 @@ class TestResultsEndpointTest(APITestCase):
         url = self.reverse_url()
         query_params = {
             "branch": "develop",
-            "sortBy": "FLAKY_TESTS",
-            "orderBy": "-AVG_DURATION",
+            "filterBy": "FLAKY_TESTS",
+            "sortBy": "-AVG_DURATION",
             "interval": "INTERVAL_7_DAY",
             "first": "10",
         }


### PR DESCRIPTION
This PR aims to add and uptake a number of path and query parameters for the first codecov endpoint being called in sentry.

First, we're adding both the path parameters:
- Repository: string
- Owner: string

Second, we're adding a number of query paramters:
- sortBy: string
- filterBy: string
- interval: string (date)
- branch: string
- first: int
- last: int

If neither first nor last are supplied, the default is 20

You'll notice that for the orderby parameter, sentry opts to use a "-" to denote descending rather than "DESC" like we did on the codecov side, so we had to accommodate for that. Otherwise it's fairly straightforward.

This should also update the openAPI spec accordingly.

<img width="665" alt="Screenshot 2025-06-10 at 3 17 23 PM" src="https://github.com/user-attachments/assets/5135883e-df48-4121-a07e-8cf2e9b650a0" />

<img width="690" alt="Screenshot 2025-06-10 at 3 19 06 PM" src="https://github.com/user-attachments/assets/e738413c-b70f-4303-804f-9eb50e6c008a" />



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
