### PR TITLE
fix(insights): overview page operation selector not working

### DIFF
--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -339,9 +339,13 @@ function FrontendOverviewPageWithProviders() {
   );
 }
 
+const isPageSpanOp = (op?: string): op is PageSpanOps => {
+  return PAGE_SPAN_OPS.includes(op as PageSpanOps);
+};
+
 const getSpanOpFromQuery = (op?: string): PageSpanOps => {
-  if (op && op in PAGE_SPAN_OPS) {
-    return op as PageSpanOps;
+  if (isPageSpanOp(op)) {
+    return op;
   }
   return DEFAULT_SPAN_OP_SELECTION;
 };


### PR DESCRIPTION
Fixes an issue where the operation selector (see below), would update the query param correctly, but not actually do anything after that.
<img width="197" alt="image" src="https://github.com/user-attachments/assets/422db799-fa41-4e7f-b63b-038b0cf772aa" />

The reason was `getSpanOpFromQuery` checked if `op in PAGE_SPAN_OPS`, where `PAGE_SPAN_OPS` is an array of strings. However we should be doing `PAGE_SPAN_OPS.includes(op)`.

The `in` operator is for properties of an object while `includes` is for elements of an arry