### PR TITLE
fix(billing): Hide gift budget action when no applicable budgets

### DIFF
--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -13,6 +13,7 @@ import {OnboardingTasksFixture} from 'getsentry-test/fixtures/onboardingTasks';
 import {OwnerFixture} from 'getsentry-test/fixtures/owner';
 import {PoliciesFixture} from 'getsentry-test/fixtures/policies';
 import {ProjectFixture} from 'getsentry-test/fixtures/project';
+import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
 import {
   Am3DsEnterpriseSubscriptionFixture,
   SubscriptionFixture,
@@ -1100,7 +1101,19 @@ describe('Customer Details', function () {
   });
 
   it('renders correct sections', async function () {
-    setUpMocks(organization);
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+      planTier: 'am3',
+      hasReservedBudgets: true,
+    });
+    subscription.reservedBudgets = [
+      SeerReservedBudgetFixture({
+        id: '0',
+        reservedBudget: 0,
+      }),
+    ];
+    setUpMocks(organization, subscription);
 
     render(<CustomerDetails />, {
       initialRouterConfig: {
@@ -1139,6 +1152,9 @@ describe('Customer Details', function () {
     expect(screen.getByRole('option', {name: /Gift errors/})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: /Gift transactions/})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: /Gift attachments/})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {name: /Gift to reserved budget/})
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('option', {name: /Change Plan/})).toBeInTheDocument();
     expect(
       screen.getByRole('option', {name: /Start Enterprise Trial/})

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -1,5 +1,6 @@
 import {useEffect} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
+import some from 'lodash/some';
 import scrollToElement from 'scroll-to-element';
 
 import {
@@ -752,7 +753,9 @@ export default function CustomerDetails() {
             key: 'addGiftBudgetAction',
             name: 'Gift to reserved budget',
             help: 'Select a reserved budget and gift it free dollars for the current billing period.',
-            visible: subscription.hasReservedBudgets,
+            visible:
+              (subscription.reservedBudgets?.length ?? 0) > 0 &&
+              some(subscription.reservedBudgets, budget => budget.reservedBudget > 0),
             skipConfirmModal: true,
             onAction: () => {
               addGiftBudgetAction({


### PR DESCRIPTION
Hides the budget gifting action in _admin based on `reservedBudgets` instead of `hasReservedBudgets`.