### PR TITLE
fix(aci): Freeze UniqueConditionQuery filters to make them hashable

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
@@ -35,6 +36,7 @@ from sentry.utils.registry import NoRegistrationExistsError
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
     BaseEventFrequencyQueryHandler,
+    QueryFilter,
     QueryResult,
     slow_condition_query_handler_registry,
 )
@@ -83,7 +85,26 @@ class UniqueConditionQuery:
     interval: str
     environment_id: int | None
     comparison_interval: str | None = None
-    filters: list[dict[str, Any]] | None = None
+    # Hashable representation of the filters
+    frozen_filters: Sequence[frozenset[tuple[str, Any]]] | None = None
+
+    @staticmethod
+    def freeze_filters(
+        filters: Sequence[Mapping[str, Any]] | None,
+    ) -> Sequence[frozenset[tuple[str, Any]]] | None:
+        """
+        Convert the sorted representation of filters into a frozen one that can
+        be safely hashed.
+        """
+        if filters is None:
+            return None
+        return tuple(frozenset(sorted(filter.items())) for filter in filters)
+
+    @property
+    def filters(self) -> list[QueryFilter] | None:
+        if self.frozen_filters is None:
+            return None
+        return [dict(filter) for filter in self.frozen_filters]
 
     def __repr__(self):
         return f"UniqueConditionQuery(handler={self.handler.__name__}, interval={self.interval}, environment_id={self.environment_id}, comparison_interval={self.comparison_interval}, filters={self.filters})"
@@ -203,7 +224,7 @@ def generate_unique_queries(
             handler=handler,
             interval=condition.comparison["interval"],
             environment_id=environment_id,
-            filters=condition.comparison.get("filters"),
+            frozen_filters=UniqueConditionQuery.freeze_filters(condition.comparison.get("filters")),
         )
     ]
     if condition_type in PERCENT_CONDITIONS:
@@ -213,7 +234,9 @@ def generate_unique_queries(
                 interval=condition.comparison["interval"],
                 environment_id=environment_id,
                 comparison_interval=condition.comparison.get("comparison_interval"),
-                filters=condition.comparison.get("filters"),
+                frozen_filters=UniqueConditionQuery.freeze_filters(
+                    condition.comparison.get("filters")
+                ),
             )
         )
     return unique_queries

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -13,6 +13,7 @@ from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.rules.conditions.event_frequency import ComparisonType
+from sentry.rules.match import MatchType
 from sentry.rules.processing.buffer_processing import process_in_batches
 from sentry.rules.processing.delayed_processing import fetch_project
 from sentry.testutils.helpers import override_options, with_feature
@@ -352,6 +353,36 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
         comparison_query_dict["comparison_interval"] = "1w"
         expected_comparison_query = UniqueConditionQuery(**comparison_query_dict)
         assert percent_queries[1] == expected_comparison_query
+
+    def test_generate_unique_queries__filters_hashable(self):
+        dc = self.create_data_condition(
+            condition_group=self.create_data_condition_group(
+                logic_type=DataConditionGroup.Type.ALL
+            ),
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={
+                "interval": "1h",
+                "value": 100,
+                "filters": [
+                    {
+                        "key": "http.method",
+                        "match": MatchType.IS_IN,
+                        "value": "GET,POST",
+                    }
+                ],
+            },
+            condition_result=True,
+        )
+        queries = generate_unique_queries(dc, None)
+        [hash(query) for query in queries]  # shouldn't raise
+        assert len(queries) == 1
+        assert queries[0].filters == [
+            {
+                "key": "http.method",
+                "match": MatchType.IS_IN,
+                "value": "GET,POST",
+            }
+        ]
 
     def test_generate_unique_queries__invalid(self):
         dc = self.create_data_condition(


### PR DESCRIPTION
When the filters are `None`, it's not a problem, but as soon as we populate it with a list of dicts, it's a runtime error.
