### PR TITLE
fix(insights): open in explore/alerts query wrong

### DIFF
--- a/static/app/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget.tsx
@@ -50,17 +50,17 @@ export default function HttpDomainSummaryResponseCodesChartWidget(
     {
       yAxes: ['count()'],
       label: '3xx',
-      query: `${stringifiedSearch} ${responseRateField}:>300 ${responseRateField}:<=399`,
+      query: `${stringifiedSearch} ${responseRateField}:>=300 ${responseRateField}:<=399`,
     },
     {
       yAxes: ['count()'],
       label: '4xx',
-      query: `${stringifiedSearch} ${responseRateField}:>400 ${responseRateField}:<=499`,
+      query: `${stringifiedSearch} ${responseRateField}:>=400 ${responseRateField}:<=499`,
     },
     {
       yAxes: ['count()'],
       label: '5xx',
-      query: `${stringifiedSearch} ${responseRateField}:>500 ${responseRateField}:<=599`,
+      query: `${stringifiedSearch} ${responseRateField}:>=500 ${responseRateField}:<=599`,
     },
   ];
 

--- a/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/httpResponseCodesChartWidget.tsx
@@ -48,17 +48,17 @@ export default function HttpResponseCodesChartWidget(props: LoadableChartWidgetP
     {
       yAxes: ['count()'],
       label: '3xx',
-      query: `${stringifiedSearch} ${responseRateField}:>300 ${responseRateField}:<=399`,
+      query: `${stringifiedSearch} ${responseRateField}:>=300 ${responseRateField}:<=399`,
     },
     {
       yAxes: ['count()'],
       label: '4xx',
-      query: `${stringifiedSearch} ${responseRateField}:>400 ${responseRateField}:<=499`,
+      query: `${stringifiedSearch} ${responseRateField}:>=400 ${responseRateField}:<=499`,
     },
     {
       yAxes: ['count()'],
       label: '5xx',
-      query: `${stringifiedSearch} ${responseRateField}:>500 ${responseRateField}:<=599`,
+      query: `${stringifiedSearch} ${responseRateField}:>=500 ${responseRateField}:<=599`,
     },
   ];
 


### PR DESCRIPTION
Should be greater then and equal to so that it includes the right codes