### PR TITLE
fix(taskworker) Increase deadline for handle_trigger_action

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -53,7 +53,7 @@ def handle_snuba_query_update(
             times=5,
             delay=60,
         ),
-        processing_deadline_duration=30,
+        processing_deadline_duration=60,
     ),
 )
 def handle_trigger_action(


### PR DESCRIPTION
This deadline has been hit a few times in production. Increase it to accomodate longer running tasks.

Fixes SENTRY-FOR-SENTRY-5VJF
