### PR TITLE
feat(autofix): Add setting to control automation stopping point

### DIFF
--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -262,6 +262,7 @@ export interface SeerRepoDefinition {
 
 export interface ProjectSeerPreferences {
   repositories: SeerRepoDefinition[];
+  automated_run_stopping_point?: 'solution' | 'code_changes' | 'open_pr';
 }
 
 export const AUTOFIX_TTL_IN_DAYS = 30;

--- a/static/app/views/settings/projectSeer/autofixRepositories.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepositories.tsx
@@ -44,6 +44,9 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
   const [selectedRepoIds, setSelectedRepoIds] = useState<string[]>([]);
   const [repoSettings, setRepoSettings] = useState<Record<string, RepoSettings>>({});
   const [showSaveNotice, setShowSaveNotice] = useState(false);
+  const [automatedRunStoppingPoint, setAutomatedRunStoppingPoint] = useState<
+    'solution' | 'code_changes' | 'open_pr'
+  >('solution');
 
   useEffect(() => {
     if (repositories) {
@@ -70,6 +73,9 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         });
 
         setRepoSettings(initialSettings);
+        setAutomatedRunStoppingPoint(
+          preference.automated_run_stopping_point || 'solution'
+        );
       } else if (codeMappingRepos?.length) {
         // Set default settings using codeMappingRepos when no preferences exist
         const repoIds = codeMappingRepos.map(repo => repo.external_id);
@@ -84,22 +90,26 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
         });
 
         setRepoSettings(initialSettings);
