### PR TITLE
fix(agent-insights): Handle messages array

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -34,7 +34,7 @@ function renderToolMessage(content: any) {
 
 function parseAIMessages(messages: string) {
   try {
-    const array: any[] = JSON.parse(messages);
+    const array: any[] = Array.isArray(messages) ? messages : JSON.parse(messages);
     return array
       .map((message: any) => {
         switch (message.role) {


### PR DESCRIPTION
When traces are loaded via the non-EAP endpoint attributes like the AI messages also can be a JSON object instead of its string representation.

This PR adds handling for that case.