### PR TITLE
fix(agent-insights): Clear sort order when switching table

### DIFF
--- a/static/app/views/insights/agentMonitoring/hooks/useActiveTable.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useActiveTable.tsx
@@ -50,9 +50,12 @@ export function useActiveTable() {
       });
       updateQuery({
         view,
+        // Clear table cursors and sort order
         tracesCursor: undefined,
         modelsCursor: undefined,
         toolsCursor: undefined,
+        field: undefined,
+        order: undefined,
       });
     },
     [organization, updateQuery]


### PR DESCRIPTION
- closes [TET-651: Agents insights - reset sort on switching table](https://linear.app/getsentry/issue/TET-651/agents-insights-reset-sort-on-switching-table)