### PR TITLE
feat(agents-insights): Add span aggregation columns to trace table

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -7,41 +7,60 @@ import GridEditable, {
   type GridColumnHeader,
   type GridColumnOrder,
 } from 'sentry/components/gridEditable';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import type {CursorHandler} from 'sentry/components/pagination';
 import Pagination from 'sentry/components/pagination';
+import Placeholder from 'sentry/components/placeholder';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import getDuration from 'sentry/utils/duration/getDuration';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useProjects from 'sentry/utils/useProjects';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
 import {useTraceViewDrawer} from 'sentry/views/insights/agentMonitoring/components/drawer';
 import {useColumnOrder} from 'sentry/views/insights/agentMonitoring/hooks/useColumnOrder';
-import {getAITracesFilter} from 'sentry/views/insights/agentMonitoring/utils/query';
+import {
+  AI_TOKEN_USAGE_ATTRIBUTE_SUM,
+  getAITracesFilter,
+} from 'sentry/views/insights/agentMonitoring/utils/query';
+import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
+import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 
 interface TableData {
   agentFlow: string;
   duration: number;
   errors: number;
-  project: string;
+  llmCalls: number;
   timestamp: number;
+  toolCalls: number;
+  totalTokens: number;
   traceId: string;
+  isSpanDataLoading?: boolean;
 }
 
 const EMPTY_ARRAY: never[] = [];
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
-  {key: 'traceId', name: t('Trace ID'), width: 120},
-  {key: 'project', name: t('Project'), width: 180},
+  {key: 'traceId', name: t('Trace ID'), width: 110},
   {key: 'agentFlow', name: t('Agent Flow'), width: COL_WIDTH_UNDEFINED},
   {key: 'duration', name: t('Duration'), width: 100},
   {key: 'errors', name: t('Errors'), width: 100},
-  {key: 'timestamp', name: t('Timestamp'), width: 120},
+  {key: 'llmCalls', name: t('LLM Calls'), width: 110},
+  {key: 'toolCalls', name: t('Tool Calls'), width: 110},
+  {key: 'totalTokens', name: t('Total Tokens'), width: 120},
+  {key: 'timestamp', name: t('Timestamp'), width: 100},
 ];
+
+const rightAlignColumns = new Set([
+  'duration',
+  'errors',
+  'llmCalls',
+  'totalTokens',
+  'toolCalls',
+  'timestamp',
+]);
 
 export function TracesTable() {
   const navigate = useNavigate();
@@ -61,6 +80,42 @@ export function TracesTable() {
   });
 
   const pageLinks = tracesRequest.getResponseHeader?.('Link') ?? undefined;
