### PR TITLE
chore: Allow pnpm built dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
       "react-mentions>@babel/runtime": "7.26.10",
       "react-is": "19.1.0"
     },
-    "ignoredBuiltDependencies": [
+    "onlyBuiltDependencies": [
       "@sentry-internal/node-cpu-profiler",
       "@sentry/cli",
       "core-js",

--- a/package.json
+++ b/package.json
@@ -228,7 +228,13 @@
     "overrides": {
       "react-mentions>@babel/runtime": "7.26.10",
       "react-is": "19.1.0"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@sentry-internal/node-cpu-profiler",
+      "@sentry/cli",
+      "core-js",
+      "esbuild"
+    ]
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
We're getting this warning when installing npm dependencies, and so these build scripts don't seem to be running... so I'll add them to the list and silence the warning.

<img width="735" alt="SCR-20250613-lbqb" src="https://github.com/user-attachments/assets/465ceccf-9ff0-4f85-822a-cdda4ef037a5" />

```
Warning
Ignored build scripts: @sentry-internal/node-cpu-profiler, @sentry/cli, core-js, esbuild.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```
