### PR TITLE
fix(grouping): Validate type of stored project grouping config when loading

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -143,7 +143,7 @@ class ProjectGroupingConfigLoader(GroupingConfigLoader):
     def _get_config_id(self, project: Project) -> str:
         return project.get_option(
             self.option_name,
-            validate=lambda x: x in CONFIGURATIONS,
+            validate=lambda x: isinstance(x, str) and x in CONFIGURATIONS,
         )
 
 


### PR DESCRIPTION
Somehow, there's a project which has gotten a serialized version of `CONFIGURATIONS` (basically, a bunch of metadata about our built-in grouping configs) as their grouping config project option value. When we try to load their grouping config in order to be able to group an event, it crashes out because our validation assumes the value is a string. 

This fixes that by doing a typecheck on the value before validating it. If the value is invalid, the default config is used.