### PR TITLE
ref: improve release serializer where Release.authors is None

### DIFF
--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -130,6 +130,14 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
             == current_project_meta["last_release_version"]
         )
 
+    def test_authors_is_none(self):
+        release = Release.objects.create(
+            organization_id=self.organization.id, version="1", authors=None
+        )
+        release.add_project(self.project)
+        result = serialize(release, self.user)
+        assert result["authors"] == []
+
     def test_mobile_version(self):
         user = self.create_user()
         project = self.create_project()


### PR DESCRIPTION
mypy helpfully points out the bug here:

```
src/sentry/api/serializers/models/release.py:129: error: Argument 1 to "update" of "set" has incompatible type "list[str] | None"; expected "Iterable[Any]"  [arg-type]
src/sentry/api/serializers/models/release.py:151: error: Item "None" of "list[str] | None" has no attribute "__iter__" (not iterable)  [union-attr]
```

resolves SENTRY-3ZWS

<!-- Describe your PR here. -->