### PR TITLE
:wrench: chore: add logging for project transfers

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -162,7 +162,11 @@ class AcceptProjectTransferEndpoint(Endpoint):
             organization=project.organization,
             target_object=project.id,
             event=audit_log.get_event_id("PROJECT_ACCEPT_TRANSFER"),
-            data=project.get_audit_log_data(),
+            data={
+                "old_organization_slug": old_organization.slug,
+                "new_organization_slug": organization.slug,
+                "project_slug": project.slug,
+            },
             transaction_id=transaction_id,
         )
 

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.signing import BadSignature, SignatureExpired
 from django.http import Http404
 from django.utils.encoding import force_str
@@ -22,6 +24,8 @@ from sentry.signals import project_transferred
 from sentry.users.models.user import User
 from sentry.utils import metrics
 from sentry.utils.signing import unsign
+
+logger = logging.getLogger(__name__)
 
 
 class InvalidPayload(Exception):
@@ -142,6 +146,15 @@ class AcceptProjectTransferEndpoint(Endpoint):
             old_org_id=old_organization.id,
             project=project,
             sender=self,
+        )
+
+        logger.info(
+            "project_transferred",
+            extra={
+                "old_organization_id": old_organization.id,
+                "new_organization_id": organization.id,
+                "project_id": project.id,
+            },
         )
 
         self.create_audit_entry(

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -100,7 +100,7 @@ default_manager.add(
         event_id=36,
         name="PROJECT_ACCEPT_TRANSFER",
         api_name="project.accept-transfer",
-        template="accepted transfer of project {slug}",
+        template="accepted transfer of project {project_slug} from {old_organization_slug} to {new_organization_slug}",
     )
 )
 default_manager.add(events.ProjectEnableAuditLogEvent())


### PR DESCRIPTION
there was no log when a project was transferred, just audit log.

the audit log was also pretty bare and doesn't say from what project we transferred the project from so adding it

closes ECO-730
