### PR TITLE
fix(ui): arcade element in dark mode

### DIFF
--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -432,6 +432,7 @@ const Arcade = styled('iframe')`
   max-width: 100%;
   height: 500px;
   border: 0;
+  color-scheme: auto;
 `;
 
 const StyledButtonBar = styled(ButtonBar)`


### PR DESCRIPTION
this isn't UI2 related, as this was also not nice in the old UI in dark mode. There's no difference in light mode.

| before | after |
|--------|--------|
| ![Screenshot 2025-06-17 at 11 51 17](https://github.com/user-attachments/assets/7ffb1ceb-f3b8-4102-988c-5f8192f0729e) | ![Screenshot 2025-06-17 at 11 51 40](https://github.com/user-attachments/assets/b4dade40-af20-4aa1-8715-4d64c697cb80) |
| ![Screenshot 2025-06-17 at 11 51 35](https://github.com/user-attachments/assets/bd4fba77-84ae-44a3-b356-46cd4406663d) | ![Screenshot 2025-06-17 at 11 51 24](https://github.com/user-attachments/assets/508d3d9e-cab6-4ef0-a3a7-3b774ac20a13) | 
