### PR TITLE
feat(explore): Auto manage fields from visualize

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -34,3 +34,7 @@ export function updateLocationWithFields(
     delete location.query.field;
   }
 }
+
+export function isDefaultFields(location: Location): boolean {
+  return decodeList(location.query.field).length === 0;
+}

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -150,7 +150,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
@@ -174,7 +174,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
@@ -197,7 +197,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
@@ -220,7 +220,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
@@ -254,7 +254,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
         sortBys: [{field: 'timestamp', kind: 'desc'}],
@@ -292,7 +292,14 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'sdk.name', 'sdk.version', 'timestamp', 'span.op'],
+        fields: [
+          'id',
+          'sdk.name',
+          'sdk.version',
+          'timestamp',
+          'span.self_time',
+          'span.op',
+        ],
         mode: Mode.SAMPLES,
         query: '',
         sortBys: [{field: 'timestamp', kind: 'desc'}],
@@ -318,7 +325,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: 'foo:bar',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
@@ -341,7 +348,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
         sortBys: [{field: 'id', kind: 'desc'}],
@@ -364,7 +371,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
         sortBys: [{field: 'timestamp', kind: 'desc'}],
@@ -397,7 +404,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'max(span.duration)', kind: 'desc'}],
@@ -434,7 +441,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
@@ -471,7 +478,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'sdk.name', kind: 'desc'}],
@@ -504,7 +511,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
@@ -558,7 +565,7 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         dataset: DiscoverDatasets.SPANS_EAP_RPC,
-        fields: ['id', 'timestamp'],
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
         mode: Mode.AGGREGATE,
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
@@ -591,5 +598,148 @@ describe('PageParamsProvider', function () {
     renderTestComponent();
     act(() => setTitle('My Query'));
     expect(pageParams).toEqual(expect.objectContaining({title: 'My Query'}));
+  });
+
+  it('manages inserting and deleting a column when added/removed', function () {
+    renderTestComponent();
+
+    act(() =>
+      setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+
+    act(() =>
+      setVisualizes([
+        {yAxes: ['count(span.self_time)']},
+        {yAxes: ['avg(span.duration)']},
+        {yAxes: ['p50(span.self_time)']},
+        {yAxes: ['p75(span.duration)']},
+      ])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+
+    act(() => setVisualizes([{yAxes: ['count(span.self_time)']}]));
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time'],
+      })
+    );
+  });
+
+  it('only deletes 1 managed columns when there are duplicates', function () {
+    renderTestComponent();
+
+    act(() =>
+      setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+
+    act(() =>
+      setFields(['id', 'timestamp', 'span.self_time', 'span.duration', 'span.duration'])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration', 'span.duration'],
+      })
+    );
+
+    act(() => setVisualizes([{yAxes: ['count(span.self_time)']}]));
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+  });
+
+  it('re-adds managed column if a new reference is found', function () {
+    renderTestComponent();
+
+    act(() =>
+      setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+
+    act(() => setFields(['id', 'timestamp', 'span.self_time']));
+
+    act(() =>
+      setVisualizes([
+        {yAxes: ['count(span.self_time)']},
+        {yAxes: ['avg(span.duration)']},
+        {yAxes: ['p50(span.self_time)']},
+      ])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time'],
+      })
+    );
+
+    act(() =>
+      setVisualizes([
+        {yAxes: ['count(span.self_time)']},
+        {yAxes: ['avg(span.duration)']},
+        {yAxes: ['p50(span.duration)']},
+      ])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+  });
+
+  it('should not manage an existing column', function () {
+    renderTestComponent();
+
+    act(() => setFields(['id', 'timestamp', 'span.self_time', 'span.duration']));
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+
+    act(() =>
+      setVisualizes([{yAxes: ['count(span.self_time)']}, {yAxes: ['avg(span.duration)']}])
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+
+    act(() => setVisualizes([{yAxes: ['count(span.self_time)']}]));
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
   });
 });

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -1,8 +1,17 @@
 import type React from 'react';
-import {createContext, useCallback, useContext, useMemo} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import type {Location} from 'history';
 
+import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
+import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -26,7 +35,12 @@ import {
   getDatasetFromLocation,
   updateLocationWithDataset,
 } from './dataset';
-import {defaultFields, getFieldsFromLocation, updateLocationWithFields} from './fields';
+import {
+  defaultFields,
+  getFieldsFromLocation,
+  isDefaultFields,
+  updateLocationWithFields,
+} from './fields';
 import {defaultMode, getModeFromLocation, Mode, updateLocationWithMode} from './mode';
 import {defaultQuery, getQueryFromLocation, updateLocationWithQuery} from './query';
 import {
@@ -122,7 +136,23 @@ function defaultPageParams(): ReadablePageParams {
   });
 }
 
