### PR TITLE
ref: type some decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ disable_error_code = [
 module = [
     "fixtures.safe_migrations_apps.*",
     "sentry.analytics.*",
+    "sentry.api.decorators",
     "sentry.api.endpoints.integrations.sentry_apps.installation.external_issue.*",
     "sentry.api.endpoints.project_repo_path_parsing",
     "sentry.api.endpoints.release_thresholds.health_checks.*",

--- a/src/sentry/api/decorators.py
+++ b/src/sentry/api/decorators.py
@@ -1,8 +1,10 @@
+from collections.abc import Callable
 from functools import wraps
+from typing import Concatenate
 
 from django.contrib.auth.models import AnonymousUser
+from django.http.response import HttpResponseBase
 from rest_framework.request import Request
-from rest_framework.response import Response
 
 from sentry.api.exceptions import PrimaryEmailVerificationRequired, SudoRequired
 from sentry.models.apikey import is_api_key_auth
@@ -23,9 +25,12 @@ def is_considered_sudo(request: Request) -> bool:
     )
 
 
-def sudo_required(func):
+type _RFMethod[T, **P] = Callable[Concatenate[T, Request, P], HttpResponseBase]
+
+
+def sudo_required[T, **P](func: _RFMethod[T, P]) -> _RFMethod[T, P]:
     @wraps(func)
-    def wrapped(self, request: Request, *args, **kwargs) -> Response:
+    def wrapped(self: T, request: Request, *args: P.args, **kwargs: P.kwargs) -> HttpResponseBase:
         # If we are already authenticated through an API key we do not
         # care about the sudo flag.
         if not is_considered_sudo(request):
@@ -37,9 +42,9 @@ def sudo_required(func):
     return wrapped
 
 
-def primary_email_verification_required(func):
+def primary_email_verification_required[T, **P](func: _RFMethod[T, P]) -> _RFMethod[T, P]:
     @wraps(func)
-    def wrapped(self, request: Request, *args, **kwargs) -> Response:
+    def wrapped(self: T, request: Request, *args: P.args, **kwargs: P.kwargs) -> HttpResponseBase:
         if isinstance(request.user, AnonymousUser) or not request.user.has_verified_primary_email():
             raise PrimaryEmailVerificationRequired(request.user)
         return func(self, request, *args, **kwargs)

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import sentry_sdk
 from django.db import IntegrityError, router, transaction
+from django.http.response import HttpResponseBase
 from django.utils.text import slugify
 from drf_spectacular.utils import extend_schema, extend_schema_serializer, inline_serializer
 from rest_framework import serializers, status
@@ -336,7 +337,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         },
         examples=SCIMExamples.QUERY_INDIVIDUAL_TEAM,
     )
-    def get(self, request: Request, organization, team) -> Response:  # type: ignore[override]  # convert_args changed shape from baseclass
+    def get(self, request: Request, organization: Organization, team: Team) -> Response:  # type: ignore[override]  # convert_args changed shape from baseclass
         """
         Query an individual team with a SCIM Group GET Request.
         - Note that the members field will only contain up to 10000 members.
@@ -486,14 +487,14 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(self, request: Request, organization, team) -> Response:
+    def delete(self, request: Request, organization: Organization, team: Team) -> HttpResponseBase:  # type: ignore[override]  # convert_args changed shape from baseclass
         """
         Delete a team with a SCIM Group DELETE Request.
         """
         metrics.incr("sentry.scim.team.delete")
         return super().delete(request, team)
 
-    def put(self, request: Request, organization, team) -> Response:  # type: ignore[override]  # convert_args changed shape from baseclass
+    def put(self, request: Request, organization: Organization, team: Team) -> Response:  # type: ignore[override]  # convert_args changed shape from baseclass
         # override parent's put since we don't have puts
         # in SCIM Team routes
         return self.http_method_not_allowed(request)

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -11,7 +11,7 @@ import typing
 from collections.abc import Callable, Collection, Generator, Iterable, Mapping, MutableSet, Sequence
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, overload
 from unittest import TestCase
 
 import pytest
@@ -155,6 +155,16 @@ class SiloModeTestDecorator:
 
     def __init__(self, *silo_modes: SiloMode) -> None:
         self.silo_modes = frozenset(silo_modes)
+
+    @overload
+    def __call__[T: (type[Any], Callable[..., Any])](self, decorated_obj: T) -> T: ...
+
+    @overload
+    def __call__[
+        T: (type[Any], Callable[..., Any])
+    ](self, *, regions: Sequence[Region] = (), include_monolith_run: bool = False) -> Callable[
+        [T], T
+    ]: ...
 
     def __call__(
         self,


### PR DESCRIPTION
this prevents the decorated functions from becoming untyped -- eventually I want to turn on --disallow-untyped-decorators

<!-- Describe your PR here. -->