### PR TITLE
ref(tempest): Use playstation URL coming from the API instead of assembling it

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -110,6 +110,7 @@ export type ProjectKey = {
     crons: string;
     csp: string;
     minidump: string;
+    playstation: string;
     public: string;
     secret: string;
     security: string;

--- a/static/app/views/settings/project/loaderScript.spec.tsx
+++ b/static/app/views/settings/project/loaderScript.spec.tsx
@@ -98,6 +98,8 @@ describe('LoaderScript', function () {
             'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f662',
           unreal: '',
           crons: '',
+          playstation:
+            'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
         },
         public: '188ee45a58094d939428d8585aa6f662',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',
@@ -236,6 +238,8 @@ describe('LoaderScript', function () {
             'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f662',
           unreal: '',
           crons: '',
+          playstation:
+            'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
         },
         public: '188ee45a58094d939428d8585aa6f662',
         secret: 'a33bf9aba64c4bbdaf873bb9023b6d2c',

--- a/static/app/views/settings/project/projectKeys/list/index.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.spec.tsx
@@ -161,6 +161,8 @@ describe('ProjectKeys', function () {
           cdn: '',
           unreal: '',
           crons: '',
+          playstation:
+            'http://dev.getsentry.net:8000/api/1/playstation?sentry_key=188ee45a58094d939428d8585aa6f662',
         },
         dateCreated: '2018-02-28T07:13:51.087Z',
         public: '188ee45a58094d939428d8585aa6f662',

--- a/static/app/views/settings/project/tempest/DevKitSettings.tsx
+++ b/static/app/views/settings/project/tempest/DevKitSettings.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
@@ -39,16 +39,6 @@ export default function DevKitSettings({organization, project}: Props) {
     orgSlug: organization.slug,
     projSlug: project.slug,
   });
-
-  const playstationURL = useMemo(() => {
-    if (!projectKeys) {
-      return null;
-    }
-
-    // xxx (vgrozdanic): this is a temporary hack since the playstation URL is almost the same as for the minidump
-    const primaryKey = projectKeys[0];
-    return primaryKey?.dsn?.minidump.replace('minidump', 'playstation');
-  }, [projectKeys]);
 
   if (isLoadingKeys) {
     return <LoadingIndicator />;
@@ -94,7 +84,7 @@ export default function DevKitSettings({organization, project}: Props) {
                       </p>
                       <CodeSnippetWrapper>
                         <OnboardingCodeSnippet>
-                          {playstationURL || ''}
+                          {projectKeys?.[0]?.dsn?.playstation || ''}
                         </OnboardingCodeSnippet>
                       </CodeSnippetWrapper>
                     </DescriptionWrapper>

--- a/tests/js/fixtures/projectKeys.ts
+++ b/tests/js/fixtures/projectKeys.ts
@@ -15,6 +15,8 @@ export function ProjectKeysFixture(params: ProjectKey[] = []): ProjectKey[] {
         csp: 'http://dev.getsentry.net:8000/api/1/csp-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
         security:
           'http://dev.getsentry.net:8000/api/1/security-report/?sentry_key=188ee45a58094d939428d8585aa6f661',
+        playstation:
+          'http://dev.getsentry.net:8000/api/1/playstation/?sentry_key=188ee45a58094d939428d8585aa6f661',
       },
       public: '188ee45a58094d939428d8585aa6f661',
       secret: 'a33bf9aba64c4bbdaf873bb9023b6d2d',

--- a/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
+++ b/tests/js/sentry-test/onboarding/renderWithOnboardingLayout.tsx
@@ -76,6 +76,7 @@ export function renderWithOnboardingLayout<
         csp: 'test-csp',
         minidump: 'test-minidump',
         unreal: 'test-unreal',
+        playstation: 'test-playstation',
       }}
       platformKey="java-spring-boot"
       projectId="test-project-id"


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/93232 playstation URL has been implemented in our API so there is no longer a need to assemble it on the frontend

Closes [TET-587: Add playstation URL in project keys endpoint, like there is for minidumps](https://linear.app/getsentry/issue/TET-587/add-playstation-url-in-project-keys-endpoint-like-there-is-for)