### PR TITLE
feat(ACI): Generate title for metric issue occurrence

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -2,22 +2,28 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
 
 from sentry import features
+from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.handlers.condition import *  # noqa
 from sentry.incidents.metric_alert_detector import MetricAlertsDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
+from sentry.incidents.utils.format_duration import format_duration_idiomatic
+from sentry.incidents.utils.metric_issue_poc import QUERY_AGGREGATION_DISPLAY
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
+from sentry.integrations.metric_alerts import TEXT_COMPARISON_DELTA
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
 from sentry.ratelimits.sliding_windows import Quota
+from sentry.snuba.metrics import format_mri_field, is_mri_field
+from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import DetectorOccurrence, StatefulDetectorHandler
-from sentry.workflow_engine.handlers.detector.base import EvidenceData
+from sentry.workflow_engine.handlers.detector.base import EventData, EvidenceData
+from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
-from sentry.workflow_engine.types import DetectorPriorityLevel, DetectorSettings
+from sentry.workflow_engine.types import DetectorException, DetectorPriorityLevel, DetectorSettings
 
 COMPARISON_DELTA_CHOICES: list[None | int] = [choice.value for choice in ComparisonDeltaChoices]
 COMPARISON_DELTA_CHOICES.append(None)
@@ -28,16 +34,37 @@ class MetricIssueEvidenceData(EvidenceData):
     alert_id: int
 
 
-class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate, int]):
+class MetricIssueDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate, int]):
     def create_occurrence(
         self,
         evaluation_result: ProcessedDataConditionGroup,
         data_packet: DataPacket[QuerySubscriptionUpdate],
         priority: DetectorPriorityLevel,
-    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
-        # Returning a placeholder for now, this may require us passing more info
+    ) -> tuple[DetectorOccurrence, EventData]:
+        try:
+            detector_trigger = DataCondition.objects.get(
+                condition_group=self.detector.workflow_condition_group, condition_result=priority
+            )
+        except DataCondition.DoesNotExist:
+            raise DetectorException(
+                f"Failed to find detector trigger for detector id {self.detector.id}, cannot create metric issue occurrence"
+            )
+
+        try:
+            query_subscription = QuerySubscription.objects.get(id=data_packet.source_id)
+        except QuerySubscription.DoesNotExist:
+            raise DetectorException(
+                f"Failed to find query subscription for detector id {self.detector.id}, cannot create metric issue occurrence"
+            )
+
+        try:
+            snuba_query = SnubaQuery.objects.get(id=query_subscription.snuba_query_id)
+        except SnubaQuery.DoesNotExist:
+            raise DetectorException(
+                f"Failed to find snuba query for detector id {self.detector.id}, cannot create metric issue occurrence"
+            )
         occurrence = DetectorOccurrence(
-            issue_title="Some Issue Title",
+            issue_title=self.construct_title(snuba_query, detector_trigger, priority),
             subtitle="An Issue Subtitle",
             type=MetricIssue,
             level="error",
@@ -50,6 +77,56 @@ class MetricAlertDetectorHandler(StatefulDetectorHandler[QuerySubscriptionUpdate
 
     def extract_value(self, data_packet: DataPacket[QuerySubscriptionUpdate]) -> int:
         return data_packet.packet["values"]["value"]
+
+    def construct_title(
+        self,
+        snuba_query: SnubaQuery,
+        detector_trigger: DataCondition,
+        priority: DetectorPriorityLevel,
+    ) -> str:
+        comparison_delta = self.detector.config.get("comparison_delta")
+        agg_display_key = snuba_query.aggregate
+
+        if is_mri_field(agg_display_key):
+            aggregate = format_mri_field(agg_display_key)
+        elif CRASH_RATE_ALERT_AGGREGATE_ALIAS in agg_display_key:
+            agg_display_key = agg_display_key.split(f"AS {CRASH_RATE_ALERT_AGGREGATE_ALIAS}")[
+                0
+            ].strip()
+            aggregate = QUERY_AGGREGATION_DISPLAY.get(agg_display_key, agg_display_key)
+        else:
+            aggregate = QUERY_AGGREGATION_DISPLAY.get(agg_display_key, agg_display_key)
+
+        # Determine the higher or lower comparison
+        higher_or_lower = ""
+        if detector_trigger.type == Condition.GREATER:
+            higher_or_lower = "greater than" if comparison_delta else "above"
+        else:
+            higher_or_lower = "less than" if comparison_delta else "below"
+
+        label = "Warning" if priority == DetectorPriorityLevel.MEDIUM else "Critical"
+
+        # Format the time window for the threshold
+        time_window = format_duration_idiomatic(snuba_query.time_window // 60)
+
+        # If the detector_trigger has a comparison delta, format the comparison string
+        comparison: str | int | float = "threshold"
+        if comparison_delta:
+            comparison_delta_minutes = comparison_delta // 60
+            comparison = TEXT_COMPARISON_DELTA.get(
+                comparison_delta_minutes, f"same time {comparison_delta_minutes} minutes ago "
+            )
+        else:
+            comparison = detector_trigger.comparison
+
+        template = "{label}: {metric} in the last {time_window} {higher_or_lower} {comparison}"
+        return template.format(
+            label=label.capitalize(),
+            metric=aggregate,
+            higher_or_lower=higher_or_lower,
+            comparison=comparison,
+            time_window=time_window,
+        )
 
 
 # Example GroupType and detector handler for metric alerts. We don't create these issues yet, but we'll use something
@@ -66,7 +143,7 @@ class MetricIssue(GroupType):
     enable_auto_resolve = False
     enable_escalation_detection = False
     detector_settings = DetectorSettings(
-        handler=MetricAlertDetectorHandler,
+        handler=MetricIssueDetectorHandler,
         validator=MetricAlertsDetectorValidator,
         config_schema={
             "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+class DetectorException(Exception):
+    pass
+
+
 class DetectorPriorityLevel(IntEnum):
     OK = 0
     LOW = PriorityLevel.LOW

--- a/tests/sentry/workflow_engine/handlers/detector/test_metric_issue_detector_handler.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_metric_issue_detector_handler.py
@@ -1,0 +1,121 @@
+from datetime import timedelta
+
+from sentry.incidents.grouptype import MetricIssueDetectorHandler
+from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
+from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
+from tests.sentry.workflow_engine.handlers.detector.test_base import BaseDetectorHandlerTest
+
+
+@freeze_time()
+class TestEvaluateMetricDetector(BaseDetectorHandlerTest):
+    def setUp(self):
+        super().setUp()
+        self.detector_group_key = None
+        self.detector, self.critical_detector_trigger = self.create_detector_and_condition(
+            "handler_with_state"
+        )
+        self.warning_detector_trigger = self.create_data_condition(
+            comparison=3,
+            type=Condition.GREATER,
+            condition_result=DetectorPriorityLevel.MEDIUM,
+            condition_group=self.detector.workflow_condition_group,
+        )
+        with self.tasks():
+            self.snuba_query = create_snuba_query(
+                query_type=SnubaQuery.Type.ERROR,
+                dataset=Dataset.Events,
+                query="hello",
+                aggregate="count()",
+                time_window=timedelta(minutes=1),
+                resolution=timedelta(minutes=1),
+                environment=self.environment,
+                event_types=[SnubaQueryEventType.EventType.ERROR],
+            )
+            self.query_subscription = create_snuba_subscription(
+                project=self.detector.project,
+                subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+                snuba_query=self.snuba_query,
+            )
+        self.alert_rule = self.create_alert_rule()
+        self.create_alert_rule_detector(alert_rule_id=self.alert_rule.id, detector=self.detector)
+
+        self.handler = MetricIssueDetectorHandler(self.detector)
+
+
+class TestConstructTitle(TestEvaluateMetricDetector):
+    def test_title_critical(self):
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == f"Critical: Number of events in the last minute above {self.critical_detector_trigger.comparison}"
+        )
+
+    def test_title_warning(self):
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.warning_detector_trigger,
+            priority=self.warning_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == f"Warning: Number of events in the last minute above {self.warning_detector_trigger.comparison}"
+        )
+
+    def test_title_comparison_delta(self):
+        self.detector.config.update({"comparison_delta": 60 * 60})
+
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == "Critical: Number of events in the last minute greater than same time one hour ago"
+        )
+
+    def test_title_below_threshold(self):
+        self.warning_detector_trigger.type = Condition.LESS
+        self.warning_detector_trigger.save()
+
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.warning_detector_trigger,
+            priority=self.warning_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == f"Warning: Number of events in the last minute below {self.warning_detector_trigger.comparison}"
+        )
+
+    def test_title_different_aggregate(self):
+        self.snuba_query.aggregate = "count_unique(tags[sentry:user])"
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == f"Critical: Number of users affected in the last minute above {self.critical_detector_trigger.comparison}"
+        )
+
+        self.snuba_query.aggregate = "percentage(sessions_crashed, sessions)"
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == f"Critical: Crash free session rate in the last minute above {self.critical_detector_trigger.comparison}"
+        )

