### PR TITLE
fix(colors): frontend insights -> session health -> issues widget

### DIFF
--- a/static/app/views/insights/common/components/widgets/newAndResolvedIssueChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/newAndResolvedIssueChartWidget.tsx
@@ -21,7 +21,7 @@ export default function NewAndResolvedIssueChartWidget(props: LoadableChartWidge
     resolved_issues_count: 'resolved_issues',
   };
 
-  const colorPalette = theme.chart.getColorPalette(series.length - 2);
+  const colorPalette = theme.chart.getColorPalette(series.length - 1);
 
   const plottables = series.map(
     (ts, index) =>


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/93699 changed the returned number of colors for getColorPalette. Other code depended on this - as indicated by comments, which broke some charts (missing colors, same colors).
- 
Before: 
![Screenshot 2025-06-18 at 14 29 45](https://github.com/user-attachments/assets/87595323-eb02-48ae-8410-aa45c5e9660e)

After:
![Screenshot 2025-06-18 at 14 29 50](https://github.com/user-attachments/assets/388845fd-6320-4787-b76a-56d2357d84ed)
