### PR TITLE
:bug: fix(aci): annotate `workflow_id` on the `Action`

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
 
+from django.db import models
 from django.utils import timezone
 
 from sentry import features
@@ -184,7 +185,11 @@ def filter_recently_fired_workflow_actions(
     update_workflow_action_group_statuses(now, statuses_to_update, missing_statuses)
 
     # TODO: somehow attach workflows so we can fire actions with the appropriate workflow env
-    return Action.objects.filter(id__in=list(action_to_workflow_ids.keys()))
+    return Action.objects.filter(id__in=list(action_to_workflow_ids.keys())).annotate(
+        workflow_id=models.F(
+            "dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow__id"
+        )
+    )
 
 
 def get_available_action_integrations_for_org(organization: Organization) -> list[RpcIntegration]:

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -184,7 +184,6 @@ def filter_recently_fired_workflow_actions(
     )
     update_workflow_action_group_statuses(now, statuses_to_update, missing_statuses)
 
-    # TODO: somehow attach workflows so we can fire actions with the appropriate workflow env
     return Action.objects.filter(id__in=list(action_to_workflow_ids.keys())).annotate(
         workflow_id=models.F(
             "dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow__id"

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -56,6 +56,9 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action}
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
+            self.workflow.id,
+        }
 
         for status in [status_1, status_2]:
             status.refresh_from_db()
@@ -103,6 +106,10 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         # dedupes action if both workflows will fire it
         assert set(triggered_actions) == {self.action}
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
+            self.workflow.id,
+            workflow.id,
+        }
 
         assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
 
@@ -125,6 +132,10 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         # fires one action for the workflow that can fire it
         assert set(triggered_actions) == {self.action}
+        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
+            self.workflow.id,
+            workflow.id,
+        }
 
         assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
 


### PR DESCRIPTION
add back annotating triggered Actions with the corresponding `workflow_id`

doing https://github.com/getsentry/sentry/pull/93382 again