### PR TITLE
fix(feedback): Apply disabled feedback logic to all input buttons and dropdowns

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -149,7 +149,7 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
             onAction: onDelete,
             tooltip: enableDelete
               ? undefined
-              : t('You must be an admin to delete feedback.'),
+              : t('You must be an admin to delete feedback'),
           },
         ]}
       />
@@ -207,7 +207,7 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           onAction: onDelete,
           tooltip: enableDelete
             ? undefined
-            : t('You must be an admin to delete feedback.'),
+            : t('You must be an admin to delete feedback'),
         },
       ]}
     />

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -14,7 +14,6 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
-import useProjectFromId from 'sentry/utils/useProjectFromId';
 
 interface Props {
   eventData: Event | undefined;
@@ -53,17 +52,16 @@ export default function FeedbackActions({
 
 function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
-    disableDelete,
+    enableDelete,
     onDelete,
     isResolved,
     onResolveClick,
     isSpam,
     onSpamClick,
     hasSeen,
+    enableMarkAsRead,
     onMarkAsReadClick,
   } = useFeedbackActions({feedbackItem});
-
-  const project = useProjectFromId({project_id: feedbackItem.project?.id});
 
   return (
     <Fragment>
@@ -78,18 +76,18 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
         {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
       </Button>
       <Tooltip
-        disabled={project?.isMember}
+        disabled={enableMarkAsRead}
         title={t('You must be a member of the project')}
       >
-        <Button size="xs" onClick={onMarkAsReadClick} disabled={!project?.isMember}>
+        <Button size="xs" onClick={onMarkAsReadClick} disabled={!enableMarkAsRead}>
           {hasSeen ? t('Mark Unread') : t('Mark Read')}
         </Button>
       </Tooltip>
       <Tooltip
-        disabled={!disableDelete}
+        disabled={enableDelete}
         title={t('You must be an admin to delete feedback')}
       >
-        <Button size="xs" onClick={onDelete} disabled={disableDelete}>
+        <Button size="xs" onClick={onDelete} disabled={!enableDelete}>
           {t('Delete')}
         </Button>
       </Tooltip>
@@ -99,13 +97,14 @@ function LargeWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
 function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
-    disableDelete,
+    enableDelete,
     onDelete,
     isResolved,
     onResolveClick,
     isSpam,
     onSpamClick,
     hasSeen,
+    enableMarkAsRead,
     onMarkAsReadClick,
   } = useFeedbackActions({feedbackItem});
 
@@ -136,17 +135,21 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
           {
             key: 'read',
             label: hasSeen ? t('Mark Unread') : t('Mark Read'),
+            disabled: !enableMarkAsRead,
             onAction: onMarkAsReadClick,
+            tooltip: enableMarkAsRead
+              ? undefined
+              : t('You must be a member of the project'),
           },
           {
             key: 'delete',
             priority: 'danger' as const,
             label: t('Delete'),
-            disabled: disableDelete,
+            disabled: !enableDelete,
             onAction: onDelete,
-            tooltip: disableDelete
-              ? t('You must be an admin to delete feedback.')
-              : undefined,
+            tooltip: enableDelete
+              ? undefined
+              : t('You must be an admin to delete feedback.'),
           },
         ]}
       />
@@ -156,13 +159,14 @@ function MediumWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 
 function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
   const {
-    disableDelete,
+    enableDelete,
     onDelete,
     isResolved,
     onResolveClick,
     isSpam,
     onSpamClick,
     hasSeen,
+    enableMarkAsRead,
     onMarkAsReadClick,
   } = useFeedbackActions({feedbackItem});
 
@@ -189,17 +193,21 @@ function SmallWidth({feedbackItem}: {feedbackItem: FeedbackIssue}) {
         {
           key: 'read',
           label: hasSeen ? t('Mark Unread') : t('Mark Read'),
+          disabled: !enableMarkAsRead,
           onAction: onMarkAsReadClick,
+          tooltip: enableMarkAsRead
+            ? undefined
+            : t('You must be a member of the project'),
         },
         {
           key: 'delete',
           priority: 'danger' as const,
           label: t('Delete'),
-          disabled: disableDelete,
+          disabled: !enableDelete,
           onAction: onDelete,
-          tooltip: disableDelete
-            ? t('You must be an admin to delete feedback.')
-            : undefined,
+          tooltip: enableDelete
+            ? undefined
+            : t('You must be an admin to delete feedback.'),
         },
       ]}
     />

