### PR TITLE
fix(taskworker): Add processing deadline to async_send_notification task

### DIFF
--- a/src/sentry/notifications/utils/tasks.py
+++ b/src/sentry/notifications/utils/tasks.py
@@ -106,7 +106,7 @@ def async_send_notification(
     silo_mode=SiloMode.REGION,
     queue="notifications",
     taskworker_config=TaskworkerConfig(
-        namespace=notifications_tasks,
+        namespace=notifications_tasks, processing_deadline_duration=20
     ),
 )
 def _send_notification(notification_class_name: str, arg_list: Iterable[Mapping[str, Any]]) -> None:


### PR DESCRIPTION
Over the past month at its max, this task can take up to 15 seconds. Add a processing deadline of 20s to `async_send_notification` task
Refs: SENTRY-406M