### PR TITLE
feat(aci): Add sorting to monitor list table

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -93,6 +93,8 @@ const StyledIssueCell = styled(IssueCell)`
 
 const RowWrapper = styled('div')<{disabled?: boolean}>`
   display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
   position: relative;
   align-items: center;
   padding: ${space(2)};
@@ -108,43 +110,4 @@ const RowWrapper = styled('div')<{disabled?: boolean}>`
         opacity: 0.6;
       }
     `}
-
-  .type,
-  .owner,
-  .last-issue,
-  .connected-automations {
-    display: none;
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.xsmall}) {
-    grid-template-columns: 3fr 0.8fr;
-
-    .type {
-      display: flex;
-    }
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
-
-    .last-issue {
-      display: flex;
-    }
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
-
-    .owner {
-      display: flex;
-    }
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-columns: 4.5fr 0.8fr 1.5fr 0.8fr 2fr;
-
-    .connected-automations {
-      display: flex;
-    }
-  }
 `;

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -60,7 +60,12 @@ function HeaderCell({
   };
 
   return (
-    <HeaderCellDiv className={name} sortable={defined(sortKey)} onClick={handleSort}>
+    <HeaderCellDiv
+      className={name}
+      sortable={defined(sortKey)}
+      onClick={handleSort}
+      role="columnheader"
+    >
       {divider && <HeaderDivider />}
       {sortKey && <InteractionStateLayer />}
       <Heading sorted={isSortedByField}>{children}</Heading>

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,12 +1,18 @@
+import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/core/layout';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {defined} from 'sentry/utils';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {
   DetectorListRow,
   DetectorListRowSkeleton,
@@ -16,6 +22,7 @@ import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/constants';
 type DetectorListTableProps = {
   detectors: Detector[];
   isPending: boolean;
+  sort: Sort | undefined;
 };
 
 function LoadingSkeletons() {
@@ -24,31 +31,72 @@ function LoadingSkeletons() {
   ));
 }
 
-function DetectorListTable({detectors, isPending}: DetectorListTableProps) {
+function HeaderCell({
+  children,
+  name,
+  divider,
+  sortKey,
+  sort,
+}: {
+  children: React.ReactNode;
+  name: string;
+  sort: Sort | undefined;
+  divider?: boolean;
+  sortKey?: string;
+}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isSortedByField = sort?.field === sortKey;
+  const handleSort = () => {
+    if (!sortKey) {
+      return;
+    }
+    const newSort =
+      sort && isSortedByField ? `${sort.kind === 'asc' ? '-' : ''}${sortKey}` : sortKey;
+    navigate({
+      pathname: location.pathname,
+      query: {...location.query, sort: newSort},
+    });
+  };
+
   return (
-    <Panel>
+    <HeaderCellDiv className={name} sortable={defined(sortKey)} onClick={handleSort}>
+      {divider && <HeaderDivider />}
+      {sortKey && <InteractionStateLayer />}
+      <Heading sorted={isSortedByField}>{children}</Heading>
+      {sort && sort.field === sortKey && (
+        <IconArrow size="xs" direction={sort.kind === 'asc' ? 'up' : 'down'} />
+      )}
+    </HeaderCellDiv>
+  );
+}
+
+function DetectorListTable({detectors, isPending, sort}: DetectorListTableProps) {
+  return (
+    <PanelGrid>
       <StyledPanelHeader>
-        <Flex className="type">
-          <Heading>{t('Type')}</Heading>
-        </Flex>
-        <Flex className="type">
-          <HeaderDivider />
-          <Heading>{t('Type')}</Heading>
-        </Flex>
-        <Flex className="issue">
-          <HeaderDivider />
-          <Heading>{t('Last Issue')}</Heading>
-        </Flex>
-        <Flex className="assignee">
-          <HeaderDivider />
-          <Heading>{t('Assignee')}</Heading>
-        </Flex>
-        <Flex className="connected-automations">
-          <HeaderDivider />
-          <Heading>{t('Automations')}</Heading>
-        </Flex>
+        <HeaderCell name="name" sortKey="name" sort={sort}>
+          {t('Name')}
+        </HeaderCell>
+        <HeaderCell name="type" divider sortKey="type" sort={sort}>
+          {t('Type')}
+        </HeaderCell>
+        <HeaderCell name="issue" divider sort={sort}>
+          {t('Last Issue')}
+        </HeaderCell>
+        <HeaderCell name="assignee" divider sort={sort}>
+          {t('Assignee')}
+        </HeaderCell>
+        <HeaderCell
+          name="connected-automations"
+          divider
+          sortKey="connectedWorkflows"
+          sort={sort}
+        >
+          {t('Automations')}
+        </HeaderCell>
       </StyledPanelHeader>
-      <PanelBody>
+      <Fragment>
         {isPending ? (
           <LoadingSkeletons />
         ) : (
@@ -56,31 +104,14 @@ function DetectorListTable({detectors, isPending}: DetectorListTableProps) {
             <DetectorListRow key={detector.id} detector={detector} />
           ))
         )}
-      </PanelBody>
-    </Panel>
+      </Fragment>
+    </PanelGrid>
   );
 }
 
-const HeaderDivider = styled('div')`
-  background-color: ${p => p.theme.gray200};
-  width: 1px;
-  border-radius: ${p => p.theme.borderRadius};
-`;
-
-const Heading = styled('div')`
-  display: flex;
-  padding: 0 ${space(2)};
-  color: ${p => p.theme.subText};
-  align-items: center;
-`;
-
-const StyledPanelHeader = styled(PanelHeader)`
-  justify-content: left;
-  padding: ${space(0.75)} ${space(2)};
-  min-height: 40px;
-  align-items: center;
+const PanelGrid = styled(Panel)`
   display: grid;
-  text-transform: none;
+  grid-template-columns: 1fr;
 
   .type,
   .creator,
@@ -120,6 +151,58 @@ const StyledPanelHeader = styled(PanelHeader)`
       display: flex;
     }
   }
