### PR TITLE
feat(multi-query): Add ability to duplicate queries

### DIFF
--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -731,7 +731,54 @@ describe('MultiQueryModeContent', function () {
         query: '',
       },
     ]);
-    await userEvent.click(screen.getAllByLabelText('Delete Query')[0]!);
+
+    await userEvent.click(screen.getAllByRole('button', {name: 'More options'})[0]!);
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Duplicate Query'}));
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+      {
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    await userEvent.click(screen.getAllByRole('button', {name: 'More options'})[0]!);
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Delete Query'}));
+    await userEvent.click(screen.getAllByRole('button', {name: 'More options'})[0]!);
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Delete Query'}));
+
     expect(queries).toEqual([
       {
         yAxes: ['count(span.duration)'],
@@ -960,14 +1007,11 @@ describe('MultiQueryModeContent', function () {
         },
       },
     });
-    function Component() {
-      return <MultiQueryModeContent />;
-    }
 
     render(
       <PageParamsProvider>
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
-          <Component />
+          <MultiQueryModeContent />
         </SpanTagsProvider>
       </PageParamsProvider>,
       {
@@ -1046,14 +1090,10 @@ describe('MultiQueryModeContent', function () {
       },
     });
 
-    function Component() {
-      return <MultiQueryModeContent />;
-    }
-
     render(
       <PageParamsProvider>
         <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
-          <Component />
+          <MultiQueryModeContent />
         </SpanTagsProvider>
       </PageParamsProvider>,
       {

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -641,7 +641,185 @@ describe('MultiQueryModeContent', function () {
     ]);
   });
 
-  it('updates query at the correct index', async function () {
+  it('allows changing a query', async function () {
+    let queries: any;
+    function Component() {
+      queries = useReadQueriesFromLocation();
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>
+    );
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    const section = screen.getByTestId('section-visualize-0');
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+    expect(queries).toEqual([
+      {
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+  });
+
+  it('allows adding a query', async function () {
+    let queries: any;
+    function Component() {
+      queries = useReadQueriesFromLocation();
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>
+    );
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    // Add chart
+    await userEvent.click(screen.getByRole('button', {name: 'Add Query'}));
+    expect(queries).toEqual([
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+  });
+
+  it('allows duplicating a query', async function () {
+    let queries: any;
+    function Component() {
+      queries = useReadQueriesFromLocation();
+      return <MultiQueryModeContent />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+          <Component />
+        </SpanTagsProvider>
+      </PageParamsProvider>
+    );
+
+    expect(queries).toEqual([
+      {
+        yAxes: ['count(span.duration)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.duration', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+
+    const section = screen.getByTestId('section-visualize-0');
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+
+    // Duplicate chart
+    await userEvent.click(screen.getByRole('button', {name: 'More options'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Duplicate Query'}));
+    expect(queries).toEqual([
+      {
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+      {
+        yAxes: ['avg(span.self_time)'],
+        sortBys: [
+          {
+            field: 'timestamp',
+            kind: 'desc',
+          },
+        ],
+        fields: ['id', 'span.self_time', 'timestamp'],
+        groupBys: [],
+        query: '',
+      },
+    ]);
+  });
+
+  it('allows deleting a query', async function () {
     let queries: any;
     function Component() {
       queries = useReadQueriesFromLocation();
@@ -732,50 +910,6 @@ describe('MultiQueryModeContent', function () {
       },
     ]);
 
-    await userEvent.click(screen.getAllByRole('button', {name: 'More options'})[0]!);
-    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Duplicate Query'}));
-
-    expect(queries).toEqual([
-      {
-        yAxes: ['avg(span.self_time)'],
-        sortBys: [
-          {
-            field: 'timestamp',
-            kind: 'desc',
-          },
-        ],
-        fields: ['id', 'span.self_time', 'timestamp'],
-        groupBys: [],
-        query: '',
-      },
-      {
-        yAxes: ['avg(span.self_time)'],
-        sortBys: [
-          {
-            field: 'timestamp',
-            kind: 'desc',
-          },
-        ],
-        fields: ['id', 'span.self_time', 'timestamp'],
-        groupBys: [],
-        query: '',
-      },
-      {
-        yAxes: ['count(span.duration)'],
-        sortBys: [
-          {
-            field: 'timestamp',
-            kind: 'desc',
-          },
-        ],
-        fields: ['id', 'span.duration', 'timestamp'],
-        groupBys: [],
-        query: '',
-      },
-    ]);
-
-    await userEvent.click(screen.getAllByRole('button', {name: 'More options'})[0]!);
-    await userEvent.click(screen.getByRole('menuitemradio', {name: 'Delete Query'}));
     await userEvent.click(screen.getAllByRole('button', {name: 'More options'})[0]!);
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Delete Query'}));
 

--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -212,6 +212,25 @@ export function useDeleteQueryAtIndex() {
   );
 }
 
+export function useDuplicateQueryAtIndex() {
+  const location = useLocation();
+  const queries = useReadQueriesFromLocation();
+  const navigate = useNavigate();
+
+  return useCallback(
+    (index: number) => {
+      const query = queries[index];
+      if (defined(query)) {
+        const duplicate = structuredClone(query);
+        const newQueries = queries.toSpliced(index + 1, 0, duplicate);
+        const target = getUpdatedLocationWithQueries(location, newQueries);
+        navigate(target);
+      }
+    },
+    [location, navigate, queries]
+  );
+}
+
 export function getSamplesTargetAtIndex(
   index: number,
   queries: ReadableExploreQueryParts[],

--- a/static/app/views/explore/multiQueryMode/queryConstructors/menu.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/menu.tsx
@@ -1,0 +1,43 @@
+import {Button} from 'sentry/components/core/button';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconEllipsis} from 'sentry/icons/iconEllipsis';
+import {t} from 'sentry/locale';
+import {
+  useDeleteQueryAtIndex,
+  useDuplicateQueryAtIndex,
+} from 'sentry/views/explore/multiQueryMode/locationUtils';
+
+type Props = {
+  index: number;
+  totalQueryRows: number;
+};
+
+export function MenuSection({index, totalQueryRows}: Props) {
+  const deleteQuery = useDeleteQueryAtIndex();
+  const duplicateQuery = useDuplicateQueryAtIndex();
+
+  return (
+    <DropdownMenu
+      items={[
+        {
+          key: 'delete-query',
+          label: t('Delete Query'),
+          onAction: () => deleteQuery(index),
+          disabled: totalQueryRows === 1,
+        },
+        {
+          key: 'duplicate-query',
+          label: t('Duplicate Query'),
+          onAction: () => duplicateQuery(index),
+        },
+      ]}
+      trigger={triggerProps => (
+        <Button
+          {...triggerProps}
+          aria-label={t('More options')}
+          icon={<IconEllipsis size="xs" />}
+        />
+      )}
+    />
+  );
+}

--- a/static/app/views/explore/multiQueryMode/queryRow.tsx
+++ b/static/app/views/explore/multiQueryMode/queryRow.tsx
@@ -1,10 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/core/button';
 import {LazyRender} from 'sentry/components/lazyRender';
-import {IconDelete} from 'sentry/icons/iconDelete';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCompareAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
@@ -17,9 +14,9 @@ import {useMultiQueryTimeseries} from 'sentry/views/explore/multiQueryMode/hooks
 import {
   getQueryMode,
   type ReadableExploreQueryParts,
-  useDeleteQueryAtIndex,
 } from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {GroupBySection} from 'sentry/views/explore/multiQueryMode/queryConstructors/groupBy';
+import {MenuSection} from 'sentry/views/explore/multiQueryMode/queryConstructors/menu';
 import {SearchBarSection} from 'sentry/views/explore/multiQueryMode/queryConstructors/search';
 import {SortBySection} from 'sentry/views/explore/multiQueryMode/queryConstructors/sortBy';
 import {VisualizeSection} from 'sentry/views/explore/multiQueryMode/queryConstructors/visualize';
@@ -33,8 +30,6 @@ type Props = {
 };
 
 export function QueryRow({query: queryParts, index, totalQueryRows}: Props) {
-  const deleteQuery = useDeleteQueryAtIndex();
-
   const {groupBys, query, yAxes, sortBys} = queryParts;
   const mode = getQueryMode(groupBys);
 
@@ -80,14 +75,7 @@ export function QueryRow({query: queryParts, index, totalQueryRows}: Props) {
           <VisualizeSection query={queryParts} index={index} />
           <GroupBySection query={queryParts} index={index} />
           <SortBySection query={queryParts} index={index} />
-          <DeleteButton
-            borderless
-            icon={<IconDelete />}
-            size="zero"
-            disabled={totalQueryRows === 1}
-            onClick={() => deleteQuery(index)}
-            aria-label={t('Delete Query')}
-          />
+          <MenuSection index={index} totalQueryRows={totalQueryRows} />
         </DropDownGrid>
       </QueryConstructionSection>
       <QueryVisualizationSection data-test-id={`section-visualization-${index}`}>
@@ -125,13 +113,9 @@ const QueryConstructionSection = styled('div')`
 
 const DropDownGrid = styled('div')`
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, auto)) ${space(2)};
-  align-items: center;
+  grid-template-columns: repeat(3, minmax(0, auto)) min-content;
+  align-items: end;
   gap: ${space(1)};
-`;
-
-const DeleteButton = styled(Button)`
-  margin-top: ${space(2)};
 `;
 
 const QueryVisualizationSection = styled('div')`


### PR DESCRIPTION
Adds a new option to duplicate a query. This also means we moved the delete button into a menu along side the duplicate button.

Closes EXP-303