### PR TITLE
fix(detectors): Filter packages in SQL Injection Detector 

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-invalid-package.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-invalid-package.json
@@ -25,6 +25,9 @@
       ["single", "u"]
     ]
   },
+  "modules": {
+    "sequelize": "1.0.0"
+  },
   "spans": [
     {
       "timestamp": 1747089758.567536,

--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
@@ -25,6 +25,9 @@
       ["single", "u"]
     ]
   },
+  "modules": {
+    "test-package": "1.0.0"
+  },
   "spans": [
     {
       "timestamp": 1747089758.567536,

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -55,6 +55,8 @@ EXCLUDED_KEYWORDS = [
     "PAGE",
 ]
 
+EXCLUDED_PACKAGES = ["github.com/go-sql-driver/mysql", "sequelize"]
+
 
 class SQLInjectionDetector(PerformanceDetector):
     type = DetectorType.SQL_INJECTION
@@ -194,7 +196,7 @@ class SQLInjectionDetector(PerformanceDetector):
             return True
         # Filter out events with packages known to internally escape inputs
         for package_name in packages.keys():
-            if package_name == "sequelize":
+            if package_name in EXCLUDED_PACKAGES:
                 return False
         return True
 

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -57,3 +57,7 @@ class SQLInjectionDetectorTest(TestCase):
     def test_sql_injection_on_non_vulnerable_query(self):
         injection_event = get_event("sql-injection/sql-injection-event-non-vulnerable")
         assert len(self.find_problems(injection_event)) == 0
+
+    def test_sql_injection_on_invalid_package(self):
+        injection_event = get_event("sql-injection/sql-injection-event-invalid-package")
+        assert len(self.find_problems(injection_event)) == 0


### PR DESCRIPTION
this pr makes two improvements to the sql injection detector: 
1) It looks at the packages on the event and checks if `sequelize` or `go-sql-driver/mysql`, packages that do internal interpolation on inputs and creates false positives, are present. if they are, we skip the event. while this might filter out some false negatives, it's at the cost of filtering out the false positives. 
2) adds a few additional keywords to exclude if we see them. 