### PR TITLE
fix(ui): restore height for pageFilterBar

### DIFF
--- a/static/app/components/organizations/pageFilterBar.tsx
+++ b/static/app/components/organizations/pageFilterBar.tsx
@@ -168,6 +168,8 @@ except in mobile */
   display: flex;
   position: relative;
 
+  height: ${p.theme.form.md.height};
+
   & button[aria-haspopup] {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-06-18 at 13 51 14](https://github.com/user-attachments/assets/434cca79-25d5-4321-b99d-dbce0633bd8b) | ![Screenshot 2025-06-18 at 13 51 08](https://github.com/user-attachments/assets/b037f6b5-8870-4d56-876f-8955d6c0c90f) | 

@JonasBa we used to have the `height` explicitly set - like it’s also done in the old theme - but it was removed here:

https://github.com/getsentry/sentry/pull/90243/files#diff-32f8334cfccf64122985ca68a14eb551d05ece05ea1e4f3390974d3765195a03L170

do you remember why it was removed, and is it safe to bring it back like this?