### PR TITLE
:wrench: chore(aci): update copy to use call detectors "monitor"

### DIFF
--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -19,7 +19,7 @@ def create_project_detectors(instance, created, **kwargs):
                 "organizations:workflow-engine-issue-alert-dual-write", instance.organization
             ):
                 Detector.objects.create(
-                    name="Error Detector", type=ErrorGroupType.slug, project=instance, config={}
+                    name="Error Monitor", type=ErrorGroupType.slug, project=instance, config={}
                 )
                 logger.info("project.detector-created", extra={"project_id": instance.id})
         except IntegrityError as e:

--- a/src/sentry/receivers/project_detectors.py
+++ b/src/sentry/receivers/project_detectors.py
@@ -8,6 +8,7 @@ from sentry import features
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.project import Project
 from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.types import ERROR_DETECTOR_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def create_project_detectors(instance, created, **kwargs):
                 "organizations:workflow-engine-issue-alert-dual-write", instance.organization
             ):
                 Detector.objects.create(
-                    name="Error Monitor", type=ErrorGroupType.slug, project=instance, config={}
+                    name=ERROR_DETECTOR_NAME, type=ErrorGroupType.slug, project=instance, config={}
                 )
                 logger.info("project.detector-created", extra={"project_id": instance.id})
         except IntegrityError as e:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -37,6 +37,7 @@ from sentry.workflow_engine.models.data_condition import (
     Condition,
     enforce_data_condition_json_schema,
 )
+from sentry.workflow_engine.types import ERROR_DETECTOR_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ def ensure_default_error_detector(project: Project) -> Detector:
             detector, _ = Detector.objects.get_or_create(
                 type=ErrorGroupType.slug,
                 project=project,
-                defaults={"config": {}, "name": "Error Monitor"},
+                defaults={"config": {}, "name": ERROR_DETECTOR_NAME},
             )
             return detector
     except UnableToAcquireLock:
@@ -145,7 +146,7 @@ class IssueAlertMigrator:
             error_detector, _ = Detector.objects.get_or_create(
                 type=ErrorGroupType.slug,
                 project=self.project,
-                defaults={"config": {}, "name": "Error Monitor"},
+                defaults={"config": {}, "name": ERROR_DETECTOR_NAME},
             )
             _, created = AlertRuleDetector.objects.get_or_create(
                 detector=error_detector, rule_id=self.rule.id

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -82,7 +82,7 @@ def ensure_default_error_detector(project: Project) -> Detector:
             detector, _ = Detector.objects.get_or_create(
                 type=ErrorGroupType.slug,
                 project=project,
-                defaults={"config": {}, "name": "Error Detector"},
+                defaults={"config": {}, "name": "Error Monitor"},
             )
             return detector
     except UnableToAcquireLock:
@@ -145,7 +145,7 @@ class IssueAlertMigrator:
             error_detector, _ = Detector.objects.get_or_create(
                 type=ErrorGroupType.slug,
                 project=self.project,
-                defaults={"config": {}, "name": "Error Detector"},
+                defaults={"config": {}, "name": "Error Monitor"},
             )
             _, created = AlertRuleDetector.objects.get_or_create(
                 detector=error_detector, rule_id=self.rule.id

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+ERROR_DETECTOR_NAME = "Error Monitor"
+
 
 class DetectorPriorityLevel(IntEnum):
     OK = 0

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -269,7 +269,7 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
         data_condition_group = self.create_data_condition_group()
         error_detector = self.create_detector(
             project_id=self.project.id,
-            name="Error Detector",
+            name="Error Monitor",
             type=ErrorGroupType.slug,
             workflow_condition_group=data_condition_group,
         )

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -140,7 +140,7 @@ class IssueAlertMigratorTest(TestCase):
         assert workflow.enabled == is_enabled
 
         detector = Detector.objects.get(id=issue_alert_detector.detector.id)
-        assert detector.name == "Error Detector"
+        assert detector.name == "Error Monitor"
         assert detector.project_id == self.project.id
         assert detector.enabled is True
         assert detector.owner_user_id is None
@@ -442,7 +442,7 @@ class TestEnsureDefaultErrorDetector(TestCase):
     def test_ensure_default_error_detector(self):
         project = self.create_project()
         detector = ensure_default_error_detector(project)
-        assert detector.name == "Error Detector"
+        assert detector.name == "Error Monitor"
         assert detector.project_id == project.id
         assert detector.type == ErrorGroupType.slug
 


### PR DESCRIPTION
before i run the migration to call all new error detectors "Error Monitors," in this [pr](https://github.com/getsentry/sentry/pull/93294), we need to make sure we create all new detectors with "Monitor"