### PR TITLE
:wrench: chore(slack): remove unused metrics

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -21,17 +21,12 @@ from sentry.integrations.base import (
 from sentry.integrations.mixins import NotifyBasicMixin
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline_types import IntegrationPipelineViewT
-from sentry.integrations.slack.metrics import (
-    SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC,
-    SLACK_NOTIFY_MIXIN_SUCCESS_DATADOG_METRIC,
-)
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.tasks.link_slack_user_identities import link_slack_user_identities
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline import NestedPipelineView
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 
 _logger = logging.getLogger("sentry.integrations.slack")
@@ -95,9 +90,8 @@ class SlackIntegration(NotifyBasicMixin, IntegrationInstallation):
 
         try:
             client.chat_postMessage(channel=channel_id, text=message)
-            metrics.incr(SLACK_NOTIFY_MIXIN_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
         except SlackApiError:
-            metrics.incr(SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC, sample_rate=1.0)
+            pass
 
 
 class SlackIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/slack/metrics.py
+++ b/src/sentry/integrations/slack/metrics.py
@@ -8,44 +8,11 @@ from sentry.integrations.slack.utils.errors import (
 )
 from sentry.integrations.utils.metrics import EventLifecycle
 
-# Webhooks
-SLACK_WEBHOOK_EVENT_ENDPOINT_SUCCESS_DATADOG_METRIC = (
-    "sentry.integrations.slack.event_endpoint.success"
-)
-SLACK_WEBHOOK_EVENT_ENDPOINT_FAILURE_DATADOG_METRIC = (
-    "sentry.integrations.slack.event_endpoint.failure"
-)
-SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC = (
-    "sentry.integrations.slack.group_actions.success"
-)
-SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC = (
-    "sentry.integrations.slack.group_actions.failure"
-)
-
-# Sending messages upon linking/unlinking
-SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC = (
-    "sentry.integrations.slack.link_identity_msg.success"
-)
-SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC = (
-    "sentry.integrations.slack.link_identity_msg.failure"
-)
-SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.link_team_msg.success"
-SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.link_team_msg.failure"
-
-
-SLACK_NOTIFY_MIXIN_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.notify_mixin.success"
-SLACK_NOTIFY_MIXIN_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.notify_mixin.failure"
-
 # Utils
 SLACK_UTILS_GET_USER_LIST_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.utils.users.success"
 SLACK_UTILS_GET_USER_LIST_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.utils.users.failure"
 SLACK_UTILS_CHANNEL_SUCCESS_DATADOG_METRIC = "sentry.integrations.slack.utils.channel.success"
 SLACK_UTILS_CHANNEL_FAILURE_DATADOG_METRIC = "sentry.integrations.slack.utils.channel.failure"
-
-
-# Middleware Parsers
-SLACK_MIDDLE_PARSERS_SUCCESS_DATADOG_METRIC = "sentry.middleware.integrations.slack.parsers.success"
-SLACK_MIDDLE_PARSERS_FAILURE_DATADOG_METRIC = "sentry.middleware.integrations.slack.parsers.failure"
 
 
 def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: SlackApiError) -> None:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -44,11 +44,7 @@ from sentry.integrations.repository.notification_action import (
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.integrations.slack.message_builder.types import SlackBlock
-from sentry.integrations.slack.metrics import (
-    SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
-    SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
-    record_lifecycle_termination_level,
-)
+from sentry.integrations.slack.metrics import record_lifecycle_termination_level
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.threads import NotificationActionThreadUtils
@@ -56,7 +52,6 @@ from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.notifications.utils.open_period import open_period_start_for_group
-from sentry.utils import metrics
 from sentry.workflow_engine.models.action import Action
 
 _logger = logging.getLogger(__name__)
@@ -487,20 +482,9 @@ def respond_to_slack_command(
             webhook_client.send(
                 text=command_response.message, replace_original=False, response_type="ephemeral"
             )
-            metrics.incr(
-                SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": "webhook", "command": command_response.command},
-            )
         except (SlackApiError, SlackRequestError) as e:
-            metrics.incr(
-                SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": "webhook", "command": command_response.command},
-            )
-            _logger.exception(log_msg("error"), extra={"error": str(e)})
+            _logger.info(log_msg("error"), extra={"error": str(e)})
     else:
-        _logger.info(log_msg("respond-ephemeral"))
         try:
             client = SlackSdkClient(integration_id=integration.id)
             client.chat_postMessage(
@@ -509,15 +493,5 @@ def respond_to_slack_command(
                 replace_original=False,
                 response_type="ephemeral",
             )
-            metrics.incr(
-                SLACK_LINK_IDENTITY_MSG_SUCCESS_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": "ephemeral", "command": command_response.command},
-            )
         except SlackApiError as e:
-            metrics.incr(
-                SLACK_LINK_IDENTITY_MSG_FAILURE_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": "ephemeral", "command": command_response.command},
-            )
-            _logger.exception(log_msg("error"), extra={"error": str(e)})
+            _logger.info(log_msg("error"), extra={"error": str(e)})

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -11,14 +11,9 @@ from slack_sdk.errors import SlackApiError
 from sentry.integrations.messaging.linkage import LinkTeamView
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
-from sentry.integrations.slack.metrics import (
-    SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC,
-    SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC,
-)
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.views.linkage import SlackLinkageView
 from sentry.models.team import Team
-from sentry.utils import metrics
 from sentry.web.frontend.base import region_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -71,10 +66,9 @@ class SlackLinkTeamView(SlackLinkageView, LinkTeamView):
         try:
             client = SlackSdkClient(integration_id=integration.id)
             client.chat_postMessage(channel=channel_id, text=message)
-            metrics.incr(SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
         except SlackApiError:
             # whether or not we send a Slack message, the team was linked successfully
-            metrics.incr(SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC, sample_rate=1.0)
+            pass
 
     def notify_team_already_linked(
         self, request: HttpRequest, channel_id: str, integration: RpcIntegration, team: Team
@@ -83,10 +77,9 @@ class SlackLinkTeamView(SlackLinkageView, LinkTeamView):
         try:
             client = SlackSdkClient(integration_id=integration.id)
             client.chat_postMessage(channel=channel_id, text=message)
-            metrics.incr(SLACK_LINK_TEAM_MSG_SUCCESS_DATADOG_METRIC, sample_rate=1.0)
         except SlackApiError:
             # whether or not we send a Slack message, the team is already linked
-            metrics.incr(SLACK_LINK_TEAM_MSG_FAILURE_DATADOG_METRIC, sample_rate=1.0)
+            pass
 
         return render_to_response(
             "sentry/integrations/slack/post-linked-team.html",

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -504,15 +504,14 @@ class SlackActionEndpoint(Endpoint):
                 delete_original=False,
                 replace_original=True,
             )
+        except SlackApiError:
             _logger.info(
-                "slack.webhook.update_status.success",
+                "slack.webhook.update_status.response-error",
                 extra={
                     "integration_id": slack_request.integration.id,
                     "blocks": response.get("blocks"),
                 },
             )
-        except SlackApiError:
-            _logger.info("slack.webhook.update_status.response-error")
 
         return self.respond(response)
 
@@ -894,12 +893,13 @@ class _ModalDialog(ABC):
             else:
                 self._update_modal(slack_client, external_id, modal_payload, slack_request)
 
-        except SlackApiError:
+        except SlackApiError as e:
             _logger.info(
                 "slack.action.response-error",
                 extra={
                     "organization_id": org.id,
                     "integration_id": slack_request.integration.id,
+                    "exec_summary": repr(e),
                 },
             )
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -32,10 +32,6 @@ from sentry.integrations.messaging.metrics import (
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
-from sentry.integrations.slack.metrics import (
-    SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC,
-    SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
-)
 from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.sdk_client import SlackSdkClient
@@ -52,7 +48,6 @@ from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAct
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models import User
 from sentry.users.services.user import RpcUser
-from sentry.utils import metrics
 
 _logger = logging.getLogger(__name__)
 
@@ -370,6 +365,12 @@ class SlackActionEndpoint(Endpoint):
             with self.record_event(
                 MessagingInteractionType.VIEW_SUBMISSION, group, request
             ).capture() as lifecycle:
+                lifecycle.add_extras(
+                    {
+                        "integration_id": slack_request.integration.id,
+                        "organization_id": group.project.organization_id,
+                    }
+                )
 
                 # Masquerade a status action
                 selection = None
@@ -425,26 +426,8 @@ class SlackActionEndpoint(Endpoint):
                     webhook_client.send(
                         blocks=blocks.get("blocks"), delete_original=False, replace_original=True
                     )
-                    metrics.incr(
-                        SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
-                        sample_rate=1.0,
-                        tags={"type": "submit_modal"},
-                    )
                 except SlackApiError as e:
                     lifecycle.record_failure(e)
-                    metrics.incr(
-                        SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC,
-                        sample_rate=1.0,
-                        tags={"type": "submit_modal"},
-                    )
-                    _logger.exception(
-                        "slack.webhook.view_submission.response-error",
-                        extra={
-                            "error": str(e),
-                            "integration_id": slack_request.integration.id,
-                            "organization_id": group.project.organization_id,
-                        },
-                    )
 
                 return self.respond()
 
@@ -528,18 +511,8 @@ class SlackActionEndpoint(Endpoint):
                     "blocks": response.get("blocks"),
                 },
             )
-            metrics.incr(
-                SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": "update_message"},
-            )
         except SlackApiError:
-            metrics.incr(
-                SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": "update_message"},
-            )
-            _logger.exception("slack.webhook.update_status.response-error")
+            _logger.info("slack.webhook.update_status.response-error")
 
         return self.respond(response)
 
@@ -861,17 +834,11 @@ class _ModalDialog(ABC):
             # If the external_id is not found, Slack we send `not_found` error
             # https://api.slack.com/methods/views.update
             if unpack_slack_api_error(e) == MODAL_NOT_FOUND:
-                metrics.incr(
-                    SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC,
-                    sample_rate=1.0,
-                    tags={"type": "update_modal"},
-                )
                 logging_data = slack_request.get_logging_data()
-                _logger.exception(
+                _logger.info(
                     "slack.action.update-modal-not-found",
                     extra={
                         **logging_data,
-                        "trigger_id": slack_request.data["trigger_id"],
                         "dialog": self.dialog_type,
                     },
                 )
@@ -927,24 +894,12 @@ class _ModalDialog(ABC):
             else:
                 self._update_modal(slack_client, external_id, modal_payload, slack_request)
 
-            metrics.incr(
-                SLACK_WEBHOOK_GROUP_ACTIONS_SUCCESS_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": f"{self.dialog_type}_modal_open"},
-            )
         except SlackApiError:
-            metrics.incr(
-                SLACK_WEBHOOK_GROUP_ACTIONS_FAILURE_DATADOG_METRIC,
-                sample_rate=1.0,
-                tags={"type": f"{self.dialog_type}_modal_open"},
-            )
-            _logger.exception(
+            _logger.info(
                 "slack.action.response-error",
                 extra={
                     "organization_id": org.id,
                     "integration_id": slack_request.integration.id,
-                    "trigger_id": slack_request.data["trigger_id"],
-                    "dialog": self.dialog_type,
                 },
             )
 

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -17,10 +17,6 @@ from sentry.api.base import all_silo_endpoint
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.integrations.slack.message_builder.prompt import SlackPromptLinkMessageBuilder
-from sentry.integrations.slack.metrics import (
-    SLACK_WEBHOOK_EVENT_ENDPOINT_FAILURE_DATADOG_METRIC,
-    SLACK_WEBHOOK_EVENT_ENDPOINT_SUCCESS_DATADOG_METRIC,
-)
 from sentry.integrations.slack.requests.base import SlackDMRequest, SlackRequestError
 from sentry.integrations.slack.requests.event import COMMANDS, SlackEventRequest
 from sentry.integrations.slack.sdk_client import SlackSdkClient
@@ -46,9 +42,6 @@ class SlackEventEndpoint(SlackDMEndpoint):
     XXX(dcramer): a lot of this is copied from sentry-plugins right now, and will need refactoring
     """
 
-    _METRIC_FAILURE_KEY = SLACK_WEBHOOK_EVENT_ENDPOINT_FAILURE_DATADOG_METRIC
-    _METRICS_SUCCESS_KEY = SLACK_WEBHOOK_EVENT_ENDPOINT_SUCCESS_DATADOG_METRIC
-
     authentication_classes = ()
     permission_classes = ()
     slack_request_class = SlackEventRequest
@@ -67,8 +60,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
         try:
             client.chat_postMessage(channel=slack_request.channel_id, text=message)
         except SlackApiError:
-            _logger.exception("reply.post-message-error", extra=logger_params)
-            metrics.incr(self._METRIC_FAILURE_KEY + ".reply.post_message", sample_rate=1.0)
+            _logger.info("reply.post-message-error", extra=logger_params)
 
         return self.respond()
 

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -118,8 +118,7 @@ class SlackActionHandlerTest(FireTest):
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")
     @patch("sentry.integrations.slack.sdk_client.SlackSdkClient.chat_postMessage")
-    @patch("sentry.integrations.slack.utils.notifications.metrics")
-    def test_fire_metric_alert_sdk(self, mock_metrics, mock_post, mock_api_call, mock_record):
+    def test_fire_metric_alert_sdk(self, mock_post, mock_api_call, mock_record):
         mock_api_call.return_value = {
             "body": orjson.dumps({"ok": True}).decode(),
             "headers": {},
@@ -141,8 +140,7 @@ class SlackActionHandlerTest(FireTest):
         assert send_notification_success.args[0] == EventLifecycleOutcome.SUCCESS
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.integrations.slack.utils.notifications.metrics")
-    def test_fire_metric_alert_sdk_error(self, mock_metrics, mock_record):
+    def test_fire_metric_alert_sdk_error(self, mock_record):
         self.run_fire_test()
 
         assert NotificationMessage.objects.all().count() == 1

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -78,8 +78,7 @@ class SlackIntegrationLinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         assert identity[0].status == IdentityStatus.VALID
         assert self.mock_webhook.call_count == 1
 
-    @patch("sentry.integrations.slack.utils.notifications._logger")
-    def test_basic_flow_with_webhook_client_error(self, mock_logger):
+    def test_basic_flow_with_webhook_client_error(self):
         """Do the auth flow and assert that the identity was created."""
         self.mock_webhook.side_effect = SlackApiError("", response={"ok": False})
 
@@ -98,8 +97,6 @@ class SlackIntegrationLinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         identity = Identity.objects.filter(external_id="new-slack-id", user=self.user)
 
         assert len(identity) == 1
-        assert mock_logger.exception.call_count == 1
-        assert mock_logger.exception.call_args.args == ("slack.link-identity.error",)
 
     def test_basic_flow_with_web_client(self):
         """No response URL is provided, so we use WebClient."""
@@ -138,8 +135,6 @@ class SlackIntegrationLinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         identity = Identity.objects.filter(external_id="new-slack-id", user=self.user)
 
         assert len(identity) == 1
-        assert mock_logger.exception.call_count == 1
-        assert mock_logger.exception.call_args.args == ("slack.link-identity.error",)
 
     def test_overwrites_existing_identities_with_sdk(self):
         external_id_2 = "slack-id2"

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -552,10 +552,6 @@ class StatusActionTest(BaseEventTest, PerformanceIssueTestCase, HybridCloudTestM
             "integration": ActivityIntegration.SLACK.value,
         }
 
-        mock_logger.exception.assert_called_with(
-            "slack.webhook.update_status.response-error",
-        )
-
     def test_assign_issue_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
         self.create_member(user=user2, organization=self.organization, teams=[self.team])


### PR DESCRIPTION
we don't have any dashboards or use any of these metrics, so lets remove and save us some 💸  it should be close to 1k in savings

also changed some loggers from exception to info since we don't need the stacktrace or issues for a lot of these issues