+`;
+
+const HeaderDivider = styled('div')`
+  background-color: ${p => p.theme.gray200};
+  width: 1px;
+  border-radius: ${p => p.theme.borderRadius};
+  height: 14px;
+`;
+
+const Heading = styled('div')<{sorted?: boolean}>`
+  display: flex;
+  padding: 0 ${space(2)};
+  color: ${p => p.theme.subText};
+  align-items: center;
+
+  ${p =>
+    p.sorted &&
+    css`
+      color: ${p.theme.textColor};
+    `}
+`;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  justify-content: left;
+  padding: 0;
+  min-height: 40px;
+  align-items: center;
+  text-transform: none;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+`;
+
+const HeaderCellDiv = styled('div')<{sortable?: boolean}>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+
+  &:first-child {
+    padding-left: ${space(2)};
+  }
+
+  &:last-child {
+    padding-right: ${space(2)};
+  }
+
+  ${p =>
+    p.sortable &&
+    css`
+      cursor: pointer;
+    `}
 `;
 
 export default DetectorListTable;

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -4,12 +4,10 @@ import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Panel from 'sentry/components/panels/panel';
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
-import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -60,19 +58,25 @@ function HeaderCell({
   };
 
   return (
-    <HeaderCellDiv
+    <ColumnHeaderCell
       className={name}
-      sortable={defined(sortKey)}
+      isSorted={isSortedByField}
       onClick={handleSort}
       role="columnheader"
+      as={sortKey ? 'button' : 'div'}
     >
       {divider && <HeaderDivider />}
       {sortKey && <InteractionStateLayer />}
-      <Heading sorted={isSortedByField}>{children}</Heading>
-      {sort && sort.field === sortKey && (
-        <IconArrow size="xs" direction={sort.kind === 'asc' ? 'up' : 'down'} />
+      <Heading>{children}</Heading>
+      {sortKey && (
+        <SortIndicator
+          aria-hidden
+          size="xs"
+          direction={sort?.kind === 'asc' ? 'up' : 'down'}
+          isSorted={isSortedByField}
+        />
       )}
-    </HeaderCellDiv>
+    </ColumnHeaderCell>
   );
 }
 
@@ -159,26 +163,24 @@ const PanelGrid = styled(Panel)`
 `;
 
 const HeaderDivider = styled('div')`
