### PR TITLE
feat(nav): Dismiss nav preview if hovering in a dead area

### DIFF
--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -1,4 +1,6 @@
 export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-collapsed';
+export const NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE = 'data-primary-navigation-link';
+export const NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE = 'data-secondary-navigation-sidebar';
 
 export const PRIMARY_SIDEBAR_WIDTH = 74;
 export const SECONDARY_SIDEBAR_WIDTH = 190;
@@ -9,3 +11,4 @@ export const SECONDARY_SIDEBAR_MAX_WIDTH = 450;
 export const NAV_SIDEBAR_COLLAPSE_DELAY_MS = 200;
 export const NAV_SIDEBAR_OPEN_DELAY_MS = 150;
 export const NAV_SIDEBAR_PREVIEW_DELAY_MS = 300;
+export const NAV_SIDEBAR_RESET_DELAY_MS = 300;

--- a/static/app/views/nav/constants.tsx
+++ b/static/app/views/nav/constants.tsx
@@ -1,5 +1,5 @@
 export const NAV_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY = 'navigation-sidebar-is-collapsed';
-export const NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE = 'data-primary-navigation-link';
+export const NAV_PRIMARY_LINK_DATA_ATTRIBUTE = 'data-primary-navigation-link';
 export const NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE = 'data-secondary-navigation-sidebar';
 
 export const PRIMARY_SIDEBAR_WIDTH = 74;

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -21,6 +21,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
+  NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE,
   NAV_SIDEBAR_PREVIEW_DELAY_MS,
   PRIMARY_SIDEBAR_WIDTH,
 } from 'sentry/views/nav/constants';
