### PR TITLE
fix(taskworker): Bump deliver_digest task processing deadline

### DIFF
--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -48,7 +48,7 @@ def schedule_digests() -> None:
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=digests_tasks,
-        processing_deadline_duration=60,
+        processing_deadline_duration=300,
     ),
 )
 def deliver_digest(


### PR DESCRIPTION
At its max, the `deliver_digests` task can take up to 4 minutes (sometimes even higher). This PR bumps its processing deadline to 5 minutes

Refs: SENTRY-402M