### PR TITLE
feat(aci): Remove resolution input, allow blank priorities

### DIFF
--- a/static/app/components/workflowEngine/form/control/priorityControl.spec.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.spec.tsx
@@ -24,8 +24,8 @@ describe('PriorityControl', function () {
     );
 
     expect(await screen.findByText('Above 0s')).toBeInTheDocument();
-    expect(await screen.findByTestId('priority-control-medium')).toBeInTheDocument();
-    expect(await screen.findByTestId('priority-control-high')).toBeInTheDocument();
+    expect(screen.getByLabelText('Medium threshold')).toBeInTheDocument();
+    expect(screen.getByLabelText('High threshold')).toBeInTheDocument();
   });
 
   it('allows configuring priority', async function () {
@@ -65,10 +65,10 @@ describe('PriorityControl', function () {
         <PriorityControl minimumPriority={DetectorPriorityLevel.LOW} />
       </Form>
     );
-    const medium = await screen.findByTestId('priority-control-medium');
+    const medium = screen.getByLabelText('Medium threshold');
     await userEvent.type(medium, '4');
 
-    const high = await screen.findByTestId('priority-control-high');
+    const high = screen.getByLabelText('High threshold');
     await userEvent.type(high, '5');
 
     expect(formModel.getValue(METRIC_DETECTOR_FORM_FIELDS.mediumThreshold)).toBe('4');

--- a/static/app/components/workflowEngine/form/control/priorityControl.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.tsx
@@ -254,7 +254,6 @@ const Cell = styled('div')`
   align-items: center;
   justify-content: flex-end;
   padding: ${space(1)};
-  min-width: 125px;
 `;
 
 const SmallNumberField = styled(NumberField)`

--- a/static/app/components/workflowEngine/form/control/priorityControl.tsx
+++ b/static/app/components/workflowEngine/form/control/priorityControl.tsx
@@ -19,6 +19,7 @@ import {
   METRIC_DETECTOR_FORM_FIELDS,
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metricFormData';
+import {useDetectorThresholdSuffix} from 'sentry/views/detectors/components/forms/useDetectorThresholdSuffix';
 
 const priorities = [
   DetectorPriorityLevel.LOW,
@@ -35,6 +36,20 @@ const DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL: Record<
   [DetectorPriorityLevel.HIGH]: PriorityLevel.HIGH,
 };
 
+const conditionKindAndTypeToLabel: Record<
+  'static' | 'percent',
+  Record<DataConditionType.GREATER | DataConditionType.LESS, string>
+> = {
+  static: {
+    [DataConditionType.GREATER]: t('Above'),
+    [DataConditionType.LESS]: t('Below'),
+  },
+  percent: {
+    [DataConditionType.GREATER]: t('higher'),
+    [DataConditionType.LESS]: t('lower'),
+  },
+};
+
 function ThresholdPriority() {
   const conditionType = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.conditionType
@@ -42,10 +57,12 @@ function ThresholdPriority() {
   const conditionValue = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.conditionValue
   );
+  const thresholdSuffix = useDetectorThresholdSuffix();
   return (
     <div>
-      {conditionType === DataConditionType.GREATER ? t('Above') : t('Below')}{' '}
-      {conditionValue === '' ? '0s' : `${conditionValue}s`}
+      {conditionKindAndTypeToLabel.static[conditionType!]}{' '}
+      {conditionValue === '' ? '0' : conditionValue}
+      {thresholdSuffix}
     </div>
   );
 }
@@ -57,10 +74,11 @@ function ChangePriority() {
   const conditionValue = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.conditionValue
   );
+  const thresholdSuffix = useDetectorThresholdSuffix();
   return (
     <div>
-      {conditionValue === '' ? '0' : conditionValue}%{' '}
-      {conditionType === DataConditionType.GREATER ? t('higher') : t('lower')}
+      {conditionValue === '' ? '0' : conditionValue}
+      {thresholdSuffix} {conditionKindAndTypeToLabel.percent[conditionType!]}
     </div>
   );
 }
@@ -70,11 +88,18 @@ interface PriorityControlProps {
 }
 
 export default function PriorityControl({minimumPriority}: PriorityControlProps) {
-  // TODO: kind type not yet available from detector types
   const detectorKind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
   const initialPriorityLevel = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.initialPriorityLevel
   );
+  const thresholdSuffix = useDetectorThresholdSuffix();
+  const conditionType = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.conditionType
+  );
+
+  if (detectorKind === 'dynamic') {
+    return null;
+  }
 
   return (
     <Grid>
@@ -94,18 +119,20 @@ export default function PriorityControl({minimumPriority}: PriorityControlProps)
       {priorityIsConfigurable(initialPriorityLevel, DetectorPriorityLevel.MEDIUM) && (
         <PrioritizeRow
           left={
-            <SmallNumberField
-              alignRight
-              inline
-              hideLabel
-              flexibleControlStateSize
-              size="sm"
-              suffix="s"
-              placeholder="0"
-              name={METRIC_DETECTOR_FORM_FIELDS.mediumThreshold}
-              data-test-id="priority-control-medium"
-              required
-            />
+            <Flex align="center" gap={space(1)}>
+              <SmallNumberField
+                alignRight
+                inline
+                hideLabel
+                flexibleControlStateSize
+                size="sm"
+                suffix={thresholdSuffix}
+                placeholder="0"
+                name={METRIC_DETECTOR_FORM_FIELDS.mediumThreshold}
+                aria-label={t('Medium threshold')}
+              />
+              <div>{conditionKindAndTypeToLabel[detectorKind][conditionType!]}</div>
+            </Flex>
           }
           right={<GroupPriorityBadge showLabel priority={PriorityLevel.MEDIUM} />}
         />
@@ -113,18 +140,20 @@ export default function PriorityControl({minimumPriority}: PriorityControlProps)
       {priorityIsConfigurable(initialPriorityLevel, DetectorPriorityLevel.HIGH) && (
         <PrioritizeRow
           left={
-            <SmallNumberField
-              alignRight
-              inline
-              hideLabel
-              flexibleControlStateSize
-              size="sm"
-              suffix="s"
-              placeholder="0"
-              name={METRIC_DETECTOR_FORM_FIELDS.highThreshold}
-              data-test-id="priority-control-high"
-              required
-            />
+            <Flex align="center" gap={space(1)}>
+              <SmallNumberField
+                alignRight
+                inline
+                hideLabel
+                flexibleControlStateSize
+                size="sm"
+                suffix={thresholdSuffix}
+                placeholder="0"
+                name={METRIC_DETECTOR_FORM_FIELDS.highThreshold}
+                aria-label={t('High threshold')}
+              />
+              <div>{conditionKindAndTypeToLabel[detectorKind][conditionType!]}</div>
+            </Flex>
           }
           right={<GroupPriorityBadge showLabel priority={PriorityLevel.HIGH} />}
         />
@@ -145,7 +174,7 @@ function PrioritizeRow({left, right}: {left: React.ReactNode; right: React.React
     <Row>
       <Cell>{left}</Cell>
       <IconArrow color="gray300" direction="right" />
-      <Cell>{right}</Cell>
+      <Flex align="center">{right}</Flex>
     </Row>
   );
 }
@@ -223,13 +252,17 @@ const Row = styled('div')`
 const Cell = styled('div')`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   padding: ${space(1)};
+  min-width: 125px;
 `;
 
 const SmallNumberField = styled(NumberField)`
-  width: 5rem;
+  width: 3.5rem;
   padding: 0;
+  & > div {
+    padding-left: 0;
+  }
 `;
 
 const SecondaryLabel = styled('div')`

--- a/static/app/components/workflowEngine/ui/section.tsx
+++ b/static/app/components/workflowEngine/ui/section.tsx
@@ -4,8 +4,8 @@ import {Flex} from 'sentry/components/container/flex';
 import {space} from 'sentry/styles/space';
 
 type SectionProps = {
-  children: React.ReactNode;
   title: string;
+  children?: React.ReactNode;
   description?: string;
 };
 

--- a/static/app/views/detectors/components/forms/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric.tsx
@@ -95,29 +95,27 @@ function ResolveSection() {
   } else if (kind === 'static') {
     if (conditionType === DataConditionType.GREATER) {
       description = t(
-        'Issue will be resolved when the query is less than %s%s higher than the previous %s.',
+        'Issue will be resolved when the query value is less than %s%s.',
         conditionValue || '0',
-        thresholdSuffix,
-        conditionComparisonAgo ? <Duration seconds={conditionComparisonAgo} /> : ''
+        thresholdSuffix
       );
     } else {
       description = t(
-        'Issue will be resolved when the query is less than %s%s lower than the previous %s.',
+        'Issue will be resolved when the query value is more than %s%s.',
         conditionValue || '0',
-        thresholdSuffix,
-        conditionComparisonAgo ? <Duration seconds={conditionComparisonAgo} /> : ''
+        thresholdSuffix
       );
     }
   } else if (kind === 'percent') {
     if (conditionType === DataConditionType.GREATER) {
       description = t(
-        'Issue will be resolved when the query is less than %s%% higher than the previous %s.',
+        'Issue will be resolved when the query value is less than %s%% higher than the previous %s.',
         conditionValue || '0',
         conditionComparisonAgo ? <Duration seconds={conditionComparisonAgo} /> : ''
       );
     } else {
       description = t(
-        'Issue will be resolved when the query is less than %s%% lower than the previous %s.',
+        'Issue will be resolved when the query value is less than %s%% lower than the previous %s.',
         conditionValue || '0',
         conditionComparisonAgo ? <Duration seconds={conditionComparisonAgo} /> : ''
       );

--- a/static/app/views/detectors/components/forms/useDetectorThresholdSuffix.tsx
+++ b/static/app/views/detectors/components/forms/useDetectorThresholdSuffix.tsx
@@ -1,0 +1,19 @@
+import {METRIC_DETECTOR_FORM_FIELDS, useMetricDetectorFormField} from './metricFormData';
+
+/**
+ * Returns the threshold suffix for the detector
+ */
+export function useDetectorThresholdSuffix(): 's' | '%' | '' {
+  const kind = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.kind);
+
+  if (kind === 'static') {
+    // TODO: Look at the aggregate to determine the suffix
+    return 's';
+  }
+
+  if (kind === 'percent') {
+    return '%';
+  }
+
+  return '';
+}


### PR DESCRIPTION
Allows priorities to be blank, before they were required. Issues will be created at just medium priority.

Removes the input field that was in the "Resolve" section.

before

![image](https://github.com/user-attachments/assets/ee6894e8-57ce-43ce-afb8-c2f830a7f1a2)


after

![image](https://github.com/user-attachments/assets/70a1f446-e257-4e15-8a9e-0df1c1a4a90a)
