### PR TITLE
fix(ui): Make badge look less bad

### DIFF
--- a/static/app/components/core/badge/featureBadge.tsx
+++ b/static/app/components/core/badge/featureBadge.tsx
@@ -55,8 +55,6 @@ const StyledBadge = withChonk(
     margin: 0;
     padding: 0 ${space(0.75)};
     height: ${space(2)};
-    font-weight: ${p => p.theme.fontWeightNormal};
-    font-size: ${p => p.theme.fontSizeExtraSmall};
     vertical-align: middle;
   `,
   ChonkStyledBadge

--- a/static/app/components/core/badge/index.tsx
+++ b/static/app/components/core/badge/index.tsx
@@ -78,12 +78,13 @@ const StyledBadge = styled('span')<BadgeProps>`
   line-height: 20px;
   border-radius: 20px;
   font-weight: ${p => p.theme.fontWeightNormal};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: 0 ${space(0.75)};
 
   /* @TODO(jonasbadalic) can we standardize this transition? */
   transition: background 100ms linear;
 
   /* @TODO(jonasbadalic) why are these needed? */
-  padding: 0 5px;
   margin-left: ${space(0.5)};
   position: relative;
 `;


### PR DESCRIPTION
Not sure if this will break anything anywhere, but definitely makes these look more good.

Before
<img width="294" alt="image" src="https://github.com/user-attachments/assets/fa377295-35bc-48a9-8619-b9da76ee2c3a" />

After 
<img width="260" alt="image" src="https://github.com/user-attachments/assets/49b63c5f-7369-4457-8a5b-6944bc89cec9" />
