### PR TITLE
enh(flutter-replay): add screen name tooltip to flutter replays

### DIFF
--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -2,6 +2,8 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import ExternalLink from 'sentry/components/links/externalLink';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentScreen from 'sentry/components/replays/replayCurrentScreen';
@@ -10,6 +12,7 @@ import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import {ReplaySidebarToggleButton} from 'sentry/components/replays/replaySidebarToggleButton';
 import TextCopyInput from 'sentry/components/textCopyInput';
+import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
@@ -39,7 +42,25 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
                 {''}
               </TextCopyInput>
             ) : isVideoReplay ? (
-              <ReplayCurrentScreen />
+              <ScreenNameContainer>
+                {replay?.getReplay()?.sdk.name?.includes('flutter') ? (
+                  <QuestionTooltip
+                    isHoverable
+                    title={tct(
+                      'In order to see the correct screen name, you need to configure the [link:Sentry Routing Instrumentation].',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/platforms/dart/guides/flutter/integrations/routing-instrumentation/" />
+                        ),
+                      }
+                    )}
+                    size={'sm'}
+                  />
+                ) : null}
+                <ScreenNameInputContainer>
+                  <ReplayCurrentScreen />
+                </ScreenNameInputContainer>
+              </ScreenNameContainer>
             ) : (
               <ReplayCurrentUrl />
             )}
@@ -98,6 +119,19 @@ const ContextContainer = styled('div')`
   grid-template-columns: 1fr max-content;
   align-items: center;
   gap: ${space(1)};
+`;
+
+const ScreenNameContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  width: 100%;
+  flex: 1;
+`;
+
+const ScreenNameInputContainer = styled('div')`
+  flex: 1;
+  width: 100%;
 `;
 
 const PlayerContainer = styled('div')`


### PR DESCRIPTION
Flutter Replay requires more manual setup to have the correct screen names shown.

This PR adds a tooltip on the left side of the screen name bar (only for Flutter replays).

Alternatively we can also add the tooltip next to the operating system icon on the right instead?

Cursor helped me here so pls lmk if the container styling can be made better/differently

## Flutter Replay

<img width="1517" alt="Screenshot 2025-06-11 at 19 08 53" src="https://github.com/user-attachments/assets/363a6924-c6ed-423b-8cd0-53772b5b5199" />

## Other Replay (in this example Android)

<img width="1517" alt="Screenshot 2025-06-11 at 19 09 10" src="https://github.com/user-attachments/assets/95d17817-6ced-4a7a-b03b-d562daef15aa" />

