### PR TITLE
ref: simplify migration squasher now that there are no cycles

### DIFF
--- a/tools/migrations/squash.py
+++ b/tools/migrations/squash.py
@@ -1,8 +1,8 @@
 import ast
-import collections
-import graphlib
+import contextlib
 import os.path
 import subprocess
+from collections.abc import Generator
 from typing import NamedTuple
 
 # for squash
@@ -77,15 +77,16 @@ def _migration_root(app: str) -> str:
         return f"src/sentry/{app}/migrations"
 
 
-def _is_migration(fname: str) -> bool:
-    return fname.startswith("0") and fname.endswith(".py")
+def _migrations(root: str) -> Generator[str]:
+    for fname in os.listdir(root):
+        if fname.startswith("0") and fname.endswith(".py"):
+            yield fname
 
 
 def _get_replaces(root: str) -> list[str]:
     ret = []
-    for fname in os.listdir(root):
-        if _is_migration(fname):
-            ret.append(fname.removesuffix(".py"))
+    for fname in _migrations(root):
+        ret.append(fname.removesuffix(".py"))
     ret.sort()
     return ret
 
@@ -108,86 +109,61 @@ def _parse_lockfile() -> list[App]:
     return apps
 
 
-def _find_migration(app: App, n: int) -> str:
-    (fname,) = (
-        fname
-        for fname in os.listdir(app.root)
-        if _is_migration(fname) and fname.startswith(f"{n:04}_")
-    )
-    return os.path.join(app.root, fname)
+def _dependencies(app: App, tree: ast.AST) -> Generator[tuple[ast.Tuple, str]]:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and _is_assign_to(node, "dependencies")
+            and isinstance(node.value, ast.List)
+        ):
+            for elt in node.value.elts:
+                if isinstance(elt, ast.Tuple):
+                    cand, _ = ast.literal_eval(elt)
+                    if cand != app.name:
+                        yield elt, cand
 
 
-class FindReplaces(ast.NodeVisitor):
-    def __init__(self) -> None:
-        self.replaces_range: slice | None = None
-
-    def visit_Assign(self, node: ast.Assign) -> None:
-        if _is_assign_to(node, "replaces"):
-            self.replaces_range = slice(node.lineno - 1, node.end_lineno)
-
-        self.generic_visit(node)
+def _target_line(target: str, squashed: dict[str, App]) -> str:
+    return f'        ("{target}", "{squashed[target].squash_name}"),'
 
 
-def _clear_out_replaces(apps: list[App]) -> None:
-    for app in apps:
-        fname = _find_migration(app, 1)
+@contextlib.contextmanager
+def _cleared_deps(already_squashed: list[App], squash: dict[str, App]) -> Generator[None]:
+    all_fixups = []
+    for app in already_squashed:
+        with open(app.squash_fname, encoding="UTF-8") as f:
+            lines = f.readlines()
 
-        with open(fname, encoding="UTF-8") as f:
-            lines = list(f)
-
-        visitor = FindReplaces()
-        visitor.visit(ast.parse("".join(lines), filename=fname))
-
-        if visitor.replaces_range is not None:
-            del lines[visitor.replaces_range]
-
-            with open(fname, "w", encoding="UTF-8") as f:
-                f.writelines(lines)
-
-
-def _clean_one_depends(app: App, already_squashed: set[tuple[str, str]]) -> dict[str, set[str]]:
-    ret: dict[str, set[str]]
-    ret = collections.defaultdict(set)
-    for fname in os.listdir(app.root):
-        if not _is_migration(fname):
-            continue
-
-        joined = os.path.join(app.root, fname)
-        with open(joined, encoding="UTF-8") as f:
-            lines = list(f)
-
-        tree = ast.parse("".join(lines), filename=joined)
-
-        fixups = []
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Assign)
-                and _is_assign_to(node, "dependencies")
-                and isinstance(node.value, ast.List)
-            ):
-                for elt in node.value.elts:
-                    if isinstance(elt, ast.Tuple):
-                        target = ast.literal_eval(elt)
-                        cand, _ = target
-                        if cand != app.name:
-                            ret[cand].add(fname.removesuffix(".py"))
-                            if target not in already_squashed:
-                                fixups.append(elt.lineno)
+        tree = ast.parse("".join(lines), filename=app.squash_fname)
+        fixups = {elt.lineno: target for elt, target in _dependencies(app, tree)}
 
         if fixups:
