### PR TITLE
fix: Add ensure assignment when swapping seats from onboarding to auto created

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -344,7 +344,7 @@ def update_project_uptime_subscription(
                 case ObjectStatus.DISABLED:
                     disable_uptime_detector(detector)
                 case ObjectStatus.ACTIVE:
-                    enable_uptime_detector(detector)
+                    enable_uptime_detector(detector, ensure_assignment=True)
 
     # ProjectUptimeSubscription may have been updated as part of
     # {enable,disable}_uptime_detector

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -604,7 +604,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 trace_sampling=False,
                 status=ObjectStatus.ACTIVE,
             )
-        mock_enable_uptime_detector.assert_called()
+        mock_enable_uptime_detector.assert_called_with(mock.ANY, ensure_assignment=True)
 
 
 class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):


### PR DESCRIPTION
Currently when an uptime is converted from onboarding to auto created, we aren't actually creating a seat assignment. When we create this seat we should be "ensuring a seat gets assigned," which requires passing in the additional parameter.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
