### PR TITLE
fix(autofix): Prevent duplicate recommended starred views

### DIFF
--- a/static/app/components/events/autofix/seerCreateViewButton.tsx
+++ b/static/app/components/events/autofix/seerCreateViewButton.tsx
@@ -1,0 +1,158 @@
+import {useMemo} from 'react';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {Button} from 'sentry/components/core/button';
+import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
+import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
+import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
+import type {GroupSearchView} from 'sentry/views/issueList/types';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+interface StarFixabilityViewButtonProps {
+  isCompleted: boolean;
+  onSkip: () => void;
+  project: Project;
+}
+
+function StarFixabilityViewButton({
+  isCompleted,
+  project,
+  onSkip,
+}: StarFixabilityViewButtonProps) {
+  const organization = useOrganization();
+
+  const {mutate: createIssueView} = useCreateGroupSearchView({
+    onMutate: () => {
+      addLoadingMessage(t('Creating view...'));
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('View starred successfully'));
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to create view'));
+    },
+  });
+
+  const {mutate: starExistingView} = useUpdateGroupSearchViewStarred({
+    onMutate: () => {
+      addLoadingMessage(t('Starring view...'));
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('View starred successfully'));
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to star view'));
+    },
+  });
+
+  // Fetch all views to check for existing ones with our target name
+  const {data: allViews = []} = useFetchGroupSearchViews({
+    orgSlug: organization.slug,
+    limit: 25,
+    query: 'Easy Fixes 🤖', // Search by name
+  });
+
+  // Define the properties of the view we want to create/find
+  const targetViewProperties = useMemo(
+    () => ({
+      name: 'Easy Fixes 🤖',
+      query: 'is:unresolved issue.seer_actionability:[high,super_high]',
+      querySort: IssueSortOptions.DATE,
+      projects: organization.features.includes('global-views')
+        ? []
+        : [Number(project.id)],
+      environments: [],
+      timeFilters: {
+        start: null,
+        end: null,
+        period: '7d',
+        utc: null,
+      },
+    }),
+    [organization.features, project.id]
+  );
+
+  // Check if an existing view matches our criteria
+  const existingMatchingView = useMemo(() => {
+    return allViews.find((view: GroupSearchView) => {
+      // Must have exact name match
+      if (view.name !== targetViewProperties.name) {
+        return false;
+      }
+
+      // Must have exact query match
+      if (!view.query.includes('issue.seer_actionability:')) {
+        return false;
+      }
+
+      // Check project match - either matches current project or is "All Projects" (empty array)
+      const viewHasNoProjects = view.projects.length === 0;
+      const viewHasCurrentProject = view.projects.includes(Number(project.id));
+      const projectMatches = viewHasNoProjects || viewHasCurrentProject;
+
+      if (!projectMatches) {
+        return false;
+      }
+
+      return true;
+    });
+  }, [allViews, targetViewProperties, project.id]);
+
+  const handleStarFixabilityView = () => {
+    if (existingMatchingView) {
+      // Star the existing view instead of creating a new one
+      starExistingView({
+        id: existingMatchingView.id,
+        starred: true,
+        view: existingMatchingView,
+      });
+    } else {
+      // Create a new view
+      let projects: number[] = [];
+      if (!organization.features.includes('global-views')) {
+        projects = [Number(project.id)];
+      }
+      createIssueView({
+        name: 'Easy Fixes 🤖',
+        query: 'is:unresolved issue.seer_actionability:[high,super_high]',
+        querySort: IssueSortOptions.DATE,
+        projects,
+        environments: [],
+        timeFilters: {
+          start: null,
+          end: null,
+          period: '7d',
+          utc: null,
+        },
+        starred: true,
+      });
+    }
+  };
+
+  return (
+    <GuidedSteps.StepButtons>
+      <Button onClick={onSkip} size="sm" aria-label={t('Skip for now')}>
+        {t('Skip for Now')}
+      </Button>
+      <Button
+        onClick={handleStarFixabilityView}
+        size="sm"
+        priority="primary"
+        disabled={isCompleted}
+        aria-label={isCompleted ? t('View already starred') : t('Star recommended view')}
+      >
+        {isCompleted ? t('View Already Starred') : t('Star Recommended View')}
+      </Button>
+    </GuidedSteps.StepButtons>
+  );
+}
+
+export default StarFixabilityViewButton;

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -106,6 +106,10 @@ describe('SeerNotices', function () {
 
   it('shows fixability view step if automation is allowed and view not starred', () => {
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       method: 'GET',
       url: `/projects/${organization.slug}/${ProjectFixture().slug}/`,
       body: {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -28,9 +28,6 @@ import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
-import {useUpdateGroupSearchViewStarred} from 'sentry/views/issueList/mutations/useUpdateGroupSearchViewStarred';
-import {useFetchGroupSearchViews} from 'sentry/views/issueList/queries/useFetchGroupSearchViews';
-import {GroupSearchViewCreatedBy, type GroupSearchView} from 'sentry/views/issueList/types';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
@@ -61,27 +58,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
       addErrorMessage(t('Failed to create view'));
     },
   });
-  const {mutate: starExistingView} = useUpdateGroupSearchViewStarred({
-    onMutate: () => {
-      addLoadingMessage(t('Starring view...'));
-    },
-    onSuccess: () => {
-      addSuccessMessage(t('View starred successfully'));
-    },
-    onError: () => {
-      addErrorMessage(t('Failed to star view'));
-    },
-  });
   const detailedProject = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
-  });
-
-  // Fetch views created by others to check for existing identical views
-  const {data: otherViews = []} = useFetchGroupSearchViews({
-    orgSlug: organization.slug,
-    createdBy: GroupSearchViewCreatedBy.OTHERS,
-    limit: 100, // Get more views to check for matches
   });
 
   const isAutomationAllowed = organization.features.includes(
@@ -95,37 +74,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const nonGithubRepos = unreadableRepos.filter(
     repo => !repo.provider.includes('github')
   );
-
-  // Define the properties of the view we want to create/find
-  const targetViewProperties = {
-    name: 'Easy Fixes 🤖',
-    query: 'is:unresolved issue.seer_actionability:[high,super_high]',
-    querySort: IssueSortOptions.DATE,
-    projects: !organization.features.includes('global-views') ? [Number(project.id)] : [],
-    environments: [],
-    timeFilters: {
-      start: null,
-      end: null,
-      period: '7d',
-      utc: null,
-    },
-  };
-
-  // Check if an identical view already exists in the organization
-  const existingMatchingView = otherViews.find((view: GroupSearchView) => {
-    const projectsMatch = JSON.stringify(view.projects.sort()) === JSON.stringify(targetViewProperties.projects.sort());
-    const environmentsMatch = JSON.stringify(view.environments.sort()) === JSON.stringify(targetViewProperties.environments.sort());
-    const timeFiltersMatch = JSON.stringify(view.timeFilters) === JSON.stringify(targetViewProperties.timeFilters);
-
-    return (
-      view.name === targetViewProperties.name &&
-      view.query === targetViewProperties.query &&
-      view.querySort === targetViewProperties.querySort &&
-      projectsMatch &&
-      environmentsMatch &&
-      timeFiltersMatch
-    );
-  });
 
   // Onboarding conditions
   const needsGithubIntegration = !hasGithubIntegration;
@@ -168,35 +116,25 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const anyStepIncomplete = incompleteSteps > 0;
 
   const handleStarFixabilityView = () => {
-    if (existingMatchingView) {
-      // Star the existing view instead of creating a new one
-      starExistingView({
-        id: existingMatchingView.id,
-        starred: true,
-        view: existingMatchingView,
-      });
-    } else {
-      // Create a new view as before
-      let projects: number[] = [];
-      if (!organization.features.includes('global-views')) {
-        // org cannot have a view with multiple projects, so we'll just use the current project
-        projects = [Number(project.id)];
-      }
-      createIssueView({
-        name: 'Easy Fixes 🤖',
-        query: 'is:unresolved issue.seer_actionability:[high,super_high]',
-        querySort: IssueSortOptions.DATE,
-        projects,
-        environments: [],
-        timeFilters: {
-          start: null,
-          end: null,
-          period: '7d',
-          utc: null,
-        },
-        starred: true,
-      });
+    let projects: number[] = [];
+    if (!organization.features.includes('global-views')) {
+      // org cannot have a view with multiple projects, so we'll just use the current project
+      projects = [Number(project.id)];
     }
+    createIssueView({
+      name: 'Easy Fixes 🤖',
+      query: 'is:unresolved issue.seer_actionability:[high,super_high]',
+      querySort: IssueSortOptions.DATE,
+      projects,
+      environments: [],
+      timeFilters: {
+        start: null,
+        end: null,
+        period: '7d',
+        utc: null,
+      },
+      starred: true,
+    });
   };
 
   return (

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -312,7 +312,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                     priority="primary"
                     disabled={!needsFixabilityView}
                   >
-                    {!needsFixabilityView ? t('View Already Starred') : t('Star Recommended View')}
+                    {needsFixabilityView
+                      ? t('Star Recommended View')
+                      : t('View Already Starred')}
                   </Button>
                 </GuidedSteps.StepButtons>
               </GuidedSteps.Step>

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -6,16 +6,12 @@ import feedbackOnboardingImg from 'sentry-images/spot/feedback-onboarding.svg';
 import onboardingCompass from 'sentry-images/spot/onboarding-compass.svg';
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
 import {SeerWaitingIcon} from 'sentry/components/ai/SeerIcon';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
+import StarFixabilityViewButton from 'sentry/components/events/autofix/seerCreateViewButton';
 import {useAutofixRepos} from 'sentry/components/events/autofix/useAutofix';
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -27,8 +23,6 @@ import {FieldKey} from 'sentry/utils/fields';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useCreateGroupSearchView} from 'sentry/views/issueList/mutations/useCreateGroupSearchView';
-import {IssueSortOptions} from 'sentry/views/issueList/utils';
 import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
@@ -47,17 +41,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
     isLoading: isLoadingPreferences,
   } = useProjectSeerPreferences(project);
   const {starredViews: views} = useStarredIssueViews();
-  const {mutate: createIssueView} = useCreateGroupSearchView({
-    onMutate: () => {
-      addLoadingMessage(t('Creating view...'));
-    },
-    onSuccess: () => {
-      addSuccessMessage(t('View starred successfully'));
-    },
-    onError: () => {
-      addErrorMessage(t('Failed to create view'));
-    },
-  });
+
   const detailedProject = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
@@ -114,28 +98,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   ];
   const incompleteSteps = stepConditions.filter(Boolean).length;
   const anyStepIncomplete = incompleteSteps > 0;
