### PR TITLE
fix(colors): discover chart colors after getColorPalette update

### DIFF
--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -32,7 +32,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         | {stats: Record<string, EventsStats>; seriesName?: string}
     ) => {
       if (Array.isArray(data.stats.data)) {
-        const color = theme.chart.getColorPalette(data.stats.data.length - 2);
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
         const areaSeries = AreaSeries({
           name: data.seriesName,
           data: data.stats.data.map(([timestamp, countsForTimestamp]) => [
@@ -54,7 +54,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
       const stats = Object.keys(data.stats).map(key =>
         Object.assign({}, {key}, (data.stats as any)[key])
       );
-      const color = theme.chart.getColorPalette(stats.length - 2);
+      const color = theme.chart.getColorPalette(stats.length - 1);
 
       const series = stats
         .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
@@ -92,7 +92,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         | {stats: Record<string, EventsStats>; seriesName?: string}
     ) => {
       if (Array.isArray(data.stats.data)) {
-        const color = theme.chart.getColorPalette(data.stats.data.length - 2);
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
 
         const barSeries = BarSeries({
           name: data.seriesName,
@@ -117,7 +117,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
       const stats = Object.keys(data.stats).map(key =>
         Object.assign({}, {key}, (data.stats as any)[key])
       );
-      const color = theme.chart.getColorPalette(stats.length - 2);
+      const color = theme.chart.getColorPalette(stats.length - 1);
 
       const series = stats
         .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
@@ -156,7 +156,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         | {stats: EventsStats; seriesName?: string}
     ) => {
       if (Array.isArray(data.stats.data)) {
-        const color = theme.chart.getColorPalette(data.stats.data.length - 2);
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
 
         const areaSeries = AreaSeries({
           data: data.stats.data.map(([timestamp, countsForTimestamp]) => [
@@ -178,7 +178,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
       const stats = Object.values(data.stats);
       const hasOther = Object.keys(data.stats).includes('Other');
       const color = theme.chart
-        .getColorPalette(stats.length - 2 - (hasOther ? 1 : 0))
+        .getColorPalette(stats.length - 1 - (hasOther ? 1 : 0))
         ?.slice() as string[];
 
       if (hasOther) {
@@ -220,7 +220,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         | {stats: EventsStats; seriesName?: string}
     ) => {
       if (Array.isArray(data.stats.data)) {
-        const color = theme.chart.getColorPalette(data.stats.data.length - 2);
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
 
         const lineSeries = LineSeries({
           data: data.stats.data.map(([timestamp, countsForTimestamp]) => [
@@ -242,7 +242,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
       const stats = Object.values(data.stats);
       const hasOther = Object.keys(data.stats).includes('Other');
       const color = theme.chart
-        .getColorPalette(stats.length - 2 - (hasOther ? 1 : 0))
+        .getColorPalette(stats.length - 1 - (hasOther ? 1 : 0))
         ?.slice() as string[];
       if (hasOther) {
         color.push(theme.chartOther);
@@ -282,7 +282,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         | {stats: EventsStats; seriesName?: string}
     ) => {
       if (Array.isArray(data.stats.data)) {
-        const color = theme.chart.getColorPalette(data.stats.data.length - 2);
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
 
         const areaSeries = AreaSeries({
           data: data.stats.data.map(([timestamp, countsForTimestamp]) => [
@@ -304,7 +304,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
       const stats = Object.values(data.stats);
       const hasOther = Object.keys(data.stats).includes('Other');
       const color = theme.chart
-        .getColorPalette(stats.length - 2 - (hasOther ? 1 : 0))
+        .getColorPalette(stats.length - 1 - (hasOther ? 1 : 0))
         ?.slice() as string[] | undefined;
       if (hasOther) {
         color?.push(theme.chartOther);
@@ -347,7 +347,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
         const dataMiddleIndex = Math.floor(data.stats.data.length / 2);
         const current = data.stats.data.slice(dataMiddleIndex);
         const previous = data.stats.data.slice(0, dataMiddleIndex);
-        const color = theme.chart.getColorPalette(data.stats.data.length - 2);
+        const color = theme.chart.getColorPalette(data.stats.data.length - 1);
         const areaSeries = AreaSeries({
           name: data.seriesName,
           data: current.map(([timestamp, countsForTimestamp]) => [
@@ -379,7 +379,7 @@ export const makeDiscoverCharts = (theme: Theme): Array<RenderDescriptor<ChartTy
       const stats = Object.keys(data.stats).map(key =>
         Object.assign({}, {key}, (data.stats as any)[key])
       );
-      const color = theme.chart.getColorPalette(stats.length - 2) ?? [];
+      const color = theme.chart.getColorPalette(stats.length - 1) ?? [];
       const previousPeriodColor = lightenHexToRgb(color);
 
       const areaSeries: SeriesOption[] = [];

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -402,7 +402,7 @@ function BaseChart({
     resolveColors ||
     (series.length
       ? theme.chart.getColorPalette(series.length)
-      : theme.chart.getColorPalette(theme.chart.colors.length - 1));
+      : theme.chart.getColorPalette(theme.chart.colors.length));
 
   const resolvedSeries = useMemo(() => {
     const previousPeriodColors =

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -274,7 +274,7 @@ class Chart extends Component<ChartProps, State> {
     const chartColors = timeseriesData.length
       ? (colors?.slice(0, series.length) ??
         this.props.theme.chart
-          .getColorPalette(timeseriesData.length - 2 - (hasOther ? 1 : 0))
+          .getColorPalette(timeseriesData.length - 1 - (hasOther ? 1 : 0))
           .slice())
       : undefined;
     if (chartColors?.length && hasOther) {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -65,7 +65,7 @@ function WidgetTemplatesList({
   return (
     <Fragment>
       {widgets.map((widget, index) => {
-        const iconColor = theme.chart.getColorPalette(widgets.length - 2)?.[index]!;
+        const iconColor = theme.chart.getColorPalette(widgets.length - 1)?.[index]!;
 
         const Icon = getWidgetIcon(widget.displayType);
         const lastWidget = index === widgets.length - 1;

--- a/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetLibrary/index.tsx
@@ -52,7 +52,7 @@ export function WidgetLibrary({
       <Header>{t('Widget Library')}</Header>
       <WidgetLibraryWrapper>
         {defaultWidgets.map((widget, index) => {
-          const iconColor = theme.chart.getColorPalette(defaultWidgets.length - 2)?.[
+          const iconColor = theme.chart.getColorPalette(defaultWidgets.length - 1)?.[
             index
           ]!;
 

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -330,7 +330,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
     );
     const colors = timeseriesResults
       ? (theme.chart
-          .getColorPalette(timeseriesResults.length - (shouldColorOther ? 3 : 2))
+          .getColorPalette(timeseriesResults.length - (shouldColorOther ? 2 : 1))
           .slice() as string[])
       : [];
     // TODO(wmak): Need to change this when updating dashboards to support variable topEvents

--- a/static/app/views/discover/miniGraph.tsx
+++ b/static/app/views/discover/miniGraph.tsx
@@ -204,7 +204,7 @@ class MiniGraph extends Component<Props> {
           const hasOther = topEvents && topEvents + 1 === allSeries.length;
           const chartColors = allSeries.length
             ? (theme.chart
-                .getColorPalette(allSeries.length - 2 - (hasOther ? 1 : 0))
+                .getColorPalette(allSeries.length - 1 - (hasOther ? 1 : 0))
                 .slice() as string[])
             : undefined;
 

--- a/static/app/views/discover/table/topResultsIndicator.tsx
+++ b/static/app/views/discover/table/topResultsIndicator.tsx
@@ -18,6 +18,6 @@ export const TopResultsIndicator = styled('div')<TopResultsIndicatorProps>`
     // app/components/charts/eventsChart so that the ordering matches
 
     // the color pallete contains n + 2 colors, so we subtract 2 here
-    return p.theme.chart.getColorPalette(p.count - 2)?.[p.index];
+    return p.theme.chart.getColorPalette(p.count - 1)?.[p.index];
   }};
 `;

--- a/static/app/views/discover/table/topResultsIndicator.tsx
+++ b/static/app/views/discover/table/topResultsIndicator.tsx
@@ -17,7 +17,7 @@ export const TopResultsIndicator = styled('div')<TopResultsIndicatorProps>`
     // this background color needs to match the colors used in
     // app/components/charts/eventsChart so that the ordering matches
 
-    // the color pallete contains n + 2 colors, so we subtract 2 here
+    // the color palette contains n + 1 colors, so we subtract 1 here
     return p.theme.chart.getColorPalette(p.count - 1)?.[p.index];
   }};
 `;

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -106,7 +106,7 @@ function AggregatesTable({
 
   const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
 
-  const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor);
+  const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 1);
 
   return (
     <Fragment>

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -106,7 +106,7 @@ function AggregatesTable({
 
   const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
 
-  const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 2); // -2 because getColorPalette artificially adds 1, I'm not sure why
+  const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor);
 
   return (
     <Fragment>

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -79,7 +79,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
   const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
 
-  const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 2); // -2 because getColorPalette artificially adds 1, I'm not sure why
+  const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 1);
 
   const paginationAnalyticsEvent = usePaginationAnalytics(
     'aggregates',

--- a/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
@@ -76,7 +76,7 @@ export function SamplingBreakdown({
 
   const getSpanRate = (spanCount: any) => (total === 0 ? 0 : spanCount / total);
   const otherRate = getSpanRate(otherSpanCount);
-  const palette = theme.chart.getColorPalette(ITEMS_TO_SHOW - 1);
+  const palette = theme.chart.getColorPalette(ITEMS_TO_SHOW);
 
   return (
     <StyledPanel {...props}>

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -38,7 +38,7 @@ const known_categories = [
 
 function makeStatOPColors(fallbackColor: string, theme: Theme): Record<string, string> {
   const result: Record<string, string> = {};
-  const colors = theme.chart.getColorPalette(known_categories.length - 1);
+  const colors = theme.chart.getColorPalette(known_categories.length);
 
   known_categories.forEach((category, index) => {
     const color = colors?.[index % colors.length] ?? fallbackColor;


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/93699 changed the returned number of colors for getColorPalette. Other code depended on this - as indicated by comments, which broke some charts (missing colors, same colors).

| Product Area | Before | After |
|-------------|--------|-------|
| Discover | <img width="742" alt="Screenshot 2025-06-18 at 11 12 35" src="https://github.com/user-attachments/assets/a6cacf90-f472-4e18-b2b7-ab1d3387a317" /> | <img width="745" alt="Screenshot 2025-06-18 at 11 12 40" src="https://github.com/user-attachments/assets/60d4bfb6-d0a1-4695-abfe-1157cbd80a03" /> |
| Dashboards | <img width="721" alt="Screenshot 2025-06-18 at 11 17 48" src="https://github.com/user-attachments/assets/e3c7498b-5f5c-4a6a-998b-6e567f8b748e" />| <img width="719" alt="Screenshot 2025-06-18 at 11 17 43" src="https://github.com/user-attachments/assets/809e20b0-b39d-4a34-9a7b-4cca052d9d98" />|

and some more in tables, etc. 
