### PR TITLE
ref: fix test_exception_reporter_filter when run by itself

### DIFF
--- a/tests/sentry/debug/utils/test_exception_reporter_filter.py
+++ b/tests/sentry/debug/utils/test_exception_reporter_filter.py
@@ -13,8 +13,9 @@ from sentry.web.frontend.error_500 import Error500View
 class TestNoSettingsInDebugView(TestCase):
     def test(self):
         self.client.raise_request_exception = False
+        url = reverse("error-500")
         # force an unhandled exception
         with mock.patch.object(Error500View, "dispatch", side_effect=ValueError):
-            resp = self.client.get(reverse("error-500"))
+            resp = self.client.get(url)
         # we should have scrubbed the settings from the output
         assert b"SETTINGS_MODULE" not in resp.content


### PR DESCRIPTION
previously failing with:

```
___________________________________________________ TestNoSettingsInDebugView.test ___________________________________________________
tests/sentry/debug/utils/test_exception_reporter_filter.py:18: in test
    resp = self.client.get(reverse("error-500"))
.venv/lib/python3.13/site-packages/django/urls/base.py:98: in reverse
    resolved_url = resolver._reverse_with_prefix(view, prefix, *args, **kwargs)
.venv/lib/python3.13/site-packages/django/urls/resolvers.py:749: in _reverse_with_prefix
    self._populate()
.venv/lib/python3.13/site-packages/django/urls/resolvers.py:548: in _populate
    for url_pattern in reversed(self.url_patterns):
.venv/lib/python3.13/site-packages/django/utils/functional.py:47: in __get__
    res = instance.__dict__[self.name] = self.func(instance)
.venv/lib/python3.13/site-packages/django/urls/resolvers.py:718: in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
.venv/lib/python3.13/site-packages/django/utils/functional.py:47: in __get__
    res = instance.__dict__[self.name] = self.func(instance)
.venv/lib/python3.13/site-packages/django/urls/resolvers.py:711: in urlconf_module
    return import_module(self.urlconf_name)
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:1026: in exec_module
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
src/sentry/conf/urls.py:3: in <module>
    from sentry.web.urls import urlpatterns
src/sentry/web/urls.py:70: in <module>
    Error500View.as_view(),
.venv/lib/python3.13/site-packages/django/views/generic/base.py:114: in as_view
    view.__annotations__ = cls.dispatch.__annotations__
../../.local/share/sentry-devenv/pythons/3.13.1/python/lib/python3.13/unittest/mock.py:690: in __getattr__
    raise AttributeError(name)
E   AttributeError: __annotations__
```

<!-- Describe your PR here. -->