+        setAutomatedRunStoppingPoint('solution');
       }
     }
   }, [preference, repositories, codeMappingRepos, updateProjectSeerPreferences]);
 
   const updatePreferences = useCallback(
-    (updatedIds?: string[], updatedSettings?: Record<string, RepoSettings>) => {
+    (
+      updatedIds?: string[],
+      updatedSettings?: Record<string, RepoSettings>,
+      newStoppingPoint?: 'solution' | 'code_changes' | 'open_pr'
+    ) => {
       if (!repositories) {
         return;
       }
-
       const idsToUse = updatedIds || selectedRepoIds;
       const settingsToUse = updatedSettings || repoSettings;
+      const stoppingPointToUse = newStoppingPoint || automatedRunStoppingPoint;
       const selectedRepos = repositories.filter(repo =>
         idsToUse.includes(repo.externalId)
       );
-
       const reposData = selectedRepos.map(repo => {
         const [owner, name] = (repo.name || '/').split('/');
         return {
@@ -111,14 +121,19 @@ export function AutofixRepositories({project}: ProjectSeerProps) {
           instructions: settingsToUse[repo.externalId]?.instructions || '',
         };
       });
-
       updateProjectSeerPreferences({
         repositories: reposData,
+        automated_run_stopping_point: stoppingPointToUse,
       });
-
       setShowSaveNotice(true);
     },
-    [repositories, selectedRepoIds, repoSettings, updateProjectSeerPreferences]
+    [
+      repositories,
+      selectedRepoIds,
+      repoSettings,
+      automatedRunStoppingPoint,
+      updateProjectSeerPreferences,
+    ]
   );
 
   const handleSaveModalSelections = useCallback(

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -142,6 +142,7 @@ describe('ProjectSeer', function () {
         expect.anything(),
         expect.objectContaining({
           data: {
+            automated_run_stopping_point: 'solution',
             repositories: [
               {
                 branch_name: '',
@@ -197,6 +198,7 @@ describe('ProjectSeer', function () {
         expect.anything(),
         expect.objectContaining({
           data: {
+            automated_run_stopping_point: 'solution',
             repositories: [
               {
                 external_id: '101',
@@ -241,6 +243,7 @@ describe('ProjectSeer', function () {
         expect.anything(),
         expect.objectContaining({
           data: {
+            automated_run_stopping_point: 'solution',
             repositories: [],
           },
         })
@@ -333,6 +336,69 @@ describe('ProjectSeer', function () {
       expect(projectPutRequest).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({data: {seerScannerAutomation: true}})
+      );
+    });
+  });
+
+  it('can update the automation stopping point setting', async function () {
+    const initialProject: Project = {
+      ...project,
+      autofixAutomationTuning: 'medium',
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      method: 'GET',
+      body: initialProject,
+    });
+
+    const projectPutRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      method: 'PUT',
+      body: {},
+    });
+
+    const seerPreferencesPostRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/seer/preferences/`,
+      method: 'POST',
+    });
+
+    render(<ProjectSeer project={initialProject} />, {organization});
+
+    // Find the select menu for Stopping Point for Automatic Fixes
+    const select = await screen.findByRole('textbox', {
+      name: /Stopping Point for Automatic Fixes/i,
+    });
+
+    act(() => {
+      select.focus();
+    });
+
+    // Open the menu and select a new value (e.g., 'Code Changes')
+    await userEvent.click(select);
+    const option = await screen.findByText('Code Changes');
+    await userEvent.click(option);
+
+    // Form has saveOnBlur=true, so wait for the PUT request
+    await waitFor(() => {
+      expect(projectPutRequest).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(projectPutRequest).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({data: {automated_run_stopping_point: 'code_changes'}})
+      );
+    });
+
+    // Also check that the seer preferences POST was called with the new stopping point
+    await waitFor(() => {
+      expect(seerPreferencesPostRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            automated_run_stopping_point: 'code_changes',
+          }),
+        })
       );
     });
   });

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -5,6 +5,8 @@ import {useQueryClient} from '@tanstack/react-query';
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {Alert} from 'sentry/components/core/alert';
+import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
@@ -56,7 +58,7 @@ export const autofixAutomatingTuningField = {
   label: t('Automate Issue Fixes'),
   help: () =>
     t(
-      "Seer will automatically find a root cause and solution for incoming issues if it thinks the issue is actionable enough. It won't open PRs without your approval."
+      "Seer will automatically find a root cause and solution for incoming issues if it thinks the issue is actionable enough. By default, it won't open PRs without your approval."
     ),
   type: 'choice',
   options: [
@@ -105,16 +107,11 @@ export const autofixAutomatingTuningField = {
   saveMessage: t('Automatic Seer settings updated'),
 } satisfies FieldObject;
 
-const seerFormGroups: JsonFormObject[] = [
-  {
-    title: t('Automation'),
-    fields: [seerScannerAutomationField, autofixAutomatingTuningField],
-  },
-];
-
 function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
+  const {preference} = useProjectSeerPreferences(project);
+  const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
 
   const canWriteProject = hasEveryAccess(['project:write'], {organization, project});
 
@@ -131,9 +128,61 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
     [project.slug, queryClient, organization.slug]
   );
 
+  const handleStoppingPointChange = useCallback(
+    (value: 'solution' | 'code_changes' | 'open_pr') => {
+      updateProjectSeerPreferences({
+        repositories: preference?.repositories || [],
+        automated_run_stopping_point: value,
+      });
+    },
+    [updateProjectSeerPreferences, preference?.repositories]
+  );
+
+  const automatedRunStoppingPointField = {
+    name: 'automated_run_stopping_point',
+    label: t('Stopping Point for Automatic Fixes'),
+    help: () =>
+      t(
+        'Choose how far Seer should go without your approval when running automatically. This does not affect Issue Fixes that you manually start.'
+      ),
+    type: 'choice',
+    options: [
+      {
+        value: 'solution',
+        label: <SeerSelectLabel>{t('Solution (default)')}</SeerSelectLabel>,
+        details: t('Seer will stop after planning out a solution.'),
+      },
+      {
+        value: 'code_changes',
+        label: <SeerSelectLabel>{t('Code Changes')}</SeerSelectLabel>,
+        details: t('Seer will stop after writing the code changes.'),
+      },
+      {
+        value: 'open_pr',
+        label: <SeerSelectLabel>{t('Pull Request')}</SeerSelectLabel>,
+        details: t('Seer will go all the way and open a pull request automatically.'),
+      },
+    ],
+    saveOnBlur: true,
+    saveMessage: t('Stopping point updated'),
+    onChange: handleStoppingPointChange,
+  } satisfies FieldObject;
+
+  const seerFormGroups: JsonFormObject[] = [
+    {
+      title: t('Automation'),
+      fields: [
+        seerScannerAutomationField,
+        autofixAutomatingTuningField,
+        automatedRunStoppingPointField,
+      ],
+    },
+  ];
+
   return (
     <Fragment>
       <Form
+        key={preference?.automated_run_stopping_point ?? 'solution'}
         saveOnBlur
         apiMethod="PUT"
         apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
@@ -141,6 +190,8 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
         initialData={{
           seerScannerAutomation: project.seerScannerAutomation ?? false,
           autofixAutomationTuning: project.autofixAutomationTuning ?? 'off',
+          automated_run_stopping_point:
+            preference?.automated_run_stopping_point ?? 'solution',
         }}
         onSubmitSuccess={handleSubmitSuccess}
         additionalFieldProps={{organization}}


### PR DESCRIPTION
Adds selector to control whether autofix should run to solution, code changes, or open PR when automated.

<img width="1164" alt="Screenshot 2025-06-10 at 9 08 51 PM" src="https://github.com/user-attachments/assets/16c26c25-74b2-4cc5-84b2-ef7136494b93" />
