### PR TITLE
perf(aci): Batch redis operations

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -369,7 +369,11 @@ class RedisBuffer(Buffer):
         return pipe.execute()[0]
 
     def push_to_sorted_set(self, key: str, value: list[int] | int) -> None:
-        value_dict = {value: time()}
+        now = time()
+        if isinstance(value, list):
+            value_dict = {v: now for v in value}
+        else:
+            value_dict = {value: now}
         self._execute_redis_operation(key, RedisOperation.SORTED_SET_ADD, value_dict)
 
     def get_sorted_set(self, key: str, min: float, max: float) -> list[tuple[int, datetime]]:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -107,17 +107,6 @@ def enqueue_workflows(
     )
 
 
-def enqueue_workflow(
-    workflow: Workflow,
-    delayed_conditions: list[DataCondition],
-    event: GroupEvent,
-    source: WorkflowDataConditionGroupType,
-) -> None:
-    enqueue_workflows(
-        {event.group.project.id: [DelayedWorkflowItem(workflow, delayed_conditions, event, source)]}
-    )
-
-
 @sentry_sdk.trace
 def evaluate_workflow_triggers(
     workflows: set[Workflow], event_data: WorkflowEventData

--- a/tests/sentry/buffer/test_redis.py
+++ b/tests/sentry/buffer/test_redis.py
@@ -234,8 +234,7 @@ class TestRedisBuffer:
         event4_id = 11
 
         # store the project ids
-        self.buf.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=project_id)
-        self.buf.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=project_id2)
+        self.buf.push_to_sorted_set(key=PROJECT_ID_BUFFER_LIST_KEY, value=[project_id, project_id2])
 
         # store the rules and group per project
         self.buf.push_to_hash(

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import asdict
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -58,6 +58,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
 )
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+    DelayedWorkflowItem,
     WorkflowDataConditionGroupType,
 )
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -807,7 +808,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.detector,
         )
 
-    @patch("sentry.workflow_engine.processors.workflow.enqueue_workflow")
+    @patch("sentry.workflow_engine.processors.workflow.enqueue_workflows")
     def test_fire_actions_for_groups__enqueue(self, mock_enqueue):
         # enqueue the IF DCGs with slow conditions!
 
@@ -819,17 +820,33 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
         )
 
         assert mock_enqueue.call_count == 2
