### PR TITLE
ref(aci): Big delayed_workflow refactor

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
+import logging
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, Sequence, Iterable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from functools import cached_property
+from typing import Any, TypeAlias
 
 import sentry_sdk
 from celery import Task
 from django.utils import timezone
+from pydantic import BaseModel, validator
 
 from sentry import buffer, features, nodestore
 from sentry.buffer.base import BufferField
@@ -29,7 +34,7 @@ from sentry.tasks.post_process import should_retry_fetch
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.taskworker.retry import Retry
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
@@ -67,10 +72,129 @@ logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workf
 EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
 
-DataConditionGroupGroups = dict[int, set[int]]
-WorkflowMapping = dict[int, Workflow]
-WorkflowEnvMapping = dict[int, int | None]
-DataConditionGroupEvent = dict[tuple[int, int], dict[str, str | None]]
+GroupId: TypeAlias = int
+DataConditionGroupId: TypeAlias = int
+WorkflowId: TypeAlias = int
+
+
+class EventInstance(BaseModel):
+    event_id: str
+    occurrence_id: str | None = None
+
+    @validator("occurrence_id")
+    def validate_occurrence_id(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            return None
+        return v
+
+
+@dataclass(frozen=True)
+class EventKey:
+    workflow_id: WorkflowId
+    group_id: GroupId
+    dcg_ids: frozenset[DataConditionGroupId]
+    dcg_type: DataConditionHandler.Group
+    original_key: str
+
+    @classmethod
+    def from_redis_key(cls, key: str) -> EventKey:
+        parts = key.split(":")
+        return cls(
+            workflow_id=int(parts[0]),
+            group_id=int(parts[1]),
+            dcg_ids=frozenset(int(dcg_id) for dcg_id in parts[2].split(",")),
+            dcg_type=DataConditionHandler.Group(parts[3]),
+            original_key=key,
+        )
+
+    def __str__(self) -> str:
+        return self.original_key
+
+    def __hash__(self) -> int:
+        return hash(self.original_key)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, EventKey):
+            return NotImplemented
+        return self.original_key == other.original_key
+
+
+@dataclass(frozen=True)
+class EventRedisData:
+    """
+    Immutable container for all data from Redis.
+    Any lookups or summaries or other processing that can be purely derived
+    from the data should be done on this object so that it's obvious where we're operating
+    based on parameter data.
+    """
+
+    events: Mapping[EventKey, EventInstance]
+
+    @classmethod
+    def from_redis_data(cls, redis_data: dict[str, str]) -> EventRedisData:
+        events = {}
+        for key, value in redis_data.items():
+            try:
+                event_key = EventKey.from_redis_key(key)
+                event_instance = EventInstance.parse_raw(value)
+                events[event_key] = event_instance
+            except Exception as e:
+                logger.exception(
+                    "Failed to parse workflow event data",
+                    extra={"key": key, "value": value, "error": str(e)},
+                )
+                raise ValueError(f"Failed to parse Redis data: {str(e)}") from e
+        return cls(events=events)
+
+    @cached_property
+    def dcg_ids(self) -> set[DataConditionGroupId]:
+        return {dcg_id for key in self.events for dcg_id in key.dcg_ids}
+
+    @cached_property
+    def dcg_to_groups(self) -> Mapping[DataConditionGroupId, set[GroupId]]:
+        dcg_to_groups: dict[DataConditionGroupId, set[GroupId]] = defaultdict(set)
+        for key in self.events:
+            for dcg_id in key.dcg_ids:
+                dcg_to_groups[dcg_id].add(key.group_id)
+        return dcg_to_groups
+
+    @cached_property
+    def trigger_group_to_dcg_model(
+        self,
+    ) -> dict[DataConditionHandler.Group, dict[DataConditionGroupId, WorkflowId]]:
+        trigger_group_to_dcg_model: dict[
+            DataConditionHandler.Group, dict[DataConditionGroupId, WorkflowId]
+        ] = defaultdict(dict)
+        for key in self.events:
+            for dcg_id in key.dcg_ids:
+                trigger_group_to_dcg_model[key.dcg_type][dcg_id] = key.workflow_id
+        return trigger_group_to_dcg_model
+
+    @cached_property
+    def dcg_to_workflow(self) -> dict[DataConditionGroupId, WorkflowId]:
+        """Get mapping of DCG IDs to workflow IDs, combining both trigger and action filter groups."""
+        return {
+            **self.trigger_group_to_dcg_model[DataConditionHandler.Group.WORKFLOW_TRIGGER],
+            **self.trigger_group_to_dcg_model[DataConditionHandler.Group.ACTION_FILTER],
+        }
+
+    @cached_property
+    def workflow_ids(self) -> set[WorkflowId]:
+        return {key.workflow_id for key in self.events}
+
+    @cached_property
+    def event_ids(self) -> set[str]:
+        return {instance.event_id for instance in self.events.values() if instance.event_id}
+
+    @cached_property
+    def occurrence_ids(self) -> set[str]:
+        return {
+            instance.occurrence_id for instance in self.events.values() if instance.occurrence_id
+        }
+
+    @cached_property
+    def group_ids(self) -> set[GroupId]:
+        return {key.group_id for key in self.events}
 
 
 @dataclass(frozen=True)
@@ -121,7 +245,6 @@ def fetch_project(project_id: int) -> Project | None:
         return None
 
 
-# TODO: replace with shared function with delayed_processing.py
 def fetch_group_to_event_data(
     project_id: int, model: type[models.Model], batch_key: str | None = None
 ) -> dict[str, str]:
