### PR TITLE
fix(aci): prepare sentry app components in action handler serializer

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -11,6 +11,7 @@ from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
 from sentry.rules.actions.notify_event_service import PLUGINS_WITH_FIRST_PARTY_EQUIVALENTS
 from sentry.rules.history.base import TimeSeriesValue
+from sentry.sentry_apps.models.sentry_app_installation import prepare_ui_component
 from sentry.workflow_engine.models import (
     Action,
     DataCondition,
@@ -116,9 +117,16 @@ class ActionHandlerSerializer(Serializer):
                 "status": installation.sentry_app.status,
             }
             if component:
-                sentry_app["settings"] = component.app_schema.get("settings", {})
-                if component.app_schema.get("title"):
-                    sentry_app["title"] = component.app_schema.get("title")
+                prepared_component = prepare_ui_component(
+                    installation=installation,
+                    component=component,
+                    project_slug=None,
+                    values=None,
+                )
+                if prepared_component:
+                    sentry_app["settings"] = prepared_component.app_schema.get("settings", {})
+                    if prepared_component.app_schema.get("title"):
+                        sentry_app["title"] = prepared_component.app_schema.get("title")
             result["sentryApp"] = sentry_app
 
         services = kwargs.get("services")

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -173,8 +173,7 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             self.org_integration.config = {"team_table": [self.og_team]}
             self.org_integration.save()
 
-    @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")
-    def setup_sentry_apps(self, mock_sentry_app_component_preparer):
+    def setup_sentry_apps(self):
         @self.registry.register(Action.Type.SENTRY_APP)
         @dataclass(frozen=True)
         class SentryAppActionHandler(ActionHandler):
@@ -337,7 +336,8 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             },
         ]
 
-    def test_sentry_apps(self):
+    @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")
+    def test_sentry_apps(self, mock_sentry_app_component_preparer):
         self.setup_sentry_apps()
 
         response = self.get_success_response(
@@ -397,7 +397,8 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             }
         ]
 
-    def test_actions_sorting(self):
+    @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")
+    def test_actions_sorting(self, mock_sentry_app_component_preparer):
 
         self.setup_sentry_apps()
         self.setup_integrations()


### PR DESCRIPTION
we need to prepare the sentry app components in order to have all of the choices for the settings form fields