### PR TITLE
fix(search): Use type='button' in search elements to avoid submitting forms

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -1,4 +1,5 @@
 import {type ReactNode, useMemo} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {mergeProps} from '@react-aria/utils';
 import type {ListState} from '@react-stately/list';
@@ -267,7 +268,9 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
   );
 }
 
-const OpButton = styled(UnstyledButton)<{onlyOperator?: boolean}>`
+const OpButton = styled(UnstyledButton, {
+  shouldForwardProp: isPropValid,
+})<{onlyOperator?: boolean}>`
   padding: 0 ${space(0.25)} 0 ${space(0.5)};
   height: 100%;
   border-left: 1px solid transparent;

--- a/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
@@ -5,13 +5,13 @@ export function UnstyledButton({
   ...props
 }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
-    <button type="button" {...props}>
+    <RemovedStylesButton type="button" {...props}>
       {children}
-    </button>
+    </RemovedStylesButton>
   );
 }
 
-export const RemovedStylesButton = styled('button')`
+const RemovedStylesButton = styled('button')`
   background: none;
   border: none;
   outline: none;

--- a/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/unstyledButton.tsx
@@ -1,6 +1,17 @@
 import styled from '@emotion/styled';
 
-export const UnstyledButton = styled('button')`
+export function UnstyledButton({
+  children,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  );
+}
+
+export const RemovedStylesButton = styled('button')`
   background: none;
   border: none;
   outline: none;


### PR DESCRIPTION
Fixes JAVASCRIPT-31KR (user submitted bug)

The metric alert form was erroneously submitting is some rare cases. Adding `type="button"` to all buttons in the component to prevent them from submitting the form.