### PR TITLE
fix(dashboards): Chart zoom stops working after timeout

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -591,6 +591,7 @@ const StyledTransparentLoadingMask = styled((props: any) => (
   gap: ${space(2)};
   justify-content: center;
   align-items: center;
+  pointer-events: none;
 `;
 
 function LoadingScreen({

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -226,6 +226,7 @@ const StyledTransparentLoadingMask = styled((props: any) => (
   gap: ${space(2)};
   justify-content: center;
   align-items: center;
+  pointer-events: none;
 `;
 
 function LoadingScreen({


### PR DESCRIPTION
The transparent mask for charts might be trapping pointer events, preventing the chart zoom from triggering