### PR TITLE
feat(ui): Reset error boundaries on HMR in dev

### DIFF
--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -56,6 +56,31 @@ class ErrorBoundary extends Component<Props, State> {
     error: null,
   };
 
+  componentDidMount(): void {
+    // Reset error state on HMR (Hot Module Replacement) in development
+    // This ensures that when React Fast Refresh occurs, the error boundary
+    // doesn't persist stale error state after code fixes
+    if (process.env.NODE_ENV === 'development') {
+      if (typeof module !== 'undefined' && module.hot) {
+        module.hot.accept(() => {
+          // Reset error state when this module is hot-reloaded
+          this.setState({error: null});
+        });
+      }
+    }
+  }
+
+  componentWillUnmount(): void {
+    // Clean up HMR listeners to prevent memory leaks
+    if (process.env.NODE_ENV === 'development') {
+      if (typeof module !== 'undefined' && module.hot) {
+        module.hot.dispose(() => {
+          // Cleanup when module is being replaced
+        });
+      }
+    }
+  }
+
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     const {errorTag} = this.props;
 

--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -56,26 +56,6 @@ class ErrorBoundary extends Component<Props, State> {
     error: null,
   };
 
-  componentDidMount(): void {
-    // Reset error state on HMR (Hot Module Replacement) in development
-    // This ensures that when React Fast Refresh occurs, the error boundary
-    // doesn't persist stale error state after code fixes
-    if (process.env.NODE_ENV === 'development') {
-      if (typeof module !== 'undefined' && module.hot) {
-        module.hot.accept(this.handleClose.bind(this));
-      }
-    }
-  }
-
-  componentWillUnmount(): void {
-    // Clean up HMR listeners to prevent memory leaks
-    if (process.env.NODE_ENV === 'development') {
-      if (typeof module !== 'undefined' && module.hot) {
-        module.hot.dispose(this.handleClose.bind(this));
-      }
-    }
-  }
-
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     const {errorTag} = this.props;
 
@@ -101,9 +81,29 @@ class ErrorBoundary extends Component<Props, State> {
     });
   }
 
-  handleClose() {
-    this.setState({error: null});
+  componentDidMount(): void {
+    // Reset error state on HMR (Hot Module Replacement) in development
+    // This ensures that when React Fast Refresh occurs, the error boundary
+    // doesn't persist stale error state after code fixes
+    if (process.env.NODE_ENV === 'development') {
+      if (typeof module !== 'undefined' && module.hot) {
+        module.hot.accept(this.handleClose);
+      }
+    }
   }
+
+  componentWillUnmount(): void {
+    // Clean up HMR listeners to prevent memory leaks
+    if (process.env.NODE_ENV === 'development') {
+      if (typeof module !== 'undefined' && module.hot) {
+        module.hot.dispose(this.handleClose);
+      }
+    }
+  }
+
+  handleClose = () => {
+    this.setState({error: null});
+  };
 
   render() {
     const {error} = this.state;
@@ -129,9 +129,7 @@ class ErrorBoundary extends Component<Props, State> {
           <Alert type="error" showIcon className={className}>
             <AlertContent>
               {message || t('There was a problem rendering this component')}
-              {this.props.allowDismiss && (
-                <IconClose onClick={() => this.handleClose()} />
-              )}
+              {this.props.allowDismiss && <IconClose onClick={this.handleClose} />}
             </AlertContent>
           </Alert>
         </Alert.Container>

--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -62,10 +62,7 @@ class ErrorBoundary extends Component<Props, State> {
     // doesn't persist stale error state after code fixes
     if (process.env.NODE_ENV === 'development') {
       if (typeof module !== 'undefined' && module.hot) {
-        module.hot.accept(() => {
-          // Reset error state when this module is hot-reloaded
-          this.setState({error: null});
-        });
+        module.hot.accept(this.handleClose.bind(this));
       }
     }
   }
@@ -74,9 +71,7 @@ class ErrorBoundary extends Component<Props, State> {
     // Clean up HMR listeners to prevent memory leaks
     if (process.env.NODE_ENV === 'development') {
       if (typeof module !== 'undefined' && module.hot) {
-        module.hot.dispose(() => {
-          // Cleanup when module is being replaced
-        });
+        module.hot.dispose(this.handleClose.bind(this));
       }
     }
   }

--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -56,6 +56,17 @@ class ErrorBoundary extends Component<Props, State> {
     error: null,
   };
 
+  componentDidMount(): void {
+    // Reset error state on HMR (Hot Module Replacement) in development
+    // This ensures that when React Fast Refresh occurs, the error boundary
+    // doesn't persist stale error state after code fixes
+    if (process.env.NODE_ENV === 'development') {
+      if (typeof module !== 'undefined' && module.hot) {
+        module.hot.accept(this.handleClose);
+      }
+    }
+  }
+
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     const {errorTag} = this.props;
 
@@ -79,17 +90,6 @@ class ErrorBoundary extends Component<Props, State> {
         Sentry.captureException(error);
       }
     });
-  }
-
-  componentDidMount(): void {
-    // Reset error state on HMR (Hot Module Replacement) in development
-    // This ensures that when React Fast Refresh occurs, the error boundary
-    // doesn't persist stale error state after code fixes
-    if (process.env.NODE_ENV === 'development') {
-      if (typeof module !== 'undefined' && module.hot) {
-        module.hot.accept(this.handleClose);
-      }
-    }
   }
 
   componentWillUnmount(): void {


### PR DESCRIPTION
If you hit an error boundary right now you have to refresh the page to get rid of it. This will listen to updates from webpack HMR and attempt to render again.
