### PR TITLE
feat(feedback): add react native and flutter widget feedback onboarding

### DIFF
--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -90,6 +90,10 @@ export function FeedbackOnboardingLayout({
     projectKeyId,
   ]);
 
+  const hideFeedbackConfigTogglePlatforms = ['flutter'];
+  const hideFeedbackConfigToggle =
+    hideFeedbackConfigTogglePlatforms.includes(platformKey);
+
   return (
     <AuthTokenGeneratorProvider projectSlug={projectSlug}>
       <Wrapper>
@@ -101,7 +105,7 @@ export function FeedbackOnboardingLayout({
                 key={step.title ?? step.type}
                 {...{
                   ...step,
-                  codeHeader: (
+                  codeHeader: !hideFeedbackConfigToggle && (
                     <FeedbackConfigToggle
                       emailToggle={email}
                       nameToggle={name}

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -272,6 +272,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   }
 
   const excludedPlatformOptions = ['react-native', 'flutter'];
+  const isExcluded = excludedPlatformOptions.includes(currentPlatform.id);
 
   const radioButtons = (
     <Header>
@@ -317,7 +318,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       ) : (
         newDocs?.platformOptions &&
         widgetPlatform &&
-        !excludedPlatformOptions.includes(currentPlatform.id) &&
+        !isExcluded &&
         !crashReportOnboarding &&
         !isLoading && (
           <PlatformSelect>

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -271,6 +271,8 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     return <FeedbackOnboardingWebApiBanner />;
   }
 
+  const excludedPlatformOptions = ['react-native'];
+
   const radioButtons = (
     <Header>
       {showRadioButtons ? (
@@ -315,6 +317,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       ) : (
         newDocs?.platformOptions &&
         widgetPlatform &&
+        !excludedPlatformOptions.includes(currentPlatform.id) &&
         !crashReportOnboarding &&
         !isLoading && (
           <PlatformSelect>

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -271,7 +271,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     return <FeedbackOnboardingWebApiBanner />;
   }
 
-  const excludedPlatformOptions = ['react-native'];
+  const excludedPlatformOptions = ['react-native', 'flutter'];
 
   const radioButtons = (
     <Header>

--- a/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding.tsx
@@ -24,6 +24,23 @@ export const getFeedbackConfigureDescription = ({
     }
   );
 
+export const getFeedbackConfigureMobileDescription = ({
+  linkConfig,
+  linkButton,
+}: {
+  linkButton: string;
+  linkConfig: string;
+}) =>
+  tct(
+    'To set up the integration, add the following to your Sentry initialization. There are many options you can pass to the [code:integrations] constructor to customize your form. [break] [break] You can even [linkButton:customize your button] style. Learn more about configuring User Feedback by reading the [linkConfig:configuration docs].',
+    {
+      code: <code />,
+      break: <br />,
+      linkConfig: <ExternalLink href={linkConfig} />,
+      linkButton: <ExternalLink href={linkButton} />,
+    }
+  );
+
 export const getFeedbackSDKSetupSnippet = ({
   importStatement,
   dsn,

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -521,6 +521,7 @@ export const replayJsLoaderInstructionsPlatformList: readonly PlatformKey[] = [
 export const feedbackNpmPlatforms: readonly PlatformKey[] = [
   'ionic',
   'react-native',
+  'flutter',
   ...replayFrontendPlatforms,
 ];
 
@@ -545,7 +546,6 @@ export const feedbackCrashApiPlatforms: readonly PlatformKey[] = [
   'dotnet-wpf',
   'dotnet-winforms',
   'dotnet-xamarin',
-  'flutter',
   'java',
   'java-log4j2',
   'java-logback',

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -520,6 +520,7 @@ export const replayJsLoaderInstructionsPlatformList: readonly PlatformKey[] = [
 // Feedback platforms that show only NPM widget setup instructions (no loader)
 export const feedbackNpmPlatforms: readonly PlatformKey[] = [
   'ionic',
+  'react-native',
   ...replayFrontendPlatforms,
 ];
 
@@ -550,7 +551,6 @@ export const feedbackCrashApiPlatforms: readonly PlatformKey[] = [
   'java-logback',
   'kotlin',
   'node-koa',
-  'react-native',
   'unity',
   'unreal',
 ];

--- a/static/app/gettingStartedDocs/react-native/react-native.tsx
+++ b/static/app/gettingStartedDocs/react-native/react-native.tsx
@@ -13,6 +13,8 @@ import type {
 import {
   getCrashReportApiIntroduction,
   getCrashReportInstallDescription,
+  getFeedbackConfigOptions,
+  getFeedbackConfigureMobileDescription,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
 import {
   getReplayMobileConfigureDescription,
@@ -131,6 +133,26 @@ Sentry.mobileReplayIntegration({
   maskAllVectors: true,
 }),`;
 
+const getFeedbackConfigureSnippet = (params: Params) => `
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  integrations: [
+    Sentry.feedbackIntegration({
+      // Additional SDK configuration goes in here, for example:
+      styles: {
+        submitButton: {
+          backgroundColor: "#6a1b9a",
+        },
+      },
+      namePlaceholder: "Fullname",
+      ${getFeedbackConfigOptions(params.feedbackOptions)}
+    }),
+  ],
+});
+`;
+
 const getReactNativeProfilingOnboarding = (): OnboardingConfig => ({
   install: params => [
     {
@@ -176,6 +198,82 @@ const getReactNativeProfilingOnboarding = (): OnboardingConfig => ({
     },
   ],
 });
+
+const feedbackOnboarding: OnboardingConfig<PlatformOptions> = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: t(
+        "If you're using a self-hosted Sentry instance, you'll need to be on version 24.4.2 or higher in order to use the full functionality of the User Feedback feature. Lower versions may have limited functionality."
+      ),
+      configurations: [
+        {
+          description: tct(
+            'To collect user feedback from inside your application, use the [code:showFeedbackWidget] method.',
+            {code: <code />}
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: `import * as Sentry from "@sentry/react-native";
+
+Sentry.wrap(RootComponent);
+Sentry.showFeedbackWidget();`,
+            },
+          ],
+        },
+        {
+          description: tct(
+            'You may also use the [code:showFeedbackButton] and [code:hideFeedbackButton] to show and hide a button that opens the Feedback Widget.',
+            {
+              code: <code />,
+            }
+          ),
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: `import * as Sentry from "@sentry/react-native";
+
+Sentry.wrap(RootComponent);
+
+Sentry.showFeedbackWidget();
+Sentry.hideFeedbackButton();`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: getFeedbackConfigureMobileDescription({
+        linkConfig:
+          'https://docs.sentry.io/platforms/react-native/user-feedback/configuration/',
+        linkButton:
+          'https://docs.sentry.io/platforms/react-native/user-feedback/configuration/#feedback-button-customization',
+      }),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getFeedbackConfigureSnippet(params),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: () => [],
+  nextSteps: () => [],
+};
 
 const onboarding: OnboardingConfig<PlatformOptions> = {
   install: params =>
@@ -568,7 +666,7 @@ const replayOnboarding: OnboardingConfig<PlatformOptions> = {
 
 const docs: Docs<PlatformOptions> = {
   onboarding,
-  feedbackOnboardingCrashApi,
+  feedbackOnboardingNpm: feedbackOnboarding,
   crashReportOnboarding: feedbackOnboardingCrashApi,
   replayOnboarding,
   platformOptions,


### PR DESCRIPTION
mirrors the docs from https://docs.sentry.io/platforms/react-native/user-feedback/ and https://docs.sentry.io/platforms/dart/guides/flutter/user-feedback/

closes https://linear.app/getsentry/issue/REPLAY-399/update-onboarding-flyout-for-react-native-and-flutter-for-user

## RN: 

https://github.com/user-attachments/assets/f06e562a-9343-4c66-969d-bc5d6d366183

## Flutter: 

<img width="658" alt="SCR-20250610-octy" src="https://github.com/user-attachments/assets/c7e24682-9f6f-423f-b7f4-b30cea8cc315" />

