### PR TITLE
fix(release): Publish image on release branches

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -103,7 +103,7 @@ jobs:
 
   assemble:
     needs: [self-hosted]
-    if: ${{ github.ref_name == 'master' && github.event_name != 'pull_request' }}
+    if: ${{ github.ref_name == 'master' && github.event_name != 'pull_request'  || github.ref_name == 'releases/**' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -103,7 +103,7 @@ jobs:
 
   assemble:
     needs: [self-hosted]
-    if: ${{ github.ref_name == 'master' && github.event_name != 'pull_request'  || github.ref_name == 'releases/**' }}
+    if: ${{ (github.ref_name == 'master' || github.ref_name == 'releases/**') && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/83907

publish is still failing: https://github.com/getsentry/publish/actions/runs/15717244959/job/44289929012