-const PageParamsContext = createContext<ReadablePageParams>(defaultPageParams());
+type PageParamsContextValue = {
+  managedFields: Set<string>;
+  pageParams: ReadablePageParams;
+  setManagedFields: (managedFields: Set<string>) => void;
+};
+
+function defaultPageParamsContextValue() {
+  return {
+    managedFields: new Set<string>(),
+    pageParams: defaultPageParams(),
+    setManagedFields: () => {},
+  };
+}
+
+const PageParamsContext = createContext<PageParamsContextValue>(
+  defaultPageParamsContextValue()
+);
 
 interface PageParamsProviderProps {
   children: React.ReactNode;
@@ -131,6 +161,19 @@ interface PageParamsProviderProps {
 export function PageParamsProvider({children}: PageParamsProviderProps) {
   const location = useLocation();
   const organization = useOrganization();
+
+  const [managedFields, setManagedFields] = useState(new Set<string>());
+
+  // Whenever the fields is reset to the defaults, we should wipe the state of the
+  // managed fields. This can happen when
+  // 1. user clicks on the side bar when already on the page
+  // 2. some code intentionally wipes the fields
+  const isUsingDefaultFields = isDefaultFields(location);
+  useEffect(() => {
+    if (isUsingDefaultFields) {
+      setManagedFields(new Set());
+    }
+  }, [isUsingDefaultFields]);
 
   const pageParams: ReadablePageParams = useMemo(() => {
     const aggregateFields = getAggregateFieldsFromLocation(location, organization);
@@ -156,11 +199,30 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
     });
   }, [location, organization]);
 
-  return <PageParamsContext value={pageParams}>{children}</PageParamsContext>;
+  const pageParamsContextValue: PageParamsContextValue = useMemo(() => {
+    return {
+      pageParams,
+      managedFields,
+      setManagedFields,
+    };
+  }, [pageParams, managedFields, setManagedFields]);
+
+  return <PageParamsContext value={pageParamsContextValue}>{children}</PageParamsContext>;
+}
+
+function useExploreAutoFields(): Set<string> {
+  const contextValue = useContext(PageParamsContext);
+  return contextValue.managedFields;
+}
+
+function useSetExploreAutoFields(): (managedFields: Set<string>) => void {
+  const contextValue = useContext(PageParamsContext);
+  return contextValue.setManagedFields;
 }
 
 export function useExplorePageParams(): ReadablePageParams {
-  return useContext(PageParamsContext);
+  const contextValue = useContext(PageParamsContext);
+  return contextValue.pageParams;
 }
 
 export function useExploreDataset(): DiscoverDatasets {
@@ -228,16 +290,213 @@ export function newExploreTarget(
   return target;
 }
 
-export function useSetExplorePageParams(): (pageParams: WritablePageParams) => void {
+function findAllFields(
+  readablePageParams: ReadablePageParams,
+  writablePageParams: WritablePageParams
+): {
+  addedFields: Set<string>;
+  removedFields: Set<string>;
+} {
+  if (!defined(writablePageParams.fields)) {
+    return {
+      addedFields: new Set<string>(),
+      removedFields: new Set<string>(),
+    };
+  }
+
+  const curFields: Map<string, number> = readablePageParams.fields.reduce(
+    (fields, field) => {
+      const count = fields.get(field) || 0;
+      fields.set(field, count + 1);
+      return fields;
+    },
+    new Map<string, number>()
+  );
+  const newFields: Map<string, number> = writablePageParams.fields.reduce(
+    (fields, field) => {
+      const count = fields.get(field) || 0;
+      fields.set(field, count + 1);
+      return fields;
+    },
+    new Map<string, number>()
+  );
+
+  const addedFields = new Set<string>();
+  const removedFields = new Set<string>();
+
+  function checkField(field: string) {
+    const curCount = curFields.get(field) || 0;
+    const newCount = newFields.get(field) || 0;
+    if (curCount > newCount) {
+      removedFields.add(field);
+    } else if (curCount < newCount) {
+      addedFields.add(field);
+    }
+  }
+
+  curFields.keys().forEach(checkField);
+  newFields.keys().forEach(checkField);
+
+  return {addedFields, removedFields};
+}
+
+/**
+ * Get a count of all the fields that are referenced else where in the query.
+ * This is useful to compute the changes (added/removed references) that will
+ * be used to determine if a field should be managed and added to the table.
+ */
+function findAllFieldRefs(
+  readablePageParams: ReadablePageParams,
+  writablePageParams: WritablePageParams
+): {
+  curRefs: Map<string, number>;
+  newRefs: Map<string, number>;
+} {
+  const curRefs: Map<string, number> = new Map();
+  const newRefs: Map<string, number> = new Map();
+
+  const readableVisualizeFields = readablePageParams.aggregateFields
+    .filter<Visualize>(isVisualize)
+    .flatMap(visualize => visualize.yAxes)
+    .map(yAxis => parseFunction(yAxis)?.arguments?.[0])
+    .filter<string>(defined);
+
+  readableVisualizeFields.forEach(field => {
+    const count = curRefs.get(field) || 0;
+    curRefs.set(field, count + 1);
+  });
+
+  const writableVisualizeFields =
+    // null means to clear it so make sure to handle it correctly
+    writablePageParams.aggregateFields === null
+      ? []
+      : writablePageParams.aggregateFields
+          ?.filter<Visualize>(isVisualize)
+          ?.flatMap(visualize => visualize.yAxes)
+          ?.map(yAxis => parseFunction(yAxis)?.arguments?.[0])
+          ?.filter<string>(defined);
+
+  // if visualize fields aren't set on the writable page params, it means
+  // it didn't change, so we fall back to using the fields from the readable
+  // page params
+  (writableVisualizeFields ?? readableVisualizeFields).forEach(field => {
+    const count = newRefs.get(field) || 0;
+    newRefs.set(field, count + 1);
+  });
+
+  return {curRefs, newRefs};
+}
+
+function deriveUpdatedAutoFields(
+  managedFields: Set<string>,
+  readablePageParams: ReadablePageParams,
+  writablePageParams: WritablePageParams
+): {
+  updatedFields?: string[];
+  updatedManagedFields?: Set<string>;
+} {
+  // null means to clear it, when this happens we should stop managing all fields
+  if (writablePageParams.fields === null) {
+    return {
+      updatedManagedFields: new Set(),
+    };
+  }
+
+  const {curRefs, newRefs} = findAllFieldRefs(readablePageParams, writablePageParams);
+
+  const allFields = new Set<string>([...curRefs.keys(), ...newRefs.keys()]);
+
+  // if the writable fields is undefined, it means we're not changing it
+  // so we should infer it from the readable fields
+  const fields = writablePageParams.fields ?? readablePageParams.fields;
+
+  const fieldsToAdd = new Set<string>();
+  const fieldsToDelete = new Set<string>();
+  const updatedManagedFields = new Set(managedFields);
+
+  allFields.forEach(field => {
+    const curCount = curRefs.get(field) || 0;
+    const newCount = newRefs.get(field) || 0;
+
+    if (
+      newCount > curCount &&
+      !updatedManagedFields.has(field) &&
+      !fields.includes(field)
+    ) {
+      // found a field that
+      // 1. isn't in the list of fields
+      // 2. isn't being managed
+      // 3. a new reference was found
+      // this means we should start managing the field
+      updatedManagedFields.add(field);
+      fieldsToAdd.add(field);
+    } else if (curCount > 0 && newCount <= 0 && updatedManagedFields.has(field)) {
+      // found a field that
+      // 1. is being managed
+      // 2. all references have been removed
+      updatedManagedFields.delete(field);
+      fieldsToDelete.add(field);
+    }
+  });
+
+  const {removedFields} = findAllFields(readablePageParams, writablePageParams);
+
+  // when a field is intentionally removed, it should no longer be managed
+  removedFields.forEach(field => {
+    updatedManagedFields.delete(field);
+    fieldsToDelete.delete(field);
+  });
+
+  let updatedFields: string[] | undefined = undefined;
+
+  if (fieldsToAdd.size || fieldsToDelete.size) {
+    updatedFields = fields.filter(field => {
+      const keep = !fieldsToDelete.has(field);
+      if (!keep) {
+        // it's possible the user manually added a duplicate of the field,
+        // but we want to only delete 1 instance of the field
+        fieldsToDelete.delete(field);
+      }
+      return keep;
+    });
+    updatedFields.push(...fieldsToAdd);
+  }
+
+  return {
+    updatedFields,
+    updatedManagedFields,
+  };
+}
+
+export function useSetExplorePageParams(): (
+  writablePageParams: WritablePageParams
+) => void {
   const location = useLocation();
   const navigate = useNavigate();
+  const managedFields = useExploreAutoFields();
+  const setManagedFields = useSetExploreAutoFields();
+  const readablePageParams = useExplorePageParams();
 
   return useCallback(
-    (pageParams: WritablePageParams) => {
-      const target = newExploreTarget(location, pageParams);
+    (writablePageParams: WritablePageParams) => {
+      const {updatedFields, updatedManagedFields} = deriveUpdatedAutoFields(
+        managedFields,
+        readablePageParams,
+        writablePageParams
+      );
+
+      if (defined(updatedManagedFields)) {
+        setManagedFields(updatedManagedFields);
+      }
+
+      if (defined(updatedFields)) {
+        writablePageParams.fields = updatedFields;
+      }
+
+      const target = newExploreTarget(location, writablePageParams);
       navigate(target);
     },
-    [location, navigate]
+    [location, navigate, readablePageParams, managedFields, setManagedFields]
   );
 }
 
@@ -283,11 +542,7 @@ export function useSetExploreGroupBys() {
         aggregateFields.push(groupBy);
       }
 
-      if (mode) {
-        setPageParams({aggregateFields, mode});
-      } else {
-        setPageParams({aggregateFields});
-      }
+      setPageParams({aggregateFields, mode});
     },
     [pageParams, setPageParams]
   );
@@ -346,7 +601,7 @@ export function useSetExploreVisualizes() {
   const pageParams = useExplorePageParams();
   const setPageParams = useSetExplorePageParams();
   return useCallback(
-    (visualizes: BaseVisualize[], fields?: string[]) => {
+    (visualizes: BaseVisualize[]) => {
       const aggregateFields: WritablePageParams['aggregateFields'] = [];
       let i = 0;
       for (const aggregateField of pageParams.aggregateFields) {
@@ -362,14 +617,7 @@ export function useSetExploreVisualizes() {
         aggregateFields.push(visualizes[i]!);
       }
 
-      const writablePageParams: WritablePageParams = {aggregateFields};
-
-      const newFields = fields?.filter(field => !pageParams.fields.includes(field)) || [];
-      if (newFields.length > 0) {
-        writablePageParams.fields = [...pageParams.fields, ...newFields];
-      }
-
-      setPageParams(writablePageParams);
+      setPageParams({aggregateFields});
     },
     [pageParams, setPageParams]
   );

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -17,7 +17,6 @@ import {
 import type {BaseVisualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {
   DEFAULT_VISUALIZATION,
-  DEFAULT_VISUALIZATION_FIELD,
   MAX_VISUALIZES,
   updateVisualizeAggregate,
   Visualize,
@@ -42,7 +41,7 @@ export function ToolbarVisualize() {
     const newVisualizes = [...visualizes, new Visualize([DEFAULT_VISUALIZATION])].map(
       visualize => visualize.toJSON()
     );
-    setVisualizes(newVisualizes, [DEFAULT_VISUALIZATION_FIELD]);
+    setVisualizes(newVisualizes);
   }, [setVisualizes, visualizes]);
 
   const deleteOverlay = useCallback(
@@ -121,7 +120,7 @@ interface VisualizeDropdownProps {
   deleteOverlay: (group: number, index: number) => void;
   group: number;
   index: number;
-  setVisualizes: (visualizes: BaseVisualize[], fields?: string[]) => void;
+  setVisualizes: (visualizes: BaseVisualize[]) => void;
   visualizes: Visualize[];
   yAxis: string;
   label?: string;
@@ -159,7 +158,7 @@ function VisualizeDropdown({
   });
 
   const setYAxis = useCallback(
-    (newYAxis: string, fields?: string[]) => {
+    (newYAxis: string) => {
       const newVisualizes = visualizes.map((visualize, i) => {
         if (i === group) {
           const newYAxes = [...visualize.yAxes];
@@ -168,7 +167,7 @@ function VisualizeDropdown({
         }
         return visualize.toJSON();
       });
-      setVisualizes(newVisualizes, fields);
+      setVisualizes(newVisualizes);
     },
     [group, index, setVisualizes, visualizes]
   );
@@ -187,7 +186,7 @@ function VisualizeDropdown({
 
   const setChartField = useCallback(
     (option: SelectOption<SelectKey>) => {
-      setYAxis(`${parsedFunction?.name}(${option.value})`, [option.value as string]);
+      setYAxis(`${parsedFunction?.name}(${option.value})`);
     },
     [parsedFunction?.name, setYAxis]
   );


### PR DESCRIPTION
This tries to automatically manage the fields used in visualize. When a field is visualized, we will automatically add it to the table. But when that visualization is removed, it is also removed from the table. Also makes sure it interacts well with user interactions such as adding/removing a column.

Closes EXP-34