### PR TITLE
fix(command-menu): Fix duplicate settings link items

### DIFF
--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -9,8 +9,10 @@ import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
+import {prefersStackedNav} from 'sentry/views/nav/prefersStackedNav';
 import accountSettingsNavigation from 'sentry/views/settings/account/navigationConfiguration';
 import {getOrganizationNavigationConfiguration} from 'sentry/views/settings/organization/navigationConfiguration';
+import {getUserOrgNavigationConfiguration} from 'sentry/views/settings/organization/userOrgNavigationConfiguration';
 import projectSettingsNavigation from 'sentry/views/settings/project/navigationConfiguration';
 import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
 
@@ -78,12 +80,20 @@ function RouteSource({searchOptions, query, children}: Props) {
         )
       : [];
 
-    const searchMap: NavigationItem[] = [
-      mapFunc(accountSettingsNavigation, context),
-      mapFunc(projectSettingsNavigation, context),
-      mapFunc(getOrganizationNavigationConfiguration, context),
-      mapFunc(navigationFromHook, context),
-    ].flat(2);
+    const searchMap: NavigationItem[] = (
+      prefersStackedNav(organization)
+        ? [
+            mapFunc(getUserOrgNavigationConfiguration, context),
+            mapFunc(projectSettingsNavigation, context),
+            mapFunc(navigationFromHook, context),
+          ]
+        : [
+            mapFunc(getOrganizationNavigationConfiguration, context),
+            mapFunc(accountSettingsNavigation, context),
+            mapFunc(projectSettingsNavigation, context),
+            mapFunc(navigationFromHook, context),
+          ]
+    ).flat(2);
 
     const search = await createFuzzySearch(searchMap, {
       ...searchOptions,


### PR DESCRIPTION
`getUserOrgNavigationConfiguration` should only have been included when the new nav was active, since it duplicates items in the account and org configs.

![CleanShot 2025-06-12 at 09 12 23@2x](https://github.com/user-attachments/assets/b76b8fe1-ddfa-4df0-9c32-6ace690c2e82)

Fixes: [RTC-1015: cmd+K serach shows duplicate link results](https://linear.app/getsentry/issue/RTC-1015/cmdk-serach-shows-duplicate-link-results)
