### PR TITLE
feat(sentry-apps): Add RPC methods for sentry app via proxy users

### DIFF
--- a/src/sentry/sentry_apps/api/serializers/sentry_app_avatar.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_avatar.py
@@ -2,6 +2,7 @@ from typing import TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
+from sentry.sentry_apps.services.app.model import RpcSentryAppAvatar
 
 
 class SentryAppAvatarSerializerResponse(TypedDict):
@@ -15,11 +16,11 @@ class SentryAppAvatarSerializerResponse(TypedDict):
 @register(SentryAppAvatar)
 class SentryAppAvatarSerializer(Serializer):
     def serialize(
-        self, obj: SentryAppAvatar, attrs, user, **kwargs
+        self, obj: SentryAppAvatar | RpcSentryAppAvatar, attrs, user, **kwargs
     ) -> SentryAppAvatarSerializerResponse:
         return {
             "avatarType": obj.get_avatar_type_display(),
-            "avatarUuid": obj.ident,
+            "avatarUuid": obj.ident or "",
             "avatarUrl": obj.absolute_url(),
             "color": obj.color,
             "photoType": obj.get_avatar_photo_type(),

--- a/src/sentry/sentry_apps/services/app/serial.py
+++ b/src/sentry/sentry_apps/services/app/serial.py
@@ -2,6 +2,7 @@ from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_apps.models.sentry_app import SentryApp
+from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.services.app import (
@@ -10,6 +11,7 @@ from sentry.sentry_apps.services.app import (
     RpcSentryAppComponent,
     RpcSentryAppInstallation,
 )
+from sentry.sentry_apps.services.app.model import RpcSentryAppAvatar
 
 
 def serialize_api_application(api_app: ApiApplication | None) -> RpcApiApplication | None:
@@ -22,7 +24,11 @@ def serialize_api_application(api_app: ApiApplication | None) -> RpcApiApplicati
     )
 
 
-def serialize_sentry_app(app: SentryApp) -> RpcSentryApp:
+def serialize_sentry_app(
+    app: SentryApp, avatars: list[SentryAppAvatar] | None = None
+) -> RpcSentryApp:
+    if avatars is None:
+        avatars = []
     return RpcSentryApp(
         id=app.id,
         scope_list=app.scope_list,
@@ -42,6 +48,7 @@ def serialize_sentry_app(app: SentryApp) -> RpcSentryApp:
         is_publish_request_inprogress=app.status == SentryAppStatus.PUBLISH_REQUEST_INPROGRESS,
         status=SentryAppStatus.as_str(app.status),
         metadata=app.metadata,
+        avatars=[serialize_sentry_app_avatar(avatar) for avatar in avatars],
     )
 
 
@@ -77,4 +84,14 @@ def serialize_sentry_app_component(component: SentryAppComponent) -> RpcSentryAp
         sentry_app_id=component.sentry_app_id,
         type=component.type,
         app_schema=component.schema,
+    )
+
+
+def serialize_sentry_app_avatar(avatar: SentryAppAvatar) -> RpcSentryAppAvatar:
+    return RpcSentryAppAvatar(
+        id=avatar.id,
+        ident=avatar.ident,
+        sentry_app_id=avatar.sentry_app_id,
+        avatar_type=avatar.avatar_type,
+        color=avatar.color,
     )

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -89,6 +89,11 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_sentry_apps_by_proxy_users(self, *, proxy_user_ids: list[int]) -> list[RpcSentryApp]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_installation_by_id(self, *, id: int) -> RpcSentryAppInstallation | None:
         pass
 

