### PR TITLE
feat(deletions): Request Seer deletions in batches

### DIFF
--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -16,7 +16,7 @@ from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.query import RangeQuerySetWrapper
 
-BATCH_SIZE = 10000
+BATCH_SIZE = 1000
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -78,6 +78,12 @@ def call_delete_seer_grouping_records_by_hash(
         ):
             group_hashes.append(group_hash.hash)
 
+            # Schedule task when we reach BATCH_SIZE
+            if len(group_hashes) >= BATCH_SIZE:
+                delete_seer_grouping_records_by_hash.apply_async(args=[project.id, group_hashes, 0])
+                group_hashes = []
+
+        # Handle any remaining hashes
         if group_hashes:
             delete_seer_grouping_records_by_hash.apply_async(args=[project.id, group_hashes, 0])
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1189,10 +1189,9 @@ class DeleteGroupsTest(TestCase):
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )
-    @patch("sentry.tasks.delete_seer_grouping_records.logger")
     @patch("sentry.signals.issue_deleted.send_robust")
     def test_delete_groups_deletes_seer_records_by_hash(
-        self, send_robust: Mock, mock_logger: Mock, mock_delete_seer_grouping_records_by_hash
+        self, send_robust: Mock, mock_delete_seer_grouping_records_by_hash: MagicMock
     ):
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
@@ -1217,10 +1216,6 @@ class DeleteGroupsTest(TestCase):
             == 0
         )
         assert send_robust.called
-        mock_logger.info.assert_called_with(
-            "calling seer record deletion by hash",
-            extra={"project_id": self.project.id, "hashes": hashes},
-        )
         mock_delete_seer_grouping_records_by_hash.assert_called_with(
             args=[self.project.id, hashes, 0]
         )

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from sentry.models.grouphash import GroupHash
 from sentry.tasks.delete_seer_grouping_records import (
     call_delete_seer_grouping_records_by_hash,
+    call_seer_delete_project_grouping_records,
     delete_seer_grouping_records_by_hash,
 )
 from sentry.testutils.cases import TestCase
@@ -81,3 +82,10 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     ) -> None:
         call_delete_seer_grouping_records_by_hash([])
         mock_apply_async.assert_not_called()
+
+    @patch("sentry.tasks.delete_seer_grouping_records.delete_project_grouping_records")
+    def test_call_delete_project_and_delete_grouping_records(
+        self, mock_delete_project_grouping_records: MagicMock
+    ) -> None:
+        call_seer_delete_project_grouping_records(self.project.id)
+        mock_delete_project_grouping_records.assert_called_once()

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 from sentry.models.grouphash import GroupHash
 from sentry.tasks.delete_seer_grouping_records import (
     call_delete_seer_grouping_records_by_hash,
-    call_seer_delete_project_grouping_records,
     delete_seer_grouping_records_by_hash,
 )
 from sentry.testutils.cases import TestCase
@@ -82,10 +81,3 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     ) -> None:
         call_delete_seer_grouping_records_by_hash([])
         mock_apply_async.assert_not_called()
-
-    @patch("sentry.tasks.delete_seer_grouping_records.delete_project_grouping_records")
-    def test_call_delete_project_and_delete_grouping_records(
-        self, mock_delete_project_grouping_records: MagicMock
-    ) -> None:
-        call_seer_delete_project_grouping_records(self.project.id)
-        mock_delete_project_grouping_records.assert_called_once()

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -5,7 +5,6 @@ from sentry.models.grouphash import GroupHash
 from sentry.tasks.delete_seer_grouping_records import (
     BATCH_SIZE,
     call_delete_seer_grouping_records_by_hash,
-    call_seer_delete_project_grouping_records,
     delete_seer_grouping_records_by_hash,
 )
 from sentry.testutils.cases import TestCase
@@ -122,10 +121,3 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     ) -> None:
         call_delete_seer_grouping_records_by_hash([])
         mock_apply_async.assert_not_called()
-
-    @patch("sentry.tasks.delete_seer_grouping_records.delete_project_grouping_records")
-    def test_call_delete_project_and_delete_grouping_records(
-        self, mock_delete_project_grouping_records: MagicMock
-    ) -> None:
-        call_seer_delete_project_grouping_records(self.project.id)
-        mock_delete_project_grouping_records.assert_called_once()

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, patch
 
 from sentry.models.grouphash import GroupHash
 from sentry.tasks.delete_seer_grouping_records import (
+    BATCH_SIZE,
     call_delete_seer_grouping_records_by_hash,
+    call_seer_delete_project_grouping_records,
     delete_seer_grouping_records_by_hash,
 )
 from sentry.testutils.cases import TestCase
@@ -49,7 +51,7 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             group = self.create_group(project=self.project)
             group_ids.append(group.id)
             group_hash = GroupHash.objects.create(
-                project=self.project, hash=str(i) * 32, group_id=group.id
+                project=self.project, hash=f"{i:032d}", group=group
             )
             expected_hashes.append(group_hash.hash)
 
@@ -57,6 +59,45 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
 
         # Verify that the task was called with the correct parameters
         mock_apply_async.assert_called_once_with(args=[self.project.id, expected_hashes, 0])
+
+    @patch(
+        "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
+    )
+    def test_call_delete_seer_grouping_records_by_hash_chunked(
+        self, mock_apply_async: MagicMock
+    ) -> None:
+        """
+        Test that call_delete_seer_grouping_records_by_hash chunks large numbers of hashes
+        into separate tasks with a maximum of 1000 hashes per task.
+        """
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
+
+        # Create 1500 group hashes to test chunking
+        group_ids, expected_hashes = [], []
+        for i in range(BATCH_SIZE + 500):
+            group = self.create_group(project=self.project)
+            group_ids.append(group.id)
+            group_hash = GroupHash.objects.create(
+                project=self.project, hash=f"{i:032d}", group=group
+            )
+            expected_hashes.append(group_hash.hash)
+
+        call_delete_seer_grouping_records_by_hash(group_ids)
+
+        # Verify that the task was called 2 times (1500 hashes / 1000 per chunk = 2 chunks)
+        assert mock_apply_async.call_count == 2
+
+        # Verify the first chunk has 1000 hashes
+        first_call_args = mock_apply_async.call_args_list[0][1]["args"]
+        assert len(first_call_args[1]) == 1000
+        assert first_call_args[0] == self.project.id
+        assert first_call_args[2] == 0
+
+        # Verify the second chunk has 500 hashes (remainder)
+        second_call_args = mock_apply_async.call_args_list[1][1]["args"]
+        assert len(second_call_args[1]) == 500
+        assert second_call_args[0] == self.project.id
+        assert second_call_args[2] == 0
 
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
@@ -81,3 +122,10 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     ) -> None:
         call_delete_seer_grouping_records_by_hash([])
         mock_apply_async.assert_not_called()
+
+    @patch("sentry.tasks.delete_seer_grouping_records.delete_project_grouping_records")
+    def test_call_delete_project_and_delete_grouping_records(
+        self, mock_delete_project_grouping_records: MagicMock
+    ) -> None:
+        call_seer_delete_project_grouping_records(self.project.id)
+        mock_delete_project_grouping_records.assert_called_once()


### PR DESCRIPTION
Some deletions are failing because the query to get group hashes times out.

Related: #inc-1236

Fixes [SENTRY-43X8](https://sentry.sentry.io/issues/6712841606/)
Fixes [SENTRY-3DVG](https://sentry.sentry.io/issues/5737861849/)
Fixes [SENTRY-3XEE](https://sentry.sentry.io/issues/6635786687/)