### PR TITLE
fix(ui): fix sticky headers in grideditable

### DIFF
--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -236,4 +236,48 @@ export default Storybook.story('GridEditable', story => {
       // Storybook.SizingWindowProps={{display: 'block'}}
     />
   ));
+
+  story('Sticky Headers and Scrolling', () => {
+    return (
+      <Fragment>
+        <p>
+          Passing
+          <Storybook.JSXProperty name="stickyHeader" value={Boolean} /> and{' '}
+          <Storybook.JSXProperty name="scrollable" value={Boolean} />
+          add sticky headers and table scrolling respectively
+        </p>
+        <Storybook.SideBySide>
+          <div>
+            <div>No sticky headers</div>
+            <GridEditable
+              data={data}
+              columnOrder={columns}
+              columnSortBy={[]}
+              grid={{
+                renderHeadCell,
+                renderBodyCell,
+              }}
+              scrollable
+              height={200}
+            />
+          </div>
+          <div>
+            <div>With sticky headers</div>
+            <GridEditable
+              data={data}
+              columnOrder={columns}
+              columnSortBy={[]}
+              grid={{
+                renderHeadCell,
+                renderBodyCell,
+              }}
+              stickyHeader
+              scrollable
+              height={200}
+            />
+          </div>
+        </Storybook.SideBySide>
+      </Fragment>
+    );
+  });
 });

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -321,15 +321,7 @@ class GridEditable<
   }
 
   renderGridHead() {
-    const {
-      error,
-      isLoading,
-      columnOrder,
-      grid,
-      data,
-      stickyHeader,
-      resizable = true,
-    } = this.props;
+    const {error, isLoading, columnOrder, grid, data, resizable = true} = this.props;
 
     // Ensure that the last column cannot be removed
     const numColumn = columnOrder.length;
@@ -354,7 +346,6 @@ class GridEditable<
               data-test-id="grid-head-cell"
               key={`${i}.${column.key}`}
               isFirst={i === 0}
-              sticky={stickyHeader}
             >
               {grid.renderHeadCell ? grid.renderHeadCell(column, i) : column.name}
               {i !== numColumn - 1 && resizable && (

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -465,6 +465,7 @@ class GridEditable<
       height,
       'aria-label': ariaLabel,
       bodyStyle,
+      stickyHeader,
     } = this.props;
     const showHeader = title || headerButtons;
     return (
@@ -486,7 +487,7 @@ class GridEditable<
               height={height}
               ref={this.refGrid}
             >
-              <GridHead>{this.renderGridHead()}</GridHead>
+              <GridHead sticky={stickyHeader}>{this.renderGridHead()}</GridHead>
               <GridBody>{this.renderGridBody()}</GridBody>
             </Grid>
           </Body>

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -130,7 +130,7 @@ export const GridHead = styled('thead')<{sticky?: boolean}>`
   ${p => (p.sticky ? `position: sticky; top: 0; z-index: ${Z_INDEX_GRID + 1}` : '')}
 `;
 
-export const GridHeadCell = styled('th')<{isFirst: boolean; sticky?: boolean}>`
+export const GridHeadCell = styled('th')<{isFirst: boolean}>`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   position: relative; /* Used by GridResizer */
@@ -142,8 +142,6 @@ export const GridHeadCell = styled('th')<{isFirst: boolean; sticky?: boolean}>`
 
   border-right: 1px solid transparent;
   border-left: 1px solid transparent;
-
-  ${p => (p.sticky ? `position: sticky; top: 0;` : '')}
 
   a,
   div,

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -110,7 +110,7 @@ export const Grid = styled('table')<{height?: string | number; scrollable?: bool
  * Grid. As the entirety of the add/remove/resize actions are performed on the
  * header, most of the elements behave different for each stage.
  */
-export const GridHead = styled('thead')`
+export const GridHead = styled('thead')<{sticky?: boolean}>`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1/-1;
@@ -126,6 +126,8 @@ export const GridHead = styled('thead')`
 
   border-top-left-radius: ${p => p.theme.borderRadius};
   border-top-right-radius: ${p => p.theme.borderRadius};
+
+  ${p => (p.sticky ? `position: sticky; top: 0; z-index: ${Z_INDEX_GRID + 1}` : '')}
 `;
 
 export const GridHeadCell = styled('th')<{isFirst: boolean; sticky?: boolean}>`


### PR DESCRIPTION
### Changes
Move where the sticky style gets applied to fix issues with sticky header not working with scrolling. Also add a story to cover both sticky headers and scrolling

### Before

![Screenshot 2025-06-16 at 4 05 50 PM](https://github.com/user-attachments/assets/d767a3fe-c416-4a20-aec9-24622d811a24)


### After

![Screenshot 2025-06-16 at 4 06 14 PM](https://github.com/user-attachments/assets/aa699f84-ce42-4d0c-b7ba-548ed01bf432)

