### PR TITLE
feat(browser repports): Add temporary reporting API collector endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -217,6 +217,7 @@ from sentry.issues.endpoints import (
     SourceMapDebugEndpoint,
     TeamGroupsOldEndpoint,
 )
+from sentry.issues.endpoints.browser_reporting_collector import BrowserReportingCollectorEndpoint
 from sentry.issues.endpoints.organization_group_search_view_starred_order import (
     OrganizationGroupSearchViewStarredOrderEndpoint,
 )
@@ -3490,6 +3491,12 @@ urlpatterns = [
         r"^secret-scanning/github/$",
         SecretScanningGitHubEndpoint.as_view(),
         name="sentry-api-0-secret-scanning-github",
+    ),
+    # Temporary public endpoint for proxying browser reports to GCP, to gather real-world data
+    re_path(
+        r"^reporting-api-experiment/$",
+        BrowserReportingCollectorEndpoint.as_view(),
+        name="sentry-api-0-reporting-api-experiment",
     ),
     # Catch all
     re_path(

--- a/src/sentry/issues/endpoints/browser_reporting_collector.py
+++ b/src/sentry/issues/endpoints/browser_reporting_collector.py
@@ -1,0 +1,47 @@
+import logging
+
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.parsers import JSONParser
+from rest_framework.request import Request
+
+from sentry import options
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, all_silo_endpoint, allow_cors_options
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+@all_silo_endpoint
+class BrowserReportingCollectorEndpoint(Endpoint):
+    """
+    An experimental endpoint which is a proxy for browser Reporting API reports. For now just
+    records metrics and forwards data to GCP, so we can collect real-world data on what gets sent,
+    how much gets sent, etc.
+    """
+
+    permission_classes = ()
+    # TODO: Do we need to specify this parser? Content type will be `application/reports+json`, so
+    # it might just work automatically.
+    parser_classes = [JSONParser]
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ISSUES
+
+    # TODO: It's unclear if either of these decorators is necessary
+    @csrf_exempt
+    @allow_cors_options
+    def post(self, request: Request, *args, **kwargs) -> HttpResponse:
+        if not options.get("issues.browser_reporting.collector_endpoint_enabled"):
+            return HttpResponse(status=404)
+
+        logger.info("browser_report_received", extra={"request_body": request.data})
+
+        metrics.incr(
+            "browser_reporting.raw_report_received", tags={"type": request.data.get("type")}
+        )
+
+        return HttpResponse(status=200)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3449,3 +3449,12 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Enable the collection of Reporting API reports via the `/api/0/reporting-api-experiment/`
+# endpoint. When this is false, the endpoint will just 404.
+register(
+    "issues.browser_reporting.collector_endpoint_enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/api/endpoints/test_browser_reporting_collector.py
+++ b/tests/sentry/api/endpoints/test_browser_reporting_collector.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.options import override_options
+
+
+class BrowserReportingCollectorEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-reporting-api-experiment"
+
+    def setUp(self):
+        super().setUp()
+
+        self.url = reverse(self.endpoint)
+        self.report_data = {
+            "age": 2,
+            "body": {
+                "columnNumber": 12,
+                "id": "RangeExpand",
+                "lineNumber": 31,
+                "message": "Range.expand() is deprecated. Please use Selection.modify() instead.",
+                "sourceFile": "https://dogs.are.great/_next/static/chunks/_4667019e._.js",
+            },
+            "type": "deprecation",
+            "url": "https://dogs.are.great/",
+            "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+        }
+
+    def test_404s_by_default(self):
+        response = self.client.post(self.url, self.report_data)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
+    @patch("sentry.issues.endpoints.browser_reporting_collector.metrics.incr")
+    @patch("sentry.issues.endpoints.browser_reporting_collector.logger.info")
+    def test_logs_request_data_if_option_enabled(
+        self, mock_logger_info: MagicMock, mock_metrics_incr: MagicMock
+    ):
+        response = self.client.post(self.url, self.report_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_logger_info.assert_any_call(
+            "browser_report_received", extra={"request_body": self.report_data}
+        )
+        mock_metrics_incr.assert_any_call(
+            "browser_reporting.raw_report_received", tags={"type": self.report_data["type"]}
+        )


### PR DESCRIPTION
This adds an API endpoint, `api/0/reporting-api-experiment`, to collect deprecation, intervention, and crash reports enabled by the [recently added `Reporting-Endpoints` header](https://github.com/getsentry/sentry/pull/93138). This will hopefully get us a bit more real-world data to work with when deciding how we want to group/process/etc the reports.

Since we don't yet  know what kind of volume we're going to see, by default the endpoint is a no-op, and just returns a 404. However, if the new `issues.browser_reporting.collector_endpoint_enabled` option is set to `True` (as we are planning to do in S4S), the endpoint will log the incoming report to GCP and collect a metric on the overall report type.

DISCLAIMER: This is proving hell on wheels to test locally. You have to proxy through an https server, it's unclear if the CORS and CSRF set up is correct, Chrome offers almost no data about the requests it's sending (and none at all unless you [flip a hidden flag](https://developer.chrome.com/docs/capabilities/web-apis/reporting-api#use_devtools)), you have to run Chrome [from the command line](https://developer.chrome.com/docs/capabilities/web-apis/reporting-api#save_time) (with a different hidden flag) in order to have the reports immediately rather than after a random delay... So thus far this endpoint has only been observed working a small handful of times, under circumstances that now seem unreplicable. However, since the entire thing is experimental and temporary (and by default doesn't do anything), we decided in the interest of time to just give it a shot and see what comes through.

If we want to guarantee reports will be sent (to test if it's working at all), adding `navigator.vibrate(2000)` to our FE pageload will generate an intervention report, and adding `new Range().expand("dogs.are.great", 0, 1)` anywhere in our FE will generate a deprecation report.