### PR TITLE
fix(nav): Fix secondary sidebar scrolling

### DIFF
--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -51,12 +51,12 @@ export function SecondarySidebar() {
   const activeNavGroup = activePrimaryNavGroup ?? defaultActiveNavGroup;
 
   return (
-    <ResizeWrapper ref={resizableContainerRef} onMouseDown={handleStartResize}>
-      <NavTourElement
-        id={stepId}
-        description={STACKED_NAVIGATION_TOUR_CONTENT[stepId].description}
-        title={STACKED_NAVIGATION_TOUR_CONTENT[stepId].title}
-      >
+    <SecondarySidebarWrapper
+      id={stepId}
+      description={STACKED_NAVIGATION_TOUR_CONTENT[stepId].description}
+      title={STACKED_NAVIGATION_TOUR_CONTENT[stepId].title}
+    >
+      <ResizeWrapper ref={resizableContainerRef} onMouseDown={handleStartResize}>
         <AnimatePresence mode="wait" initial={false}>
           <MotionDiv
             key={activeNavGroup}
@@ -77,18 +77,22 @@ export function SecondarySidebar() {
             />
           </MotionDiv>
         </AnimatePresence>
-      </NavTourElement>
-    </ResizeWrapper>
+      </ResizeWrapper>
+    </SecondarySidebarWrapper>
   );
 }
 
-const ResizeWrapper = styled('div')`
-  position: relative;
-  right: 0;
+const SecondarySidebarWrapper = styled(NavTourElement)`
+  background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface200)};
   border-right: 1px solid
     ${p => (p.theme.isChonk ? p.theme.border : p.theme.translucentGray200)};
-  background: ${p => (p.theme.isChonk ? p.theme.background : p.theme.surface200)};
+  position: relative;
   z-index: ${p => p.theme.zIndex.sidebarPanel};
+  height: 100%;
+`;
+
+const ResizeWrapper = styled('div')`
+  right: 0;
   height: 100%;
   width: ${SECONDARY_SIDEBAR_WIDTH}px;
 `;


### PR DESCRIPTION
Fixes a regression from https://github.com/getsentry/sentry/pull/91546 where you can no longer scroll the secondary sidebar when it overflows (settings menu)