### PR TITLE
fix(migrations): insights starred segment migration should account for null user_ids

### DIFF
--- a/src/sentry/insights/migrations/0002_backfill_team_starred.py
+++ b/src/sentry/insights/migrations/0002_backfill_team_starred.py
@@ -38,6 +38,7 @@ def migrate_team_stars_to_user_stars(apps: StateApps, schema_editor: BaseDatabas
                 segment_name=segment_name,
             )
             for user_id in user_ids
+            if user_id is not None
         ]
         with transaction.atomic(router.db_for_write(InsightsStarredSegment)):
             try:

--- a/tests/sentry/migrations/test_0002_backfill_insights_team_starred_segments.py
+++ b/tests/sentry/migrations/test_0002_backfill_insights_team_starred_segments.py
@@ -18,7 +18,9 @@ class BackfillUserStarredSegmentsTest(TestMigrations):
         self.environment = self.create_environment(
             organization=self.organization, project=self.project
         )
-        self.team: Team = self.create_team(organization=self.organization, members=[self.user])
+        self.team: Team = self.create_team(
+            organization=self.organization, members=[self.user, None]
+        )
 
         self.transaction_name = "my-transaction"
 


### PR DESCRIPTION
This prevents https://sentry.sentry.io/issues/6686879342/