--- a/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
+++ b/static/app/components/feedback/feedbackItem/useFeedbackActions.ts
@@ -13,6 +13,7 @@ import {GroupStatus} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
 
 interface Props {
   feedbackItem: FeedbackIssue;
@@ -42,8 +43,11 @@ export default function useFeedbackActions({feedbackItem}: Props) {
     organization,
     projectIds: feedbackItem.project ? [feedbackItem.project.id] : [],
   });
+  const project = useProjectFromId({project_id: feedbackItem.project?.id});
+  const enableMarkAsRead = project?.isMember;
+
   const onDelete = useDeleteFeedback([feedbackItem.id], projectId);
-  const disableDelete = !organization.access.includes('event:admin');
+  const enableDelete = organization.access.includes('event:admin');
 
   const isResolved = feedbackItem.status === GroupStatus.RESOLVED;
   const onResolveClick = useCallback(() => {
@@ -74,13 +78,14 @@ export default function useFeedbackActions({feedbackItem}: Props) {
   }, [hasSeen, markAsRead, mutationOptions]);
 
   return {
-    disableDelete,
+    enableDelete,
     onDelete,
     isResolved,
     onResolveClick,
     isSpam,
     onSpamClick,
     hasSeen,
+    enableMarkAsRead,
     onMarkAsReadClick,
   };
 }

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -108,7 +108,7 @@ export default function FeedbackListBulkSelection({
                 onAction: onDelete,
                 tooltip: enableDelete
                   ? undefined
-                  : t('You must be an admin to delete feedback.'),
+                  : t('You must be an admin to delete feedback'),
               },
             ]}
           />

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -9,7 +9,6 @@ import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {GroupStatus} from 'sentry/types/group';
-import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props
   extends Pick<
