### PR TITLE
fix(colors): fix chart colors after getColorPalette was updated

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -265,10 +265,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // Set up a fallback palette for any plottable without a color
   const paletteSize = props.plottables.filter(plottable => plottable.needsColor).length;
 
-  const palette =
-    paletteSize > 0
-      ? theme.chart.getColorPalette(paletteSize - 2) // -2 because getColorPalette artificially adds 1, I'm not sure why
-      : [];
+  const palette = paletteSize > 0 ? theme.chart.getColorPalette(paletteSize - 1) : [];
 
   // Create a lookup of series names (given to ECharts) to labels (from
   // Plottable). This makes it easier to look up alises when rendering tooltips

--- a/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
@@ -73,7 +73,7 @@ export default function OverviewSlowNextjsSSRWidget(props: LoadableChartWidgetPr
   const hasData =
     spansRequest.data && spansRequest.data.length > 0 && timeSeries.length > 0;
 
-  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 2);
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
 
   const aliases = Object.fromEntries(
     spansRequest.data?.map(item => [item['span.group'], item['span.description']]) ?? []

--- a/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
@@ -191,7 +191,7 @@ function WebVitalsWidgetVisualization({
   projectData?: ProjectData[];
 }) {
   const theme = useTheme();
-  const ringSegmentColors = theme.chart.getColorPalette(3).slice() as unknown as string[];
+  const ringSegmentColors = theme.chart.getColorPalette(4).slice() as unknown as string[];
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
   return (


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/93699 changed the returned number of colors for getColorPalette. Other code depended on this - as indicated by comments, which broke some charts (missing colors, same colors).
- This PR adapts the parameters to make charts look like they should again

Before:
<img width="1411" alt="Screenshot 2025-06-18 at 10 57 29" src="https://github.com/user-attachments/assets/a2af7165-e575-4e29-9f29-ea81f2e128aa" />

After:
<img width="1416" alt="Screenshot 2025-06-18 at 10 57 20" src="https://github.com/user-attachments/assets/c4b6a252-312f-4666-83c3-92307279b047" />
