### PR TITLE
fix(insights): Prevent duplicate rows in footer of Slow Queries widget

### DIFF
--- a/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
@@ -119,7 +119,9 @@ export default function OverviewSlowQueriesChartWidget(props: LoadableChartWidge
   const footer = hasData && (
     <WidgetFooterTable>
       {queriesRequest.data?.map((item, index) => (
-        <Fragment key={item['sentry.normalized_description']}>
+        <Fragment
+          key={`${item['project.id']}-${item['span.group']}-${item['sentry.normalized_description']}`}
+        >
           <div>
             <SeriesColorIndicator
               style={{

--- a/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
@@ -70,7 +70,7 @@ export default function OverviewSlowQueriesChartWidget(props: LoadableChartWidge
       yAxis: ['avg(span.duration)'],
       sort: {field: 'avg(span.duration)', kind: 'desc'},
       topN: 3,
-      enabled: !!queriesRequest.data,
+      enabled: queriesRequest.data.length > 0,
     },
     Referrer.QUERIES_CHART,
     props.pageFilters


### PR DESCRIPTION
Closes [DAIN-630: Widget footers incorrectly render duplicate rows when changing filters](https://linear.app/getsentry/issue/DAIN-630/widget-footers-incorrectly-render-duplicate-rows-when-changing-filters). There were two errors:

1. The `enabled: ` check wasn't working correctly. `data` is _always_ an array, and `!!([])` evalues to `true` so the query was always enabled. This causes an extra query with no conditions to fire every time the filters change
2. The `key` of the items in the footer was not unique, since multiple spans of the same normalized description can come back between requests and between renders. Duplicate keys can cause duplicate items in the list in some cases (like this case)

This PR fixes both those errors. This is a little tough to see locally since it's obscured by DAIN-629.
