### PR TITLE
chore(footer): update API url to docs

### DIFF
--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -67,7 +67,7 @@ function BaseFooter({className}: Props) {
         {!isSelfHosted && (
           <FooterLink href="https://status.sentry.io/">{t('Service Status')}</FooterLink>
         )}
-        <FooterLink href="/api/">{t('API')}</FooterLink>
+        <FooterLink href="https://docs.sentry.io/api/">{t('API')}</FooterLink>
         <FooterLink href="/docs/">{t('Docs')}</FooterLink>
         <FooterLink href="https://github.com/getsentry/sentry">
           {t('Contribute')}


### PR DESCRIPTION
- Currently links to the Personal Auth token in settings, which does not seem correct
- Update the API link in the footer to docs.sentry.io/api/