@@ -135,51 +258,19 @@ def fetch_group_to_event_data(
     return buffer.backend.get_hash(model=model, field=field)
 
 
-def get_dcg_group_workflow_detector_data(
-    workflow_event_dcg_data: dict[str, str],
-) -> tuple[DataConditionGroupGroups, dict[DataConditionHandler.Group, dict[int, int]]]:
-    """
-    Parse the data in the buffer hash, which is in the form of {workflow/detector_id}:{group_id}:{dcg_id, ..., dcg_id}:{dcg_type}
-    """
-
-    dcg_to_groups: DataConditionGroupGroups = defaultdict(set)
-    trigger_group_to_dcg_model: dict[DataConditionHandler.Group, dict[int, int]] = defaultdict(dict)
-
-    for workflow_group_dcg, _ in workflow_event_dcg_data.items():
-        data = workflow_group_dcg.split(":")
-        try:
-            dcg_group = DataConditionHandler.Group(data[3])
-        except ValueError:
-            continue
-
-        group_id = int(data[1])
-        dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
-
-        for dcg_id in dcg_ids:
-            dcg_to_groups[dcg_id].add(group_id)
-
-            trigger_group_to_dcg_model[dcg_group][dcg_id] = int(data[0])
-
-    return dcg_to_groups, trigger_group_to_dcg_model
-
-
 def fetch_workflows_envs(
-    workflow_ids: list[int],
-) -> tuple[WorkflowMapping, WorkflowEnvMapping]:
-    workflows_to_envs: WorkflowEnvMapping = {}
-    workflow_ids_to_workflows: WorkflowMapping = {}
-
-    workflows = list(Workflow.objects.filter(id__in=workflow_ids))
-
-    for workflow in workflows:
-        workflows_to_envs[workflow.id] = workflow.environment_id
-        workflow_ids_to_workflows[workflow.id] = workflow
-
-    return workflow_ids_to_workflows, workflows_to_envs
+    workflow_ids: list[WorkflowId],
+) -> Mapping[WorkflowId, int | None]:
+    return {
+        workflow_id: env_id
+        for workflow_id, env_id in Workflow.objects.filter(id__in=workflow_ids).values_list(
+            "id", "environment_id"
+        )
+    }
 
 
 def fetch_data_condition_groups(
-    dcg_ids: list[int],
+    dcg_ids: list[DataConditionGroupId],
 ) -> list[DataConditionGroup]:
     """
     Fetch DataConditionGroups with enabled detectors/workflows
@@ -245,28 +336,28 @@ def generate_unique_queries(
 @sentry_sdk.trace
 def get_condition_query_groups(
     data_condition_groups: list[DataConditionGroup],
-    dcg_to_groups: DataConditionGroupGroups,
-    dcg_to_workflow: dict[int, int],
-    workflows_to_envs: WorkflowEnvMapping,
-) -> dict[UniqueConditionQuery, set[int]]:
+    event_data: EventRedisData,
+    workflows_to_envs: Mapping[WorkflowId, int | None],
+) -> dict[UniqueConditionQuery, set[GroupId]]:
     """
     Map unique condition queries to the group IDs that need to checked for that query.
     """
-    condition_groups: dict[UniqueConditionQuery, set[int]] = defaultdict(set)
-    dcg_to_slow_conditions = get_slow_conditions_for_groups(list(dcg_to_groups.keys()))
+    condition_groups: dict[UniqueConditionQuery, set[GroupId]] = defaultdict(set)
+    dcg_to_slow_conditions = get_slow_conditions_for_groups(list(event_data.dcg_to_groups.keys()))
+
     for dcg in data_condition_groups:
         slow_conditions = dcg_to_slow_conditions[dcg.id]
+        workflow_id = event_data.dcg_to_workflow.get(dcg.id)
+        workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
         for condition in slow_conditions:
-            workflow_id = dcg_to_workflow.get(dcg.id)
-            workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
             for condition_query in generate_unique_queries(condition, workflow_env):
-                condition_groups[condition_query].update(dcg_to_groups[dcg.id])
+                condition_groups[condition_query].update(event_data.dcg_to_groups[dcg.id])
     return condition_groups
 
 
 @sentry_sdk.trace
 def get_condition_group_results(
-    queries_to_groups: dict[UniqueConditionQuery, set[int]],
+    queries_to_groups: dict[UniqueConditionQuery, set[GroupId]],
 ) -> dict[UniqueConditionQuery, QueryResult]:
     condition_group_results = {}
     current_time = timezone.now()
@@ -298,20 +389,20 @@ def get_condition_group_results(
 @sentry_sdk.trace
 def get_groups_to_fire(
     data_condition_groups: list[DataConditionGroup],
-    workflows_to_envs: WorkflowEnvMapping,
-    dcg_to_workflow: dict[int, int],
-    dcg_to_groups: DataConditionGroupGroups,
+    workflows_to_envs: Mapping[WorkflowId, int | None],
+    event_data: EventRedisData,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
-) -> dict[int, set[DataConditionGroup]]:
-    groups_to_fire: dict[int, set[DataConditionGroup]] = defaultdict(set)
-    dcg_to_slow_conditions = get_slow_conditions_for_groups(list(dcg_to_groups.keys()))
+) -> dict[GroupId, set[DataConditionGroup]]:
+    groups_to_fire: dict[GroupId, set[DataConditionGroup]] = defaultdict(set)
+    dcg_to_slow_conditions = get_slow_conditions_for_groups(list(event_data.dcg_ids))
+
     for dcg in data_condition_groups:
         slow_conditions = dcg_to_slow_conditions[dcg.id]
         action_match = DataConditionGroup.Type(dcg.logic_type)
-        workflow_id = dcg_to_workflow.get(dcg.id)
+        workflow_id = event_data.dcg_to_workflow.get(dcg.id)
         workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
 
-        for group_id in dcg_to_groups[dcg.id]:
+        for group_id in event_data.dcg_to_groups[dcg.id]:
             conditions_to_evaluate: list[tuple[DataCondition, list[int | float]]] = []
             for condition in slow_conditions:
                 unique_queries = generate_unique_queries(condition, workflow_env)
@@ -330,43 +421,6 @@ def get_groups_to_fire(
                 groups_to_fire[group_id].add(dcg)
 
     return groups_to_fire
-
-
-def parse_dcg_group_event_data(
-    workflow_event_dcg_data: dict[str, str], groups_to_dcgs: dict[int, set[DataConditionGroup]]
-) -> tuple[DataConditionGroupEvent, set[str], set[str]]:
-    dcg_group_to_event_data: DataConditionGroupEvent = {}  # occurrence_id can be None
-    event_ids: set[str] = set()
-    occurrence_ids: set[str] = set()
-
-    groups_to_dcg_ids = {
-        group_id: {dcg.id for dcg in dcgs} for group_id, dcgs in groups_to_dcgs.items()
-    }
-
-    for workflow_group_dcg, instance_data in workflow_event_dcg_data.items():
-        data = workflow_group_dcg.split(":")
-
-        group_id = int(data[1])
-        if group_id not in groups_to_dcg_ids:
-            # the group did not trigger any data condition groups
-            continue
-
-        event_data = json.loads(instance_data)
-        event_id = event_data.get("event_id")
-        if event_id:
-            event_ids.add(event_id)
-
-        occurrence_id = event_data.get("occurrence_id")
-        if occurrence_id:
-            occurrence_ids.add(occurrence_id)
-
-        dcg_ids = [int(dcg_id) for dcg_id in data[2].split(",")]
-
-        for dcg_id in dcg_ids:
-            if dcg_id in groups_to_dcg_ids[group_id]:
-                dcg_group_to_event_data[(int(dcg_id), int(group_id))] = event_data
-
-    return dcg_group_to_event_data, event_ids, occurrence_ids
 
 
 def bulk_fetch_events(event_ids: list[str], project_id: int) -> dict[str, Event]:
@@ -391,40 +445,41 @@ def bulk_fetch_events(event_ids: list[str], project_id: int) -> dict[str, Event]
 
 
 def get_group_to_groupevent(
-    dcg_group_to_event_data: DataConditionGroupEvent,
-    group_ids: list[int],
-    event_ids: set[str],
-    occurrence_ids: set[str],
+    event_data: EventRedisData,
+    groups_to_dcgs: dict[GroupId, set[DataConditionGroup]],
     project_id: int,
 ) -> dict[Group, GroupEvent]:
-    groups = Group.objects.filter(id__in=group_ids)
+    groups = Group.objects.filter(id__in=event_data.group_ids)
     group_id_to_group = {group.id: group for group in groups}
 
-    bulk_event_id_to_events = bulk_fetch_events(list(event_ids), project_id)
-    bulk_occurrences = IssueOccurrence.fetch_multi(list(occurrence_ids), project_id=project_id)
+    bulk_event_id_to_events = bulk_fetch_events(list(event_data.event_ids), project_id)
+    bulk_occurrences = IssueOccurrence.fetch_multi(
+        list(event_data.occurrence_ids), project_id=project_id
+    )
 
     bulk_occurrence_id_to_occurrence = {
         occurrence.id: occurrence for occurrence in bulk_occurrences if occurrence
     }
 
+    groups_to_dcg_ids = {
+        group_id: {dcg.id for dcg in dcgs} for group_id, dcgs in groups_to_dcgs.items()
+    }
+
     group_to_groupevent: dict[Group, GroupEvent] = {}
-    for dcg_group, instance_data in dcg_group_to_event_data.items():
-        event_id = instance_data.get("event_id")
-        occurrence_id = instance_data.get("occurrence_id")
+    for key, instance in event_data.events.items():
+        if key.dcg_ids.intersection(groups_to_dcg_ids.get(key.group_id, set())):
+            event = bulk_event_id_to_events.get(instance.event_id)
+            group = group_id_to_group.get(key.group_id)
 
-        if event_id is None:
-            continue
+            if not group or not event:
+                continue
 
-        event = bulk_event_id_to_events.get(event_id)
-        group = group_id_to_group.get(int(dcg_group[1]))
-
-        if not group or not event:
-            continue
-
-        group_event = event.for_group(group)
-        if occurrence_id:
-            group_event.occurrence = bulk_occurrence_id_to_occurrence.get(occurrence_id)
-        group_to_groupevent[group] = group_event
+            group_event = event.for_group(group)
+            if instance.occurrence_id:
+                group_event.occurrence = bulk_occurrence_id_to_occurrence.get(
+                    instance.occurrence_id
+                )
+            group_to_groupevent[group] = group_event
 
     return group_to_groupevent
 
@@ -432,8 +487,8 @@ def get_group_to_groupevent(
 @sentry_sdk.trace
 def fire_actions_for_groups(
     organization: Organization,
-    groups_to_fire: dict[int, set[DataConditionGroup]],
-    trigger_group_to_dcg_model: dict[DataConditionHandler.Group, dict[int, int]],
+    groups_to_fire: dict[GroupId, set[DataConditionGroup]],
+    event_data: EventRedisData,
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
     serialized_groups = {
@@ -455,19 +510,23 @@ def fire_actions_for_groups(
         for group, group_event in group_to_groupevent.items():
             with tracker.track(str(group.id)), log_context.new_context(group_id=group.id):
                 event_data = WorkflowEventData(event=group_event)
-                detector = get_detector_by_event(event_data)
+                detector = get_detector_by_event(workflow_event_data)
 
                 workflow_triggers: set[DataConditionGroup] = set()
                 action_filters: set[DataConditionGroup] = set()
                 for dcg in groups_to_fire[group.id]:
                     if (
                         dcg.id
-                        in trigger_group_to_dcg_model[DataConditionHandler.Group.WORKFLOW_TRIGGER]
+                        in event_data.trigger_group_to_dcg_model[
+                            DataConditionHandler.Group.WORKFLOW_TRIGGER
+                        ]
                     ):
                         workflow_triggers.add(dcg)
                     elif (
                         dcg.id
-                        in trigger_group_to_dcg_model[DataConditionHandler.Group.ACTION_FILTER]
+                        in event_data.trigger_group_to_dcg_model[
+                            DataConditionHandler.Group.ACTION_FILTER
+                        ]
                     ):
                         action_filters.add(dcg)
 
@@ -479,14 +538,14 @@ def fire_actions_for_groups(
                 with log_if_slow(
                     logger,
                     "workflow_engine.delayed_workflow.slow_evaluate_workflows_action_filters",
-                    extra={"event_data": event_data},
+                    extra={"event_data": workflow_event_data},
                     threshold_seconds=1,
                 ):
                     workflows_actions = evaluate_workflows_action_filters(workflows, event_data)
                 filtered_actions = filter_recently_fired_workflow_actions(
                     action_filters | workflows_actions, event_data
                 )
-                create_workflow_fire_histories(filtered_actions, event_data)
+                create_workflow_fire_histories(filtered_actions, workflow_event_data)
 
                 metrics.incr(
                     "workflow_engine.delayed_workflow.triggered_actions",
@@ -500,7 +559,7 @@ def fire_actions_for_groups(
                         "workflow_ids": [workflow.id for workflow in workflows],
                         "actions": [action.id for action in filtered_actions],
                         "event_data": event_data,
-                        "event_id": event_data.event.event_id,
+                        "event_id": workflow_event_data.event.event_id,
                     },
                 )
 
@@ -509,14 +568,14 @@ def fire_actions_for_groups(
                     organization,
                 ):
                     for action in filtered_actions:
-                        action.trigger(event_data, detector)
+                        action.trigger(workflow_event_data, detector)
 
 
 @sentry_sdk.trace
 def cleanup_redis_buffer(
-    project_id: int, workflow_event_dcg_data: dict[str, str], batch_key: str | None
+    project_id: int, event_keys: Iterable[EventKey], batch_key: str | None
 ) -> None:
-    hashes_to_delete = list(workflow_event_dcg_data.keys())
+    hashes_to_delete = [key.original_key for key in event_keys]
     filters: dict[str, BufferField] = {"project_id": project_id}
     if batch_key:
         filters["batch_key"] = batch_key
@@ -558,36 +617,28 @@ def process_delayed_workflows(
         if not project:
             return
 
-        workflow_event_dcg_data = fetch_group_to_event_data(project_id, Workflow, batch_key)
+        redis_data = fetch_group_to_event_data(project_id, Workflow, batch_key)
+        event_data = EventRedisData.from_redis_data(redis_data)
 
         metrics.incr(
             "workflow_engine.delayed_workflow",
-            amount=len(workflow_event_dcg_data),
+            amount=len(event_data.events),
         )
 
-        # Get mappings from DataConditionGroups to other info
-        dcg_to_groups, trigger_group_to_dcg_model = get_dcg_group_workflow_detector_data(
-            workflow_event_dcg_data
-        )
-        dcg_to_workflow = trigger_group_to_dcg_model[
-            DataConditionHandler.Group.WORKFLOW_TRIGGER
-        ].copy()
-        dcg_to_workflow.update(trigger_group_to_dcg_model[DataConditionHandler.Group.ACTION_FILTER])
-
-        _, workflows_to_envs = fetch_workflows_envs(list(dcg_to_workflow.values()))
-        data_condition_groups = fetch_data_condition_groups(list(dcg_to_groups.keys()))
+        workflows_to_envs = fetch_workflows_envs(list(event_data.workflow_ids))
+        data_condition_groups = fetch_data_condition_groups(list(event_data.dcg_ids))
 
     logger.info(
         "delayed_workflow.workflows",
         extra={
             "data": workflow_event_dcg_data,
-            "workflows": set(dcg_to_workflow.values()),
+            "workflows": event_data.workflow_ids,
         },
     )
 
     # Get unique query groups to query Snuba
     condition_groups = get_condition_query_groups(
-        data_condition_groups, dcg_to_groups, dcg_to_workflow, workflows_to_envs
+        data_condition_groups, event_data, workflows_to_envs
     )
     if not condition_groups:
         return
@@ -617,8 +668,7 @@ def process_delayed_workflows(
     groups_to_dcgs = get_groups_to_fire(
         data_condition_groups,
         workflows_to_envs,
-        dcg_to_workflow,
-        dcg_to_groups,
+        event_data,
         condition_group_results,
     )
     logger.info(
@@ -627,21 +677,14 @@ def process_delayed_workflows(
     )
 
     with sentry_sdk.start_span(op="delayed_workflow.get_group_to_groupevent"):
-        dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(
-            workflow_event_dcg_data, groups_to_dcgs
-        )
         group_to_groupevent = get_group_to_groupevent(
-            dcg_group_to_event_data,
-            list(groups_to_dcgs.keys()),
-            event_ids,
-            occurrence_ids,
+            event_data,
+            groups_to_dcgs,
             project_id,
         )
 
-    fire_actions_for_groups(
-        project.organization, groups_to_dcgs, trigger_group_to_dcg_model, group_to_groupevent
-    )
-    cleanup_redis_buffer(project_id, workflow_event_dcg_data, batch_key)
+    fire_actions_for_groups(project.organization, groups_to_dcgs, event_data, group_to_groupevent)
+    cleanup_redis_buffer(project_id, event_data.events.keys(), batch_key)
 
 
 @delayed_processing_registry.register("delayed_workflow")

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -526,7 +525,7 @@ def fire_actions_for_groups(
     ) as tracker:
         for group, group_event in group_to_groupevent.items():
             with tracker.track(str(group.id)), log_context.new_context(group_id=group.id):
-                event_data = WorkflowEventData(event=group_event)
+                workflow_event_data = WorkflowEventData(event=group_event)
                 detector = get_detector_by_event(workflow_event_data)
 
                 workflow_triggers: set[DataConditionGroup] = set()
@@ -650,7 +649,7 @@ def process_delayed_workflows(
     logger.info(
         "delayed_workflow.workflows",
         extra={
-            "data": workflow_event_dcg_data,
+            "data": redis_data,
             "workflows": event_data.workflow_ids,
         },
     )

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Mapping, Sequence, Iterable
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import cached_property
@@ -541,9 +541,11 @@ def fire_actions_for_groups(
                     extra={"event_data": workflow_event_data},
                     threshold_seconds=1,
                 ):
-                    workflows_actions = evaluate_workflows_action_filters(workflows, event_data)
+                    workflows_actions = evaluate_workflows_action_filters(
+                        workflows, workflow_event_data
+                    )
                 filtered_actions = filter_recently_fired_workflow_actions(
-                    action_filters | workflows_actions, event_data
+                    action_filters | workflows_actions, workflow_event_data
                 )
                 create_workflow_fire_histories(filtered_actions, workflow_event_data)
 

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from dataclasses import asdict
 from datetime import timedelta
 from unittest.mock import Mock, call, patch
@@ -41,8 +40,9 @@ from sentry.workflow_engine.models.data_condition import (
 )
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
 from sentry.workflow_engine.processors.delayed_workflow import (
-    DataConditionGroupEvent,
-    DataConditionGroupGroups,
+    EventInstance,
+    EventKey,
+    EventRedisData,
     UniqueConditionQuery,
     bulk_fetch_events,
     cleanup_redis_buffer,
@@ -52,10 +52,8 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     generate_unique_queries,
     get_condition_group_results,
     get_condition_query_groups,
-    get_dcg_group_workflow_detector_data,
     get_group_to_groupevent,
     get_groups_to_fire,
-    parse_dcg_group_event_data,
 )
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
@@ -67,6 +65,11 @@ from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
 FROZEN_TIME = before_now(days=1).replace(hour=1, minute=30, second=0, microsecond=0)
+
+
+def dcg_ids_to_str(dcgs: list[DataConditionGroup]) -> str:
+    """Convert a list of DCGs to a comma-delimited string of their IDs."""
+    return ",".join(str(dcg.id) for dcg in dcgs)
 
 
 class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
@@ -92,10 +95,10 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         self.create_event(self.project.id, FROZEN_TIME, "group-2", self.environment.name)
 
         self.workflow_group_dcg_mapping = {
-            f"{self.workflow1.id}:{self.group1.id}:{self.workflow1_dcgs[0].id}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow1.id}:{self.group1.id}:{self.workflow1_dcgs[1].id}:{DataConditionHandler.Group.ACTION_FILTER}",
-            f"{self.workflow2.id}:{self.group2.id}:{self.workflow2_dcgs[0].id}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow2.id}:{self.group2.id}:{self.workflow2_dcgs[1].id}:{DataConditionHandler.Group.ACTION_FILTER}",
+            f"{self.workflow1.id}:{self.group1.id}:{dcg_ids_to_str([self.workflow1_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
+            f"{self.workflow1.id}:{self.group1.id}:{dcg_ids_to_str([self.workflow1_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
+            f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str([self.workflow2_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
+            f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str([self.workflow2_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
         }
 
         self.event3, self.group3 = self.setup_event(self.project2, self.environment2, "group-3")
@@ -108,42 +111,15 @@ class TestDelayedWorkflowBase(BaseWorkflowTest, BaseEventFrequencyPercentTest):
         self._make_sessions(60, project=self.project2)
 
         self.workflow_group_dcg_mapping2 = {
-            f"{self.workflow3.id}:{self.group3.id}:{self.workflow3_dcgs[0].id}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow3.id}:{self.group3.id}:{self.workflow3_dcgs[1].id}:{DataConditionHandler.Group.ACTION_FILTER}",
-            f"{self.workflow4.id}:{self.group4.id}:{self.workflow4_dcgs[0].id}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
-            f"{self.workflow4.id}:{self.group4.id}:{self.workflow4_dcgs[1].id}:{DataConditionHandler.Group.ACTION_FILTER}",
+            f"{self.workflow3.id}:{self.group3.id}:{dcg_ids_to_str([self.workflow3_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
+            f"{self.workflow3.id}:{self.group3.id}:{dcg_ids_to_str([self.workflow3_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
+            f"{self.workflow4.id}:{self.group4.id}:{dcg_ids_to_str([self.workflow4_dcgs[0]])}:{DataConditionHandler.Group.WORKFLOW_TRIGGER}",
+            f"{self.workflow4.id}:{self.group4.id}:{dcg_ids_to_str([self.workflow4_dcgs[1]])}:{DataConditionHandler.Group.ACTION_FILTER}",
         }
-
-        self.dcg_to_groups: DataConditionGroupGroups = {
-            dcg.id: {self.group1.id} for dcg in self.workflow1_dcgs
-        } | {dcg.id: {self.group2.id} for dcg in self.workflow2_dcgs}
-        self.trigger_group_to_dcg_model: dict[DataConditionHandler.Group, dict[int, int]] = (
-            defaultdict(dict)
-        )
-
-        self.workflow_dcgs = self.workflow1_dcgs + self.workflow2_dcgs
-        for i, dcg in enumerate(self.workflow_dcgs):
-            handler_type = (
-                DataConditionHandler.Group.WORKFLOW_TRIGGER
-                if i % 2 == 0
-                else DataConditionHandler.Group.ACTION_FILTER
-            )
-            workflow_id = self.workflow1.id if i < len(self.workflow1_dcgs) else self.workflow2.id
-            self.trigger_group_to_dcg_model[handler_type][dcg.id] = workflow_id
 
         self.detector = Detector.objects.get(project_id=self.project.id, type=ErrorGroupType.slug)
         self.detector_dcg = self.create_data_condition_group()
         self.detector.update(workflow_condition_group=self.detector_dcg)
-        self.trigger_group_to_dcg_model[DataConditionHandler.Group.DETECTOR_TRIGGER][
-            self.detector_dcg.id
-        ] = self.detector.id
-
-        self.dcg_to_workflow = self.trigger_group_to_dcg_model[
-            DataConditionHandler.Group.WORKFLOW_TRIGGER
-        ].copy()
-        self.dcg_to_workflow.update(
-            self.trigger_group_to_dcg_model[DataConditionHandler.Group.ACTION_FILTER]
-        )
 
         self.mock_redis_buffer = mock_redis_buffer()
         self.mock_redis_buffer.__enter__()
@@ -269,38 +245,15 @@ class TestDelayedWorkflowHelpers(TestDelayedWorkflowBase):
         assert len(buffer_data) == 4
         assert set(buffer_data.keys()) == self.workflow_group_dcg_mapping2
 
-    def test_get_dcg_group_workflow_detector_data(self):
-        self._push_base_events()
-
-        self.push_to_hash(
-            self.project.id,
-            self.detector.id,
-            self.group1.id,
-            [self.detector_dcg.id],
-            self.event1.event_id,
-            dcg_group=DataConditionHandler.Group.DETECTOR_TRIGGER,
-        )
-        self.dcg_to_groups[self.detector_dcg.id] = {self.group1.id}
-
-        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        dcg_to_groups, trigger_group_to_dcg_model = get_dcg_group_workflow_detector_data(
-            buffer_data
-        )
-
-        assert dcg_to_groups == self.dcg_to_groups
-        assert trigger_group_to_dcg_model == self.trigger_group_to_dcg_model
-
     def test_fetch_workflows_envs(self):
-        workflow_ids_to_workflows, workflows_to_envs = fetch_workflows_envs(
-            list(self.dcg_to_workflow.values())
+        self._push_base_events()
+        event_data = EventRedisData.from_redis_data(
+            fetch_group_to_event_data(self.project.id, Workflow)
         )
+        workflows_to_envs = fetch_workflows_envs(list(event_data.workflow_ids))
         assert workflows_to_envs == {
             self.workflow1.id: self.environment.id,
             self.workflow2.id: None,
-        }
-        assert workflow_ids_to_workflows == {
-            self.workflow1.id: self.workflow1,
-            self.workflow2.id: self.workflow2,
         }
 
 
@@ -444,7 +397,12 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
         }
         workflows_to_envs: dict[int, int | None] = {self.workflow.id: None}
 
-        result = get_condition_query_groups(dcgs, dcg_to_groups, dcg_to_workflow, workflows_to_envs)
+        # Create mock event data with just the required properties
+        mock_event_data = Mock(spec=EventRedisData)
+        mock_event_data.dcg_to_groups = dcg_to_groups
+        mock_event_data.dcg_to_workflow = dcg_to_workflow
+
+        result = get_condition_query_groups(dcgs, mock_event_data, workflows_to_envs)
 
         count_query = generate_unique_queries(self.count_dc, None)[0]
         percent_only_query = generate_unique_queries(self.percent_dc, None)[1]
@@ -583,7 +541,6 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         super().setUp()
 
         self.data_condition_groups = self.workflow1_dcgs + self.workflow2_dcgs + [self.detector_dcg]
-        self.dcg_to_groups[self.detector_dcg.id] = {self.group1.id}
         self.workflows_to_envs = {self.workflow1.id: self.environment.id, self.workflow2.id: None}
         self.condition_group_results: dict[UniqueConditionQuery, QueryResult] = {
             UniqueConditionQuery(
@@ -638,12 +595,26 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
             condition_result=True,
         )
 
+        # Create event data
+        self.event_data = EventRedisData(
+            events={
+                EventKey.from_redis_key(
+                    f"{self.workflow1.id}:{self.group1.id}:{dcg_ids_to_str(self.workflow1_dcgs)}:workflow_trigger"
+                ): EventInstance(event_id="test-event-1"),
+                EventKey.from_redis_key(
+                    f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str(self.workflow2_dcgs)}:workflow_trigger"
+                ): EventInstance(event_id="test-event-2"),
+                EventKey.from_redis_key(
+                    f"{self.detector.id}:{self.group1.id}:{self.detector_dcg.id}:detector_trigger"
+                ): EventInstance(event_id="test-event-1"),
+            }
+        )
+
     def test_simple(self):
         result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
-            self.dcg_to_workflow,
-            self.dcg_to_groups,
+            self.event_data,
             self.condition_group_results,
         )
 
@@ -666,8 +637,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
-            self.dcg_to_workflow,
-            self.dcg_to_groups,
+            self.event_data,
             self.condition_group_results,
         )
 
@@ -688,8 +658,7 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
-            self.dcg_to_workflow,
-            self.dcg_to_groups,
+            self.event_data,
             self.condition_group_results,
         )
 
@@ -698,20 +667,30 @@ class TestGetGroupsToFire(TestDelayedWorkflowBase):
         }
 
     def test_multiple_dcgs_per_group(self):
-        for dcg in self.workflow1_dcgs:
-            self.dcg_to_groups[dcg.id].add(self.group2.id)
-        for dcg in self.workflow2_dcgs:
-            self.dcg_to_groups[dcg.id].add(self.group1.id)
+        # Create new entries for additional DCGs
+        new_entries = {
+            # Add workflow2 DCGs for group1
+            EventKey.from_redis_key(
+                f"{self.workflow2.id}:{self.group1.id}:{dcg_ids_to_str(self.workflow2_dcgs)}:workflow_trigger"
+            ): EventInstance(event_id="test-event-1"),
+            # Add workflow1 DCGs for group2
+            EventKey.from_redis_key(
+                f"{self.workflow1.id}:{self.group2.id}:{dcg_ids_to_str(self.workflow1_dcgs)}:workflow_trigger"
+            ): EventInstance(event_id="test-event-2"),
+            # Add workflow2 DCGs for group2
+            EventKey.from_redis_key(
+                f"{self.workflow2.id}:{self.group2.id}:{dcg_ids_to_str(self.workflow2_dcgs)}:workflow_trigger"
+            ): EventInstance(event_id="test-event-2"),
+        }
+
+        event_data = EventRedisData(events={**self.event_data.events, **new_entries})
 
         result = get_groups_to_fire(
             self.data_condition_groups,
             self.workflows_to_envs,
-            self.dcg_to_workflow,
-            self.dcg_to_groups,
+            event_data,
             self.condition_group_results,
         )
-
-        # all dcgs except workflow 2 IF, which never passes
         assert result == {
             self.group1.id: set(self.workflow1_dcgs + [self.workflow2_dcgs[0]]),
             self.group2.id: set(
@@ -752,55 +731,11 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.group1.id: set(self.workflow1_dcgs),
             self.group2.id: set(self.workflow2_dcgs),
         }
-        self.dcg_group_to_event_data: DataConditionGroupEvent = {}
-        for i, dcg in enumerate(self.workflow_dcgs):
-            if i < 2:
-                group = self.group1
-                event = self.event1
-            else:
-                group = self.group2
-                event = self.event2
-
-            self.dcg_group_to_event_data[(dcg.id, group.id)] = {
-                "event_id": event.event_id,
-                "occurrence_id": None,
-            }
 
         self.group_to_groupevent = {
             self.group1: self.event1.for_group(self.group1),
             self.group2: self.event2.for_group(self.group2),
         }
-
-    def test_parse_dcg_group_event_data(self):
-        self._push_base_events()
-        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(
-            buffer_data, self.groups_to_dcgs
-        )
-
-        assert dcg_group_to_event_data == self.dcg_group_to_event_data
-        assert event_ids == {self.event1.event_id, self.event2.event_id}
-        assert occurrence_ids == set()
-
-    def test_parse_dcg_group_event_data__triggered_groups_only(self):
-        # buffer data represents all the data from the buffer
-        # groups_to_dcgs represents that groups that triggered DCGs --> fire actions
-        # the groups in the buffer may not be fired.
-
-        del self.groups_to_dcgs[self.group1.id]
-
-        self._push_base_events()
-        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
-        dcg_group_to_event_data, event_ids, occurrence_ids = parse_dcg_group_event_data(
-            buffer_data, self.groups_to_dcgs
-        )
-
-        del self.dcg_group_to_event_data[(self.workflow1_dcgs[0].id, self.group1.id)]
-        del self.dcg_group_to_event_data[(self.workflow1_dcgs[1].id, self.group1.id)]
-
-        assert dcg_group_to_event_data == self.dcg_group_to_event_data
-        assert event_ids == {self.event2.event_id}
-        assert occurrence_ids == set()
 
     def test_bulk_fetch_events(self):
         event_ids = [self.event1.event_id, self.event2.event_id]
@@ -810,11 +745,12 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             assert event.event_id in event_ids
 
     def test_get_group_to_groupevent(self):
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        event_data = EventRedisData.from_redis_data(buffer_data)
         group_to_groupevent = get_group_to_groupevent(
-            self.dcg_group_to_event_data,
-            [self.group1.id, self.group2.id],
-            {self.event1.event_id, self.event2.event_id},
-            set(),
+            event_data,
+            self.groups_to_dcgs,
             self.project.id,
         )
         assert group_to_groupevent == self.group_to_groupevent
@@ -822,10 +758,13 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     @patch("sentry.workflow_engine.models.action.Action.trigger")
     @with_feature("organizations:workflow-engine-trigger-actions")
     def test_fire_actions_for_groups__fire_actions(self, mock_trigger):
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        event_data = EventRedisData.from_redis_data(buffer_data)
         fire_actions_for_groups(
             self.project.organization,
             self.groups_to_dcgs,
-            self.trigger_group_to_dcg_model,
+            event_data,
             self.group_to_groupevent,
         )
 
@@ -842,11 +781,13 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     @patch("sentry.workflow_engine.processors.workflow.enqueue_workflows")
     def test_fire_actions_for_groups__enqueue(self, mock_enqueue):
         # enqueue the IF DCGs with slow conditions!
-
+        self._push_base_events()
+        buffer_data = fetch_group_to_event_data(self.project.id, Workflow)
+        event_data = EventRedisData.from_redis_data(buffer_data)
         fire_actions_for_groups(
             self.project.organization,
             self.groups_to_dcgs,
-            self.trigger_group_to_dcg_model,
+            event_data,
             self.group_to_groupevent,
         )
 
@@ -887,20 +828,27 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             [],
         )
 
-        self.trigger_group_to_dcg_model[DataConditionHandler.Group.WORKFLOW_TRIGGER] = {
-            self.workflow1_dcgs[0].id: self.workflow1.id,
-        }
-        self.trigger_group_to_dcg_model[DataConditionHandler.Group.ACTION_FILTER] = {
-            self.workflow2_dcgs[1].id: self.workflow2.id,
-        }
+        # Create event data with specific workflow trigger and action filter mappings
+        event_data = EventRedisData(
+            events={
+                EventKey.from_redis_key(
+                    f"{self.workflow1.id}:{self.group1.id}:{self.workflow1_dcgs[0].id}:workflow_trigger"
+                ): EventInstance(event_id=self.event1.event_id),
+                EventKey.from_redis_key(
+                    f"{self.workflow2.id}:{self.group2.id}:{self.workflow2_dcgs[1].id}:action_filter"
+                ): EventInstance(event_id=self.event2.event_id),
+            }
+        )
+
         self.groups_to_dcgs = {
             self.group1.id: {self.workflow1_dcgs[0]},
             self.group2.id: {self.workflow2_dcgs[1]},
         }
+
         fire_actions_for_groups(
             self.project.organization,
             self.groups_to_dcgs,
-            self.trigger_group_to_dcg_model,
+            event_data,
             self.group_to_groupevent,
         )
 
@@ -924,7 +872,8 @@ class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
         data = buffer.backend.get_hash(Workflow, {"project_id": self.project.id})
         assert set(data.keys()) == self.workflow_group_dcg_mapping
 
-        cleanup_redis_buffer(self.project.id, data, None)
+        event_data = EventRedisData.from_redis_data(data)
+        cleanup_redis_buffer(self.project.id, event_data.events.keys(), None)
         data = buffer.backend.get_hash(Workflow, {"project_id": self.project.id})
         assert data == {}
 
@@ -947,7 +896,8 @@ class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
         first_batch = buffer.backend.get_hash(
             model=Workflow, field={"project_id": self.project.id, "batch_key": batch_one_key}
         )
-        cleanup_redis_buffer(self.project.id, first_batch, batch_one_key)
+        event_data = EventRedisData.from_redis_data(first_batch)
+        cleanup_redis_buffer(self.project.id, event_data.events.keys(), batch_one_key)
 
         # Verify the batch we "executed" is removed
         data = buffer.backend.get_hash(
@@ -962,3 +912,47 @@ class TestCleanupRedisBuffer(TestDelayedWorkflowBase):
         for key in first_batch.keys():
             all_data.pop(key)
         assert data == all_data
+
+
+class TestEventKeyAndInstance:
+    def test_event_key_from_redis_key(self):
+        key = "123:456:789,101:workflow_trigger"
+        event_key = EventKey.from_redis_key(key)
+        assert event_key.workflow_id == 123
+        assert event_key.group_id == 456
+        assert event_key.dcg_ids == frozenset([789, 101])
+        assert event_key.dcg_type == DataConditionHandler.Group.WORKFLOW_TRIGGER
+        assert event_key.original_key == key
+
+    def test_event_key_str_and_hash(self):
+        key = "123:456:789:workflow_trigger"
+        event_key = EventKey.from_redis_key(key)
+        assert str(event_key) == key
+        assert hash(event_key) == hash(key)
+        assert event_key == EventKey.from_redis_key(key)
+        assert event_key != EventKey.from_redis_key("123:456:789:action_filter")
+
+    def test_event_instance_validation(self):
+        # Test valid event instance
+        instance = EventInstance(event_id="test-event")
+        assert instance.event_id == "test-event"
+        assert instance.occurrence_id is None
+
+        # Test with occurrence ID
+        instance = EventInstance(event_id="test-event", occurrence_id="test-occurrence")
+        assert instance.event_id == "test-event"
+        assert instance.occurrence_id == "test-occurrence"
+
+        # Test empty occurrence ID is converted to None
+        instance = EventInstance(event_id="test-event", occurrence_id="")
+        assert instance.event_id == "test-event"
+        assert instance.occurrence_id is None
+
+        # Test whitespace occurrence ID is converted to None
+        instance = EventInstance(event_id="test-event", occurrence_id="   ")
+        assert instance.event_id == "test-event"
+        assert instance.occurrence_id is None
+
+        # Test that parsing without event_id fails
+        with pytest.raises(ValueError, match="event_id"):
+            EventInstance.parse_raw('{"occurrence_id": "test-occurrence"}')


### PR DESCRIPTION
Still some weirdness here, but the aim is to bundle up all of the redis-derived data (TODO: better name for it) and pass that around as an immutable fact rather than obscuring things by having various dicts being passed everywhere.
