### PR TITLE
feat(ACI): Enable and disable detectors

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -99,6 +99,7 @@ from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.not_set import NOT_SET, NotSet
 from sentry.utils.snuba import is_measurement
+from sentry.workflow_engine.models.detector import Detector
 
 # We can return an incident as "windowed" which returns a range of points around the start of the incident
 # It attempts to center the start of the incident, only showing earlier data if there isn't enough time
@@ -1002,12 +1003,28 @@ def update_alert_rule(
     return alert_rule
 
 
+def update_detector(alert_rule: AlertRule, enabled: bool) -> None:
+    if features.has(
+        "organizations:workflow-engine-metric-alert-dual-write", alert_rule.organization
+    ):
+        try:
+            detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
+        except Detector.DoesNotExist:
+            return None
+
+        if detector:
+            status = ObjectStatus.ACTIVE if enabled else ObjectStatus.DISABLED
+            detector.update(status=status)
+
+
 def enable_alert_rule(alert_rule: AlertRule) -> None:
     if alert_rule.status != AlertRuleStatus.DISABLED.value:
         return
     with transaction.atomic(router.db_for_write(AlertRule)):
         alert_rule.update(status=AlertRuleStatus.PENDING.value)
         bulk_enable_snuba_subscriptions(_unpack_snuba_query(alert_rule).subscriptions.all())
+
+    update_detector(alert_rule=alert_rule, enabled=True)
 
 
 def disable_alert_rule(alert_rule: AlertRule) -> None:
@@ -1016,6 +1033,8 @@ def disable_alert_rule(alert_rule: AlertRule) -> None:
     with transaction.atomic(router.db_for_write(AlertRule)):
         alert_rule.update(status=AlertRuleStatus.DISABLED.value)
         bulk_disable_snuba_subscriptions(_unpack_snuba_query(alert_rule).subscriptions.all())
+
+    update_detector(alert_rule=alert_rule, enabled=False)
 
 
 def delete_alert_rule(


### PR DESCRIPTION
When we enable and disable alert rules we want to do the same for detectors. There will be a follow up getsentry PR to handle this on that side for when it's just detectors and we're not looking it up through the lookup table. 