### PR TITLE
feat(insights): switch to human readable field aliases in charts

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
@@ -6,6 +6,7 @@ import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/p
 import {Thresholds} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds';
 import {WEB_VITAL_FULL_NAME_MAP} from 'sentry/views/insights/browser/webVitals/components/webVitalDescription';
 import {Referrer} from 'sentry/views/insights/browser/webVitals/referrers';
+import {FIELD_ALIASES} from 'sentry/views/insights/browser/webVitals/settings';
 import type {WebVitals} from 'sentry/views/insights/browser/webVitals/types';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {
@@ -91,6 +92,7 @@ export function WebVitalStatusLineChart({
       {webVital && (
         <InsightsLineChartWidget
           title={`${WEB_VITAL_FULL_NAME_MAP[webVital]} (P75)`}
+          aliases={FIELD_ALIASES}
           showReleaseAs="none"
           showLegend="never"
           isLoading={isTimeseriesLoading}

--- a/static/app/views/insights/browser/webVitals/settings.ts
+++ b/static/app/views/insights/browser/webVitals/settings.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import type {SpanMetricsProperty} from 'sentry/views/insights/types';
 
 export const MODULE_TITLE = t('Web Vitals');
 export const BASE_URL = 'pageloads';
@@ -15,3 +16,11 @@ export const DEFAULT_EAP_QUERY_FILTER =
   'span.op:[ui.interaction.click,ui.interaction.hover,ui.interaction.drag,ui.interaction.press,ui.webvital.cls,pageload,""] !transaction:"<< unparameterized >>"';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];
+
+export const FIELD_ALIASES = {
+  'p75(measurements.lcp)': 'LCP',
+  'p75(measurements.fcp)': 'FCP',
+  'p75(measurements.inp)': 'INP',
+  'p75(measurements.cls)': 'CLS',
+  'p75(measurements.ttfb)': 'TTFB',
+} satisfies Partial<Record<SpanMetricsProperty, string>>;

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -42,7 +42,7 @@ import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/compon
 import type {DiscoverSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
-import {INGESTION_DELAY} from 'sentry/views/insights/settings';
+import {BASE_FIELD_ALIASES, INGESTION_DELAY} from 'sentry/views/insights/settings';
 import type {SpanFields} from 'sentry/views/insights/types';
 
 export interface InsightsTimeSeriesWidgetProps
@@ -93,6 +93,11 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
       version,
     })) ?? [];
 
+  const aliases: Record<string, string> = {
+    ...BASE_FIELD_ALIASES,
+    ...props?.aliases,
+  };
+
   const hasChartActionsEnabled =
     organization.features.includes('insights-chart-actions') && useEap && props.queryInfo;
   const yAxes = new Set<string>();
@@ -115,7 +120,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
       return new PlottableDataConstructor(timeSeries, {
         color: serie.color ?? COMMON_COLORS(theme)[timeSeries.yAxis],
         stack: props.stacked && props.visualizationType === 'bar' ? 'all' : undefined,
-        alias: props.aliases?.[timeSeries.yAxis],
+        alias: aliases?.[timeSeries.yAxis],
       });
     }),
     ...(props.extraPlottables ?? []),
@@ -215,7 +220,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
                 groupBy={props.queryInfo?.groupBy}
                 title={props.title}
                 search={props.queryInfo?.search}
-                aliases={props.aliases}
+                aliases={aliases}
                 referrer={props.queryInfo?.referrer ?? ''}
               />
             )}

