### PR TITLE
ref(spans): Wrap trace item search query builder

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -163,7 +163,7 @@ export function SpanSearchQueryBuilder(props: SpanSearchQueryBuilderProps) {
   const {useEap} = props;
 
   if (useEap) {
-    return <EapSpanSearchQueryBuilder {...props} />;
+    return <EapSpanSearchQueryBuilderWrapper {...props} />;
   }
 
   return <IndexedSpanSearchQueryBuilder {...props} />;
@@ -191,17 +191,17 @@ function IndexedSpanSearchQueryBuilder({
   return <SearchQueryBuilder {...searchQueryBuilderProps} />;
 }
 
-function EapSpanSearchQueryBuilder(props: SpanSearchQueryBuilderProps) {
+function EapSpanSearchQueryBuilderWrapper(props: SpanSearchQueryBuilderProps) {
   const {tags: numberTags} = useSpanTags('number');
   const {tags: stringTags} = useSpanTags('string');
 
-  const eapSearchQueryBuilderProps = useEAPSpanSearchQueryBuilderProps({
-    ...props,
-    numberTags,
-    stringTags,
-  });
-
-  return <SearchQueryBuilder {...eapSearchQueryBuilderProps} />;
+  return (
+    <EAPSpanSearchQueryBuilder
+      numberTags={numberTags}
+      stringTags={stringTags}
+      {...props}
+    />
+  );
 }
 
 export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {


### PR DESCRIPTION
There were 2 separate implementations of the search query builder for eap spans. This consolidates them and use the same trace item search query builder.