### PR TITLE
:bug: fix(deletions): delete integration when no associated org integration left

### DIFF
--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -24,7 +24,7 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
             integration_id=instance.integration.id,
         )
 
-        # If the organization integration is the only one associated with the integration, delete the integration.
+        # If the org integration to be deleted is the only one associated with the integration, delete the integration.
         if len(org_integrations) == 1 and org_integrations[0].id == instance.id:
             relations.append(ModelRelation(Integration, {"id": instance.integration.id}))
 

--- a/src/sentry/deletions/defaults/organizationintegration.py
+++ b/src/sentry/deletions/defaults/organizationintegration.py
@@ -1,6 +1,7 @@
 from sentry.constants import ObjectStatus
 from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository import repository_service
 from sentry.types.region import RegionMappingNotFound
 
@@ -10,6 +11,7 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
         return instance.status in {ObjectStatus.DELETION_IN_PROGRESS, ObjectStatus.PENDING_DELETION}
 
     def get_child_relations(self, instance: OrganizationIntegration) -> list[BaseRelation]:
+        from sentry.integrations.models.integration import Integration
         from sentry.users.models.identity import Identity
 
         relations: list[BaseRelation] = []
@@ -17,6 +19,14 @@ class OrganizationIntegrationDeletionTask(ModelDeletionTask[OrganizationIntegrat
         # delete the identity attached through the default_auth_id
         if instance.default_auth_id:
             relations.append(ModelRelation(Identity, {"id": instance.default_auth_id}))
+
+        org_integrations = integration_service.get_organization_integrations(
+            integration_id=instance.integration.id,
+        )
+
+        # If the organization integration is the only one associated with the integration, delete the integration.
+        if len(org_integrations) == 1 and org_integrations[0].id == instance.id:
+            relations.append(ModelRelation(Integration, {"id": instance.integration.id}))
 
         return relations
 


### PR DESCRIPTION
https://redash.getsentry.net/queries/9029/ - ~20% of our integrations are orphaned (no associated org integration)

to first stop this leaky bucket, i propose deleting integrations when there are no more associated org integrations left.

i put it in the `get_child_relation` because we need the Org Integration to be deleted before the Integration

One thing is dealing with concurrency for when someone installs a new org integration while we are deleting - maybe I mark the integration to be deleted so we don't fetch it?