### PR TITLE
fix(nav): Fix sticky z-index for 'configure'

### DIFF
--- a/static/app/views/nav/secondary/secondary.tsx
+++ b/static/app/views/nav/secondary/secondary.tsx
@@ -349,7 +349,7 @@ const TrailingItems = styled('div')`
 `;
 
 const SeparatorWrapper = styled('div')`
-  padding: ${space(1.5)} 0;
+  margin: ${space(1.5)} 0;
   display: none;
 `;
 

--- a/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issuesSecondaryNav.tsx
@@ -83,10 +83,10 @@ export function IssuesSecondaryNav() {
 }
 
 function ConfigureSection({baseUrl}: {baseUrl: string}) {
-  const {layout, isCollapsed} = useNavContext();
+  const {layout} = useNavContext();
   const hasWorkflowEngine = useWorkflowEngineFeatureGate();
 
-  const isSticky = layout === NavLayout.SIDEBAR && !isCollapsed;
+  const isSticky = layout === NavLayout.SIDEBAR;
 
   return (
     <StickyBottomSection
@@ -133,6 +133,7 @@ const StickyBottomSection = styled(SecondaryNav.Section, {
     css`
       position: sticky;
       bottom: 0;
+      z-index: 1;
       background: ${p.theme.isChonk ? p.theme.background : p.theme.surface200};
     `}
 `;


### PR DESCRIPTION
Menu items were peeking through the sticky footer

New:

![CleanShot 2025-06-16 at 13 33 20](https://github.com/user-attachments/assets/15025333-b936-47ab-b733-c191500fa879)
