### PR TITLE
fix(ui): Use flexibleControlStateSize for token details

### DIFF
--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -6,6 +6,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import Confirm from 'sentry/components/confirm';
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
 import Form from 'sentry/components/forms/form';
 import FormField from 'sentry/components/forms/formField';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -114,7 +115,7 @@ function ApiApplicationsDetails() {
           <PanelHeader>{t('Credentials')}</PanelHeader>
 
           <PanelBody>
-            <FormField name="clientID" label="Client ID">
+            <FormField name="clientID" label="Client ID" flexibleControlStateSize>
               {({value}: any) => (
                 <TextCopyInput>
                   {getDynamicText({value, fixed: 'CI_CLIENT_ID'})}
@@ -127,6 +128,7 @@ function ApiApplicationsDetails() {
               label={t('Client Secret')}
               help={t(`Your secret is only available briefly after application creation. Make
                   sure to save this value!`)}
+              flexibleControlStateSize
             >
               {({value}: any) =>
                 value ? (
@@ -151,13 +153,13 @@ function ApiApplicationsDetails() {
               }
             </FormField>
 
-            <FormField name="" label={t('Authorization URL')}>
-              {() => <TextCopyInput>{`${urlPrefix}/oauth/authorize/`}</TextCopyInput>}
-            </FormField>
+            <FieldGroup label={t('Authorization URL')} flexibleControlStateSize>
+              <TextCopyInput>{`${urlPrefix}/oauth/authorize/`}</TextCopyInput>
+            </FieldGroup>
 
-            <FormField name="" label={t('Token URL')}>
-              {() => <TextCopyInput>{`${urlPrefix}/oauth/token/`}</TextCopyInput>}
-            </FormField>
+            <FieldGroup label={t('Token URL')} flexibleControlStateSize>
+              <TextCopyInput>{`${urlPrefix}/oauth/token/`}</TextCopyInput>
+            </FieldGroup>
           </PanelBody>
         </Panel>
       </Form>


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="1107" src="https://i.imgur.com/Evx14Lr.png" />

After

<img alt="clipboard.png" width="1123" src="https://i.imgur.com/nPRcgok.png" />