### PR TITLE
feat(workflow_engine): Add support for Issue Status Changes

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from django.utils import timezone
 
+from sentry.eventstore.models import GroupEvent
 from sentry.rules.age import AgeComparisonType, age_comparison_map
 from sentry.rules.filters.age_comparison import timeranges
 from sentry.workflow_engine.models.data_condition import Condition
@@ -31,6 +32,10 @@ class AgeComparisonConditionHandler(DataConditionHandler[WorkflowEventData]):
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
+        if not isinstance(event, GroupEvent) or event.group is None:
+            # If the event is not a GroupEvent, we cannot evaluate age comparison
+            return False
+
         first_seen = event.group.first_seen
         current_time = timezone.now()
         comparison_type = comparison["comparison_type"]

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -45,6 +45,11 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
         target_type = AssigneeTargetType(comparison.get("target_type"))
+
+        if event.group is None:
+            # If we don't have an event group, we cannot evaluate the assignees
+            return False
+
         assignees = AssignedToConditionHandler.get_assignees(event.group)
 
         if target_type == AssigneeTargetType.UNASSIGNED:

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -76,6 +76,10 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        if not isinstance(event_data.event, GroupEvent):
+            # We got a status update, so we cannot evaluate the event attribute conditions
+            return False
+
         event = event_data.event
         attribute = comparison.get("attribute", "")
         attribute_values = EventAttributeConditionHandler.get_attribute_values(event, attribute)

