### PR TITLE
feat: add filter options for TA table when clicking on summary items

### DIFF
--- a/static/app/components/codecov/summary.spec.tsx
+++ b/static/app/components/codecov/summary.spec.tsx
@@ -17,7 +17,7 @@ function createWrapper(initialEntries: string) {
 describe('useCreateSummaryFilterLink', () => {
   describe('when the filter is not applied', () => {
     it('returns isFiltered as false', () => {
-      const {result} = renderHook(() => useCreateSummaryFilterLink('test_type'), {
+      const {result} = renderHook(() => useCreateSummaryFilterLink('slowestTests'), {
         wrapper: createWrapper('/'),
       });
 
@@ -25,28 +25,28 @@ describe('useCreateSummaryFilterLink', () => {
     });
 
     it('returns the link with search param', () => {
-      const {result} = renderHook(() => useCreateSummaryFilterLink('test_type'), {
+      const {result} = renderHook(() => useCreateSummaryFilterLink('slowestTests'), {
         wrapper: createWrapper('/'),
       });
 
       expect(result.current.filterLink).toEqual(
-        expect.objectContaining({query: {f_b_type: 'test_type'}})
+        expect.objectContaining({query: {filterBy: 'slowestTests'}})
       );
     });
   });
 
   describe('when the filter is applied', () => {
     it('returns isFiltered as true', () => {
-      const {result} = renderHook(() => useCreateSummaryFilterLink('test_type'), {
-        wrapper: createWrapper('/?f_b_type=test_type'),
+      const {result} = renderHook(() => useCreateSummaryFilterLink('slowestTests'), {
+        wrapper: createWrapper('/?filterBy=slowestTests'),
       });
 
       expect(result.current.isFiltered).toBeTruthy();
     });
 
     it('returns the link without search param', () => {
-      const {result} = renderHook(() => useCreateSummaryFilterLink('test_type'), {
-        wrapper: createWrapper('/?f_b_type=test_type'),
+      const {result} = renderHook(() => useCreateSummaryFilterLink('slowestTests'), {
+        wrapper: createWrapper('/?filterBy=slowestTests'),
       });
 
       expect(result.current.filterLink).toEqual(expect.objectContaining({query: {}}));

--- a/static/app/components/codecov/summary.tsx
+++ b/static/app/components/codecov/summary.tsx
@@ -6,17 +6,18 @@ import Link from 'sentry/components/links/link';
 import {IconFilter} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
+import type {SummaryFilterKey} from 'sentry/views/codecov/tests/config';
 
 // exporting for testing purposes
-export function useCreateSummaryFilterLink(f_b_type: string) {
+export function useCreateSummaryFilterLink(filterBy: SummaryFilterKey) {
   const location = useLocation();
-  const isFiltered = location.query.f_b_type === f_b_type;
+  const isFiltered = location.query.filterBy === filterBy;
 
   const filterLink = {
     ...location,
     query: {
       ...location.query,
-      f_b_type,
+      filterBy,
     },
   };
 
@@ -24,7 +25,7 @@ export function useCreateSummaryFilterLink(f_b_type: string) {
     ...location,
     query: {
       ...location.query,
-      f_b_type: undefined,
+      filterBy: undefined,
     },
   };
 
@@ -91,7 +92,7 @@ const StyledSummaryEntryValueLink = styled('span')`
 
 type SummaryEntryValueLinkProps = {
   children: React.ReactNode;
-  filterBy: string;
+  filterBy: SummaryFilterKey;
 };
 
 export function SummaryEntryValueLink({children, filterBy}: SummaryEntryValueLinkProps) {

--- a/static/app/views/codecov/coverage/commits/commitDetailSummary.tsx
+++ b/static/app/views/codecov/coverage/commits/commitDetailSummary.tsx
@@ -62,13 +62,13 @@ export function CommitDetailSummary() {
               >
                 {t('Uncovered lines')}
               </SummaryEntryLabel>
-              <SummaryEntryValueLink filterBy="uncovered_lines">5</SummaryEntryValueLink>
+              <SummaryEntryValueLink filterBy="uncoveredLines">5</SummaryEntryValueLink>
             </SummaryEntry>
             <SummaryEntry>
               <SummaryEntryLabel showUnderline body={<p>{t('Files changed tooltip')}</p>}>
                 {t('Files changed')}
               </SummaryEntryLabel>
-              <SummaryEntryValueLink filterBy="files_changed">4</SummaryEntryValueLink>
+              <SummaryEntryValueLink filterBy="filesChanged">4</SummaryEntryValueLink>
             </SummaryEntry>
             <SummaryEntry>
               <SummaryEntryLabel
@@ -77,7 +77,7 @@ export function CommitDetailSummary() {
               >
                 {t('Indirect changes')}
               </SummaryEntryLabel>
-              <SummaryEntryValueLink filterBy="indirect_changes">1</SummaryEntryValueLink>
+              <SummaryEntryValueLink filterBy="indirectChanges">1</SummaryEntryValueLink>
             </SummaryEntry>
             <SourceEntry>
               <SummaryEntryLabel showUnderline body={<p>{t('Source tooltip')}</p>}>
@@ -101,7 +101,7 @@ export function CommitDetailSummary() {
               <SummaryEntryLabel showUnderline body={<p>{t('Uploads count tooltip')}</p>}>
                 {t('Uploads count')}
               </SummaryEntryLabel>
-              <SummaryEntryValueLink filterBy="uploads_count">65</SummaryEntryValueLink>
+              <SummaryEntryValueLink filterBy="uploadsCount">65</SummaryEntryValueLink>
               <StyledSubText>{t('(%s processed, %s pending)', 65, 15)}</StyledSubText>
             </SummaryEntry>
           </SummaryEntries>

--- a/static/app/views/codecov/tests/config.tsx
+++ b/static/app/views/codecov/tests/config.tsx
@@ -11,6 +11,10 @@ export const SUMMARY_TO_TABLE_FILTER_KEY = {
   flakyTests: 'FLAKY_TESTS',
   failedTests: 'FAILED_TESTS',
   skippedTests: 'SKIPPED_TESTS',
+  uncoveredLines: 'UNCOVERED_LINES',
+  indirectChanges: 'INDIRECT_CHANGES',
+  filesChanged: 'FILES_CHANGED',
+  uploadsCount: 'UPLOAD_COUNT',
 };
 
 export type SummaryFilterKey = keyof typeof SUMMARY_TO_TABLE_FILTER_KEY;

--- a/static/app/views/codecov/tests/config.tsx
+++ b/static/app/views/codecov/tests/config.tsx
@@ -6,18 +6,25 @@ export const TABLE_FIELD_NAME_TO_SORT_KEY = {
   testName: 'NAME',
 };
 
-export const SUMMARY_TO_TABLE_FILTER_KEY = {
+export const SUMMARY_TO_TA_TABLE_FILTER_KEY = {
   slowestTests: 'SLOWEST_TESTS',
   flakyTests: 'FLAKY_TESTS',
   failedTests: 'FAILED_TESTS',
   skippedTests: 'SKIPPED_TESTS',
+};
+
+export type SummaryTAFilterKey = keyof typeof SUMMARY_TO_TA_TABLE_FILTER_KEY;
+
+export const SUMMARY_TO_COMMITS_TABLE_FILTER_KEY = {
   uncoveredLines: 'UNCOVERED_LINES',
   indirectChanges: 'INDIRECT_CHANGES',
   filesChanged: 'FILES_CHANGED',
   uploadsCount: 'UPLOAD_COUNT',
 };
 
-export type SummaryFilterKey = keyof typeof SUMMARY_TO_TABLE_FILTER_KEY;
+type SummaryCommitsFilterKey = keyof typeof SUMMARY_TO_COMMITS_TABLE_FILTER_KEY;
+
+export type SummaryFilterKey = SummaryTAFilterKey | SummaryCommitsFilterKey;
 
 export const DATE_TO_QUERY_INTERVAL = {
   '24h': 'INTERVAL_1_DAY',

--- a/static/app/views/codecov/tests/config.tsx
+++ b/static/app/views/codecov/tests/config.tsx
@@ -6,6 +6,15 @@ export const TABLE_FIELD_NAME_TO_SORT_KEY = {
   testName: 'NAME',
 };
 
+export const SUMMARY_TO_TABLE_FILTER_KEY = {
+  slowestTests: 'SLOWEST_TESTS',
+  flakyTests: 'FLAKY_TESTS',
+  failedTests: 'FAILED_TESTS',
+  skippedTests: 'SKIPPED_TESTS',
+};
+
+export type SummaryFilterKey = keyof typeof SUMMARY_TO_TABLE_FILTER_KEY;
+
 export const DATE_TO_QUERY_INTERVAL = {
   '24h': 'INTERVAL_1_DAY',
   '7d': 'INTERVAL_7_DAY',

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -9,10 +9,13 @@ import {
   type QueryKeyEndpointOptions,
   useInfiniteQuery,
 } from 'sentry/utils/queryClient';
-import type {SummaryFilterKey} from 'sentry/views/codecov/tests/config';
+import type {
+  SummaryFilterKey,
+  SummaryTAFilterKey,
+} from 'sentry/views/codecov/tests/config';
 import {
   DATE_TO_QUERY_INTERVAL,
-  SUMMARY_TO_TABLE_FILTER_KEY,
+  SUMMARY_TO_TA_TABLE_FILTER_KEY,
   TABLE_FIELD_NAME_TO_SORT_KEY,
 } from 'sentry/views/codecov/tests/config';
 import type {SortableTAOptions} from 'sentry/views/codecov/tests/testAnalyticsTable/testAnalyticsTable';
@@ -59,10 +62,15 @@ type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 export function useInfiniteTestResults() {
   const {integratedOrg, repository, branch, codecovPeriod} = useCodecovContext();
   const [searchParams] = useSearchParams();
+
   const sortBy = searchParams.get('sort') || '-commitsFailed';
   const signedSortBy = sortValueToSortKey(sortBy);
+
   const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
-  const mappedFilterBy = filterBy && SUMMARY_TO_TABLE_FILTER_KEY[filterBy];
+  let mappedFilterBy = null;
+  if (filterBy in SUMMARY_TO_TA_TABLE_FILTER_KEY) {
+    mappedFilterBy = SUMMARY_TO_TA_TABLE_FILTER_KEY[filterBy as SummaryTAFilterKey];
+  }
 
   const {data, ...rest} = useInfiniteQuery<
     ApiResult<TestResults>,

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -9,8 +9,10 @@ import {
   type QueryKeyEndpointOptions,
   useInfiniteQuery,
 } from 'sentry/utils/queryClient';
+import type {SummaryFilterKey} from 'sentry/views/codecov/tests/config';
 import {
   DATE_TO_QUERY_INTERVAL,
+  SUMMARY_TO_TABLE_FILTER_KEY,
   TABLE_FIELD_NAME_TO_SORT_KEY,
 } from 'sentry/views/codecov/tests/config';
 import type {SortableTAOptions} from 'sentry/views/codecov/tests/testAnalyticsTable/testAnalyticsTable';
@@ -59,6 +61,8 @@ export function useInfiniteTestResults() {
   const [searchParams] = useSearchParams();
   const sortBy = searchParams.get('sort') || '-commitsFailed';
   const signedSortBy = sortValueToSortKey(sortBy);
+  const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
+  const mappedFilterBy = filterBy && SUMMARY_TO_TABLE_FILTER_KEY[filterBy];
 
   const {data, ...rest} = useInfiniteQuery<
     ApiResult<TestResults>,
@@ -68,7 +72,7 @@ export function useInfiniteTestResults() {
   >({
     queryKey: [
       `/prevent/owner/${integratedOrg}/repository/${repository}/test-results/`,
-      {query: {branch, codecovPeriod, signedSortBy}},
+      {query: {branch, codecovPeriod, signedSortBy, mappedFilterBy}},
     ],
     queryFn: async ({
       queryKey: [url],
@@ -84,6 +88,7 @@ export function useInfiniteTestResults() {
               interval: DATE_TO_QUERY_INTERVAL[codecovPeriod],
               sortBy: signedSortBy,
               branch,
+              ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
             },
           },
         ],

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.spec.tsx
@@ -23,7 +23,7 @@ describe('CIEfficiency', () => {
     expect(formattedSlowestTests).toBeInTheDocument();
     expect(formattedSlowestTests).toHaveAttribute(
       'href',
-      '/mock-pathname/?f_b_type=slowest_tests'
+      '/mock-pathname/?filterBy=slowestTests'
     );
   });
 

--- a/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
+++ b/static/app/views/codecov/tests/summaries/ciEfficiency.tsx
@@ -106,7 +106,7 @@ function CIEfficiencyBody({
         >
           {t('Slowest Tests (P95)')}
         </SummaryEntryLabel>
-        <SummaryEntryValueLink filterBy="slowest_tests">
+        <SummaryEntryValueLink filterBy="slowestTests">
           {formatTimeDuration(slowestTestsDuration, 2)}
         </SummaryEntryValueLink>
       </SummaryEntry>

--- a/static/app/views/codecov/tests/summaries/testPerformance.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/testPerformance.spec.tsx
@@ -21,7 +21,7 @@ describe('TestPerformance', () => {
     expect(flakyTestNumber).toBeInTheDocument();
     expect(flakyTestNumber).toHaveAttribute(
       'href',
-      '/mock-pathname/?f_b_type=flaky_tests'
+      '/mock-pathname/?filterBy=flakyTests'
     );
   });
 
@@ -39,7 +39,7 @@ describe('TestPerformance', () => {
     expect(cumulativeFailures).toBeInTheDocument();
     expect(cumulativeFailures).toHaveAttribute(
       'href',
-      '/mock-pathname/?f_b_type=cumulative_failures'
+      '/mock-pathname/?filterBy=failedTests'
     );
   });
 
@@ -48,9 +48,6 @@ describe('TestPerformance', () => {
 
     const skippedTests = screen.getByRole('link', {name: '50'});
     expect(skippedTests).toBeInTheDocument();
-    expect(skippedTests).toHaveAttribute(
-      'href',
-      '/mock-pathname/?f_b_type=skipped_tests'
-    );
+    expect(skippedTests).toHaveAttribute('href', '/mock-pathname/?filterBy=skippedTests');
   });
 });

--- a/static/app/views/codecov/tests/summaries/testPerformance.tsx
+++ b/static/app/views/codecov/tests/summaries/testPerformance.tsx
@@ -101,7 +101,7 @@ function TestPerformanceBody({
           {t('Flaky Tests')}
         </SummaryEntryLabel>
         <SummaryEntryValue>
-          <SummaryEntryValueLink filterBy="flaky_tests">
+          <SummaryEntryValueLink filterBy="flakyTests">
             {flakyTests}
           </SummaryEntryValueLink>
           {flakyTestsChange ? (
@@ -129,7 +129,7 @@ function TestPerformanceBody({
           {t('Cumulative Failures')}
         </SummaryEntryLabel>
         <SummaryEntryValue>
-          <SummaryEntryValueLink filterBy="cumulative_failures">
+          <SummaryEntryValueLink filterBy="failedTests">
             {cumulativeFailures}
           </SummaryEntryValueLink>
           {cumulativeFailuresChange ? (
@@ -144,7 +144,7 @@ function TestPerformanceBody({
           {t('Skipped Tests')}
         </SummaryEntryLabel>
         <SummaryEntryValue>
-          <SummaryEntryValueLink filterBy="skipped_tests">
+          <SummaryEntryValueLink filterBy="skippedTests">
             {skippedTests}
           </SummaryEntryValueLink>
           {skippedTestsChange ? (


### PR DESCRIPTION
This PR adds the ability to filter the Test Analytics table by the selections of the Test Analytics Summary cards.

Notes
-
- Added the `filterBy` query param to talk to the backend.
- Added object that maps filter selections to those that the backend expects.
- Adjusted `f_b_type` to `filterBy` and related tests.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
