### PR TITLE
fix(ui): Consistent can-not-edit alerts in settings

### DIFF
--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -16,14 +16,11 @@ import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationSampling} from 'sentry/views/settings/dynamicSampling/organizationSampling';
 import {ProjectSampling} from 'sentry/views/settings/dynamicSampling/projectSampling';
-import {
-  useHasDynamicSamplingReadAccess,
-  useHasDynamicSamplingWriteAccess,
-} from 'sentry/views/settings/dynamicSampling/utils/access';
+import {useHasDynamicSamplingReadAccess} from 'sentry/views/settings/dynamicSampling/utils/access';
+import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 export default function DynamicSamplingSettings() {
   const organization = useOrganization();
-  const hasWriteAccess = useHasDynamicSamplingWriteAccess();
   const hasReadAccess = useHasDynamicSamplingReadAccess();
 
   if (
@@ -86,15 +83,7 @@ export default function DynamicSamplingSettings() {
           </LinkButton>
         }
       />
-      {!hasWriteAccess && (
-        <Alert.Container>
-          <Alert type="warning">
-            {t(
-              'These settings can only be edited by users with the organization owner or manager role.'
-            )}
-          </Alert>
-        </Alert.Container>
-      )}
+      <OrganizationPermissionAlert />
       {hasReadAccess ? (
         <Fragment>
           <Paragraph>

--- a/static/app/views/settings/project/projectPermissionAlert.tsx
+++ b/static/app/views/settings/project/projectPermissionAlert.tsx
@@ -22,7 +22,12 @@ export function ProjectPermissionAlert({
       {({hasAccess}) =>
         !hasAccess && (
           <Alert.Container>
-            <Alert data-test-id="project-permission-alert" type="warning" {...props}>
+            <Alert
+              data-test-id="project-permission-alert"
+              type="warning"
+              showIcon
+              {...props}
+            >
               {t(
                 'These settings can only be edited by users with the organization-level owner, manager, or team-level admin roles.'
               )}

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -22,6 +22,7 @@ import {setApiQueryData} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
 import {AutofixRepositories} from './autofixRepositories';
 
@@ -226,13 +227,7 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
                       }
                     )}
                   </Alert>
-                  {!canWriteProject && (
-                    <Alert type="warning" system>
-                      {t(
-                        'These settings can only be edited by users with the organization-level owner, manager, or team-level admin role.'
-                      )}
-                    </Alert>
-                  )}
+                  <ProjectPermissionAlert project={project} />
                   {showWarning && (
                     <Alert type="warning" system showIcon>
                       {t(


### PR DESCRIPTION
Fixes: [RTC-1017: Inconsistent settings warning alert](https://linear.app/getsentry/issue/RTC-1017/inconsistent-settings-warning-alert)