### PR TITLE
feat(ourlogs): Render aggregates table properly, with sorts and pagination

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -22,6 +22,7 @@ import {
   getLogAggregateSortBysFromLocation,
   getLogSortBysFromLocation,
   logsTimestampDescendingSortBy,
+  updateLocationWithAggregateSortBys,
   updateLocationWithLogSortBys,
 } from 'sentry/views/explore/contexts/logs/sortBys';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -236,7 +237,8 @@ function setLogsPageParams(location: Location, pageParams: LogPageParamsUpdate) 
   updateNullableLocation(target, LOGS_AGGREGATE_PARAM_KEY, pageParams.aggregateParam);
   if (!pageParams.isTableFrozen) {
     updateLocationWithLogSortBys(target, pageParams.sortBys);
-    if (pageParams.sortBys || pageParams.search) {
+    updateLocationWithAggregateSortBys(target, pageParams.aggregateSortBys);
+    if (pageParams.sortBys || pageParams.aggregateSortBys || pageParams.search) {
       // make sure to clear the cursor every time the query is updated
       delete target.query[LOGS_CURSOR_KEY];
       delete target.query[LOGS_AUTO_REFRESH_KEY];

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -19,6 +19,7 @@ import {
   getLogFieldsFromLocation,
 } from 'sentry/views/explore/contexts/logs/fields';
 import {
+  getLogAggregateSortBysFromLocation,
   getLogSortBysFromLocation,
   logsTimestampDescendingSortBy,
   updateLocationWithLogSortBys,
@@ -29,6 +30,7 @@ import {useLogsQueryKeyWithInfinite} from 'sentry/views/explore/logs/useLogsQuer
 const LOGS_PARAMS_VERSION = 2;
 export const LOGS_QUERY_KEY = 'logsQuery'; // Logs may exist on other pages.
 export const LOGS_CURSOR_KEY = 'logsCursor';
+export const LOGS_AGGREGATE_CURSOR_KEY = 'logsAggregateCursor';
 export const LOGS_FIELDS_KEY = 'logsFields';
 export const LOGS_AGGREGATE_FN_KEY = 'logsAggregate'; // e.g., p99
 export const LOGS_AGGREGATE_PARAM_KEY = 'logsAggregateParam'; // e.g., message.parameters.0
@@ -39,6 +41,10 @@ const LOGS_REFRESH_INTERVAL_KEY = 'refreshEvery';
 const LOGS_REFRESH_INTERVAL_DEFAULT = 5000;
 
 interface LogsPageParams {
+  /** In the 'aggregates' table, if you GROUP BY, there can be many rows. This is the cursor for pagination there. */
+  readonly aggregateCursor: string;
+  /** In the 'aggregates' table, if you GROUP BY, there can be many rows. This is the 'sort by' for that table. */
+  readonly aggregateSortBys: Sort[];
   readonly analyticsPageSource: LogsAnalyticsPageSource;
   readonly autoRefresh: boolean;
   readonly blockRowExpanding: boolean | undefined;
@@ -154,10 +160,19 @@ export function LogsPageParamsProvider({
     : decodeScalar(location.query[LOGS_GROUP_BY_KEY]);
   const aggregateFn = isTableFrozen
     ? undefined
-    : decodeScalar(location.query[LOGS_AGGREGATE_FN_KEY]);
-  const aggregateParam = isTableFrozen
+    : (decodeScalar(location.query[LOGS_AGGREGATE_FN_KEY]) ?? 'count');
+  const _aggregateParam = isTableFrozen
     ? undefined
     : decodeScalar(location.query[LOGS_AGGREGATE_PARAM_KEY]);
+  const aggregateParam =
+    aggregateFn === 'count' && !_aggregateParam
+      ? OurLogKnownFieldKey.MESSAGE
+      : _aggregateParam;
+  const aggregate = `${aggregateFn}(${aggregateParam})`;
+  const aggregateSortBys = getLogAggregateSortBysFromLocation(location, [
+    ...(groupBy ? [groupBy] : []),
+    aggregate,
+  ]);
   const pageFilters = usePageFilters();
   const projectIds = isTableFrozen
     ? (limitToProjectIds ?? [-1])
@@ -167,10 +182,13 @@ export function LogsPageParamsProvider({
   const cursor = isTableFrozen
     ? cursorForFrozenPages
     : getLogCursorFromLocation(location);
+  const aggregateCursor = getLogAggregateCursorFromLocation(location);
 
   return (
     <LogsPageParamsContext
       value={{
+        aggregateCursor,
+        aggregateSortBys,
         fields,
         search,
         setSearchForFrozenPages,
@@ -211,6 +229,7 @@ function setLogsPageParams(location: Location, pageParams: LogPageParamsUpdate) 
   const target: Location = {...location, query: {...location.query}};
   updateNullableLocation(target, LOGS_QUERY_KEY, pageParams.search?.formatString());
   updateNullableLocation(target, LOGS_CURSOR_KEY, pageParams.cursor);
+  updateNullableLocation(target, LOGS_AGGREGATE_CURSOR_KEY, pageParams.aggregateCursor);
   updateNullableLocation(target, LOGS_FIELDS_KEY, pageParams.fields);
   updateNullableLocation(target, LOGS_GROUP_BY_KEY, pageParams.groupBy);
   updateNullableLocation(target, LOGS_AGGREGATE_FN_KEY, pageParams.aggregateFn);
@@ -302,7 +321,7 @@ export function useLogsCursor() {
 
 export function useLogsAggregateFunction() {
   const {aggregateFn} = useLogsPageParams();
-  return aggregateFn ?? 'count';
+  return aggregateFn;
 }
 
 export function useLogsAggregateParam() {
@@ -313,11 +332,7 @@ export function useLogsAggregateParam() {
 export function useLogsAggregate() {
   const aggregateFn = useLogsAggregateFunction();
   const aggregateParam = useLogsAggregateParam();
-  const effectiveParam =
-    aggregateFn === 'count' && !aggregateParam
-      ? OurLogKnownFieldKey.MESSAGE
-      : aggregateParam;
-  return `${aggregateFn}(${effectiveParam})`;
+  return `${aggregateFn}(${aggregateParam})`;
 }
 
 export function useLogsGroupBy() {
@@ -374,6 +389,16 @@ export function usePersistedLogsPageParams() {
     fields: defaultLogFields() as string[],
     sortBys: [logsTimestampDescendingSortBy],
   });
+}
+
+export function useLogsAggregateSortBys() {
+  const {aggregateSortBys} = useLogsPageParams();
+  return aggregateSortBys;
+}
+
+export function useLogsAggregateCursor() {
+  const {aggregateCursor} = useLogsPageParams();
+  return aggregateCursor;
 }
 
 export function useLogsSortBys() {
@@ -451,6 +476,14 @@ function getLogCursorFromLocation(location: Location): string {
   }
 
   return decodeScalar(location.query[LOGS_CURSOR_KEY], '');
+}
+
+function getLogAggregateCursorFromLocation(location: Location): string {
+  if (!location.query?.[LOGS_AGGREGATE_CURSOR_KEY]) {
+    return '';
+  }
+
+  return decodeScalar(location.query[LOGS_AGGREGATE_CURSOR_KEY], '');
 }
 
 export function stripLogParamsFromLocation(location: Location): Location {

--- a/static/app/views/explore/contexts/logs/sortBys.tsx
+++ b/static/app/views/explore/contexts/logs/sortBys.tsx
@@ -3,10 +3,14 @@ import type {Location} from 'history';
 import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
-import {LOGS_CURSOR_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {
+  LOGS_AGGREGATE_CURSOR_KEY,
+  LOGS_CURSOR_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 
 export const LOGS_SORT_BYS_KEY = 'logsSortBys';
+export const LOGS_AGGREGATE_SORT_BYS_KEY = 'logsAggregateSortBys';
 
 export const logsTimestampDescendingSortBy: Sort = {
   field: OurLogKnownFieldKey.TIMESTAMP,
@@ -40,6 +44,32 @@ export function getLogSortBysFromLocation(location: Location, fields: string[]):
   ];
 }
 
+export function getLogAggregateSortBysFromLocation(
+  location: Location,
+  fields: string[]
+): Sort[] {
+  const sortBys = decodeSorts(location.query[LOGS_AGGREGATE_SORT_BYS_KEY]);
+
+  if (sortBys.length > 0) {
+    if (sortBys.every(sortBy => fields.includes(sortBy.field))) {
+      return sortBys;
+    }
+  }
+
+  if (!fields.length) {
+    throw new Error(
+      'fields should not be empty - did you somehow delete all of the fields?'
+    );
+  }
+
+  return [
+    {
+      field: fields[fields.length - 1]!,
+      kind: 'desc' as const,
+    },
+  ];
+}
+
 export function updateLocationWithLogSortBys(
   location: Location,
   sortBys: Sort[] | null | undefined
@@ -53,5 +83,21 @@ export function updateLocationWithLogSortBys(
     delete location.query[LOGS_CURSOR_KEY];
   } else if (sortBys === null) {
     delete location.query[LOGS_SORT_BYS_KEY];
+  }
+}
+
+export function updateLocationWithAggregateSortBys(
+  location: Location,
+  sortBys: Sort[] | null | undefined
+) {
+  if (defined(sortBys)) {
+    location.query[LOGS_AGGREGATE_SORT_BYS_KEY] = sortBys.map(sortBy =>
+      sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
+    );
+
+    // make sure to clear the cursor every time the query is updated
+    delete location.query[LOGS_AGGREGATE_CURSOR_KEY];
+  } else if (sortBys === null) {
+    delete location.query[LOGS_AGGREGATE_SORT_BYS_KEY];
   }
 }

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import {ThemeProvider} from '@emotion/react';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {
+  LOGS_AGGREGATE_FN_KEY,
+  LOGS_AGGREGATE_PARAM_KEY,
+  LOGS_FIELDS_KEY,
+  LOGS_GROUP_BY_KEY,
+  LOGS_QUERY_KEY,
+  LogsPageParamsProvider,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
+import * as useLogsQueryModule from 'sentry/views/explore/logs/useLogsQuery';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+import {LogsAggregateTable} from './logsAggregateTable';
+
+jest.mock('sentry/views/explore/logs/useLogsQuery');
+
+jest.mock('sentry/utils/useLocation');
+const mockUseLocation = jest.mocked(useLocation);
+
+const queryClient = makeTestQueryClient();
+
+describe('LogsAggregateTable', () => {
+  const {organization, project} = initializeOrg({
+    organization: {
+      features: ['ourlogs-enabled'],
+    },
+  });
+  function createWrapper() {
+    return function Wrapper({children}: {children?: React.ReactNode}) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <OrganizationContext.Provider value={organization}>
+            <ThemeProvider theme={{}}>
+              <LogsPageParamsProvider
+                analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+              >
+                {children}
+              </LogsPageParamsProvider>
+            </ThemeProvider>
+          </OrganizationContext.Provider>
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  ProjectsStore.loadInitialData([project]);
+
+  PageFiltersStore.init();
+  PageFiltersStore.onInitializeUrlState(
+    {
+      projects: [parseInt(project.id, 10)],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: null,
+      },
+    },
+    new Set()
+  );
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        pathname: `/organizations/${organization.slug}/explore/logs/?end=2025-04-10T20%3A04%3A51&project=${project.id}&start=2025-04-10T14%3A37%3A55`,
+        query: {
+          [LOGS_AGGREGATE_SORT_BYS_KEY]: '-p99(severity_number)',
+          [LOGS_QUERY_KEY]: 'test',
+          [LOGS_GROUP_BY_KEY]: 'message.template',
+          [LOGS_AGGREGATE_FN_KEY]: 'p99',
+          [LOGS_AGGREGATE_PARAM_KEY]: 'severity_number',
+          [LOGS_FIELDS_KEY]: ['timestamp', 'message'],
+        },
+      })
+    );
+  });
+
+  it('renders loading state', () => {
+    (useLogsQueryModule.useLogsAggregatesQuery as jest.Mock).mockReturnValue({
+      isLoading: true,
+      error: null,
+      data: null,
+      pageLinks: undefined,
+    });
+    render(<LogsAggregateTable />, {wrapper: createWrapper()});
+    expect(screen.getByLabelText('Aggregates')).toBeInTheDocument();
+  });
+
+  it('renders error state', () => {
+    (useLogsQueryModule.useLogsAggregatesQuery as jest.Mock).mockReturnValue({
+      isLoading: false,
+      error: 'Error!',
+      data: null,
+      pageLinks: undefined,
+    });
+    render(<LogsAggregateTable />, {wrapper: createWrapper()});
+    expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
+  });
+
+  it('renders data rows', () => {
+    (useLogsQueryModule.useLogsAggregatesQuery as jest.Mock).mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: {
+        data: [
+          {
+            'message.template': 'Fetching the latest item id failed.',
+            'p99(severity_number)': 17.0,
+          },
+          {
+            'message.template':
+              '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
+            'p99(severity_number)': 13.0,
+          },
+          {
+            'message.template':
+              '/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp',
+            'p99(severity_number)': 12.0,
+          },
+        ],
+      },
+      pageLinks: undefined,
+    });
+    render(<LogsAggregateTable />, {wrapper: createWrapper()});
+    const rows = screen.getAllByTestId('grid-body-row');
+    expect(rows).toHaveLength(3);
+    const expected = [
+      ['Fetching the latest item id failed.', '17'],
+      [
+        'message.template": "/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
+        '13',
+      ],
+      ['/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp', '12'],
+    ];
+    rows.forEach((row, i) => {
+      const cells = within(row).getAllByTestId('grid-body-cell');
+      expect(cells[0]).toHaveTextContent(expected[i]![0]!);
+      expect(cells[1]).toHaveTextContent(expected[i]![1]!);
+    });
+  });
+});

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -141,10 +141,7 @@ describe('LogsAggregateTable', () => {
     expect(rows).toHaveLength(3);
     const expected = [
       ['Fetching the latest item id failed.', '17'],
-      [
-        'message.template": "/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp',
-        '13',
-      ],
+      ['/usr/src/sentry/src/sentry/db/models/manager/base.py:282: derp', '13'],
       ['/usr/src/sentry/src/sentry/db/models/manager/base.py:282: herp', '12'],
     ];
     rows.forEach((row, i) => {

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -1,26 +1,40 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {prettifyTagKey} from 'sentry/utils/fields';
-import {TableBodyCell, TableHeadCell} from 'sentry/views/explore/components/table';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
+  LOGS_AGGREGATE_CURSOR_KEY,
   useLogsAggregate,
+  useLogsAggregateSortBys,
   useLogsGroupBy,
-  useSetLogsCursor,
+  useSetLogsPageParams,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LOGS_AGGREGATE_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
+import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
+import {LogFieldRenderer} from 'sentry/views/explore/logs/fieldRenderers';
+import {getLogColors} from 'sentry/views/explore/logs/styles';
 import {useLogsAggregatesQuery} from 'sentry/views/explore/logs/useLogsQuery';
+import {SeverityLevel} from 'sentry/views/explore/logs/utils';
 
 export function LogsAggregateTable() {
   const {data, pageLinks, isLoading, error} = useLogsAggregatesQuery({
     limit: 50,
   });
 
-  const setLogsCursor = useSetLogsCursor();
+  const setLogsPageParams = useSetLogsPageParams();
   const groupBy = useLogsGroupBy();
   const aggregate = useLogsAggregate();
+  const aggregateSortBys = useLogsAggregateSortBys();
+  const location = useLocation();
+  const theme = useTheme();
+  const organization = useOrganization();
 
   const fields: string[] = [];
   if (groupBy) {
@@ -49,26 +63,71 @@ export function LogsAggregateTable() {
         grid={{
           renderHeadCell: (column, i) => {
             const field = column.name;
-            let label: string;
+            let title: string;
             const func = parseFunction(field);
             if (func) {
-              label = prettifyParsedFunction(func);
+              title = prettifyParsedFunction(func);
             } else {
-              label = prettifyTagKey(field);
+              title = prettifyTagKey(field);
             }
 
             return (
-              <TableHeadCell key={i} isFirst={i === 0}>
-                {label}
-              </TableHeadCell>
+              <SortLink
+                key={i}
+                align={func ? 'right' : 'left'}
+                canSort
+                direction={
+                  aggregateSortBys?.[0]?.field === column.key
+                    ? aggregateSortBys?.[0]?.kind
+                    : undefined
+                }
+                generateSortLink={() => ({
+                  ...location,
+                  query: {
+                    ...location.query,
+                    [LOGS_AGGREGATE_SORT_BYS_KEY]:
+                      aggregateSortBys?.[0]?.field === column.key
+                        ? aggregateSortBys?.[0]?.kind === 'asc'
+                          ? `-${column.key}`
+                          : column.key
+                        : `-${column.key}`,
+                    [LOGS_AGGREGATE_CURSOR_KEY]: undefined,
+                  },
+                })}
+                title={title}
+              />
             );
           },
-          renderBodyCell: (column, row) => (
-            <TableBodyCell key={row[column.key]}>{row[column.key]}</TableBodyCell>
-          ),
+          renderBodyCell: (column, row) => {
+            const value =
+              typeof row[column.key] === 'undefined'
+                ? null
+                : (row[column.key] as string | number);
+            const extra: RendererExtra = {
+              attributes: row,
+              highlightTerms: [],
+              logColors: getLogColors(SeverityLevel.DEFAULT, theme),
+              location,
+              organization,
+              theme,
+            };
+            return (
+              <LogFieldRenderer
+                key={column.key}
+                extra={extra}
+                item={{
+                  fieldKey: column.key,
+                  value,
+                }}
+              />
+            );
+          },
         }}
       />
-      <Pagination pageLinks={pageLinks} onCursor={setLogsCursor} />
+      <Pagination
+        pageLinks={pageLinks}
+        onCursor={cursor => setLogsPageParams({aggregateCursor: cursor})}
+      />
     </TableContainer>
   );
 }

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -19,6 +19,8 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   useLogsAggregate,
+  useLogsAggregateCursor,
+  useLogsAggregateSortBys,
   useLogsAutoRefresh,
   useLogsBaseSearch,
   useLogsCursor,
@@ -108,10 +110,8 @@ function useLogsAggregatesQueryKey({
   const projectIds = useLogsProjectIds();
   const groupBy = useLogsGroupBy();
   const aggregate = useLogsAggregate();
-  const aggregateSort: Sort = {
-    field: aggregate,
-    kind: 'desc',
-  };
+  const aggregateSortBys = useLogsAggregateSortBys();
+  const aggregateCursor = useLogsAggregateCursor();
   const fields: string[] = [];
   if (groupBy) {
     fields.push(groupBy);
@@ -128,7 +128,7 @@ function useLogsAggregatesQueryKey({
   const eventView = getEventView(
     search,
     fields,
-    [aggregateSort],
+    aggregateSortBys,
     pageFilters,
     dataset,
     projectIds
@@ -137,6 +137,7 @@ function useLogsAggregatesQueryKey({
     query: {
       ...eventView.getEventsAPIPayload(location),
       per_page: limit ? limit : undefined,
+      cursor: aggregateCursor,
       referrer,
     },
     pageFiltersReady,


### PR DESCRIPTION
Implement 'aggregate sort by', 'aggregate group by', aggregate cursor, and log field renderers for functions, and in the aggregate table.