--- a/tests/sentry/sentry_apps/api/serializers/test_sentry_app_avatar.py
+++ b/tests/sentry/sentry_apps/api/serializers/test_sentry_app_avatar.py
@@ -1,0 +1,29 @@
+from sentry.api.serializers import serialize
+from sentry.sentry_apps.api.serializers.sentry_app_avatar import SentryAppAvatarSerializer
+from sentry.sentry_apps.services.app.serial import serialize_sentry_app_avatar
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class SentryAppSerializerTest(TestCase):
+    def setUp(self):
+        self.sentry_app = self.create_sentry_app(organization=self.organization)
+        self.avatar = self.create_sentry_app_avatar(sentry_app=self.sentry_app)
+
+    def test_avatar(self):
+        serial_avatar = serialize(self.avatar, None)
+        assert serial_avatar["avatarType"] == self.avatar.get_avatar_type_display()
+        assert serial_avatar["avatarUuid"] == self.avatar.ident
+        assert serial_avatar["avatarUrl"] == self.avatar.absolute_url()
+        assert serial_avatar["color"] == self.avatar.color
+        assert serial_avatar["photoType"] == self.avatar.get_avatar_photo_type().value
+
+    def test_rpc_avatar(self):
+        rpc_avatar = serialize_sentry_app_avatar(self.avatar)
+        serial_rpc_avatar = serialize(rpc_avatar, None, SentryAppAvatarSerializer())
+        assert serial_rpc_avatar["avatarType"] == self.avatar.get_avatar_type_display()
+        assert serial_rpc_avatar["avatarUuid"] == self.avatar.ident
+        assert serial_rpc_avatar["avatarUrl"] == self.avatar.absolute_url()
+        assert serial_rpc_avatar["color"] == self.avatar.color
+        assert serial_rpc_avatar["photoType"] == self.avatar.get_avatar_photo_type().value

--- a/tests/sentry/sentry_apps/services/test_model.py
+++ b/tests/sentry/sentry_apps/services/test_model.py
@@ -1,7 +1,33 @@
-from sentry.sentry_apps.services.app.serial import serialize_sentry_app_installation
+from sentry.sentry_apps.services.app.serial import (
+    serialize_sentry_app_avatar,
+    serialize_sentry_app_installation,
+)
 from sentry.sentry_apps.services.app.service import app_service
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import control_silo_test, region_silo_test
+
+
+@control_silo_test
+class TestSentryAppAvatar(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sentry_app = self.create_sentry_app(organization=self.organization)
+        self.avatar = self.create_sentry_app_avatar(sentry_app=self.sentry_app)
+
+    def test_rpc_avatar_properties(self):
+        rpc_avatar = serialize_sentry_app_avatar(self.avatar)
+        assert rpc_avatar.id == self.avatar.id
+        assert rpc_avatar.ident == self.avatar.ident
+        assert rpc_avatar.sentry_app_id == self.avatar.sentry_app_id
+        assert rpc_avatar.avatar_type == self.avatar.avatar_type
+        assert rpc_avatar.color == self.avatar.color
+        assert rpc_avatar.AVATAR_TYPES == self.avatar.AVATAR_TYPES
+        assert rpc_avatar.url_path == self.avatar.url_path
+        assert rpc_avatar.FILE_TYPE == self.avatar.FILE_TYPE
+        assert rpc_avatar.get_avatar_type_display() == self.avatar.get_avatar_type_display()
+        assert rpc_avatar.get_cache_key(20) == self.avatar.get_cache_key(20)
+        assert rpc_avatar.get_avatar_photo_type() == self.avatar.get_avatar_photo_type()
+        assert rpc_avatar.absolute_url() == self.avatar.absolute_url()
 
 
 @region_silo_test


### PR DESCRIPTION
Breaking up new RPC methods from https://github.com/getsentry/sentry/pull/93078

Adds a serialized RPCSentryAppAvatar and allows it to be serialized. Also adds optional parameters to the existing serializers to accept a list of avatars, if they've been fetched, but for now only including it on the new method, which searches by proxy user.

The reason for this method is that Sentry Apps issue API tokens that when used, attritbute to the 'proxy user' in some cases, one of them being in Issue activity.

This will allow that endpoint to fetch a trim version of the Sentry App containing everything needed to display the proper author as the sentry app, and not an unknown user with a UUID name.