### PR TITLE
fix(wizard): Use default project key instead of the first one

### DIFF
--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -25,7 +25,7 @@ from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.projects.services.project.model import RpcProject
 from sentry.projects.services.project.service import project_service
-from sentry.projects.services.project_key.model import ProjectKeyRole, RpcProjectKey
+from sentry.projects.services.project_key.model import RpcProjectKey
 from sentry.projects.services.project_key.service import project_key_service
 from sentry.types.token import AuthTokenType
 from sentry.users.models.user import User
@@ -207,10 +207,9 @@ def serialize_project(project: RpcProject, organization: dict, keys: list[dict])
 def get_cache_data(
     mapping: OrganizationMapping, project: RpcProject, user: User | AnonymousUser | RpcUser
 ):
-    project_key = project_key_service.get_project_key(
+    project_key = project_key_service.get_default_project_key(
         organization_id=mapping.organization_id,
         project_id=project.id,
-        role=ProjectKeyRole.store,
     )
     if project_key is None:
         raise Http404()


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-wizard/issues/986

Instead of just taking the first DSN, we should take the default one, which should be the first active key as far as I can tell based on https://github.com/getsentry/sentry/blob/master/src/sentry/projects/services/project_key/impl.py#L28.

Verified this locally, while debugging this I also came across other issues that I tried to fix here:

* https://github.com/getsentry/sentry/pull/93787
* https://github.com/getsentry/sentry/pull/93788