### PR TITLE
feat(aci): Pass project id, environment to new detector

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -21,6 +21,10 @@ type Props = {
   isDisabled?: boolean;
   maxLength?: number;
   name?: string;
+  /**
+   * The placeholder text to display when the input is empty.
+   */
+  placeholder?: string;
   successMessage?: React.ReactNode;
 };
 
@@ -35,6 +39,7 @@ function EditableText({
   autoSelect = false,
   className,
   'aria-label': ariaLabel,
+  placeholder,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(value);
@@ -162,6 +167,7 @@ function EditableText({
             onChange={handleInputChange}
             onFocus={event => autoSelect && event.target.select()}
             maxLength={maxLength}
+            placeholder={placeholder}
           />
           <InputLabel>{inputValue}</InputLabel>
         </InputWrapper>
@@ -172,7 +178,7 @@ function EditableText({
           isDisabled={isDisabled}
           data-test-id="editable-text-label"
         >
-          <InnerLabel>{inputValue}</InnerLabel>
+          <InnerLabel>{inputValue || placeholder}</InnerLabel>
           {!isDisabled && <IconEdit />}
         </Label>
       )}

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import EditableText from 'sentry/components/editableText';
+import FormField from 'sentry/components/forms/formField';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {ActionsFromContext} from 'sentry/components/workflowEngine/layout/actions';
 import {BreadcrumbsFromContext} from 'sentry/components/workflowEngine/layout/breadcrumbs';
@@ -13,28 +14,42 @@ interface WorkflowEngineEditLayoutProps {
    * Expected to include `<EditLayout.Chart>` and `<EditLayout.Panel>` components.
    */
   children: React.ReactNode;
-  title: string;
   onTitleChange?: (title: string) => void;
 }
 
 /**
  * Precomposed full-width layout for Automations / Monitors edit pages.
  */
-function EditLayout({children, onTitleChange, title}: WorkflowEngineEditLayoutProps) {
+function EditLayout({children, onTitleChange}: WorkflowEngineEditLayoutProps) {
   return (
     <Layout.Page>
       <Layout.Header unified>
         <Layout.HeaderContent>
           <BreadcrumbsFromContext />
           <Layout.Title>
-            <EditableText
-              isDisabled={false}
-              value={title}
-              onChange={newTitle => onTitleChange?.(newTitle)}
-              errorMessage={t('Please set a title')}
-              placeholder={t('New Monitor')}
+            <FormField
               name="title"
-            />
+              inline={false}
+              flexibleControlStateSize
+              stacked
+              onChange={onTitleChange}
+            >
+              {({onChange, value}) => (
+                <EditableText
+                  isDisabled={false}
+                  value={value || ''}
+                  onChange={newValue => {
+                    onChange(newValue, {
+                      target: {
+                        value: newValue,
+                      },
+                    });
+                  }}
+                  errorMessage={t('Please set a title')}
+                  placeholder={t('New Monitor')}
+                />
+              )}
+            </FormField>
           </Layout.Title>
         </Layout.HeaderContent>
         <ActionsFromContext />

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import EditableText from 'sentry/components/editableText';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {ActionsFromContext} from 'sentry/components/workflowEngine/layout/actions';
 import {BreadcrumbsFromContext} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 import {t} from 'sentry/locale';
@@ -14,14 +13,14 @@ interface WorkflowEngineEditLayoutProps {
    * Expected to include `<EditLayout.Chart>` and `<EditLayout.Panel>` components.
    */
   children: React.ReactNode;
+  title: string;
   onTitleChange?: (title: string) => void;
 }
 
 /**
  * Precomposed full-width layout for Automations / Monitors edit pages.
  */
-function EditLayout({children, onTitleChange}: WorkflowEngineEditLayoutProps) {
-  const title = useDocumentTitle();
+function EditLayout({children, onTitleChange, title}: WorkflowEngineEditLayoutProps) {
   return (
     <Layout.Page>
       <Layout.Header unified>
@@ -33,6 +32,8 @@ function EditLayout({children, onTitleChange}: WorkflowEngineEditLayoutProps) {
               value={title}
               onChange={newTitle => onTitleChange?.(newTitle)}
               errorMessage={t('Please set a title')}
+              placeholder={t('New Monitor')}
+              name="title"
             />
           </Layout.Title>
         </Layout.HeaderContent>

--- a/static/app/components/workflowEngine/layout/index.spec.tsx
+++ b/static/app/components/workflowEngine/layout/index.spec.tsx
@@ -5,7 +5,6 @@ import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
 import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 
 import DetailLayout from './detail';
-import EditLayout from './edit';
 import ListLayout from './list';
 
 function Fixture({children}: any) {
@@ -19,21 +18,6 @@ function Fixture({children}: any) {
     </SentryDocumentTitle>
   );
 }
-
-describe('Edit Layout component', function () {
-  it('renders children and context values', function () {
-    render(
-      <Fixture>
-        <EditLayout>children-test-value</EditLayout>
-      </Fixture>
-    );
-
-    expect(screen.getByText('children-test-value')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'action-test-value'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'breadcrumb-test-value'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'title-test-value'})).toBeInTheDocument();
-  });
-});
 
 describe('Detail Layout component', function () {
   it('renders children and context values', function () {

--- a/static/app/components/workflowEngine/layout/index.stories.tsx
+++ b/static/app/components/workflowEngine/layout/index.stories.tsx
@@ -7,7 +7,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {ActionsProvider} from 'sentry/components/workflowEngine/layout/actions';
 import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
-import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import ListLayout from 'sentry/components/workflowEngine/layout/list';
 import {IconAdd, IconEdit} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
@@ -36,7 +35,6 @@ function withProviders(Layout: any) {
 
 const List = withProviders(ListLayout);
 const Detail = withProviders(DetailLayout);
-const Edit = withProviders(EditLayout);
 
 const Container = styled(Flex)`
   background: ${p => p.theme.background};
@@ -146,41 +144,6 @@ export default Storybook.story('Layout Components', story => {
               <Placeholder>sidebar</Placeholder>
             </DetailLayout.Sidebar>
           </Detail>
-        </Container>
-      </Storybook.SizingWindow>
-    </Fragment>
-  ));
-
-  story('EditLayout', () => (
-    <Fragment>
-      <p>
-        Configuration pages for Monitors and Automations both use the{' '}
-        <Storybook.JSXNode name="EditLayout" /> component.
-      </p>
-
-      <p>
-        The <Storybook.JSXNode name="EditLayout" /> component expects{' '}
-        <Storybook.JSXProperty name="children" value={undefined} /> to be{' '}
-        <Storybook.JSXNode name="EditLayout.Chart" /> and{' '}
-        <Storybook.JSXNode name="EditLayout.Panels" /> components.
-      </p>
-
-      <Storybook.SizingWindow display="block">
-        <Container>
-          <Edit
-            title="Notify Slack team"
-            breadcrumb="Automations"
-            action={<Button priority="primary">Save</Button>}
-          >
-            <EditLayout.Chart>
-              <Placeholder>chart</Placeholder>
-            </EditLayout.Chart>
-            <EditLayout.Panels>
-              <Placeholder>panels</Placeholder>
-              <Placeholder>panels</Placeholder>
-              <Placeholder>panels</Placeholder>
-            </EditLayout.Panels>
-          </Edit>
         </Container>
       </Storybook.SizingWindow>
     </Fragment>

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -20,25 +20,21 @@ function getDefaultProject(projects: Project[]) {
 export function DetectorTypeForm() {
   return (
     <Flex column>
-      <Group column>
-        <Header column>
-          <h3>{t('Project and Environment')}</h3>
-        </Header>
-        <Flex>
-          <ProjectField />
-          <EnvironmentField />
-        </Flex>
-      </Group>
-      <Group column>
-        <Header column>
-          <h3>{t('Monitor type')}</h3>
-          <p>
-            {t("Monitor type can't be edited once the monitor has been created.")}{' '}
-            <a href="#">{t('Learn more about monitor types.')}</a>
-          </p>
-        </Header>
-        <MonitorTypeField />
-      </Group>
+      <Header>
+        <h3>{t('Project and Environment')}</h3>
+      </Header>
+      <Flex>
+        <ProjectField />
+        <EnvironmentField />
+      </Flex>
+      <Header>
+        <h3>{t('Monitor type')}</h3>
+        <p>
+          {t("Monitor type can't be edited once the monitor has been created.")}{' '}
+          <a href="#">{t('Learn more about monitor types.')}</a>
+        </p>
+      </Header>
+      <MonitorTypeField />
     </Flex>
   );
 }
@@ -200,11 +196,9 @@ const StyledRadioField = styled(RadioField)`
   }
 `;
 
-const Group = styled(Flex)`
-  padding-inline: ${space(4)};
-`;
-
-const Header = styled(Flex)`
+const Header = styled('div')`
+  display: flex;
+  flex-direction: column;
   gap: ${space(0.5)};
   margin-top: ${space(3)};
   margin-bottom: ${space(1)};

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -6,81 +6,50 @@ import {Flex} from 'sentry/components/container/flex';
 import RadioField from 'sentry/components/forms/fields/radioField';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import SentryProjectSelectorField from 'sentry/components/forms/fields/sentryProjectSelectorField';
-import Form from 'sentry/components/forms/form';
-import FormModel from 'sentry/components/forms/model';
-import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Environment} from 'sentry/types/project';
-import {useApiQuery} from 'sentry/utils/queryClient';
-import useOrganization from 'sentry/utils/useOrganization';
+import type {Project} from 'sentry/types/project';
+import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 
-const model = new FormModel({
-  initialData: {
-    name: t('New Monitor'),
-    project: undefined,
-    environment: 'all',
-    type: 'metric',
-  },
-});
+function getDefaultProject(projects: Project[]) {
+  return projects.find(p => p.isMember) ?? projects[0];
+}
 
 export function DetectorTypeForm() {
-  const {projects} = useProjects();
-  const title = useDocumentTitle();
-
-  useEffect(() => {
-    model.setValue('name', title);
-  }, [title]);
-  useEffect(() => {
-    const firstProject = projects.find(p => p.isMember);
-    model.setInitialData({
-      name: title,
-      project: firstProject?.id,
-      environment: 'all',
-      type: 'metric',
-    });
-    const prevHook = model.options.onFieldChange;
-    model.setFormOptions({
-      onFieldChange(id, value) {
-        if (id === 'project') {
-          model.setValue('environment', 'all');
-        }
-        prevHook?.(id, value);
-      },
-    });
-  }, [projects, title]);
-
   return (
-    <Form hideFooter model={model}>
-      <Flex column>
-        <Group column>
-          <Header column>
-            <h3>{t('Project and Environment')}</h3>
-          </Header>
-          <Flex>
-            <ProjectField />
-            <EnvironmentField />
-          </Flex>
-        </Group>
-        <Group column>
-          <Header column>
-            <h3>{t('Monitor type')}</h3>
-            <p>
-              {t("Monitor type can't be edited once the monitor has been created.")}{' '}
-              <a href="#">{t('Learn more about monitor types.')}</a>
-            </p>
-          </Header>
-          <MonitorTypeField />
-        </Group>
-      </Flex>
-    </Form>
+    <Flex column>
+      <Group column>
+        <Header column>
+          <h3>{t('Project and Environment')}</h3>
+        </Header>
+        <Flex>
+          <ProjectField />
+          <EnvironmentField />
+        </Flex>
+      </Group>
+      <Group column>
+        <Header column>
+          <h3>{t('Monitor type')}</h3>
+          <p>
+            {t("Monitor type can't be edited once the monitor has been created.")}{' '}
+            <a href="#">{t('Learn more about monitor types.')}</a>
+          </p>
+        </Header>
+        <MonitorTypeField />
+      </Group>
+    </Flex>
   );
 }
 
 function ProjectField() {
-  const {projects} = useProjects();
+  const location = useLocation();
+  const {projects, fetching} = useProjects();
+  const queryProjectId = location.query.project as string | undefined;
+  const currentProject = queryProjectId
+    ? projects.find(p => p.id === queryProjectId)
+    : getDefaultProject(projects);
 
   return (
     <StyledProjectField
@@ -93,36 +62,50 @@ function ProjectField() {
         {key: 'member', label: t('My Projects')},
         {key: 'all', label: t('All Projects')},
       ]}
+      value={currentProject?.id}
       name="project"
       placeholder={t('Project')}
+      aria-label={t('Select Project')}
+      disabled={fetching}
     />
   );
 }
 
 function EnvironmentField() {
-  const project = useFormField('project');
-  const {environments} = useProjectEnvironments({projectSlug: project?.toString()});
+  const {projects} = useProjects();
+  const projectId = useFormField<string>('project');
+  const currentProject = projectId
+    ? projects.find(p => p.id === projectId)
+    : getDefaultProject(projects);
+
+  const environments = currentProject?.environments ?? [];
+
   return (
     <StyledEnvironmentField
       choices={[
-        ['all', t('All Environments')],
-        ...(environments?.map(environment => [environment.id, environment.name]) ?? []),
+        ['', t('All Environments')],
+        ...(environments?.map(environment => [environment, environment]) ?? []),
       ]}
       inline={false}
       flexibleControlStateSize
       stacked
       name="environment"
       placeholder={t('Environment')}
+      aria-label={t('Select Environment')}
     />
   );
 }
 
 function MonitorTypeField() {
+  const location = useLocation();
+  const queryType = location.query.detectorType as string | undefined;
+
   return (
     <StyledRadioField
       inline={false}
       flexibleControlStateSize
-      name="type"
+      name="detectorType"
+      value={queryType}
       choices={[
         [
           'metric',
@@ -154,22 +137,9 @@ function MonitorTypeField() {
           />,
         ],
       ]}
+      required
     />
   );
-}
-
-function useProjectEnvironments({projectSlug}: {projectSlug?: string}) {
-  const organization = useOrganization();
-  const {data: environments = [], isLoading} = useApiQuery<Environment[]>(
-    [
-      `/projects/${organization.slug}/${projectSlug}/environments/`,
-      {query: {visibility: 'visible'}},
-    ],
-    {
-      staleTime: 30_000,
-    }
-  );
-  return {environments, isLoading};
 }
 
 const StyledProjectField = styled(SentryProjectSelectorField)`

--- a/static/app/views/detectors/components/forms/editableDetectorTitle.tsx
+++ b/static/app/views/detectors/components/forms/editableDetectorTitle.tsx
@@ -1,0 +1,25 @@
+import EditableText from 'sentry/components/editableText';
+import FormField from 'sentry/components/forms/formField';
+import {t} from 'sentry/locale';
+
+export function EditableDetectorTitle() {
+  return (
+    <FormField name="title" inline={false} flexibleControlStateSize stacked>
+      {({onChange, value}) => (
+        <EditableText
+          isDisabled={false}
+          value={value || ''}
+          onChange={newValue => {
+            onChange(newValue, {
+              target: {
+                value: newValue,
+              },
+            });
+          }}
+          errorMessage={t('Please set a title')}
+          placeholder={t('New Monitor')}
+        />
+      )}
+    </FormField>
+  );
+}

--- a/static/app/views/detectors/layouts/new.tsx
+++ b/static/app/views/detectors/layouts/new.tsx
@@ -1,15 +1,14 @@
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {t} from 'sentry/locale';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function NewDetectorLayout({children}: {children: React.ReactNode}) {
-  const location = useLocation();
   const organization = useOrganization();
-  const title = (location.query.title as string | undefined) ?? '';
+  const title = useFormField<string>('title');
 
   return (
     <SentryDocumentTitle title={title || t('New Monitor')}>

--- a/static/app/views/detectors/layouts/new.tsx
+++ b/static/app/views/detectors/layouts/new.tsx
@@ -16,7 +16,7 @@ export default function NewDetectorLayout({children}: {children: React.ReactNode
       <BreadcrumbsProvider
         crumb={{label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)}}
       >
-        <EditLayout title={title}>{children}</EditLayout>
+        <EditLayout>{children}</EditLayout>
       </BreadcrumbsProvider>
     </SentryDocumentTitle>
   );

--- a/static/app/views/detectors/layouts/new.tsx
+++ b/static/app/views/detectors/layouts/new.tsx
@@ -1,21 +1,22 @@
-import {useState} from 'react';
-
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {BreadcrumbsProvider} from 'sentry/components/workflowEngine/layout/breadcrumbs';
 import EditLayout from 'sentry/components/workflowEngine/layout/edit';
 import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function NewDetectorLayout({children}: {children: React.ReactNode}) {
+  const location = useLocation();
   const organization = useOrganization();
-  const [title, setTitle] = useState(t('New Monitor'));
+  const title = (location.query.title as string | undefined) ?? '';
+
   return (
-    <SentryDocumentTitle title={title} noSuffix>
+    <SentryDocumentTitle title={title || t('New Monitor')}>
       <BreadcrumbsProvider
         crumb={{label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)}}
       >
-        <EditLayout onTitleChange={value => setTitle(value)}>{children}</EditLayout>
+        <EditLayout title={title}>{children}</EditLayout>
       </BreadcrumbsProvider>
     </SentryDocumentTitle>
   );

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -34,6 +34,10 @@ describe('DetectorNew', function () {
     await userEvent.click(screen.getByRole('textbox', {name: 'Select Environment'}));
     await userEvent.click(await screen.findByText('prod-2'));
 
+    // Set title
+    await userEvent.click(screen.getByText('New Monitor'));
+    await userEvent.type(await screen.findByRole('textbox', {name: ''}), 'test-title');
+
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
     expect(router.location).toEqual(
@@ -43,6 +47,7 @@ describe('DetectorNew', function () {
           detectorType: 'uptime',
           project: '2',
           environment: 'prod-2',
+          title: 'test-title',
         },
       })
     );

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -35,7 +35,7 @@ describe('DetectorNew', function () {
     await userEvent.click(await screen.findByText('prod-2'));
 
     // Set title
-    await userEvent.click(screen.getByText('New Monitor'));
+    await userEvent.click(screen.getAllByText('New Monitor')[1]!);
     await userEvent.type(await screen.findByRole('textbox', {name: ''}), 'test-title');
 
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -1,0 +1,50 @@
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import DetectorNew from 'sentry/views/detectors/new';
+
+describe('DetectorNew', function () {
+  const projects = [
+    ProjectFixture({
+      id: '2',
+      slug: 'project-2',
+      name: 'Project 2',
+      isMember: false,
+      environments: ['prod-2'],
+    }),
+    ProjectFixture({id: '1', slug: 'project-1', name: 'Project 1', isMember: true}),
+  ];
+  beforeEach(function () {
+    ProjectsStore.loadInitialData(projects);
+  });
+
+  it('sets query parameters for title, project, environment, and detectorType', async function () {
+    const {router} = render(<DetectorNew />);
+
+    // Set detectorType
+    await userEvent.click(screen.getByRole('radio', {name: 'Uptime'}));
+
+    // Set project
+    await userEvent.click(screen.getByRole('textbox', {name: 'Select Project'}));
+    await userEvent.click(await screen.findByText('project-2'));
+
+    // Set environment
+    await userEvent.click(screen.getByRole('textbox', {name: 'Select Environment'}));
+    await userEvent.click(await screen.findByText('prod-2'));
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    expect(router.location).toEqual(
+      expect.objectContaining({
+        pathname: `/organizations/org-slug/issues/monitors/new/settings/`,
+        query: {
+          detectorType: 'uptime',
+          project: '2',
+          environment: 'prod-2',
+        },
+      })
+    );
+  });
+});

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -1,9 +1,13 @@
 import styled from '@emotion/styled';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {Flex} from 'sentry/components/container/flex';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import Form from 'sentry/components/forms/form';
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {
   StickyFooter,
   StickyFooterLabel,
@@ -15,8 +19,26 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {DetectorTypeForm} from 'sentry/views/detectors/components/detectorTypeForm';
-import NewDetectorLayout from 'sentry/views/detectors/layouts/new';
+import {EditableDetectorTitle} from 'sentry/views/detectors/components/forms/editableDetectorTitle';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
+
+function NewDetectorBreadcrumbs() {
+  const title = useFormField<string>('title');
+  const organization = useOrganization();
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
+        {label: title ? title : t('New Monitor')},
+      ]}
+    />
+  );
+}
+
+function NewDetectorDocumentTitle() {
+  const title = useFormField<string>('title');
+  return <SentryDocumentTitle title={title ? title : t('New Monitor')} />;
+}
 
 export default function DetectorNew() {
   const navigate = useNavigate();
@@ -45,9 +67,22 @@ export default function DetectorNew() {
         environment: '',
       }}
     >
-      <NewDetectorLayout>
-        <DetectorTypeForm />
-      </NewDetectorLayout>
+      <NewDetectorDocumentTitle />
+      <Layout.Page>
+        <StyledLayoutHeader>
+          <Layout.HeaderContent>
+            <NewDetectorBreadcrumbs />
+            <Layout.Title>
+              <EditableDetectorTitle />
+            </Layout.Title>
+          </Layout.HeaderContent>
+        </StyledLayoutHeader>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <DetectorTypeForm />
+          </Layout.Main>
+        </Layout.Body>
+      </Layout.Page>
       <StickyFooter>
         <StickyFooterLabel>{t('Step 1 of 2')}</StickyFooterLabel>
         <Flex gap={space(1)}>
@@ -62,6 +97,10 @@ export default function DetectorNew() {
     </FullHeightForm>
   );
 }
+
+const StyledLayoutHeader = styled(Layout.Header)`
+  background-color: ${p => p.theme.background};
+`;
 
 // Make the form full height
 const FullHeightForm = styled(Form)`

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -1,5 +1,9 @@
+import styled from '@emotion/styled';
+
 import {Flex} from 'sentry/components/container/flex';
+import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
+import Form from 'sentry/components/forms/form';
 import {
   StickyFooter,
   StickyFooterLabel,
@@ -7,29 +11,67 @@ import {
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {DetectorTypeForm} from 'sentry/views/detectors/components/detectorTypeForm';
 import NewDetectorLayout from 'sentry/views/detectors/layouts/new';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
 export default function DetectorNew() {
+  const navigate = useNavigate();
   const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
+  const {projects} = useProjects();
+
+  const defaultProject = projects.find(p => p.isMember) ?? projects[0];
 
   return (
-    <NewDetectorLayout>
-      <DetectorTypeForm />
+    <FullHeightForm
+      onSubmit={data => {
+        navigate({
+          pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
+          // Filter out empty values
+          query: Object.fromEntries(
+            Object.entries(data).filter(([_, value]) => value !== '')
+          ),
+        });
+      }}
+      hideFooter
+      initialData={{
+        detectorType: 'metric',
+        project: defaultProject?.id,
+        title: '',
+        environment: '',
+      }}
+    >
+      <NewDetectorLayout>
+        <DetectorTypeForm />
+      </NewDetectorLayout>
       <StickyFooter>
         <StickyFooterLabel>{t('Step 1 of 2')}</StickyFooterLabel>
         <Flex gap={space(1)}>
           <LinkButton priority="default" to={makeMonitorBasePathname(organization.slug)}>
             {t('Cancel')}
           </LinkButton>
-          <LinkButton priority="primary" to="settings">
+          <Button priority="primary" type="submit">
             {t('Next')}
-          </LinkButton>
+          </Button>
         </Flex>
       </StickyFooter>
-    </NewDetectorLayout>
+    </FullHeightForm>
   );
 }
+
+// Make the form full height
+const FullHeightForm = styled(Form)`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+
+  & > div:first-child {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+`;


### PR DESCRIPTION
On the first step of creating a new detector we let the user decide:
- Detector type
- Project
- Environment (optional)
- title (optional)

We send them to a new route on "next", we preserve their choices by setting query parameters.
