### PR TITLE
fix(feedback): Fix tabs inside feedback Activity section

### DIFF
--- a/static/app/components/activity/note/input.tsx
+++ b/static/app/components/activity/note/input.tsx
@@ -159,10 +159,10 @@ function NoteInput({
   return (
     <NoteInputForm data-test-id="note-input-form" noValidate onSubmit={handleSubmit}>
       <Tabs>
-        <StyledTabList>
+        <TabList variant="floating" hideBorder>
           <TabList.Item key="edit">{existingItem ? t('Edit') : t('Write')}</TabList.Item>
           <TabList.Item key="preview">{t('Preview')}</TabList.Item>
-        </StyledTabList>
+        </TabList>
         <NoteInputPanel>
           <TabPanels.Item key="edit">
             <MentionsInput
@@ -287,11 +287,6 @@ const getNoteInputErrorStyles = (p: {theme: Theme; error?: string}) => {
   `;
 };
 
-const StyledTabList = styled(TabList)`
-  padding: 0 ${space(2)};
-  padding-top: ${space(0.5)};
-`;
-
 const NoteInputForm = styled('form')<{error?: string}>`
   transition: padding 0.2s ease-in-out;
 
@@ -300,6 +295,8 @@ const NoteInputForm = styled('form')<{error?: string}>`
 
 const NoteInputPanel = styled(TabPanels)`
   ${textStyles}
+  border-top: 1px solid ${p => p.theme.border};
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
 `;
 
 const Footer = styled('div')`

--- a/static/app/components/core/tabs/index.stories.tsx
+++ b/static/app/components/core/tabs/index.stories.tsx
@@ -185,7 +185,7 @@ export default Storybook.story('Tabs', story => {
         </p>
         <Storybook.SizingWindow>
           <Tabs>
-            <TabList variant={'floating'} hideBorder>
+            <TabList variant="floating" hideBorder>
               {TABS.map(tab => (
                 <TabList.Item key={tab.key}>{tab.label}</TabList.Item>
               ))}


### PR DESCRIPTION
| | UI 1 | UI 2 |
| --- | --- | --- |
| Before | ![feedback activity - before - ui1 ](https://github.com/user-attachments/assets/29439672-0ddb-4c0a-b99f-02988290ccfa) | ![feedback activity - before ui2](https://github.com/user-attachments/assets/c6fd9558-b87f-4108-aecb-a55051461b39)
| After | ![feedback activity - after - ui1](https://github.com/user-attachments/assets/2d8f97f2-5c19-4b2b-9a48-73af258e8775) | ![feedback activity - after - ui2](https://github.com/user-attachments/assets/2469e9bf-f7fa-4d9d-9e58-3bba2c31a136)

Follows https://github.com/getsentry/sentry/pull/92821
