### PR TITLE
chore(crons/uptime): Unobstruct crons/uptime cursor overlay 

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -147,6 +147,10 @@ interface GridLineOverlayProps {
    */
   cursorOffsets?: CursorOffsets;
   /**
+   * The vertical offset of the cursor overlay from the top of the container
+   */
+  cursorOverlayTopOffset?: number;
+  /**
    * Configres where the timeline labels are displayed
    */
   labelPosition?: LabelPosition;
@@ -170,6 +174,7 @@ export function GridLineOverlay({
   additionalUi,
   stickyCursor,
   cursorOffsets,
+  cursorOverlayTopOffset,
   allowZoom,
   className,
   labelPosition = 'left-top',
@@ -218,6 +223,7 @@ export function GridLineOverlay({
     sticky: stickyCursor,
     offsets: cursorOffsets,
     labelText: makeCursorLabel,
+    cursorOverlayTopOffset,
   });
 
   const overlayRef = mergeRefs(cursorContainerRef, selectionContainerRef);

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -147,9 +147,14 @@ interface GridLineOverlayProps {
    */
   cursorOffsets?: CursorOffsets;
   /**
-   * The vertical offset of the cursor overlay from the top of the container
+   * Whether to anchor the cursor overlay to the top or bottom of the container. Defaults to 'top'
    */
-  cursorOverlayTopOffset?: number;
+  cursorOverlayAnchor?: 'top' | 'bottom';
+  /**
+   * The offset of the cursor overlay. If anchor is 'top', this will be added to the top offset.
+   * If anchor is 'bottom', this will be added to the bottom offset.
+   */
+  cursorOverlayAnchorOffset?: number;
   /**
    * Configres where the timeline labels are displayed
    */
@@ -174,7 +179,8 @@ export function GridLineOverlay({
   additionalUi,
   stickyCursor,
   cursorOffsets,
-  cursorOverlayTopOffset,
+  cursorOverlayAnchor,
+  cursorOverlayAnchorOffset,
   allowZoom,
   className,
   labelPosition = 'left-top',
@@ -223,7 +229,8 @@ export function GridLineOverlay({
     sticky: stickyCursor,
     offsets: cursorOffsets,
     labelText: makeCursorLabel,
-    cursorOverlayTopOffset,
+    anchor: cursorOverlayAnchor,
+    anchorOffset: cursorOverlayAnchorOffset,
   });
 
   const overlayRef = mergeRefs(cursorContainerRef, selectionContainerRef);

--- a/static/app/components/checkInTimeline/timelineCursor.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.tsx
@@ -21,6 +21,10 @@ interface Options {
    */
   labelText: (positionX: number) => string;
   /**
+   * The vertical offset of the cursor overlay from the top of the container
+   */
+  cursorOverlayTopOffset?: number;
+  /**
    * May be set to false to disable rendering the timeline cursor
    */
   enabled?: boolean;
@@ -31,7 +35,7 @@ interface Options {
    */
   offsets?: CursorOffsets;
   /**
-   * Should the label stick to teh top of the screen?
+   * Should the label stick to the top of the screen?
    */
   sticky?: boolean;
 }
@@ -41,6 +45,7 @@ function useTimelineCursor<E extends HTMLElement>({
   sticky,
   offsets,
   labelText,
+  cursorOverlayTopOffset,
 }: Options) {
   const rafIdRef = useRef<number | null>(null);
 
@@ -113,7 +118,13 @@ function useTimelineCursor<E extends HTMLElement>({
   }, [enabled, handleMouseMove]);
 
   const labelOverlay = (
-    <CursorLabel ref={labelRef} animated placement="right" offsets={offsets} />
+    <CursorLabel
+      ref={labelRef}
+      animated
+      placement="right"
+      offsets={offsets}
+      cursorOverlayTopOffset={cursorOverlayTopOffset}
+    />
   );
   const cursorLabel = sticky ? <StickyLabel>{labelOverlay}</StickyLabel> : labelOverlay;
 
@@ -154,7 +165,10 @@ const Cursor = styled(motion.div)`
   z-index: 3;
 `;
 
-const CursorLabel = styled(Overlay)<{offsets?: CursorOffsets}>`
+const CursorLabel = styled(Overlay)<{
+  cursorOverlayTopOffset?: number;
+  offsets?: CursorOffsets;
+}>`
   font-variant-numeric: tabular-nums;
   width: max-content;
   padding: ${space(0.75)} ${space(1)};
@@ -162,7 +176,7 @@ const CursorLabel = styled(Overlay)<{offsets?: CursorOffsets}>`
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 1.2;
   position: absolute;
-  top: 12px;
+  top: ${p => (p.cursorOverlayTopOffset ?? 0) + 12}px;
   left: clamp(
     0px,
     calc(var(--cursorOffset) + ${p => p.offsets?.left ?? 0}px + ${TOOLTIP_OFFSET}px),

--- a/static/app/components/checkInTimeline/timelineCursor.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.tsx
@@ -21,9 +21,14 @@ interface Options {
    */
   labelText: (positionX: number) => string;
   /**
-   * The vertical offset of the cursor overlay from the top of the container
+   * Whether to anchor the cursor overlay to the top or bottom of the container. Defaults to 'top'
    */
-  cursorOverlayTopOffset?: number;
+  anchor?: 'top' | 'bottom';
+  /**
+   * The offset of the cursor overlay. If anchor is 'top', this will be added to the top offset.
+   * If anchor is 'bottom', this will be added to the bottom offset.
+   */
+  anchorOffset?: number;
   /**
    * May be set to false to disable rendering the timeline cursor
    */
@@ -45,7 +50,8 @@ function useTimelineCursor<E extends HTMLElement>({
   sticky,
   offsets,
   labelText,
-  cursorOverlayTopOffset,
+  anchor = 'top',
+  anchorOffset = 0,
 }: Options) {
   const rafIdRef = useRef<number | null>(null);
 
@@ -123,7 +129,8 @@ function useTimelineCursor<E extends HTMLElement>({
       animated
       placement="right"
       offsets={offsets}
-      cursorOverlayTopOffset={cursorOverlayTopOffset}
+      anchor={anchor}
+      anchorOffset={anchorOffset}
     />
   );
   const cursorLabel = sticky ? <StickyLabel>{labelOverlay}</StickyLabel> : labelOverlay;
@@ -166,7 +173,8 @@ const Cursor = styled(motion.div)`
 `;
 
 const CursorLabel = styled(Overlay)<{
-  cursorOverlayTopOffset?: number;
+  anchor: 'top' | 'bottom';
+  anchorOffset: number;
   offsets?: CursorOffsets;
 }>`
   font-variant-numeric: tabular-nums;
@@ -176,7 +184,8 @@ const CursorLabel = styled(Overlay)<{
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 1.2;
   position: absolute;
-  top: ${p => (p.cursorOverlayTopOffset ?? 0) + 12}px;
+  ${p =>
+    p.anchor === 'top' ? `top: ${p.anchorOffset}px;` : `bottom: ${p.anchorOffset}px;`}
   left: clamp(
     0px,
     calc(var(--cursorOffset) + ${p => p.offsets?.left ?? 0}px + ${TOOLTIP_OFFSET}px),

--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -107,6 +107,8 @@ export function CronTimelineSection({event, organization, project}: Props) {
           additionalUi={
             !isPending && <CronServiceIncidents timeWindowConfig={timeWindowConfig} />
           }
+          cursorOverlayAnchor="top"
+          cursorOverlayAnchorOffset={10}
         />
         {monitorStats && !isPending ? (
           <Fragment>

--- a/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
+++ b/static/app/views/alerts/rules/uptime/detailsTimeline.tsx
@@ -50,6 +50,8 @@ export function DetailsTimeline({uptimeRule, onStatsLoaded}: Props) {
         resetPaginationOnZoom
         showCursor
         timeWindowConfig={timeWindowConfig}
+        cursorOverlayAnchor="top"
+        cursorOverlayAnchorOffset={10}
       />
       <OverviewRow
         uptimeRule={uptimeRule}

--- a/static/app/views/insights/crons/components/detailsTimeline.tsx
+++ b/static/app/views/insights/crons/components/detailsTimeline.tsx
@@ -123,6 +123,8 @@ export function DetailsTimeline({monitor, onStatsLoaded}: Props) {
         resetPaginationOnZoom
         timeWindowConfig={timeWindowConfig}
         additionalUi={<CronServiceIncidents timeWindowConfig={timeWindowConfig} />}
+        cursorOverlayAnchor="top"
+        cursorOverlayAnchorOffset={10}
       />
       <OverviewRow
         monitor={monitor}

--- a/static/app/views/insights/crons/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/index.tsx
@@ -154,6 +154,8 @@ export function OverviewTimeline({monitorList}: Props) {
         cursorOffsets={{right: 40}}
         additionalUi={<CronServiceIncidents timeWindowConfig={timeWindowConfig} />}
         timeWindowConfig={timeWindowConfig}
+        cursorOverlayAnchor="top"
+        cursorOverlayAnchorOffset={10}
       />
 
       <MonitorRows>

--- a/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/index.tsx
@@ -57,6 +57,8 @@ export function OverviewTimeline({uptimeRules}: Props) {
         showCursor
         cursorOffsets={{right: 40}}
         timeWindowConfig={timeWindowConfig}
+        cursorOverlayAnchor="top"
+        cursorOverlayAnchorOffset={10}
       />
       <UptimeAlertRow>
         {uptimeRules.map(uptimeRule => (

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -151,6 +151,7 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
         timeWindowConfig={timeWindowConfig}
         labelPosition="center-bottom"
         envCount={statEnvironments.length}
+        cursorOverlayTopOffset={60}
       />
       <IssueGridLineLabels
         timeWindowConfig={timeWindowConfig}

--- a/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueCronCheckTimeline.tsx
@@ -151,7 +151,8 @@ export function IssueCronCheckTimeline({group}: {group: Group}) {
         timeWindowConfig={timeWindowConfig}
         labelPosition="center-bottom"
         envCount={statEnvironments.length}
-        cursorOverlayTopOffset={60}
+        cursorOverlayAnchor="bottom"
+        cursorOverlayAnchorOffset={4}
       />
       <IssueGridLineLabels
         timeWindowConfig={timeWindowConfig}

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
@@ -109,7 +109,8 @@ export function IssueUptimeCheckTimeline({group}: {group: Group}) {
         showCursor
         timeWindowConfig={timeWindowConfig}
         labelPosition="center-bottom"
-        cursorOverlayTopOffset={59}
+        cursorOverlayAnchor="bottom"
+        cursorOverlayAnchorOffset={2}
       />
       <GridLineLabels timeWindowConfig={timeWindowConfig} labelPosition="center-bottom" />
       <TimelineContainer>

--- a/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
+++ b/static/app/views/issueDetails/streamline/issueUptimeCheckTimeline.tsx
@@ -109,6 +109,7 @@ export function IssueUptimeCheckTimeline({group}: {group: Group}) {
         showCursor
         timeWindowConfig={timeWindowConfig}
         labelPosition="center-bottom"
+        cursorOverlayTopOffset={59}
       />
       <GridLineLabels timeWindowConfig={timeWindowConfig} labelPosition="center-bottom" />
       <TimelineContainer>


### PR DESCRIPTION
Moves the cursor overlay that displays the time in the uptime/crons timeline to not be obstructed by the other tooltip. 

Before: 

![image](https://github.com/user-attachments/assets/5cd64538-d058-4d4a-af47-ae93dac5c5fb)

After: 

![Screenshot 2025-06-10 at 2 28 09 PM](https://github.com/user-attachments/assets/2bf60eca-dbae-487f-bdba-a9f28633d84e)

This has been updated for both uptime and crons issue details pages. 