### PR TITLE
fix(workflow_engine): Fix action metrics while in dual processing

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -309,6 +309,14 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
                         "event_data": asdict(event_data),
                     },
                 )
+        else:
+            # If the feature flag is not enabled, only send a metric
+            for action in actions:
+                metrics_incr(
+                    "process_workflows.action_triggered",
+                    1,
+                    tags={"action_type": action.type},
+                )
 
     # in order to check if workflow engine is firing 1:1 with the old system, we must only count once rather than each action
     if len(actions) > 0:


### PR DESCRIPTION
# Description
Moved the `metrics_incr` to after the action has been triggered, which broke our current dashboards.

This will reintroduce a metric `workflow_engine.process_workflows.action_triggered` -- with the tag that includes the type of action we would have triggered.