### PR TITLE
fix(aci): save `created_by_id` when creating detectors/workflows

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -104,6 +104,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
                 workflow_condition_group=condition_group,
                 type=validated_data["type"].slug,
                 config=validated_data.get("config", {}),
+                created_by_id=self.context["request"].user.id,
             )
             DataSourceDetector.objects.create(data_source=detector_data_source, detector=detector)
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -185,6 +185,7 @@ class WorkflowValidator(CamelSnakeSerializer):
                 organization_id=self.context["organization"].id,
                 environment_id=validated_value.get("environment_id"),
                 when_condition_group=when_condition_group,
+                created_by_id=self.context["request"].user.id,
             )
 
             # TODO -- can we bulk create: actions, dcga's and the workflow dcg?

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -160,7 +160,7 @@ class DetectorValidatorTest(BaseValidatorTest):
         self.context = {
             "organization": self.project.organization,
             "project": self.project,
-            "request": self.make_request(),
+            "request": self.make_request(user=self.user),
         }
         self.valid_data = {
             "name": "Test Detector",
@@ -200,6 +200,7 @@ class DetectorValidatorTest(BaseValidatorTest):
         assert detector.name == "Test Detector"
         assert detector.type == MetricIssue.slug
         assert detector.project_id == self.project.id
+        assert detector.created_by_id == self.user.id
 
         # Verify data source in DB
         data_source = DataSource.objects.get(detector=detector)

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -107,7 +107,7 @@ class TestWorkflowValidatorCreate(TestCase):
     def setUp(self):
         self.context = {
             "organization": self.organization,
-            "request": self.make_request(),
+            "request": self.make_request(user=self.user),
         }
 
         self.valid_data = {
@@ -134,6 +134,7 @@ class TestWorkflowValidatorCreate(TestCase):
         assert workflow.enabled == self.valid_data["enabled"]
         assert workflow.config == self.valid_data["config"]
         assert workflow.organization_id == self.organization.id
+        assert workflow.created_by_id == self.user.id
 
     def test_create__validate_triggers_empty(self):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)


### PR DESCRIPTION
fixing the detector and workflow validators to store the user id that created the detector/workflow