### PR TITLE
fix(crons): Expand trace id column header width

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -65,7 +65,7 @@ export function UptimeChecksGrid({uptimeRule, uptimeChecks}: Props) {
         {key: 'httpStatusCode', width: 100, name: t('HTTP Code')},
         {key: 'durationMs', width: 110, name: t('Duration')},
         {key: 'regionName', width: 200, name: t('Region')},
-        {key: 'traceId', width: 100, name: t('Trace')},
+        {key: 'traceId', width: 150, name: t('Trace')},
       ]}
       columnSortBy={[]}
       grid={{


### PR DESCRIPTION
Fixes RTC-1009

Expands the width of the traceId column header to be the same as the body cell width: 


<img width="323" alt="Screenshot 2025-06-10 at 2 59 22 PM" src="https://github.com/user-attachments/assets/a87f2883-d4c9-47f2-8ac6-6ef3eac47320" />
