### PR TITLE
fix(taskworker) Increase processing deadline for activity notifications

### DIFF
--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -29,7 +29,7 @@ def get_activity_notifiers(project):
     queue="activity.notify",
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
-        namespace=notifications_tasks,
+        namespace=notifications_tasks, processing_deadline_duration=60
     ),
 )
 def send_activity_notifications(activity_id: int) -> None:


### PR DESCRIPTION
These typically run in a few seconds, but occasionally take much longer. With 60s more of the p99+ tasks will run to completion.
