### PR TITLE
fix(nextjs-insights): fix percentage formatting for small numbers

### DIFF
--- a/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/ErrorRateCell.tsx
@@ -6,6 +6,7 @@ import Link from 'sentry/components/links/link';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {ThresholdCell} from 'sentry/views/insights/pages/platform/shared/table/ThresholdCell';
 
 export function getErrorCellIssuesLink({
@@ -46,7 +47,8 @@ export function ErrorRateCell({
   return (
     <ThresholdCell value={errorRate}>
       <Flex align="center" justify="flex-end" gap={space(0.5)}>
-        {(errorRate * 100).toFixed(2)}%{defined(errorCount) ? errorCountElement : null}
+        {formatPercentage(errorRate, 2, {minimumValue: 0.0001})}
+        {defined(errorCount) ? errorCountElement : null}
       </Flex>
     </ThresholdCell>
   );


### PR DESCRIPTION
- Use utility function for percentage formatting to correctly show 0% and small percentage numbers that are lower than the display threshold
- (Ignore link color - that's incidental)

Closes TET-632

Before: 
<img width="202" alt="Screenshot 2025-06-13 at 14 38 31" src="https://github.com/user-attachments/assets/2bc5bd48-54a4-49d0-b345-d043c255fc4d" />

After: 
<img width="210" alt="Screenshot 2025-06-13 at 14 38 23" src="https://github.com/user-attachments/assets/ae69c307-9b57-4f28-8b59-82df5d47fc4a" />
