### PR TITLE
ref(replay): bring back rage clicks to the mock-replay script

### DIFF
--- a/bin/mock-replay
+++ b/bin/mock-replay
@@ -54,7 +54,7 @@ def create_recording(replay_id, project_id, timestamp):
             24,
         ),
         mock_segment_click(
-            timestamp + timedelta(seconds=2),
+            timestamp + timedelta(seconds=3),
             "nav.app-65yvxw.e1upz5ks6[aria-label='Primary Navigation'] > div.app-1v175cc.e1upz5ks4",
             "sidebar-item-performance",
             "a",
@@ -65,7 +65,7 @@ def create_recording(replay_id, project_id, timestamp):
             hrefTo="/performance/",
         ),
         mock_segment_rageclick(
-            timestamp + timedelta(seconds=6),
+            timestamp + timedelta(seconds=7),
             "nav.app-65yvxw.e1upz5ks6[aria-label='Primary Navigation'] > div.app-1v175cc.e1upz5ks4",
             "sidebar-item-performance",
             "a",

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -448,9 +448,11 @@ def mock_segment_rageclick(
         {
             "timestamp": sec(timestamp),  # sentry data inside rrweb is in seconds
             "type": "default",
-            "category": "ui.multiClick",
+            "category": "ui.slowClickDetected",
             "message": message,
             "data": {
+                "endReason": "timeout",
+                "timeAfterClickMs": 7000,
                 "node": {
                     "tagName": tagName,
                     "attributes": {


### PR DESCRIPTION
the rage clicks in `./bin/mock-replay` were being filtered out

before:

<img width="1276" alt="SCR-20250613-ntwr" src="https://github.com/user-attachments/assets/27c3856b-d2f1-4ed3-ae39-825b9dee284c" />

after:

<img width="1294" alt="SCR-20250613-ntvn" src="https://github.com/user-attachments/assets/44ad7113-5f51-4842-b0b2-b6c7fd1bbc0e" />
