### PR TITLE
fix(taskworker): Have the option call actually use options

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -255,6 +255,7 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
     """
     from django.conf import settings
 
+    from sentry import options as featureflags
     from sentry.taskworker.registry import taskregistry
     from sentry.taskworker.scheduler.runner import RunStorage, ScheduleRunner
     from sentry.utils.redis import redis_clusters
@@ -266,7 +267,7 @@ def taskworker_scheduler(redis_cluster: str, **options: Any) -> None:
 
     with managed_bgtasks(role="taskworker-scheduler"):
         runner = ScheduleRunner(taskregistry, run_storage)
-        enabled_schedules = set(options.get("taskworker.scheduler.rollout", []))
+        enabled_schedules = set(featureflags.get("taskworker.scheduler.rollout", []))
         for key, schedule_data in settings.TASKWORKER_SCHEDULES.items():
             if key in enabled_schedules:
                 runner.add(key, schedule_data)
@@ -479,6 +480,8 @@ def cron(**options: Any) -> None:
     "Run periodic task dispatcher."
     from django.conf import settings
 
+    from sentry import options as featureflags
+
     if settings.CELERY_ALWAYS_EAGER:
         raise click.ClickException(
             "Disable CELERY_ALWAYS_EAGER in your settings file to spawn workers."
@@ -488,7 +491,7 @@ def cron(**options: Any) -> None:
 
     old_schedule = app.conf.CELERYBEAT_SCHEDULE
     new_schedule = {}
-    task_schedules = set(options.get("taskworker.scheduler.rollout", []))
+    task_schedules = set(featureflags.get("taskworker.scheduler.rollout", []))
     for key, schedule_data in old_schedule.items():
         if key not in task_schedules:
             new_schedule[key] = schedule_data


### PR DESCRIPTION
Fix a bug where instead of checking the options DB a local options variable was being accessed.