### PR TITLE
fix(explore): Use map for each instead of iterator

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -324,7 +324,7 @@ function findAllFields(
   const addedFields = new Set<string>();
   const removedFields = new Set<string>();
 
-  function checkField(field: string) {
+  function checkField(_count: number, field: string) {
     const curCount = curFields.get(field) || 0;
     const newCount = newFields.get(field) || 0;
     if (curCount > newCount) {
@@ -334,8 +334,8 @@ function findAllFields(
     }
   }
 
-  curFields.keys().forEach(checkField);
-  newFields.keys().forEach(checkField);
+  curFields.forEach(checkField);
+  newFields.forEach(checkField);
 
   return {addedFields, removedFields};
 }


### PR DESCRIPTION
Iterator forEach is only available for recent browsers. For better compatibility, use the map forEach instead as that has better support.

Fixes JAVASCRIPT-31Q7