### PR TITLE
ref(grouping): Add log to grouping config upgrade

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -86,6 +86,10 @@ def update_or_set_grouping_config_if_needed(project: Project, source: str) -> st
                     }
                 )
 
+            project_option_exists = ProjectOption.objects.filter(
+                key="sentry:grouping_config", project_id=project.id
+            ).exists()
+
             for key, value in changes.items():
                 project.update_option(key, value)
 
@@ -113,6 +117,18 @@ def update_or_set_grouping_config_if_needed(project: Project, source: str) -> st
                     tags={
                         "source": source,
                         "current_config": current_config,
+                    },
+                )
+                # TODO: Temporary log to debug how we're still landing in this branch even though
+                # theoretically there are no projects on outdated configs
+                logger.info(
+                    "grouping.outdated_config_updated",
+                    extra={
+                        "project_id": project.id,
+                        "source": source,
+                        "current_config": current_config,
+                        "project_option_exists": project_option_exists,
+                        "options_epoch": project.get_option("sentry:option-epoch"),
                     },
                 )
                 outcome = "record updated"


### PR DESCRIPTION
In theory, we should only hit the branch of `update_or_set_grouping_config_if_needed` where we're starting with an outdated config and updating it if the project in question has an outdated config. We've long since force-upgraded not only every project on an old config but also every project from an options epoch that would mean it defaults to an old config, so in theory we should no longer be landing in that branch. And yet.

In order to debug how we're still seeing the metric from that branch ping, this adds a log with more specific data (like project id) than what we can gather in DataDog. 

(The extra weird thing is, DataDog says the upgrades are upgrades from the legacy config, and yet no no new transition periods have started, which they should have if the existing config is a valid one. Very mysterious.)