### PR TITLE
fix(dashboards): pass title in url params when opening in widget editor

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -317,7 +317,7 @@ describe('add to dashboard modal', () => {
     await userEvent.click(screen.getByText('Open in Widget Builder'));
     expect(initialData.router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/dashboard/1/widget-builder/widget/new/',
-      query: mockWidgetAsQueryParams,
+      query: {...mockWidgetAsQueryParams, title: 'Test title'},
     });
   });
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -189,6 +189,7 @@ function AddToDashboardModal({
         pathname,
         query: {
           ...widgetAsQueryParams,
+          title: newWidgetTitle,
           ...(selectedDashboard ? getSavedPageFilters(selectedDashboard) : {}),
         },
       })


### PR DESCRIPTION
### Changes
Pass the new widget title via query params so that when a user selected open in widget builder from the add to dashboard modal, the title persists

### Before

See: https://sentry.slack.com/archives/C01MYDW8Y7K/p1749587701335129

### After

https://github.com/user-attachments/assets/395b81ff-6fa2-4d61-b366-559ed4592da7


