### PR TITLE
chore(aci): log action ids we'd fire in workflow engine

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -475,7 +475,7 @@ def fire_actions_for_groups(
                     "workflow_engine.delayed_workflow.triggered_actions",
                     extra={
                         "workflow_ids": [workflow.id for workflow in workflows],
-                        "actions": filtered_actions,
+                        "actions": [action.id for action in filtered_actions],
                         "event_data": event_data,
                         "group_id": group.id,
                         "event_id": event_data.event.event_id,

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -310,6 +310,14 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
                     },
                 )
         else:
+            logger.info(
+                "workflow_engine.triggered_actions",
+                extra={
+                    "detector_id": detector.id,
+                    "action_ids": [action.id for action in actions],
+                    "event_data": asdict(event_data),
+                },
+            )
             # If the feature flag is not enabled, only send a metric
             for action in actions:
                 metrics_incr(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -97,7 +97,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         triggered_workflows = process_workflows(self.event_data)
         assert triggered_workflows == {self.error_workflow}
 
-        mock_logger.info.assert_called_with(
+        mock_logger.info.assert_any_call(
             "workflow_engine.evaluate_workflows_action_filters",
             extra={
                 "group_id": self.group.id,


### PR DESCRIPTION
I would like to be able to see which actions we would fire in workflow engine (post-process and delayed processing)