### PR TITLE
fix(aci): update detector serializer to accept list of `dataSources`

### DIFF
--- a/src/sentry/incidents/metric_alert_detector.py
+++ b/src/sentry/incidents/metric_alert_detector.py
@@ -74,7 +74,13 @@ class MetricAlertConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
-    data_source = SnubaQueryValidator(required=True)
+    data_sources = serializers.ListField(
+        child=SnubaQueryValidator(),
+        required=True,
+        min_length=1,
+        max_length=1,
+        help_text="List of data sources to monitor",
+    )
     condition_group = MetricAlertConditionGroupValidator(required=True)
 
     def validate(self, attrs):
@@ -165,9 +171,9 @@ class MetricAlertsDetectorValidator(BaseDetectorTypeValidator):
         if data_conditions:
             self.update_data_conditions(instance, data_conditions)
 
-        data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
-        if data_source:
-            self.update_data_source(instance, data_source)
+        data_sources: list[SnubaQueryDataSourceType] = validated_data.pop("data_sources", [])
+        if len(data_sources) > 0:
+            self.update_data_source(instance, data_sources[0])
 
         instance.save()
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -122,15 +122,17 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             "type": MetricIssue.slug,
             "dateCreated": self.detector.date_added,
             "dateUpdated": timezone.now(),
-            "dataSource": {
-                "queryType": self.snuba_query.type,
-                "dataset": self.snuba_query.dataset,
-                "query": "updated query",
-                "aggregate": self.snuba_query.aggregate,
-                "timeWindow": 5,  # minutes
-                "environment": self.environment.name,
-                "eventTypes": [event_type.name for event_type in self.snuba_query.event_types],
-            },
+            "dataSources": [
+                {
+                    "queryType": self.snuba_query.type,
+                    "dataset": self.snuba_query.dataset,
+                    "query": "updated query",
+                    "aggregate": self.snuba_query.aggregate,
+                    "timeWindow": 5,  # minutes
+                    "environment": self.environment.name,
+                    "eventTypes": [event_type.name for event_type in self.snuba_query.event_types],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -276,15 +276,17 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             "name": "Test Detector",
             "type": MetricIssue.slug,
             "projectId": self.project.id,
-            "dataSource": {
-                "queryType": SnubaQuery.Type.ERROR.value,
-                "dataset": Dataset.Events.name.lower(),
-                "query": "test query",
-                "aggregate": "count()",
-                "timeWindow": 60,
-                "environment": self.environment.name,
-                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
-            },
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.ERROR.value,
+                    "dataset": Dataset.Events.name.lower(),
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 60,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,
@@ -440,7 +442,7 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
     def test_empty_query_string(self):
         data = {**self.valid_data}
-        data["dataSource"]["query"] = ""
+        data["dataSources"][0]["query"] = ""
 
         with self.tasks():
             response = self.get_success_response(

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -101,7 +101,11 @@ class MockConditionGroupValidator(BaseDataConditionGroupValidator):
 
 
 class MockDetectorValidator(BaseDetectorTypeValidator):
-    data_source = MockDataSourceValidator()
+    data_sources = serializers.ListField(
+        child=MockDataSourceValidator(),
+        required=True,
+        min_length=1,
+    )
     condition_group = MockConditionGroupValidator()
 
 
@@ -165,10 +169,12 @@ class DetectorValidatorTest(BaseValidatorTest):
         self.valid_data = {
             "name": "Test Detector",
             "type": MetricIssue.slug,
-            "dataSource": {
-                "field1": "test",
-                "field2": 123,
-            },
+            "dataSources": [
+                {
+                    "field1": "test",
+                    "field2": 123,
+                }
+            ],
             "conditionGroup": {
                 "id": self.data_condition_group.id,
                 "organizationId": self.organization.id,


### PR DESCRIPTION
in the future detectors could have multiple data sources, so it's better to have the validator already set up to accept a list of `dataSources` now