### PR TITLE
feat(otlp): Use OTel-friendly default Explore fields

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -138,6 +138,8 @@ export enum FieldKey {
   OTA_UPDATES_CHANNEL = 'ota_updates.channel',
   OTA_UPDATES_RUNTIME_VERSION = 'ota_updates.runtime_version',
   OTA_UPDATES_UPDATE_ID = 'ota_updates.update_id',
+  NAME = 'name',
+  KIND = 'kind',
 }
 
 export enum FieldValueType {
@@ -1732,7 +1734,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     valueType: FieldValueType.BOOLEAN,
   },
   [FieldKey.STATUS]: {
-    desc: t('Status of the issue'),
+    desc: t('Status of the issue or span'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
@@ -1874,6 +1876,20 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
   },
   [FieldKey.OTA_UPDATES_UPDATE_ID]: {
     desc: t('The UUID that uniquely identifies the update.'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.NAME]: {
+    desc: t(
+      'The name of the span. A short, human-readable identifier for the operation being performed by a span.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FieldKey.KIND]: {
+    desc: t(
+      'The kind of span. Indicates the type of span such as server, client, internal, producer, or consumer.'
+    ),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1732,7 +1732,7 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     valueType: FieldValueType.BOOLEAN,
   },
   [FieldKey.STATUS]: {
-    desc: t('Status of the issue or span'),
+    desc: t('Status of the issue'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
@@ -1911,6 +1911,11 @@ const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     desc: t(
       'The kind of span. Indicates the type of span such as server, client, internal, producer, or consumer.'
     ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [SpanFields.STATUS]: {
+    desc: t('Span status. Indicates whether the span operation was successful.'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {CONDITIONS_ARGUMENTS, WEB_VITALS_QUALITY} from 'sentry/utils/discover/types';
-import {SpanIndexedField} from 'sentry/views/insights/types';
+import {SpanFields, SpanIndexedField} from 'sentry/views/insights/types';
 // Don't forget to update https://docs.sentry.io/product/sentry-basics/search/searchable-properties/ for any changes made here
 
 export enum FieldKind {
@@ -138,8 +138,6 @@ export enum FieldKey {
   OTA_UPDATES_CHANNEL = 'ota_updates.channel',
   OTA_UPDATES_RUNTIME_VERSION = 'ota_updates.runtime_version',
   OTA_UPDATES_UPDATE_ID = 'ota_updates.update_id',
-  NAME = 'name',
-  KIND = 'kind',
 }
 
 export enum FieldValueType {
@@ -1879,20 +1877,6 @@ const EVENT_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
-  [FieldKey.NAME]: {
-    desc: t(
-      'The name of the span. A short, human-readable identifier for the operation being performed by a span.'
-    ),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
-  [FieldKey.KIND]: {
-    desc: t(
-      'The kind of span. Indicates the type of span such as server, client, internal, producer, or consumer.'
-    ),
-    kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
-  },
 };
 
 const SPAN_HTTP_FIELD_DEFINITIONS: Record<SpanHttpField, FieldDefinition> = {
@@ -1912,11 +1896,24 @@ const SPAN_HTTP_FIELD_DEFINITIONS: Record<SpanHttpField, FieldDefinition> = {
     valueType: FieldValueType.SIZE,
   },
 };
-
-const SPAN_FIELD_DEFINITIONS: Record<AllEventFieldKeys, FieldDefinition> = {
+const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   ...EVENT_FIELD_DEFINITIONS,
   ...SPAN_AGGREGATION_FIELDS,
   ...SPAN_HTTP_FIELD_DEFINITIONS,
+  [SpanFields.NAME]: {
+    desc: t(
+      'The span name. A short, human-readable identifier for the operation being performed by the span.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [SpanFields.KIND]: {
+    desc: t(
+      'The kind of span. Indicates the type of span such as server, client, internal, producer, or consumer.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
 };
 
 const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {};
@@ -2625,8 +2622,8 @@ export const getFieldDefinition = (
       }
       return null;
     case 'span':
-      if (SPAN_FIELD_DEFINITIONS[key as keyof typeof SPAN_FIELD_DEFINITIONS]) {
-        return SPAN_FIELD_DEFINITIONS[key as keyof typeof SPAN_FIELD_DEFINITIONS];
+      if (SPAN_FIELD_DEFINITIONS[key]) {
+        return SPAN_FIELD_DEFINITIONS[key];
       }
 
       // In EAP we have numeric tags that can be passed as parameters to

--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -3,10 +3,16 @@ import type {Location} from 'history';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {decodeList} from 'sentry/utils/queryString';
+import {SpanFields} from 'sentry/views/insights/types';
 
 export function defaultFields(organization?: Organization): string[] {
   if (organization?.features.includes('performance-otel-friendly-ui')) {
-    return ['id', 'name', 'span.duration', 'timestamp'];
+    return [
+      SpanFields.ID,
+      SpanFields.NAME,
+      SpanFields.SPAN_DURATION,
+      SpanFields.TIMESTAMP,
+    ];
   }
 
   return [

--- a/static/app/views/explore/contexts/pageParamsContext/fields.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/fields.tsx
@@ -1,9 +1,14 @@
 import type {Location} from 'history';
 
+import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {decodeList} from 'sentry/utils/queryString';
 
-export function defaultFields(): string[] {
+export function defaultFields(organization?: Organization): string[] {
+  if (organization?.features.includes('performance-otel-friendly-ui')) {
+    return ['id', 'name', 'span.duration', 'timestamp'];
+  }
+
   return [
     'id',
     'span.op',
@@ -14,14 +19,17 @@ export function defaultFields(): string[] {
   ];
 }
 
-export function getFieldsFromLocation(location: Location): string[] {
+export function getFieldsFromLocation(
+  location: Location,
+  organization?: Organization
+): string[] {
   const fields = decodeList(location.query.field);
 
   if (fields.length) {
     return fields;
   }
 
-  return defaultFields();
+  return defaultFields(organization);
 }
 
 export function updateLocationWithFields(

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -1,3 +1,5 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -739,6 +741,25 @@ describe('PageParamsProvider', function () {
     expect(pageParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
+      })
+    );
+  });
+
+  it('uses OTel-friendly default fields in OTel-friendly mode', function () {
+    const organization = OrganizationFixture({
+      features: ['performance-otel-friendly-ui'],
+    });
+
+    render(
+      <PageParamsProvider>
+        <Component />
+      </PageParamsProvider>,
+      {organization}
+    );
+
+    expect(pageParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'name', 'span.duration', 'timestamp'],
       })
     );
   });

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -759,7 +759,7 @@ describe('PageParamsProvider', function () {
 
     expect(pageParams).toEqual(
       expect.objectContaining({
-        fields: ['id', 'name', 'span.duration', 'timestamp'],
+        fields: ['id', 'span.name', 'span.duration', 'timestamp'],
       })
     );
   });

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -178,7 +178,7 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
   const pageParams: ReadablePageParams = useMemo(() => {
     const aggregateFields = getAggregateFieldsFromLocation(location, organization);
     const dataset = getDatasetFromLocation(location);
-    const fields = getFieldsFromLocation(location);
+    const fields = getFieldsFromLocation(location, organization);
     const mode = getModeFromLocation(location);
     const query = getQueryFromLocation(location);
     const groupBys = aggregateFields.filter(isGroupBy).map(groupBy => groupBy.groupBy);

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -69,12 +69,14 @@ export enum SpanMetricsField {
   MOBILE_SLOW_FRAMES = 'mobile.slow_frames',
 }
 
-// TODO: This will be the final field type for eap spans
+// TODO: This will be the final field type for EAP spans
 export enum SpanFields {
   TRANSACTION = 'transaction',
   IS_TRANSACTION = 'is_transaction',
   CACHE_HIT = 'cache.hit',
   IS_STARRED_TRANSACTION = 'is_starred_transaction',
+  ID = 'id',
+  TIMESTAMP = 'timestamp',
   SPAN_DURATION = 'span.duration',
   USER = 'user',
   MOBILE_FROZEN_FRAMES = 'mobile.frozen_frames',
@@ -89,6 +91,9 @@ export enum SpanFields {
   SPAN_DESCRIPTION = 'span.description',
   SPAN_GROUP = 'span.group',
   SPAN_OP = 'span.op',
+  NAME = 'span.name',
+  KIND = 'span.kind',
+  STATUS = 'span.status',
   RELEASE = 'release',
   PROJECT_ID = 'project.id',
   RESPONSE_CODE = 'span.status_code',
@@ -137,7 +142,10 @@ type SpanNumberFields =
 type SpanStringFields =
   | SpanMetricsField.RESOURCE_RENDER_BLOCKING_STATUS
   | SpanFields.RAW_DOMAIN
-  | 'id'
+  | SpanFields.ID
+  | SpanFields.NAME
+  | SpanFields.KIND
+  | SpanFields.STATUS
   | 'span_id'
   | 'span.op'
   | 'span.description'


### PR DESCRIPTION
If the OTel-friendly UI flag is on, change the default fields for Explore to ID, Name, Duration, and Timestamp. We are moving away from OP and Description. Is waiting for https://github.com/getsentry/sentry/pull/93725 to add backend support

I added field definitions to `FieldKeys`, since this `name` and `kind` are `SpanV2` fields, that are EAP-specific an the most recent.

I also updated the type of span definitions to `Record<string, FieldDefinition>` since span fields are set by the user, so we'll never have a complete listing to definitions.
