### PR TITLE
fix(search): Do not commit empty filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -90,9 +90,16 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
 
   const onValueCommited = useCallback(
     (keyName: string) => {
-      handleSelectKey(getSuggestedFilterKey(keyName) ?? keyName);
+      const trimmedKeyName = keyName.trim();
+
+      if (!trimmedKeyName) {
+        onCommit();
+        return;
+      }
+
+      handleSelectKey(getSuggestedFilterKey(trimmedKeyName) ?? trimmedKeyName);
     },
-    [handleSelectKey, getSuggestedFilterKey]
+    [handleSelectKey, getSuggestedFilterKey, onCommit]
   );
 
   const onCustomValueBlurred = useCallback(() => {


### PR DESCRIPTION
If you click a filter key to edit it, then hit enter it will commit an empty string as the filter key. This makes it exit without changes instead.