### PR TITLE
feat(dashboards): Update the endpoint to use manager to favorite

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -217,6 +217,9 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
         if not features.has(EDIT_FEATURE, organization, actor=request.user):
             return Response(status=404)
 
+        if not request.user.is_authenticated:
+            return Response(status=401)
+
         if isinstance(dashboard, dict):
             return Response(status=204)
 

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -219,6 +219,9 @@ class Dashboard(Model):
 
     @property
     def favorited_by(self):
+        """
+        @deprecated Use the DashboardFavoriteUser object manager instead.
+        """
         user_ids = DashboardFavoriteUser.objects.filter(dashboard=self).values_list(
             "user_id", flat=True
         )
@@ -226,6 +229,9 @@ class Dashboard(Model):
 
     @favorited_by.setter
     def favorited_by(self, user_ids):
+        """
+        @deprecated Use the DashboardFavoriteUser object manager instead.
+        """
         from django.db import router, transaction
 
         existing_user_ids = DashboardFavoriteUser.objects.filter(dashboard=self).values_list(


### PR DESCRIPTION
This updates the endpoint so it uses the DashboardFavoriteUser manager to create updates. This has the benefit that the API will update positions as well.

These tests and uses currently expect that all positions are set properly, or else the operations will error trying to increment or decrement positions. Enforcing positions to be filled in will be a separate PR, for now this is feature flagged so it can make this assumption.