+  position: absolute;
+  left: 0;
   background-color: ${p => p.theme.gray200};
   width: 1px;
   border-radius: ${p => p.theme.borderRadius};
   height: 14px;
 `;
 
-const Heading = styled('div')<{sorted?: boolean}>`
+const Heading = styled('div')`
   display: flex;
-  padding: 0 ${space(2)};
-  color: ${p => p.theme.subText};
   align-items: center;
-
-  ${p =>
-    p.sorted &&
-    css`
-      color: ${p.theme.textColor};
-    `}
 `;
 
-const StyledPanelHeader = styled(PanelHeader)`
+const StyledPanelHeader = styled('div')`
+  background: ${p => p.theme.backgroundSecondary};
+  border-bottom: 1px solid ${p => p.theme.border};
+  border-radius: calc(${p => p.theme.borderRadius} + 1px)
+    calc(${p => p.theme.borderRadius} + 1px) 0 0;
   justify-content: left;
   padding: 0;
   min-height: 40px;
@@ -189,24 +191,44 @@ const StyledPanelHeader = styled(PanelHeader)`
   grid-column: 1 / -1;
 `;
 
-const HeaderCellDiv = styled('div')<{sortable?: boolean}>`
+const ColumnHeaderCell = styled('div')<{isSorted?: boolean}>`
+  background: none;
+  outline: none;
+  border: none;
+  padding: 0 ${space(2)};
+  text-transform: inherit;
+  font-weight: ${p => p.theme.fontWeightBold};
+  text-align: left;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.subText};
+
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: ${space(1)};
   height: 100%;
 
   &:first-child {
-    padding-left: ${space(2)};
-  }
-
-  &:last-child {
-    padding-right: ${space(2)};
+    padding-left: ${space(4)};
   }
 
   ${p =>
-    p.sortable &&
+    p.isSorted &&
     css`
-      cursor: pointer;
+      color: ${p.theme.textColor};
+    `}
+`;
+
+const SortIndicator = styled(IconArrow, {
+  shouldForwardProp: prop => prop !== 'isSorted',
+})<{isSorted?: boolean}>`
+  visibility: hidden;
+
+  ${p =>
+    p.isSorted &&
+    css`
+      visibility: visible;
     `}
 `;
 

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -12,6 +12,8 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -28,12 +30,18 @@ export default function DetectorsList() {
   const navigate = useNavigate();
   const {selection} = usePageFilters();
 
-  const query =
-    typeof location.query.query === 'string' ? location.query.query : undefined;
-  const sortBy =
-    typeof location.query.sort === 'string' ? location.query.sort : undefined;
-  const cursor =
-    typeof location.query.cursor === 'string' ? location.query.cursor : undefined;
+  const {
+    sort: sorts,
+    query,
+    cursor,
+  } = useLocationQuery({
+    fields: {
+      sort: decodeSorts,
+      query: decodeScalar,
+      cursor: decodeScalar,
+    },
+  });
+  const sort = sorts[0] ?? {kind: 'desc', field: 'connectedWorkflows'};
 
   const {
     data: detectors,
@@ -42,7 +50,7 @@ export default function DetectorsList() {
   } = useDetectorsQuery({
     cursor,
     query,
-    sortBy,
+    sortBy: sort ? `${sort?.kind === 'asc' ? '' : '-'}${sort?.field}` : undefined,
     projects: selection.projects,
   });
 
@@ -53,7 +61,11 @@ export default function DetectorsList() {
           <ListLayout>
             <TableHeader />
             <div>
-              <DetectorListTable detectors={detectors ?? []} isPending={isPending} />
+              <DetectorListTable
+                detectors={detectors ?? []}
+                isPending={isPending}
+                sort={sort}
+              />
               <Pagination
                 pageLinks={getResponseHeader?.('Link')}
                 onCursor={newCursor => {


### PR DESCRIPTION
Adds the ability to click column headers to change the sort. This is a little different than tables in other parts of the app since it uses a button element and has hover/pressed states because I wanted it to be obvious which columns were sortable. Will need to extract some of this to use in the automations page as well.

![CleanShot 2025-06-18 at 11 18 20@2x](https://github.com/user-attachments/assets/ed402f5d-03ab-42f4-9fd7-8296ed065697)
