### PR TITLE
fix(self-hosted): Self-hosted release uses wrong workflow name

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,7 +6,8 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'self-hosted'
+      - 'self-hosted-ubuntu-24.04-amd64'
+      - 'self-hosted-ubuntu-24.04-arm64'
 artifactProvider:
   name: none
 targets:

--- a/.craft.yml
+++ b/.craft.yml
@@ -7,7 +7,7 @@ statusProvider:
   config:
     contexts:
       - 'self-hosted-ubuntu-24.04-amd64'
-      - 'self-hosted-ubuntu-24.04-arm64'
+      - 'self-hosted-ubuntu-24.04-arm-arm64'
 artifactProvider:
   name: none
 targets:

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -27,6 +27,7 @@ jobs:
             platform: amd64
           - os: ubuntu-24.04-arm
             platform: arm64
+    name: self-hosted-${{ matrix.os }}-${{ matrix.platform }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Seen here: https://github.com/getsentry/publish/actions/runs/15688973336/job/44199206790

Seems to be from https://github.com/getsentry/sentry/pull/83907

