### PR TITLE
fix(ui): super-user badge positioning

### DIFF
--- a/static/app/views/nav/sidebar.tsx
+++ b/static/app/views/nav/sidebar.tsx
@@ -145,8 +145,9 @@ const SuperuserBadgeContainer = styled('div')`
 `;
 
 const ChonkSuperuserBadgeContainer = chonkStyled('div')`
-  position: fixed;
-  top: -1px;
+  position: absolute;
+  top: -${p => p.theme.space.lg};
+  z-index: ${p => p.theme.zIndex.initial};
   left: 0;
   width: ${PRIMARY_SIDEBAR_WIDTH}px;
   background: ${p => p.theme.colors.chonk.red400};


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-06-17 at 10 40 10](https://github.com/user-attachments/assets/1d0113d2-266e-4e99-af74-4ba0d49a11db) | ![Screenshot 2025-06-17 at 10 40 46](https://github.com/user-attachments/assets/50e3e734-ac35-47b7-b3d7-a31a66ea37b4) | 