@@ -217,6 +218,9 @@ function SidebarNavLink({
       aria-selected={activePrimaryNavGroup === group ? true : isActive}
       aria-current={isActive ? 'page' : undefined}
       isMobile={layout === NavLayout.MOBILE}
+      {...{
+        [NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE]: true,
+      }}
       {...hoverProps}
     >
       {layout === NavLayout.MOBILE ? (

--- a/static/app/views/nav/primary/components.tsx
+++ b/static/app/views/nav/primary/components.tsx
@@ -21,7 +21,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
-  NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE,
+  NAV_PRIMARY_LINK_DATA_ATTRIBUTE,
   NAV_SIDEBAR_PREVIEW_DELAY_MS,
   PRIMARY_SIDEBAR_WIDTH,
 } from 'sentry/views/nav/constants';
@@ -219,7 +219,7 @@ function SidebarNavLink({
       aria-current={isActive ? 'page' : undefined}
       isMobile={layout === NavLayout.MOBILE}
       {...{
-        [NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE]: true,
+        [NAV_PRIMARY_LINK_DATA_ATTRIBUTE]: true,
       }}
       {...hoverProps}
     >

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -32,7 +32,11 @@ import {UserDropdown} from 'sentry/views/nav/userDropdown';
 
 function SidebarBody({children}: {children: React.ReactNode}) {
   const {layout} = useNavContext();
-  return <SidebarList isMobile={layout === NavLayout.MOBILE}>{children}</SidebarList>;
+  return (
+    <SidebarList isMobile={layout === NavLayout.MOBILE} data-primary-list-container>
+      {children}
+    </SidebarList>
+  );
 }
 
 function SidebarFooter({children}: {children: React.ReactNode}) {

--- a/static/app/views/nav/secondary/secondarySidebar.tsx
+++ b/static/app/views/nav/secondary/secondarySidebar.tsx
@@ -5,6 +5,7 @@ import {AnimatePresence, motion} from 'framer-motion';
 import useResizable from 'sentry/utils/useResizable';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 import {
+  NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE,
   SECONDARY_SIDEBAR_MAX_WIDTH,
   SECONDARY_SIDEBAR_MIN_WIDTH,
   SECONDARY_SIDEBAR_WIDTH,
@@ -56,7 +57,13 @@ export function SecondarySidebar() {
       description={STACKED_NAVIGATION_TOUR_CONTENT[stepId].description}
       title={STACKED_NAVIGATION_TOUR_CONTENT[stepId].title}
     >
-      <ResizeWrapper ref={resizableContainerRef} onMouseDown={handleStartResize}>
+      <ResizeWrapper
+        ref={resizableContainerRef}
+        onMouseDown={handleStartResize}
+        {...{
+          [NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE]: true,
+        }}
+      >
         <AnimatePresence mode="wait" initial={false}>
           <MotionDiv
             key={activeNavGroup}

--- a/static/app/views/nav/useResetActiveNavGroup.tsx
+++ b/static/app/views/nav/useResetActiveNavGroup.tsx
@@ -1,34 +1,82 @@
-import {useRef} from 'react';
-import {useHover} from '@react-aria/interactions';
+import type {MouseEventHandler} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
+import type {DOMAttributes, FocusableElement} from '@react-types/shared';
 
-import {NAV_SIDEBAR_COLLAPSE_DELAY_MS} from 'sentry/views/nav/constants';
+import {
+  NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE,
+  NAV_SIDEBAR_RESET_DELAY_MS,
+} from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
+import {NavLayout} from 'sentry/views/nav/types';
 
 /**
  * Resets the active nav group when the user moves their mouse away from the
- * nav. This is delayed slightly to prevent accidental dismissals.
+ * nav or into the dead space of the primary navigation. This is delayed slightly
+ * to prevent accidental dismissals.
  */
-export function useResetActiveNavGroup() {
-  const {setActivePrimaryNavGroup} = useNavContext();
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+export function useResetActiveNavGroup(): DOMAttributes<FocusableElement> {
+  const {layout, setActivePrimaryNavGroup} = useNavContext();
+  const resetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const {hoverProps} = useHover({
-    onHoverEnd: () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      timeoutRef.current = setTimeout(() => {
-        setActivePrimaryNavGroup(null);
-        // This delay needs to be longer than the collapse delay to prevent
-        // content from shifting before the nav closes
-      }, NAV_SIDEBAR_COLLAPSE_DELAY_MS + 100);
-    },
-    onHoverStart: () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    },
-  });
+  const resetActiveNavGroup = useCallback(() => {
+    if (resetTimeoutRef.current) {
+      return;
+    }
 
-  return hoverProps;
+    resetTimeoutRef.current = setTimeout(() => {
+      setActivePrimaryNavGroup(null);
+    }, NAV_SIDEBAR_RESET_DELAY_MS);
+  }, [setActivePrimaryNavGroup]);
+
+  const clearResetTimeout = useCallback(() => {
+    if (resetTimeoutRef.current) {
+      clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = null;
+    }
+  }, []);
+
+  const onMouseMove = useCallback<MouseEventHandler<FocusableElement>>(
+    e => {
+      requestAnimationFrame(() => {
+        const target = e.target as HTMLElement;
+
+        // Check if we're inside the primary nav list container
+        const isInPrimaryNavListContainer =
+          target.closest(`[${NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE}]`) !== null;
+        const isInSecondaryNavListContainer =
+          target.closest('[data-secondary-navigation-sidebar]') !== null;
+
+        if (isInPrimaryNavListContainer || isInSecondaryNavListContainer) {
+          clearResetTimeout();
+        } else {
+          resetActiveNavGroup();
+        }
+      });
+    },
+    [clearResetTimeout, resetActiveNavGroup]
+  );
+
+  const onMouseLeave = useCallback(() => {
+    requestAnimationFrame(() => {
+      resetActiveNavGroup();
+    });
+  }, [resetActiveNavGroup]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  if (layout !== NavLayout.SIDEBAR) {
+    return {};
+  }
+
+  return {
+    onMouseMove,
+    onMouseLeave,
+  };
 }

--- a/static/app/views/nav/useResetActiveNavGroup.tsx
+++ b/static/app/views/nav/useResetActiveNavGroup.tsx
@@ -3,7 +3,8 @@ import {useCallback, useEffect, useRef} from 'react';
 import type {DOMAttributes, FocusableElement} from '@react-types/shared';
 
 import {
-  NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE,
+  NAV_PRIMARY_LINK_DATA_ATTRIBUTE,
+  NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE,
   NAV_SIDEBAR_RESET_DELAY_MS,
 } from 'sentry/views/nav/constants';
 import {useNavContext} from 'sentry/views/nav/context';
@@ -40,11 +41,10 @@ export function useResetActiveNavGroup(): DOMAttributes<FocusableElement> {
       requestAnimationFrame(() => {
         const target = e.target as HTMLElement;
 
-        // Check if we're inside the primary nav list container
         const isInPrimaryNavListContainer =
-          target.closest(`[${NAV_PRIMARY_NAV_LINK_DATA_ATTRIBUTE}]`) !== null;
+          target.closest(`[${NAV_PRIMARY_LINK_DATA_ATTRIBUTE}]`) !== null;
         const isInSecondaryNavListContainer =
-          target.closest('[data-secondary-navigation-sidebar]') !== null;
+          target.closest(`[${NAV_SECONDARY_SIDEBAR_DATA_ATTRIBUTE}]`) !== null;
 
         if (isInPrimaryNavListContainer || isInSecondaryNavListContainer) {
           clearResetTimeout();
@@ -62,7 +62,6 @@ export function useResetActiveNavGroup(): DOMAttributes<FocusableElement> {
     });
   }, [resetActiveNavGroup]);
 
-  // Cleanup on unmount
   useEffect(() => {
     return () => {
       if (resetTimeoutRef.current) {


### PR DESCRIPTION
This will hopefully help address feedback that the hover preview is too eager. This will dismiss the previewed navigation if your mouse goes to other areas of the primary nav.

https://github.com/user-attachments/assets/892d34b0-47f3-4886-8c5b-f74dcc05ce57

