### PR TITLE
chore(trace ai queries): Pull in query as context to search

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -216,8 +216,8 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
   sections,
 }: FilterKeyMenuContentProps<T>) {
   const {filterKeys, setDisplaySeerResults} = useSearchQueryBuilder();
-  const focusedItem = state.collection.getItem(state.selectionManager.focusedKey!)?.props
-    ?.value as string | undefined;
+  const focusedItem = state.collection.getItem(state.selectionManager.focusedKey ?? '')
+    ?.props?.value as string | undefined;
   const focusedKey = focusedItem ? filterKeys[focusedItem] : null;
   const showRecentFilters = recentFilters.length > 0;
   const showDetailsPane = fullWidth && selectedSection !== RECENT_SEARCH_CATEGORY_VALUE;

--- a/static/app/views/explore/components/seerSearch.tsx
+++ b/static/app/views/explore/components/seerSearch.tsx
@@ -18,7 +18,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import QueryTokens from 'sentry/views/explore/components/queryTokens';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {getExploreUrl} from 'sentry/views/explore/utils';
+import {formatQueryToNaturalLanguage, getExploreUrl} from 'sentry/views/explore/utils';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
 interface Visualization {
@@ -66,9 +66,14 @@ function SeerSearchSkeleton() {
   );
 }
 
-export function SeerSearch() {
+interface SeerSearchProps {
+  initialQuery?: string;
+}
+
+export function SeerSearch({initialQuery = ''}: SeerSearchProps) {
+  const formattedInitialQuery = formatQueryToNaturalLanguage(initialQuery);
   const {setDisplaySeerResults} = useSearchQueryBuilder();
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState(formattedInitialQuery);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const openForm = useFeedbackForm();
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -149,10 +149,10 @@ function SpansSearchBar({
 }: {
   eapSpanSearchQueryBuilderProps: EAPSpanSearchQueryBuilderProps;
 }) {
-  const {displaySeerResults} = useSearchQueryBuilder();
+  const {displaySeerResults, query} = useSearchQueryBuilder();
 
   return displaySeerResults ? (
-    <SeerSearch />
+    <SeerSearch initialQuery={query} />
   ) : (
     <EAPSpanSearchQueryBuilder autoFocus {...eapSpanSearchQueryBuilderProps} />
   );

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -598,3 +598,44 @@ function isSimpleFilter(
 function normalizeKey(key: string): string {
   return key.startsWith('!') ? key.slice(1) : key;
 }
+
+export function formatQueryToNaturalLanguage(query: string): string {
+  if (!query.trim()) return '';
+  const parts = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+  return parts.map(formatQueryPart).join(' ');
+}
+
+function formatQueryPart(part: string): string {
+  const isNegated = part.startsWith('!') && part.includes(':');
+  const actualPart = isNegated ? part.slice(1) : part;
+
+  const operators = [
+    [':>=', 'greater than or equal to'],
+    [':<=', 'less than or equal to'],
+    [':!=', 'not'],
+    [':>', 'greater than'],
+    [':<', 'less than'],
+    ['>=', 'greater than or equal to'],
+    ['<=', 'less than or equal to'],
+    ['!=', 'not'],
+    ['!:', 'not'],
+    ['>', 'greater than'],
+    ['<', 'less than'],
+    [':', ''],
+  ] as const;
+
+  for (const [op, desc] of operators) {
+    if (actualPart.includes(op)) {
+      const [key, value] = actualPart.split(op);
+      const cleanKey = key?.trim() || '';
+      const cleanVal = value?.trim() || '';
+
+      const negation = isNegated ? 'not ' : '';
+      const description = desc ? `${negation}${desc}` : negation ? 'not' : '';
+
+      return `${cleanKey} is ${description} ${cleanVal}`.replace(/\s+/g, ' ').trim();
+    }
+  }
+
+  return part;
+}


### PR DESCRIPTION
- Pull in query from the original search bar into search so the model can use that as context while preserving some of what the user already intends to look for

<img width="1112" alt="Screenshot 2025-06-17 at 4 14 21 PM" src="https://github.com/user-attachments/assets/024cfbc7-c896-4549-8118-d24a2d77378a" />
turns into
<img width="1087" alt="Screenshot 2025-06-17 at 4 14 34 PM" src="https://github.com/user-attachments/assets/13601848-42ee-4738-8b7e-ac3ab934e10d" />

