### PR TITLE
chore(trace ai queries): Comma between tokens

### DIFF
--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -608,6 +608,8 @@ export function formatQueryToNaturalLanguage(query: string): string {
     if (index === 0) return token;
 
     const prevToken = formattedTokens[index - 1];
+    if (!prevToken) return `${result}, ${token}`;
+
     const isLogicalOp = token.toUpperCase() === 'AND' || token.toUpperCase() === 'OR';
     const prevIsLogicalOp =
       prevToken.toUpperCase() === 'AND' || prevToken.toUpperCase() === 'OR';

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -601,13 +601,13 @@ function normalizeKey(key: string): string {
 
 export function formatQueryToNaturalLanguage(query: string): string {
   if (!query.trim()) return '';
-  const parts = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
-  return parts.map(formatQueryPart).join(' ');
+  const tokens = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+  return tokens.map(formatToken).join(', ');
 }
 
-function formatQueryPart(part: string): string {
-  const isNegated = part.startsWith('!') && part.includes(':');
-  const actualPart = isNegated ? part.slice(1) : part;
+function formatToken(token: string): string {
+  const isNegated = token.startsWith('!') && token.includes(':');
+  const actualToken = isNegated ? token.slice(1) : token;
 
   const operators = [
     [':>=', 'greater than or equal to'],
@@ -625,8 +625,8 @@ function formatQueryPart(part: string): string {
   ] as const;
 
   for (const [op, desc] of operators) {
-    if (actualPart.includes(op)) {
-      const [key, value] = actualPart.split(op);
+    if (actualToken.includes(op)) {
+      const [key, value] = actualToken.split(op);
       const cleanKey = key?.trim() || '';
       const cleanVal = value?.trim() || '';
 
@@ -637,5 +637,5 @@ function formatQueryPart(part: string): string {
     }
   }
 
-  return part;
+  return token;
 }

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -602,7 +602,22 @@ function normalizeKey(key: string): string {
 export function formatQueryToNaturalLanguage(query: string): string {
   if (!query.trim()) return '';
   const tokens = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
-  return tokens.map(formatToken).join(', ');
+  const formattedTokens = tokens.map(formatToken);
+
+  return formattedTokens.reduce((result, token, index) => {
+    if (index === 0) return token;
+
+    const prevToken = formattedTokens[index - 1];
+    const isLogicalOp = token.toUpperCase() === 'AND' || token.toUpperCase() === 'OR';
+    const prevIsLogicalOp =
+      prevToken.toUpperCase() === 'AND' || prevToken.toUpperCase() === 'OR';
+
+    if (isLogicalOp || prevIsLogicalOp) {
+      return `${result} ${token}`;
+    }
+
+    return `${result}, ${token}`;
+  }, '');
 }
 
 function formatToken(token: string): string {


### PR DESCRIPTION
- Add comma between tokens so its easier to read
  - Does not include commas around `and`/`or` tokens
- Clean up variable names

<img width="1103" alt="Screenshot 2025-06-17 at 9 51 24 PM" src="https://github.com/user-attachments/assets/1fdeeecd-88da-4cad-b247-1755f391bd76" />
<img width="1111" alt="Screenshot 2025-06-17 at 9 51 36 PM" src="https://github.com/user-attachments/assets/8b237658-76c0-46af-9798-2a6f35aba7f1" />
