### PR TITLE
chore(detectors): Normalize evidence data for query injection issues 

### DIFF
--- a/src/sentry/performance_issues/detectors/query_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/query_injection_detector.py
@@ -57,6 +57,7 @@ class QueryInjectionDetector(PerformanceDetector):
 
         unsafe_inputs = []
         for input_key, input_value in self.potential_unsafe_inputs:
+            original_input_value = input_value.copy()
             # Replace all operands in filter with "?" since the query description is sanitized
             if input_value and isinstance(input_value, dict):
                 for dict_key, dict_value in input_value.items():
@@ -66,7 +67,7 @@ class QueryInjectionDetector(PerformanceDetector):
             input_dict = {input_key: input_value}
             if json.dumps(input_dict) in description:
                 description = description.replace(json.dumps(input_value), "?")
-                unsafe_inputs.append(input_key)
+                unsafe_inputs.append((input_key, original_input_value))
 
         if len(unsafe_inputs) == 0:
             return
@@ -87,7 +88,7 @@ class QueryInjectionDetector(PerformanceDetector):
                 "parent_span_ids": [],
                 "offender_span_ids": spans_involved,
                 "transaction_name": self._event.get("transaction", ""),
-                "unsafe_inputs": unsafe_inputs,
+                "vulnerable_parameters": unsafe_inputs,
                 "request_url": self.request_url,
             },
             evidence_display=[

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -122,9 +122,7 @@ class SQLInjectionDetector(PerformanceDetector):
         if "WHERE" not in description.upper():
             return
 
-        for parameter in self.request_parameters:
-            value = parameter[1]
-            key = parameter[0]
+        for key, value in self.request_parameters:
             regex_key = rf'(?<![\w.$])"?{re.escape(key)}"?(?![\w.$"])'
             regex_value = rf'(?<![\w.$])"?{re.escape(value)}"?(?![\w.$"])'
             where_index = description.upper().find("WHERE")
@@ -134,7 +132,7 @@ class SQLInjectionDetector(PerformanceDetector):
                 description = description[:where_index] + re.sub(
                     regex_value, "?", description[where_index:]
                 )
-                vulnerable_parameters.append(key)
+                vulnerable_parameters.append((key, value))
 
         if len(vulnerable_parameters) == 0:
             return
@@ -155,7 +153,7 @@ class SQLInjectionDetector(PerformanceDetector):
                 "parent_span_ids": [],
                 "offender_span_ids": spans_involved,
                 "transaction_name": self._event.get("transaction", ""),
-                "vulnerable_parameters": list(set(vulnerable_parameters)),
+                "vulnerable_parameters": vulnerable_parameters,
                 "request_url": self.request_url,
             },
             evidence_display=[

--- a/tests/sentry/performance_issues/test_query_injection_detector.py
+++ b/tests/sentry/performance_issues/test_query_injection_detector.py
@@ -40,5 +40,5 @@ class QueryInjectionDetectorTest(TestCase):
             == '{"find":"?","filter":{"username":?},"limit":"?","singleBatch":"?","batchSize":"?"}'
         )
         assert problem.evidence_data is not None
-        assert problem.evidence_data["unsafe_inputs"] == ["username"]
+        assert problem.evidence_data["vulnerable_parameters"] == [("username", {"$ne": None})]
         assert problem.evidence_data["request_url"] == "http://localhost:3000/login"

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -37,7 +37,7 @@ class SQLInjectionDetectorTest(TestCase):
         assert problem.op == "db"
         assert problem.desc == "SELECT * FROM users WHERE username = '?' ORDER BY username ASC"
         assert problem.evidence_data is not None
-        assert problem.evidence_data["vulnerable_parameters"] == ["username"]
+        assert problem.evidence_data["vulnerable_parameters"] == [("username", "hello")]
         assert problem.evidence_data["request_url"] == "http://localhost:3001/vulnerable-login"
 
     def test_sql_injection_detection_in_body(self):
@@ -51,7 +51,7 @@ class SQLInjectionDetectorTest(TestCase):
         assert problem.op == "db"
         assert problem.desc == "SELECT * FROM users WHERE username = '?'"
         assert problem.evidence_data is not None
-        assert problem.evidence_data["vulnerable_parameters"] == ["username"]
+        assert problem.evidence_data["vulnerable_parameters"] == [("username", "hello")]
         assert problem.evidence_data["request_url"] == "http://localhost:3001/vulnerable-login"
 
     def test_sql_injection_regex(self):


### PR DESCRIPTION
since sql injection and query injection detectors create the same issue type, the issue details page should work for both. this pr normalizes the evidence data so the issue details page will more easily show the data for this type of issue. including the value as well, instead of just the key, to provide more evidence to the user. 