--- a/static/app/views/insights/common/components/widgets/databaseLandingThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseLandingThroughputChartWidget.tsx
@@ -4,6 +4,7 @@ import {useDatabaseLandingThroughputQuery} from 'sentry/views/insights/common/co
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/database/referrers';
+import {FIELD_ALIASES} from 'sentry/views/insights/database/settings';
 
 export default function DatabaseLandingThroughputChartWidget(
   props: LoadableChartWidgetProps
@@ -18,6 +19,7 @@ export default function DatabaseLandingThroughputChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
+      aliases={FIELD_ALIASES}
       queryInfo={{search, referrer}}
       id="databaseLandingThroughputChartWidget"
       title={getThroughputChartTitle('db')}

--- a/static/app/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/databaseSummaryThroughputChartWidget.tsx
@@ -5,6 +5,7 @@ import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/compon
 import {useSpanMetricsSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getThroughputChartTitle} from 'sentry/views/insights/common/views/spans/types';
 import {Referrer} from 'sentry/views/insights/database/referrers';
+import {FIELD_ALIASES} from 'sentry/views/insights/database/settings';
 import type {SpanMetricsQueryFilters} from 'sentry/views/insights/types';
 
 export default function DatabaseSummaryThroughputChartWidget(
@@ -30,6 +31,7 @@ export default function DatabaseSummaryThroughputChartWidget(
   return (
     <InsightsLineChartWidget
       {...props}
+      aliases={FIELD_ALIASES}
       queryInfo={{search, referrer}}
       id="databaseSummaryThroughputChartWidget"
       title={getThroughputChartTitle('db')}

--- a/static/app/views/insights/database/settings.ts
+++ b/static/app/views/insights/database/settings.ts
@@ -9,7 +9,11 @@ import {
   TWO_WEEKS,
 } from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
-import {type Aggregate, ModuleName} from 'sentry/views/insights/types';
+import {
+  type Aggregate,
+  ModuleName,
+  type SpanMetricsProperty,
+} from 'sentry/views/insights/types';
 
 export const MODULE_TITLE = t('Queries');
 export const DATA_TYPE = t('Query');
@@ -62,3 +66,7 @@ export const DISTRIBUTION_GRANULARITIES = new GranularityLadder([
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/backend/queries/';
 
 export const MODULE_FEATURES = ['insights-initial-modules'];
+
+export const FIELD_ALIASES = {
+  'epm()': t('Queries Per Minute'),
+} satisfies Partial<Record<SpanMetricsProperty, string>>;

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -27,6 +27,7 @@ import {
   MODULE_FEATURES as CACHE_MODULE_FEATURES,
   MODULE_TITLE as CACHE_MODULE_TITLE,
 } from 'sentry/views/insights/cache/settings';
+import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {
   DATA_TYPE as DB_DATA_TYPE,
   DATA_TYPE_PLURAL as DB_DATA_TYPE_PLURAL,
@@ -100,6 +101,7 @@ import {
   MODULE_VISIBLE_FEATURES as SESSIONS_MODULE_VISIBLE_FEATURES,
 } from 'sentry/views/insights/sessions/settings';
 
+import type {SpanMetricsProperty} from './types';
 import {ModuleName} from './types';
 
 export const INSIGHTS_TITLE = t('Insights');
@@ -238,3 +240,11 @@ export const MODULES_CONSIDERED_NEW: Set<ModuleName> = new Set([
 ]);
 
 export const INGESTION_DELAY = 90;
+
+// Base aliases used to map insights yAxis to human readable name
+export const BASE_FIELD_ALIASES: Partial<Record<SpanMetricsProperty, string>> = {
+  'avg(span.duration)': DataTitles.avg,
+  'avg(span.self_time)': DataTitles.avg,
+  'epm()': t('Requests Per Minute'),
+  'cache_miss_rate()': t('Cache Miss Rate'),
+};


### PR DESCRIPTION
Adds aliases to insight charts so that the tooltips are human readable. The names are documented here
https://linear.app/getsentry/document/human-readable-tooltips-feb33fdb464e

Example
Before
<img width="467" alt="image" src="https://github.com/user-attachments/assets/da6f3174-ed98-451e-8203-423da225f613" />


After
<img width="595" alt="image" src="https://github.com/user-attachments/assets/01bbbdc4-55c2-4644-8328-33acd5b8227a" />
