### PR TITLE
add quick link to insight page for laravel and nextjs projects

### DIFF
--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import type {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 import {IconLink} from 'sentry/icons';
@@ -10,6 +11,11 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
+import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
+import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {
   getPerformanceBaseUrl,
@@ -30,7 +36,34 @@ function ProjectQuickLinks({organization, project}: Props) {
     ? platformToDomainView([project], [parseInt(project.id, 10)])
     : 'backend';
 
+  const isLaravelInsightsAvailable = useIsLaravelInsightsAvailable();
+  const isNextJsInsightsAvailable = useIsNextJsInsightsAvailable();
+
   const quickLinks = [
+    ...(isLaravelInsightsAvailable && project?.platform === 'php-laravel'
+      ? [
+          {
+            title: t('Laravel Insights'),
+            to: {
+              pathname: `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${BACKEND_LANDING_SUB_PATH}/`,
+              query: {project: project.id},
+            },
+            showNewBadge: true,
+          },
+        ]
+      : []),
+    ...(isNextJsInsightsAvailable && project?.platform === 'javascript-nextjs'
+      ? [
+          {
+            title: t('Next.js Insights'),
+            to: {
+              pathname: `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${FRONTEND_LANDING_SUB_PATH}/`,
+              query: {project: project.id},
+            },
+            showNewBadge: true,
+          },
+        ]
+      : []),
     {
       title: t('User Feedback'),
       to: {
@@ -56,7 +89,7 @@ function ProjectQuickLinks({organization, project}: Props) {
       {quickLinks
         // push disabled links to the bottom
         .sort((link1, link2) => Number(!!link1.disabled) - Number(!!link2.disabled))
-        .map(({title, to, disabled}) => (
+        .map(({title, to, disabled, showNewBadge}) => (
           <div key={title}>
             <Tooltip
               title={t("You don't have access to this feature")}
@@ -64,7 +97,10 @@ function ProjectQuickLinks({organization, project}: Props) {
             >
               <QuickLink to={to} disabled={disabled}>
                 <IconLink />
-                <QuickLinkText>{title}</QuickLinkText>
+                <QuickLinkTextContainer>
+                  <QuickLinkText>{title}</QuickLinkText>
+                  {showNewBadge && <FeatureBadge type="new" />}
+                </QuickLinkTextContainer>
               </QuickLink>
             </Tooltip>
           </div>
@@ -94,6 +130,12 @@ const QuickLink = styled((p: any) =>
       color: ${p.theme.gray200};
       cursor: not-allowed;
     `}
+`;
+
+const QuickLinkTextContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const QuickLinkText = styled('span')`


### PR DESCRIPTION
redirect to nextjs/laravel pages were removed in #93591 . Putting link to page under quick links to try to make it more discoverable - will only show on nextjs & laravel pages
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/173b0df0-6024-455c-9af7-0e24cb4e02df" />

- ex next proj: https://demo.dev.getsentry.net:7999/insights/projects/nextjs/?project=4508968158429184
- ex laravel proj: https://demo.dev.getsentry.net:7999/insights/projects/laravel/?project=4508968152989696

https://github.com/user-attachments/assets/a13026a5-f183-4a56-a1f4-2aad2df99bd0



separate from this pr, but it does seem strange that Team-access is the first sidebar section. That seems like its less important than the others