### PR TITLE
Cleanup imports to always use the top level api.

### DIFF
--- a/src/sentry/api/bases/group.py
+++ b/src/sentry/api/bases/group.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import sentry_sdk
 from rest_framework.permissions import SAFE_METHODS
 from rest_framework.request import Request
 
@@ -14,7 +15,7 @@ from sentry.integrations.tasks import create_comment, update_comment
 from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
-from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.utils.sdk import bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ class GroupEndpoint(Endpoint):
 
         self.check_object_permissions(request, group)
 
-        Scope.get_isolation_scope().set_tag("project", group.project_id)
+        sentry_sdk.get_isolation_scope().set_tag("project", group.project_id)
 
         # we didn't bind context above, so do it now
         if not organization:

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -4,6 +4,7 @@ import http
 from collections.abc import Mapping
 from typing import Any
 
+import sentry_sdk
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -183,7 +184,7 @@ class ProjectEndpoint(Endpoint):
 
         self.check_object_permissions(request, project)
 
-        Scope.get_isolation_scope().set_tag("project", project.id)
+        sentry_sdk.get_isolation_scope().set_tag("project", project.id)
 
         bind_organization_context(project.organization)
 

--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -1,8 +1,8 @@
 import pydantic
+import sentry_sdk
 from rest_framework.exceptions import NotFound, ParseError, PermissionDenied, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import Scope, capture_exception
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -32,7 +32,7 @@ class InternalRpcServiceEndpoint(Endpoint):
         return False
 
     def post(self, request: Request, service_name: str, method_name: str) -> Response:
-        Scope.get_isolation_scope().set_tag("rpc_method", f"{service_name}.{method_name}")
+        sentry_sdk.get_isolation_scope().set_tag("rpc_method", f"{service_name}.{method_name}")
         if not self._is_authorized(request):
             raise PermissionDenied
 
@@ -53,17 +53,17 @@ class InternalRpcServiceEndpoint(Endpoint):
                 # from within the privileged RPC channel.
                 auth_context = AuthenticationContext.parse_obj(auth_context_json)
             except pydantic.ValidationError as e:
-                capture_exception()
+                sentry_sdk._exception()
                 raise ParseError from e
 
         try:
             with auth_context.applied_to_request(request):
                 result = dispatch_to_local_service(service_name, method_name, arguments)
         except RpcResolutionException as e:
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise NotFound from e
         except SerializableFunctionValueException as e:
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise ParseError from e
         except Exception as e:
             # Produce more detailed log
@@ -71,6 +71,6 @@ class InternalRpcServiceEndpoint(Endpoint):
                 raise Exception(
                     f"Problem processing rpc service endpoint {service_name}/{method_name}"
                 ) from e
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise ValidationError from e
         return Response(data=result)

--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -53,7 +53,7 @@ class InternalRpcServiceEndpoint(Endpoint):
                 # from within the privileged RPC channel.
                 auth_context = AuthenticationContext.parse_obj(auth_context_json)
             except pydantic.ValidationError as e:
-                sentry_sdk._exception()
+                sentry_sdk.capture_exception()
                 raise ParseError from e
 
         try:

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework.exceptions import ParseError
@@ -38,7 +39,7 @@ from sentry.models.release import Release, ReleaseStatus
 from sentry.models.releases.exceptions import ReleaseCommitError, UnsafeReleaseDeletion
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
-from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.utils.sdk import bind_organization_context
 
 
 class InvalidSortException(Exception):
