### PR TITLE
chore(dashboards): Log when the user time zone doesn't match the system time zone

### DIFF
--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import moment from 'moment-timezone';
 import {createStore} from 'reflux';
 
@@ -10,6 +11,8 @@ interface ConfigStoreDefinition extends StrictStoreDefinition<Config> {
   loadInitialData(config: Config): void;
   set<K extends keyof Config>(key: K, value: Config[K]): void;
 }
+
+const {warn} = Sentry.logger;
 
 const storeConfig: ConfigStoreDefinition = {
   // When the app is booted we will _immediately_ hydrate the config store,
@@ -44,7 +47,21 @@ const storeConfig: ConfigStoreDefinition = {
     // TODO(dcramer): abstract this out of ConfigStore
     if (config.user) {
       config.user.permissions = new Set(config.user.permissions);
-      moment.tz.setDefault(config.user.options.timezone);
+
+      const systemTimeZone = moment.tz.guess();
+      const userTimeZone = config.user.options.timezone;
+
+      const nowInSystemTimezone = moment.tz(undefined, systemTimeZone);
+      const nowInUserTimezone = moment.tz(undefined, userTimeZone);
+
+      if (nowInSystemTimezone.utcOffset() !== nowInUserTimezone.utcOffset()) {
+        warn('System time zone does not match user preferences time zone', {
+          systemTimeZone,
+          userTimeZone,
+        });
+      }
+
+      moment.tz.setDefault(userTimeZone);
     }
 
     this.trigger(config);


### PR DESCRIPTION
There's [an issue](https://linear.app/getsentry/issue/DAIN-594/time-series-chart-x-axis-ticks-are-not-aligned-to-dates-when-system) where the chart ticks don't look right when the user's time zone doesn't match the system time zone. The fix is gnarly, so we want to figure out how often this happens, first, and why.

There are a few places in bootstrap where we import the Sentry SDK, so I assume it's fine to do it here, too.
