### PR TITLE
fix chonk button text for tour component

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -518,8 +518,6 @@ const ActionRow = styled('div')`
 `;
 
 export const TourAction = styled(Button)`
-  border: 0;
-  background: ${p => p.theme.white};
   color: ${p => p.theme.tour.next};
 
   &:hover,
@@ -527,6 +525,18 @@ export const TourAction = styled(Button)`
   &:focus {
     color: ${p => p.theme.tour.next};
   }
+
+  ${p =>
+    p.theme.isChonk
+      ? `
+    &::after {
+      background: ${p.theme.white};
+    }
+  `
+      : `
+    border: 0;
+    background: ${p.theme.white};
+  `}
 `;
 
 export const TextTourAction = styled(Button)`


### PR DESCRIPTION
Add conditional styles to support chonk UI for `<TourAction>` button. Not sure if we want to handle chonk UI styles differently when there's custom theming.
Before change:
<img width="398" alt="image" src="https://github.com/user-attachments/assets/4855635d-e9f8-466b-885e-3ff1b7b8dc98" />

After change:
dark mode
<img width="392" alt="image" src="https://github.com/user-attachments/assets/332cd644-0e9a-48af-8636-c123688fbf82" />
lightmode