### PR TITLE
feat(issues): Add parameterization for traceparent

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -95,6 +95,9 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
         """,
     ),
     ParameterizationRegex(
+        name="traceparent", raw_pattern=r"""\b00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\b"""
+    ),
+    ParameterizationRegex(
         name="uuid",
         raw_pattern=r"""\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b""",
     ),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2615,6 +2615,11 @@ register(
     default=0.0,
     flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
+register(
+    "grouping.experiments.parameterization.traceparent",
+    default=0.0,
+    flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
+)
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at
 # any given time, so we're sampling at 100% in order to be able to get good signal. Once we've fully

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -7,28 +7,13 @@ from sentry.grouping.parameterization import (
     Parameterizer,
     UniqueIdExperiment,
 )
+from sentry.grouping.strategies.message import REGEX_PATTERN_KEYS_WITH_TRACEPARENT
 
 
 @pytest.fixture
 def parameterizer():
     return Parameterizer(
-        regex_pattern_keys=(
-            "email",
-            "url",
-            "hostname",
-            "ip",
-            "traceparent",
-            "uuid",
-            "sha1",
-            "md5",
-            "date",
-            "duration",
-            "hex",
-            "float",
-            "int",
-            "quoted_str",
-            "bool",
-        ),
+        regex_pattern_keys=REGEX_PATTERN_KEYS_WITH_TRACEPARENT,
         experiments=(UniqueIdExperiment,),
     )
 

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -17,6 +17,7 @@ def parameterizer():
             "url",
             "hostname",
             "ip",
+            "traceparent",
             "uuid",
             "sha1",
             "md5",
@@ -130,6 +131,11 @@ def parameterizer():
         ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
         ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
         ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
+        (
+            "traceparent",
+            """traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01""",
+            """traceparent: <traceparent>""",
+        ),
         ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
         ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
         (


### PR DESCRIPTION
These are currently parameterized as something like the following which is unhelpful for grouping (redacted example): `<int>-<md5>-0a0000000000abcd<int>`.

The regex here is intentionally strict and will only support the current version (`00`) to help ensure this is conservative in matching.

The option for this is done outside of our normal path since we need the `traceparent` parameterization to happen before `int`/`md5` in the order of operations. Once this is rolled out, a follow-up PR will clean up quite a bit of our experiment logic here.

See also: https://www.w3.org/TR/trace-context/#traceparent-header