### PR TITLE
fix(wizard): Ensure API errors are correctly displayed

### DIFF
--- a/static/app/views/setupWizard/index.tsx
+++ b/static/app/views/setupWizard/index.tsx
@@ -1,3 +1,6 @@
+import {Fragment} from 'react';
+
+import Indicators from 'sentry/components/indicators';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -24,10 +27,15 @@ function SetupWizard({hash, enableProjectSelection = false}: Props) {
     return <LoadingError message={t('Failed to load organizations')} />;
   }
 
-  return enableProjectSelection ? (
-    <WizardProjectSelection hash={hash} organizations={organizations} />
-  ) : (
-    <WaitingForWizardToConnect hash={hash} organizations={organizations} />
+  return (
+    <Fragment>
+      <Indicators />
+      {enableProjectSelection ? (
+        <WizardProjectSelection hash={hash} organizations={organizations} />
+      ) : (
+        <WaitingForWizardToConnect hash={hash} organizations={organizations} />
+      )}
+    </Fragment>
   );
 }
 

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -8,7 +8,6 @@ import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Input} from 'sentry/components/core/input';
 import IdBadge from 'sentry/components/idBadge';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
-import Indicators from 'sentry/components/indicators';
 import {canCreateProject} from 'sentry/components/projects/canCreateProject';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -261,7 +260,6 @@ export function WizardProjectSelection({
 
   return (
     <StyledForm onSubmit={handleSubmit}>
-      <Indicators />
       <Heading>{t('Select your Sentry project')}</Heading>
       <FieldWrapper>
         <label>{t('Organization')}</label>


### PR DESCRIPTION
I noticed that the error messages are not displayed at all right now, I guess because the `Indicators` have been missing. So I added this, and while at it also added some more specific error message for the case when no active DSN can be found in the project.

The DSN error is based on changed here: https://github.com/getsentry/sentry/pull/93787 but this PR should work unrelated to that still (it will just never show this message).