### PR TITLE
flex: add support for inline flex

### DIFF
--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -1,4 +1,5 @@
 import type {CSSProperties} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 interface FlexProps {
@@ -6,12 +7,16 @@ interface FlexProps {
   direction?: CSSProperties['flexDirection'];
   flex?: CSSProperties['flex'];
   gap?: CSSProperties['gap'];
+  /**
+   * Determines whether the flex container should be displayed as an inline-flex.
+   */
+  inline?: boolean;
   justify?: CSSProperties['justifyContent'];
   wrap?: CSSProperties['flexWrap'];
 }
 
 const FlexContainer = styled('div')<FlexProps>`
-  display: flex;
+  display: ${p => (p.inline ? 'inline-flex' : 'flex')};
   flex-direction: ${p => p.direction};
   justify-content: ${p => p.justify};
   align-items: ${p => p.align};
@@ -22,15 +27,22 @@ const FlexContainer = styled('div')<FlexProps>`
 
 interface FlexItemProps {
   basis?: CSSProperties['flexBasis'];
+  flex?: CSSProperties['flex'];
   grow?: CSSProperties['flexGrow'];
   shrink?: CSSProperties['flexShrink'];
 }
 
 const FlexItem = styled('div')<FlexItemProps>`
-  flex-grow: ${p => p.grow ?? 0};
-  flex-shrink: ${p => p.shrink ?? 1};
-  flex-basis: ${p => p.basis ?? 'auto'};
-  overflow: hidden;
+  ${p =>
+    p.flex
+      ? css`
+          flex: ${p.flex};
+        `
+      : css`
+          flex-grow: ${p.grow ?? 0};
+          flex-shrink: ${p.shrink ?? 1};
+          flex-basis: ${p.basis ?? 'auto'};
+        `}
 `;
 
 export const Flex = Object.assign(FlexContainer, {


### PR DESCRIPTION
This should support inline flex. I've went ahead and also removed overflow hidden from Flex.Item (there are only 3 cases where Flex.Item is used, and neither seem sensitive to overflow problems)