### PR TITLE
fix(ui): Mark modal backdrop as data-overlay

### DIFF
--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -222,6 +222,7 @@ function GlobalModal({onClose}: Props) {
   return createPortal(
     <Fragment>
       <Backdrop
+        data-overlay
         style={backdrop && visible ? {opacity: 0.5, pointerEvents: 'auto'} : {}}
         css={options?.backdropCss}
       />


### PR DESCRIPTION
This helps things like the timeline zoom detect when they're being occluded by an overlay component.