### PR TITLE
feat(ui): add fitMaxContent prop to grideditable

### DIFF
--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -280,4 +280,53 @@ export default Storybook.story('GridEditable', story => {
       </Fragment>
     );
   });
+
+  story('Enforcing Cell to fit Content', () => {
+    const newData = [
+      ...data,
+      {
+        name: 'Something very long',
+        category:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent fringilla ultricies turpis, quis lobortis leo varius ut. Maecenas venenatis purus a sodales facilisis.',
+      },
+    ] as ExampleDataItem[];
+    return (
+      <Fragment>
+        <p>
+          Passing
+          <Storybook.JSXProperty name="fitMaxContent" value={Boolean} /> will set the
+          min-width of the each cell to fit around the content. By default this is set to
+          false.
+        </p>
+        <Storybook.SideBySide>
+          <div style={{width: 400}}>
+            <div>If false, content is forced in multiple lines or cut off</div>
+            <GridEditable
+              data={newData}
+              columnOrder={columns}
+              columnSortBy={[]}
+              grid={{
+                renderHeadCell,
+                renderBodyCell,
+              }}
+              scrollable
+            />
+          </div>
+          <div style={{width: 400}}>
+            <div>If true, the content forces the table to expand (scroll)</div>
+            <GridEditable
+              data={newData}
+              columnOrder={columns}
+              columnSortBy={[]}
+              grid={{
+                renderHeadCell,
+                renderBodyCell,
+              }}
+              fitMaxContent
+            />
+          </div>
+        </Storybook.SideBySide>
+      </Fragment>
+    );
+  });
 });

