### PR TITLE
perf(aci): Pass DataConditionGroup to process_data_condition_group

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -516,7 +516,7 @@ class StatefulDetectorHandler(
             metrics.incr("workflow_engine.detector.skipping_invalid_condition_group")
             return None, new_priority
 
-        condition_evaluation, _ = process_data_condition_group(self.condition_group.id, value)
+        condition_evaluation, _ = process_data_condition_group(self.condition_group, value)
 
         if condition_evaluation.logic_result:
             validated_condition_results: list[DetectorPriorityLevel] = [

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from typing import Any, ClassVar
 
@@ -16,9 +17,12 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.models.owner_base import OwnerModel
 from sentry.workflow_engine.models.data_condition import DataCondition, is_slow_condition
+from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
 from sentry.workflow_engine.types import WorkflowEventData
 
 from .json_config import JSONConfigBase
+
+logger = logging.getLogger(__name__)
 
 
 class WorkflowManager(BaseManager["Workflow"]):
@@ -103,8 +107,17 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
             return True, []
 
         workflow_event_data = replace(event_data, workflow_env=self.environment)
+        try:
+            group = DataConditionGroup.objects.get_from_cache(id=self.when_condition_group_id)
+        except DataConditionGroup.DoesNotExist:
+            # TODO: Possible?
+            logger.exception(
+                "DataConditionGroup does not exist",
+                extra={"id": self.when_condition_group_id},
+            )
+            return False, []
         group_evaluation, remaining_conditions = process_data_condition_group(
-            self.when_condition_group_id, workflow_event_data
+            group, workflow_event_data
         )
         return group_evaluation.logic_result, remaining_conditions
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -110,7 +110,8 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         try:
             group = DataConditionGroup.objects.get_from_cache(id=self.when_condition_group_id)
         except DataConditionGroup.DoesNotExist:
-            # TODO: Possible?
+            # This isn't expected under normal conditions, but weird things can happen in the
+            # midst of deletions and migrations.
             logger.exception(
                 "DataConditionGroup does not exist",
                 extra={"id": self.when_condition_group_id},

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -148,7 +148,7 @@ def evaluate_data_conditions(
 
 
 def process_data_condition_group(
-    data_condition_group_id: int,
+    group: DataConditionGroup,
     value: T,
     is_fast: bool = True,
 ) -> DataConditionGroupResult:
@@ -159,15 +159,6 @@ def process_data_condition_group(
     condition_results: list[ProcessedDataCondition] = []
 
     try:
-        group = DataConditionGroup.objects.get_from_cache(id=data_condition_group_id)
-    except DataConditionGroup.DoesNotExist:
-        logger.exception(
-            "DataConditionGroup does not exist",
-            extra={"id": data_condition_group_id},
-        )
-        return invalid_group_result
-
-    try:
         logic_type = DataConditionGroup.Type(group.logic_type)
     except ValueError:
         logger.exception(
@@ -176,7 +167,7 @@ def process_data_condition_group(
         )
         return invalid_group_result
 
-    conditions = get_data_conditions_for_group(data_condition_group_id)
+    conditions = get_data_conditions_for_group(group.id)
 
     if is_fast:
         conditions, remaining_conditions = split_conditions_by_speed(conditions)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -153,7 +153,7 @@ def evaluate_workflows_action_filters(
             event_data, workflow_env=workflows_by_id[action_condition.workflow_id].environment
         )
         group_evaluation, remaining_conditions = process_data_condition_group(
-            action_condition.id, workflow_event_data
+            action_condition, workflow_event_data
         )
 
         if remaining_conditions:

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
@@ -25,17 +23,6 @@ class TestGetDataConditionsForGroup(TestCase):
 
 
 class TestProcessDataConditionGroup(TestCase):
-    def test_process_data_condition_group(self):
-        with mock.patch(
-            "sentry.workflow_engine.processors.data_condition_group.logger"
-        ) as mock_logger:
-            expected_result = ProcessedDataConditionGroup(logic_result=False, condition_results=[])
-            expected_remaining_conditions: list[DataCondition] = []
-            assert process_data_condition_group(1, 1) == (
-                expected_result,
-                expected_remaining_conditions,
-            )
-            assert mock_logger.exception.call_args[0][0] == "DataConditionGroup does not exist"
 
     def test_process_data_condition_group__exists__fails(self):
         data_condition_group = self.create_data_condition_group()
@@ -48,7 +35,7 @@ class TestProcessDataConditionGroup(TestCase):
             condition_results=[],
         )
         expected_remaining_conditions: list[DataCondition] = []
-        assert process_data_condition_group(data_condition_group.id, 1) == (
+        assert process_data_condition_group(data_condition_group, 1) == (
             expected_result,
             expected_remaining_conditions,
         )
@@ -71,7 +58,7 @@ class TestProcessDataConditionGroup(TestCase):
                 )
             ],
         )
-        assert process_data_condition_group(data_condition_group.id, 10) == (expected_result, [])
+        assert process_data_condition_group(data_condition_group, 10) == (expected_result, [])
 
 
 class TestEvaluationConditionCase(TestCase):
@@ -345,7 +332,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         )
 
         group_evaluation, remaining_conditions = process_data_condition_group(
-            self.data_condition_group.id,
+            self.data_condition_group,
             10,
             True,
         )
@@ -360,7 +347,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
     def test_basic_only_slow_conditions(self):
         self.data_condition.delete()
         group_evaluation, remaining_conditions = process_data_condition_group(
-            self.data_condition_group.id,
+            self.data_condition_group,
             10,
             True,
         )
@@ -384,7 +371,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
 
     def test_short_circuit_with_all(self):
         group_evaluation, remaining_conditions = process_data_condition_group(
-            self.data_condition_group.id,
+            self.data_condition_group,
             1,
             True,
         )
@@ -396,7 +383,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
     def test_short_circuit_with_any(self):
         self.data_condition_group.update(logic_type=DataConditionGroup.Type.ANY)
         group_evaluation, remaining_conditions = process_data_condition_group(
-            self.data_condition_group.id,
+            self.data_condition_group,
             10,
             True,
         )


### PR DESCRIPTION
The caches sometimes work for us, but when they don't DataConditionGroup loads are a major contributor to query time.
Making `process_data_condition_group` take a DataConditionGroup rather than an ID allow us to pass the one we have and avoid any querying risk while being roughly the same in cases where we don't have one.
