### PR TITLE
direnv: node not required anymore for getsentry

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -182,20 +182,23 @@ python3 -m tools.docker_memory_check
 
 ### Node ###
 
-debug "Checking node..."
+# not needed for getsentry
+if [ "${PWD##*/}" = "sentry" ]; then
+    debug "Checking node..."
 
-if [ "${SENTRY_DEVENV_SKIP_FRONTEND}" != "1" ]; then
-    if ! require node; then
-        die "You don't seem to have node installed. Please run devenv sync."
-    fi
+    if [ "${SENTRY_DEVENV_SKIP_FRONTEND}" != "1" ]; then
+        if ! require node; then
+            die "You don't seem to have node installed. Please run devenv sync."
+        fi
 
-    read -r node_version < .node-version
-    if [ "v${node_version}" != "$(node --version)" ]; then
-        die "Unexpected $(command -v node) version. Please run devenv sync."
-    fi
+        read -r node_version < .node-version
+        if [ "v${node_version}" != "$(node --version)" ]; then
+            die "Unexpected $(command -v node) version. Please run devenv sync."
+        fi
 
-    if [ ! -d "node_modules" ]; then
-        die "You don't seem to have yarn packages installed. Please run devenv sync."
+        if [ ! -d "node_modules" ]; then
+            die "You don't seem to have yarn packages installed. Please run devenv sync."
+        fi
     fi
 fi
 


### PR DESCRIPTION
getsentry direnv shouldn't fail anymore if there isn't node_modules or node in its environment