### PR TITLE
chore(eslint): disable `no-webpack-loader-syntax` for stories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -862,6 +862,7 @@ export default typescript.config([
     name: 'files/sentry-stories',
     files: ['**/*.stories.tsx'],
     rules: {
+      'import/no-webpack-loader-syntax': 'off', // type loader requires webpack syntax
       'no-loss-of-precision': 'off', // Sometimes we have wild numbers hard-coded in stories
     },
   },
@@ -952,6 +953,10 @@ export default typescript.config([
     ...mdx.flat,
     name: 'files/mdx',
     files: ['**/*.mdx'],
+    rules: {
+      ...mdx.flat.rules,
+      'import/no-webpack-loader-syntax': 'off', // type loader requires webpack syntax
+    },
   },
   {
     name: 'plugin/boundaries',

--- a/static/app/components/charts/chartWidgetLoader.stories.tsx
+++ b/static/app/components/charts/chartWidgetLoader.stories.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/charts/chartWidgetLoader';
 
 export default Storybook.story('ChartWidgetLoader', (story, APIReference) => {

--- a/static/app/components/core/alert/alertLink.stories.tsx
+++ b/static/app/components/core/alert/alertLink.stories.tsx
@@ -4,7 +4,6 @@ import {AlertLink, type AlertLinkProps} from 'sentry/components/core/alert/alert
 import {IconMail} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/alert/alertLink';
 
 const DUMMY_LINK = '/stories';

--- a/static/app/components/core/alert/index.stories.tsx
+++ b/static/app/components/core/alert/index.stories.tsx
@@ -6,7 +6,6 @@ import {IconClose, IconSentry, IconStar} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/alert';
 
 const ALERT_VARIANTS: Array<AlertProps['type']> = [

--- a/static/app/components/core/avatar/index.stories.tsx
+++ b/static/app/components/core/avatar/index.stories.tsx
@@ -9,7 +9,6 @@ import {SentryAppAvatar} from './sentryAppAvatar';
 import {TeamAvatar} from './teamAvatar';
 import {UserAvatar} from './userAvatar';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!./projectAvatar';
 
 export default Storybook.story('Avatar', (story, APIReference) => {

--- a/static/app/components/core/badge/index.stories.tsx
+++ b/static/app/components/core/badge/index.stories.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import {Badge} from 'sentry/components/core/badge';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/badge';
 
 export default Storybook.story('Badge', (story, APIReference) => {

--- a/static/app/components/core/badge/tag.stories.tsx
+++ b/static/app/components/core/badge/tag.stories.tsx
@@ -6,7 +6,6 @@ import {IconCheckmark, IconFire, IconSentry} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/badge/tag.tsx';
 
 export default Storybook.story('Tag', (story, APIReference) => {

--- a/static/app/components/core/button/buttonBar.stories.tsx
+++ b/static/app/components/core/button/buttonBar.stories.tsx
@@ -4,7 +4,6 @@ import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/button/buttonBar';
 
 export default Storybook.story('ButtonBar', (story, APIReference) => {

--- a/static/app/components/core/button/index.stories.tsx
+++ b/static/app/components/core/button/index.stories.tsx
@@ -4,7 +4,6 @@ import {Button, type ButtonProps} from 'sentry/components/core/button';
 import {IconDelete} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/button';
 
 export default Storybook.story('Button', (story, APIReference) => {

--- a/static/app/components/core/button/linkButton.stories.tsx
+++ b/static/app/components/core/button/linkButton.stories.tsx
@@ -3,7 +3,6 @@ import {useTheme} from '@emotion/react';
 import {LinkButton, type LinkButtonProps} from 'sentry/components/core/button/linkButton';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/button';
 
 export default Storybook.story('LinkButton', (story, APIReference) => {

--- a/static/app/components/core/checkbox/index.stories.tsx
+++ b/static/app/components/core/checkbox/index.stories.tsx
@@ -5,7 +5,6 @@ import {Checkbox} from 'sentry/components/core/checkbox';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/checkbox/index.tsx';
 
 export default Storybook.story('Checkbox', (story, APIReference) => {

--- a/static/app/components/core/input/index.stories.tsx
+++ b/static/app/components/core/input/index.stories.tsx
@@ -5,7 +5,6 @@ import {Input} from 'sentry/components/core/input';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input';
 
 export default Storybook.story('Input', (story, APIReference) => {

--- a/static/app/components/core/input/inputGroup.stories.tsx
+++ b/static/app/components/core/input/inputGroup.stories.tsx
@@ -8,7 +8,6 @@ import {space} from 'sentry/styles/space';
 
 import {InputGroup} from './inputGroup';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input/inputGroup';
 
 export default Storybook.story('InputGroup', (story, APIReference) => {

--- a/static/app/components/core/input/numberDragInput.stories.tsx
+++ b/static/app/components/core/input/numberDragInput.stories.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {NumberDragInput} from 'sentry/components/core/input/numberDragInput';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input/numberDragInput';
 
 export default Storybook.story('NumberDragInput', (story, APIReference) => {

--- a/static/app/components/core/input/numberInput.stories.tsx
+++ b/static/app/components/core/input/numberInput.stories.tsx
@@ -4,7 +4,6 @@ import * as Storybook from 'sentry/stories';
 
 import {NumberInput} from './numberInput';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/input/numberInput';
 
 export default Storybook.story('NumberInput', (story, APIReference) => {

--- a/static/app/components/core/menuListItem/index.stories.tsx
+++ b/static/app/components/core/menuListItem/index.stories.tsx
@@ -4,7 +4,6 @@ import {MenuListItem} from 'sentry/components/core/menuListItem/index';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/menuListItem';
 
 export default Storybook.story('MenuListItem', (story, APIReference) => {

--- a/static/app/components/core/radio/index.stories.tsx
+++ b/static/app/components/core/radio/index.stories.tsx
@@ -5,7 +5,6 @@ import {Radio, type RadioProps} from 'sentry/components/core/radio';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/radio';
 
 export default Storybook.story('Radio', (story, APIReference) => {

--- a/static/app/components/core/select/index.stories.tsx
+++ b/static/app/components/core/select/index.stories.tsx
@@ -4,7 +4,6 @@ import {Select} from 'sentry/components/core/select';
 import {IconGraphBar} from 'sentry/icons/iconGraphBar';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/select';
 
 export default Storybook.story('Select', (story, APIReference) => {

--- a/static/app/components/core/slider/index.stories.tsx
+++ b/static/app/components/core/slider/index.stories.tsx
@@ -5,7 +5,6 @@ import {Slider} from 'sentry/components/core/slider';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/slider';
 
 export default Storybook.story('Slider', (story, APIReference) => {

--- a/static/app/components/core/switch/index.stories.tsx
+++ b/static/app/components/core/switch/index.stories.tsx
@@ -5,7 +5,6 @@ import {Switch, type SwitchProps} from 'sentry/components/core/switch';
 import * as Storybook from 'sentry/stories';
 import {space} from 'sentry/styles/space';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/switch';
 
 export default Storybook.story('Switch', (story, APIReference) => {

--- a/static/app/components/core/toast/index.stories.tsx
+++ b/static/app/components/core/toast/index.stories.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import {Toast, type ToastProps} from 'sentry/components/core/toast';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/toast';
 
 function makeToastProps(type: 'success' | 'error' | 'loading' | 'undo'): ToastProps {

--- a/static/app/components/core/tooltip/index.stories.tsx
+++ b/static/app/components/core/tooltip/index.stories.tsx
@@ -4,7 +4,6 @@ import {Button} from 'sentry/components/core/button';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import * as Storybook from 'sentry/stories';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/components/core/tooltip';
 
 export default Storybook.story('Tooltip', (story, APIReference) => {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.stories.tsx
@@ -32,7 +32,6 @@ import {Line} from './plottables/line';
 import {Samples} from './plottables/samples';
 import {TimeSeriesWidgetVisualization} from './timeSeriesWidgetVisualization';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 
 const sampleDurationTimeSeriesP50: TimeSeries = {

--- a/static/app/views/dashboards/widgets/widget/widget.stories.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.stories.tsx
@@ -11,7 +11,6 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 
 import {Widget} from './widget';
 
-// eslint-disable-next-line import/no-webpack-loader-syntax
 import types from '!!type-loader!sentry/views/dashboards/widgets/widget/widget';
 
 export default Storybook.story('Widget', (story, APIReference) => {


### PR DESCRIPTION
`*.stories.tsx` and `*.mdx` files regularly use `!!type-loader` imports to expose types to our storybook loader. instead of disabling this rule each time we use it, we should blanket disable the rule for stories files.