### PR TITLE
fix(useTeamsById): Fix fetching multiple team IDs

### DIFF
--- a/static/app/utils/useOwners.spec.tsx
+++ b/static/app/utils/useOwners.spec.tsx
@@ -10,6 +10,7 @@ import MemberListStore from 'sentry/stores/memberListStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useOwners} from './useOwners';
 
@@ -24,7 +25,11 @@ describe('useOwners', () => {
   const queryClient = makeTestQueryClient();
 
   function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    return (
+      <OrganizationContext.Provider value={org}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </OrganizationContext.Provider>
+    );
   }
 
   beforeEach(() => {

--- a/static/app/utils/useTeamsById.spec.tsx
+++ b/static/app/utils/useTeamsById.spec.tsx
@@ -96,7 +96,7 @@ describe('useTeamsById', function () {
     expect(teams).toEqual(expect.arrayContaining(mockTeams));
   });
 
-  it('can load teams by id', async function () {
+  it('can load team by id', async function () {
     const requestedTeams = [TeamFixture({id: '2', slug: 'requested-team'})];
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/teams/`,
@@ -112,7 +112,10 @@ describe('useTeamsById', function () {
     });
 
     expect(result.current.isLoading).toBe(true);
-    expect(mockRequest).toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({query: {query: 'id:2'}})
+    );
 
     await waitFor(() => expect(result.current.teams).toHaveLength(1));
 
@@ -121,16 +124,79 @@ describe('useTeamsById', function () {
     expect(TeamStore.getState().teams).toEqual(expect.arrayContaining(requestedTeams));
   });
 
-  it('only loads ids when needed', function () {
+  it('can load multiple teams by id', async function () {
+    const requestedTeams = [
+      TeamFixture({id: '2', slug: 'requested-team'}),
+      TeamFixture({id: '3', slug: 'requested-team-2'}),
+    ];
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      method: 'GET',
+      body: requestedTeams,
+    });
+
     TeamStore.loadInitialData(mockTeams);
 
     const {result} = renderHook(useTeamsById, {
-      initialProps: {ids: [mockTeams[0]!.id]},
+      initialProps: {ids: ['2', '3']},
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({query: {query: 'id:2 id:3'}})
+    );
+
+    await waitFor(() => expect(result.current.teams).toHaveLength(2));
+
+    const {teams} = result.current;
+    expect(teams).toEqual(expect.arrayContaining(requestedTeams));
+    expect(TeamStore.getState().teams).toEqual(expect.arrayContaining(requestedTeams));
+  });
+
+  it('does not fetch anything if the teams are already loaded', function () {
+    TeamStore.loadInitialData(mockTeams);
+
+    const {result} = renderHook(useTeamsById, {
+      initialProps: {ids: ['1']},
       wrapper,
     });
 
     const {teams, isLoading} = result.current;
     expect(isLoading).toBe(false);
     expect(teams).toEqual(expect.arrayContaining(mockTeams));
+  });
+
+  it('only loads ids when needed', async function () {
+    const mockTeamsToFetch = [
+      TeamFixture({id: '1', slug: 'requested-team-1'}),
+      TeamFixture({id: '2', slug: 'requested-team-2'}),
+    ];
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      method: 'GET',
+      match: [MockApiClient.matchQuery({query: 'id:2'})],
+      body: [mockTeamsToFetch[1]],
+    });
+
+    // Team 1 is already loaded
+    TeamStore.loadInitialData([mockTeamsToFetch[0]!]);
+
+    // Request teams 1 and 2
+    const {result} = renderHook(useTeamsById, {
+      initialProps: {ids: ['1', '2']},
+      wrapper,
+    });
+
+    // Should return both teams
+    await waitFor(() => expect(result.current.teams).toEqual(mockTeamsToFetch));
+
+    // Should only have fetched team 2
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({query: {query: 'id:2'}})
+    );
   });
 });

--- a/static/app/utils/useTeamsById.spec.tsx
+++ b/static/app/utils/useTeamsById.spec.tsx
@@ -6,6 +6,7 @@ import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {useTeamsById as useTeamsById} from './useTeamsById';
 
@@ -22,7 +23,9 @@ describe('useTeamsById', function () {
   const mockTeams = [TeamFixture()];
 
   const wrapper = ({children}: {children?: any}) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <OrganizationContext.Provider value={org}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </OrganizationContext.Provider>
   );
 
   beforeEach(function () {

--- a/static/app/utils/useTeamsById.tsx
+++ b/static/app/utils/useTeamsById.tsx
@@ -1,11 +1,11 @@
 import {useEffect, useMemo} from 'react';
 
-import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Team} from 'sentry/types/organization';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface UseTeamsById {
   ids: string[] | undefined;
@@ -53,18 +53,18 @@ function buildTeamsQueryKey(
  * ```
  */
 export function useTeamsById(options: UseTeamOptions = {}): UseTeamsResult {
-  const {organization} = useLegacyStore(OrganizationStore);
+  const organization = useOrganization({allowNull: true});
   const storeState = useLegacyStore(TeamStore);
 
   const teamQueryValues = useMemo<{
     property: 'id' | 'slug';
     values: Set<string> | undefined;
   } | null>(() => {
-    if ('ids' in options) {
+    if ('ids' in options && options.ids?.length) {
       return {property: 'id', values: new Set(options.ids)};
     }
 
-    if ('slugs' in options) {
+    if ('slugs' in options && options.slugs?.length) {
       return {property: 'slug', values: new Set(options.slugs)};
     }
 
@@ -90,6 +90,7 @@ export function useTeamsById(options: UseTeamOptions = {}): UseTeamsResult {
         missingValues ?? []
       )
     : ([`/organizations/${organization?.slug}/teams/`] as const);
+
   const {
     data: additionalTeams = [],
     isPending,

--- a/static/app/utils/useTeamsById.tsx
+++ b/static/app/utils/useTeamsById.tsx
@@ -28,37 +28,22 @@ interface UseTeamsResult {
   teams: Team[];
 }
 
-type TeamQuery = [field: string, ids: string[]];
-
-function buildTeamsQueryKey(orgSlug: string, teamQuery: TeamQuery | null): ApiQueryKey {
-  const query: {query?: string} = {};
-
-  if (teamQuery?.[1].length) {
-    query.query = `${teamQuery[0]}:${teamQuery[1].join(',')}`;
+function buildTeamsQueryKey(
+  orgSlug: string,
+  property: 'id' | 'slug',
+  values: string[]
+): ApiQueryKey {
+  if (property === 'id') {
+    return [
+      `/organizations/${orgSlug}/teams/`,
+      {query: {query: values.map(id => `id:${id}`).join(' ')}},
+    ];
   }
 
-  return [`/organizations/${orgSlug}/teams/`, {query}];
-}
-
-/**
- * @returns a tuple of the identifier field and the list of identifiers
- */
-function getQueryFromOptions(options: UseTeamOptions): TeamQuery | null {
-  if ('ids' in options) {
-    if (!options.ids?.length) {
-      return null;
-    }
-    return ['id', options.ids];
-  }
-
-  if ('slugs' in options) {
-    if (!options.slugs?.length) {
-      return null;
-    }
-    return ['slug', options.slugs];
-  }
-
-  return null;
+  return [
+    `/organizations/${orgSlug}/teams/`,
+    {query: {query: `slug:${values.join(',')}`}},
+  ];
 }
 
 /**
@@ -71,19 +56,40 @@ export function useTeamsById(options: UseTeamOptions = {}): UseTeamsResult {
   const {organization} = useLegacyStore(OrganizationStore);
   const storeState = useLegacyStore(TeamStore);
 
-  const query = useMemo<TeamQuery | null>(() => getQueryFromOptions(options), [options]);
-  const missingIds = query
-    ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      query[1].filter(id => !storeState.teams.some(team => team[query[0]] === id))
+  const teamQueryValues = useMemo<{
+    property: 'id' | 'slug';
+    values: Set<string> | undefined;
+  } | null>(() => {
+    if ('ids' in options) {
+      return {property: 'id', values: new Set(options.ids)};
+    }
+
+    if ('slugs' in options) {
+      return {property: 'slug', values: new Set(options.slugs)};
+    }
+
+    return null;
+  }, [options]);
+
+  const missingValues = teamQueryValues?.values
+    ? Array.from(teamQueryValues.values).filter(
+        value => !storeState.teams.some(team => team[teamQueryValues.property] === value)
+      )
     : [];
 
   // Wait until the store has loaded to start fetching
   const shouldConsiderFetching = !!organization?.slug && !storeState.loading;
   // Only fetch if there are missing teams
-  const hasMissing = missingIds.length > 0;
+  const hasMissing = missingValues.length > 0;
   const queryEnabled = shouldConsiderFetching && hasMissing;
 
-  const queryKey = buildTeamsQueryKey(organization?.slug ?? '', query);
+  const queryKey = teamQueryValues
+    ? buildTeamsQueryKey(
+        organization?.slug ?? '',
+        teamQueryValues.property,
+        missingValues ?? []
+      )
+    : ([`/organizations/${organization?.slug}/teams/`] as const);
   const {
     data: additionalTeams = [],
     isPending,
@@ -101,11 +107,12 @@ export function useTeamsById(options: UseTeamOptions = {}): UseTeamsResult {
   }, [additionalTeams]);
 
   const teams = useMemo<Team[]>(() => {
-    return query
-      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        storeState.teams.filter(team => query[1].includes(team[query[0]]))
+    return teamQueryValues
+      ? storeState.teams.filter(team =>
+          teamQueryValues.values?.has(team[teamQueryValues.property])
+        )
       : storeState.teams;
-  }, [storeState.teams, query]);
+  }, [storeState.teams, teamQueryValues]);
 
   return {
     teams,


### PR DESCRIPTION
While trying to use this hook, I found that it did not work when passing multiple team IDs. The backend expects the query to be `id:1 id:2` instead of `id:1,2`. Fixed that and cleaned up the hook while I was in here.

Changes:

- Fix fetching teams with multiple IDs
- Fix overfetching when the store has a subset of the IDs passed to it (e.g. the store has `{id: 1}` and you pass `{id: [1, 2]` - this hook should only fetch team 2)
- Refactor to avoid typescript errors