### PR TITLE
fix(taskworker) Remove redundant namespace definition

### DIFF
--- a/src/sentry/tasks/auth/__init__.py
+++ b/src/sentry/tasks/auth/__init__.py
@@ -1,4 +1,0 @@
-from sentry.taskworker.registry import TaskNamespace, taskregistry
-
-auth_tasks: TaskNamespace = taskregistry.create_namespace("auth")
-auth_control_tasks: TaskNamespace = taskregistry.create_namespace("auth.control")

--- a/src/sentry/tasks/auth/check_auth.py
+++ b/src/sentry/tasks/auth/check_auth.py
@@ -15,9 +15,9 @@ from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.organizations.services.organization import RpcOrganizationMember, organization_service
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
-from sentry.tasks.auth import auth_control_tasks
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.namespaces import auth_control_tasks
 from sentry.utils import metrics
 from sentry.utils.env import in_test_environment
 

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -248,6 +248,8 @@ class TaskRegistry:
 
         Namespaces can define default behavior for tasks defined within a namespace.
         """
+        if name in self._namespaces:
+            raise ValueError(f"Task namespace with name {name} already exists.")
         namespace = TaskNamespace(
             name=name,
             router=self._router,

--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -287,6 +287,14 @@ def test_registry_create_namespace_simple() -> None:
 
 
 @pytest.mark.django_db
+def test_registry_create_namespace_duplicate() -> None:
+    registry = TaskRegistry()
+    registry.create_namespace(name="tests")
+    with pytest.raises(ValueError, match="tests already exists"):
+        registry.create_namespace(name="tests")
+
+
+@pytest.mark.django_db
 def test_registry_create_namespace_route_setting() -> None:
     with override_settings(TASKWORKER_ROUTES='{"profiling":"profiles", "lol":"nope"}'):
         registry = TaskRegistry()


### PR DESCRIPTION
This was resulting in tasks not being found.

Fixes SENTRY-419F