+
+  const spansRequest = useEAPSpans(
+    {
+      search: `trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
+      fields: [
+        'trace',
+        'count_if(span.op,gen_ai.chat)',
+        'count_if(span.op,gen_ai.generate_text)',
+        'count_if(span.op,gen_ai.execute_tool)',
+        AI_TOKEN_USAGE_ATTRIBUTE_SUM,
+      ],
+      limit: tracesRequest.data?.data.length ?? 0,
+      enabled: tracesRequest.data && tracesRequest.data.data.length > 0,
+    },
+    'test-traces-table'
+  );
+
+  const spanDataMap = useMemo(() => {
+    if (!spansRequest.data) {
+      return {};
+    }
+
+    return spansRequest.data.reduce(
+      (acc, span) => {
+        acc[span.trace] = {
+          llmCalls:
+            (span['count_if(span.op,gen_ai.chat)'] ?? 0) +
+            (span['count_if(span.op,gen_ai.generate_text)'] ?? 0),
+          toolCalls: span['count_if(span.op,gen_ai.execute_tool)'] ?? 0,
+          totalTokens: Number(span[AI_TOKEN_USAGE_ATTRIBUTE_SUM] ?? 0),
+        };
+        return acc;
+      },
+      {} as Record<string, {llmCalls: number; toolCalls: number; totalTokens: number}>
+    );
+  }, [spansRequest.data]);
 
   const handleCursor: CursorHandler = (cursor, pathname, previousQuery) => {
     navigate(
@@ -82,17 +137,20 @@ export function TracesTable() {
 
     return tracesRequest.data.data.map(span => ({
       traceId: span.trace,
-      project: span.project ?? '',
       agentFlow: span.name ?? '',
       duration: span.duration,
       errors: span.numErrors,
+      llmCalls: spanDataMap[span.trace]?.llmCalls ?? 0,
+      toolCalls: spanDataMap[span.trace]?.toolCalls ?? 0,
+      totalTokens: spanDataMap[span.trace]?.totalTokens ?? 0,
       timestamp: span.start,
+      isSpanDataLoading: spansRequest.isLoading,
     }));
-  }, [tracesRequest.data]);
+  }, [tracesRequest.data, spanDataMap, spansRequest.isLoading]);
 
   const renderHeadCell = useCallback((column: GridColumnHeader<string>) => {
     return (
-      <HeadCell>
+      <HeadCell align={rightAlignColumns.has(column.key) ? 'right' : 'left'}>
         {column.name}
         {column.key === 'agentFlow' && <CellExpander />}
       </HeadCell>
@@ -138,39 +196,42 @@ const BodyCell = memo(function BodyCell({
 }) {
   const {openTraceViewDrawer} = useTraceViewDrawer({});
 
-  const {projects} = useProjects();
-
-  const project = useMemo(
-    () => projects.find(p => p.slug === dataRow.project),
-    [projects, dataRow.project]
-  );
-
   switch (column.key) {
     case 'traceId':
       return (
-        <Button priority="link" onClick={() => openTraceViewDrawer(dataRow.traceId)}>
-          {dataRow.traceId.slice(0, 8)}
-        </Button>
+        <span>
+          <Button priority="link" onClick={() => openTraceViewDrawer(dataRow.traceId)}>
+            {dataRow.traceId.slice(0, 8)}
+          </Button>
+        </span>
       );
-    case 'project':
-      return project ? (
-        <ProjectBadge project={project} avatarSize={16} />
-      ) : (
-        <ProjectBadge project={{slug: dataRow.project}} avatarSize={16} />
-      );
-
     case 'agentFlow':
       return dataRow.agentFlow;
     case 'duration':
-      return getDuration(dataRow.duration / 1000, 2, true);
+      return <DurationCell milliseconds={dataRow.duration} />;
     case 'errors':
-      return dataRow.errors;
+      return <NumberCell value={dataRow.errors} />;
+    case 'llmCalls':
+    case 'toolCalls':
+    case 'totalTokens':
+      if (dataRow.isSpanDataLoading) {
+        return <NumberPlaceholder />;
+      }
+      return <NumberCell value={dataRow[column.key]} />;
     case 'timestamp':
-      return <TimeSince unitStyle="extraShort" date={new Date(dataRow.timestamp)} />;
+      return (
+        <TextAlignRight>
+          <TimeSince unitStyle="extraShort" date={new Date(dataRow.timestamp)} />
+        </TextAlignRight>
+      );
     default:
       return null;
   }
 });
+
+function NumberPlaceholder() {
+  return <Placeholder style={{marginLeft: 'auto'}} height={'14px'} width={'50px'} />;
+}
 
 const GridEditableContainer = styled('div')`
   position: relative;
@@ -196,7 +257,9 @@ const CellExpander = styled('div')`
   width: 100vw;
 `;
 
-const HeadCell = styled('div')`
+const HeadCell = styled('div')<{align: 'left' | 'right'}>`
   display: flex;
+  flex: 1;
   align-items: center;
+  justify-content: ${p => (p.align === 'right' ? 'flex-end' : 'flex-start')};
 `;


### PR DESCRIPTION
Add columns `LLM Calls`, `Tool Calls` & `Total Tokens` to the traces column. These are calculated in a separate request by aggregating span data of spans in each trace.

<img width="1432" alt="Screenshot 2025-06-17 at 08 05 35" src="https://github.com/user-attachments/assets/e4f9b8ee-bc47-4664-9f8b-d832ebcc8841" />

- closes [TET-642: Add some of these columns to traces table](https://linear.app/getsentry/issue/TET-642/add-some-of-these-columns-to-traces-table)
- closes [TET-641: Remove project from the table](https://linear.app/getsentry/issue/TET-641/remove-project-from-the-table)