### PR TITLE
fix(dashboards): Clear timeout for setting data loading message

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -125,6 +125,10 @@ function WidgetCard(props: Props) {
 
     setData(prevData => ({...prevData, ...rest}));
 
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     setIsLoadingTextVisible(false);
   };
 


### PR DESCRIPTION
We should clear the timeout when the data loads so it doesn't re-render unnecessarily.