### PR TITLE
fix(demo-mode): fixing error when no target project was found

### DIFF
--- a/tests/sentry/demo_mode/test_tasks.py
+++ b/tests/sentry/demo_mode/test_tasks.py
@@ -27,6 +27,7 @@ class SyncArtifactBundlesTest(TestCase):
         self.source_org = self.create_organization(slug="source_org")
         self.target_org = self.create_organization(slug="target_org")
         self.unrelated_org = self.create_organization(slug="unrelated_org")
+        self.empty_org = self.create_organization(slug="empty_org")
 
         self.source_proj_foo = self.create_project(organization=self.source_org, slug="foo")
         self.target_proj_foo = self.create_project(organization=self.target_org, slug="foo")
@@ -162,6 +163,15 @@ class SyncArtifactBundlesTest(TestCase):
         assert target_artifact_bundles.count() == 1
         assert target_artifact_bundles[0].bundle_id == source_artifact_bundle.bundle_id
 
+    def test_sync_artifact_bundles_with_empty_org_does_not_fail(self):
+        self.set_up_artifact_bundle(self.source_org, self.source_proj_foo)
+
+        _sync_artifact_bundles(
+            source_org=self.source_org,
+            target_org=self.empty_org,
+            cutoff_date=self.last_three_days(),
+        )
+
     def test_sync_project_artifact_bundles(self):
         self.set_up_artifact_bundle(self.source_org, self.source_proj_foo)
 
@@ -257,6 +267,15 @@ class SyncArtifactBundlesTest(TestCase):
             debug_id=source_project_debug_file.debug_id,
         ).exists()
 
+    def test_sync_project_debug_files_with_empty_org_does_not_fail(self):
+        self.create_dif_file(self.source_proj_foo)
+
+        _sync_project_debug_files(
+            source_org=self.source_org,
+            target_org=self.empty_org,
+            cutoff_date=self.last_three_days(),
+        )
+
     def test_sync_proguard_artifact_releases(self):
         source_proguard_artifact_release = self.set_up_proguard_artifact_release(
             self.source_org,
@@ -311,3 +330,12 @@ class SyncArtifactBundlesTest(TestCase):
             organization_id=self.target_org.id,
             proguard_uuid=source_proguard_artifact_release.proguard_uuid,
         ).exists()
+
+    def test_sync_proguard_artifact_releases_with_empty_org_does_not_fail(self):
+        self.set_up_proguard_artifact_release(self.source_org, self.source_proj_foo)
+
+        _sync_proguard_artifact_releases(
+            source_org=self.source_org,
+            target_org=self.empty_org,
+            cutoff_date=self.last_three_days(),
+        )


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-622/symbols-not-appearing-on-sandbox-environment

`_find_matching_product` used to raise. Now it seems we have a new project in the source org, why all of a sudden the task fails. The function now returns `None` which was already expected by the client code.