### PR TITLE
feat(codecov): Add interval param to TestResultsAggregates endpoint

### DIFF
--- a/src/sentry/codecov/endpoints/TestResultsAggregates/query.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/query.py
@@ -20,6 +20,12 @@ query = """query GetTestResultsAggregates(
                         totalSkips
                         totalSkipsPercentChange
                     }
+                    flakeAggregates(interval: $interval) {
+                        flakeCount
+                        flakeCountPercentChange
+                        flakeRate
+                        flakeRatePercentChange
+                    }
                 }
             }
             ... on NotFoundError {

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/serializers.py
@@ -21,15 +21,19 @@ class TestResultAggregatesSerializer(serializers.Serializer):
     totalFailsPercentChange = serializers.FloatField()
     totalSkips = serializers.IntegerField()
     totalSkipsPercentChange = serializers.FloatField()
+    flakeCount = serializers.IntegerField()
+    flakeCountPercentChange = serializers.FloatField()
+    flakeRate = serializers.FloatField()
+    flakeRatePercentChange = serializers.FloatField()
 
-    def to_representation(self, graphql_response):
+    def to_representation(self, instance):
         """
         Transform the GraphQL response to the serialized format
         """
         try:
-            response_data = graphql_response["data"]["owner"]["repository"]["testAnalytics"][
-                "testResultsAggregates"
-            ]
+            test_analytics = instance["data"]["owner"]["repository"]["testAnalytics"]
+            response_data = test_analytics["testResultsAggregates"]
+            response_data.update(test_analytics["flakeAggregates"])
 
             return super().to_representation(response_data)
 
@@ -41,9 +45,7 @@ class TestResultAggregatesSerializer(serializers.Serializer):
                     "error": str(e),
                     "endpoint": "test-results-aggregates",
                     "response_keys": (
-                        list(graphql_response.keys())
-                        if isinstance(graphql_response, dict)
-                        else None
+                        list(instance.keys()) if isinstance(instance, dict) else None
                     ),
                 },
             )

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
@@ -29,6 +29,7 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
         parameters=[
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
+            PreventParams.INTERVAL,
         ],
         request=None,
         responses={
@@ -44,16 +45,15 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
         Also accepts a query parameter to specify the time period for the metrics.
         """
 
-        owner = "codecov"
-        repository = "gazebo"
-
         variables = {
             "owner": owner,
             "repo": repository,
-            "interval": MeasurementInterval.INTERVAL_30_DAY.value,
+            "interval": request.query_params.get(
+                "interval", MeasurementInterval.INTERVAL_30_DAY.value
+            ),
         }
 
-        client = CodecovApiClient(git_provider_org="codecov")
+        client = CodecovApiClient(git_provider_org=owner)
         graphql_response = client.query(query=query, variables=variables)
         test_results = TestResultAggregatesSerializer().to_representation(graphql_response.json())
 

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from django.urls import reverse
 
@@ -6,7 +6,7 @@ from sentry.testutils.cases import APITestCase
 
 
 class TestResultsAggregatesEndpointTest(APITestCase):
-    endpoint = "sentry-api-0-test-results-aggregates"
+    endpoint_name = "sentry-api-0-test-results-aggregates"
 
     def setUp(self):
         super().setUp()
@@ -15,7 +15,7 @@ class TestResultsAggregatesEndpointTest(APITestCase):
     def reverse_url(self, owner="testowner", repository="testrepo"):
         """Custom reverse URL method to handle required URL parameters"""
         return reverse(
-            self.endpoint,
+            self.endpoint_name,
             kwargs={
                 "owner": owner,
                 "repository": repository,
@@ -59,7 +59,7 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         url = self.reverse_url()
         response = self.client.get(url)
 
-        mock_codecov_client_class.assert_called_once_with(git_provider_org="codecov")
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
         assert mock_codecov_client_instance.query.call_count == 1
         assert response.status_code == 200
 
@@ -73,3 +73,51 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         assert response.data["totalFailsPercentChange"] == 10.0
         assert response.data["totalSkips"] == 100
         assert response.data["totalSkipsPercentChange"] == 10.0
+
+    @patch(
+        "sentry.codecov.endpoints.TestResultsAggregates.test_results_aggregates.CodecovApiClient"
+    )
+    def test_get_with_interval_query_param(self, mock_codecov_client_class):
+        mock_graphql_response = {
+            "data": {
+                "owner": {
+                    "repository": {
+                        "__typename": "Repository",
+                        "testAnalytics": {
+                            "testResultsAggregates": {
+                                "totalDuration": 100.0,
+                                "totalDurationPercentChange": 11.11,
+                                "slowestTestsDuration": 100.0,
+                                "slowestTestsDurationPercentChange": 11.11,
+                                "totalSlowTests": 100,
+                                "totalSlowTestsPercentChange": 11.11,
+                                "totalFails": 100,
+                                "totalFailsPercentChange": 10,
+                                "totalSkips": 100,
+                                "totalSkipsPercentChange": 10,
+                            }
+                        },
+                    }
+                }
+            }
+        }
+
+        mock_codecov_client_instance = Mock()
+        mock_response = Mock()
+        mock_response.json.return_value = mock_graphql_response
+        mock_codecov_client_instance.query.return_value = mock_response
+        mock_codecov_client_class.return_value = mock_codecov_client_instance
+
+        url = self.reverse_url()
+        response = self.client.get(url, {"interval": "INTERVAL_7_DAY"})
+
+        assert response.status_code == 200
+        mock_codecov_client_class.assert_called_once_with(git_provider_org="testowner")
+        mock_codecov_client_instance.query.assert_called_once_with(
+            query=ANY,
+            variables={
+                "owner": "testowner",
+                "repo": "testrepo",
+                "interval": "INTERVAL_7_DAY",
+            },
+        )

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -43,7 +43,13 @@ class TestResultsAggregatesEndpointTest(APITestCase):
                                 "totalFailsPercentChange": 10,
                                 "totalSkips": 100,
                                 "totalSkipsPercentChange": 10,
-                            }
+                            },
+                            "flakeAggregates": {
+                                "flakeCount": 10,
+                                "flakeCountPercentChange": 5.0,
+                                "flakeRate": 0.5,
+                                "flakeRatePercentChange": 0.1,
+                            },
                         },
                     }
                 }
@@ -73,6 +79,10 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         assert response.data["totalFailsPercentChange"] == 10.0
         assert response.data["totalSkips"] == 100
         assert response.data["totalSkipsPercentChange"] == 10.0
+        assert response.data["flakeCount"] == 10
+        assert response.data["flakeCountPercentChange"] == 5.0
+        assert response.data["flakeRate"] == 0.5
+        assert response.data["flakeRatePercentChange"] == 0.1
 
     @patch(
         "sentry.codecov.endpoints.TestResultsAggregates.test_results_aggregates.CodecovApiClient"
@@ -95,7 +105,13 @@ class TestResultsAggregatesEndpointTest(APITestCase):
                                 "totalFailsPercentChange": 10,
                                 "totalSkips": 100,
                                 "totalSkipsPercentChange": 10,
-                            }
+                            },
+                            "flakeAggregates": {
+                                "flakeCount": 10,
+                                "flakeCountPercentChange": 5.0,
+                                "flakeRate": 0.5,
+                                "flakeRatePercentChange": 0.1,
+                            },
                         },
                     }
                 }


### PR DESCRIPTION
This commit adds support for the interval query parameter to the
TestResultsAggregates endpoint.

Depends on: https://github.com/getsentry/sentry/pull/93264