### PR TITLE
chore(billing): include OD categories where applicable

### DIFF
--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -868,36 +868,18 @@ describe('getOnDemandCategories', function () {
     const categories = getOnDemandCategories({
       plan,
       budgetMode: OnDemandBudgetMode.PER_CATEGORY,
-      configurableOnly: true,
     });
     expect(categories).toHaveLength(plan.onDemandCategories.length - 2);
     expect(categories).not.toContain(DataCategory.SEER_SCANNER);
     expect(categories).not.toContain(DataCategory.SEER_AUTOFIX);
   });
 
-  it('does not filter out unconfigurable categories for per-category budget mode', function () {
-    const categories = getOnDemandCategories({
-      plan,
-      budgetMode: OnDemandBudgetMode.PER_CATEGORY,
-      configurableOnly: false,
-    });
-    expect(categories).toHaveLength(plan.onDemandCategories.length);
-    expect(categories).toContain(DataCategory.SEER_SCANNER);
-    expect(categories).toContain(DataCategory.SEER_AUTOFIX);
-  });
-
   it('does not filter out any categories for shared budget mode', function () {
     const categories = getOnDemandCategories({
       plan,
       budgetMode: OnDemandBudgetMode.SHARED,
-      configurableOnly: false,
     });
     expect(categories).toHaveLength(plan.onDemandCategories.length);
-    const configurableCategories = getOnDemandCategories({
-      plan,
-      budgetMode: OnDemandBudgetMode.SHARED,
-      configurableOnly: true,
-    });
-    expect(categories).toEqual(configurableCategories);
+    expect(categories).toEqual(plan.onDemandCategories);
   });
 });

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -7,7 +7,7 @@ import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {DataCategory} from 'sentry/types/core';
 
 import {BILLION, GIGABYTE, MILLION, UNLIMITED} from 'getsentry/constants';
