### PR TITLE
ref(grouping): Disallow setting grouping config using API

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1,6 +1,4 @@
 import logging
-import math
-import time
 from datetime import timedelta
 from uuid import uuid4
 
@@ -355,22 +353,15 @@ E.g. `['release', 'environment']`""",
 
         return value
 
+    # TODO: Once these have been in place for a while we can probably remove them
+    def validate_groupingConfig(self, value):
+        raise serializers.ValidationError("Grouping config cannot be manually set.")
+
+    def validate_secondaryGroupingConfig(self, value):
+        raise serializers.ValidationError("Secondary grouping config cannot be manually set.")
+
     def validate_secondaryGroupingExpiry(self, value):
-        if not isinstance(value, (int, float)) or math.isnan(value):
-            raise serializers.ValidationError(
-                f"Grouping expiry must be a numerical value, a UNIX timestamp with second resolution, found {type(value)}"
-            )
-        now = time.time()
-        if value < now:
-            raise serializers.ValidationError(
-                "Grouping expiry must be sometime within the next 90 days and not in the past. Perhaps you specified the timestamp not in seconds?"
-            )
-
-        max_expiry_date = now + (91 * 24 * 3600)
-        if value > max_expiry_date:
-            value = max_expiry_date
-
-        return value
+        raise serializers.ValidationError("Secondary grouping expiry cannot be manually set.")
 
     def validate_fingerprintingRules(self, value):
         if not value:
@@ -659,9 +650,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if result.get("scrubIPAddresses") is not None:
             if project.update_option("sentry:scrub_ip_address", result["scrubIPAddresses"]):
                 changed_proj_settings["sentry:scrub_ip_address"] = result["scrubIPAddresses"]
-        if result.get("groupingConfig") is not None:
-            if project.update_option("sentry:grouping_config", result["groupingConfig"]):
-                changed_proj_settings["sentry:grouping_config"] = result["groupingConfig"]
         if result.get("groupingEnhancements") is not None:
             if project.update_option(
                 "sentry:grouping_enhancements", result["groupingEnhancements"]
@@ -672,20 +660,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if result.get("fingerprintingRules") is not None:
             if project.update_option("sentry:fingerprinting_rules", result["fingerprintingRules"]):
                 changed_proj_settings["sentry:fingerprinting_rules"] = result["fingerprintingRules"]
-        if result.get("secondaryGroupingConfig") is not None:
-            if project.update_option(
-                "sentry:secondary_grouping_config", result["secondaryGroupingConfig"]
-            ):
-                changed_proj_settings["sentry:secondary_grouping_config"] = result[
-                    "secondaryGroupingConfig"
-                ]
-        if result.get("secondaryGroupingExpiry") is not None:
-            if project.update_option(
-                "sentry:secondary_grouping_expiry", result["secondaryGroupingExpiry"]
-            ):
-                changed_proj_settings["sentry:secondary_grouping_expiry"] = result[
-                    "secondaryGroupingExpiry"
-                ]
         if result.get("securityToken") is not None:
             if project.update_option("sentry:token", result["securityToken"]):
                 changed_proj_settings["sentry:token"] = result["securityToken"]

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1307,6 +1307,22 @@ class ProjectUpdateTest(APITestCase):
         self.get_success_response(self.org_slug, self.proj_slug, targetSampleRate=0.1)
         assert self.project.get_option("sentry:target_sample_rate") == 0.1
 
+    def test_no_setting_grouping_configs(self):
+        response = self.get_error_response(
+            self.org_slug, self.proj_slug, groupingConfig="some config", status_code=400
+        )
+        assert "Grouping config cannot be manually set" in response.text
+
+        response = self.get_error_response(
+            self.org_slug, self.proj_slug, secondaryGroupingConfig="another config", status_code=400
+        )
+        assert "Secondary grouping config cannot be manually set" in response.text
+
+        response = self.get_error_response(
+            self.org_slug, self.proj_slug, secondaryGroupingExpiry=12311121, status_code=400
+        )
+        assert "Secondary grouping expiry cannot be manually set" in response.text
+
 
 class CopyProjectSettingsTest(APITestCase):
     endpoint = "sentry-api-0-project-details"

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1097,32 +1097,6 @@ class ProjectUpdateTest(APITestCase):
         assert self.project.get_option("digests:mail:minimum_delay") == min_delay
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
-    def test_cap_secondary_grouping_expiry(self):
-        now = time()
-
-        response = self.get_response(self.org_slug, self.proj_slug, secondaryGroupingExpiry=0)
-        assert response.status_code == 400
-
-        expiry = int(now + 3600 * 24 * 1)
-        response = self.get_success_response(
-            self.org_slug, self.proj_slug, secondaryGroupingExpiry=expiry
-        )
-        assert response.data["secondaryGroupingExpiry"] == expiry
-
-        expiry = int(now + 3600 * 24 * 89)
-        response = self.get_success_response(
-            self.org_slug, self.proj_slug, secondaryGroupingExpiry=expiry
-        )
-        assert response.data["secondaryGroupingExpiry"] == expiry
-
-        # Larger timestamps are capped to 91 days:
-        expiry = int(now + 3600 * 24 * 365)
-        response = self.get_success_response(
-            self.org_slug, self.proj_slug, secondaryGroupingExpiry=expiry
-        )
-        expiry = response.data["secondaryGroupingExpiry"]
-        assert (now + 3600 * 24 * 90) < expiry < (now + 3600 * 24 * 92)
-
     @mock.patch("sentry.api.base.create_audit_entry")
     def test_redacted_symbol_source_secrets(self, create_audit_entry):
         with Feature(


### PR DESCRIPTION
In the past, grouping config was an option that could be set in project settings. The project details endpoint therefore accepted `groupingConfig`, `secondaryGroupingConfig`, and `secondaryGroupingExpiry` as things you could change via the API. Now that that's no longer the case, we don't need this ability, and having it just allows users to shoot themselves in the foot by setting an invalid value.

This therefore removes the ability to set those values via API. Just in case some customer has a script which does this, for now the endpoint returns option-specific validation errors. Eventually we can probably remove those, though.