### PR TITLE
fix(ui): button is cut-off in chonk

### DIFF
--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -272,7 +272,5 @@ const CrashFreeWrapper = styled('div')`
 `;
 
 const ViewColumn = styled('div')`
-  ${p => p.theme.overflowEllipsis};
-  line-height: 20px;
   text-align: right;
 `;


### PR DESCRIPTION
there's no apparent reason why we'd need overflowEllipsis in a column that shows a button, and line-height doesn't change anything either from what I an see

| before | after |
|--------|--------|
| ![Screenshot 2025-06-18 at 13 23 32](https://github.com/user-attachments/assets/e4fd4805-b01e-4b7e-a33e-7a7867415fad) | ![Screenshot 2025-06-18 at 13 23 20](https://github.com/user-attachments/assets/157aa163-2c65-4170-8beb-26d02a33c5bd) |
| ![Screenshot 2025-06-18 at 13 23 29](https://github.com/user-attachments/assets/00d6654a-5aae-4d03-923b-bf62988735d0) | ![Screenshot 2025-06-18 at 13 23 14](https://github.com/user-attachments/assets/dbf494c4-307a-47ec-8726-f280f6790f57) | 