### PR TITLE
fix(otlp): Add attribute aliases for span `name` and `kind`

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -48,6 +48,21 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             validator=[is_empty_string, is_span_id],
         ),
         ResolvedAttribute(
+            public_alias="name",
+            internal_name="sentry.name",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="kind",
+            internal_name="sentry.kind",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="status",
+            internal_name="sentry.status",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="span.action",
             internal_name="sentry.action",
             search_type="string",

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -552,7 +552,6 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[Literal["string", "number"], dict[
         # Temporarily reverse map these old aliases.
         # TODO: Once TraceItemAttributeNamesResponse is updated
         # to return the new aliases, remove these temp mappings.
-        "sentry.name": "span.description",
         "sentry.description": "sentry.normalized_description",
         "sentry.span_id": "id",
         "sentry.segment_name": "transaction",

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -48,12 +48,12 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             validator=[is_empty_string, is_span_id],
         ),
         ResolvedAttribute(
-            public_alias="name",
+            public_alias="span.name",
             internal_name="sentry.name",
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="kind",
+            public_alias="span.kind",
             internal_name="sentry.kind",
             search_type="string",
         ),

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -58,11 +58,6 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="status",
-            internal_name="sentry.status",
-            search_type="string",
-        ),
-        ResolvedAttribute(
             public_alias="span.action",
             internal_name="sentry.action",
             search_type="string",


### PR DESCRIPTION
`kind`, `name`, and `status` are top-level fields in the Span V2 schema, and in the OTLP span schema. We expect users to be able to search for these fields in Explore with syntax like `"name:GET*"`. In EAP, these fields are stored as `sentry.kind` and `sentry.name` respectively. This PR adds the aliases, with a `span.` prefix to disambiguate. `span.status` is already aliased to `sentry.status`

N.B. This PR also removes the reverse alias of from `sentry.name` to `span.description` from `SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS`!

N.B.2. This is not feature-flagged but `name`, `kind`, and `status` aren't in the autocomplete for span searches, and _that_ will be feature-flagged.
