### PR TITLE
fix(insights): Prevent backend overview widgets from growing out of control

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -295,6 +295,6 @@ const StackedWidgetWrapper = styled('div')`
 const TripleRowWidgetWrapper = styled('div')`
   display: grid;
   grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: 300px;
   gap: ${space(2)};
-  height: 300px;
 `;


### PR DESCRIPTION
Closes [DAIN-629: Charts with footers grow uncontrollably in height in some cases](https://linear.app/getsentry/issue/DAIN-629/charts-with-footers-grow-uncontrollably-in-height-in-some-cases). Sets the three-widget grid height via row height rather than overall height. This allows grid cell children to obey the `height: 100%` rule correctly. The widgets are overflowing their parents by a fraction of a pixel, because their heights are set with height: 100%. This doesn't work in a CSS grid context! The overflow causes ECharts to detect a resize, which sets the ECharts element to a pixel height without a fraction, which increases the widgets height, which causes a resize, and so on.

Note: This reveals _another_ heinous bug to be fixed separately, tracked in DAIN-630