### PR TITLE
fix(alerts): Return old info to alerts.html - workshop has passed

### DIFF
--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -95,7 +95,7 @@
   {% elif show_login_banner %}
   <div class="alert-banner default">
     <div class="alert-message">
-      Join our live full-stack debugging workshop on June 10th. &nbsp<a target="_blank" href="https://sentry.io/resources/sentry-build/">RSVP</a>
+      Sentry & Codecov live demos. Bi-weekly Thursdays, 10 AM PT. &nbsp<a target="_blank" href="https://sentry.io/resources/find-fix-test/">RSVP & ask anything.</a>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
Workshop has passed, so returning the old text that was changed in https://github.com/getsentry/sentry/pull/92773/files