### PR TITLE
fix: getColorPalette indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "eslint-plugin-testing-library": "^7.1.1",
     "eslint-plugin-typescript-sort-keys": "^3.3.0",
     "eslint-plugin-unicorn": "^57.0.0",
+    "expect-type": "1.2.1",
     "globals": "^15.14.0",
     "jest": "29.7.0",
     "jest-canvas-mock": "^2.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,6 +607,9 @@ importers:
       eslint-plugin-unicorn:
         specifier: ^57.0.0
         version: 57.0.0(eslint@9.22.0(jiti@2.4.2))
+      expect-type:
+        specifier: 1.2.1
+        version: 1.2.1
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -4704,6 +4707,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -13279,6 +13286,8 @@ snapshots:
   exit-hook@4.0.0: {}
 
   exit@0.1.2: {}
+
+  expect-type@1.2.1: {}
 
   expect@29.7.0:
     dependencies:

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -251,19 +251,14 @@ export const pickBarColor = (input: string | undefined, theme: Theme): string =>
 
   if (!input || input.length < 3) {
     const colors = theme.chart.getColorPalette(17);
-    return colors[4]!;
+    return colors[4];
   }
 
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-  if (barColors[input]) {
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    return barColors[input];
+  if (input in barColors) {
+    return barColors[input as keyof typeof barColors];
   }
 
-  const colorsAsArray = Object.keys(theme.chart.colors[17]).map(
-    // @ts-expect-error TS(7015): Element implicitly has an 'any' type because index... Remove this comment to see the full error message
-    key => theme.chart.colors[17][key]
-  );
+  const colorsAsArray = Object.values(theme.chart.colors[17]);
 
   const letterIndex1 = getLetterIndex(input[0]!);
   const letterIndex2 = getLetterIndex(input[1]!);
@@ -272,7 +267,7 @@ export const pickBarColor = (input: string | undefined, theme: Theme): string =>
 
   return colorsAsArray[
     (letterIndex1 + letterIndex2 + letterIndex3 + letterIndex4) % colorsAsArray.length
-  ];
+  ]!;
 };
 
 export const lightenBarColor = (

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -185,7 +185,7 @@ export function getCountSeries(
 }
 
 export function initSessionsChart(theme: Theme) {
-  const colors = theme.chart.getColorPalette(14);
+  const colors = theme.chart.getColorPalette(15);
   return {
     [SessionStatus.HEALTHY]: {
       seriesName: sessionTerm.healthy,

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -379,18 +379,6 @@ type TupleOf<N extends number, A extends unknown[] = []> = A['length'] extends N
 
 type ValidLengthArgument = TupleOf<ColorLength>[number];
 
-// eslint-disable-next-line @typescript-eslint/no-restricted-types
-type NextTuple<T extends unknown[], A extends unknown[] = []> = T extends [
-  infer _First,
-  ...infer Rest,
-]
-  ? // eslint-disable-next-line @typescript-eslint/no-restricted-types
-    Record<A['length'], Rest extends [] ? never : Rest[0]> &
-      NextTuple<Rest, [...A, unknown]>
-  : Record<number, unknown>;
-
-type NextMap = NextTuple<TupleOf<ColorLength>>;
-type Next<R extends ValidLengthArgument> = NextMap[R];
 /**
  * Returns the color palette for a given number of series.
  * If length argument is statically analyzable, the return type will be narrowed
@@ -401,16 +389,14 @@ type Next<R extends ValidLengthArgument> = NextMap[R];
  */
 function makeChartColorPalette<T extends ChartColorPalette>(
   palette: T
-): <Length extends ValidLengthArgument>(
-  length: Length | number
-) => Exclude<ChartColorPalette[Next<Length>], undefined> {
+): <Length extends ValidLengthArgument>(length: Length | number) => T[Length] {
   return function getChartColorPalette<Length extends ValidLengthArgument>(
     length: Length | number
-  ): Exclude<ChartColorPalette[Next<Length>], undefined> {
+  ): T[Length] {
     // @TODO(jonasbadalic) we guarantee type safety and sort of guarantee runtime safety by clamping and
     // the palette is not sparse, but we should probably add a runtime check here as well.
-    const index = Math.max(0, Math.min(palette.length - 1, length + 1));
-    return palette[index] as Exclude<ChartColorPalette[Next<Length>], undefined>;
+    const index = Math.max(0, Math.min(palette.length - 1, length));
+    return palette[index] as T[Length];
   };
 }
 

--- a/static/app/utils/theme/theme.spec.tsx
+++ b/static/app/utils/theme/theme.spec.tsx
@@ -1,0 +1,36 @@
+import {useTheme} from '@emotion/react';
+import {QueryClient} from '@tanstack/react-query';
+import {expectTypeOf} from 'expect-type';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {ThemeAndStyleProvider} from 'sentry/components/themeAndStyleProvider';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+
+const wrapper = ({children}: {children?: React.ReactNode}) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <ThemeAndStyleProvider>{children}</ThemeAndStyleProvider>
+  </QueryClientProvider>
+);
+
+describe('theme', () => {
+  describe('getColorPalette', () => {
+    it('should return correct amount of colors', () => {
+      const {result} = renderHook(useTheme, {wrapper});
+
+      const theme = result.current;
+
+      expect(theme.chart.getColorPalette(2)).toHaveLength(3);
+    });
+
+    it('should have strict types', () => {
+      const {result} = renderHook(useTheme, {wrapper});
+
+      const theme = result.current;
+
+      const colors = theme.chart.getColorPalette(2);
+
+      expectTypeOf(colors).toEqualTypeOf<readonly ['#444674', '#d6567f', '#f2b712']>();
+    });
+  });
+});

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -199,18 +199,6 @@ type TupleOf<N extends number, A extends unknown[] = []> = A['length'] extends N
 
 type ValidLengthArgument = TupleOf<ColorLength>[number];
 
-// eslint-disable-next-line @typescript-eslint/no-restricted-types
-type NextTuple<T extends unknown[], A extends unknown[] = []> = T extends [
-  infer _First,
-  ...infer Rest,
-]
-  ? // eslint-disable-next-line @typescript-eslint/no-restricted-types
-    Record<A['length'], Rest extends [] ? never : Rest[0]> &
-      NextTuple<Rest, [...A, unknown]>
-  : Record<number, unknown>;
-
-type NextMap = NextTuple<TupleOf<ColorLength>>;
-type Next<R extends ValidLengthArgument> = NextMap[R];
 /**
  * Returns the color palette for a given number of series.
  * If length argument is statically analyzable, the return type will be narrowed
@@ -221,16 +209,14 @@ type Next<R extends ValidLengthArgument> = NextMap[R];
  */
 function makeChartColorPalette<T extends ChartColorPalette>(
   palette: T
-): <Length extends ValidLengthArgument>(
-  length: Length | number
-) => Exclude<ChartColorPalette[Next<Length>], undefined> {
+): <Length extends ValidLengthArgument>(length: Length | number) => T[Length] {
   return function getChartColorPalette<Length extends ValidLengthArgument>(
     length: Length | number
-  ): Exclude<ChartColorPalette[Next<Length>], undefined> {
+  ): T[Length] {
     // @TODO(jonasbadalic) we guarantee type safety and sort of guarantee runtime safety by clamping and
     // the palette is not sparse, but we should probably add a runtime check here as well.
-    const index = Math.max(0, Math.min(palette.length - 1, length + 1));
-    return palette[index] as Exclude<ChartColorPalette[Next<Length>], undefined>;
+    const index = Math.max(0, Math.min(palette.length - 1, length));
+    return palette[index] as T[Length];
   };
 }
 

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -176,7 +176,7 @@ export const WIDGET_DEFINITIONS: ({
       titleTooltip: getTermHelp(organization, PerformanceTerm.APDEX),
       fields: ['apdex()'],
       dataType: GenericPerformanceWidgetDataType.AREA,
-      chartColor: theme.isChonk ? theme.chart.getColorPalette(3)[4] : WIDGET_PALETTE[4],
+      chartColor: theme.isChonk ? theme.chart.getColorPalette(4)[4] : WIDGET_PALETTE[4],
       allowsOpenInDiscover: true,
     },
     [PerformanceWidgetSetting.P50_DURATION_AREA]: {
@@ -240,7 +240,7 @@ export const WIDGET_DEFINITIONS: ({
       titleTooltip: getTermHelp(organization, PerformanceTerm.APP_START_COLD),
       fields: ['p75(measurements.app_start_cold)'],
       dataType: GenericPerformanceWidgetDataType.AREA,
-      chartColor: theme.isChonk ? theme.chart.getColorPalette(3)[4] : WIDGET_PALETTE[4],
+      chartColor: theme.isChonk ? theme.chart.getColorPalette(4)[4] : WIDGET_PALETTE[4],
       allowsOpenInDiscover: true,
     },
     [PerformanceWidgetSetting.WARM_STARTUP_AREA]: {
@@ -264,7 +264,7 @@ export const WIDGET_DEFINITIONS: ({
       titleTooltip: getTermHelp(organization, PerformanceTerm.FROZEN_FRAMES),
       fields: ['p75(measurements.frames_frozen_rate)'],
       dataType: GenericPerformanceWidgetDataType.AREA,
-      chartColor: theme.isChonk ? theme.chart.getColorPalette(4)[5] : WIDGET_PALETTE[5],
+      chartColor: theme.isChonk ? theme.chart.getColorPalette(5)[5] : WIDGET_PALETTE[5],
       allowsOpenInDiscover: true,
     },
     [PerformanceWidgetSetting.MOST_RELATED_ERRORS]: {
@@ -369,7 +369,7 @@ export const WIDGET_DEFINITIONS: ({
       titleTooltip: getTermHelp(organization, PerformanceTerm.TIME_TO_INITIAL_DISPLAY),
       fields: ['p75(measurements.time_to_initial_display)'],
       dataType: GenericPerformanceWidgetDataType.AREA,
-      chartColor: theme.isChonk ? theme.chart.getColorPalette(3)[4] : WIDGET_PALETTE[4],
+      chartColor: theme.isChonk ? theme.chart.getColorPalette(4)[4] : WIDGET_PALETTE[4],
       allowsOpenInDiscover: true,
     },
     [PerformanceWidgetSetting.TIME_TO_FULL_DISPLAY]: {
@@ -377,7 +377,7 @@ export const WIDGET_DEFINITIONS: ({
       titleTooltip: getTermHelp(organization, PerformanceTerm.TIME_TO_FULL_DISPLAY),
       fields: ['p75(measurements.time_to_full_display)'],
       dataType: GenericPerformanceWidgetDataType.AREA,
-      chartColor: theme.isChonk ? theme.chart.getColorPalette(3)[4] : WIDGET_PALETTE[4],
+      chartColor: theme.isChonk ? theme.chart.getColorPalette(4)[4] : WIDGET_PALETTE[4],
       allowsOpenInDiscover: true,
     },
     [PerformanceWidgetSetting.MOST_SLOW_FRAMES]: {

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -145,7 +145,7 @@ class ReleaseSessionsChart extends Component<Props> {
 
   getColors(): string[] | undefined {
     const {theme, chartType} = this.props;
-    const colors = theme.chart.getColorPalette(14);
+    const colors = theme.chart.getColorPalette(15);
     switch (chartType) {
       case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:
         return [colors[0]];


### PR DESCRIPTION
The `getColorPalette` function was returning one too many elements: If we invoke `getColorPalette(2)`, it returned an array with 4 elements.

The desired behaviour is for it to return 3 elements when invoked with `getColorPalette(2)`, because we’d want the indices 0,1,2 to be available on it.