### PR TITLE
feat(workflow_engine): Add a metrics to track writing / reading from issue platform

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -953,7 +953,7 @@ def process_workflow_engine(job: PostProcessJob) -> None:
 
     Eventually, we'll want to replace `process_rule` with this method.
     """
-    metrics.incr("workflow_engine.issue_platform.payload.processed")
+    metrics.incr("workflow_engine.issue_platform.payload.received")
 
     from sentry.workflow_engine.processors.workflow import process_workflows
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -945,65 +945,65 @@ def process_replay_link(job: PostProcessJob) -> None:
 
 
 def process_workflow_engine(job: PostProcessJob) -> None:
+    """
+    Invoke the workflow_engine to process workflows given the job.
+
+    Currently, we do not want to add this to an event in post processing,
+    instead wrap this with a check for a feature flag before invoking.
+
+    Eventually, we'll want to replace `process_rule` with this method.
+    """
+    metrics.incr("workflow_engine.issue_platform.payload.processed")
+
+    from sentry.workflow_engine.processors.workflow import process_workflows
+
+    # PostProcessJob event is optional, WorkflowEventData event is required
+    if "event" not in job:
+        logger.error("Missing event to create WorkflowEventData", extra={"job": job})
+        return
+
+    try:
+        workflow_event_data = WorkflowEventData(
+            event=job["event"],
+            group_state=job.get("group_state"),
+            has_reappeared=job.get("has_reappeared"),
+            has_escalated=job.get("has_escalated"),
+        )
+    except Exception:
+        logger.exception("Could not create WorkflowEventData", extra={"job": job})
+        return
+
+    with sentry_sdk.start_span(op="tasks.post_process_group.workflow_engine.process_workflow"):
+        process_workflows(workflow_event_data)
+
+
+def process_workflow_engine_issue_alerts(job: PostProcessJob) -> None:
+    """
+    Call for process_workflow_engine with the issue alert feature flag
+    """
     if job["is_reprocessed"]:
         return
 
     org = job["event"].project.organization
-    # TODO: only fire one system. to test, fire from both systems and observe metrics
+    # TODO: only fire one system. To test, fire from both systems and observe metrics
     if not features.has("organizations:workflow-engine-process-workflows", org):
         return
 
-    from sentry.workflow_engine.processors.workflow import process_workflows
-
-    # PostProcessJob event is optional, WorkflowEventData event is required
-    if "event" not in job:
-        logger.error("Missing event to create WorkflowEventData", extra={"job": job})
-        return
-
-    try:
-        workflow_event_data = WorkflowEventData(
-            event=job["event"],
-            group_state=job.get("group_state"),
-            has_reappeared=job.get("has_reappeared"),
-            has_escalated=job.get("has_escalated"),
-        )
-    except Exception:
-        logger.exception("Could not create WorkflowEventData", extra={"job": job})
-        return
-
-    with sentry_sdk.start_span(op="tasks.post_process_group.workflow_engine.process_workflow"):
-        process_workflows(workflow_event_data)
+    process_workflow_engine(job)
 
 
 def process_workflow_engine_metric_issues(job: PostProcessJob) -> None:
+    """
+    Call for process_workflow_engine for metric alerts
+    """
     if job["is_reprocessed"]:
         return
 
     org = job["event"].project.organization
-    # TODO: only fire one system. to test, fire from both systems and observe metrics
     if not features.has("organizations:workflow-engine-process-metric-issue-workflows", org):
         return
 
-    from sentry.workflow_engine.processors.workflow import process_workflows
-
-    # PostProcessJob event is optional, WorkflowEventData event is required
-    if "event" not in job:
-        logger.error("Missing event to create WorkflowEventData", extra={"job": job})
-        return
-
-    try:
-        workflow_event_data = WorkflowEventData(
-            event=job["event"],
-            group_state=job.get("group_state"),
-            has_reappeared=job.get("has_reappeared"),
-            has_escalated=job.get("has_escalated"),
-        )
-    except Exception:
-        logger.exception("Could not create WorkflowEventData", extra={"job": job})
-        return
-
-    with sentry_sdk.start_span(op="tasks.post_process_group.workflow_engine.process_workflow"):
-        process_workflows(workflow_event_data)
+    process_workflow_engine(job)
 
 
 def process_rules(job: PostProcessJob) -> None:
@@ -1609,7 +1609,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE = {
         handle_auto_assignment,
         kick_off_seer_automation,
         process_rules,
-        process_workflow_engine,
+        process_workflow_engine_issue_alerts,
         process_service_hooks,
         process_resource_change_bounds,
         process_plugins,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -953,7 +953,7 @@ def process_workflow_engine(job: PostProcessJob) -> None:
 
     Eventually, we'll want to replace `process_rule` with this method.
     """
-    metrics.incr("workflow_engine.issue_platform.payload.received")
+    metrics.incr("workflow_engine.issue_platform.payload.received.occurrence")
 
     from sentry.workflow_engine.processors.workflow import process_workflows
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -34,9 +34,12 @@ def create_issue_platform_payload(result: DetectorEvaluationResult):
     if isinstance(result.result, IssueOccurrence):
         occurrence = result.result
         payload_type = PayloadType.OCCURRENCE
+
+        metrics.incr("workflow_engine.issue_platform.payload.sent.occurrence")
     else:
         status_change = result.result
         payload_type = PayloadType.STATUS_CHANGE
+        metrics.incr("workflow_engine.issue_platform.payload.sent.status_change")
 
     produce_occurrence_to_kafka(
         payload_type=payload_type,
@@ -44,8 +47,6 @@ def create_issue_platform_payload(result: DetectorEvaluationResult):
         status_change=status_change,
         event_data=result.event_data,
     )
-
-    metrics.incr("workflow_engine.issue_platform.payload.sent")
 
 
 def process_detectors(

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -45,6 +45,8 @@ def create_issue_platform_payload(result: DetectorEvaluationResult):
         event_data=result.event_data,
     )
 
+    metrics.incr("workflow_engine.issue_platform.payload.sent")
+
 
 def process_detectors(
     data_packet: DataPacket, detectors: list[Detector]


### PR DESCRIPTION
# Description
- Add new metrics to help track when we are passing events from the issue platform into the workflow engine.
  - `workflow_engine.issue_platform.payload.sent.occurrence` - when we send a new issue occurrence
  - `workflow_engine.issue_platform.payload.sent.status_change` - when we send a status change message
  - `workflow_engine.issue_platform.payload.received.occurrence` - when we begin processing in `post_process`
  - TODO - once we have support for status change messages in workflow engine, we'll want to add a metric to say it was received and triggering process_workflows (in `update_status` where we will call `process_workflows` with the update)