### PR TITLE
fix(ui): Disable timeline zoom when cursor occluded

### DIFF
--- a/static/app/components/checkInTimeline/timelineCursor.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.tsx
@@ -66,7 +66,7 @@ function useTimelineCursor<E extends HTMLElement>({
       // elements within the container may trigger an onMouseLeave even when
       // the mouse is still "inside" of the container
       //
-      // Also tests that the mouse is not obscured by a overlay element.
+      // Also tests that the mouse is not occluded by a overlay element.
       const isInsideContainer =
         e.clientX > containerRect.left &&
         e.clientX < containerRect.right &&

--- a/static/app/components/checkInTimeline/timelineZoom.spec.tsx
+++ b/static/app/components/checkInTimeline/timelineZoom.spec.tsx
@@ -21,6 +21,8 @@ function TestComponent({onSelect}: TestProps) {
 }
 
 beforeEach(() => {
+  document.elementsFromPoint = () => [];
+
   jest
     .spyOn(window, 'requestAnimationFrame')
     .mockImplementation((callback: FrameRequestCallback): number => {

--- a/static/app/components/checkInTimeline/timelineZoom.tsx
+++ b/static/app/components/checkInTimeline/timelineZoom.tsx
@@ -90,12 +90,16 @@ function useTimelineZoom<E extends HTMLElement>({enabled = true, onSelect}: Opti
     const containerRect = containerRef.current.getBoundingClientRect();
     const offset = e.clientX - containerRect.left;
 
-    // Selection is only activated when inside the container
+    // Selection is only activated when inside the container. Also tests that
+    // the mouse is not occluded by a overlay element.
     const isInsideContainer =
       e.clientX > containerRect.left &&
       e.clientX < containerRect.right &&
       e.clientY > containerRect.top &&
-      e.clientY < containerRect.bottom;
+      e.clientY < containerRect.bottom &&
+      !document
+        .elementsFromPoint(e.clientX, e.clientY)
+        .some(el => el.hasAttribute('data-overlay'));
 
     if (!isInsideContainer) {
       return;


### PR DESCRIPTION
Adds the modal backdrop to the list of elements that occlude the
timeline cursor. Additionally the zoom handler now filters on occluded
elements.