### PR TITLE
feat(nextjs-insights): adapt client table to differentiate between navigations and pageloads

### DIFF
--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -28,7 +28,7 @@ const pageloadColumnOrder: Array<GridColumnOrder<string>> = [
   {
     key: 'avg(span.duration)',
     name: t('AVG Duration'),
-    width: 122,
+    width: 140,
   },
   {
     key: 'performance_score(measurements.score.total)',

--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -22,12 +22,13 @@ import {useTableData} from 'sentry/views/insights/pages/platform/shared/table/us
 
 const pageloadColumnOrder: Array<GridColumnOrder<string>> = [
   {key: 'transaction', name: t('Page'), width: COL_WIDTH_UNDEFINED},
-  {key: 'count()', name: t('Pageloads'), width: 122},
+  {key: 'span.op', name: t('Operation'), width: 122},
+  {key: 'count()', name: t('Views'), width: 122},
   {key: 'failure_rate()', name: t('Error Rate'), width: 122},
   {
-    key: 'avg_if(span.duration,span.op,navigation)',
-    name: t('AVG Navigation Duration'),
-    width: 210,
+    key: 'avg(span.duration)',
+    name: t('AVG Duration'),
+    width: 122,
   },
   {
     key: 'performance_score(measurements.score.total)',
@@ -36,11 +37,7 @@ const pageloadColumnOrder: Array<GridColumnOrder<string>> = [
   },
 ];
 
-const rightAlignColumns = new Set([
-  'count()',
-  'failure_rate()',
-  'avg_if(span.duration,span.op,navigation)',
-]);
+const rightAlignColumns = new Set(['count()', 'failure_rate()', 'avg(span.duration)']);
 
 export function ClientTable() {
   const tableDataRequest = useTableData({
@@ -48,9 +45,10 @@ export function ClientTable() {
     fields: [
       'transaction',
       'project.id',
+      'span.op',
       'count()',
       'failure_rate()',
-      'avg_if(span.duration,span.op,navigation)',
+      'avg(span.duration)',
       'performance_score(measurements.score.total)',
       'count_if(span.op,navigation)',
       'count_if(span.op,pageload)',
@@ -100,9 +98,12 @@ export function ClientTable() {
               dataRow={dataRow}
               targetView="frontend"
               projectId={dataRow['project.id'].toString()}
+              query={`transaction.op:${dataRow['span.op']}`}
             />
           );
         }
+        case 'span.op':
+          return <div>{dataRow['span.op']}</div>;
         case 'count()':
           return <NumberCell value={dataRow['count()']} />;
         case 'failure_rate()': {
@@ -117,15 +118,8 @@ export function ClientTable() {
             />
           );
         }
-        case 'avg_if(span.duration,span.op,navigation)': {
-          if (!dataRow['count_if(span.op,navigation)']) {
-            return <NoData>{' — '}</NoData>;
-          }
-          return (
-            <DurationCell
-              milliseconds={dataRow['avg_if(span.duration,span.op,navigation)']}
-            />
-          );
+        case 'avg(span.duration)': {
+          return <DurationCell milliseconds={dataRow['avg(span.duration)']} />;
         }
         default:
           return <div />;
@@ -156,9 +150,4 @@ export function ClientTable() {
 
 const AlignCenter = styled('div')`
   text-align: center;
-`;
-
-const NoData = styled('div')`
-  text-align: right;
-  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/insights/pages/platform/shared/table/TransactionCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/TransactionCell.tsx
@@ -9,6 +9,16 @@ import CellAction, {Actions} from 'sentry/views/discover/table/cellAction';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
+interface TransactionCellProps {
+  column: GridColumnOrder<string>;
+  dataRow: Record<string, any>;
+  projectId: string;
+  targetView: 'backend' | 'frontend';
+  transaction: string;
+  details?: React.ReactNode;
+  query?: string;
+}
+
 export function TransactionCell({
   transaction,
   projectId,
@@ -16,14 +26,8 @@ export function TransactionCell({
   dataRow,
   details,
   targetView,
-}: {
-  column: GridColumnOrder<string>;
-  dataRow: Record<string, any>;
-  projectId: string;
-  targetView: 'backend' | 'frontend';
-  transaction: string;
-  details?: React.ReactNode;
-}) {
+  query,
+}: TransactionCellProps) {
   const organization = useOrganization();
   const {setTransactionFilter} = useTransactionNameQuery();
 
@@ -32,7 +36,9 @@ export function TransactionCell({
     transaction,
     view: targetView,
     projectID: projectId,
-    query: {},
+    query: {
+      query: query || '',
+    },
   });
 
   return (


### PR DESCRIPTION
- Adds an `operation` column that differentiates between pageloads and navigation like we previously have
- Shows durations for both navigations and pageloads
- Deep-links transaction page with filter on `transaction.op` 

Closes TET-638

![Screenshot 2025-06-13 at 09 12 56](https://github.com/user-attachments/assets/01b297d5-8066-4aab-b6d8-99ee411c56a1)
