### PR TITLE
fix: pass explicit ensure_assignment param down

### DIFF
--- a/src/sentry/uptime/detectors/result_handler.py
+++ b/src/sentry/uptime/detectors/result_handler.py
@@ -91,6 +91,7 @@ def handle_onboarding_result(
                 project_subscription,
                 interval_seconds=int(AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL.total_seconds()),
                 mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                ensure_assignment=True,
             )
             create_system_audit_entry(
                 organization=detector.project.organization,

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -282,6 +282,7 @@ def update_project_uptime_subscription(
     trace_sampling: bool | NotSet = NOT_SET,
     status: int = ObjectStatus.ACTIVE,
     mode: ProjectUptimeSubscriptionMode = ProjectUptimeSubscriptionMode.MANUAL,
+    ensure_assignment: bool = False,
 ):
     """
     Links a project to an uptime subscription so that it can process results.
@@ -344,7 +345,7 @@ def update_project_uptime_subscription(
                 case ObjectStatus.DISABLED:
                     disable_uptime_detector(detector)
                 case ObjectStatus.ACTIVE:
-                    enable_uptime_detector(detector, ensure_assignment=True)
+                    enable_uptime_detector(detector, ensure_assignment=ensure_assignment)
 
     # ProjectUptimeSubscription may have been updated as part of
     # {enable,disable}_uptime_detector

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -603,6 +603,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 owner=Actor.from_orm_user(self.user),
                 trace_sampling=False,
                 status=ObjectStatus.ACTIVE,
+                ensure_assignment=True,
             )
         mock_enable_uptime_detector.assert_called_with(mock.ANY, ensure_assignment=True)
 


### PR DESCRIPTION
We don't want to assign seats everytime, namely for the following case:

- Monitor already enabled and has seat assigned
- Status "active" passed in to monitor endpoint
- Endpoint "ensures" seat assignment and creates a new seat

I'm unsure if the assignment logic is smart enough to not create this new seat, so its probably better to be safe than sorry.

Amends https://github.com/getsentry/sentry/pull/93751

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