-            for fixup in fixups:
-                lines[fixup - 1] = lines[fixup - 1].replace("(", "# (", count=1)
-            with open(joined, "w", encoding="UTF-8") as f:
-                f.writelines(lines)
+            all_fixups.append((app.squash_fname, fixups))
 
-    subprocess.check_call(("git", "add", app.root))
+            with open(app.squash_fname, "w", encoding="UTF-8") as f:
+                f.writelines(
+                    (f"# {line}" if i in fixups else line for i, line in enumerate(lines, start=1))
+                )
 
-    return ret
+    try:
+        yield
+    finally:
+        for fname, fixups in all_fixups:
+            with open(fname, encoding="UTF-8") as f:
+                lines = f.readlines()
+
+            with open(fname, "w", encoding="UTF-8") as f:
+                f.writelines(
+                    (
+                        _target_line(fixups[i], squash) if i in fixups else line
+                        for i, line in enumerate(lines, start=1)
+                    )
+                )
 
 
-def _clear_out_depends(apps: list[App]) -> dict[str, dict[str, set[str]]]:
-    already_squashed = {(app.name, app.current) for app in apps if app.is_already_squashed}
-    return {app.name: _clean_one_depends(app, already_squashed) for app in apps}
+def _delete_migrations(app: App) -> None:
+    for fname in _migrations(app.root):
+        os.remove(os.path.join(app.root, fname))
 
 
 class FixupVisitor(ast.NodeVisitor):
@@ -225,16 +201,26 @@ class FixupVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def _fixup(fname: str, replaces: list[tuple[str, str]]) -> None:
-    with open(fname, encoding="UTF-8") as f:
+def _fixup(app: App, squash: dict[str, App]) -> None:
+    os.rename(os.path.join(app.root, "0001_squash.py"), app.squash_fname)
+
+    with open(app.squash_fname, encoding="UTF-8") as f:
         lines = list(f)
 
+    tree = ast.parse("".join(lines), filename=app.squash_fname)
+
+    for elt, target in _dependencies(app, tree):
+        if target in squash:
+            lines[elt.lineno - 1] = _target_line(target, squash)
+
     visitor = FixupVisitor()
-    visitor.visit(ast.parse("".join(lines), filename=fname))
+    visitor.visit(tree)
 
     if visitor.first_exclude_constraint is not None:
         gist_table, gist_line = visitor.first_exclude_constraint
         lines.insert(gist_line - 1, _GIST_EXT.format(table=gist_table))