-
-  const handleStarFixabilityView = () => {
-    let projects: number[] = [];
-    if (!organization.features.includes('global-views')) {
-      // org cannot have a view with multiple projects, so we'll just use the current project
-      projects = [Number(project.id)];
-    }
-    createIssueView({
-      name: 'Easy Fixes 🤖',
-      query: 'is:unresolved issue.seer_actionability:[high,super_high]',
-      querySort: IssueSortOptions.DATE,
-      projects,
-      environments: [],
-      timeFilters: {
-        start: null,
-        end: null,
-        period: '7d',
-        utc: null,
-      },
-      starred: true,
-    });
-  };
 
   return (
     <NoticesContainer>
@@ -306,16 +268,11 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                   <Button onClick={() => setStepsCollapsed(true)} size="sm">
                     {t('Skip for Now')}
                   </Button>
-                  <Button
-                    onClick={handleStarFixabilityView}
-                    size="sm"
-                    priority="primary"
-                    disabled={!needsFixabilityView}
-                  >
-                    {needsFixabilityView
-                      ? t('Star Recommended View')
-                      : t('View Already Starred')}
-                  </Button>
+                  <StarFixabilityViewButton
+                    isCompleted={!needsFixabilityView}
+                    project={project}
+                    onSkip={() => setStepsCollapsed(true)}
+                  />
                 </GuidedSteps.StepButtons>
               </GuidedSteps.Step>
             )}

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -271,7 +271,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                   <StarFixabilityViewButton
                     isCompleted={!needsFixabilityView}
                     project={project}
-                    onSkip={() => setStepsCollapsed(true)}
                   />
                 </GuidedSteps.StepButtons>
               </GuidedSteps.Step>


### PR DESCRIPTION
Disables button to create starred view if the step is already complete.
Also stars an existing view in the org instead of creating a new one if there is a decent match.