### PR TITLE
chore(admin): filter for employees or not in admin

### DIFF
--- a/static/gsAdmin/views/sentryEmployees.tsx
+++ b/static/gsAdmin/views/sentryEmployees.tsx
@@ -124,6 +124,13 @@ function SentryEmployees(props: Props) {
               ['false', 'False'],
             ],
           },
+          isMember: {
+            name: 'Employee',
+            options: [
+              ['true', 'True'],
+              ['false', 'False'],
+            ],
+          },
           staff: {
             name: 'Staff',
             options: [


### PR DESCRIPTION
Allow filtering for whether a user is member of the `sentry` org in admin. Not having this filter (`None`) will show all members of the `sentry` org AND all users with elevated permissions (any `UserPermission` or `superuser` or `staff`)