+
+    replaces = [(app.name, replace) for replace in app.replaces]
 
     assert visitor.is_post_deployment_lineno is not None
     post_deploy_and_replaces = f"""\
@@ -255,216 +241,39 @@ def _fixup(fname: str, replaces: list[tuple[str, str]]) -> None:
     if visitor.first_exclude_constraint is not None:
         lines.insert(2, _SAFE_RUN_SQL_IMPORT)
 
-    with open(fname, "w", encoding="UTF-8") as f:
-        f.writelines(lines)
-
-
-def _squash_one(repo: str, app: App) -> None:
-    print(f"squashing {app.name}...")
-    if app.is_already_squashed:
-        print("==> skipped (already squashed!)")
-        return
-    for fname in os.listdir(app.root):
-        if _is_migration(fname):
-            os.remove(os.path.join(app.root, fname))
-
-    name = f"squashed_{app.current}"
-    cmd = (repo, "django", "makemigrations", app.name, "-n", name)
-    subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
-
-    replaces = [(app.name, mod) for mod in app.replaces]
-    _fixup(app.squash_fname, replaces)
-
-
-def _remove_sentry_references(apps: list[App]) -> None:
-    for app in apps:
-        if app.name == "sentry":
-            continue
-
-        with open(app.squash_fname, encoding="UTF-8") as f:
-            lines = list(f)
-
-        lines = [
-            line.replace("(", "# (", count=1) if line.startswith('        ("sentry", ') else line
-            for line in lines
-        ]
-
-        with open(app.squash_fname, "w", encoding="UTF-8") as f:
-            f.writelines(lines)
-
-
-class RemoveWorkflowEngineVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
-        self.dependencies_range: slice | None = None
-        self.fkey_range: slice | None = None
-        self.constraint_range: slice | None = None
-
-    def visit_Assign(self, node: ast.Assign) -> None:
-        if _is_assign_to(node, "dependencies"):
-            self.dependencies_range = slice(node.lineno - 1, node.end_lineno)
-
-        self.generic_visit(node)
-
-    def visit_Tuple(self, node: ast.Tuple) -> None:
-        if (
-            len(node.elts) == 2
-            and isinstance(node.elts[0], ast.Constant)
-            and node.elts[0].value == "action"
-            and isinstance(node.elts[1], ast.Call)
-            and isinstance(node.elts[1].func, ast.Attribute)
-            and node.elts[1].func.attr == "FlexibleForeignKey"
-        ):
-            kw = _get_kw(node.elts[1].keywords, "to")
-            if (
-                kw is not None
-                and isinstance(kw.value, ast.Constant)
-                and kw.value.value == "workflow_engine.action"
-            ):
-                self.fkey_range = slice(node.lineno - 1, node.end_lineno)
-
-        self.generic_visit(node)
-
-    def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Attribute) and node.func.attr == "AddConstraint":
-            kw = _get_kw(node.keywords, "constraint")
-            if kw is not None and isinstance(kw.value, ast.Call):
-                kw = _get_kw(kw.value.keywords, "name")
-                if (
-                    kw is not None
-                    and isinstance(kw.value, ast.Constant)
-                    and kw.value.value == "notification_type_mutual_exclusivity"
-                ):
-                    self.constraint_range = slice(node.lineno - 1, node.end_lineno)
-
-        self.generic_visit(node)
-
-
-def _remove_workflow_engine(app: App) -> None:
-    with open(app.squash_fname, encoding="UTF-8") as f:
-        lines = list(f)
-
-    visitor = RemoveWorkflowEngineVisitor()
-    visitor.visit(ast.parse("".join(lines), filename=app.squash_fname))
-
-    assert visitor.constraint_range is not None
-    del lines[visitor.constraint_range]
-
-    assert visitor.fkey_range is not None
-    del lines[visitor.fkey_range]
-
-    assert visitor.dependencies_range is not None
-    lines[visitor.dependencies_range] = ["    dependencies = []\n"]
-
     with open(app.squash_fname, "w", encoding="UTF-8") as f:
         f.writelines(lines)
 
 
-def _fix_sentry_cycle(repo: str, app: App, replaces: set[str]) -> None:
-    name = "fix_workflow_engine_cycle"
-    cmd = (repo, "django", "makemigrations", app.name, "-n", name)
-    subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
+def _write_lockfile(apps: list[App]) -> None:
+    with open("migrations_lockfile.txt", encoding="UTF-8") as f:
+        lines = f.readlines()
 
-    n = int(app.current.split("_")[0]) + 1
-    fname = os.path.join(app.root, f"{n:04}_{name}.py")
-    _fixup(fname, [(app.name, mod) for mod in sorted(replaces)])
-
-
-def _fix_sentry_references(apps: list[App], sentry: App) -> None:
-    for app in apps:
-        with open(app.squash_fname, encoding="UTF-8") as f:
-            lines = list(f)
-
-        lines = [
-            (
-                f'        ("sentry", "{sentry.squash_name}"),\n'
-                if line.startswith('        # ("sentry", ')
-                else line
-            )
-            for line in lines
-        ]
-
-        with open(app.squash_fname, "w", encoding="UTF-8") as f:
-            f.writelines(lines)
-
-        subprocess.check_call(("git", "add", "--", app.squash_fname))
-
-
-class DependenciesVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
-        self.dependencies_range: slice | None = None
-
-    def visit_Assign(self, node: ast.Assign) -> None:
-        if _is_assign_to(node, "dependencies"):
-            self.dependencies_range = slice(node.lineno - 1, node.end_lineno)
-
-        self.generic_visit(node)
-
-
-def _fix_replaced(sentry: App, replaced: set[str]) -> None:
-    for name in replaced:
-        fname = _find_migration(sentry, int(name[:4]) + 1)
-
-        with open(fname, encoding="UTF-8") as f:
-            lines = list(f)
-
-        visitor = DependenciesVisitor()
-        visitor.visit(ast.parse("".join(lines), filename=fname))
-
-        assert visitor.dependencies_range is not None
-        lines[visitor.dependencies_range] = ["    dependencies = []\n"]
-
-        with open(fname, "w", encoding="UTF-8") as f:
-            f.writelines(lines)
-
-    subprocess.check_call(("git", "add", "--", sentry.root))
+    with open("migrations_lockfile.txt", "w", encoding="UTF-8") as f:
+        f.writelines(lines[:6])
+        for app in apps:
+            f.write(f"\n{app.name}: {app.squash_name}\n")
 
 
 def main() -> int:
     repo = _get_repo()
     apps = _parse_lockfile()
-    by_name = {app.name: app for app in apps}
 
-    print("clearing out previous squash replaces...")
-    _clear_out_replaces(apps)
+    already_squashed = [app for app in apps if app.is_already_squashed]
+    squash = {app.name: app for app in apps if not app.is_already_squashed}
 
-    print("clearing out cross-app dependencies...")
-    deps = _clear_out_depends(apps)
+    with _cleared_deps(already_squashed, squash):
+        for app in squash.values():
+            _delete_migrations(app)
 
-    # hack around the sentry <=> workflow_engine cycle
-    if "sentry" in deps:
-        sentry_to_workflow_engine = deps["sentry"].pop("workflow_engine")
-    else:
-        sentry_to_workflow_engine = set()
+        print(f"squashing {', '.join(sorted(squash))}...")
+        cmd = (repo, "django", "makemigrations", "-n", "squash")
+        subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
 
-    for v in deps.values():
-        # remove cross-repo deps: consider them "done"
-        for k in tuple(v):
-            if k not in deps:
-                v.pop(k)
+    for app in squash.values():
+        _fixup(app, squash)
 
-    sorter = graphlib.TopologicalSorter(deps)
-    sorter.prepare()
-    while sorter.is_active():
-        for node in sorter.get_ready():
-            if node != "sentry":
-                _squash_one(repo, by_name[node])
-            sorter.done(node)
-
-    # fix the cycle last
-    if "sentry" in deps:
-        sentry = by_name["sentry"]
-        # we'll put these as replaces in the second migration
-        sentry.replaces[:] = sorted(set(sentry.replaces) - sentry_to_workflow_engine)
-        _remove_sentry_references(apps)
-        _squash_one(repo, sentry)
-        _remove_workflow_engine(sentry)
-        _fix_sentry_cycle(repo, sentry, sentry_to_workflow_engine)
-        _fix_sentry_references(apps, sentry)
-        subprocess.check_call(("git", "checkout", "--", sentry.root))
-        _fix_replaced(sentry, sentry_to_workflow_engine)
-
-    # restore the old migration files for now
-    subprocess.check_call(("git", "checkout", "--", *(app.root for app in apps)))
+    _write_lockfile(apps)
 
     return 0
 


### PR DESCRIPTION
after https://github.com/getsentry/sentry/pull/93582 there are no longer migration cycles \o/

<!-- Describe your PR here. -->