### PR TITLE
chore: Initialize Sentry SDK before the config store

### DIFF
--- a/static/app/bootstrap/initializeApp.tsx
+++ b/static/app/bootstrap/initializeApp.tsx
@@ -11,8 +11,8 @@ import {renderMain} from './renderMain';
 import {renderOnDomReady} from './renderOnDomReady';
 
 export function initializeApp(config: Config) {
-  commonInitialization(config);
   initializeSdk(config);
+  commonInitialization(config);
 
   // Used for operational metrics to determine that the application js
   // bundle was loaded by browser.

--- a/static/app/bootstrap/initializeApp.tsx
+++ b/static/app/bootstrap/initializeApp.tsx
@@ -12,6 +12,7 @@ import {renderOnDomReady} from './renderOnDomReady';
 
 export function initializeApp(config: Config) {
   initializeSdk(config);
+  // Initialize the config store after the SDK, so we can log errors to Sentry during config initialization if needed. N.B. This mutates the config slightly
   commonInitialization(config);
 
   // Used for operational metrics to determine that the application js

--- a/static/app/bootstrap/initializePipelineView.tsx
+++ b/static/app/bootstrap/initializePipelineView.tsx
@@ -7,7 +7,6 @@ import {renderOnDomReady} from './renderOnDomReady';
 import {renderPipelineView} from './renderPipelineView';
 
 export function initializePipelineView(config: Config) {
-  commonInitialization(config);
   /**
    * XXX: Note we do not include routingInstrumentation because importing
    * `app/routes` significantly increases bundle size.
@@ -16,6 +15,8 @@ export function initializePipelineView(config: Config) {
    * `app/routes` to pass to `initializeSdk()`
    */
   initializeSdk(config);
+
+  commonInitialization(config);
 
   // Used for operational metrics to determine that the application js
   // bundle was loaded by browser.

--- a/static/app/bootstrap/initializePipelineView.tsx
+++ b/static/app/bootstrap/initializePipelineView.tsx
@@ -16,6 +16,7 @@ export function initializePipelineView(config: Config) {
    */
   initializeSdk(config);
 
+  // Initialize the config store after the SDK, so we can log errors to Sentry during config initialization if needed. N.B. This mutates the config slightly
   commonInitialization(config);
 
   // Used for operational metrics to determine that the application js

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -87,6 +87,7 @@ function getSentryIntegrations() {
  * entrypoints require this.
  */
 export function initializeSdk(config: Config) {
+  // NOTE: This config is mutated by `commonInitialization`
   const {apmSampling, sentryConfig, userIdentity} = config;
   const tracesSampleRate = apmSampling ?? 0;
   const extraTracePropagationTargets = SPA_DSN

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -45,11 +45,11 @@ const storeConfig: ConfigStoreDefinition = {
     };
 
     // TODO(dcramer): abstract this out of ConfigStore
-    if (config.user) {
-      config.user.permissions = new Set(config.user.permissions);
+    if (this.state.user) {
+      this.state.user.permissions = new Set(this.state.user.permissions);
 
       const systemTimeZone = moment.tz.guess();
-      const userTimeZone = config.user.options.timezone;
+      const userTimeZone = this.state.user.options.timezone;
 
       const nowInSystemTimezone = moment.tz(undefined, systemTimeZone);
       const nowInUserTimezone = moment.tz(undefined, userTimeZone);
@@ -64,7 +64,7 @@ const storeConfig: ConfigStoreDefinition = {
       moment.tz.setDefault(userTimeZone);
     }
 
-    this.trigger(config);
+    this.trigger(this.state);
   },
 
   getState() {

--- a/static/gsAdmin/init.tsx
+++ b/static/gsAdmin/init.tsx
@@ -13,8 +13,8 @@ import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {routes6} from 'admin/routes';
 
 export function init(config: Config) {
-  commonInitialization(config);
   initializeSdk(config);
+  commonInitialization(config);
 
   ConfigStore.set('getsentry.sendgridApiKey', window.__sendGridApiKey);
 }

--- a/static/gsAdmin/init.tsx
+++ b/static/gsAdmin/init.tsx
@@ -14,6 +14,8 @@ import {routes6} from 'admin/routes';
 
 export function init(config: Config) {
   initializeSdk(config);
+
+  // Initialize the config store after the SDK, so we can log errors to Sentry during config initialization if needed
   commonInitialization(config);
 
   ConfigStore.set('getsentry.sendgridApiKey', window.__sendGridApiKey);


### PR DESCRIPTION
This allows us to log warnings during config store initialization. Config store initialization technically mutates the user config, but the SDK initialization doesn't seem to rely on that data.
