### PR TITLE
chore(docker): set persistent uid/gid

### DIFF
--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.vendor="Functional Software, Inc."
 LABEL org.opencontainers.image.authors="oss@sentry.io"
 
 # add our user and group first to make sure their IDs get assigned consistently
-RUN groupadd -r sentry && useradd -r -m -g sentry sentry
+RUN groupadd -r sentry --gid 999 && useradd -r -m -g sentry --uid 999 sentry
 
 RUN : \
     && apt-get update \


### PR DESCRIPTION
Current Docker images have uid/gid of `sentry` user / group set to 999. Here we just set them explicitly to the same value to avoid any potential uid/gid changes in the future.