### PR TITLE
feat(aci): Report metrics on bulk snuba querying

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -574,7 +574,9 @@ def process_delayed_workflows(
         },
     )
 
-    condition_group_results = get_condition_group_results(condition_groups)
+    with metrics.timer("workflow_engine.delayed_workflow.get_condition_group_results"):
+        condition_group_results = get_condition_group_results(condition_groups)
+
     logger.info(
         "delayed_workflow.condition_group_results",
         extra={

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -574,7 +574,11 @@ def process_delayed_workflows(
         },
     )
 
-    with metrics.timer("workflow_engine.delayed_workflow.get_condition_group_results"):
+    with metrics.timer(
+        "workflow_engine.delayed_workflow.get_condition_group_results",
+        # We want this to be accurate enough for alerting, so sample 100%
+        sample_rate=1.0,
+    ):
         condition_group_results = get_condition_group_results(condition_groups)
 
     logger.info(


### PR DESCRIPTION
Add a `metrics.timer` around get_condition_group_results, allowing us to monitor for persistent issues that impact success rate and latency.
