### PR TITLE
chore(auth): log idp verification mismatch

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -507,7 +507,6 @@ class AuthIdentityHandler:
                 logger.info(
                     "sso.login-pipeline.missing-verification",
                     extra={
-                        "verification_user_id": verification_value["user_id"],
                         "user_id": self.user.id,
                         "request_user_id": self.request.user.id,
                     },

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -494,6 +494,15 @@ class AuthIdentityHandler:
             verification_value = get_verification_value_from_key(verification_key)
             if verification_value:
                 is_account_verified = self.has_verified_account(verification_value)
+                if not is_account_verified:
+                    logger.info(
+                        "sso.login-pipeline.verification-mismatch",
+                        extra={
+                            "verification_user_id": verification_value["user_id"],
+                            "user_id": self.user.id,
+                            "request_user_id": self.request.user.id,
+                        },
+                    )
 
         is_new_account = not self.user.is_authenticated  # stateful
         if self._app_user and (self.identity.get("email_verified") or is_account_verified):

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -503,6 +503,15 @@ class AuthIdentityHandler:
                             "request_user_id": self.request.user.id,
                         },
                     )
+            else:
+                logger.info(
+                    "sso.login-pipeline.missing-verification",
+                    extra={
+                        "verification_user_id": verification_value["user_id"],
+                        "user_id": self.user.id,
+                        "request_user_id": self.request.user.id,
+                    },
+                )
 
         is_new_account = not self.user.is_authenticated  # stateful
         if self._app_user and (self.identity.get("email_verified") or is_account_verified):


### PR DESCRIPTION
People are hitting an auth loop because somehow the confirm email logic for an account without a password (provisioned through IDP) is not sending them through the `attach_identity` logic.

Log when this happens, I'm suspecting it's a mismatch in user ids