### PR TITLE
feat(explore): add span.system as searchable field

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -55,6 +55,8 @@ export const SENTRY_SPAN_STRING_TAGS: string[] = [
   SpanIndexedField.NORMALIZED_DESCRIPTION,
   SpanIndexedField.RELEASE, // temporary as orgs with >1k keys still want releases
   SpanFields.PROJECT_ID,
+  SpanFields.SPAN_SYSTEM,
+  SpanFields.SPAN_CATEGORY,
 ];
 
 export const SENTRY_SPAN_NUMBER_TAGS: string[] = [...SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS];

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -93,6 +93,8 @@ export enum SpanFields {
   PROJECT_ID = 'project.id',
   RESPONSE_CODE = 'span.status_code',
   DEVICE_CLASS = 'device.class',
+  SPAN_SYSTEM = 'span.system',
+  SPAN_CATEGORY = 'span.category',
 }
 
 type WebVitalsMeasurements =


### PR DESCRIPTION
add span category and span system as searchable fields in explore.
Makes it so when we link from insights to explore, these fields aren't red