-import type {ProductTrial} from 'getsentry/types';
+import {OnDemandBudgetMode, type ProductTrial} from 'getsentry/types';
 import {
   formatReservedWithUnits,
   formatUsageWithUnits,
@@ -863,9 +863,41 @@ describe('isNewPayingCustomer', function () {
 });
 
 describe('getOnDemandCategories', function () {
-  it('filters out seer categories', function () {
-    const categories = getOnDemandCategories(PlanDetailsLookupFixture('am1_business')!);
+  const plan = PlanDetailsLookupFixture('am1_business')!;
+  it('filters out unconfigurable categories for per-category budget mode', function () {
+    const categories = getOnDemandCategories({
+      plan,
+      budgetMode: OnDemandBudgetMode.PER_CATEGORY,
+      configurableOnly: true,
+    });
+    expect(categories).toHaveLength(plan.onDemandCategories.length - 2);
     expect(categories).not.toContain(DataCategory.SEER_SCANNER);
     expect(categories).not.toContain(DataCategory.SEER_AUTOFIX);
+  });
+
+  it('does not filter out unconfigurable categories for per-category budget mode', function () {
+    const categories = getOnDemandCategories({
+      plan,
+      budgetMode: OnDemandBudgetMode.PER_CATEGORY,
+      configurableOnly: false,
+    });
+    expect(categories).toHaveLength(plan.onDemandCategories.length);
+    expect(categories).toContain(DataCategory.SEER_SCANNER);
+    expect(categories).toContain(DataCategory.SEER_AUTOFIX);
+  });
+
+  it('does not filter out any categories for shared budget mode', function () {
+    const categories = getOnDemandCategories({
+      plan,
+      budgetMode: OnDemandBudgetMode.SHARED,
+      configurableOnly: false,
+    });
+    expect(categories).toHaveLength(plan.onDemandCategories.length);
+    const configurableCategories = getOnDemandCategories({
+      plan,
+      budgetMode: OnDemandBudgetMode.SHARED,
+      configurableOnly: true,
+    });
+    expect(categories).toEqual(configurableCategories);
   });
 });

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -369,14 +369,8 @@ export const displayBudgetName = (
 };
 
 /**
- * Returns the on-demand/PAYG categories for the given plan
+ * Returns the configurable on-demand/PAYG categories for the given plan
  * and budget mode.
- *
- * If `configurableOnly` is true, then only the on-demand/PAYG
- * categories that can be configured for the specified budget mode
- * are returned.
- *
- * Otherwise, we return all on-demand/PAYG categories.
  *
  * @param plan - The plan to get the on-demand/PAYG categories for
  * @param budgetMode - The on-demand/PAYG budget mode

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -380,19 +380,16 @@ export const displayBudgetName = (
  *
  * @param plan - The plan to get the on-demand/PAYG categories for
  * @param budgetMode - The on-demand/PAYG budget mode
- * @param configurableOnly - Whether to return only the on-demand/PAYG categories that can be configured for the specified budget mode
- * @returns A list of the appropriate on-demand/PAYG categories for the given plan, budget mode, and `configurableOnly` flag
+ * @returns A list of the appropriate on-demand/PAYG categories for the given plan and budget mode
  */
 export const getOnDemandCategories = ({
   plan,
   budgetMode,
-  configurableOnly,
 }: {
   budgetMode: OnDemandBudgetMode | null;
-  configurableOnly: boolean;
   plan: Plan;
 }) => {
-  if (budgetMode === OnDemandBudgetMode.PER_CATEGORY && configurableOnly) {
+  if (budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
     return plan.onDemandCategories.filter(category => {
       return Object.values(plan.availableReservedBudgetTypes).every(
         budgetType => !budgetType.dataCategories.includes(category)

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -144,7 +144,6 @@ class OnDemandBudgets extends Component<Props> {
           {getOnDemandCategories({
             plan: subscription.planDetails,
             budgetMode: onDemandBudgets.budgetMode,
-            configurableOnly: true,
           }).map(category => (
             <Category key={category}>
               <DetailTitle>
@@ -211,7 +210,6 @@ class OnDemandBudgets extends Component<Props> {
       categories: getOnDemandCategories({
         plan: subscription.planDetails,
         budgetMode: onDemandBudgets.budgetMode,
-        configurableOnly: true,
       }),
     });
     let description = t('Applies to %s.', oxfordCategories);

--- a/static/gsApp/views/onDemandBudgets/index.tsx
+++ b/static/gsApp/views/onDemandBudgets/index.tsx
@@ -141,7 +141,11 @@ class OnDemandBudgets extends Component<Props> {
     if (onDemandBudgets.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
       return (
         <PerCategoryBudgetContainer data-test-id="per-category-budget-info">
-          {subscription.planDetails.onDemandCategories.map(category => (
+          {getOnDemandCategories({
+            plan: subscription.planDetails,
+            budgetMode: onDemandBudgets.budgetMode,
+            configurableOnly: true,
+          }).map(category => (
             <Category key={category}>
               <DetailTitle>
                 {getPlanCategoryName({plan: subscription.planDetails, category})}
@@ -201,13 +205,17 @@ class OnDemandBudgets extends Component<Props> {
       return this.renderNeedsPaymentSource();
     }
 
+    const onDemandBudgets = subscription.onDemandBudgets!;
     const oxfordCategories = listDisplayNames({
       plan: subscription.planDetails,
-      categories: getOnDemandCategories(subscription.planDetails),
+      categories: getOnDemandCategories({
+        plan: subscription.planDetails,
+        budgetMode: onDemandBudgets.budgetMode,
+        configurableOnly: true,
+      }),
     });
     let description = t('Applies to %s.', oxfordCategories);
 
-    const onDemandBudgets = subscription.onDemandBudgets!;
     if (
       onDemandBudgets.budgetMode === OnDemandBudgetMode.SHARED &&
       onDemandBudgets.sharedMaxBudget > 0

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -121,7 +121,6 @@ class OnDemandBudgetEdit extends Component<Props> {
           {getOnDemandCategories({
             plan: activePlan,
             budgetMode: displayBudgetMode,
-            configurableOnly: true,
           }).map(category => {
             const categoryBudgetKey = `${category}Budget`;
             const displayName = getPlanCategoryName({plan: activePlan, category});
@@ -205,7 +204,6 @@ class OnDemandBudgetEdit extends Component<Props> {
       categories: getOnDemandCategories({
         plan: activePlan,
         budgetMode: selectedBudgetMode,
-        configurableOnly: true,
       }),
     });
 

--- a/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
+++ b/static/gsApp/views/onDemandBudgets/onDemandBudgetEdit.tsx
@@ -118,7 +118,11 @@ class OnDemandBudgetEdit extends Component<Props> {
     ) {
       return (
         <InputFields>
-          {getOnDemandCategories(activePlan).map(category => {
+          {getOnDemandCategories({
+            plan: activePlan,
+            budgetMode: displayBudgetMode,
+            configurableOnly: true,
+          }).map(category => {
             const categoryBudgetKey = `${category}Budget`;
             const displayName = getPlanCategoryName({plan: activePlan, category});
             return (
@@ -198,7 +202,11 @@ class OnDemandBudgetEdit extends Component<Props> {
     const selectedBudgetMode = onDemandBudget.budgetMode;
     const oxfordCategories = listDisplayNames({
       plan: activePlan,
-      categories: getOnDemandCategories(activePlan),
+      categories: getOnDemandCategories({
+        plan: activePlan,
+        budgetMode: selectedBudgetMode,
+        configurableOnly: true,
+      }),
     });
 
     if (subscription.planDetails.budgetTerm === 'pay-as-you-go') {

--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -116,7 +116,11 @@ export function formatOnDemandBudget(
     categories = plan.onDemandCategories.map(category => category);
   }
   if (budget.budgetMode === OnDemandBudgetMode.PER_CATEGORY) {
-    categories = getOnDemandCategories(plan); // filter seer when budget mode is per-category
+    categories = getOnDemandCategories({
+      plan,
+      budgetMode: budget.budgetMode,
+      configurableOnly: true,
+    });
     return `per-category ${displayBudgetName(plan, {
       withBudget: true,
       pluralOndemand: true,

--- a/static/gsApp/views/onDemandBudgets/utils.tsx
+++ b/static/gsApp/views/onDemandBudgets/utils.tsx
@@ -119,7 +119,6 @@ export function formatOnDemandBudget(
     categories = getOnDemandCategories({
       plan,
       budgetMode: budget.budgetMode,
-      configurableOnly: true,
     });
     return `per-category ${displayBudgetName(plan, {
       withBudget: true,


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-912/am2-with-per-category-showing-seer-on-demand-budget
![Screenshot 2025-06-11 at 2 58 11 PM](https://github.com/user-attachments/assets/786ddb5c-398a-4f19-884b-1dfa10b108b6)

Closes https://linear.app/getsentry/issue/BIL-811/payg-setup-copy-does-not-include-seer
![Screenshot 2025-06-11 at 2 58 45 PM](https://github.com/user-attachments/assets/b59a0a3b-255f-4423-80de-a5e081ae87bd)


Ignore the fonts in the screenshots, my local dev wasn't loading them.
