### PR TITLE
feat(dashboards): Add endpoint for reordering dashboard positions

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/api/endpoints/organization_dashboards_starred.py
@@ -1,0 +1,58 @@
+from django.db import IntegrityError, router, transaction
+from rest_framework import status
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers.rest_framework.dashboard import DashboardStarredOrderSerializer
+from sentry.models.dashboard import DashboardFavoriteUser
+from sentry.models.organization import Organization
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "PUT": ["member:read", "member:write"],
+    }
+
+
+class OrganizationDashboardsStarredOrderEndpoint(OrganizationEndpoint):
+    publish_status = {"PUT": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.PERFORMANCE
+    permission_classes = (MemberPermission,)
+
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:dashboards-starred-reordering", organization, actor=request.user
+        )
+
+    def put(self, request: Request, organization: Organization) -> Response:
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        if not self.has_feature(organization, request):
+            return self.respond(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = DashboardStarredOrderSerializer(
+            data=request.data, context={"organization": organization, "user": request.user}
+        )
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        dashboard_ids = serializer.validated_data["dashboard_ids"]
+
+        try:
+            with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
+                DashboardFavoriteUser.objects.reorder_favorite_dashboards(
+                    organization=organization,
+                    user_id=request.user.id,
+                    new_dashboard_positions=dashboard_ids,
+                )
+        except (IntegrityError, ValueError):
+            raise ParseError("Mismatch between existing and provided starred dashboards.")
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/api/endpoints/organization_dashboards_starred.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers.rest_framework.dashboard import DashboardStarredOrderSerializer
 from sentry.models.dashboard import DashboardFavoriteUser
@@ -19,6 +20,7 @@ class MemberPermission(OrganizationPermission):
     }
 
 
+@region_silo_endpoint
 class OrganizationDashboardsStarredOrderEndpoint(OrganizationEndpoint):
     publish_status = {"PUT": ApiPublishStatus.PRIVATE}
     owner = ApiOwner.PERFORMANCE

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -983,6 +983,15 @@ class DashboardSerializer(DashboardDetailsSerializer):
     )
 
 
+class DashboardStarredOrderSerializer(serializers.Serializer):
+    dashboard_ids = serializers.ListField(child=serializers.IntegerField(), required=True)
+
+    def validate_dashboard_ids(self, dashboard_ids):
+        if len(dashboard_ids) != len(set(dashboard_ids)):
+            raise serializers.ValidationError("Single dashboard cannot take up multiple positions")
+        return dashboard_ids
+
+
 def schedule_update_project_configs(dashboard: Dashboard):
     """
     Schedule a task to update project configs for all projects of an organization when a dashboard is updated.

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -11,6 +11,9 @@ from sentry.api.endpoints.organization_auth_token_details import (
     OrganizationAuthTokenDetailsEndpoint,
 )
 from sentry.api.endpoints.organization_auth_tokens import OrganizationAuthTokensEndpoint
+from sentry.api.endpoints.organization_dashboards_starred import (
+    OrganizationDashboardsStarredOrderEndpoint,
+)
 from sentry.api.endpoints.organization_events_anomalies import OrganizationEventsAnomaliesEndpoint
 from sentry.api.endpoints.organization_events_root_cause_analysis import (
     OrganizationEventsRootCauseAnalysisEndpoint,
@@ -1395,6 +1398,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^\/]+)/dashboards/(?P<dashboard_id>[^\/]+)/visit/$",
         OrganizationDashboardVisitEndpoint.as_view(),
         name="sentry-api-0-organization-dashboard-visit",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/dashboards/starred/order/$",
+        OrganizationDashboardsStarredOrderEndpoint.as_view(),
+        name="sentry-api-0-organization-dashboard-starred-order",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^\/]+)/dashboards/(?P<dashboard_id>[^\/]+)/favorite/$",

--- a/tests/sentry/api/endpoints/test_organization_dashboards_starred.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards_starred.py
@@ -1,0 +1,123 @@
+from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.models.dashboard import DashboardFavoriteUser
+from sentry.testutils.cases import OrganizationDashboardWidgetTestCase
+
+
+class OrganizationDashboardsStarredOrderTest(OrganizationDashboardWidgetTestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.url = reverse(
+            "sentry-api-0-organization-dashboard-starred-order",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        self.dashboard_1 = self.create_dashboard(title="Dashboard 1")
+        self.dashboard_2 = self.create_dashboard(title="Dashboard 2")
+        self.dashboard_3 = self.create_dashboard(title="Dashboard 3")
+
+    def create_dashboard_favorite(self, dashboard, user, organization, position):
+        DashboardFavoriteUser.objects.create(
+            dashboard=dashboard, user_id=user.id, organization=organization, position=position
+        )
+
+    def test_reorder_dashboards(self):
+        self.create_dashboard_favorite(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite(self.dashboard_3, self.user, self.organization, 2)
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [
+            self.dashboard_1.id,
+            self.dashboard_2.id,
+            self.dashboard_3.id,
+        ]
+
+        # Reorder the favorited dashboards
+        with self.feature("organizations:dashboards-starred-reordering"):
+            response = self.do_request(
+                "put",
+                self.url,
+                data={
+                    "dashboard_ids": [self.dashboard_3.id, self.dashboard_1.id, self.dashboard_2.id]
+                },
+            )
+        assert response.status_code == 204
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [
+            self.dashboard_3.id,
+            self.dashboard_1.id,
+            self.dashboard_2.id,
+        ]
+
+    def test_throws_an_error_if_dashboard_ids_are_not_unique(self):
+        self.create_dashboard_favorite(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite(self.dashboard_3, self.user, self.organization, 2)
+
+        with self.feature("organizations:dashboards-starred-reordering"):
+            response = self.do_request(
+                "put",
+                self.url,
+                data={
+                    "dashboard_ids": [self.dashboard_1.id, self.dashboard_1.id, self.dashboard_2.id]
+                },
+            )
+        assert response.status_code == 400
+        assert response.data == {
+            "dashboard_ids": ["Single dashboard cannot take up multiple positions"]
+        }
+
+    def test_throws_an_error_if_reordered_dashboard_ids_are_not_complete(self):
+        self.create_dashboard_favorite(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite(self.dashboard_3, self.user, self.organization, 2)
+
+        with self.feature("organizations:dashboards-starred-reordering"):
+            response = self.do_request(
+                "put",
+                self.url,
+                data={"dashboard_ids": [self.dashboard_1.id, self.dashboard_2.id]},
+            )
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": ErrorDetail(
+                string="Mismatch between existing and provided starred dashboards.",
+                code="parse_error",
+            )
+        }
+
+    def test_allows_reordering_even_if_no_initial_positions(self):
+        self.create_dashboard_favorite(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite(self.dashboard_3, self.user, self.organization, 2)
+
+        with self.feature("organizations:dashboards-starred-reordering"):
+            response = self.do_request(
+                "put",
+                self.url,
+                data={
+                    "dashboard_ids": [self.dashboard_3.id, self.dashboard_1.id, self.dashboard_2.id]
+                },
+            )
+        assert response.status_code == 204
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [self.dashboard_3.id, self.dashboard_1.id, self.dashboard_2.id]


### PR DESCRIPTION
Adds functionality to support reordering dashboard positions. Expose the functionality through a new endpoint at `/dashboards/starred/order/` to mimic issue views and explore queries. 

Adds tests to cover cases such as basic reordering, error validation on duplicates or missing IDs, as well as allowing reordering even if positions aren't already set.