### PR TITLE
fix(agents-insights): Use fallback attributes in AI IO sections

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -147,15 +147,16 @@ export function getTraceNodeAttribute(
   }
 
   if (isEAPSpanNode(node) && attributes) {
-    return attributes.find(attribute => attribute.name === name)?.value;
+    const attributeObject = ensureAttributeObject(attributes);
+    return getAttribute(attributeObject, name);
   }
 
   if (isTransactionNode(node) && event) {
-    return event.contexts.trace?.data?.[name];
+    return getAttribute(event.contexts.trace?.data || {}, name);
   }
 
   if (isSpanNode(node)) {
-    return node.value.data?.[name];
+    return getAttribute(node.value.data || {}, name);
   }
 
   return undefined;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -143,10 +143,10 @@ export function AIInputSection({
       event,
       attributes
     );
-    promptMessages = transformInputMessages(inputMessages);
+    promptMessages = inputMessages && transformInputMessages(inputMessages);
   }
 
-  const aiInput = defined(promptMessages) && parseAIMessages(promptMessages as string);
+  const aiInput = defined(promptMessages) && parseAIMessages(promptMessages);
 
   if (!aiInput) {
     return null;


### PR DESCRIPTION
The helper function `getTraceNodeAttribute` was not yet falling back to old attribute names.
Using the `getAttribute` helper internally fixes this.