### PR TITLE
fix(dashboards-comparison): Add additional sentry logging comparison script

### DIFF
--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -50,8 +50,6 @@ def compare_table_results(metrics_query_result: EventsResponse, eap_result: EAPR
     metrics_data_row = (
         metrics_query_result["data"][0] if len(metrics_query_result["data"]) > 0 else {}
     )
-    logger.info("metrics_data_row: %s", metrics_data_row)
-    logger.info("eap_data_row: %s", eap_data_row)
     metrics_fields = metrics_query_result["meta"]["fields"]
 
     mismatches: list[str] = []
@@ -95,6 +93,7 @@ def compare_table_results(metrics_query_result: EventsResponse, eap_result: EAPR
     )
 
 
+@sentry_sdk.tracing.trace
 def compare_tables_for_dashboard_widget_queries(
     widget_query: DashboardWidgetQuery,
 ) -> CompareTableResultDict:

--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -188,7 +188,7 @@ def compare_tables_for_dashboard_widget_queries(
 
     widget_viewer_url = (
         generate_organization_url(organization.slug)
-        + f"/dashboard/{dashboard.id}/widget/{widget.order}/"
+        + f"/dashboard/{dashboard.id}/widget/{widget.id}/"
     )
 
     if has_metrics_error and has_eap_error:

--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -107,6 +107,12 @@ def compare_tables_for_dashboard_widget_queries(
     )
 
     if len(list(projects)) == 0:
+        with sentry_sdk.isolation_scope() as scope:
+            scope.set_tag("passed", False)
+            scope.set_tag("failed_reason", CompareTableResult.NO_PROJECT.value)
+            sentry_sdk.capture_message(
+                "dashboard_widget_comparison_done", level="info", scope=scope
+            )
         return {
             "passed": False,
             "reason": CompareTableResult.NO_PROJECT,
@@ -118,6 +124,13 @@ def compare_tables_for_dashboard_widget_queries(
 
     fields = widget_query.fields
     if len(fields) == 0:
+        with sentry_sdk.isolation_scope() as scope:
+            scope.set_tag("passed", False)
+            scope.set_tag("failed_reason", CompareTableResult.NO_FIELDS.value)
+            scope.set_tag("widget_fields", fields)
+            sentry_sdk.capture_message(
+                "dashboard_widget_comparison_done", level="info", scope=scope
+            )
         return {
             "passed": False,
             "reason": CompareTableResult.NO_FIELDS,


### PR DESCRIPTION
Added some logging for 
- primary error checks (no projects or fields)
- list of all fields in the widget
- a trace of the compare function
