### PR TITLE
fix(profiling): Allow free text search in profiling search bar

### DIFF
--- a/static/app/components/performance/transactionSearchQueryBuilder.tsx
+++ b/static/app/components/performance/transactionSearchQueryBuilder.tsx
@@ -31,6 +31,7 @@ interface TransactionSearchQueryBuilderProps {
   searchSource: string;
   datetime?: PageFilters['datetime'];
   disableLoadingTags?: boolean;
+  disallowFreeText?: boolean;
   filterKeyMenuWidth?: number;
   onSearch?: (query: string, state: CallbackSearchState) => void;
   placeholder?: string;
@@ -45,6 +46,7 @@ export function TransactionSearchQueryBuilder({
   onSearch,
   placeholder,
   projects,
+  disallowFreeText = true,
   disableLoadingTags,
   filterKeyMenuWidth,
   trailingItems,
@@ -135,7 +137,7 @@ export function TransactionSearchQueryBuilder({
       searchSource={searchSource}
       filterKeySections={filterKeySections}
       getTagValues={getTransactionFilterTagValues}
-      disallowFreeText
+      disallowFreeText={disallowFreeText}
       disallowUnsupportedFilters
       recentSearches={SavedSearchType.EVENT}
       filterKeyMenuWidth={filterKeyMenuWidth}

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -298,6 +298,7 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
           initialQuery={query}
           onSearch={handleSearch}
           searchSource="profile_landing"
+          disallowFreeText={false}
         />
       </SearchbarContainer>
       {transactionsError && (


### PR DESCRIPTION
The search bar allows free text search on so remove this check as it's unnecessary.