@@ -435,7 +436,7 @@ class OrganizationReleaseDetailsEndpoint(
         """
         bind_organization_context(organization)
 
-        scope = Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
         scope.set_tag("version", version)
         try:
             release = Release.objects.get(organization_id=organization, version=version)

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from datetime import datetime, timedelta
 
+import sentry_sdk
 from django.db import IntegrityError
 from django.db.models import F, Q
 from rest_framework.exceptions import ParseError
@@ -47,7 +48,7 @@ from sentry.signals import release_created
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache
-from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.utils.sdk import bind_organization_context
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
 
@@ -476,7 +477,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
             data=request.data, context={"organization": organization}
         )
 
-        scope = Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
         if serializer.is_valid():
             result = serializer.validated_data
             scope.set_tag("version", result["version"])

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -16,7 +17,7 @@ from sentry.models.releases.exceptions import UnsafeReleaseDeletion
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
-from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.utils.sdk import bind_organization_context
 
 
 @region_silo_endpoint
@@ -95,7 +96,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
         :auth: required
         """
         bind_organization_context(project.organization)
-        scope = Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
         scope.set_tag("version", version)
         try:
             release = Release.objects.get(

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sentry_sdk
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from rest_framework.request import Request
@@ -22,7 +23,7 @@ from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.signals import release_created
 from sentry.types.activity import ActivityType
-from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.utils.sdk import bind_organization_context
 
 
 @region_silo_endpoint
@@ -117,7 +118,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
             data=request.data, context={"organization": project.organization}
         )
 
-        scope = Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/project_stacktrace_coverage.py
+++ b/src/sentry/api/endpoints/project_stacktrace_coverage.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import Scope, start_span
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -58,14 +58,14 @@ class ProjectStacktraceCoverageEndpoint(ProjectEndpoint):
 
         # Post-processing before exiting scope context
         if result["current_config"]:
-            scope = Scope.get_isolation_scope()
+            scope = sentry_sdk.get_isolation_scope()
 
             serialized_config = serialize(result["current_config"]["config"], request.user)
             provider = serialized_config["provider"]["key"]
             # Use the provider key to split up stacktrace-link metrics by integration type
             scope.set_tag("integration_provider", provider)  # e.g. github
 
-            with start_span(op="fetch_codecov_data"):
+            with sentry_sdk.start_span(op="fetch_codecov_data"):
                 with metrics.timer("issues.stacktrace.fetch_codecov_data"):
                     codecov_data = fetch_codecov_data(
                         config={

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
@@ -24,7 +25,6 @@ from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
 )
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
-from sentry_sdk import Scope, capture_exception
 
 from sentry import options
 from sentry.api.api_owners import ApiOwner
@@ -116,7 +116,7 @@ class SeerRpcSignatureAuthentication(StandardAuthentication):
         if not compare_signature(request.path_info, request.body, token):
             raise AuthenticationFailed("Invalid signature")
 
-        Scope.get_isolation_scope().set_tag("seer_rpc_auth", True)
+        sentry_sdk.get_isolation_scope().set_tag("seer_rpc_auth", True)
 
         return (AnonymousUser(), token)
 
@@ -164,21 +164,21 @@ class SeerRpcServiceEndpoint(Endpoint):
         try:
             result = self._dispatch_to_local_method(method_name, arguments)
         except RpcResolutionException as e:
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise NotFound from e
         except SerializableFunctionValueException as e:
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise ParseError from e
         except ObjectDoesNotExist as e:
             # Let this fall through, this is normal.
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise NotFound from e
         except Exception as e:
             if in_test_environment():
                 raise
             if settings.DEBUG:
                 raise Exception(f"Problem processing seer rpc endpoint {method_name}") from e
-            capture_exception()
+            sentry_sdk.capture_exception()
             raise ValidationError from e
         return Response(data=result)
 

--- a/src/sentry/integrations/api/bases/doc_integrations.py
+++ b/src/sentry/integrations/api/bases/doc_integrations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import sentry_sdk
 from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -12,7 +13,6 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.integrations.api.bases.integration import PARANOID_GET
 from sentry.integrations.api.parsers.doc_integration import METADATA_PROPERTIES
 from sentry.integrations.models.doc_integration import DocIntegration
-from sentry.utils.sdk import Scope
 
 
 class DocIntegrationsPermission(SentryPermission):
@@ -89,7 +89,7 @@ class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):
 
         self.check_object_permissions(request, doc_integration)
 
-        Scope.get_isolation_scope().set_tag("doc_integration", doc_integration.slug)
+        sentry_sdk.get_isolation_scope().set_tag("doc_integration", doc_integration.slug)
 
         kwargs["doc_integration"] = doc_integration
         return (args, kwargs)

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, NamedTuple, Never, NoReturn, NotRequired, TypedDict
 
+import sentry_sdk
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 
@@ -46,7 +47,6 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.users.models.identity import Identity
 from sentry.utils.audit import create_audit_entry, create_system_audit_entry
-from sentry.utils.sdk import Scope
 
 if TYPE_CHECKING:
     from django.utils.functional import _StrPromise
@@ -452,7 +452,7 @@ class IntegrationInstallation(abc.ABC):
                 raise Identity.DoesNotExist
         identity = identity_service.get_identity(filter={"id": org_integration.default_auth_id})
         if identity is None:
-            scope = Scope.get_isolation_scope()
+            scope = sentry_sdk.get_isolation_scope()
             scope.set_tag("integration_provider", self.model.get_provider().name)
             scope.set_tag("org_integration_id", org_integration.id)
             scope.set_tag("default_auth_id", org_integration.default_auth_id)

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -27,7 +27,6 @@ from sentry.integrations.github.webhook import (
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.utils import metrics
-from sentry.utils.sdk import Scope
 
 logger = logging.getLogger("sentry.webhooks")
 from sentry.api.base import Endpoint, region_silo_endpoint
@@ -152,7 +151,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
 
     def _handle(self, request: HttpRequest) -> HttpResponse:
         clear_tags_and_context()
-        scope = Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
 
         try:
             host = get_host(request=request)

--- a/src/sentry/integrations/jira/views/sentry_issue_details.py
+++ b/src/sentry/integrations/jira/views/sentry_issue_details.py
@@ -6,6 +6,7 @@ from functools import reduce
 from typing import Any
 from urllib.parse import quote
 
+import sentry_sdk
 from django.db.models.query import QuerySet
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
@@ -25,7 +26,6 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
-from sentry.utils.sdk import Scope
 from sentry.web.frontend.base import region_silo_view
 
 from ..utils import handle_jira_api_error, set_badge
@@ -124,7 +124,7 @@ class JiraSentryIssueDetailsView(JiraSentryUIBaseView):
             raise
 
     def get(self, request: Request, issue_key, *args, **kwargs) -> Response:
-        scope = Scope.get_isolation_scope()
+        scope = sentry_sdk.get_isolation_scope()
 
         try:
             integration = get_integration_from_request(request, "jira")

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from functools import wraps
 from typing import Any
 
+import sentry_sdk
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -31,7 +32,6 @@ from sentry.sentry_apps.utils.errors import (
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
-from sentry.utils.sdk import Scope
 from sentry.utils.strings import to_single_line_str
 
 COMPONENT_TYPES = ["stacktrace-link", "issue-link"]
@@ -287,7 +287,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 
         self.check_object_permissions(request, sentry_app)
 
-        Scope.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
+        sentry_sdk.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
 
         kwargs["sentry_app"] = sentry_app
         return (args, kwargs)
@@ -306,7 +306,7 @@ class RegionSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 
         self.check_object_permissions(request, sentry_app)
 
-        Scope.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
+        sentry_sdk.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
 
         kwargs["sentry_app"] = sentry_app
         return (args, kwargs)
@@ -432,7 +432,7 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
 
         self.check_object_permissions(request, installation)
 
-        Scope.get_isolation_scope().set_tag("sentry_app_installation", installation.uuid)
+        sentry_sdk.get_isolation_scope().set_tag("sentry_app_installation", installation.uuid)
 
         kwargs["installation"] = installation
         return (args, kwargs)

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -40,7 +40,7 @@ from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import attachments_tasks
 from sentry.utils import metrics, redis
 from sentry.utils.db import atomic_transaction
-from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.utils.sdk import bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +240,7 @@ def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
     from sentry.models.debugfile import BadDif, create_dif_from_id, detect_dif_from_path
     from sentry.models.project import Project
 
-    Scope.get_isolation_scope().set_tag("project", project_id)
+    sentry_sdk.get_isolation_scope().set_tag("project", project_id)
 
     delete_file = False
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -108,7 +108,7 @@ def is_current_event_safe():
     Tests the current stack for unsafe locations that would likely cause
     recursion if an attempt to send to Sentry was made.
     """
-    scope = Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     # Scope was explicitly marked as unsafe
     if scope._tags.get(UNSAFE_TAG):
@@ -135,7 +135,7 @@ def set_current_event_project(project_id):
     relevant to event processing, or that task may crash ingesting
     sentry-internal errors, causing infinite recursion.
     """
-    scope = Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     scope.set_tag("processing_event_for_project", project_id)
     scope.set_tag("project", project_id)
@@ -506,7 +506,7 @@ def check_tag_for_scope_bleed(
     # force the string version to prevent false positives
     expected_value = str(expected_value)
 
-    scope = Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     current_value = scope._tags.get(tag_key)
 
@@ -627,7 +627,7 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
     # Callable to bind additional context for the Sentry SDK
     helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
 
-    scope = Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     # XXX(dcramer): this is duplicated in organizationContext.jsx on the frontend
     with sentry_sdk.start_span(op="other", name="bind_organization_context"):
@@ -676,7 +676,7 @@ def bind_ambiguous_org_context(
             f"... ({len(orgs) - (_AMBIGUOUS_ORG_CUTOFF - 1)} more)"
         ]
 
-    scope = Scope.get_isolation_scope()
+    scope = sentry_sdk.get_isolation_scope()
 
     # It's possible we've already set the org context with one of the orgs in our list,
     # somewhere we could narrow it down to one org. In that case, we don't want to overwrite

--- a/tests/sentry/integrations/api/bases/test_integration.py
+++ b/tests/sentry/integrations/api/bases/test_integration.py
@@ -15,7 +15,7 @@ class IntegrationEndpointTest(TestCase):
     # Since both `IntegrationEndpoint.handle_exception_with_details` and `Endpoint.handle_exception_with_details` potentially
     # run, and they both call their own module's copy of `capture_exception`, in order to prove that
     # neither one is not called, we assert on the underlying method from the SDK
-    @patch("sentry_sdk.Scope.capture_exception")
+    @patch("sentry_sdk.capture_exception")
     def test_handle_rest_framework_exception(
         self, mock_capture_exception: MagicMock, mock_stderror_write: MagicMock
     ):

--- a/tests/sentry/tasks/test_base.py
+++ b/tests/sentry/tasks/test_base.py
@@ -92,21 +92,21 @@ def test_task_silo_limit_call_monolith():
     assert "Control task hi" == control_task("hi")
 
 
-@patch("sentry.tasks.base.capture_exception")
+@patch("sentry_sdk.capture_exception")
 def test_ignore_and_retry(capture_exception):
     ignore_and_capture_retry_task("bruh")
 
     assert capture_exception.call_count == 1
 
 
-@patch("sentry.tasks.base.capture_exception")
+@patch("sentry_sdk.capture_exception")
 def test_ignore_exception_retry(capture_exception):
     ignore_on_exception_task("bruh")
 
     assert capture_exception.call_count == 0
 
 
-@patch("sentry.tasks.base.capture_exception")
+@patch("sentry_sdk.capture_exception")
 def test_exclude_exception_retry(capture_exception):
     with pytest.raises(Exception):
         exclude_on_exception_task("bruh")
@@ -161,7 +161,7 @@ def test_validate_parameters_call():
 
 
 @patch("sentry.taskworker.retry.current_task")
-@patch("sentry.tasks.base.capture_exception")
+@patch("sentry_sdk.capture_exception")
 def test_retry_on(capture_exception, current_task):
 
     # In reality current_task.retry will cause the given exception to be re-raised but we patch it here so no need to .raises :bufo-shrug:


### PR DESCRIPTION
We want every user to always use the top level API provided by the SDK. This does not change any behavior it just makes sure that users do not use classes/APIs that are not strictly public.

Also of note: If you see `sentry_sdk.capture_exception()` you immediately know that it is from the Sentry SDk. If you see `capture_exception()` it could come from some other place that does god knows what.