--- a/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_created_by_detector_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -12,6 +13,10 @@ class EventCreatedByDetectorConditionHandler(DataConditionHandler[WorkflowEventD
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
+        if not isinstance(event, GroupEvent):
+            # If this is a status update, we don't need to evaluate the condition
+            return False
+
         if event.occurrence is None or event.occurrence.evidence_data is None:
             return False
 

--- a/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_seen_count_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -12,4 +13,8 @@ class EventSeenCountConditionHandler(DataConditionHandler[WorkflowEventData]):
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
+        if not isinstance(event, GroupEvent):
+            # We can only count the events for a GroupEvent
+            return False
+
         return event.group.times_seen == comparison

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import GroupCategory
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -21,6 +22,10 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        if not isinstance(event_data.event, GroupEvent):
+            # The event is not a GroupEvent, so we cannot evaluate the issue category
+            return False
+
         group = event_data.event.group
 
         try:

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_deescalating_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.eventstore.models import GroupEvent
 from sentry.models.group import GroupStatus
 from sentry.models.groupopenperiod import get_latest_open_period
 from sentry.workflow_engine.models.data_condition import Condition, DataConditionEvaluationException
@@ -14,6 +15,10 @@ class IssuePriorityDeescalatingConditionHandler(DataConditionHandler[WorkflowEve
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        if not isinstance(event_data.event, GroupEvent):
+            # this condition only applies to group events
+            return False
+
         group = event_data.event.group
 
         # we will fire actions on de-escalation if the priority seen is >= the threshold

--- a/src/sentry/workflow_engine/handlers/condition/issue_priority_greater_or_equal_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_priority_greater_or_equal_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -12,5 +13,9 @@ class IssuePriorityGreaterOrEqualConditionHandler(DataConditionHandler[WorkflowE
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
+        if not isinstance(event_data.event, GroupEvent):
+            # If the event is not a GroupEvent, we cannot evaluate priority
+            return False
+
         group = event_data.event.group
         return group.priority >= comparison

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.models.release import follows_semver_versioning_scheme
 from sentry.rules.age import AgeComparisonType, ModelAgeType
@@ -39,6 +40,8 @@ class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventDat
         environment_name = comparison["environment"]
 
         event = event_data.event
+        if not isinstance(event, GroupEvent):
+            return False
 
         if follows_semver_versioning_scheme(event.organization.id, event.project.id):
             order_type = LatestReleaseOrders.SEMVER

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -48,6 +48,9 @@ class LatestReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
+        if not isinstance(event, GroupEvent):
+            # The latest release condition can only be evaluated for a GroupEvent
+            return False
 
         latest_release = get_latest_release_for_env(event_data.workflow_env, event)
         if not latest_release:

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from sentry.constants import LOG_LEVELS_MAP
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import MatchType
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -25,6 +26,10 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
+        if not isinstance(event, GroupEvent):
+            # If the event is not a group event, we cannot evaluate the level condition
+            return False
+
         level_name = event.get_tag("level")
         if level_name is None:
             return False

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -19,4 +19,5 @@ class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventDat
         if not event.project.flags.has_high_priority_alerts:
             return is_new
 
-        return is_new and event.group.priority == PriorityLevel.HIGH
+        priority = event.group.priority if event.group else 0
+        return is_new and priority == PriorityLevel.HIGH

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from sentry import tagstore
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import MatchType, match_values
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -51,6 +52,10 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:
         event = event_data.event
+        if not isinstance(event, GroupEvent):
+            # This condition is not applicable to status updates
+            return False
+
         raw_tags = event.tags
         key = comparison["key"]
         match = comparison["match"]

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -101,7 +101,7 @@ def evaluate_workflow_triggers(
     for workflow in workflows:
         evaluation, remaining_conditions = workflow.evaluate_trigger_conditions(event_data)
 
-        if remaining_conditions:
+        if remaining_conditions and isinstance(event_data.event, GroupEvent):
             enqueue_workflow(
                 workflow,
                 remaining_conditions,
@@ -125,11 +125,16 @@ def evaluate_workflow_triggers(
         except Environment.DoesNotExist:
             return set()
 
+    event_id = (
+        event_data.event.id if isinstance(event_data.event, Activity) else event_data.event.event_id
+    )
+
     logger.info(
         "workflow_engine.process_workflows.triggered_workflows",
         extra={
             "group_id": event_data.event.group_id,
-            "event_id": event_data.event.event_id,
+            "is_activity": isinstance(event_data.event, Activity),
+            "event_id": event_id,
             "event_data": asdict(event_data),
             "event_environment_id": environment.id,
             "triggered_workflows": [workflow.id for workflow in triggered_workflows],

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from sentry.eventstream.base import GroupState
     from sentry.issues.issue_occurrence import IssueOccurrence
     from sentry.issues.status_change_message import StatusChangeMessage
+    from sentry.models.activity import Activity
     from sentry.models.environment import Environment
     from sentry.snuba.models import SnubaQueryEventType
     from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
@@ -59,7 +60,14 @@ class DetectorEvaluationResult:
 
 @dataclass(frozen=True)
 class WorkflowEventData:
-    event: GroupEvent
+    """
+    A WorkflowEventData instance is created by the issue platform in `post_process` after a detectors issue occurrence has been processed.
+
+    This class contains data the event from the issue platform, and additional information about the `Job` that it's running in.
+    TODO - @saponifi3d - add additional information about how this is used in `process_workflows`
+    """
+
+    event: GroupEvent | Activity
     group_state: GroupState | None = None
     has_reappeared: bool | None = None
     has_escalated: bool | None = None
@@ -68,6 +76,13 @@ class WorkflowEventData:
 
 
 class ActionHandler:
+    """
+    This is the abstract base class for an action handler. It's used to define
+    the interface for actions, ensuring the `execute` method is implemented.
+
+    `execute` - This method invokes the action with the data for notification templates or for future implementation ideas (e.g., AutoFix).
+    """
+
     config_schema: ClassVar[dict[str, Any]]
     data_schema: ClassVar[dict[str, Any]]
 

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -1,4 +1,5 @@
 import logging
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
@@ -344,3 +345,25 @@ class ActivityTest(TestCase):
         )
 
         mock_send_activity_notifications.assert_not_called()
+
+
+class TestActivityCreationHandlers(TestCase):
+    def test_create_group_activity(self):
+        project = self.create_project(name="test_create_group_activity")
+        group = self.create_group(project)
+        user = self.create_user()
+
+        with mock.patch("sentry.models.activity.activity_creation_registry") as mock_registry:
+            mock_handler = mock.Mock()
+            mock_registry.registrations = {"test_handler": mock_handler}
+
+            activity = Activity.objects.create_group_activity(
+                group=group,
+                type=ActivityType.SET_UNRESOLVED,
+                user=user,
+                data=None,
+                send_notification=False,
+            )
+
+            assert mock_handler.called
+            assert mock_handler.call_args[0][0] == activity

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -8,6 +8,7 @@ from sentry.eventstream.base import GroupState
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule
+from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -30,6 +31,7 @@ from sentry.workflow_engine.processors.workflow import (
     enqueue_workflow,
     evaluate_workflow_triggers,
     evaluate_workflows_action_filters,
+    handle_activity_creation,
     process_workflows,
 )
 from sentry.workflow_engine.types import ActionHandler, WorkflowEventData
@@ -745,3 +747,12 @@ class TestDeleteWorkflow:
         workflow_id = self.workflow.id
         delete_workflow(self.workflow)
         assert not Workflow.objects.filter(id=workflow_id).exists()
+
+
+class TestHandleActivityCreation(TestCase):
+    def test(self):
+        with patch(
+            "sentry.workflow_engine.processors.workflow.process_workflows"
+        ) as mock_process_workflows:
+            handle_activity_creation(self.activity)
+            mock_process_workflows.assert_called_once_with(WorkflowEventData(event=self.activity))


### PR DESCRIPTION
## Description
Whenever an Issue Group has a new activity, an `Activity` model is created.

This PR adds a registry to when an activity is created, so we can have a hook into when the model is created.

This also adds a handler for the registry, `workflow_issue_status_change`. This method will take the Activity, and create a `WorkflowEventData` object.

All of the conditions marked as `WORKFLOW_TRIGGERS` can work with `Activity | GroupEvent` already.

The `ACTION_FILTER` conditions were updated accordingly, most are just saying they don't know how to be evaluated for now.

---

Let me know if it'd help to break this PR up for review -- i have a few branches that built up this PR.