### PR TITLE
fix(platform-insights): Use different param name for table cursor

### DIFF
--- a/static/app/views/insights/pages/platform/nextjs/apiTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/apiTable.tsx
@@ -55,7 +55,7 @@ export function ApiTable() {
       'count()',
       'sum(span.duration)',
     ],
-    cursorParamName: 'cursor',
+    cursorParamName: 'tableCursor',
     referrer: Referrer.API_TABLE,
   });
 
@@ -65,7 +65,7 @@ export function ApiTable() {
         sortKey={column.key}
         align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
         forceCellGrow={column.key === 'transaction'}
-        cursorParamName="cursor"
+        cursorParamName="tableCursor"
       >
         {column.name}
       </HeadSortCell>
@@ -130,7 +130,7 @@ export function ApiTable() {
         renderBodyCell,
         renderHeadCell,
       }}
-      cursorParamName="cursor"
+      cursorParamName="tableCursor"
       pageLinks={tableDataRequest.pageLinks}
       isPlaceholderData={tableDataRequest.isPlaceholderData}
     />

--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -55,7 +55,7 @@ export function ClientTable() {
       'count_if(span.op,navigation)',
       'count_if(span.op,pageload)',
     ],
-    cursorParamName: 'cursor',
+    cursorParamName: 'tableCursor',
     referrer: Referrer.CLIENT_TABLE,
   });
 
@@ -64,7 +64,7 @@ export function ClientTable() {
       <HeadSortCell
         sortKey={column.key}
         align={rightAlignColumns.has(column.key) ? 'right' : 'left'}
-        cursorParamName={'cursor'}
+        cursorParamName={'tableCursor'}
         forceCellGrow={column.key === 'transaction'}
       >
         {column.name}
@@ -143,7 +143,7 @@ export function ClientTable() {
       data={tableDataRequest.data}
       initialColumnOrder={pageloadColumnOrder}
       stickyHeader
-      cursorParamName={'cursor'}
+      cursorParamName={'tableCursor'}
       pageLinks={pagesTablePageLinks}
       isPlaceholderData={tableDataRequest.isPlaceholderData}
       grid={{

--- a/static/app/views/insights/pages/platform/nextjs/index.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/index.tsx
@@ -80,7 +80,7 @@ export function NextJsOverviewPage({
       updateQuery({
         view,
         // Clear table cursor and sort order
-        cursor: undefined,
+        tableCursor: undefined,
         field: undefined,
         order: undefined,
       });


### PR DESCRIPTION
### Problem

As `useEAPSpans` creates an `EventView` internally, it picks up the `cursor` param from the url and passes it to the requests. Therefore changing the page on the table which uses the `cursor` param for pagination updates all widgets that use `useEAPSpans`. On some the underlying logic does not expect that and results in a broken visualization (e.g. web witals widget).

### Solution

As it is not clear whether the behavior of `useEAPSpans` is intentional,  we can simply updated the name of the table's cursor param to `tableCursor`

- closes [TET-629: Web Vitals widget resets when paginating](https://linear.app/getsentry/issue/TET-629/web-vitals-widget-resets-when-paginating)