@@ -25,8 +24,15 @@ export default function FeedbackListBulkSelection({
   selectedIds,
   deselectAll,
 }: Props) {
-  const organization = useOrganization();
-  const {onDelete, onToggleResolved, onMarkAsRead, onMarkUnread} = useBulkEditFeedbacks({
+  const {
+    hasDelete,
+    enableDelete,
+    enableMarkAsRead,
+    onDelete,
+    onToggleResolved,
+    onMarkAsRead,
+    onMarkUnread,
+  } = useBulkEditFeedbacks({
     selectedIds,
     deselectAll,
   });
@@ -37,12 +43,6 @@ export default function FeedbackListBulkSelection({
   // reuse the issues ignored category for spam feedbacks
   const newMailboxSpam =
     mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
-
-  const hasDelete = selectedIds !== 'all';
-  const disableDelete = !organization.access.includes('event:admin');
-
-  // TODO(ryan953): We should disable markAsRead if you're not a member of any project selected
-  const disableMarkAsRead = false;
 
   return (
     <Flex gap={space(1)} align="center" justify="space-between" flex="1 0 auto">
@@ -89,7 +89,10 @@ export default function FeedbackListBulkSelection({
                 key: 'mark read',
                 label: t('Mark Read'),
                 onAction: onMarkAsRead,
-                disabled: disableMarkAsRead,
+                disabled: !enableMarkAsRead,
+                tooltip: enableMarkAsRead
+                  ? undefined
+                  : t('You must be a member of the project'),
               },
               {
                 key: 'mark unread',
@@ -101,11 +104,11 @@ export default function FeedbackListBulkSelection({
                 priority: 'danger' as const,
                 label: t('Delete'),
                 hidden: !hasDelete,
-                disabled: disableDelete,
+                disabled: !enableDelete,
                 onAction: onDelete,
-                tooltip: disableDelete
-                  ? t('You must be an admin to delete feedback.')
-                  : undefined,
+                tooltip: enableDelete
+                  ? undefined
+                  : t('You must be an admin to delete feedback.'),
               },
             ]}
           />

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -57,7 +57,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
   const mutationOptions = useMemo(
     () => ({
       onError: () => {
-        addErrorMessage(t('An error occurred while updating the feedbacks.'));
+        addErrorMessage(t('An error occurred while updating the feedbacks'));
       },
       onSuccess: () => {
         addSuccessMessage(t('Updated feedbacks'));
@@ -115,7 +115,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
           addLoadingMessage(t('Updating feedbacks...'));
           markAsRead(false, {
             onError: () => {
-              addErrorMessage(t('An error occurred while updating the feedbacks.'));
+              addErrorMessage(t('An error occurred while updating the feedbacks'));
             },
             onSuccess: () => {
               addSuccessMessage(t('Updated feedbacks'));

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {
   addErrorMessage,
@@ -46,9 +46,26 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
     organization,
     projectIds: queryView.project,
   });
-  const deleteFeedback = useDeleteFeedback(selectedIds, queryView.project);
+  // TODO: should only be true if you're a member of some of the projects of the
+  // selected feedbacks... which is not currently available
+  const enableMarkAsRead = true;
 
-  const onDelete = deleteFeedback;
+  const onDelete = useDeleteFeedback(selectedIds, queryView.project);
+  const hasDelete = selectedIds !== 'all';
+  const enableDelete = organization.access.includes('event:admin');
+
+  const mutationOptions = useMemo(
+    () => ({
+      onError: () => {
+        addErrorMessage(t('An error occurred while updating the feedbacks.'));
+      },
+      onSuccess: () => {
+        addSuccessMessage(t('Updated feedbacks'));
+        deselectAll();
+      },
+    }),
+    [deselectAll]
+  );
 
   const onToggleResolved = useCallback(
     ({newMailbox, moveToInbox}: {newMailbox: GroupStatus; moveToInbox?: boolean}) => {
@@ -63,15 +80,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
             });
           }
           addLoadingMessage(t('Updating feedbacks...'));
-          resolve(newMailbox, {
-            onError: () => {
-              addErrorMessage(t('An error occurred while updating the feedbacks.'));
-            },
-            onSuccess: () => {
-              addSuccessMessage(t('Updated feedbacks'));
-              deselectAll();
-            },
-          });
+          resolve(newMailbox, mutationOptions);
         },
         message: moveToInbox
           ? t('Are you sure you want to move these feedbacks to the inbox?')
@@ -81,7 +90,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
         confirmText: moveToInbox ? t('Move to Inbox') : statusToButtonLabel[newMailbox],
       });
     },
-    [deselectAll, resolve, selectedIds, organization]
+    [selectedIds, resolve, mutationOptions, organization]
   );
 
   const onMarkAsRead = useCallback(
@@ -90,20 +99,12 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
         bypass: Array.isArray(selectedIds) && selectedIds.length === 1,
         onConfirm: () => {
           addLoadingMessage(t('Updating feedbacks...'));
-          markAsRead(true, {
-            onError: () => {
-              addErrorMessage(t('An error occurred while updating the feedbacks.'));
-            },
-            onSuccess: () => {
-              addSuccessMessage(t('Updated feedbacks'));
-              deselectAll();
-            },
-          });
+          markAsRead(true, mutationOptions);
         },
         message: t('Are you sure you want to mark these feedbacks as read?'),
         confirmText: 'Mark read',
       }),
-    [deselectAll, markAsRead, selectedIds]
+    [markAsRead, mutationOptions, selectedIds]
   );
 
   const onMarkUnread = useCallback(
@@ -129,8 +130,11 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
   );
 
   return {
+    hasDelete,
+    enableDelete,
     onDelete,
     onToggleResolved,
+    enableMarkAsRead,
     onMarkAsRead,
     onMarkUnread,
   };


### PR DESCRIPTION
This disables the `delete` button when the screen is normal width or narrow. And moves a bunch of logic into the hooks to try and cleanup some stuff.

The original bug report was about deleting a feedback from the list view, which I still can't repro.

Related to REPLAY-400