### PR TITLE
ref(integrations): raise ApiError in integration identity OAuth flows

### DIFF
--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -110,7 +110,7 @@ class GitlabIdentityProvider(OAuth2Provider):
             refresh_token=refresh_token,
             url=refresh_token_url,
             identity=identity,
-            verify_ssl=kwargs["verify_ssl"] ** kwargs,
+            verify_ssl=kwargs["verify_ssl"],
         )
 
         try:

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -7,7 +7,7 @@ import orjson
 
 from sentry import http
 from sentry.auth.exceptions import IdentityNotValid
-from sentry.http import safe_urlopen, safe_urlread
+from sentry.http import safe_urlread
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.identity.services.identity import identity_service
 from sentry.identity.services.identity.model import RpcIdentity
@@ -106,10 +106,11 @@ class GitlabIdentityProvider(OAuth2Provider):
         if not refresh_token_url:
             raise IdentityNotValid("Missing refresh token url")
 
-        data = self.get_refresh_token_params(refresh_token=refresh_token, identity=identity)
-
-        req = safe_urlopen(
-            url=refresh_token_url, headers={}, data=data, verify_ssl=kwargs["verify_ssl"]
+        req = self.get_refresh_token(
+            refresh_token=refresh_token,
+            url=refresh_token_url,
+            identity=identity,
+            **kwargs,
         )
 
         try:
@@ -129,8 +130,6 @@ class GitlabIdentityProvider(OAuth2Provider):
                 },
             )
             payload = {}
-
-        self.handle_refresh_error(req, payload)
 
         identity.data.update(get_oauth_data(payload))
         return identity_service.update_data(identity_id=identity.id, data=identity.data)

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -110,7 +110,7 @@ class GitlabIdentityProvider(OAuth2Provider):
             refresh_token=refresh_token,
             url=refresh_token_url,
             identity=identity,
-            **kwargs,
+            verify_ssl=kwargs["verify_ssl"] ** kwargs,
         )
 
         try:

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -29,6 +29,7 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
+from sentry.pipeline.views.base import PipelineView
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, ApiUnauthorized
 from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
@@ -164,6 +165,7 @@ class OAuth2Provider(Provider):
                 url=url,
                 headers=self.get_refresh_token_headers(),
                 data=data,
+                verify_ssl=kwargs.get("verify_ssl", True),
             )
             req.raise_for_status()
         except HTTPError as e:
@@ -284,7 +286,7 @@ class OAuth2CallbackView:
             "client_secret": self.client_secret,
         }
 
-    def get_access_token(self, pipeline: IdentityPipelineT, code: str) -> Response:
+    def get_access_token(self, pipeline: IdentityPipeline, code: str) -> Response:
         data = self.get_token_params(code=code, redirect_uri=absolute_uri(_redirect_url(pipeline)))
         verify_ssl = pipeline.config.get("verify_ssl", True)
         return safe_urlopen(self.access_token_url, data=data, verify_ssl=verify_ssl)

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -13,7 +13,7 @@ from django.http.response import HttpResponseBase
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from requests.exceptions import SSLError
+from requests.exceptions import HTTPError, SSLError
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.exceptions import NotRegistered
@@ -215,9 +215,17 @@ class OAuth2Provider(Provider):
 
         data = self.get_refresh_token_params(refresh_token, identity, **kwargs)
 
-        req = safe_urlopen(
-            url=self.get_refresh_token_url(), headers=self.get_refresh_token_headers(), data=data
-        )
+        try:
+            url = self.get_refresh_token_url()
+            req = safe_urlopen(
+                url=self.get_refresh_token_url(),
+                headers=self.get_refresh_token_headers(),
+                data=data,
+            )
+            req.raise_for_status()
+        except HTTPError as e:
+            error_resp = e.response
+            raise ApiError.from_response(error_resp, url=url) from e
 
         try:
             body = safe_urlread(req)
@@ -330,17 +338,14 @@ class OAuth2CallbackView:
             verify_ssl = pipeline.config.get("verify_ssl", True)
             try:
                 req = safe_urlopen(self.access_token_url, data=data, verify_ssl=verify_ssl)
-                body = safe_urlread(req)
-                content_type = req.headers.get("Content-Type", "").lower()
-                if content_type.startswith("application/x-www-form-urlencoded"):
-                    return dict(parse_qsl(body))
-                return orjson.loads(body)
+                req.raise_for_status()
+            except HTTPError as e:
+                error_resp = e.response
+                raise ApiError.from_response(error_resp, url=self.access_token_url) from e
             except SSLError:
