### PR TITLE
ref: fix incorrect `"project"` key in performance issues

### DIFF
--- a/src/sentry/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/performance_issues/detectors/io_main_thread_detector.py
@@ -120,7 +120,7 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
         event = self._event
         if "debug_meta" in event:
             images = event["debug_meta"].get("images", [])
-            project_id = event.get("project")
+            project_id = event["project_id"]
             if not isinstance(images, list):
                 return
             if project_id is not None:

--- a/src/sentry/testutils/performance_issues/event_generators.py
+++ b/src/sentry/testutils/performance_issues/event_generators.py
@@ -29,7 +29,7 @@ for dirpath, dirnames, filenames in os.walk(_fixture_path):
 
         with open(filepath) as f:
             event = json.load(f)
-            event["project"] = PROJECT_ID
+            event["project_id"] = PROJECT_ID
 
         EVENTS[full_event_name] = event
 
@@ -67,7 +67,7 @@ def create_span(
 def create_event(spans, event_id: str = "a" * 16) -> dict[str, Any]:
     return {
         "event_id": event_id,
-        "project": PROJECT_ID,
+        "project_id": PROJECT_ID,
         "spans": spans,
         "sdk": {"name": "sentry.python"},
     }

--- a/tests/sentry/performance_issues/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/performance_issues/test_file_io_on_main_thread_detector.py
@@ -128,7 +128,7 @@ class FileIOMainThreadDetectorTest(TestCase):
 
     def test_file_io_with_proguard(self):
         event = get_event("file-io-on-main-thread-with-obfuscation")
-        event["project"] = self.project.id
+        event["project_id"] = self.project.id
 
         uuid = event["debug_meta"]["images"][0]["uuid"]
         self.create_proguard(uuid)

--- a/tests/sentry/performance_issues/test_http_overhead_detector.py
+++ b/tests/sentry/performance_issues/test_http_overhead_detector.py
@@ -42,7 +42,7 @@ def overhead_span(
 def _valid_http_overhead_event(url: str) -> dict[str, Any]:
     return {
         "event_id": "a" * 16,
-        "project": PROJECT_ID,
+        "project_id": PROJECT_ID,
         "spans": [
             overhead_span(1000, 100, url),
             overhead_span(1000, 200, url),

--- a/tests/sentry/performance_issues/test_render_blocking_asset_detector.py
+++ b/tests/sentry/performance_issues/test_render_blocking_asset_detector.py
@@ -25,7 +25,7 @@ from sentry.testutils.performance_issues.event_generators import (
 def _valid_render_blocking_asset_event(url: str) -> dict[str, Any]:
     return {
         "event_id": "a" * 16,
-        "project": PROJECT_ID,
+        "project_id": PROJECT_ID,
         "measurements": {
             "fcp": {
                 "value": 2500.0,

--- a/tests/sentry/performance_issues/test_uncompressed_asset_detector.py
+++ b/tests/sentry/performance_issues/test_uncompressed_asset_detector.py
@@ -54,7 +54,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_detects_uncompressed_asset_with_none_tag(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [None, ["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
@@ -91,7 +91,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_detects_uncompressed_asset(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
@@ -128,7 +128,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_detects_uncompressed_asset_with_trailing_query_params(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
@@ -166,7 +166,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_detects_uncompressed_asset_stylesheet(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
@@ -205,7 +205,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_does_not_detect_jpg_asset(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
@@ -260,7 +260,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_does_not_detect_woff_asset(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [["browser.name", "chrome"]],
             "spans": [
                 create_asset_span(
@@ -315,7 +315,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_does_not_detect_mobile_uncompressed_asset(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "tags": [["browser.name", "firefox_mobile"]],
             "spans": [
                 create_asset_span(
@@ -335,7 +335,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_ignores_assets_under_size(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "spans": [
                 create_asset_span(
                     duration=1000.0,
@@ -354,7 +354,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_ignores_compressed_assets(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "spans": [
                 create_asset_span(
                     duration=1000.0,
@@ -373,7 +373,7 @@ class UncompressedAssetsDetectorTest(TestCase):
     def test_ignores_assets_under_duration(self):
         event = {
             "event_id": "a" * 16,
-            "project": PROJECT_ID,
+            "project_id": PROJECT_ID,
             "spans": [
                 create_asset_span(
                     duration=50.0,


### PR DESCRIPTION
the fake Event is created here: https://github.com/getsentry/sentry/blob/9f17c976f666881dea7f0c777adaff01b13b6675/src/sentry/spans/consumers/process_segments/message.py#L203

found while attempting to fix the typing of performance detectors with TypedDict

<!-- Describe your PR here. -->