-        assert mock_enqueue.call_args_list[0][0] == (
-            self.workflow1,
-            [self.workflow1_dcgs[1].conditions.all()[0]],
-            self.event1.for_group(self.group1),
-            WorkflowDataConditionGroupType.ACTION_FILTER,
-        )
-        assert mock_enqueue.call_args_list[1][0] == (
-            self.workflow2,
-            [self.workflow2_dcgs[1].conditions.all()[0]],
-            self.event2.for_group(self.group2),
-            WorkflowDataConditionGroupType.ACTION_FILTER,
+        mock_enqueue.assert_has_calls(
+            [
+                call(
+                    {
+                        self.project.id: [
+                            DelayedWorkflowItem(
+                                workflow=self.workflow1,
+                                delayed_conditions=[self.workflow1_dcgs[1].conditions.all()[0]],
+                                event=self.event1.for_group(self.group1),
+                                source=WorkflowDataConditionGroupType.ACTION_FILTER,
+                            ),
+                        ],
+                    }
+                ),
+                call(
+                    {
+                        self.project.id: [
+                            DelayedWorkflowItem(
+                                workflow=self.workflow2,
+                                delayed_conditions=[self.workflow2_dcgs[1].conditions.all()[0]],
+                                event=self.event2.for_group(self.group2),
+                                source=WorkflowDataConditionGroupType.ACTION_FILTER,
+                            ),
+                        ],
+                    }
+                ),
+            ]
         )
 
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -25,9 +25,10 @@ from sentry.workflow_engine.models import (
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
+    DelayedWorkflowItem,
     WorkflowDataConditionGroupType,
     delete_workflow,
-    enqueue_workflow,
+    enqueue_workflows,
     evaluate_workflow_triggers,
     evaluate_workflows_action_filters,
     process_workflows,
@@ -326,6 +327,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
             )
 
 
+@mock_redis_buffer()
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
     def setUp(self):
         (
@@ -539,6 +541,7 @@ class TestEnqueueWorkflow(BaseWorkflowTest):
         assert len(project_ids) == 0
 
 
+@mock_redis_buffer()
 class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
     def setUp(self):
         (
@@ -634,48 +637,64 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
         self.condition = self.create_data_condition(condition_group=self.data_condition_group)
         _, self.event, self.group_event = self.create_group_event()
 
-    @patch("sentry.buffer.backend.push_to_hash")
     @patch("sentry.buffer.backend.push_to_sorted_set")
-    def test_enqueue_workflow__adds_to_workflow_engine_buffer(
-        self, mock_push_to_hash, mock_push_to_sorted_set
+    @patch("sentry.buffer.backend.push_to_hash_bulk")
+    def test_enqueue_workflows__adds_to_workflow_engine_buffer(
+        self, mock_push_to_hash_bulk, mock_push_to_sorted_set
     ):
-        enqueue_workflow(
-            self.workflow,
-            [self.condition],
-            self.group_event,
-            WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
+        enqueue_workflows(
+            {
+                self.group_event.project_id: [
+                    DelayedWorkflowItem(
+                        self.workflow,
+                        [self.condition],
+                        self.group_event,
+                        WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
+                    )
+                ]
+            }
         )
 
-        mock_push_to_hash.assert_called_once_with(
+        mock_push_to_sorted_set.assert_called_once_with(
             key=WORKFLOW_ENGINE_BUFFER_LIST_KEY,
-            value=self.group_event.project_id,
+            value=[self.group_event.project_id],
         )
 
-    @patch("sentry.buffer.backend.push_to_hash")
     @patch("sentry.buffer.backend.push_to_sorted_set")
+    @patch("sentry.buffer.backend.push_to_hash_bulk")
     def test_enqueue_workflow__adds_to_workflow_engine_set(
-        self, mock_push_to_hash, mock_push_to_sorted_set
+        self, mock_push_to_hash_bulk, mock_push_to_sorted_set
     ):
         condition2 = self.create_data_condition(condition_group=self.create_data_condition_group())
         condition3 = self.create_data_condition(condition_group=self.create_data_condition_group())
-        enqueue_workflow(
-            self.workflow,
-            [self.condition, condition2, condition3],
-            self.group_event,
-            WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
+        enqueue_workflows(
+            {
+                self.group_event.project_id: [
+                    DelayedWorkflowItem(
+                        self.workflow,
+                        [self.condition, condition2, condition3],
+                        self.group_event,
+                        WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
+                    )
+                ]
+            }
         )
 
         condition_group_ids = ",".join(
             str(condition.condition_group_id)
             for condition in [self.condition, condition2, condition3]
         )
-        mock_push_to_sorted_set.assert_called_once_with(
+        mock_push_to_hash_bulk.assert_called_once_with(
             model=Workflow,
             filters={"project_id": self.group_event.project_id},
-            field=f"{self.workflow.id}:{self.group_event.group_id}:{condition_group_ids}:workflow_trigger",
-            value=json.dumps(
-                {"event_id": self.event.event_id, "occurrence_id": self.group_event.occurrence_id}
-            ),
+            data={
+                f"{self.workflow.id}:{self.group_event.group_id}:{condition_group_ids}:workflow_trigger": json.dumps(
+                    {
+                        "event_id": self.event.event_id,
+                        "occurrence_id": self.group_event.occurrence_id,
+                    }
+                )
+            },
         )
 
 


### PR DESCRIPTION
When process_workflow_engine is reported as slow, traces show 60-75% of the time being spent performing the many redis operations.
Batching our redis operations should avoid some of the overhead from these many round-trips.