### PR TITLE
fix: Busy button should display wait cursor and have aria-busy

### DIFF
--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -28,12 +28,14 @@ export function Button({
   type = 'button',
   title,
   tooltipProps,
+  busy,
   ...props
 }: ButtonProps) {
   const {handleClick, hasChildren, accessibleLabel} = useButtonFunctionality({
     ...props,
     type,
     disabled,
+    busy,
   });
 
   return (
@@ -41,9 +43,11 @@ export function Button({
       <StyledButton
         aria-label={accessibleLabel}
         aria-disabled={disabled}
+        aria-busy={busy}
         disabled={disabled}
         size={size}
         type={type}
+        busy={busy}
         {...props}
         onClick={handleClick}
         role="button"

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -157,7 +157,7 @@ export function DO_NOT_USE_getButtonStyles(
     border-radius: ${p.theme.borderRadius};
     text-transform: none;
     font-weight: ${p.theme.fontWeightBold};
-    cursor: ${p.disabled ? 'not-allowed' : 'pointer'};
+    cursor: ${p.disabled ? 'not-allowed' : p.busy ? 'wait' : 'pointer'};
     opacity: ${(p.busy || p.disabled) && '0.65'};
 
     ${getColors(p)}


### PR DESCRIPTION
I was unable to make my cursor appear in my recordings, so unfortunately, there are no before-and-after images.