### PR TITLE
fix(self-hosted): Use json to define dockerfile entrypoint

### DIFF
--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -79,7 +79,7 @@ RUN : double-check some built files are available \
 EXPOSE 9000
 VOLUME /data
 
-ENTRYPOINT exec /docker-entrypoint.sh "$0" "$@"
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["run", "web"]
 
 ARG SOURCE_COMMIT


### PR DESCRIPTION
Original: Runs through shell, passes $0 (command name) and $@ (all arguments) to the script
New: Directly executes the script and automatically appends CMD arguments

![image](https://github.com/user-attachments/assets/58cfe31a-9302-48fa-acb8-5bd658d6257d)

