### PR TITLE
feat(uptime): Increase max timeout to 60s

### DIFF
--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -99,7 +99,7 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
     timeout_ms = serializers.IntegerField(
         required=True,
         min_value=1000,
-        max_value=30_000,
+        max_value=60_000,
         help_text="The number of milliseconds the request will wait for a response before timing-out.",
     )
     mode = serializers.IntegerField(required=False)

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -298,3 +298,26 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         )
         uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
         assert uptime_monitor.status == ObjectStatus.DISABLED
+
+    def test_timeout_too_large(self):
+        resp = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            environment=self.environment.name,
+            name="test",
+            owner=f"user:{self.user.id}",
+            url="http://sentry.io",
+            interval_seconds=60,
+            timeout_ms=60_001,
+            method="POST",
+            body="body",
+            headers=[["header", "value"]],
+        )
+        assert resp.data == {
+            "timeoutMs": [
+                ErrorDetail(
+                    string="Ensure this value is less than or equal to 60000.",
+                    code="max_value",
+                )
+            ]
+        }


### PR DESCRIPTION
We had a request for this, and it doesn't materially change the risk of timeouts causing problems, so bumping the max up to 60s

<!-- Describe your PR here. -->