### PR TITLE
feat(crons): Add notice to edit / details when upserting

### DIFF
--- a/static/app/views/insights/crons/components/detailsSidebar.tsx
+++ b/static/app/views/insights/crons/components/detailsSidebar.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
+import {Alert} from 'sentry/components/core/alert';
 import {ActorAvatar} from 'sentry/components/core/avatar/actorAvatar';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
@@ -9,7 +10,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import Text from 'sentry/components/text';
 import TimeSince from 'sentry/components/timeSince';
-import {IconCopy} from 'sentry/icons';
+import {IconCopy, IconJson} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getFormattedDate} from 'sentry/utils/dates';
@@ -164,6 +165,15 @@ export function DetailsSidebar({monitorEnv, monitor, showUnknownLegend}: Props) 
           value={getFormattedDate(monitor.dateCreated, 'MMM D, YYYY')}
         />
       </KeyValueTable>
+      {monitor.isUpserting && (
+        <Alert.Container>
+          <Alert type="muted" icon={<IconJson />} showIcon>
+            {t(
+              'This monitor is managed in code and updates automatically with each check-in.'
+            )}
+          </Alert>
+        </Alert.Container>
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -257,6 +257,16 @@ function MonitorForm({
       submitLabel={submitLabel}
     >
       <StyledList symbol="colored-numeric">
+        {monitor?.isUpserting && (
+          <Alert.Container>
+            <Alert type="warning" showIcon>
+              {t(
+                'This monitor is managed in code and updates automatically with each check-in. Changes made here may be overwritten!'
+              )}
+            </Alert>
+          </Alert.Container>
+        )}
+
         <StyledListItem>{t('Add a name and project')}</StyledListItem>
         <ListItemSubText>{t('The name will show up in notifications.')}</ListItemSubText>
         <InputGroup noPadding>

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -117,6 +117,7 @@ export interface Monitor {
   environments: MonitorEnvironment[];
   id: string;
   isMuted: boolean;
+  isUpserting: boolean;
   name: string;
   owner: Actor;
   project: Project;

--- a/tests/js/fixtures/monitor.ts
+++ b/tests/js/fixtures/monitor.ts
@@ -16,6 +16,7 @@ export function MonitorFixture(params: Partial<Monitor> = {}): Monitor {
     slug: 'my-monitor',
     status: 'active',
     owner: ActorFixture(),
+    isUpserting: false,
     config: {
       checkin_margin: 5,
       max_runtime: 10,


### PR DESCRIPTION
Looks like This

<img alt="clipboard.png" width="742" src="https://i.imgur.com/BwKkZdR.png" />

<img alt="clipboard.png" width="875" src="https://i.imgur.com/hZOBHfo.png" />

Fixes: [NEW-162: Indicate when a monitor has been created via upsert](https://linear.app/getsentry/issue/NEW-162/indicate-when-a-monitor-has-been-created-via-upsert)