### PR TITLE
Increase maximum timeout and extend tick values in uptime alert form

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -231,9 +231,12 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
               name="timeoutMs"
               label={t('Timeout')}
               min={1000}
-              max={30_000}
+              max={60_000}
               step={250}
-              tickValues={[1_000, 5_000, 10_000, 15_000, 20_000, 25_000, 30_000]}
+              tickValues={[
+                1_000, 5_000, 10_000, 15_000, 20_000, 25_000, 30_000, 35_000, 40_000,
+                45_000, 50_000, 55_000, 60_000,
+              ]}
               defaultValue={5_000}
               showTickLabels
               formatLabel={value => getDuration((value || 0) / 1000, 2, true)}


### PR DESCRIPTION
Updated the maximum timeout value from 30s to 60s.