### PR TITLE
fix(ui): select menu positioning

### DIFF
--- a/static/app/components/core/select/index.chonk.tsx
+++ b/static/app/components/core/select/index.chonk.tsx
@@ -94,8 +94,6 @@ export const getChonkStylesConfig = ({
       width: 'auto',
       minWidth: '100%',
       maxWidth: maxMenuWidth ?? 'auto',
-      top: '100%',
-      marginTop: '8px',
     }),
     noOptionsMessage: provided => ({
       ...provided,

--- a/static/app/components/core/select/index.stories.tsx
+++ b/static/app/components/core/select/index.stories.tsx
@@ -16,7 +16,7 @@ export default Storybook.story('Select', (story, APIReference) => {
         <p>
           The <Storybook.JSXNode name="Select" /> component comes in different sizes:
         </p>
-        <Storybook.SideBySide>
+        <Storybook.Grid>
           <Select
             size="md"
             placeholder="medium"
@@ -42,7 +42,7 @@ export default Storybook.story('Select', (story, APIReference) => {
               {value: 'item2', label: 'Item 2'},
             ]}
           />
-        </Storybook.SideBySide>
+        </Storybook.Grid>
       </Fragment>
     );
   });
@@ -50,7 +50,7 @@ export default Storybook.story('Select', (story, APIReference) => {
   story('Disabled', () => {
     return (
       <Fragment>
-        <Storybook.SideBySide>
+        <Storybook.Grid>
           <Select
             isDisabled
             size="md"
@@ -79,14 +79,14 @@ export default Storybook.story('Select', (story, APIReference) => {
               {value: 'item2', label: 'Item 2'},
             ]}
           />
-        </Storybook.SideBySide>
+        </Storybook.Grid>
       </Fragment>
     );
   });
 
   story('With inFieldLabel', () => {
     return (
-      <Storybook.SideBySide>
+      <Storybook.Grid>
         <Select
           inFieldLabel="Hello world"
           size="md"
@@ -115,13 +115,13 @@ export default Storybook.story('Select', (story, APIReference) => {
             {value: 'item2', label: 'Item 2'},
           ]}
         />
-      </Storybook.SideBySide>
+      </Storybook.Grid>
     );
   });
 
   story('Clearable', () => {
     return (
-      <Storybook.SideBySide>
+      <Storybook.Grid>
         <Select
           isClearable
           defaultValue={{value: 'item1', label: 'Item 1'}}
@@ -152,13 +152,13 @@ export default Storybook.story('Select', (story, APIReference) => {
             {value: 'item2', label: 'Item 2'},
           ]}
         />
-      </Storybook.SideBySide>
+      </Storybook.Grid>
     );
   });
 
   story('Searchable', () => {
     return (
-      <Storybook.SideBySide>
+      <Storybook.Grid>
         <Select
           isSearchable
           size="md"
@@ -187,7 +187,7 @@ export default Storybook.story('Select', (story, APIReference) => {
             {value: 'item2', label: 'Item 2'},
           ]}
         />
-      </Storybook.SideBySide>
+      </Storybook.Grid>
     );
   });
 
@@ -199,7 +199,7 @@ export default Storybook.story('Select', (story, APIReference) => {
           <Storybook.JSXNode name="leadingItems" /> prop to add an icon to the left of the
           option.
         </p>
-        <Storybook.SideBySide>
+        <Storybook.Grid>
           <Select
             isSearchable
             size="md"
@@ -242,7 +242,7 @@ export default Storybook.story('Select', (story, APIReference) => {
               {value: 'item2', label: 'Item 2', leadingItems: <IconGraphBar />},
             ]}
           />
-        </Storybook.SideBySide>
+        </Storybook.Grid>
       </Fragment>
     );
   });


### PR DESCRIPTION
the `...provided` spread will give us top/bottom 100% depending on where the menu should be opened, so the hardcoded top:100% is harmful; also, margin top/bottom is provided already

| before | after |
|--------|--------|
| ![Screenshot 2025-06-17 at 10 15 23](https://github.com/user-attachments/assets/23f5c6d4-4e98-4bb1-a6ec-54a0061e4eb3) | ![Screenshot 2025-06-17 at 10 15 06](https://github.com/user-attachments/assets/5e96dbb7-459a-4085-b71f-05ab39046a30) | 