### PR TITLE
feat: Disable entry points creating txn alerts

### DIFF
--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -44,6 +44,7 @@ import {
   handleAddQueryToDashboard,
   SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
 } from 'sentry/views/discover/utils';
+import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 
 import {
   getDatasetFromLocationOrSavedQueryDataset,
@@ -411,6 +412,13 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
       location,
       savedQuery?.queryDataset
     );
+
+    if (
+      currentDataset === DiscoverDatasets.TRANSACTIONS &&
+      deprecateTransactionAlerts(organization)
+    ) {
+      return null;
+    }
 
     let alertType: any;
     let buttonEventView = eventView;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -24,6 +24,7 @@ import useReplayCountForTransactions from 'sentry/utils/replayCount/useReplayCou
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
 import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
@@ -356,7 +357,9 @@ function TransactionHeader({
         <ButtonBar gap={1}>
           <Feature organization={organization} features="incidents">
             {({hasFeature}) =>
-              hasFeature && !metricsCardinality?.isLoading ? (
+              hasFeature &&
+              !metricsCardinality?.isLoading &&
+              !deprecateTransactionAlerts(organization) ? (
                 <CreateAlertFromViewButton
                   size="sm"
                   eventView={eventView}

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -37,6 +37,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import Teams from 'sentry/utils/teams';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withProjects from 'sentry/utils/withProjects';
+import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 
@@ -274,7 +275,11 @@ function VitalDetailContent(props: Props) {
           <ButtonBar gap={1}>
             {renderVitalSwitcher()}
             <Feature organization={organization} features="incidents">
-              {({hasFeature}) => hasFeature && renderCreateAlertButton()}
+              {({hasFeature}) =>
+                hasFeature &&
+                !deprecateTransactionAlerts(organization) &&
+                renderCreateAlertButton()
+              }
             </Feature>
           </ButtonBar>
         </Layout.HeaderActions>


### PR DESCRIPTION
Hide create alert buttons from transaction summary and
discover pages. These open transaction alerts which we
want to deprecate soon. This change is behind a feature flag.