### PR TITLE
Add user email and name to feedback

### DIFF
--- a/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
@@ -61,18 +61,37 @@ export default function PlayStationSdkAccessModal({
       game_engines: formData.gameEngines,
     });
 
-    // (ab)uses captureFeedback to send an SDK access request notification to the GDX team
-    captureFeedback({
-      message: `PlayStation SDK Access Request by ${user.email}`,
-      source: 'playstation-sdk-access',
-      tags: {
-        feature: 'playstation-sdk-access',
-        githubProfile: formData.githubProfile,
-        gameEngines: formData.gameEngines.join(','),
-        'user.email': user.email,
-        'org.slug': organization.slug,
+    // Format the message body with user details, engines, and org slug
+    const messageBody = [
+      `User: ${user.name || 'No Name'}`,
+      `Email: ${user.email || 'No Email'}`,
+      `Engines: ${formData.gameEngines.map((engine: string) =>
+        GAME_ENGINE_OPTIONS.find(option => option.value === engine)?.label || engine
+      ).join(', ')}`,
+      `Org Slug: ${organization.slug}`,
+    ].join('\n');
+
+    // Use captureFeedback with proper user context instead of tags
+    captureFeedback(
+      {
+        message: messageBody,
+        source: 'playstation-sdk-access',
+        tags: {
+          feature: 'playstation-sdk-access',
+          githubProfile: formData.githubProfile,
+        },
       },
-    });
+      {
+        captureContext: {
+          user: {
+            id: user.id,
+            email: user.email,
+            username: user.username,
+            name: user.name,
+          },
+        },
+      }
+    );
 
     addSuccessMessage(t('Your PlayStation SDK access request has been submitted!'));
     setIsSubmitting(false);

--- a/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
@@ -65,9 +65,12 @@ export default function PlayStationSdkAccessModal({
     const messageBody = [
       `User: ${user.name || 'No Name'}`,
       `Email: ${user.email || 'No Email'}`,
-      `Engines: ${formData.gameEngines.map((engine: string) =>
-        GAME_ENGINE_OPTIONS.find(option => option.value === engine)?.label || engine
-      ).join(', ')}`,
+      `Engines: ${formData.gameEngines
+        .map(
+          (engine: string) =>
+            GAME_ENGINE_OPTIONS.find(option => option.value === engine)?.label || engine
+        )
+        .join(', ')}`,
       `Org Slug: ${organization.slug}`,
     ].join('\n');
 


### PR DESCRIPTION
The `captureFeedback` call in `static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx` was significantly refactored to align with Sentry's recommended API for user context and to customize the feedback message.

Changes include:
*   **User Context**: User details (`id`, `email`, `username`, `name`) are now passed via `hint.captureContext.user` in the `captureFeedback` options. This replaces the previous approach of setting the user email via the `'user.email'` tag.
*   **Message Body**: The `message` property now constructs a multi-line string containing:
    *   `User: [Name]`
    *   `Email: [Email]`
    *   `Engines: [Engine1, Engine2]` (formatted with human-readable labels)
    *   `Org Slug: [Org Slug]`
*   **Game Engines**: Game engines are now included directly in the message body, formatted for readability, instead of being stored as a separate tag.
*   **Tag Cleanup**: Redundant tags such as `'user.email'`, `'org.slug'`, and `gameEngines` were removed, retaining only `feature` and `githubProfile`.

These modifications ensure user information is captured correctly according to Sentry's API and provide a structured, human-readable feedback message.