--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest import mock
 from uuid import uuid4
@@ -8,11 +8,14 @@ from sentry.backup.scopes import RelocationScope
 from sentry.db.models import Model
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.incidents.grouptype import MetricIssue
+from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.types import QuerySubscriptionUpdate
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
 from sentry.models.project import Project
-from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import EventType, Factories
 from sentry.utils.registry import AlreadyRegisteredError
@@ -223,13 +226,30 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
 
     def create_test_query_data_source(self, detector: Detector) -> tuple[DataSource, DataPacket]:
         """
-        Create a DataSource and DataPacket for testing; this will create a fake QuerySubscriptionUpdate and link it to a data_source.
+        Create a DataSource and DataPacket for testing; this will create a QuerySubscriptionUpdate and link it to a data_source.
 
         A detector is required to create this test data, so we can ensure that the detector
         has a condition to evaluate for the data_packet that evalutes to true.
         """
+        with self.tasks():
+            snuba_query = create_snuba_query(
+                query_type=SnubaQuery.Type.ERROR,
+                dataset=Dataset.Events,
+                query="hello",
+                aggregate="count()",
+                time_window=timedelta(minutes=1),
+                resolution=timedelta(minutes=1),
+                environment=self.environment,
+                event_types=[SnubaQueryEventType.EventType.ERROR],
+            )
+            query_subscription = create_snuba_subscription(
+                project=detector.project,
+                subscription_type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
+                snuba_query=snuba_query,
+            )
+
         subscription_update: QuerySubscriptionUpdate = {
-            "subscription_id": "123",
+            "subscription_id": str(query_subscription.id),
             "values": {"value": 1},
             "timestamp": datetime.now(UTC),
             "entity": "test-entity",


### PR DESCRIPTION
Another piece of the reverted https://github.com/getsentry/sentry/pull/92702 that just adds `construct_title` to generate a non-hardcoded metric issue occurrence title. 