### PR TITLE
ref(aci): Move create_workflow_fire_histories

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -78,6 +78,10 @@ def get_action_last_updated_statuses(now: datetime, actions: BaseQuerySet[Action
 def create_workflow_fire_histories(
     actions_to_fire: BaseQuerySet[Action], event_data: WorkflowEventData
 ) -> list[WorkflowFireHistory]:
+    """
+    Record that the workflows associated with these actions were fired for this
+    event.
+    """
     # Create WorkflowFireHistory objects for workflows we fire actions for
     workflow_ids = set(
         WorkflowDataConditionGroup.objects.filter(
@@ -132,8 +136,6 @@ def filter_recently_fired_actions(
 
     # dual write to WorkflowActionGroupStatus, ignoring results for now until they are canonical
     _ = filter_recently_fired_workflow_actions(filtered_action_groups, event_data)
-
-    create_workflow_fire_histories(filtered_actions, event_data)
 
     return filtered_actions
 
@@ -259,9 +261,6 @@ def filter_recently_fired_workflow_actions(
         )
     )
     update_workflow_action_group_statuses(now, statuses_to_update, missing_statuses)
-
-    # TODO: write this in a single spot
-    # create_workflow_fire_histories
 
     # TODO: somehow attach workflows so we can fire actions with the appropriate workflow env
     return Action.objects.filter(id__in=list(action_to_workflow_ids.keys()))

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -44,7 +44,10 @@ from sentry.workflow_engine.models.data_condition import (
     SLOW_CONDITIONS,
     Condition,
 )
-from sentry.workflow_engine.processors.action import filter_recently_fired_actions
+from sentry.workflow_engine.processors.action import (
+    create_workflow_fire_histories,
+    filter_recently_fired_actions,
+)
 from sentry.workflow_engine.processors.data_condition_group import (
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
@@ -460,6 +463,7 @@ def fire_actions_for_groups(
                 filtered_actions = filter_recently_fired_actions(
                     action_filters | workflows_actions, event_data
                 )
+                create_workflow_fire_histories(filtered_actions, event_data)
 
                 metrics.incr(
                     "workflow_engine.delayed_workflow.triggered_actions",

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -17,14 +17,13 @@ from sentry.workflow_engine.models import (
     Detector,
     Workflow,
 )
-from sentry.workflow_engine.processors.action import filter_recently_fired_actions
-from sentry.workflow_engine.processors.contexts.workflow_event_context import (
-    WorkflowEventContext,
-    WorkflowEventContextData,
-)
 from sentry.workflow_engine.processors.action import (
     create_workflow_fire_histories,
     filter_recently_fired_actions,
+)
+from sentry.workflow_engine.processors.contexts.workflow_event_context import (
+    WorkflowEventContext,
+    WorkflowEventContextData,
 )
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
 from sentry.workflow_engine.processors.detector import get_detector_by_event

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -22,6 +22,10 @@ from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
     WorkflowEventContextData,
 )
+from sentry.workflow_engine.processors.action import (
+    create_workflow_fire_histories,
+    filter_recently_fired_actions,
+)
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
 from sentry.workflow_engine.processors.detector import get_detector_by_event
 from sentry.workflow_engine.types import WorkflowEventData
@@ -280,6 +284,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
     if not actions:
         # If there aren't any actions on the associated workflows, there's nothing to trigger
         return triggered_workflows
+    create_workflow_fire_histories(actions, event_data)
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):
         if features.has(

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -100,15 +100,6 @@ class TestFilterRecentlyFiredActions(BaseWorkflowTest):
         )
         assert set(triggered_actions) == {self.action}
 
-        assert (
-            WorkflowFireHistory.objects.filter(
-                workflow=workflow,
-                group=self.group,
-                event_id=self.group_event.event_id,
-            ).count()
-            == 1
-        )
-
 
 @freeze_time("2024-01-09")
 class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):


### PR DESCRIPTION
Makes some sense and is structurally convenient to call our "record the things we're actually going to fire" at the top-level of the task function, where it can be easily verified to be accurate.