--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -294,12 +294,22 @@ export default Storybook.story('GridEditable', story => {
       <Fragment>
         <p>
           Passing
-          <Storybook.JSXProperty name="fitMaxContent" value={Boolean} /> will set the
-          width of the grid to fit around the content. By default this is set to false.
+          <Storybook.JSXProperty name="fit" value={'max-content'} /> will set the width of
+          the grid to fit around the content.
+        </p>
+        <p>
+          <Storybook.JSXNode name="GridEditable" /> will by default resize the columns to
+          fit within it's container. So columns of long width may take up multiple lines
+          or be cut off, which might not be desired (ex. when the table has many columns
+          or is placed into a small container). One way to control column width this is to
+          provide
+          <Storybook.JSXProperty name="minColumnWidth" value={'number'} />, which applies
+          the same width to all columns. However, this does not account for varying widths
+          between columns, unlike this prop does.
         </p>
         <Storybook.SideBySide>
           <div style={{width: 400}}>
-            <div>If false, content is forced in multiple lines or cut off</div>
+            <div>Without fit content is forced in multiple lines or cut off</div>
             <GridEditable
               data={newData}
               columnOrder={columns}
@@ -308,11 +318,10 @@ export default Storybook.story('GridEditable', story => {
                 renderHeadCell,
                 renderBodyCell,
               }}
-              scrollable
             />
           </div>
           <div style={{width: 400}}>
-            <div>If true, the content forces the table to expand (scroll)</div>
+            <div>With fit the content forces the table to expand (scroll)</div>
             <GridEditable
               data={newData}
               columnOrder={columns}
@@ -321,7 +330,7 @@ export default Storybook.story('GridEditable', story => {
                 renderHeadCell,
                 renderBodyCell,
               }}
-              fitMaxContent
+              fit="max-content"
             />
           </div>
         </Storybook.SideBySide>

--- a/static/app/components/gridEditable/index.stories.tsx
+++ b/static/app/components/gridEditable/index.stories.tsx
@@ -295,8 +295,7 @@ export default Storybook.story('GridEditable', story => {
         <p>
           Passing
           <Storybook.JSXProperty name="fitMaxContent" value={Boolean} /> will set the
-          min-width of the each cell to fit around the content. By default this is set to
-          false.
+          width of the grid to fit around the content. By default this is set to false.
         </p>
         <Storybook.SideBySide>
           <div style={{width: 400}}>

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import type {CSSProperties, ReactNode} from 'react';
 import {Component, createRef, Fragment} from 'react';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -98,15 +98,15 @@ type GridEditableProps<DataRow, ColumnKey> = {
   bodyStyle?: React.CSSProperties;
   emptyMessage?: React.ReactNode;
   error?: unknown | null;
-  fitMaxContent?: boolean;
 
+  fit?: 'max-content';
   /**
    * Inject a set of buttons into the top of the grid table.
    * The controlling component is responsible for handling any actions
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
-  height?: string | number;
+  height?: CSSProperties['height'];
 
   highlightedRowKey?: number;
 
@@ -459,7 +459,7 @@ class GridEditable<
       'aria-label': ariaLabel,
       bodyStyle,
       stickyHeader,
-      fitMaxContent,
+      fit,
     } = this.props;
     const showHeader = title || headerButtons;
     return (
@@ -480,7 +480,7 @@ class GridEditable<
               scrollable={scrollable}
               height={height}
               ref={this.refGrid}
-              fitMaxContent={fitMaxContent}
+              fit={fit}
             >
               <GridHead sticky={stickyHeader}>{this.renderGridHead()}</GridHead>
               <GridBody>{this.renderGridBody()}</GridBody>

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -98,23 +98,24 @@ type GridEditableProps<DataRow, ColumnKey> = {
   bodyStyle?: React.CSSProperties;
   emptyMessage?: React.ReactNode;
   error?: unknown | null;
+  fitMaxContent?: boolean;
+
   /**
    * Inject a set of buttons into the top of the grid table.
    * The controlling component is responsible for handling any actions
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
-
   height?: string | number;
+
   highlightedRowKey?: number;
 
   isLoading?: boolean;
 
   minimumColWidth?: number;
-
   onRowMouseOut?: (row: DataRow, key: number, event: React.MouseEvent) => void;
-  onRowMouseOver?: (row: DataRow, key: number, event: React.MouseEvent) => void;
 
+  onRowMouseOver?: (row: DataRow, key: number, event: React.MouseEvent) => void;
   /**
    * Whether columns in the grid can be resized.
    *
@@ -123,6 +124,7 @@ type GridEditableProps<DataRow, ColumnKey> = {
   resizable?: boolean;
   scrollable?: boolean;
   stickyHeader?: boolean;
+
   /**
    * GridEditable (mostly) do not maintain any internal state and relies on the
    * parent component to tell it how/what to render and will mutate the view
@@ -457,6 +459,7 @@ class GridEditable<
       'aria-label': ariaLabel,
       bodyStyle,
       stickyHeader,
+      fitMaxContent,
     } = this.props;
     const showHeader = title || headerButtons;
     return (
@@ -477,6 +480,7 @@ class GridEditable<
               scrollable={scrollable}
               height={height}
               ref={this.refGrid}
+              fitMaxContent={fitMaxContent}
             >
               <GridHead sticky={stickyHeader}>{this.renderGridHead()}</GridHead>
               <GridBody>{this.renderGridBody()}</GridBody>

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -1,3 +1,4 @@
+import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -80,9 +81,8 @@ export const Body = styled(
  * The entire layout is determined by the usage of <th> and <td>.
  */
 export const Grid = styled('table')<{
-  fit?: string;
-  fitMaxContent?: boolean;
-  height?: string | number;
+  fit?: 'max-content';
+  height?: CSSProperties['height'];
   scrollable?: boolean;
 }>`
   position: inherit;

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -79,7 +79,11 @@ export const Body = styled(
  * <thead>, <tbody>, <tr> are ignored by CSS Grid.
  * The entire layout is determined by the usage of <th> and <td>.
  */
-export const Grid = styled('table')<{height?: string | number; scrollable?: boolean}>`
+export const Grid = styled('table')<{
+  fitMaxContent?: boolean;
+  height?: string | number;
+  scrollable?: boolean;
+}>`
   position: inherit;
   display: grid;
 
@@ -103,6 +107,12 @@ export const Grid = styled('table')<{height?: string | number; scrollable?: bool
           max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height};
         `
       : ''}
+
+  ${p =>
+    p.fitMaxContent &&
+    css`
+      min-width: max-content;
+    `}
 `;
 
 /**

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -57,7 +57,7 @@ export const Body = styled(
     showVerticalScrollbar?: boolean;
   }) => (
     <Panel {...props}>
-      <PanelBody style={{height: '100%'}}>{children}</PanelBody>
+      <StyledPanelBody>{children}</StyledPanelBody>
     </Panel>
   )
 )`
@@ -80,6 +80,7 @@ export const Body = styled(
  * The entire layout is determined by the usage of <th> and <td>.
  */
 export const Grid = styled('table')<{
+  fit?: string;
   fitMaxContent?: boolean;
   height?: string | number;
   scrollable?: boolean;
@@ -108,11 +109,7 @@ export const Grid = styled('table')<{
         `
       : ''}
 
-  ${p =>
-    p.fitMaxContent &&
-    css`
-      width: max-content;
-    `}
+  width: ${p => p.fit}
 `;
 
 /**
@@ -341,4 +338,8 @@ export const GridResizer = styled('div')<{dataRows: number}>`
     background-color: ${p => p.theme.purple300};
     opacity: 0.4;
   }
+`;
+
+const StyledPanelBody = styled(PanelBody)`
+  height: 100%;
 `;

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -57,7 +57,7 @@ export const Body = styled(
     showVerticalScrollbar?: boolean;
   }) => (
     <Panel {...props}>
-      <PanelBody>{children}</PanelBody>
+      <PanelBody style={{height: '100%'}}>{children}</PanelBody>
     </Panel>
   )
 )`
@@ -111,7 +111,7 @@ export const Grid = styled('table')<{
   ${p =>
     p.fitMaxContent &&
     css`
-      min-width: max-content;
+      width: max-content;
     `}
 `;
 


### PR DESCRIPTION
### Changes
Add a boolean prop to allow the table to expand to fit all content and related story. This is to enable replacement of the table widgets in dashboards (this draft [PR: https://github.com/getsentry/sentry/pull/93434](https://github.com/getsentry/sentry/pull/93810)).

Also add `height: 100%` style to `PanelBody`--need to set height so that sticky headers works when table is placed in the widget container

### Before
<img width="418" alt="Screenshot 2025-06-17 at 11 43 23 AM" src="https://github.com/user-attachments/assets/69b51c82-5f07-4df8-9a2b-786531f2dd79" />


### After
<img width="423" alt="Screenshot 2025-06-17 at 11 43 54 AM" src="https://github.com/user-attachments/assets/c17ab9c7-d850-4218-b178-7ff88983b0d8" />

<img width="420" alt="Screenshot 2025-06-17 at 11 44 02 AM" src="https://github.com/user-attachments/assets/d2aecf5f-bd38-40b2-8131-52747cab1c8a" />