### PR TITLE
fix(snuba): Missing referrers for self hosted

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -116,6 +116,7 @@ class Referrer(StrEnum):
     API_ISSUES_ISSUE_EVENTS = "api.issues.issue_events"
     API_ISSUES_RELATED_ISSUES = "api.issues.related_issues"
     API_METRICS_TOTALS = "api.metrics.totals"
+    API_METRICS_TOTALS_INITIAL_QUERY = "api.metrics.totals.initial_query"
     API_ORGANIZATION_TRACE_ITEM_DETAILS = "api.organization-trace-item-details"
     API_ORGANIZATION_EVENT_STATS_FIND_TOPN = "api.organization-event-stats.find-topn"
     API_ORGANIZATION_EVENT_STATS_METRICS_ENHANCED = "api.organization-event-stats.metrics-enhanced"
@@ -396,6 +397,9 @@ class Referrer(StrEnum):
     API_PERFORMANCE_TRANSACTION_NAME_SEARCH_BAR = "api.performance.transaction-name-search-bar"
     API_PERFORMANCE_TRANSACTION_SPANS = "api.performance.transaction-spans"
     API_PERFORMANCE_TRANSACTION_SUMMARY_DURATION = "api.performance.transaction-summary.duration"
+    API_PERFORMANCE_TRANSACTION_SUMMARY_METRICS_ENHANCED_PRIMARY = (
+        "api.performance.transaction-summary.metrics-enhanced.primary"
+    )
     API_PERFORMANCE_TRANSACTION_SUMMARY_SIDEBAR_CHART_METRICS_ENHANCED = (
         "api.performance.transaction-summary.sidebar-chart.metrics-enhanced"
     )


### PR DESCRIPTION
These 2 referrers were missing in the self hosted release.
- api.metrics.totals.initial_query
- api.performance.transaction-summary.metrics-enhanced.primary

Closes getsentry/self-hosted#3652
Closes getsentry/self-hosted#3741