### PR TITLE
feat(agent-insights): Add pagination to traces table

### DIFF
--- a/static/app/views/explore/hooks/useTraces.tsx
+++ b/static/app/views/explore/hooks/useTraces.tsx
@@ -1,3 +1,5 @@
+import {keepPreviousData as keepPreviousDataFn} from '@tanstack/react-query';
+
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
 import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -60,6 +62,7 @@ interface UseTracesOptions {
   dataset?: DiscoverDatasets;
   datetime?: PageFilters['datetime'];
   enabled?: boolean;
+  keepPreviousData?: boolean;
   limit?: number;
   query?: string | string[];
   sort?: 'timestamp' | '-timestamp';
@@ -77,6 +80,7 @@ export function useTraces({
   limit,
   query,
   sort,
+  keepPreviousData,
 }: UseTracesOptions): UseTracesResult {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -103,6 +107,7 @@ export function useTraces({
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     retry: false,
+    placeholderData: keepPreviousData ? keepPreviousDataFn : undefined,
     enabled,
   });
 

--- a/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
@@ -1,6 +1,5 @@
 import {Fragment, memo, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -70,11 +69,14 @@ export function ModelsTable() {
 
   const fullQuery = `${getAIGenerationsFilter()} ${query}`.trim();
 
-  const handleCursor: CursorHandler = (cursor, pathname, transactionQuery) => {
+  const handleCursor: CursorHandler = (cursor, pathname, previousQuery) => {
     navigate(
       {
         pathname,
-        search: qs.stringify({...transactionQuery, modelsCursor: cursor}),
+        query: {
+          ...previousQuery,
+          tableCursor: cursor,
+        },
       },
       {replace: true, preventScrollReset: true}
     );

--- a/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
@@ -1,5 +1,4 @@
 import {Fragment, memo, useCallback, useMemo} from 'react';
-import * as qs from 'query-string';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -62,11 +61,14 @@ export function ToolsTable() {
 
   const fullQuery = `${getAIToolCallsFilter()} ${query}`.trim();
 
-  const handleCursor: CursorHandler = (cursor, pathname, transactionQuery) => {
+  const handleCursor: CursorHandler = (cursor, pathname, previousQuery) => {
     navigate(
       {
         pathname,
-        search: qs.stringify({...transactionQuery, toolsCursor: cursor}),
+        query: {
+          ...previousQuery,
+          tableCursor: cursor,
+        },
       },
       {replace: true, preventScrollReset: true}
     );

--- a/static/app/views/insights/agentMonitoring/hooks/useActiveTable.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useActiveTable.tsx
@@ -51,9 +51,7 @@ export function useActiveTable() {
       updateQuery({
         view,
         // Clear table cursors and sort order
-        tracesCursor: undefined,
-        modelsCursor: undefined,
-        toolsCursor: undefined,
+        tableCursor: undefined,
         field: undefined,
         order: undefined,
       });


### PR DESCRIPTION
Add pagination to traces table.
Add keepPreviousData functionality to `useTraces` hook.
Disable sorting in traces table, as future columns will not support sorting in the first iteration.

- closes [TET-650: Traces Table pagination & sort](https://linear.app/getsentry/issue/TET-650/traces-table-pagination-and-sort)
