### PR TITLE
fix(tempest): Include GH profile in message body

### DIFF
--- a/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSdkAccessModal.tsx
@@ -72,6 +72,7 @@ export default function PlayStationSdkAccessModal({
         )
         .join(', ')}`,
       `Org Slug: ${organization.slug}`,
+      `GitHub Profile: ${formData.githubProfile}`,
     ].join('\n');
 
     // Use captureFeedback with proper user context instead of tags
@@ -83,7 +84,6 @@ export default function PlayStationSdkAccessModal({
         source: 'playstation-sdk-access',
         tags: {
           feature: 'playstation-sdk-access',
-          githubProfile: formData.githubProfile,
         },
       },
       {


### PR DESCRIPTION
We want to see github profile immediately in the message body and not need to open the feedback to inspect the tags