### PR TITLE
fix(colors): web vitals & cache widgets

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/charts/webVitalWeightList.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/webVitalWeightList.tsx
@@ -14,7 +14,7 @@ interface WebVitalsWeightListProps {
 }
 export function WebVitalsWeightList({weights}: WebVitalsWeightListProps) {
   const theme = useTheme();
-  const segmentColors = theme.chart.getColorPalette(3);
+  const segmentColors = theme.chart.getColorPalette(4);
 
   return (
     <Content>

--- a/static/app/views/insights/common/components/widgets/overviewCacheMissChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewCacheMissChartWidget.tsx
@@ -86,7 +86,7 @@ export default function OverviewCacheMissChartWidget(props: LoadableChartWidgetP
     cachesRequest.data.length > 0 &&
     timeSeries.length > 0;
 
-  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 2);
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
 
   const visualization = (
     <WidgetVisualizationStates


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/93699 changed the returned number of colors for getColorPalette. Other code depended on this - as indicated by comments, which broke some charts (missing colors, same colors).

- fix a leftover web vitals widget and a cache widget