### PR TITLE
chore: Set the @sentry/toolbar version to be latest

### DIFF
--- a/static/app/utils/useInitSentryToolbar.tsx
+++ b/static/app/utils/useInitSentryToolbar.tsx
@@ -14,6 +14,7 @@ export default function useInitSentryToolbar(organization: null | Organization) 
 
   useSentryToolbar({
     enabled: showDevToolbar && isEmployee,
+    version: 'latest',
     initProps: {
       organizationSlug: organization?.slug ?? 'sentry',
       projectIdOrSlug: 'javascript',


### PR DESCRIPTION
The npm package is still set to whatever is in package.json, but that is just a loader for the actual toolbar code. By loading the latest toolbar code we will be on the edge by default, which is the recommendation for users too. The npm loader package changes much less often
