### PR TITLE
ref(aci): Use updated detector list API for connected automations

### DIFF
--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -4,8 +4,8 @@ import type {
   DataConditionHandler,
   DataConditionHandlerGroupType,
 } from 'sentry/types/workflowEngine/dataConditions';
-import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {useApiQueries, useApiQuery} from 'sentry/utils/queryClient';
+import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const makeAutomationsQueryKey = ({
@@ -41,12 +41,16 @@ interface UseAutomationsQueryOptions {
   query?: string;
   sort?: string;
 }
-export function useAutomationsQuery(options: UseAutomationsQueryOptions = {}) {
+export function useAutomationsQuery(
+  options: UseAutomationsQueryOptions = {},
+  queryOptions: Partial<UseApiQueryOptions<Automation[]>> = {}
+) {
   const {slug: orgSlug} = useOrganization();
 
   return useApiQuery<Automation[]>(makeAutomationsQueryKey({orgSlug, ...options}), {
     staleTime: 0,
     retry: false,
+    ...queryOptions,
   });
 }
 
@@ -78,16 +82,4 @@ export function useAvailableActionsQuery() {
     staleTime: Infinity,
     retry: false,
   });
-}
-
-export function useDetectorQueriesByIds(automationIds: string[]) {
-  const org = useOrganization();
-
-  return useApiQueries<Automation>(
-    automationIds.map(id => makeAutomationQueryKey(org.slug, id)),
-    {
-      staleTime: 0,
-      retry: false,
-    }
-  );
 }

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -1,21 +1,19 @@
-import {useEffect, useState} from 'react';
-
-import {Flex} from 'sentry/components/container/flex';
 import {Button} from 'sentry/components/core/button';
-import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Pagination from 'sentry/components/pagination';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import AutomationTitleCell from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
-import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useDetectorQueriesByIds} from 'sentry/views/automations/hooks';
+import {useAutomationsQuery} from 'sentry/views/automations/hooks';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
 import {makeAutomationDetailsPathname} from 'sentry/views/automations/pathnames';
 
