### PR TITLE
fix(billing): provision subscription action allows for 0 cpe

### DIFF
--- a/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.spec.tsx
@@ -1437,6 +1437,122 @@ describe('provisionSubscriptionAction', function () {
     );
   }, 15_000);
 
+  it('calls api with seer reserved budget args with 0 values', async () => {
+    const am3Sub = SubscriptionFixture({organization: mockOrg, plan: 'am3_f'});
+    triggerProvisionSubscription({
+      subscription: am3Sub,
+      orgId: am3Sub.slug,
+      onSuccess,
+      billingConfig: mockBillingConfig,
+    });
+
+    await loadModal();
+
+    await selectEvent.select(
+      await screen.findByRole('textbox', {name: 'Plan'}),
+      'Enterprise (Business) (am3)'
+    );
+
+    await selectEvent.select(
+      await screen.findByRole('textbox', {name: 'Billing Interval'}),
+      'Annual'
+    );
+
+    await selectEvent.select(
+      await screen.findByRole('textbox', {name: 'Billing Type'}),
+      'Invoiced'
+    );
+
+    await selectEvent.select(
+      await screen.findByRole('textbox', {name: 'On-Demand Max Spend Setting'}),
+      'Disable'
+    );
+
+    await clickCheckbox('Apply Changes To Current Subscription');
+    await typeNumForField('Reserved Replays', '75000');
+    await typeNumForField('Reserved Uptime Monitors', '250');
+    await typeNumForField('Reserved Cost-Per-Event Issue Fixes', '0');
+    await typeNumForField('Reserved Cost-Per-Event Issue Scans', '0');
+    await typeNumForMatchingFields('Price for', '0', false);
+    await typeNumForField('Price for Issue Fixes (Seer ARR)', '0');
+    await typeNumForField('Price for PCSS', '500');
+    await typeNumForField('Annual Contract Value', '500');
+    await typeNumForField('Seer Budget', '24000');
+
+    const updateMock = MockApiClient.addMockResponse({
+      url: `/customers/${mockOrg.slug}/provision-subscription/`,
+      method: 'POST',
+      body: {},
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Submit'}));
+
+    expect(updateMock).toHaveBeenCalledWith(
+      `/customers/${mockOrg.slug}/provision-subscription/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: {
+          billingInterval: 'annual',
+          coterm: true,
+          customPrice: 50000,
+          customPriceAttachments: 0,
+          customPriceErrors: 0,
+          customPriceMonitorSeats: 0,
+          customPricePcss: 50000,
+          customPriceProfileDuration: 0,
+          customPriceProfileDurationUI: 0,
+          customPriceReplays: 0,
+          customPriceSeerAutofix: 0,
+          customPriceSeerScanner: 0,
+          customPriceSpans: 0,
+          customPriceUptime: 0,
+          managed: true,
+          onDemandInvoicedManual: 'DISABLE',
+          plan: 'am3_business_ent',
+          reservedAttachments: 1,
+          reservedBudgets: [
+            {budget: 2400000, categories: ['seerAutofix', 'seerScanner']},
+          ],
+          reservedCpeSeerAutofix: 0,
+          reservedCpeSeerScanner: 0,
+          reservedErrors: 50000,
+          reservedMonitorSeats: 1,
+          reservedProfileDuration: 0,
+          reservedProfileDurationUI: 0,
+          reservedReplays: 75000,
+          reservedSeerAutofix: -2,
+          reservedSeerScanner: -2,
+          reservedSpans: 10000000,
+          reservedUptime: 250,
+          retainOnDemandBudget: false,
+          softCapTypeAttachments: null,
+          softCapTypeErrors: null,
+          softCapTypeMonitorSeats: null,
+          softCapTypeProfileDuration: null,
+          softCapTypeProfileDurationUI: null,
+          softCapTypeReplays: null,
+          softCapTypeSeerAutofix: null,
+          softCapTypeSeerScanner: null,
+          softCapTypeSpans: null,
+          softCapTypeUptime: null,
+          trueForward: {
+            attachments: false,
+            errors: false,
+            monitorSeats: false,
+            profileDuration: false,
+            profileDurationUI: false,
+            replays: false,
+            seerAutofix: false,
+            seerScanner: false,
+            spans: false,
+            uptime: false,
+          },
+          type: 'invoiced',
+        },
+      })
+    );
+  }, 15_000);
+
   it('calls api with correct manually invoiced on-demand args', async () => {
     const am2Sub = SubscriptionFixture({organization: mockOrg, plan: 'am2_f'});
     triggerProvisionSubscription({

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -328,7 +328,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
     isAm3DsPlan(this.state.data.plan) &&
     Object.entries(this.state.data)
       .filter(([key, _]) => key.startsWith('reservedCpeSpans'))
-      .every(([_, value]) => !!value) &&
+      .every(([_, value]) => value !== null || value !== undefined) &&
     Object.keys(this.state.data).filter(key => key.startsWith('reservedCpeSpans'))
       .length >= 2;
 
@@ -336,7 +336,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
   isSettingSeerBudget = () =>
     Object.entries(this.state.data)
       .filter(([key, _]) => key.startsWith('reservedCpeSeer'))
-      .every(([_, value]) => !!value) &&
+      .every(([_, value]) => value !== null && value !== undefined) &&
     Object.keys(this.state.data).filter(key => key.startsWith('reservedCpeSeer'))
       .length >= 2;
 

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -363,7 +363,6 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
     Object.entries(this.state.data)
       .filter(([key, _]) => key.startsWith('reservedSpans'))
       .every(([_, value]) => value === RESERVED_BUDGET_QUOTA) &&
-    this.state.data.customPriceSpans &&
     this.state.data.dynamicSamplingBudget;
 
   // Same as above, but for Seer budgets
@@ -372,7 +371,6 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
     Object.entries(this.state.data)
       .filter(([key, _]) => key.startsWith('reservedSeer'))
       .every(([_, value]) => value === RESERVED_BUDGET_QUOTA) &&
-    this.state.data.customPriceSeerAutofix &&
     this.state.data.seerBudget;
 
   /**
@@ -591,6 +589,9 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
         categories: [DataCategory.SEER_AUTOFIX, DataCategory.SEER_SCANNER],
         budget: postData.seerBudget,
       });
+    } else {
+      delete postData.reservedCpeSeerAutofix;
+      delete postData.reservedCpeSeerScanner;
     }
     delete postData.seerBudget;
 
@@ -891,7 +892,7 @@ class ProvisionSubscriptionModal extends Component<ModalProps, ModalState> {
                                   name={`reservedCpe${capitalizedApiName}`}
                                   value={data[`reservedCpe${capitalizedApiName}`]}
                                   step={0.00000001}
-                                  min={0.00000001}
+                                  min={0}
                                   max={1}
                                   onChange={v =>
                                     this.setState(state => ({


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/BIL-916/fix-provision-subscription-form
depends on https://github.com/getsentry/getsentry/pull/17681

allows for 0 `reservedCpes`

<img width="429" alt="Screenshot 2025-06-11 at 3 51 39 PM" src="https://github.com/user-attachments/assets/37ddde1a-6d80-4ac8-962d-a2c8fb9a9b84" />
