### PR TITLE
fix: change default test result endpoint ordering param

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1059,7 +1059,7 @@ Available fields are:
         location="query",
         required=False,
         type=str,
-        description="""The branch to search for results by. If not specified, the default branch is returned.
+        description="""The branch to search for results by. If not specified, the default is `main`.
         """,
     )
     TEST_RESULTS_FILTER_BY = OpenApiParameter(
@@ -1081,7 +1081,7 @@ Available fields are:
         location="query",
         required=False,
         type=str,
-        description="""The property to sort results by. If not specified, all results are returned. Use `-`
+        description="""The property to sort results by. If not specified, the default is `COMMITS_WHERE_FAIL` in descending order. Use `-`
         for descending order.
 
 Available fields are:

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -50,7 +50,9 @@ class TestResultsEndpoint(CodecovEndpoint):
     def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
         """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
 
-        sort_by = request.query_params.get("sortBy", OrderingParameter.COMMITS_WHERE_FAIL.value)
+        sort_by = request.query_params.get(
+            "sortBy", f"-{OrderingParameter.COMMITS_WHERE_FAIL.value}"
+        )
 
         if sort_by and sort_by.startswith("-"):
             sort_by = sort_by[1:]

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -98,7 +98,7 @@ class TestResultsEndpointTest(APITestCase):
                 "test_suites": None,
             },
             "ordering": {
-                "direction": "ASC",
+                "direction": "DESC",
                 "parameter": "COMMITS_WHERE_FAIL",
             },
             "first": 20,
@@ -221,7 +221,7 @@ class TestResultsEndpointTest(APITestCase):
                 "test_suites": None,
             },
             "ordering": {
-                "direction": "ASC",
+                "direction": "DESC",
                 "parameter": "COMMITS_WHERE_FAIL",
             },
             "first": None,


### PR DESCRIPTION
This PR changes the default ordering for the test results endpoint from commits_where_fail ascending to descending. This matches what we have in the codecov UI


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
