### PR TITLE
style(explore): Use single Add a Column button

### DIFF
--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -180,7 +180,10 @@ describe('AggregateColumnEditorModal', function () {
       new Visualize(['count(span.duration)']),
     ]);
 
-    await userEvent.click(screen.getByRole('button', {name: 'Add a Group By'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Group By / Attribute'})
+    );
 
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
@@ -189,7 +192,10 @@ describe('AggregateColumnEditorModal', function () {
       {groupBy: ''},
     ]);
 
-    await userEvent.click(screen.getByRole('button', {name: 'Add an Aggregation'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
+    await userEvent.click(
+      screen.getByRole('menuitemradio', {name: 'Visualize / Function'})
+    );
 
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -9,6 +9,7 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import type {SelectKey, SelectOption} from 'sentry/components/core/compactSelect';
 import {CompactSelect} from 'sentry/components/core/compactSelect';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {SPAN_PROPS_DOCS_URL} from 'sentry/constants';
 import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconDelete} from 'sentry/icons/iconDelete';
@@ -100,24 +101,31 @@ export function AggregateColumnEditorModal({
               );
             })}
             <RowContainer>
-              <ButtonBar gap={1}>
-                <Button
-                  size="sm"
-                  aria-label={t('Add a Group By')}
-                  onClick={() => insertColumn({groupBy: ''})}
-                  icon={<IconAdd isCircled />}
-                >
-                  {t('Add a Group By')}
-                </Button>
-                <Button
-                  size="sm"
-                  aria-label={t('Add an Aggregation')}
-                  onClick={() => insertColumn(new Visualize([DEFAULT_VISUALIZATION]))}
-                  icon={<IconAdd isCircled />}
-                >
-                  {t('Add an Aggregation')}
-                </Button>
-              </ButtonBar>
+              <DropdownMenu
+                items={[
+                  {
+                    key: 'add-group-by',
+                    label: t('Group By / Attribute'),
+                    details: t('ex. browser, device, release'),
+                    onAction: () => insertColumn({groupBy: ''}),
+                  },
+                  {
+                    key: 'add-visualize',
+                    label: t('Visualize / Function'),
+                    details: t('ex. p50(span.duration)'),
+                    onAction: () => insertColumn(new Visualize([DEFAULT_VISUALIZATION])),
+                  },
+                ]}
+                trigger={triggerProps => (
+                  <Button
+                    {...triggerProps}
+                    aria-label={t('Add a Column')}
+                    icon={<IconAdd isCircled />}
+                  >
+                    {t('Add a Column')}
+                  </Button>
+                )}
+              />
             </RowContainer>
           </Body>
           <Footer data-test-id="editor-footer">


### PR DESCRIPTION
Instead of having 2 separate buttons, this merges them into a single button with 2 options.