### PR TITLE
fix(spans): Write falsy values when converting to trace item in span buffer

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -70,8 +70,9 @@ def convert_span_to_item(span: Span) -> TraceItem:
             attributes[k] = AnyValue(string_value=str(v))
 
     for field_name, attribute_name in FIELD_TO_ATTRIBUTE.items():
-        if value := span.get(field_name):
-            attributes[attribute_name] = _anyvalue(value)
+        v = span.get(field_name)
+        if v is not None:
+            attributes[attribute_name] = _anyvalue(v)
 
     return TraceItem(
         organization_id=span["organization_id"],

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -174,3 +174,11 @@ def test_convert_span_to_item():
             )
         ),
     }
+
+
+def test_convert_falsy_fields():
+    message = {**SPAN_KAFKA_MESSAGE, "duration_ms": 0}
+
+    item = convert_span_to_item(cast(Span, message))
+
+    assert item.attributes.get("sentry.duration_ms") == AnyValue(int_value=0)

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -177,8 +177,9 @@ def test_convert_span_to_item():
 
 
 def test_convert_falsy_fields():
-    message = {**SPAN_KAFKA_MESSAGE, "duration_ms": 0}
+    message = {**SPAN_KAFKA_MESSAGE, "duration_ms": 0, "is_segment": False}
 
     item = convert_span_to_item(cast(Span, message))
 
     assert item.attributes.get("sentry.duration_ms") == AnyValue(int_value=0)
+    assert item.attributes.get("sentry.is_segment") == AnyValue(bool_value=False)


### PR DESCRIPTION
The walrus operator `:=` in the conditional while renaming `sentry.` fields was skipping falsy values like `False` and `0`. This is significant in some cases like `duration_ms`, which might come back as `0` from Relay (that's a separate problem). There's a big difference here in whether the duration is unset vs. 0! Instead, manually check for `None` before writing.
