### PR TITLE
fix(agent-insights): Filter empty input messages

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -18,17 +18,7 @@ import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/tr
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
-function renderUserMessage(content: any) {
-  if (!Array.isArray(content)) {
-    return content;
-  }
-  return content
-    .filter((part: any) => part.type === 'text')
-    .map((part: any) => part.text)
-    .join('\n');
-}
-
-function renderAssistantMessage(content: any) {
+function renderTextMessages(content: any) {
   if (!Array.isArray(content)) {
     return content;
   }
@@ -51,17 +41,17 @@ function parseAIMessages(messages: string) {
           case 'system':
             return {
               role: 'system' as const,
-              content: message.content.toString(),
+              content: renderTextMessages(message.content),
             };
           case 'user':
             return {
               role: 'user' as const,
-              content: renderUserMessage(message.content),
+              content: renderTextMessages(message.content),
             };
           case 'assistant':
             return {
               role: 'assistant' as const,
-              content: renderAssistantMessage(message.content),
+              content: renderTextMessages(message.content),
             };
           case 'tool':
             return {
@@ -77,7 +67,10 @@ function parseAIMessages(messages: string) {
             return null;
         }
       })
-      .filter(message => message !== null);
+      .filter(
+        (message): message is Exclude<typeof message, null> =>
+          message !== null && Boolean(message.content)
+      );
   } catch (error) {
     Sentry.captureMessage('Error parsing ai.prompt.messages', {
       extra: {


### PR DESCRIPTION
Sometimes we receive messages with not renderable content.
![Screenshot 2025-06-12 at 11 16 03](https://github.com/user-attachments/assets/d4c30206-8dd4-4cb7-a771-01451e7b19e9)

This PR filters those messages.