### PR TITLE
fix(ui): linkButton focus state

### DIFF
--- a/static/app/components/core/button/linkButton.stories.tsx
+++ b/static/app/components/core/button/linkButton.stories.tsx
@@ -22,6 +22,7 @@ export default Storybook.story('LinkButton', (story, APIReference) => {
       disabled: [false, true],
       external: [false, true],
       title: [undefined, 'Delete this'],
+      href: ['#'],
     };
 
     return (

--- a/static/app/components/core/button/styles.chonk.tsx
+++ b/static/app/components/core/button/styles.chonk.tsx
@@ -115,6 +115,7 @@ export function DO_NOT_USE_getChonkButtonStyles(
 
     '&:focus-visible': {
       outline: 'none',
+      color: p.disabled || p.busy ? undefined : getChonkButtonTheme(type, p.theme).color,
 
       '&::after': {
         border: `1px solid ${p.theme.focusBorder}`,


### PR DESCRIPTION
the real issue are these global styles for all `a` tags:

https://github.com/getsentry/sentry/blob/3c99300d6c73ff31a6f1866000fb9dcb6e56f3b0/static/app/styles/global.tsx#L145-L151

However, removing them (even just for `chonk`) has a negative impact in many places. What we would likely need is an isolated `<Link>` component that sets all its styles rather than relying on global styles to affect it.

So this is more of a band-aid fix, as I’m just setting the same color while focusing, which overwrites the global one.