### PR TITLE
fix(seer): Check quotas before starting seer scanner task

### DIFF
--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -25,10 +25,19 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         return None
     if not features.has("organizations:trigger-autofix-on-issue-summary", group.organization):
         return None
-    if not get_seer_org_acknowledgement(org_id=group.organization.id):
-        return None
     project = group.project
     if not project.get_option("sentry:seer_scanner_automation"):
+        return None
+    if not get_seer_org_acknowledgement(org_id=group.organization.id):
+        return None
+
+    from sentry import quotas
+    from sentry.constants import DataCategory
+
+    has_budget: bool = quotas.backend.has_available_reserved_budget(
+        org_id=group.organization.id, data_category=DataCategory.SEER_SCANNER
+    )
+    if not has_budget:
         return None
 
     timeout = options.get("alerts.issue_summary_timeout") or 5

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -202,4 +202,4 @@ register(key="sentry:tempest_fetch_dumps", default=False)
 register(key="sentry:autofix_automation_tuning", default="off")
 
 # Should seer scanner run automatically on new issues
-register(key="sentry:seer_scanner_automation", default=True)
+register(key="sentry:seer_scanner_automation", default=False)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1984,7 +1984,7 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsDynamicSamplingB
             "trigger-autofix-on-issue-summary feature enabled"
             in resp.data["seerScannerAutomation"][0]
         )
-        assert self.project.get_option("sentry:seer_scanner_automation") is True  # default
+        assert self.project.get_option("sentry:seer_scanner_automation") is False  # default
 
         # Test with feature flag but invalid value - should fail
         with self.feature("organizations:trigger-autofix-on-issue-summary"):
@@ -1992,20 +1992,20 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsDynamicSamplingB
                 self.org_slug, self.proj_slug, seerScannerAutomation="invalid", status_code=400
             )
             assert "Must be a valid boolean." in resp.data["seerScannerAutomation"][0]
-            assert self.project.get_option("sentry:seer_scanner_automation") is True  # default
+            assert self.project.get_option("sentry:seer_scanner_automation") is False  # default
 
         # Test with feature flag and valid value - should succeed
-        with self.feature("organizations:trigger-autofix-on-issue-summary"):
-            resp = self.get_success_response(
-                self.org_slug, self.proj_slug, seerScannerAutomation=False
-            )
-            assert self.project.get_option("sentry:seer_scanner_automation") is False
-            assert resp.data["seerScannerAutomation"] is False
-
-        # Test setting back to on
         with self.feature("organizations:trigger-autofix-on-issue-summary"):
             resp = self.get_success_response(
                 self.org_slug, self.proj_slug, seerScannerAutomation=True
             )
             assert self.project.get_option("sentry:seer_scanner_automation") is True
             assert resp.data["seerScannerAutomation"] is True
+
+        # Test setting back to off
+        with self.feature("organizations:trigger-autofix-on-issue-summary"):
+            resp = self.get_success_response(
+                self.org_slug, self.proj_slug, seerScannerAutomation=False
+            )
+            assert self.project.get_option("sentry:seer_scanner_automation") is False
+            assert resp.data["seerScannerAutomation"] is False

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -819,14 +819,14 @@ class DetailedProjectSerializerTest(TestCase):
         assert result["autofixAutomationTuning"] == "high"
 
     def test_seer_scanner_automation_flag(self):
-        # Default is "on"
-        result = serialize(self.project, self.user, DetailedProjectSerializer())
-        assert result["seerScannerAutomation"] is True
-
-        # Update the value
-        self.project.update_option("sentry:seer_scanner_automation", False)
+        # Default is "off"
         result = serialize(self.project, self.user, DetailedProjectSerializer())
         assert result["seerScannerAutomation"] is False
+
+        # Update the value
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        result = serialize(self.project, self.user, DetailedProjectSerializer())
+        assert result["seerScannerAutomation"] is True
 
 
 class BulkFetchProjectLatestReleases(TestCase):

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1100,6 +1100,8 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         group1.type = ErrorGroupType.type_id
         group1.save()
 
+        self.project.update_option("sentry:seer_scanner_automation", True)
+
         # Test case for long exception text (over 50 characters)
         long_text = (
             "This is a very long text that exceeds the 50 character limit and should be truncated"

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2486,6 +2486,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     def test_kick_off_seer_automation_with_features(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
+        self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
@@ -2509,28 +2510,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     def test_kick_off_seer_automation_without_org_feature(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
-        event = self.create_event(
-            data={"message": "testing"},
-            project_id=self.project.id,
-        )
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
-        )
-
-        mock_start_seer_automation.assert_not_called()
-
-    @patch(
-        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
-        return_value=True,
-    )
-    @patch("sentry.tasks.autofix.start_seer_automation.delay")
-    @with_feature("organizations:gen-ai-features")
-    def test_kick_off_seer_automation_without_proj_feature(
-        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
-    ):
+        self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
@@ -2554,6 +2534,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     def test_kick_off_seer_automation_without_seer_enabled(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
+        self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,
@@ -2578,6 +2559,7 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
     def test_kick_off_seer_automation_without_scanner_on(
         self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
     ):
+        self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
             data={"message": "testing"},
             project_id=self.project.id,


### PR DESCRIPTION
Checks for available quota before starting the seer scanner task in order to reduce task volume. Billing team has made changes to the quotas endpoint to be prepared for the volume.

Also sets default for scanner automation setting to False to manage volume further.