-                logger.info(
-                    "identity.oauth2.ssl-error",
-                    extra={"url": self.access_token_url, "verify_ssl": verify_ssl},
+                lifecycle.record_failure(
+                    "ssl_error", {"verify_ssl": verify_ssl, "url": self.access_token_url}
                 )
-                lifecycle.record_failure("ssl_error")
                 url = self.access_token_url
                 return {
                     "error": "Could not verify SSL certificate",
@@ -348,15 +353,22 @@ class OAuth2CallbackView:
                 }
             except ConnectionError:
                 url = self.access_token_url
-                logger.info("identity.oauth2.connection-error", extra={"url": url})
-                lifecycle.record_failure("connection_error")
+                lifecycle.record_failure("connection_error", {"url": url})
                 return {
                     "error": "Could not connect to host or service",
                     "error_description": f"Ensure that {url} is open to connections",
                 }
+
+            try:
+                body = safe_urlread(req)
+                content_type = req.headers.get("Content-Type", "").lower()
+                if content_type.startswith("application/x-www-form-urlencoded"):
+                    return dict(parse_qsl(body))
+                return orjson.loads(body)
             except orjson.JSONDecodeError:
-                logger.info("identity.oauth2.json-error", extra={"url": self.access_token_url})
-                lifecycle.record_failure("json_error", {"content_type": content_type})
+                lifecycle.record_failure(
+                    "json_error", {"content_type": content_type, "url": self.access_token_url}
+                )
                 return {
                     "error": "Could not decode a JSON Response",
                     "error_description": "We were not able to parse a JSON response, please try again.",

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -29,9 +29,8 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
-from sentry.pipeline import Pipeline
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, ApiUnauthorized
-from sentry.users.models.identity import Identity, IdentityProvider
+from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
 
 from .base import Provider
@@ -285,7 +284,7 @@ class OAuth2CallbackView:
             "client_secret": self.client_secret,
         }
 
-    def get_access_token(self, pipeline: Pipeline[IdentityProvider], code: str) -> Response:
+    def get_access_token(self, pipeline: IdentityPipelineT, code: str) -> Response:
         data = self.get_token_params(code=code, redirect_uri=absolute_uri(_redirect_url(pipeline)))
         verify_ssl = pipeline.config.get("verify_ssl", True)
         return safe_urlopen(self.access_token_url, data=data, verify_ssl=verify_ssl)

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import parse_qsl
 
-import orjson
 from django.core.exceptions import PermissionDenied
-from django.http.request import HttpRequest
+from requests import Response
 
 from sentry import http, options
-from sentry.http import safe_urlopen, safe_urlread
-from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView, OAuth2Provider, record_event
+from sentry.http import safe_urlopen
+from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView, OAuth2Provider
 from sentry.identity.pipeline import IdentityPipeline
-from sentry.integrations.utils.metrics import IntegrationPipelineViewType
+from sentry.pipeline.base import Pipeline
 from sentry.pipeline.views.base import PipelineView
-from sentry.users.models.identity import Identity
+from sentry.users.models.identity import Identity, IdentityProvider
 from sentry.utils.http import absolute_uri
 
 
@@ -125,30 +123,19 @@ class VSTSIdentityProvider(OAuth2Provider):
 
 
 class VSTSOAuth2CallbackView(OAuth2CallbackView):
-    def exchange_token(
-        self, request: HttpRequest, pipeline: IdentityPipeline, code: str
-    ) -> dict[str, str]:
-        with record_event(
-            IntegrationPipelineViewType.TOKEN_EXCHANGE, pipeline.provider.key
-        ).capture():
-            req = safe_urlopen(
-                url=self.access_token_url,
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "Content-Length": "1322",
-                },
-                data={
-                    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                    "client_assertion": self.client_secret,
-                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-                    "assertion": code,
-                    "redirect_uri": pipeline.config.get("redirect_url"),
-                },
-            )
-            body = safe_urlread(req)
-            if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
-                return dict(parse_qsl(body))
-            return orjson.loads(body)
+    def get_access_token(self, pipeline: Pipeline[IdentityProvider], code: str) -> Response:
+        data = {
+            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion": self.client_secret,
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": code,
+            "redirect_uri": pipeline.config.get("redirect_url"),
+        }
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": "1322",
+        }
+        return safe_urlopen(self.access_token_url, data=data, headers=headers)
 
 
 # TODO(iamrajjoshi): Make this the default provider
@@ -246,27 +233,12 @@ class VSTSOAuth2LoginView(OAuth2LoginView):
 
 
 class VSTSNewOAuth2CallbackView(OAuth2CallbackView):
