### PR TITLE
chore(preprod): move endpoint to separate file to share with other preprod endpoints

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -295,9 +295,7 @@ from sentry.notifications.api.endpoints.user_notification_settings_options_detai
 from sentry.notifications.api.endpoints.user_notification_settings_providers import (
     UserNotificationSettingsProvidersEndpoint,
 )
-from sentry.preprod.api.endpoints.organization_preprod_artifact_assemble import (
-    ProjectPreprodArtifactAssembleEndpoint,
-)
+from sentry.preprod.api.endpoints.urls import preprod_urls
 from sentry.relocation.api.endpoints.abort import RelocationAbortEndpoint
 from sentry.relocation.api.endpoints.artifacts.details import RelocationArtifactDetailsEndpoint
 from sentry.relocation.api.endpoints.artifacts.index import RelocationArtifactIndexEndpoint
@@ -2524,11 +2522,6 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-assemble-dif-files",
     ),
     re_path(
-        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/assemble/$",
-        ProjectPreprodArtifactAssembleEndpoint.as_view(),
-        name="sentry-api-0-assemble-preprod-artifact-files",
-    ),
-    re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/dsyms/unknown/$",
         UnknownDebugFilesEndpoint.as_view(),
         name="sentry-api-0-unknown-dsym-files",
@@ -2992,6 +2985,7 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         ProjectSeerPreferencesEndpoint.as_view(),
         name="sentry-api-0-project-seer-preferences",
     ),
+    *preprod_urls.preprod_urlpatterns,
 ]
 
 TEAM_URLS = [

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -295,7 +295,7 @@ from sentry.notifications.api.endpoints.user_notification_settings_options_detai
 from sentry.notifications.api.endpoints.user_notification_settings_providers import (
     UserNotificationSettingsProvidersEndpoint,
 )
-from sentry.preprod.api.endpoints.urls import preprod_urls
+from sentry.preprod.api.endpoints import urls as preprod_urls
 from sentry.relocation.api.endpoints.abort import RelocationAbortEndpoint
 from sentry.relocation.api.endpoints.artifacts.details import RelocationArtifactDetailsEndpoint
 from sentry.relocation.api.endpoints.artifacts.index import RelocationArtifactIndexEndpoint

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -4,7 +4,7 @@ from .organization_preprod_artifact_assemble import ProjectPreprodArtifactAssemb
 
 preprod_urlpatterns = [
     re_path(
-        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/files/preprodartifacts/assemble/$",
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/files/preprodartifacts/assemble/$",
         ProjectPreprodArtifactAssembleEndpoint.as_view(),
         name="sentry-api-0-assemble-preprod-artifact-files",
     ),

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -1,0 +1,11 @@
+from django.urls import re_path
+
+from .organization_preprod_artifact_assemble import ProjectPreprodArtifactAssembleEndpoint
+
+preprod_urlpatterns = [
+    re_path(
+        r"^(?P<organization_id_or_slug>[^\/]+)/(?P<project_id_or_slug>[^\/]+)/files/preprodartifacts/assemble/$",
+        ProjectPreprodArtifactAssembleEndpoint.as_view(),
+        name="sentry-api-0-assemble-preprod-artifact-files",
+    ),
+]


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/92528#issuecomment-2923402577

as suggested by @JoshFerge  a few weeks back. We're going to add a few more endpoints so it makes sense to have them all in the same self contained file