### PR TITLE
ref(agent-insights): Display tool args and result in AI IO sections

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -117,22 +117,6 @@ export function getHighlightedSpanAttributes({
     });
   }
 
-  const toolArgs = getAttribute(attributeObject, 'gen_ai.tool.input');
-  if (toolArgs) {
-    highlightedAttributes.push({
-      name: t('Arguments'),
-      value: toolArgs,
-    });
-  }
-
-  const toolResult = getAttribute(attributeObject, 'gen_ai.tool.output');
-  if (toolResult) {
-    highlightedAttributes.push({
-      name: t('Result'),
-      value: toolResult,
-    });
-  }
-
   return highlightedAttributes;
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -146,9 +146,11 @@ export function AIInputSection({
     promptMessages = inputMessages && transformInputMessages(inputMessages);
   }
 
-  const aiInput = defined(promptMessages) && parseAIMessages(promptMessages);
+  const messages = defined(promptMessages) && parseAIMessages(promptMessages);
 
-  if (!aiInput) {
+  const toolArgs = getTraceNodeAttribute('gen_ai.tool.input', node, event, attributes);
+
+  if (!messages && !toolArgs) {
     return null;
   }
 
@@ -159,13 +161,13 @@ export function AIInputSection({
       disableCollapsePersistence
     >
       {/* If parsing fails, we'll just show the raw string */}
-      {typeof aiInput === 'string' ? (
+      {typeof messages === 'string' ? (
         <TraceDrawerComponents.MultilineText>
-          {aiInput}
+          {messages}
         </TraceDrawerComponents.MultilineText>
-      ) : (
+      ) : messages ? (
         <Fragment>
-          {aiInput.map((message, index) => (
+          {messages.map((message, index) => (
             <Fragment key={index}>
               <TraceDrawerComponents.MultilineTextLabel>
                 {roleHeadings[message.role]}
@@ -176,7 +178,10 @@ export function AIInputSection({
             </Fragment>
           ))}
         </Fragment>
-      )}
+      ) : null}
+      {toolArgs ? (
+        <TraceDrawerComponents.MultilineJSON value={toolArgs} maxDefaultDepth={1} />
+      ) : null}
     </FoldSection>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -50,8 +50,9 @@ export function AIOutputSection({
     event,
     attributes
   );
+  const toolOutput = getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes);
 
-  if (!responseText && !toolCalls) {
+  if (!responseText && !toolCalls && !toolOutput) {
     return null;
   }
 
@@ -85,6 +86,9 @@ export function AIOutputSection({
           </TraceDrawerComponents.MultilineText>
         </Fragment>
       )}
+      {toolOutput ? (
+        <TraceDrawerComponents.MultilineJSON value={toolOutput} maxDefaultDepth={1} />
+      ) : null}
     </FoldSection>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -30,6 +30,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import QuestionTooltip from 'sentry/components/questionTooltip';
+import {StructuredData} from 'sentry/components/structuredEventData';
 import {
   IconCircleFill,
   IconEllipsis,
@@ -1243,6 +1244,31 @@ const MultilineText = styled('div')`
   }
 `;
 
+function MultilineJSON({
+  value,
+  maxDefaultDepth = 2,
+}: {
+  value: string;
+  maxDefaultDepth?: number;
+}) {
+  try {
+    const json = JSON.parse(value);
+    return (
+      <TraceDrawerComponents.MultilineText>
+        <StructuredData
+          value={json}
+          maxDefaultDepth={maxDefaultDepth}
+          withAnnotatedText
+        />
+      </TraceDrawerComponents.MultilineText>
+    );
+  } catch (error) {
+    return (
+      <TraceDrawerComponents.MultilineText>{value}</TraceDrawerComponents.MultilineText>
+    );
+  }
+}
+
 const MultilineTextLabel = styled('div')`
   font-weight: bold;
   margin-bottom: ${space(1)};
@@ -1280,6 +1306,7 @@ const TraceDrawerComponents = {
   SectionCardGroup,
   DropdownMenuWithPortal,
   MultilineText,
+  MultilineJSON,
   MultilineTextLabel,
 };
 


### PR DESCRIPTION
Display tool args and result inside AI input and output section in the span details.

<img width="498" alt="Screenshot 2025-06-16 at 14 02 00" src="https://github.com/user-attachments/assets/5b7f0a6b-4d5f-437e-a183-cdb742fd632f" />

- closes [TET-627: Render input/output of a tool call similar to llm call input/output](https://linear.app/getsentry/issue/TET-627/render-inputoutput-of-a-tool-call-similar-to-llm-call-inputoutput)