### PR TITLE
fix(demo-mode): instead of deleting activeorg do a redirect to sentry.io/welcome instead

### DIFF
--- a/tests/sentry/middleware/test_demo_mode_guard.py
+++ b/tests/sentry/middleware/test_demo_mode_guard.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from unittest.mock import sentinel
 
+from django.http import HttpResponseRedirect
 from django.test import RequestFactory
 
 from sentry.middleware.demo_mode_guard import DemoModeGuardMiddleware
@@ -29,35 +30,40 @@ class DemoModeGuardMiddlewareTestCase(TestCase):
         demo_org = self.create_organization()
         with override_options({"demo-mode.orgs": [demo_org.id]}):
             self.request.session["activeorg"] = demo_org.slug
-            self.middleware(self.request)
+            response = self.middleware(self.request)
 
-        assert "activeorg" not in self.request.session
+        # SHOULD redirect to welcome page
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.url == "https://sentry.io/welcome"
 
     @override_options({"demo-mode.enabled": False, "demo-mode.disable-sandbox-redirect": True})
     def test_middleware_demo_mode_disabled(self):
         demo_org = self.create_organization()
         with override_options({"demo-mode.orgs": [demo_org.id]}):
             self.request.session["activeorg"] = demo_org.slug
-            self.middleware(self.request)
+            response = self.middleware(self.request)
 
-        assert "activeorg" in self.request.session
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"
 
     @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": False})
     def test_middleware_redirect_not_disabled(self):
         demo_org = self.create_organization()
         with override_options({"demo-mode.orgs": [demo_org.id]}):
             self.request.session["activeorg"] = demo_org.slug
-            self.middleware(self.request)
+            response = self.middleware(self.request)
 
-        assert "activeorg" in self.request.session
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"
 
     @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": True})
     def test_middleware_not_demo_org(self):
         demo_org = self.create_organization()
         self.request.session["activeorg"] = demo_org.slug
-        self.middleware(self.request)
+        response = self.middleware(self.request)
 
-        assert "activeorg" in self.request.session
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"
 
     @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": True})
     def test_middleware_subdomain(self):
@@ -65,6 +71,7 @@ class DemoModeGuardMiddlewareTestCase(TestCase):
         with override_options({"demo-mode.orgs": [demo_org.id]}):
             self.request.subdomain = "test"
             self.request.session["activeorg"] = demo_org.slug
-            self.middleware(self.request)
+            response = self.middleware(self.request)
 
-        assert "activeorg" in self.request.session
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-87/remove-sentryio-sandbox-redirect