### PR TITLE
feat(toolbar): Load toolbar data from the org where its running

### DIFF
--- a/static/app/utils/useInitSentryToolbar.tsx
+++ b/static/app/utils/useInitSentryToolbar.tsx
@@ -8,14 +8,14 @@ import FeatureFlagOverrides from 'sentry/utils/featureFlagOverrides';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 
 export default function useInitSentryToolbar(organization: null | Organization) {
-  const showDevToolbar = Boolean(organization?.features.includes('devtoolbar'));
+  const showDevToolbar = !!organization && !!organization.features.includes('devtoolbar');
   const isEmployee = useIsSentryEmployee();
   const config = useLegacyStore(ConfigStore);
 
   useSentryToolbar({
     enabled: showDevToolbar && isEmployee,
     initProps: {
-      organizationSlug: 'sentry',
+      organizationSlug: organization?.slug ?? 'sentry',
       projectIdOrSlug: 'javascript',
       environment: 'prod',
       theme: config.theme,


### PR DESCRIPTION
Previously we would always try to load Issue and Feedback data from sentry.sentry.io, because that is the org where we store data related to `https://sentry.sentry.io/organizations/*`. So if you're browsing `https://demo.sentry.io/explore/issues` we would query `https://us.sentry.io/api/0/organizations/sentry/issues/` to get the list of problems.

For this to continue working we'd need to have a CSP with `frame-src sentry.sentry.io`. Instead we have `frame-src 'self'`. 

So I'm changing the toolbar config to try to load/connect to the "self" domain (organization.slug of the org you're looking at). So if you're on `demo.sentry.io` then the toolbar will connect to `demo.sentry.io/api/0/organizations/sentry/issues/`. This means that the Issues and Feedback panels inside the toolbar will be empty, but the Feature Flag panel will still work.

This could be fine, because people on those orgs mostly just want to use the Feature Flags panel. During conferences or something like that, we'll be less likely to leak Issues & Feedback data at the booth... but it also makes for a bad toolbar demo.
