### PR TITLE
fix(browser reports): Validate report `type` value before logging metric

### DIFF
--- a/src/sentry/issues/endpoints/browser_reporting_collector.py
+++ b/src/sentry/issues/endpoints/browser_reporting_collector.py
@@ -40,8 +40,16 @@ class BrowserReportingCollectorEndpoint(Endpoint):
 
         logger.info("browser_report_received", extra={"request_body": request.data})
 
+        report_type = request.data.get("type")
         metrics.incr(
-            "browser_reporting.raw_report_received", tags={"type": request.data.get("type")}
+            "browser_reporting.raw_report_received",
+            tags={
+                "type": (
+                    report_type
+                    if report_type in ["crash", "deprecation", "intervention"]
+                    else "other"
+                )
+            },
         )
 
         return HttpResponse(status=200)


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/93306, restricting the values which can be sent for the `type` tag on the `browser_reporting.raw_report_received` metric we collect. 