### PR TITLE
feat(tempest): Add PlayStation SDK access request modal and button

### DIFF
--- a/static/app/views/settings/project/tempest/DevKitSettings.tsx
+++ b/static/app/views/settings/project/tempest/DevKitSettings.tsx
@@ -24,6 +24,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useProjectKeys} from 'sentry/utils/useProjectKeys';
 
+import {RequestSdkAccessButton} from './RequestSdkAccessButton';
+
 interface Props {
   organization: Organization;
   project: Project;
@@ -200,10 +202,11 @@ export default function DevKitSettings({organization, project}: Props) {
   );
 }
 
-export const getDevKitHeaderAction = () => {
+export const getDevKitHeaderAction = (organization: Organization, project: Project) => {
   return (
     <ButtonBar gap={1.5}>
       <FeedbackWidgetButton />
+      <RequestSdkAccessButton organization={organization} project={project} />
     </ButtonBar>
   );
 };

--- a/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
@@ -1,0 +1,136 @@
+import {Fragment, useCallback, useState} from 'react';
+import {captureFeedback} from '@sentry/react';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
+import SelectField from 'sentry/components/forms/fields/selectField';
+import TextField from 'sentry/components/forms/fields/textField';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useUser} from 'sentry/utils/useUser';
+
+interface Props {
+  organization: Organization;
+  project: Project;
+}
+
+interface PlayStationSdkAccessModalProps extends ModalRenderProps, Props {}
+
+interface FormData {
+  gameEngines: string[];
+  githubProfile: string;
+}
+
+const GAME_ENGINE_OPTIONS = [
+  {value: 'unity', label: 'Unity'},
+  {value: 'unreal', label: 'Unreal'},
+  {value: 'godot', label: 'Godot'},
+  {value: 'private-engine', label: 'Private Engine'},
+  {value: 'other', label: 'Other'},
+];
+
+export default function PlayStationSdkAccessModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  organization,
+  project,
+}: PlayStationSdkAccessModalProps) {
+  const user = useUser();
+  const [formData, setFormData] = useState<FormData>({
+    githubProfile: '',
+    gameEngines: [],
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(() => {
+    if (!formData.githubProfile || formData.gameEngines.length === 0) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    trackAnalytics('tempest.sdk_access_request_submitted', {
+      organization,
+      project_slug: project.slug,
+      game_engines: formData.gameEngines,
+    });
+
+    // (ab)uses captureFeedback to send an SDK access request notification to the GDX team
+    captureFeedback({
+      message: `PlayStation SDK Access Request by ${user.email}`,
+      source: 'playstation-sdk-access',
+      tags: {
+        feature: 'playstation-sdk-access',
+        githubProfile: formData.githubProfile,
+        gameEngines: formData.gameEngines.join(','),
+        'user.email': user.email,
+        'org.slug': organization.slug,
+      },
+    });
+
+    addSuccessMessage(t('Your PlayStation SDK access request has been submitted!'));
+    setIsSubmitting(false);
+    closeModal();
+  }, [formData, organization, project, user, closeModal]);
+
+  const isFormValid = formData.githubProfile.trim() && formData.gameEngines.length > 0;
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h3>{t('Request PlayStation SDK Access')}</h3>
+      </Header>
+      <Body>
+        <p>
+          {t(
+            'Request access to our PlayStation SDK. Please provide your GitHub profile and the game engines you work with.'
+          )}
+        </p>
+        <TextField
+          name="githubProfile"
+          label={t('Link to your GitHub profile')}
+          placeholder="https://github.com/username"
+          value={formData.githubProfile}
+          onChange={(value: string) =>
+            setFormData(prev => ({...prev, githubProfile: value}))
+          }
+          required
+          stacked
+          inline={false}
+        />
+        <SelectField
+          name="gameEngines"
+          label={t('Select Game Engine')}
+          placeholder={t('Select one or more game engines')}
+          options={GAME_ENGINE_OPTIONS}
+          value={formData.gameEngines}
+          onChange={(value: string[]) =>
+            setFormData(prev => ({...prev, gameEngines: value}))
+          }
+          multiple
+          required
+          stacked
+          inline={false}
+        />
+      </Body>
+      <Footer>
+        <ButtonBar gap={1}>
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button
+            priority="primary"
+            onClick={handleSubmit}
+            disabled={!isFormValid || isSubmitting}
+          >
+            {isSubmitting ? t('Submitting...') : t('Submit Request')}
+          </Button>
+        </ButtonBar>
+      </Footer>
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -27,6 +27,7 @@ import {useHasTempestWriteAccess} from 'sentry/views/settings/project/tempest/ut
 
 import {CredentialRow} from './CredentialRow';
 import EmptyState from './EmptyState';
+import {RequestSdkAccessButton} from './RequestSdkAccessButton';
 
 interface Props {
   organization: Organization;
@@ -167,6 +168,7 @@ export const getPlayStationHeaderAction = (
   <Fragment>
     <ButtonBar gap={1.5}>
       <FeedbackWidgetButton />
+      <RequestSdkAccessButton organization={organization} project={project} />
       <Tooltip
         title={t('You must be an organization admin to add new credentials.')}
         disabled={hasWriteAccess}

--- a/static/app/views/settings/project/tempest/RequestSdkAccessButton.tsx
+++ b/static/app/views/settings/project/tempest/RequestSdkAccessButton.tsx
@@ -1,0 +1,43 @@
+import {openModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/core/button';
+import {IconCode} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+import PlayStationSdkAccessModal from './PlayStationSdkAccessModal';
+
+interface RequestSdkAccessButtonProps {
+  organization: Organization;
+  project: Project;
+}
+
+export function RequestSdkAccessButton({
+  organization,
+  project,
+}: RequestSdkAccessButtonProps) {
+  return (
+    <Button
+      priority="default"
+      size="sm"
+      data-test-id="request-sdk-access"
+      icon={<IconCode />}
+      onClick={() => {
+        openModal(deps => (
+          <PlayStationSdkAccessModal
+            {...deps}
+            organization={organization}
+            project={project}
+          />
+        ));
+        trackAnalytics('tempest.sdk_access_modal_opened', {
+          organization,
+          project_slug: project.slug,
+        });
+      }}
+    >
+      {t('Request SDK Access')}
+    </Button>
+  );
+}

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -103,7 +103,7 @@ export default function TempestSettings({organization, project}: Props) {
   const getHeaderAction = () => {
     switch (tab) {
       case 'devkit-crashes':
-        return getDevKitHeaderAction();
+        return getDevKitHeaderAction(organization, project);
       case 'playstation':
       default:
         return getPlayStationHeaderAction(hasWriteAccess, organization, project);


### PR DESCRIPTION
Adds a new button that will send user feedback on submit with data needed for access to our SDK.

Closes [GDX-359: Use captureFeedback to collect requests for PS SDK access](https://linear.app/getsentry/issue/GDX-359/use-capturefeedback-to-collect-requests-for-ps-sdk-access)