### PR TITLE
fix(settings): align header and row on teams page

### DIFF
--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -210,6 +210,7 @@ class AllTeamsRow extends Component<Props, State> {
             display
           )}
         </div>
+        <div />
         <DisplayRole isHidden={teamRoleName === null}>{teamRoleName}</DisplayRole>
         <div>
           {this.state.loading ? (


### PR DESCRIPTION
missing an extra `div`

before:

<img width="1304" alt="SCR-20250617-iwkz" src="https://github.com/user-attachments/assets/72b2ec87-487f-4a4d-b163-6a4031dc16e9" />

ater:

<img width="1009" alt="SCR-20250617-iwdq" src="https://github.com/user-attachments/assets/1f99b463-ca98-4a5e-aae5-8c07ad340e06" />
