### PR TITLE
feat(sentryapps): Display sentry apps token usage as app rather than proxy user 

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -8,6 +8,7 @@ import type {FieldKind} from 'sentry/utils/fields';
 import type {Actor, TimeseriesValue} from './core';
 import type {Event, EventMetadata, EventOrGroupType, Level} from './event';
 import type {
+  AvatarSentryApp,
   Commit,
   ExternalIssue,
   PlatformExternalIssue,
@@ -472,6 +473,7 @@ interface GroupActivityBase {
   id: string;
   assignee?: string;
   issue?: Group;
+  sentry_app?: AvatarSentryApp;
   user?: null | User;
 }
 

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.tsx
@@ -35,6 +35,16 @@ import {ViewButton} from 'sentry/views/issueDetails/streamline/sidebar/viewButto
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
 
+function getAuthorName(item: GroupActivity) {
+  if (item.sentry_app) {
+    return item.sentry_app.name;
+  }
+  if (item.user) {
+    return item.user.name;
+  }
+  return 'Sentry';
+}
+
 function TimelineItem({
   item,
   handleDelete,
@@ -52,7 +62,7 @@ function TimelineItem({
 }) {
   const organization = useOrganization();
   const [editing, setEditing] = useState(false);
-  const authorName = item.user ? item.user.name : 'Sentry';
+  const authorName = getAuthorName(item);
   const {title, message} = getGroupActivityItem(
     item,
     organization,
@@ -63,7 +73,11 @@ function TimelineItem({
 
   const iconMapping = groupActivityTypeIconMapping[item.type];
   const Icon = iconMapping?.componentFunction
-    ? iconMapping.componentFunction(item.data, item.user)
+    ? iconMapping.componentFunction({
+        data: item.data,
+        user: item.user,
+        sentry_app: item.sentry_app,
+      })
     : (iconMapping?.Component ?? null);
 
   return (

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -31,10 +31,10 @@ import {
 import {space} from 'sentry/styles/space';
 import type {
   GroupActivity,
-  type GroupActivityCreateIssue,
-  type GroupActivitySetPriority,
-  GroupActivityType,
+  GroupActivityCreateIssue,
+  GroupActivitySetPriority,
 } from 'sentry/types/group';
+import {GroupActivityType} from 'sentry/types/group';
 
 interface IconWithDefaultProps {
   Component: React.ComponentType<any> | null;
@@ -60,7 +60,6 @@ export const groupActivityTypeIconMapping: Record<
           return <SentryAppAvatar sentryApp={sentry_app} />;
         };
       }
-
       return user ? () => <StyledUserAvatar user={user} /> : IconChat;
     },
   },

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -29,7 +29,7 @@ import {
   IconUser,
 } from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import {
+import type {
   GroupActivity,
   type GroupActivityCreateIssue,
   type GroupActivitySetPriority,

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {IconCellSignal} from 'sentry/components/badge/iconCellSignal';
+import {SentryAppAvatar} from 'sentry/components/core/avatar/sentryAppAvatar';
 import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {
   IconAdd,
@@ -29,20 +30,20 @@ import {
 } from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {
-  type Group,
+  GroupActivity,
   type GroupActivityCreateIssue,
   type GroupActivitySetPriority,
   GroupActivityType,
 } from 'sentry/types/group';
-import type {User} from 'sentry/types/user';
 
 interface IconWithDefaultProps {
   Component: React.ComponentType<any> | null;
   defaultProps: {locked?: boolean; type?: string};
-  componentFunction?: (
-    props: Group['activity'][number]['data'],
-    user?: User | null
-  ) => React.ComponentType<any>;
+  componentFunction?: (props: {
+    data: GroupActivity['data'];
+    sentry_app: GroupActivity['sentry_app'];
+    user: GroupActivity['user'];
+  }) => React.ComponentType<any>;
   propsFunction?: (props: any) => any;
 }
 
@@ -53,7 +54,13 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.NOTE]: {
     Component: IconChat,
     defaultProps: {},
-    componentFunction: (_data, user) => {
+    componentFunction: ({user, sentry_app}) => {
+      if (sentry_app) {
+        return function () {
+          return <SentryAppAvatar sentryApp={sentry_app} />;
+        };
+      }
+
       return user ? () => <StyledUserAvatar user={user} /> : IconChat;
     },
   },
@@ -78,7 +85,7 @@ export const groupActivityTypeIconMapping: Record<
   [GroupActivityType.SET_REGRESSION]: {Component: IconFire, defaultProps: {}},
   [GroupActivityType.CREATE_ISSUE]: {
     Component: IconAdd,
-    componentFunction: data => {
+    componentFunction: ({data}) => {
       const provider = (data as GroupActivityCreateIssue['data']).provider;
       switch (provider) {
         case 'GitHub':


### PR DESCRIPTION
Before:

<img width="980" alt="image" src="https://github.com/user-attachments/assets/257ca029-7eb5-450b-935b-b451c63cfefa" />


After:

<img width="905" alt="image" src="https://github.com/user-attachments/assets/441a792f-2678-4c2c-8236-a1b19d86c01c" />
