### PR TITLE
perf(aci): Provide Workflow.environment by default

### DIFF
--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -31,6 +31,7 @@ class WorkflowManager(BaseManager["Workflow"]):
             super()
             .get_queryset()
             .exclude(status__in=(ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS))
+            .select_related("environment")
         )
 
 


### PR DESCRIPTION
Saves us from having to work to avoid inefficiently loading it everywhere.
