### PR TITLE
chore(seer): add seer scanner rate limit

### DIFF
--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -163,6 +163,15 @@ class SeerAutomationSource(enum.Enum):
 def is_seer_scanner_rate_limited(
     project: Project, organization: Organization
 ) -> tuple[bool, int, int]:
+    """
+    Check if Seer Scanner automation is rate limited for a given project and organization.
+
+    Returns:
+        tuple[bool, int, int]:
+            - is_rate_limited: Whether the seer scanner is rate limited.
+            - current: The current number of seer scanner runs.
+            - limit: The limit for seer scanner runs.
+    """
     from sentry import features, options, ratelimits
 
     if not features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -186,7 +186,7 @@ def is_seer_scanner_rate_limited(
     return is_rate_limited, current, limit
 
 
-def is_seer_autofix_rate_limited(
+def is_seer_autotriggered_autofix_rate_limited(
     project: Project, organization: Organization
 ) -> tuple[bool, int, int]:
     """

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -7,6 +7,7 @@ import requests
 from django.conf import settings
 from pydantic import BaseModel
 
+from sentry import features, options, ratelimits
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -172,18 +173,17 @@ def is_seer_scanner_rate_limited(
             - current: The current number of seer scanner runs.
             - limit: The limit for seer scanner runs.
     """
-    from sentry import features, options, ratelimits
+    if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
+        return False, 0, 0
 
-    if not features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
-        limit = options.get("seer.max_num_scanner_autotriggered_per_hour") or 1000
-        is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
-            project=project,
-            key="seer.scanner.auto_triggered",
-            limit=limit,
-            window=60 * 60,  # 1 hour
-        )
-        return is_rate_limited, current, limit
-    return False, 0, 0
+    limit = options.get("seer.max_num_scanner_autotriggered_per_hour") or 1000
+    is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
+        project=project,
+        key="seer.scanner.auto_triggered",
+        limit=limit,
+        window=60 * 60,  # 1 hour
+    )
+    return is_rate_limited, current, limit
 
 
 def is_seer_autofix_rate_limited(
@@ -198,15 +198,14 @@ def is_seer_autofix_rate_limited(
             - current: The current number of Autofix runs.
             - limit: The limit for Autofix runs.
     """
-    from sentry import features, options, ratelimits
+    if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
+        return False, 0, 0
 
-    if not features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
-        limit = options.get("seer.max_num_autofix_autotriggered_per_hour") or 20
-        is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
-            project=project,
-            key="autofix.auto_triggered",
-            limit=limit,
-            window=60 * 60,  # 1 hour
-        )
-        return is_rate_limited, current, limit
-    return False, 0, 0
+    limit = options.get("seer.max_num_autofix_autotriggered_per_hour") or 20
+    is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
+        project=project,
+        key="autofix.auto_triggered",
+        limit=limit,
+        window=60 * 60,  # 1 hour
+    )
+    return is_rate_limited, current, limit

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -176,7 +176,7 @@ def is_seer_scanner_rate_limited(
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False, 0, 0
 
-    limit = options.get("seer.max_num_scanner_autotriggered_per_hour") or 1000
+    limit = options.get("seer.max_num_scanner_autotriggered_per_hour", 1000)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
         key="seer.scanner.auto_triggered",
@@ -201,7 +201,7 @@ def is_seer_autofix_rate_limited(
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False, 0, 0
 
-    limit = options.get("seer.max_num_autofix_autotriggered_per_hour") or 20
+    limit = options.get("seer.max_num_autofix_autotriggered_per_hour", 20)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
         key="autofix.auto_triggered",

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -5,7 +5,7 @@ from typing import Any
 import sentry_sdk
 
 from sentry import features, options
-from sentry.autofix.utils import SeerAutomationSource
+from sentry.autofix.utils import SeerAutomationSource, is_seer_scanner_rate_limited
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.seer.issue_summary import get_issue_summary
@@ -29,6 +29,17 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     if not project.get_option("sentry:seer_scanner_automation"):
         return None
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
+        return None
+
+    is_rate_limited, current, limit = is_seer_scanner_rate_limited(project, group.organization)
+    if is_rate_limited:
+        sentry_sdk.set_tags(
+            {
+                "scanner_run_count": current,
+                "scanner_run_limit": limit,
+            }
+        )
+        logger.error("Seer scanner auto-trigger rate limit hit")
         return None
 
     from sentry import quotas

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -601,6 +601,10 @@ register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Issue Summary Auto-trigger rate (max number of autofix runs auto-triggered per project per hour)
 register("seer.max_num_autofix_autotriggered_per_hour", default=20, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per hour)
+register(
+    "seer.max_num_scanner_autotriggered_per_hour", default=1000, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
 
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -16,7 +16,7 @@ from sentry.api.serializers.rest_framework.base import convert_dict_key_case, sn
 from sentry.autofix.utils import (
     SeerAutomationSource,
     get_autofix_state,
-    is_seer_autofix_rate_limited,
+    is_seer_autotriggered_autofix_rate_limited,
 )
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.eventstore.models import Event, GroupEvent
@@ -311,7 +311,9 @@ def _run_automation(
 
     if _is_issue_fixable(group, issue_summary.scores.fixability_score):
 
-        is_rate_limited, current, limit = is_seer_autofix_rate_limited(project, organization)
+        is_rate_limited, current, limit = is_seer_autotriggered_autofix_rate_limited(
+            project, organization
+        )
         if is_rate_limited:
             sentry_sdk.set_tags(
                 {


### PR DESCRIPTION
Adds a rate limit for starting seer scanner tasks (default 1000 per hour per project) to prevent surprise bills.