### PR TITLE
fix(agent-insights): Handle string content in input section

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
@@ -35,9 +35,9 @@ import {
   AI_OUTPUT_TOKENS_ATTRIBUTE_SUM,
   getAIGenerationsFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
+import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 interface TableData {
@@ -102,7 +102,7 @@ export function ModelsTable() {
           : undefined,
       keepPreviousData: true,
     },
-    Referrer.QUERIES_CHART // TODO: add referrer
+    Referrer.MODELS_TABLE
   );
 
   const tableData = useMemo(() => {

--- a/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
@@ -30,9 +30,9 @@ import {
   AI_TOOL_NAME_ATTRIBUTE,
   getAIToolCallsFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
+import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 
 interface TableData {
@@ -92,7 +92,7 @@ export function ToolsTable() {
           : undefined,
       keepPreviousData: true,
     },
-    Referrer.QUERIES_CHART // TODO: add referrer
+    Referrer.TOOLS_TABLE
   );
 
   const tableData = useMemo(() => {

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -117,7 +117,7 @@ export function getHighlightedSpanAttributes({
     });
   }
 
-  const toolArgs = getAttribute(attributeObject, 'ai.toolCall.args');
+  const toolArgs = getAttribute(attributeObject, 'gen_ai.tool.input');
   if (toolArgs) {
     highlightedAttributes.push({
       name: t('Arguments'),
@@ -125,7 +125,7 @@ export function getHighlightedSpanAttributes({
     });
   }
 
-  const toolResult = getAttribute(attributeObject, 'ai.toolCall.result');
+  const toolResult = getAttribute(attributeObject, 'gen_ai.tool.output');
   if (toolResult) {
     highlightedAttributes.push({
       name: t('Result'),

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -36,8 +36,8 @@ const AI_DESCRIPTIONS = [
   ...AI_TOOL_CALL_DESCRIPTIONS,
 ];
 
-export const AI_MODEL_ID_ATTRIBUTE = 'ai.model.id' as EAPSpanProperty;
-export const AI_TOOL_NAME_ATTRIBUTE = 'ai.toolCall.name' as EAPSpanProperty;
+export const AI_MODEL_ID_ATTRIBUTE = 'gen_ai.request.model' as EAPSpanProperty;
+export const AI_TOOL_NAME_ATTRIBUTE = 'gen_ai.tool.name' as EAPSpanProperty;
 
 export const AI_TOKEN_USAGE_ATTRIBUTE_SUM =
   `sum(tags[gen_ai.usage.total_tokens,number])` as EAPSpanProperty;
@@ -52,6 +52,8 @@ export const legacyAttributeKeys = new Map<string, string[]>([
   ['gen_ai.usage.output_tokens', ['ai.completion_tokens.used']],
   ['gen_ai.usage.total_tokens', ['ai.total_tokens.used']],
   ['gen_ai.usage.total_cost', ['ai.total_cost.used']],
+  ['gen_ai.tool.input', ['ai.toolCall.args']],
+  ['gen_ai.tool.output', ['ai.toolCall.result']],
 ]);
 
 export function getIsAiSpan({

--- a/static/app/views/insights/agentMonitoring/utils/referrers.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/referrers.tsx
@@ -1,0 +1,4 @@
+export enum Referrer {
+  MODELS_TABLE = 'api.performance.agent-monitoring.models-table',
+  TOOLS_TABLE = 'api.performance.agent-monitoring.tools-table',
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -19,6 +19,9 @@ import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceMode
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 function renderUserMessage(content: any) {
+  if (!Array.isArray(content)) {
+    return content;
+  }
   return content
     .filter((part: any) => part.type === 'text')
     .map((part: any) => part.text)
@@ -26,6 +29,9 @@ function renderUserMessage(content: any) {
 }
 
 function renderAssistantMessage(content: any) {
+  if (!Array.isArray(content)) {
+    return content;
+  }
   return content
     .filter((part: any) => part.type === 'text')
     .map((part: any) => part.text)
@@ -39,7 +45,6 @@ function renderToolMessage(content: any) {
 function parseAIMessages(messages: string) {
   try {
     const array: any[] = JSON.parse(messages);
-
     return array
       .map((message: any) => {
         switch (message.role) {


### PR DESCRIPTION
Handle string content for user and assistant messages in AI Input section of span details.
Use otel keys for tool and model attributes.

- part of [TET-576: Trace View - Update span details logic to new sdk data](https://linear.app/getsentry/issue/TET-576/trace-view-update-span-details-logic-to-new-sdk-data)