### PR TITLE
feat: Update serializer types from integer to float

### DIFF
--- a/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
@@ -11,16 +11,16 @@ class TestResultAggregatesSerializer(serializers.Serializer):
     Serializer for test results aggregates response
     """
 
-    totalDuration = serializers.IntegerField()
-    totalDurationPercentChange = serializers.IntegerField()
-    slowestTestsDuration = serializers.IntegerField()
-    slowestTestsDurationPercentChange = serializers.IntegerField()
+    totalDuration = serializers.FloatField()
+    totalDurationPercentChange = serializers.FloatField()
+    slowestTestsDuration = serializers.FloatField()
+    slowestTestsDurationPercentChange = serializers.FloatField()
     totalSlowTests = serializers.IntegerField()
-    totalSlowTestsPercentChange = serializers.IntegerField()
+    totalSlowTestsPercentChange = serializers.FloatField()
     totalFails = serializers.IntegerField()
-    totalFailsPercentChange = serializers.IntegerField()
+    totalFailsPercentChange = serializers.FloatField()
     totalSkips = serializers.IntegerField()
-    totalSkipsPercentChange = serializers.IntegerField()
+    totalSkipsPercentChange = serializers.FloatField()
 
     def to_representation(self, graphql_response):
         """

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -33,12 +33,12 @@ class TestResultsAggregatesEndpointTest(APITestCase):
                         "__typename": "Repository",
                         "testAnalytics": {
                             "testResultsAggregates": {
-                                "totalDuration": 100,
-                                "totalDurationPercentChange": 10,
-                                "slowestTestsDuration": 100,
-                                "slowestTestsDurationPercentChange": 10,
+                                "totalDuration": 100.0,
+                                "totalDurationPercentChange": 11.11,
+                                "slowestTestsDuration": 100.0,
+                                "slowestTestsDurationPercentChange": 11.11,
                                 "totalSlowTests": 100,
-                                "totalSlowTestsPercentChange": 10,
+                                "totalSlowTestsPercentChange": 11.11,
                                 "totalFails": 100,
                                 "totalFailsPercentChange": 10,
                                 "totalSkips": 100,
@@ -63,13 +63,13 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         assert mock_codecov_client_instance.query.call_count == 1
         assert response.status_code == 200
 
-        assert response.data["totalDuration"] == 100
-        assert response.data["totalDurationPercentChange"] == 10
+        assert response.data["totalDuration"] == 100.0
+        assert response.data["totalDurationPercentChange"] == 11.11
         assert response.data["slowestTestsDuration"] == 100
-        assert response.data["slowestTestsDurationPercentChange"] == 10
+        assert response.data["slowestTestsDurationPercentChange"] == 11.11
         assert response.data["totalSlowTests"] == 100
-        assert response.data["totalSlowTestsPercentChange"] == 10
+        assert response.data["totalSlowTestsPercentChange"] == 11.11
         assert response.data["totalFails"] == 100
-        assert response.data["totalFailsPercentChange"] == 10
+        assert response.data["totalFailsPercentChange"] == 10.0
         assert response.data["totalSkips"] == 100
-        assert response.data["totalSkipsPercentChange"] == 10
+        assert response.data["totalSkipsPercentChange"] == 10.0


### PR DESCRIPTION
This PR fixes an issue where types coming from codecov were getting flattened from floats to integers due to the TestResultAggregatesSerializer defining the types incorrectly.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
