### PR TITLE
fix(autofix): Update autofix integration setup check

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -37,19 +37,20 @@ def get_autofix_integration_setup_problems(
     If there is an issue, returns the reason.
     """
     organization_integrations = integration_service.get_organization_integrations(
-        organization_id=organization.id, providers=["github"], limit=1
+        organization_id=organization.id, providers=["github"]
     )
 
-    organization_integration = organization_integrations[0] if organization_integrations else None
-    integration = organization_integration and integration_service.get_integration(
-        organization_integration_id=organization_integration.id, status=ObjectStatus.ACTIVE
-    )
-    installation = integration and integration.get_installation(organization_id=organization.id)
+    # Iterate through all organization integrations to find one with an active integration
+    for organization_integration in organization_integrations:
+        integration = integration_service.get_integration(
+            organization_integration_id=organization_integration.id, status=ObjectStatus.ACTIVE
+        )
+        if integration:
+            installation = integration.get_installation(organization_id=organization.id)
+            if installation:
+                return None
 
-    if not installation:
-        return "integration_missing"
-
-    return None
+    return "integration_missing"
 
 
 def get_repos_and_access(project: Project) -> list[dict]:


### PR DESCRIPTION
The autofix setup endpoint was returning "integration missing" due to an issue in `src/sentry/api/endpoints/group_autofix_setup_check.py`.

Previously, the `get_autofix_integration_setup_problems` function:
*   Fetched only the first GitHub `OrganizationIntegration` using `limit=1`.
*   Checked if this single integration had an active `Integration` and a valid installation.
*   Returned "integration_missing" if the first integration was not active or lacked an installation, even if other valid integrations existed for the organization.

The function was updated to correctly identify an active autofix setup:
*   The `limit=1` parameter was removed from the `integration_service.get_organization_integrations` call, allowing all GitHub organization integrations to be retrieved.
*   A loop was introduced to iterate through all `organization_integrations`.
*   Inside the loop, each `organization_integration` is checked for an `ACTIVE` `Integration` and a valid `installation`.
*   If a valid setup is found, `None` is returned immediately, indicating no problems.
*   "integration_missing" is now only returned if no valid active integration with an installation is found after checking all available organization integrations.

This change ensures the endpoint accurately reflects the autofix setup status by considering all available integrations, preventing false negatives.