### PR TITLE
chore(taskworker): Update put child multiprocessing queue metric

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -217,7 +217,13 @@ class TaskWorker:
             next = self._send_update_task(result, fetch_next)
             if next:
                 try:
+                    start_time = time.monotonic()
                     self._child_tasks.put(next)
+                    metrics.distribution(
+                        "taskworker.worker.child_task.put.duration",
+                        time.monotonic() - start_time,
+                        tags={"processing_pool": self._processing_pool_name},
+                    )
                 except queue.Full:
                     logger.warning(
                         "taskworker.send_result.child_task_queue_full",


### PR DESCRIPTION
There are two places we add an inflight task to the child queue. This PR makes sure that the metric gets captures in both places.
