### PR TITLE
feat(ui): Allow empty page links to render a disabled pager

### DIFF
--- a/static/app/components/pagination.tsx
+++ b/static/app/components/pagination.tsx
@@ -7,6 +7,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -53,7 +54,7 @@ function Pagination({
     [navigate]
   );
 
-  if (!pageLinks) {
+  if (!defined(pageLinks)) {
     return null;
   }
 


### PR DESCRIPTION
Helpful when items are loading to still render the pagination buttons.