### PR TITLE
ref(deletions): Remove unnecessary Seer calls in endpoint

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -13,7 +13,8 @@ from rest_framework.response import Response
 from sentry import audit_log, eventstream
 from sentry.api.base import audit_logger
 from sentry.deletions.tasks.groups import delete_groups as delete_groups_task
-from sentry.models.group import Group, GroupInbox, GroupStatus
+from sentry.models.group import Group, GroupStatus
+from sentry.models.groupinbox import GroupInbox
 from sentry.models.project import Project
 from sentry.signals import issue_deleted
 from sentry.utils.audit import create_audit_entry

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -13,13 +13,9 @@ from rest_framework.response import Response
 from sentry import audit_log, eventstream
 from sentry.api.base import audit_logger
 from sentry.deletions.tasks.groups import delete_groups as delete_groups_task
-from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group, GroupStatus
-from sentry.models.grouphash import GroupHash
-from sentry.models.groupinbox import GroupInbox
 from sentry.models.project import Project
 from sentry.signals import issue_deleted
-from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
 from sentry.utils.audit import create_audit_entry
 
 from . import BULK_MUTATION_LIMIT, SearchFunction
@@ -47,12 +43,7 @@ def delete_group_list(
     # deterministic sort for sanity, and for very large deletions we'll
     # delete the "smaller" groups first
     group_list.sort(key=lambda g: (g.times_seen, g.id))
-    group_ids = []
-    error_ids = []
-    for g in group_list:
-        group_ids.append(g.id)
-        if g.issue_category == GroupCategory.ERROR:
-            error_ids.append(g.id)
+    group_ids = [g.id for g in group_list]
 
     transaction_id = uuid4().hex
     delete_logger.info(
@@ -83,17 +74,6 @@ def delete_group_list(
     # so that we can see who requested the deletion. Even if anything after this point
     # fails, we will still have a record of who requested the deletion.
     create_audit_entries(request, project, group_list, delete_type, transaction_id)
-
-    # Tell seer to delete grouping records for these groups
-    may_schedule_task_to_delete_hashes_from_seer(error_ids)
-
-    # Removing GroupHash rows prevents new events from associating to the groups
-    # we just deleted.
-    GroupHash.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
-
-    # We remove `GroupInbox` rows here so that they don't end up influencing queries for
-    # `Group` instances that are pending deletion
-    GroupInbox.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
 
     delete_groups_task.apply_async(
         kwargs={

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -16,7 +16,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.snuba.dataset import Dataset
-from sentry.tasks.delete_seer_grouping_records import call_delete_seer_grouping_records_by_hash
+from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
 from sentry.utils.snuba import bulk_snuba_queries
 
 from ..base import BaseDeletionTask, BaseRelation, ModelDeletionTask, ModelRelation
@@ -281,7 +281,7 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
         error_groups, issue_platform_groups = separate_by_group_category(instance_list)
 
         # Tell seer to delete grouping records with these group hashes
-        call_delete_seer_grouping_records_by_hash([group.id for group in error_groups])
+        may_schedule_task_to_delete_hashes_from_seer([group.id for group in error_groups])
 
         # If this isn't a retention cleanup also remove event data.
         if not os.environ.get("_SENTRY_CLEANUP"):

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -280,6 +280,9 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
 
         error_groups, issue_platform_groups = separate_by_group_category(instance_list)
 
+        # Tell seer to delete grouping records with these group hashes
+        call_delete_seer_grouping_records_by_hash([group.id for group in error_groups])
+
         # If this isn't a retention cleanup also remove event data.
         if not os.environ.get("_SENTRY_CLEANUP"):
             if error_groups:
@@ -296,12 +299,6 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
                 )
 
         self.delete_children(child_relations)
-
-        # If by any chance, the call to seer
-        try:
-            call_delete_seer_grouping_records_by_hash([group.id for group in error_groups])
-        except Exception:
-            logger.exception("Error calling seer delete grouping records by hash")
 
     def delete_instance(self, instance: Group) -> None:
         from sentry import similarity

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -280,11 +280,6 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
 
         error_groups, issue_platform_groups = separate_by_group_category(instance_list)
 
-        try:
-            call_delete_seer_grouping_records_by_hash([group.id for group in error_groups])
-        except Exception:
-            logger.exception("Error calling seer delete grouping records by hash")
-
         # If this isn't a retention cleanup also remove event data.
         if not os.environ.get("_SENTRY_CLEANUP"):
             if error_groups:
@@ -301,6 +296,12 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
                 )
 
         self.delete_children(child_relations)
+
+        # If by any chance, the call to seer
+        try:
+            call_delete_seer_grouping_records_by_hash([group.id for group in error_groups])
+        except Exception:
+            logger.exception("Error calling seer delete grouping records by hash")
 
     def delete_instance(self, instance: Group) -> None:
         from sentry import similarity

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1205,7 +1205,8 @@ class DeleteGroupsTest(TestCase):
             GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        delete_groups(request, [self.project], self.organization.id)
+        with self.tasks():
+            delete_groups(request, [self.project], self.organization.id)
 
         assert (
             len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1174,7 +1174,8 @@ class DeleteGroupsTest(TestCase):
             GroupHash.objects.create(project=self.project, group=group, hash=hashes[i])
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-        delete_groups(request, [self.project], self.organization.id)
+        with self.tasks():
+            delete_groups(request, [self.project], self.organization.id)
 
         assert (
             len(GroupHash.objects.filter(project_id=self.project.id, group_id__in=group_ids).all())

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -878,10 +878,7 @@ class GroupDeleteTest(APITestCase):
 
         # Deletion was deferred, so it should still exist
         assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
-        # BUT the hash should be gone
-        assert not GroupHash.objects.filter(group_id=group.id).exists()
-
-        Group.objects.filter(id=group.id).update(status=GroupStatus.UNRESOLVED)
+        assert GroupHash.objects.filter(group_id=group.id).exists()
 
     def test_delete_and_tasks_run(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -5601,7 +5601,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
     def assert_pending_deletion_groups(self, groups: Sequence[Group]) -> None:
         for group in groups:
             assert Group.objects.get(id=group.id).status == GroupStatus.PENDING_DELETION
-            assert not GroupHash.objects.filter(group_id=group.id).exists()
+            assert GroupHash.objects.filter(group_id=group.id).exists()
 
     def assert_deleted_groups(self, groups: Sequence[Group]) -> None:
         for group in groups:
@@ -5638,12 +5638,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 204
-
-        assert Group.objects.get(id=group1.id).status == GroupStatus.PENDING_DELETION
-        assert not GroupHash.objects.filter(group_id=group1.id).exists()
-
-        assert Group.objects.get(id=group2.id).status == GroupStatus.PENDING_DELETION
-        assert not GroupHash.objects.filter(group_id=group2.id).exists()
+        self.assert_pending_deletion_groups([group1, group2])
 
         assert Group.objects.get(id=group3.id).status != GroupStatus.PENDING_DELETION
         assert GroupHash.objects.filter(group_id=group3.id).exists()

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1558,6 +1558,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         self.assert_groups_being_deleted([group1, group2])
         # Group 4 is not deleted because it belongs to a different project
         self.assert_groups_not_deleted([group3, group4])
+
         with self.tasks():
             response = self.client.delete(url, format="json")
 

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1502,13 +1502,9 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
         return groups
 
-    def assert_groups_being_deleted(self, groups: Sequence[Group]) -> None:
+    def assert_groups_marked_for_deletion(self, groups: Sequence[Group]) -> None:
         for g in groups:
             assert Group.objects.get(id=g.id).status == GroupStatus.PENDING_DELETION
-            assert not GroupHash.objects.filter(group_id=g.id).exists()
-
-        # This is necessary before calling the delete task
-        Group.objects.filter(id__in=[g.id for g in groups]).update(status=GroupStatus.UNRESOLVED)
 
     def assert_groups_are_gone(self, groups: Sequence[Group]) -> None:
         for g in groups:
@@ -1556,10 +1552,12 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 204
 
-        self.assert_groups_being_deleted([group1, group2])
+        self.assert_groups_marked_for_deletion([group1, group2])
         # Group 4 is not deleted because it belongs to a different project
         self.assert_groups_not_deleted([group3, group4])
 
+        # This is necessary to undo the changes made by the previous delete call
+        Group.objects.filter(id__in=[g.id for g in groups]).update(status=GroupStatus.UNRESOLVED)
         with self.tasks():
             response = self.client.delete(url, format="json")
 
@@ -1611,8 +1609,10 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
         response = self.client.delete(url, format="json")
 
         assert response.status_code == 204
-        self.assert_groups_being_deleted(groups)
+        self.assert_groups_marked_for_deletion(groups)
 
+        # This is necessary to undo the changes made by the previous delete call
+        Group.objects.filter(id__in=[g.id for g in groups]).update(status=GroupStatus.UNRESOLVED)
         with self.tasks():
             response = self.client.delete(url, format="json")
 
@@ -1635,25 +1635,3 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             response = self.client.delete(url, format="json")
             assert response.status_code == 204
             self.assert_groups_are_gone(groups)
-
-    @patch("sentry.api.helpers.group_index.delete.may_schedule_task_to_delete_hashes_from_seer")
-    @patch("sentry.utils.audit.log_service.record_audit_log")
-    def test_audit_log_even_if_exception_raised(
-        self, mock_record_audit_log: Mock, mock_seer_delete: Mock
-    ):
-        """
-        Test that audit log is created even if an exception is raised after the audit log is created.
-        """
-        # Calling seer happens after creating the audit log entry
-        mock_seer_delete.side_effect = Exception("Seer error!")
-        group1 = self.create_group()
-        self.login_as(user=self.user)
-        url = f"{self.path}?id={group1.id}"
-        with self.tasks():
-            response = self.client.delete(url, format="json")
-            assert response.status_code == 500
-
-        self.assert_audit_log_entry([group1], mock_record_audit_log)
-
-        # They have been marked as pending deletion but the exception prevented their complete deletion
-        assert Group.objects.get(id=group1.id).status == GroupStatus.PENDING_DELETION


### PR DESCRIPTION
During the deletion API call we were calling seer & a couple more changes which the Group deletion model already does, thus, we don't need to do it during the API call.

Prior to this change, if the Seer call failed, the deletion task would not get scheduled, thus, many groups stay in a pending deletion state and never deleted.

Fixes #93509 
Fixes [ID-716](https://linear.app/getsentry/issue/ID-716/move-endpoint-code-to-the-deletion-task)