### PR TITLE
fix(colors): insights charts

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/performanceScoreChart.tsx
@@ -39,7 +39,7 @@ export function PerformanceScoreChart({
       : projectScore.totalScore
     : undefined;
 
-  let ringSegmentColors = theme.chart.getColorPalette(3).slice() as unknown as string[];
+  let ringSegmentColors = theme.chart.getColorPalette(4).slice() as unknown as string[];
   let ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
   if (webVital) {

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -104,7 +104,7 @@ export function PageOverviewSidebar({
     return undefined;
   };
 
-  const ringSegmentColors = theme.chart.getColorPalette(3);
+  const ringSegmentColors = theme.chart.getColorPalette(4);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
 
   return (

--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -122,7 +122,7 @@ export const VITAL_DESCRIPTIONS: Partial<
 
 export function WebVitalDetailHeader({score, value, webVital}: Props) {
   const theme = useTheme();
-  const colors = theme.chart.getColorPalette(3);
+  const colors = theme.chart.getColorPalette(4);
   const dotColor = colors[ORDER.indexOf(webVital)]!;
   const status = score === undefined ? undefined : scoreToStatus(score);
 

--- a/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalMeters.tsx
@@ -74,7 +74,7 @@ export default function WebVitalMeters({
   const webVitalsConfig = WEB_VITALS_METERS_CONFIG;
 
   const webVitals = Object.keys(webVitalsConfig) as WebVitals[];
-  const colors = theme.chart.getColorPalette(3);
+  const colors = theme.chart.getColorPalette(4);
 
   const renderVitals = () => {
     return webVitals.map((webVital, index) => {

--- a/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
@@ -84,7 +84,7 @@ export default function OverviewSlowQueriesChartWidget(props: LoadableChartWidge
   const hasData =
     queriesRequest.data && queriesRequest.data.length > 0 && timeSeries.length > 0;
 
-  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 2);
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
 
   const aliases = Object.fromEntries(
     queriesRequest.data?.map(item => [

--- a/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget.tsx
@@ -33,7 +33,7 @@ export default function PerformanceScoreBreakdownChartWidget(
     },
   });
   const theme = useTheme();
-  const segmentColors = theme.chart.getColorPalette(3).slice(0, 5);
+  const segmentColors = theme.chart.getColorPalette(4).slice(0, 5);
   const defaultQuery = useDefaultWebVitalsQuery();
   const search = new MutableSearch(`${defaultQuery} has:measurements.score.total`);
 

--- a/static/app/views/insights/common/components/widgets/releaseNewIssuesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/releaseNewIssuesChartWidget.tsx
@@ -15,7 +15,7 @@ export default function ReleaseNewIssuesChartWidget(props: LoadableChartWidgetPr
   });
   const theme = useTheme();
 
-  const colorPalette = theme.chart.getColorPalette(series.length - 2);
+  const colorPalette = theme.chart.getColorPalette(series.length - 1);
   const plottables = series.map(
     (ts, index) =>
       new Bars(convertSeriesToTimeseries(ts), {

--- a/static/app/views/insights/mobile/screenload/utils.tsx
+++ b/static/app/views/insights/mobile/screenload/utils.tsx
@@ -62,7 +62,7 @@ export function transformDeviceClassEvents({
       yAxes.forEach(val => {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         if (transformedData[YAXIS_COLUMNS[val]][release]) {
-          const colors = theme.chart.getColorPalette(3);
+          const colors = theme.chart.getColorPalette(4);
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           transformedData[YAXIS_COLUMNS[val]][release].data[index] = {
             name: deviceClass,

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/content.tsx
@@ -77,7 +77,7 @@ function Content({
     );
   }
 
-  const colors = (data && theme.chart.getColorPalette(data.length - 2)) || [];
+  const colors = (data && theme.chart.getColorPalette(data.length - 1)) || [];
 
   // Create a list of series based on the order of the fields,
   // We need to flip it at the end to ensure the series stack right.

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/content.tsx
@@ -59,7 +59,7 @@ function Content({
     );
   }
 
-  const colors = (data && theme.chart.getColorPalette(data.length - 2)) || [];
+  const colors = (data && theme.chart.getColorPalette(data.length - 1)) || [];
 
   // Create a list of series based on the order of the fields,
   const series = data

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
@@ -120,7 +120,7 @@ export default function ExclusiveTimeTimeSeries(props: Props) {
                   top: '40px',
                   bottom: '0px',
                 },
-                colors: theme.chart.getColorPalette(yAxis.length - 2),
+                colors: theme.chart.getColorPalette(yAxis.length - 1),
                 seriesOptions: {
                   showSymbol: false,
                 },

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -125,7 +125,7 @@ function VitalChart({
                 }
 
                 const colors =
-                  (results && theme.chart.getColorPalette(results.length - 2)) || [];
+                  (results && theme.chart.getColorPalette(results.length - 1)) || [];
 
                 const {smoothedResults} = transformEventStatsSmoothed(results);
 


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/93699 changed the returned number of colors for getColorPalette. Other code depended on this - as indicated by comments, which broke some charts (missing colors, same colors).
- Fix chart colors on web vitals, mobile page

Example Before:
![Screenshot 2025-06-18 at 12 47 53](https://github.com/user-attachments/assets/19e27cc7-0fa1-49a4-b494-da1a1d7ca0a1)

Example After:
![Screenshot 2025-06-18 at 12 47 51](https://github.com/user-attachments/assets/9a5de609-7e2c-4255-86e3-93aeee8aaa2d)
