### PR TITLE
fix(detectors): Add more targeted searching for SQL Injection Detector 

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-not-in-where-event.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-not-in-where-event.json
@@ -1,0 +1,158 @@
+{
+  "event_id": "5d6401994d7949d2ac3474f472564370",
+  "platform": "node",
+  "message": "",
+  "datetime": "2025-05-12T22:42:38.642986+00:00",
+  "breakdowns": {
+    "span_ops": {
+      "ops.db": {
+        "value": 65.715075,
+        "unit": "millisecond"
+      },
+      "total.time": {
+        "value": 67.105293,
+        "unit": "millisecond"
+      }
+    }
+  },
+  "request": {
+    "url": "http://localhost:3001/vulnerable-login",
+    "method": "GET",
+    "query_string": [["type", "account"]]
+  },
+  "spans": [
+    {
+      "timestamp": 1747089758.567536,
+      "start_timestamp": 1747089758.567,
+      "exclusive_time": 0.536203,
+      "op": "middleware.express",
+      "span_id": "4a06692f4abc8dbe",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "corsMiddleware",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "corsMiddleware",
+        "express.type": "middleware",
+        "sentry.op": "middleware.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.javascript.node",
+        "sdk.version": "9.17.0",
+        "platform": "node",
+        "os.name": "macOS",
+        "category": "middleware",
+        "op": "middleware.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "e6088cf8b370ed60"
+    },
+    {
+      "timestamp": 1747089758.568761,
+      "start_timestamp": 1747089758.568,
+      "exclusive_time": 0.761032,
+      "op": "middleware.express",
+      "span_id": "92553d2584d250b8",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "jsonParser",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "jsonParser",
+        "express.type": "middleware",
+        "sentry.op": "middleware.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.javascript.node",
+        "sdk.version": "9.17.0",
+        "platform": "node",
+        "os.name": "macOS",
+        "category": "middleware",
+        "op": "middleware.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "c81e963dad9ebc6c"
+    },
+    {
+      "timestamp": 1747089758.569093,
+      "start_timestamp": 1747089758.569,
+      "exclusive_time": 0.092983,
+      "op": "request_handler.express",
+      "span_id": "435146ab0909419d",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "/vulnerable-login",
+      "origin": "auto.http.otel.express",
+      "data": {
+        "express.name": "/vulnerable-login",
+        "express.type": "request_handler",
+        "http.route": "/vulnerable-login",
+        "sentry.op": "request_handler.express",
+        "sentry.origin": "auto.http.otel.express"
+      },
+      "sentry_tags": {
+        "user": "ip:::1",
+        "user.ip": "::1",
+        "environment": "production",
+        "transaction": "GET /vulnerable-login",
+        "transaction.method": "GET",
+        "transaction.op": "http.server",
+        "browser.name": "Chrome",
+        "sdk.name": "sentry.javascript.node",
+        "sdk.version": "9.17.0",
+        "platform": "node",
+        "os.name": "macOS",
+        "op": "request_handler.express",
+        "status": "ok",
+        "trace.status": "ok"
+      },
+      "hash": "872b0c84a6f1c590"
+    },
+    {
+      "timestamp": 1747089758.637715,
+      "start_timestamp": 1747089758.572,
+      "exclusive_time": 65.715075,
+      "op": "db",
+      "span_id": "4703181ac343f71a",
+      "parent_span_id": "91fa92ff0205967d",
+      "trace_id": "375a86eca09a4a4e91903838dd771f50",
+      "status": "ok",
+      "description": "SELECT \"company_account\".\"account\", \"company_account\".\"id\", \"company_account\".\"type\" FROM \"company_account\" WHERE \"company_account\".\"owner\" = ? ORDER BY \"company_account\".\"account\"",
+      "origin": "auto.db.otel.mysql2",
+      "data": {
+        "db.system": "mysql",
+        "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",
+        "db.name": "injection_test",
+        "db.statement": "SELECT \"company_account\".\"account\", \"company_account\".\"id\", \"company_account\".\"type\" FROM \"company_account\" WHERE \"company_account\".\"owner\" = ? ORDER BY \"company_account\".\"account\"",
+        "db.user": "root",
+        "net.peer.name": "localhost",
+        "net.peer.port": 3306,
+        "otel.kind": "CLIENT",
+        "sentry.op": "db",
+        "sentry.origin": "auto.db.otel.mysql2"
+      },
+      "hash": "45330ba0cafa5997"
+    }
+  ]
+}

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -58,6 +58,10 @@ class SQLInjectionDetectorTest(TestCase):
         injection_event = get_event("sql-injection/sql-injection-test-regex-event")
         assert len(self.find_problems(injection_event)) == 0
 
+    def test_sql_injection_not_in_where(self):
+        injection_event = get_event("sql-injection/sql-injection-not-in-where-event")
+        assert len(self.find_problems(injection_event)) == 0
+
     def test_sql_injection_on_non_vulnerable_query(self):
         injection_event = get_event("sql-injection/sql-injection-event-non-vulnerable")
         assert len(self.find_problems(injection_event)) == 0


### PR DESCRIPTION
this pr addresses 2 problems:
1) it replaces the regex match instead of the string match, this could've replaced parts of the string that weren't actually matching
2) limits the search to only the portion after "where" in the sql statement. That's where any filters would be applied and will prevent any false positives that might come from matches in the first part of the statement 