@@ -34,36 +32,23 @@ export function ConnectedAutomationsList({
 }: Props) {
   const organization = useOrganization();
   const canEdit = connectedAutomationIds && !!toggleConnected;
-  // TODO: There will eventually be a single api call to fetch a page of automations
-  const queries = useDetectorQueriesByIds(automationIds);
-  const [currentPage, setCurrentPage] = useState(0);
-  const totalPages = Math.ceil(queries.length / AUTOMATIONS_PER_PAGE);
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  // Reset the page when the automationIds change
-  useEffect(() => {
-    setCurrentPage(0);
-  }, [automationIds]);
-
-  const data = queries
-    .map((query): ConnectedAutomationsData | undefined => {
-      if (!query.data) {
-        return undefined;
-      }
-      return {
-        ...query.data,
-        link: makeAutomationDetailsPathname(organization.slug, query.data.id),
-        connected: canEdit
-          ? {
-              isConnected: connectedAutomationIds?.has(query.data.id),
-              toggleConnected: () => toggleConnected?.(query.data.id),
-            }
-          : undefined,
-      };
-    })
-    .filter(defined);
-
-  const isLoading = queries.some(query => query.isPending);
-  const isError = queries.some(query => query.isError);
+  const {
+    data: automations,
+    isLoading,
+    isError,
+    getResponseHeader,
+  } = useAutomationsQuery(
+    {
+      ids: automationIds,
+      limit: AUTOMATIONS_PER_PAGE,
+      cursor:
+        typeof location.query.cursor === 'string' ? location.query.cursor : undefined,
+    },
+    {enabled: automationIds.length > 0}
+  );
 
   if (isError) {
     return <LoadingError />;
@@ -73,52 +58,42 @@ export function ConnectedAutomationsList({
     return <LoadingIndicator />;
   }
 
-  const handlePreviousPage = () => {
-    setCurrentPage(prev => Math.max(0, prev - 1));
-  };
-  const handleNextPage = () => {
-    setCurrentPage(prev => Math.min(totalPages - 1, prev + 1));
-  };
-
-  const pagination = (
-    <Flex justify="flex-end">
-      <ButtonBar merged>
-        <Button
-          onClick={handlePreviousPage}
-          disabled={currentPage === 0}
-          aria-label={t('Previous page')}
-          icon={<IconChevron direction="left" />}
-          size="sm"
-        />
-        <Button
-          onClick={handleNextPage}
-          disabled={currentPage === totalPages - 1}
-          aria-label={t('Next page')}
-          icon={<IconChevron direction="right" />}
-          size="sm"
-        />
-      </ButtonBar>
-    </Flex>
-  );
-
-  if (canEdit) {
-    return (
-      <Flex column>
-        <SimpleTable columns={connectedColumns} data={data} />
-        {pagination}
-      </Flex>
-    );
-  }
+  const tableData: ConnectedAutomationsData[] =
+    automations
+      ?.map(automation => {
+        return {
+          ...automation,
+          link: makeAutomationDetailsPathname(organization.slug, automation.id),
+          connected: canEdit
+            ? {
+                isConnected: connectedAutomationIds?.has(automation.id),
+                toggleConnected: () => toggleConnected?.(automation.id),
+              }
+            : undefined,
+        };
+      })
+      .filter(defined) ?? [];
 
   return (
-    <Flex column>
+    <div>
       <SimpleTable
-        columns={baseColumns}
-        data={data}
+        columns={canEdit ? connectedColumns : baseColumns}
+        data={tableData}
         fallback={t('No automations connected')}
       />
-      {pagination}
-    </Flex>
+      <Pagination
+        onCursor={cursor => {
+          navigate({
+            pathname: location.pathname,
+            query: {
+              ...location.query,
+              cursor,
+            },
+          });
+        }}
+        pageLinks={getResponseHeader?.('Link')}
+      />
+    </div>
   );
 }
 

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -1,3 +1,4 @@
+import {AutomationFixture} from 'sentry-fixture/automations';
 import {DetectorFixture, SnubaQueryDataSourceFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -28,6 +29,7 @@ describe('DetectorDetails', function () {
     projectId: project.id,
     dataSources: [dataSource],
     owner: `team:${ownerTeam.id}`,
+    workflowIds: ['1', '2'], // Add workflow IDs for connected automations
   });
   const initialRouterConfig = {
     location: {
@@ -42,6 +44,14 @@ describe('DetectorDetails', function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/detectors/${snubaQueryDetector.id}/`,
       body: snubaQueryDetector,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      body: [
+        AutomationFixture({id: '1', name: 'Automation 1'}),
+        AutomationFixture({id: '2', name: 'Automation 2'}),
+      ],
+      match: [MockApiClient.matchQuery({id: ['1', '2']})],
     });
   });
 
@@ -62,5 +72,38 @@ describe('DetectorDetails', function () {
     ).toBeInTheDocument();
     // Displays the owner team
     expect(screen.getByText(`Assign to #${ownerTeam.slug}`)).toBeInTheDocument();
+  });
+
+  describe('connected automations', function () {
+    it('displays empty message when no automations are connected', async function () {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${snubaQueryDetector.id}/`,
+        body: {
+          ...snubaQueryDetector,
+          workflowIds: [],
+        },
+      });
+      render(<DetectorDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+      expect(await screen.findByText('No automations connected')).toBeInTheDocument();
+    });
+
+    it('displays connected automations', async function () {
+      render(<DetectorDetails />, {
+        organization,
+        initialRouterConfig,
+      });
+
+      // Verify both automations are displayed
+      expect(await screen.findByText('Automation 1')).toBeInTheDocument();
+      expect(await screen.findByText('Automation 2')).toBeInTheDocument();
+
+      // Verify the table shows the correct columns
+      expect(screen.getByText('Name')).toBeInTheDocument();
+      expect(screen.getByText('Last Triggered')).toBeInTheDocument();
+      expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Now that we can send `id=[1,2,3]` to the `/workflows/` endpoint, this replaces the old temporary fetching logic for connected automations on the detector details page