### PR TITLE
feat: add cursor param to test results endpoint

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1107,3 +1107,11 @@ Available fields are:
         type=int,
         description="""The number of results to return from the end of the list.""",
     )
+    CURSOR = OpenApiParameter(
+        name="cursor",
+        location="query",
+        required=False,
+        type=str,
+        description="""The cursor to start the query from. Will return results after the cursor if used with `first` or before the cursor if used with `last`.
+        """,
+    )

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -28,7 +28,7 @@ class TestResultsEndpoint(CodecovEndpoint):
         return True
 
     @extend_schema(
-        operation_id="Retrieve a paginated list of test results for a given repository and owner",
+        operation_id="Retrieve paginated list of test results for repository and owner",
         parameters=[
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
@@ -38,6 +38,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             PreventParams.BRANCH,
             PreventParams.FIRST,
             PreventParams.LAST,
+            PreventParams.CURSOR,
         ],
         request=None,
         responses={
@@ -54,7 +55,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             "sortBy", f"-{OrderingParameter.COMMITS_WHERE_FAIL.value}"
         )
 
-        if sort_by and sort_by.startswith("-"):
+        if sort_by.startswith("-"):
             sort_by = sort_by[1:]
             direction = OrderingDirection.DESC.value
         else:
@@ -62,6 +63,11 @@ class TestResultsEndpoint(CodecovEndpoint):
 
         first_param = request.query_params.get("first")
         last_param = request.query_params.get("last")
+        cursor = request.query_params.get("cursor")
+
+        # When calling request.query_params, the URL is decoded so + is replaced with spaces. We need to change them back so Codecov can properly fetch the next page.
+        if cursor:
+            cursor = cursor.replace(" ", "+")
 
         first = int(first_param) if first_param else None
         last = int(last_param) if last_param else None
@@ -94,6 +100,8 @@ class TestResultsEndpoint(CodecovEndpoint):
             },
             "first": first,
             "last": last,
+            "before": cursor if cursor and last else None,
+            "after": cursor if cursor and first else None,
         }
 
         client = CodecovApiClient(git_provider_org=owner)

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
@@ -25,7 +25,7 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
     }
 
     @extend_schema(
-        operation_id="Retrieves aggregated test result metrics for a given repository and owner",
+        operation_id="Retrieve aggregated test result metrics for repository and owner",
         parameters=[
             PreventParams.OWNER,
             PreventParams.REPOSITORY,

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -103,6 +103,8 @@ class TestResultsEndpointTest(APITestCase):
             },
             "first": 20,
             "last": None,
+            "before": None,
+            "after": None,
         }
 
         mock_codecov_client_instance.query.assert_called_once()
@@ -174,6 +176,8 @@ class TestResultsEndpointTest(APITestCase):
             },
             "first": 10,
             "last": None,
+            "before": None,
+            "after": None,
         }
 
         call_args = mock_codecov_client_instance.query.call_args
@@ -226,6 +230,8 @@ class TestResultsEndpointTest(APITestCase):
             },
             "first": None,
             "last": 5,
+            "before": None,
+            "after": None,
         }
 
         call_args = mock_codecov_client_instance.query.call_args


### PR DESCRIPTION
This PR adds the ability to input a "cursor" into the test_results endpoint so we can try to implement pagination on the Sentry UI.

Closes https://linear.app/getsentry/issue/CCMRG-1309/figure-out-pagination-for-all-endpoints

Still need to figure out how this would work on the infinite results hook but at the very least we can continually fetch pages on postman. Below are some screenshots of me fetching subsequent pages on postman using the cursor attribute

<img width="1258" alt="Screenshot 2025-06-13 at 9 56 18 AM" src="https://github.com/user-attachments/assets/d6d853ae-c6ca-4e9b-bf3d-212b6274e3f2" />
<img width="1235" alt="Screenshot 2025-06-13 at 9 56 31 AM" src="https://github.com/user-attachments/assets/6e670dcf-f226-4e55-baba-a5e92f56f8b3" />

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
