### PR TITLE
fix(search): Clear selection more reliably

### DIFF
--- a/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
+++ b/static/app/components/searchQueryBuilder/tokenizedQueryGrid.tsx
@@ -108,7 +108,12 @@ function Grid(props: GridProps) {
         dispatch({type: 'COMMIT_QUERY'});
       }}
     >
-      <SelectionKeyHandler ref={selectionKeyHandlerRef} state={state} undo={undo} />
+      <SelectionKeyHandler
+        ref={selectionKeyHandlerRef}
+        state={state}
+        undo={undo}
+        gridRef={ref}
+      />
       {[...state.collection].map(item => {
         const token = item.value;
 


### PR DESCRIPTION
The selected search filters would sometimes stick around even after clicking into another input. This ensures that anytime the selection input is blurred, the selection state is cleared.