### PR TITLE
chore(browser reports): Add collector URL to control silo patterns

### DIFF
--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -138,6 +138,7 @@ const patterns: RegExp[] = [
   new RegExp('^api/0/internal/rpc/[^/]+/[^/]+/$'),
   new RegExp('^api/0/internal/feature-flags/$'),
   new RegExp('^api/0/secret-scanning/github/$'),
+  new RegExp('^api/0/reporting-api-experiment/$'),
   new RegExp('^api/hooks/mailgun/inbound/'),
   new RegExp('^oauth/authorize/$'),
   new RegExp('^oauth/token/$'),


### PR DESCRIPTION
This adds the new experimental browser reports collector URL to the control silo patterns, in order to prepare for https://github.com/getsentry/sentry/pull/93306 (and in order to not combine FE and BE changes in one PR).