### PR TITLE
fix(insights): fix profile link not generating properly on EAP

### DIFF
--- a/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/insights/common/components/samplesTable/spanSamplesTable.tsx
@@ -9,7 +9,10 @@ import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {
+  generateContinuousProfileFlamechartRouteWithQuery,
+  generateProfileFlamechartRoute,
+} from 'sentry/utils/profiling/routes';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DurationComparisonCell} from 'sentry/views/insights/common/components/samplesTable/common';
@@ -22,7 +25,11 @@ import {
 } from 'sentry/views/insights/common/components/textAlign';
 import type {SpanSample} from 'sentry/views/insights/common/queries/useSpanSamples';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
-import {type ModuleName, SpanMetricsField} from 'sentry/views/insights/types';
+import {
+  type ModuleName,
+  SpanIndexedField,
+  SpanMetricsField,
+} from 'sentry/views/insights/types';
 import type {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 
 const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
@@ -66,7 +73,10 @@ type SpanTableRow = {
     timestamp: string;
   };
   'transaction.span_id': string;
-} & SpanSample;
+} & SpanSample & {
+    [SpanIndexedField.PROFILER_ID]?: string;
+    [SpanIndexedField.PROFILE_ID]?: string;
+  };
 
 type Props = {
   avg: number;
@@ -191,16 +201,33 @@ export function SpanSamplesTable({
     }
 
     if (column.key === 'profile_id') {
+      const profileId =
+        row[SpanIndexedField.PROFILEID] || row[SpanIndexedField.PROFILE_ID];
+      const continuousProfilerId = row[SpanIndexedField.PROFILER_ID];
+      const link =
+        continuousProfilerId && row?.transaction
+          ? generateContinuousProfileFlamechartRouteWithQuery({
+              organization,
+              projectSlug: row.project,
+              profilerId: continuousProfilerId,
+              start: new Date(row?.transaction.timestamp).toISOString(),
+              end: new Date(
+                new Date(row?.transaction.timestamp).getTime() +
+                  row?.transaction['span.duration']
+              ).toISOString(),
+            })
+          : profileId
+            ? generateProfileFlamechartRoute({
+                organization,
+                projectSlug: row.project,
+                profileId,
+              })
+            : undefined;
       return (
         <IconWrapper>
-          {row.profile_id ? (
+          {link ? (
             <Tooltip title={t('View Profile')}>
-              <LinkButton
-                to={normalizeUrl(
-                  `/organizations/${organization.slug}/profiling/profile/${row.project}/${row.profile_id}/flamegraph/?spanId=${row.span_id}`
-                )}
-                size="xs"
-              >
+              <LinkButton to={link} size="xs">
                 <IconProfiling size="xs" />
               </LinkButton>
             </Tooltip>

--- a/static/app/views/insights/common/queries/useSpanSamples.tsx
+++ b/static/app/views/insights/common/queries/useSpanSamples.tsx
@@ -39,7 +39,7 @@ export type SpanSample = Pick<
   | SpanIndexedField.PROJECT
   | SpanIndexedField.TIMESTAMP
   | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.PROFILE_ID
+  | SpanIndexedField.PROFILEID
   | SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH
   | SpanIndexedField.TRACE
 >;
@@ -49,7 +49,7 @@ export type DefaultSpanSampleFields =
   | SpanIndexedField.TRANSACTION_SPAN_ID
   | SpanIndexedField.TIMESTAMP
   | SpanIndexedField.SPAN_ID
-  | SpanIndexedField.PROFILE_ID
+  | SpanIndexedField.PROFILEID
   | SpanIndexedField.SPAN_SELF_TIME;
 
 export type NonDefaultSpanSampleFields = Exclude<

--- a/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
+++ b/static/app/views/insights/mobile/common/components/spanSamplesPanelContainer.tsx
@@ -30,6 +30,7 @@ import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanT
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   type ModuleName,
+  SpanIndexedField,
   SpanMetricsField,
   type SpanMetricsQueryFilters,
 } from 'sentry/views/insights/types';
@@ -249,6 +250,7 @@ export function SpanSamplesContainer({
               width: COL_WIDTH_UNDEFINED,
             },
           ]}
+          additionalFields={[SpanIndexedField.PROFILER_ID]}
         />
       </InsightsSpanTagProvider>
     </Fragment>

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -343,6 +343,7 @@ export enum SpanIndexedField {
   PROJECT_ID = 'project_id',
   PROFILE_ID = 'profile_id',
   PROFILEID = 'profile.id',
+  PROFILER_ID = 'profiler.id',
   RELEASE = 'release',
   TRANSACTION = 'transaction',
   ORIGIN_TRANSACTION = 'origin.transaction',
@@ -439,9 +440,9 @@ export type SpanIndexedResponse = {
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.PROJECT]: string;
   [SpanIndexedField.PROJECT_ID]: number;
-
   [SpanIndexedField.PROFILE_ID]: string;
   [SpanIndexedField.PROFILEID]: string;
+  [SpanIndexedField.PROFILER_ID]: string;
   [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
   [SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH]: string;
   [SpanIndexedField.ORIGIN_TRANSACTION]: string;


### PR DESCRIPTION
This change fixes several issues with the profile link generation in the insights span samples panel:
1. Updates link generation to use existing utility functions instead (ie `generateProfileFlamechartRoute` and `generateContinuousProfileFlamechartRouteWithQuery`)
2. On the EAP dataset (ie `spans`), samples are returned with `profile.id` attributes instead of `profile_id`. Updates the link generation to check for either case.
3. Some samples come with a continuous profile instead (ie `profiler.id`). Updates to handle these scenarios as well.