### PR TITLE
fix(ui): tour components

### DIFF
--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -539,10 +539,12 @@ export const TourAction = styled(Button)`
   `}
 `;
 
-export const TextTourAction = styled(Button)`
-  border: 0;
+function TransparentButton(props: React.ComponentProps<typeof Button>) {
+  return <Button {...props} priority="transparent" borderless />;
+}
+
+export const TextTourAction = styled(TransparentButton)`
   box-shadow: none;
-  background: transparent;
   color: ${p => p.theme.tour.previous};
   &:hover,
   &:active,

--- a/static/app/views/explore/spans/tour.tsx
+++ b/static/app/views/explore/spans/tour.tsx
@@ -79,7 +79,6 @@ function ExploreSpansTourModal({
               handleStartTour();
               closeModal();
             }}
-            borderless
             autoFocus
           >
             {t('Take a tour')}
@@ -179,7 +178,7 @@ const TextContainer = styled('div')`
 `;
 
 const Title = styled('div')`
-  color: ${p => p.theme.purple400};
+  color: ${p => p.theme.tour.header};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: ${p => p.theme.fontWeightBold};
 `;


### PR DESCRIPTION
before:

| ui1 | ui2 |
|--------|--------|
| ![ui1-before-light](https://github.com/user-attachments/assets/804b0a83-88ad-4df5-9127-adc0c4682bfc) | ![ui2-before-light](https://github.com/user-attachments/assets/06a34af6-0068-4304-88c9-3ffea0b920a5) |
| ![ui1-before-dark](https://github.com/user-attachments/assets/0e97537b-c562-48dc-bb08-48f84166f86c) | ![ui2-before-dark](https://github.com/user-attachments/assets/238b480f-61e0-4474-aaa2-2326df032734) | 

after:

| ui1 | ui2 |
|--------|--------|
| ![ui1-after-light](https://github.com/user-attachments/assets/2a5e958e-bec4-4863-a4aa-ed0b36af8984) | ![ui2-after-light](https://github.com/user-attachments/assets/1faade86-22c9-4917-a97d-6cfcffcd6116) |
| ![ui1-after-dark](https://github.com/user-attachments/assets/34a78643-dfee-4177-a3a3-15f59c1222aa) | ![ui2-after-dark](https://github.com/user-attachments/assets/432345e8-cea8-4226-becc-d2d8f3355fb9) | 