### PR TITLE
chore(ACI): Add detector type to action logs

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -314,6 +314,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
                 "workflow_engine.triggered_actions",
                 extra={
                     "detector_id": detector.id,
+                    "detector_type": detector.type,
                     "action_ids": [action.id for action in actions],
                     "event_data": asdict(event_data),
                 },
@@ -332,6 +333,7 @@ def process_workflows(event_data: WorkflowEventData) -> set[Workflow]:
                         "workflow_engine.action.would-trigger",
                         extra={
                             "detector_id": detector.id,
+                            "detector_type": detector.type,
                             "action_id": action.id,
                             "event_data": asdict(event_data),
                         },


### PR DESCRIPTION
Add the detector type to the action logs to see if we are processing metric issues this far - I am not able to find the expected logs doing manual testing and want to see how widespread the issue is.