### PR TITLE
fix(events): Filter {next,prev}EventID using stats query

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -234,5 +234,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             environments=environment_names,
             include_full_release_data="fullRelease" not in collapse,
             conditions=conditions,
+            start=start,
+            end=end,
         )
         return Response(data)

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -134,6 +134,36 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
             response_with_collapse.data["release"]
         )
 
+    def test_prev_filtered(self) -> None:
+        url = f"/api/0/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
+        response = self.client.get(
+            url,
+            {
+                "start": self.event_b.datetime.isoformat(),
+                "end": before_now(minutes=0),
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["previousEventID"] is None
+        assert response.data["nextEventID"] == str(self.event_c.event_id)
+
+    def test_next_filtered(self) -> None:
+        url = f"/api/0/issues/{self.event_b.group.id}/events/{self.event_b.event_id}/"
+        response = self.client.get(
+            url,
+            {
+                "start": self.event_a.datetime.isoformat(),
+                "end": self.event_b.datetime.isoformat(),
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["previousEventID"] == str(self.event_a.event_id)
+        assert response.data["nextEventID"] is None
+
 
 class GroupEventDetailsHelpfulEndpointTest(
     GroupEventDetailsEndpointTestBase, APITestCase, SnubaTestCase, OccurrenceTestMixin


### PR DESCRIPTION
Fixes: [RTC-856: Issue Details: the timeline filter should apply to the event paginator](https://linear.app/getsentry/issue/RTC-856/issue-details-the-timeline-filter-should-apply-to-the-event-paginator)

Passing stat period parameters (such as start, end, period, etc) will now cause the `nextEventID` and `previousEventID` fields to respect these parameters.