### PR TITLE
fix(dashboards): Alert on committing changes

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -134,6 +134,7 @@ type Props = RouteComponentProps<RouteParams> & {
 
 type State = {
   dashboardState: DashboardState;
+  isCommittingChanges: boolean;
   isSavingDashboardFilters: boolean;
   isWidgetBuilderOpen: boolean;
   modifiedDashboard: DashboardDetails | null;
@@ -263,6 +264,7 @@ class DashboardDetail extends Component<Props, State> {
     isWidgetBuilderOpen: false,
     openWidgetTemplates: undefined,
     newlyAddedWidget: undefined,
+    isCommittingChanges: false,
   };
 
   componentDidMount() {
@@ -432,11 +434,16 @@ class DashboardDetail extends Component<Props, State> {
 
   handleBeforeUnload = (event: BeforeUnloadEvent) => {
     const {dashboard} = this.props;
-    const {modifiedDashboard} = this.state;
+    const {modifiedDashboard, isCommittingChanges, isSavingDashboardFilters} = this.state;
+
+    // Conditions outside of the editing state that we want to trigger the
+    // message for.
+    const warnOnSaving = isCommittingChanges || isSavingDashboardFilters;
     if (
-      defined(modifiedDashboard) &&
-      !isEqual(modifiedDashboard, dashboard) &&
-      this.isEditingDashboard
+      (defined(modifiedDashboard) &&
+        !isEqual(modifiedDashboard, dashboard) &&
+        this.isEditingDashboard) ||
+      warnOnSaving
     ) {
       event.preventDefault();
       event.returnValue = '';
@@ -602,6 +609,7 @@ class DashboardDetail extends Component<Props, State> {
     this.setState({
       modifiedDashboard: newModifiedDashboard,
       widgetLimitReached: widgets.length >= MAX_WIDGETS,
+      isCommittingChanges: true,
     });
     if (this.isEditingDashboard || this.isPreview) {
       return null;
@@ -612,6 +620,7 @@ class DashboardDetail extends Component<Props, State> {
           onDashboardUpdate(newDashboard);
           this.setState({
             modifiedDashboard: null,
+            isCommittingChanges: false,
           });
         }
         const legendQuery =
@@ -874,6 +883,9 @@ class DashboardDetail extends Component<Props, State> {
             });
             return;
           }
+          this.setState({
+            isCommittingChanges: true,
+          });
           updateDashboard(api, organization.slug, modifiedDashboard).then(
             (newDashboard: DashboardDetails) => {
               if (onDashboardUpdate) {
@@ -885,6 +897,7 @@ class DashboardDetail extends Component<Props, State> {
                 {
                   dashboardState: DashboardState.VIEW,
                   modifiedDashboard: null,
+                  isCommittingChanges: false,
                 },
                 () => {
                   if (dashboard && newDashboard.id !== dashboard.id) {


### PR DESCRIPTION
This fixes the issue where if a user submits changes and the saving is taking a long time, when the user attempts to refresh they'll query old data. Now we at least indicate to the user that there are possibly unsaved changes so they can wait. This will alert on dashboard saves (edit mode saving) to any updates by adding or editing widgets

This is only applied to the before unload listener because I think it's unnecessary to warn on this for navigations, since likely if you navigate away you're leaving the view long enough for it to commit properly before returning.