### PR TITLE
ref(deletion): Simplify finding Group deletion errors

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -69,7 +69,7 @@ def delete_group_list(
             "project_id": project.id,
             "transaction_id": transaction_id,
             "group_deletion_project_id": project.id,
-            "group_deletion_group_ids": group_ids,
+            "group_deletion_group_ids": str(group_ids),
         },
     )
 

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -68,6 +68,8 @@ def delete_group_list(
         {
             "project_id": project.id,
             "transaction_id": transaction_id,
+            "group_deletion_project_id": project.id,
+            "group_deletion_group_ids": group_ids,
         },
     )
 


### PR DESCRIPTION
This will remove the need for extra logging.