-    def exchange_token(
-        self, request: HttpRequest, pipeline: IdentityPipeline, code: str
-    ) -> dict[str, str]:
-        with record_event(
-            IntegrationPipelineViewType.TOKEN_EXCHANGE, pipeline.provider.key
-        ).capture():
-            req = safe_urlopen(
-                url=self.access_token_url,
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded",
-                    "Content-Length": "1322",
-                },
-                data={
-                    "grant_type": "authorization_code",
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                    "code": code,
-                    "redirect_uri": absolute_uri(pipeline.config.get("redirect_url")),
-                },
-            )
-            body = safe_urlread(req)
-            if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
-                return dict(parse_qsl(body))
-            return orjson.loads(body)
+    def get_access_token(self, pipeline: Pipeline[IdentityProvider], code: str) -> Response:
+        data = self.get_token_params(
+            code=code, redirect_uri=absolute_uri(pipeline.config.get("redirect_url"))
+        )
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Length": "1322",
+        }
+        return safe_urlopen(self.access_token_url, data=data, headers=headers)

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -122,7 +122,7 @@ class VSTSIdentityProvider(OAuth2Provider):
 
 
 class VSTSOAuth2CallbackView(OAuth2CallbackView):
-    def get_access_token(self, pipeline: IdentityPipelineT, code: str) -> Response:
+    def get_access_token(self, pipeline: IdentityPipeline, code: str) -> Response:
         data = {
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
             "client_assertion": self.client_secret,
@@ -232,7 +232,7 @@ class VSTSOAuth2LoginView(OAuth2LoginView):
 
 
 class VSTSNewOAuth2CallbackView(OAuth2CallbackView):
-    def get_access_token(self, pipeline: IdentityPipelineT, code: str) -> Response:
+    def get_access_token(self, pipeline: IdentityPipeline, code: str) -> Response:
         data = self.get_token_params(
             code=code, redirect_uri=absolute_uri(pipeline.config.get("redirect_url"))
         )

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -9,9 +9,8 @@ from sentry import http, options
 from sentry.http import safe_urlopen
 from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView, OAuth2Provider
 from sentry.identity.pipeline import IdentityPipeline
-from sentry.pipeline.base import Pipeline
 from sentry.pipeline.views.base import PipelineView
-from sentry.users.models.identity import Identity, IdentityProvider
+from sentry.users.models.identity import Identity
 from sentry.utils.http import absolute_uri
 
 
@@ -123,7 +122,7 @@ class VSTSIdentityProvider(OAuth2Provider):
 
 
 class VSTSOAuth2CallbackView(OAuth2CallbackView):
-    def get_access_token(self, pipeline: Pipeline[IdentityProvider], code: str) -> Response:
+    def get_access_token(self, pipeline: IdentityPipelineT, code: str) -> Response:
         data = {
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
             "client_assertion": self.client_secret,
@@ -233,7 +232,7 @@ class VSTSOAuth2LoginView(OAuth2LoginView):
 
 
 class VSTSNewOAuth2CallbackView(OAuth2CallbackView):
-    def get_access_token(self, pipeline: Pipeline[IdentityProvider], code: str) -> Response:
+    def get_access_token(self, pipeline: IdentityPipelineT, code: str) -> Response:
         data = self.get_token_params(
             code=code, redirect_uri=absolute_uri(pipeline.config.get("redirect_url"))
         )

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from unittest.mock import patch
 from urllib.parse import parse_qs, parse_qsl, urlparse
 
+import pytest
 import responses
 from django.test import Client, RequestFactory
 from requests.exceptions import SSLError
@@ -13,6 +14,7 @@ from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.integrations.types import EventLifecycleOutcome
+from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
 from sentry.testutils.silo import control_silo_test
 
@@ -138,6 +140,21 @@ class OAuth2CallbackViewTest(TestCase):
         assert "JSON" in result["error_description"]
 
         assert_failure_metric(mock_record, "json_error")
+
+    @responses.activate
+    def test_api_error(self, mock_record):
+        responses.add(
+            responses.POST,
+            "https://example.org/oauth/token",
+            json={"token": "a-fake-token"},
+            status=401,
+        )
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        code = "auth-code"
+        with pytest.raises(ApiError):
+            self.view.exchange_token(self.request, pipeline, code)
+
+        assert_failure_metric(mock_record, ApiUnauthorized('{"token": "a-fake-token"}'))
 
 
 @control_silo_test

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -148,7 +148,7 @@ class OAuth2CallbackViewTest(TestCase):
             json={"token": "a-fake-token"},
             status=401,
         )
-        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        pipeline = IdentityPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
         result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" not in result


### PR DESCRIPTION
There is currently no distinction when exchanging a token in an OAuth flow fails due to an inability to parse the response vs if the status code >= 400. Refreshing an identity token also does not have any error handling whatsoever and always tries to parse the response. Integration clients have built in handling for these via `BaseApiClient` after calling `resp.raise_for_status()`:

https://github.com/getsentry/sentry/blob/5f977a4df39743f246e12bd11f0150d5d2de8d48/src/sentry/shared_integrations/client/base.py#L287-L298

We should be doing the same thing for our identity flows, which currently just use `safe_urlopen` (a wrapper around `session.request`).

This PR also includes some refactors to ensure all integration identity oauth2 providers subclassing `OAuth2Provider` are also utilizing the new error handling.