### PR TITLE
fix(dashboards-comparison): Stringify mismatches and widget_fields sentry tags

### DIFF
--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -220,7 +220,7 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("passed", False)
             scope.set_tag("failed_reason", CompareTableResult.BOTH_FAILED.value)
             scope.set_tag("widget_filter_query", query)
-            scope.set_tag("widget_fields", fields)
+            scope.set_tag("widget_fields", str(fields))
             scope.set_tag(
                 "widget_viewer_url",
                 widget_viewer_url,
@@ -241,7 +241,7 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("passed", False)
             scope.set_tag("failed_reason", CompareTableResult.METRICS_FAILED.value)
             scope.set_tag("widget_filter_query", query)
-            scope.set_tag("widget_fields", fields)
+            scope.set_tag("widget_fields", str(fields))
             scope.set_tag(
                 "widget_viewer_url",
                 widget_viewer_url,
@@ -262,7 +262,7 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("passed", False)
             scope.set_tag("failed_reason", CompareTableResult.EAP_FAILED.value)
             scope.set_tag("widget_filter_query", query)
-            scope.set_tag("widget_fields", fields)
+            scope.set_tag("widget_fields", str(fields))
             scope.set_tag(
                 "widget_viewer_url",
                 widget_viewer_url,
@@ -293,9 +293,9 @@ def compare_tables_for_dashboard_widget_queries(
             with sentry_sdk.isolation_scope() as scope:
                 scope.set_tag("passed", False)
                 scope.set_tag("failed_reason", reason.value)
-                scope.set_tag("mismatches", mismatches)
+                scope.set_tag("mismatches", str(mismatches))
                 scope.set_tag("widget_filter_query", query)
-                scope.set_tag("widget_fields", fields)
+                scope.set_tag("widget_fields", str(fields))
                 scope.set_tag(
                     "widget_viewer_url",
                     widget_viewer_url,


### PR DESCRIPTION
Both `mismatches` and `widget_fields` tags (being sent to sentry) were arrays and therefore not getting processed properly. I'm stringifying them so we don't get a processing error.
