### PR TITLE
ref(tests): Update create_detector_and_condition to return condition

### DIFF
--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -186,7 +186,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
         self.uuid_patcher.stop()
         self.sm_comp_patcher.stop()
 
-    def create_detector_and_conditions(self, type: str | None = None):
+    def create_detector_and_condition(self, type: str | None = None):
         if type is None:
             type = "handler_with_state"
         self.project = self.create_project()
@@ -195,19 +195,19 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             workflow_condition_group=self.create_data_condition_group(),
             type=type,
         )
-        self.create_data_condition(
+        data_condition = self.create_data_condition(
             type=Condition.GREATER,
             comparison=5,
             condition_result=DetectorPriorityLevel.HIGH,
             condition_group=detector.workflow_condition_group,
         )
-        return detector
+        return detector, data_condition
 
     def build_handler(
         self, detector: Detector | None = None, detector_type=None
     ) -> MockDetectorStateHandler:
         if detector is None:
-            detector = self.create_detector_and_conditions(detector_type)
+            detector, _ = self.create_detector_and_condition(detector_type)
         return MockDetectorStateHandler(detector)
 
     def assert_updates(

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -44,7 +44,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     def test_state_results(self, mock_produce_occurrence_to_kafka):
-        detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
+        detector, _ = self.create_detector_and_condition(type=self.handler_state_type.slug)
         data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {None: 6}})
         results = process_detectors(data_packet, [detector])
 
@@ -84,7 +84,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     def test_state_results_multi_group(self, mock_produce_occurrence_to_kafka):
-        detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
+        detector, _ = self.create_detector_and_condition(type=self.handler_state_type.slug)
         data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {"group_1": 6, "group_2": 10}})
         results = process_detectors(data_packet, [detector])
 
@@ -200,7 +200,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
     def test_metrics_and_logs_fire(
         self, mock_logger, mock_metrics, mock_produce_occurrence_to_kafka
     ):
-        detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
+        detector, _ = self.create_detector_and_condition(type=self.handler_state_type.slug)
         data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {None: 6}})
         results = process_detectors(data_packet, [detector])
 
@@ -254,7 +254,7 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
     def test_metrics_and_logs_resolve(
         self, mock_logger, mock_metrics, mock_produce_occurrence_to_kafka
     ):
-        detector = self.create_detector_and_conditions(type=self.handler_state_type.slug)
+        detector, _ = self.create_detector_and_condition(type=self.handler_state_type.slug)
         data_packet = DataPacket("1", {"dedupe": 2, "group_vals": {None: 6}})
         process_detectors(data_packet, [detector])
 


### PR DESCRIPTION
Update the base class test name `create_detector_and_conditions` to be `create_detector_and_condition` as it only creates one data condition and update the return value to include the condition as it can be useful. This is a chip off of another larger PR which will actually use this.