### PR TITLE
chore(audit): date picker for all time on audit log page

### DIFF
--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -304,7 +304,7 @@ function AuditLogList({
         relative={statsPeriod || allTime}
         onChange={onDateSelect}
         relativeOptions={{
-          allTime: t('All time'),
+          allTime,
         }}
         utc={utc}
         maxPickableDays={Infinity}
@@ -319,7 +319,7 @@ function AuditLogList({
             // Fallback to regular start/end if display values not available
             displayLabel = getAbsoluteSummary(start, end, utc);
           } else if (currentValue === allTime) {
-            displayLabel = t('All time');
+            displayLabel = allTime;
           }
 
           return (

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Tag} from 'sentry/components/core/badge/tag';
+import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Flex} from 'sentry/components/core/layout';
 import {Select} from 'sentry/components/core/select';
 import {Tooltip} from 'sentry/components/core/tooltip';
@@ -21,9 +22,10 @@ import {space} from 'sentry/styles/space';
 import type {DateString} from 'sentry/types/core';
 import type {AuditLog, Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
-import {getInternalDate, shouldUse24Hours} from 'sentry/utils/dates';
+import {getInternalDate} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {
   projectDetectorSettingsId,
@@ -270,11 +272,12 @@ function AuditLogList({
   statsPeriod,
   utc = false,
 }: Props) {
-  const is24Hours = shouldUse24Hours();
+  const user = useUser();
+  const is24Hours = user.options?.clock24Hours;
   const organization = useOrganization();
   const hasEntries = entries && entries.length > 0;
   const ipv4Length = 15;
-  const allTime = 'All time';
+  const allTime = t('All time');
 
   // Calculate display values for the dropdown - convert UTC timestamps back to user's intended timezone
   const getDisplayValues = () => {
@@ -295,7 +298,7 @@ function AuditLogList({
   const {displayStart, displayEnd} = getDisplayValues();
 
   const headerActions = (
-    <HeaderActions>
+    <ButtonBar gap={2}>
       <TimeRangeSelector
         start={start}
         end={end}
@@ -303,15 +306,9 @@ function AuditLogList({
         onChange={onDateSelect}
         relativeOptions={{
           allTime: t('All time'),
-          '1h': t('Last hour'),
-          '24h': t('Last 24 hours'),
-          '7d': t('Last 7 days'),
-          '14d': t('Last 14 days'),
-          '30d': t('Last 30 days'),
-          '90d': t('Last 90 days'),
         }}
         utc={utc}
-        maxPickableDays={10000}
+        maxPickableDays={Infinity}
         trigger={(triggerProps, isOpen) => {
           const currentValue = statsPeriod || allTime;
           let displayLabel: React.ReactNode;
@@ -324,16 +321,10 @@ function AuditLogList({
             displayLabel = getAbsoluteSummary(start, end, utc);
           } else if (currentValue === allTime) {
             displayLabel = t('All time');
-          } else {
-            displayLabel = currentValue.toUpperCase();
           }
 
           return (
-            <DropdownButton
-              isOpen={isOpen}
-              data-test-id="page-filter-timerange-selector"
-              {...triggerProps}
-            >
+            <DropdownButton isOpen={isOpen} {...triggerProps}>
               {displayLabel}
             </DropdownButton>
           );
@@ -350,7 +341,7 @@ function AuditLogList({
           onEventSelect(options?.value);
         }}
       />
-    </HeaderActions>
+    </ButtonBar>
   );
 
   return (
@@ -417,12 +408,6 @@ const Name = styled('strong')`
 
 const EventSelector = styled(Select)`
   width: 250px;
-`;
-
-const HeaderActions = styled('div')`
-  display: flex;
-  gap: ${space(2)};
-  align-items: center;
 `;
 
 const UserInfo = styled('div')`

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -8,15 +8,20 @@ import {Flex} from 'sentry/components/core/layout';
 import {Select} from 'sentry/components/core/select';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {DateTime} from 'sentry/components/dateTime';
+import DropdownButton from 'sentry/components/dropdownButton';
 import Link from 'sentry/components/links/link';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels/panelTable';
+import type {ChangeData} from 'sentry/components/timeRangeSelector';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
+import {getAbsoluteSummary} from 'sentry/components/timeRangeSelector/utils';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {DateString} from 'sentry/types/core';
 import type {AuditLog, Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
-import {shouldUse24Hours} from 'sentry/utils/dates';
+import {getInternalDate, shouldUse24Hours} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -241,42 +246,116 @@ type Props = {
   eventType: string | undefined;
   eventTypes: string[] | null;
   isLoading: boolean;
-  onCursor: CursorHandler | undefined;
+  onCursor: CursorHandler;
+  onDateSelect: (data: ChangeData) => void;
   onEventSelect: (value: string) => void;
   pageLinks: string | null;
+  statsPeriod: string | null;
+  end?: DateString;
+  start?: DateString;
+  utc?: boolean;
 };
 
 function AuditLogList({
-  isLoading,
-  pageLinks,
   entries,
   eventType,
   eventTypes,
+  isLoading,
   onCursor,
+  onDateSelect,
   onEventSelect,
+  pageLinks,
+  start,
+  end,
+  statsPeriod,
+  utc = false,
 }: Props) {
   const is24Hours = shouldUse24Hours();
   const organization = useOrganization();
   const hasEntries = entries && entries.length > 0;
   const ipv4Length = 15;
+  const allTime = 'All time';
 
-  const action = (
-    <EventSelector
-      clearable
-      isDisabled={isLoading}
-      name="eventFilter"
-      value={eventType}
-      placeholder={t('Select Action: ')}
-      options={getEventOptions(eventTypes)}
-      onChange={(options: any) => {
-        onEventSelect(options?.value);
-      }}
-    />
+  // Calculate display values for the dropdown - convert UTC timestamps back to user's intended timezone
+  const getDisplayValues = () => {
+    if (!start || !end) {
+      return {displayStart: start, displayEnd: end};
+    }
+
+    // Convert UTC timestamps to display format based on user's UTC preference
+    const displayStart = getInternalDate(start, utc);
+    const displayEnd = getInternalDate(end, utc);
+
+    return {
+      displayStart: displayStart.toISOString(),
+      displayEnd: displayEnd.toISOString(),
+    };
+  };
+
+  const {displayStart, displayEnd} = getDisplayValues();
+
+  const headerActions = (
+    <HeaderActions>
+      <TimeRangeSelector
+        start={start}
+        end={end}
+        relative={statsPeriod || allTime}
+        onChange={onDateSelect}
+        relativeOptions={{
+          allTime: t('All time'),
+          '1h': t('Last hour'),
+          '24h': t('Last 24 hours'),
+          '7d': t('Last 7 days'),
+          '14d': t('Last 14 days'),
+          '30d': t('Last 30 days'),
+          '90d': t('Last 90 days'),
+        }}
+        utc={utc}
+        maxPickableDays={10000}
+        trigger={(triggerProps, isOpen) => {
+          const currentValue = statsPeriod || allTime;
+          let displayLabel: React.ReactNode;
+
+          if (displayStart && displayEnd) {
+            // Show formatted absolute date range using display values (user's intended timezone)
+            displayLabel = getAbsoluteSummary(displayStart, displayEnd, utc);
+          } else if (start && end) {
+            // Fallback to regular start/end if display values not available
+            displayLabel = getAbsoluteSummary(start, end, utc);
+          } else if (currentValue === allTime) {
+            displayLabel = t('All time');
+          } else {
+            displayLabel = currentValue.toUpperCase();
+          }
+
+          return (
+            <DropdownButton
+              isOpen={isOpen}
+              data-test-id="page-filter-timerange-selector"
+              {...triggerProps}
+            >
+              {displayLabel}
+            </DropdownButton>
+          );
+        }}
+      />
+      <EventSelector
+        clearable
+        isDisabled={isLoading}
+        name="eventFilter"
+        value={eventType}
+        placeholder={t('Select Action: ')}
+        options={getEventOptions(eventTypes)}
+        onChange={(options: any) => {
+          onEventSelect(options?.value);
+        }}
+      />
+    </HeaderActions>
   );
 
   return (
     <div>
-      <SettingsPageHeader title={t('Audit Log')} action={action} />
+      <SettingsPageHeader title={t('Audit Log')} action={headerActions} />
       <PanelTable
         headers={[t('Member'), t('Action'), t('IP'), t('Time')]}
         isEmpty={!hasEntries && entries?.length === 0}
@@ -315,7 +394,7 @@ function AuditLogList({
                 <DateTime dateOnly date={entry.dateCreated} />
                 <DateTime
                   timeOnly
-                  format={is24Hours ? 'HH:mm zz' : 'LT zz'}
+                  format={is24Hours ? 'HH:mm z' : 'LT z'}
                   date={entry.dateCreated}
                 />
               </TimestampInfo>
@@ -338,6 +417,12 @@ const Name = styled('strong')`
 
 const EventSelector = styled(Select)`
   width: 250px;
+`;
+
+const HeaderActions = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+  align-items: center;
 `;
 
 const UserInfo = styled('div')`

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -272,8 +272,7 @@ function AuditLogList({
   statsPeriod,
   utc = false,
 }: Props) {
-  const user = useUser();
-  const is24Hours = user.options?.clock24Hours;
+  const is24Hours = useUser().options?.clock24Hours;
   const organization = useOrganization();
   const hasEntries = entries && entries.length > 0;
   const ipv4Length = 15;

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -35,7 +35,8 @@ describe('OrganizationAuditLog', function () {
     render(<OrganizationAuditLog location={router.location} />);
 
     expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    // Check that both textboxes are present (date selector search and event selector)
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
     expect(screen.getByText('Member')).toBeInTheDocument();
     expect(screen.getByText('Action')).toBeInTheDocument();
     expect(screen.getByText('IP')).toBeInTheDocument();

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -1,3 +1,4 @@
+import {AuditLogsFixture} from 'sentry-fixture/auditLogs';
 import {AuditLogsApiEventNamesFixture} from 'sentry-fixture/auditLogsApiEventNames';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -14,30 +15,7 @@ describe('OrganizationAuditLog', function () {
       url: `/organizations/org-slug/audit-logs/`,
       method: 'GET',
       body: {
-        rows: [
-          {
-            id: '4500000',
-            actor: UserFixture(),
-            event: 'project.remove',
-            ipAddress: '127.0.0.1',
-            note: 'removed project test',
-            targetObject: 5466660,
-            targetUser: null,
-            data: {},
-            dateCreated: '2021-09-28T00:29:33.940848Z',
-          },
-          {
-            id: '430000',
-            actor: UserFixture(),
-            event: 'org.create',
-            ipAddress: '127.0.0.1',
-            note: 'created the organization',
-            targetObject: 54215,
-            targetUser: null,
-            data: {},
-            dateCreated: '2016-11-21T04:02:45.929313Z',
-          },
-        ],
+        rows: AuditLogsFixture(),
         options: AuditLogsApiEventNamesFixture(),
       },
     });
@@ -51,10 +29,17 @@ describe('OrganizationAuditLog', function () {
 
     render(<OrganizationAuditLog location={router.location} />);
 
-    expect(await screen.findByText('project.remove')).toBeInTheDocument();
-    expect(screen.getByText('org.create')).toBeInTheDocument();
+    expect(await screen.findByText('project.edit')).toBeInTheDocument();
+    expect(screen.getByText('org.edit')).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
-    expect(screen.getByText('12:29 AM UTC')).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher('edited project ludic-science'))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'edited the organization setting(s): accountRateLimit from 1000 to 0'
+      )
+    ).toBeInTheDocument();
   });
 
   it('Displays pretty dynamic sampling logs', async function () {
@@ -144,19 +129,7 @@ describe('OrganizationAuditLog', function () {
       url: `/organizations/org-slug/audit-logs/`,
       method: 'GET',
       body: {
-        rows: [
-          {
-            id: '4500002',
-            actor: UserFixture(),
-            event: 'member.invite',
-            ipAddress: '10.0.0.1',
-            note: 'invited member test@example.com',
-            targetObject: 5466662,
-            targetUser: null,
-            data: {},
-            dateCreated: '2021-09-30T00:29:33.940848Z',
-          },
-        ],
+        rows: AuditLogsFixture(),
         options: AuditLogsApiEventNamesFixture(),
       },
     });
@@ -167,8 +140,8 @@ describe('OrganizationAuditLog', function () {
         params: {orgId: 'org-slug'},
         location: {
           query: {
-            start: '2021-09-01T00:00:00.000Z',
-            end: '2021-09-30T23:59:59.999Z',
+            start: '2018-02-01T00:00:00.000Z',
+            end: '2018-02-28T23:59:59.999Z',
           },
         },
       },
@@ -182,15 +155,23 @@ describe('OrganizationAuditLog', function () {
         expect.objectContaining({
           method: 'GET',
           query: expect.objectContaining({
-            start: '2021-09-01T00:00:00.000Z',
-            end: '2021-09-30T23:59:59.999Z',
+            start: '2018-02-01T00:00:00.000Z',
+            end: '2018-02-28T23:59:59.999Z',
           }),
         })
       );
     });
 
-    expect(await screen.findByText('member.invite')).toBeInTheDocument();
-    expect(screen.getByText('invited member test@example.com')).toBeInTheDocument();
-    expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+    expect(await screen.findByText('project.edit')).toBeInTheDocument();
+    expect(screen.getByText('org.edit')).toBeInTheDocument();
+    expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
+    expect(
+      screen.getByText(textWithMarkupMatcher('edited project ludic-science'))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'edited the organization setting(s): accountRateLimit from 1000 to 0'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -2,7 +2,7 @@ import {AuditLogsApiEventNamesFixture} from 'sentry-fixture/auditLogsApiEventNam
 import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -139,89 +139,7 @@ describe('OrganizationAuditLog', function () {
     }
   });
 
-  it('Handles relative date range selection', async function () {
-    const initialMockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/audit-logs/`,
-      method: 'GET',
-      body: {
-        rows: [
-          {
-            id: '4500000',
-            actor: UserFixture(),
-            event: 'project.remove',
-            ipAddress: '127.0.0.1',
-            note: 'removed project test',
-            targetObject: 5466660,
-            targetUser: null,
-            data: {},
-            dateCreated: '2021-09-28T00:29:33.940848Z',
-          },
-        ],
-        options: AuditLogsApiEventNamesFixture(),
-      },
-    });
-
-    const {router} = initializeOrg({
-      projects: [],
-      router: {
-        params: {orgId: 'org-slug'},
-      },
-    });
-
-    render(<OrganizationAuditLog location={router.location} />);
-
-    expect(await screen.findByText('project.remove')).toBeInTheDocument();
-    expect(initialMockResponse).toHaveBeenCalledTimes(1);
-
-    const secondMockResponse = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/audit-logs/`,
-      method: 'GET',
-      body: {
-        rows: [
-          {
-            id: '4500001',
-            actor: UserFixture(),
-            event: 'org.edit',
-            ipAddress: '192.168.1.1',
-            note: 'edited organization settings',
-            targetObject: 5466661,
-            targetUser: null,
-            data: {},
-            dateCreated: '2021-09-29T00:29:33.940848Z',
-          },
-        ],
-        options: AuditLogsApiEventNamesFixture(),
-      },
-    });
-
-    // Select relative date range
-    const dateSelector = screen.getByTestId('page-filter-timerange-selector');
-    await userEvent.click(dateSelector);
-    const last7DaysOption = await screen.findByRole('option', {name: 'Last 7 days'});
-    await userEvent.click(last7DaysOption);
-
-    await waitFor(() => {
-      expect(secondMockResponse).toHaveBeenCalledWith(
-        '/organizations/org-slug/audit-logs/',
-        expect.objectContaining({
-          method: 'GET',
-          query: expect.objectContaining({
-            statsPeriod: '7d',
-          }),
-        })
-      );
-    });
-
-    // Only org.edit should be included
-    expect(await screen.findByText('org.edit')).toBeInTheDocument();
-    expect(screen.getByText('edited organization settings')).toBeInTheDocument();
-    expect(screen.getByText('192.168.1.1')).toBeInTheDocument();
-
-    expect(screen.queryByText('project.remove')).not.toBeInTheDocument();
-    expect(screen.queryByText('removed project test')).not.toBeInTheDocument();
-  });
-
-  it('Handles initial absolute date range', async function () {
+  it('Handles absolute date range', async function () {
     const absoluteDateMockResponse = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/audit-logs/`,
       method: 'GET',

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -3,9 +3,13 @@ import * as Sentry from '@sentry/react';
 import type {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {normalizeDateTimeString} from 'sentry/components/organizations/pageFilters/parse';
 import type {CursorHandler} from 'sentry/components/pagination';
+import type {ChangeData} from 'sentry/components/timeRangeSelector';
+import type {DateString} from 'sentry/types/core';
 import type {AuditLog} from 'sentry/types/organization';
 import {browserHistory} from 'sentry/utils/browserHistory';
+import {getDateWithTimezoneInUtc, getUserTimezone} from 'sentry/utils/dates';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
@@ -24,7 +28,11 @@ type State = {
   eventType: string | undefined;
   eventTypes: string[] | null;
   isLoading: boolean;
+  statsPeriod: string | null;
+  utc: boolean;
   currentCursor?: string;
+  end?: DateString;
+  start?: DateString;
 };
 
 function OrganizationAuditLog({location}: Props) {
@@ -34,6 +42,10 @@ function OrganizationAuditLog({location}: Props) {
     eventType: decodeScalar(location.query.event),
     eventTypes: [],
     isLoading: true,
+    start: decodeScalar(location.query.start) as DateString | undefined,
+    end: decodeScalar(location.query.end) as DateString | undefined,
+    statsPeriod: decodeScalar(location.query.statsPeriod) ?? null,
+    utc: decodeScalar(location.query.utc) === 'true' || getUserTimezone() === 'UTC',
   });
   const organization = useOrganization();
   const api = useApi();
@@ -50,7 +62,20 @@ function OrganizationAuditLog({location}: Props) {
   useEffect(() => {
     // Watch the location for changes so we can re-fetch data.
     const eventType = decodeScalar(location.query.event);
-    setState(prevState => ({...prevState, eventType}));
+    const start = decodeScalar(location.query.start) as DateString | undefined;
+    const end = decodeScalar(location.query.end) as DateString | undefined;
+    const statsPeriod = decodeScalar(location.query.statsPeriod) ?? null;
+    const utc =
+      decodeScalar(location.query.utc) === 'true' || getUserTimezone() === 'UTC';
+
+    setState(prevState => ({
+      ...prevState,
+      eventType,
+      start,
+      end,
+      statsPeriod: statsPeriod ?? prevState.statsPeriod,
+      utc,
+    }));
   }, [location.query]);
 
   const fetchAuditLogData = useCallback(async () => {
@@ -61,14 +86,33 @@ function OrganizationAuditLog({location}: Props) {
     setState(prevState => ({...prevState, isLoading: true}));
 
     try {
-      const payload = {cursor: state.currentCursor, event: state.eventType};
-      if (!payload.cursor) {
-        delete payload.cursor;
-      }
-      if (!payload.event) {
-        delete payload.event;
-      }
-      setState(prevState => ({...prevState, isLoading: true}));
+      const payload: {
+        cursor?: string;
+        end?: DateString;
+        event?: string;
+        start?: DateString;
+        statsPeriod?: string | null;
+        utc?: boolean;
+      } = {
+        cursor: state.currentCursor,
+        event: state.eventType,
+        start: state.start,
+        end: state.end,
+        statsPeriod: state.statsPeriod,
+        utc: state.utc,
+      };
+
+      // Remove undefined values from payload
+      Object.keys(payload).forEach(key => {
+        if (
+          payload[key as keyof typeof payload] === undefined ||
+          payload[key as keyof typeof payload] === '' ||
+          payload[key as keyof typeof payload] === null
+        ) {
+          delete payload[key as keyof typeof payload];
+        }
+      });
+
       const [data, _, response] = await api.requestPromise(
         `/organizations/${organization.slug}/audit-logs/`,
         {
@@ -96,7 +140,17 @@ function OrganizationAuditLog({location}: Props) {
         addErrorMessage('Unable to load audit logs.');
       }
     }
-  }, [api, organization.slug, state.currentCursor, state.eventType, hasPermission]);
+  }, [
+    api,
+    organization.slug,
+    state.currentCursor,
+    state.eventType,
+    state.start,
+    state.end,
+    state.statsPeriod,
+    state.utc,
+    hasPermission,
+  ]);
 
   useEffect(() => {
     fetchAuditLogData();
@@ -113,6 +167,51 @@ function OrganizationAuditLog({location}: Props) {
     });
   };
 
+  const handleDateSelect = (data: ChangeData) => {
+    let formattedStart: string | undefined;
+    let formattedEnd: string | undefined;
+
+    if (data.start && data.end) {
+      // Convert to UTC because endpoint only takes in UTC timestamps
+      const startUtc = getDateWithTimezoneInUtc(data.start, data.utc);
+      const endUtc = getDateWithTimezoneInUtc(data.end, data.utc);
+      formattedStart = normalizeDateTimeString(startUtc);
+      formattedEnd = normalizeDateTimeString(endUtc);
+    } else {
+      // start and end must both be defined to pass to endpoint
+      formattedStart = undefined;
+      formattedEnd = undefined;
+    }
+
+    const formattedStatsPeriod = data.relative === 'allTime' ? null : data.relative;
+
+    setState(prevState => ({
+      ...prevState,
+      start: formattedStart,
+      end: formattedEnd,
+      statsPeriod: formattedStatsPeriod,
+      utc: data.utc ?? prevState.utc,
+    }));
+
+    // Always update URL when there are changes
+    const newQuery: Record<string, string | undefined | null> = {
+      ...location.query,
+      start: formattedStart,
+      end: formattedEnd,
+      statsPeriod: formattedStatsPeriod,
+    };
+
+    // Only include UTC in query if it's been explicitly set
+    if (data.utc !== undefined) {
+      newQuery.utc = data.utc ? 'true' : 'false';
+    }
+
+    browserHistory.push({
+      pathname: location.pathname,
+      query: newQuery,
+    });
+  };
+
   return (
     <Fragment>
       {hasPermission ? (
@@ -122,8 +221,13 @@ function OrganizationAuditLog({location}: Props) {
           eventType={state.eventType}
           eventTypes={state.eventTypes}
           onEventSelect={handleEventSelect}
+          onDateSelect={handleDateSelect}
           isLoading={state.isLoading}
           onCursor={handleCursor}
+          start={state.start}
+          end={state.end}
+          statsPeriod={state.statsPeriod}
+          utc={state.utc}
         />
       ) : (
         <OrganizationPermissionAlert />

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -86,14 +86,7 @@ function OrganizationAuditLog({location}: Props) {
     setState(prevState => ({...prevState, isLoading: true}));
 
     try {
-      const payload: {
-        cursor?: string;
-        end?: DateString;
-        event?: string;
-        start?: DateString;
-        statsPeriod?: string | null;
-        utc?: boolean;
-      } = {
+      const payload = {
         cursor: state.currentCursor,
         event: state.eventType,
         start: state.start,


### PR DESCRIPTION
https://github.com/user-attachments/assets/c94f0165-8d21-416a-aea1-7ac4bdece214

We don't remove audit logs, so if we have a date picker on the audit log page it needs to handle picking a date from when audit logs started being created.

Edit: Removed additional period options aside from "All time"

Closes https://github.com/getsentry/sentry/issues/55509