### PR TITLE
fit(feedback): Fix overflow on the Feedback page

### DIFF
--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -116,6 +116,15 @@ const Background = styled('div')`
   flex-direction: column;
   align-items: stretch;
   gap: ${space(2)};
+`;
+
+const LayoutGrid = styled('div')`
+  overflow: hidden;
+  flex-grow: 1;
+
+  display: grid;
+  gap: ${space(2)};
+  place-items: stretch;
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(2)};
@@ -128,15 +137,6 @@ const Background = styled('div')`
   @media (min-width: ${p => p.theme.breakpoints.large}) {
     padding: ${space(2)} ${space(4)};
   }
-`;
-
-const LayoutGrid = styled('div')`
-  overflow: hidden;
-  flex-grow: 1;
-
-  display: grid;
-  gap: ${space(2)};
-  place-items: stretch;
 
   grid-template-rows: max-content 1fr;
   grid-template-areas:


### PR DESCRIPTION
**Before**
| Desc | Img |
| --- | --- |
| Wide | <img width="673" alt="SCR-20250611-khrp" src="https://github.com/user-attachments/assets/8cc9e9e0-9b37-4064-9a92-52c870cad85e" />
| Narrow | <img width="590" alt="SCR-20250611-kicr" src="https://github.com/user-attachments/assets/fcba69cf-6fbe-4db3-be44-92a4f31cad8b" />

**After**
| Desc | Img |
| --- | --- |
| Wide | <img width="586" alt="SCR-20250611-khjv" src="https://github.com/user-attachments/assets/ee51d79d-c7dc-4ee6-9e2a-3c828e710c47" />
| Narrow | <img width="591" alt="SCR-20250611-kibt" src="https://github.com/user-attachments/assets/c5896a27-9a68-47bf-9f83-e0ee4c6a26eb" />



this doesn't impact UI1 or scrolling or anything else:
<img width="647" alt="SCR-20250611-khlm" src="https://github.com/user-attachments/assets/444e8c3a-cff7-4b0e-8632-2f9da6c9c3f9" />