### PR TITLE
feat:(search-bar): Hide asterisk character for contains ops

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4232,5 +4232,105 @@ describe('SearchQueryBuilder', function () {
         });
       });
     });
+
+    describe('rendering wildcarded values', function () {
+      describe('single value', function () {
+        it('renders content without asterisk', async function () {
+          const mockOnChange = jest.fn();
+          render(
+            <SearchQueryBuilder
+              {...defaultProps}
+              initialQuery="browser.name:*firefox*"
+              onChange={mockOnChange}
+            />,
+            {organization: {features: ['search-query-builder-wildcard-operators']}}
+          );
+
+          // ensure that we're rendering with wildcard value
+          // this is async because there's things going on in the background where some state updates are happening and RTL is complaining that we're not waiting for act's
+          expect(
+            await within(
+              screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+            ).findByText('contains')
+          ).toBeInTheDocument();
+
+          expect(
+            within(screen.getByRole('row', {name: 'browser.name:*firefox*'})).getByText(
+              'firefox'
+            )
+          ).toBeInTheDocument();
+        });
+      });
+
+      describe('multiple values', function () {
+        describe('all values are wildcarded', function () {
+          it('renders content without asterisk', async function () {
+            const mockOnChange = jest.fn();
+            render(
+              <SearchQueryBuilder
+                {...defaultProps}
+                initialQuery="browser.name:[*firefox*,*chrome*]"
+                onChange={mockOnChange}
+              />,
+              {organization: {features: ['search-query-builder-wildcard-operators']}}
+            );
+
+            expect(
+              await within(
+                screen.getByRole('button', {
+                  name: 'Edit operator for filter: browser.name',
+                })
+              ).findByText('contains')
+            ).toBeInTheDocument();
+
+            expect(
+              within(
+                screen.getByRole('row', {name: 'browser.name:[*firefox*,*chrome*]'})
+              ).getByText('firefox')
+            ).toBeInTheDocument();
+
+            expect(
+              within(
+                screen.getByRole('row', {name: 'browser.name:[*firefox*,*chrome*]'})
+              ).getByText('chrome')
+            ).toBeInTheDocument();
+          });
+        });
+
+        describe('some values are wildcarded', function () {
+          it('renders content with asterisk', async function () {
+            const mockOnChange = jest.fn();
+            render(
+              <SearchQueryBuilder
+                {...defaultProps}
+                initialQuery="browser.name:[*firefox*,chrome]"
+                onChange={mockOnChange}
+              />,
+              {organization: {features: ['search-query-builder-wildcard-operators']}}
+            );
+
+            expect(
+              await within(
+                screen.getByRole('button', {
+                  name: 'Edit operator for filter: browser.name',
+                })
+              ).findByText('is')
+            ).toBeInTheDocument();
+
+            expect(
+              within(
+                screen.getByRole('row', {name: 'browser.name:[*firefox*,chrome]'})
+              ).getByText('*firefox*')
+            ).toBeInTheDocument();
+
+            expect(
+              within(
+                screen.getByRole('row', {name: 'browser.name:[*firefox*,chrome]'})
+              ).getByText('chrome')
+            ).toBeInTheDocument();
+          });
+        });
+      });
+    });
   });
 });

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4269,7 +4269,7 @@ describe('SearchQueryBuilder', function () {
             render(
               <SearchQueryBuilder
                 {...defaultProps}
-                initialQuery="browser.name:[*firefox*,*chrome*]"
+                initialQuery="browser.name:[*firefox*,*chrome*,*random*value*]"
                 onChange={mockOnChange}
               />,
               {organization: {features: ['search-query-builder-wildcard-operators']}}
@@ -4285,14 +4285,26 @@ describe('SearchQueryBuilder', function () {
 
             expect(
               within(
-                screen.getByRole('row', {name: 'browser.name:[*firefox*,*chrome*]'})
+                screen.getByRole('row', {
+                  name: 'browser.name:[*firefox*,*chrome*,*random*value*]',
+                })
               ).getByText('firefox')
             ).toBeInTheDocument();
 
             expect(
               within(
-                screen.getByRole('row', {name: 'browser.name:[*firefox*,*chrome*]'})
+                screen.getByRole('row', {
+                  name: 'browser.name:[*firefox*,*chrome*,*random*value*]',
+                })
               ).getByText('chrome')
+            ).toBeInTheDocument();
+
+            expect(
+              within(
+                screen.getByRole('row', {
+                  name: 'browser.name:[*firefox*,*chrome*,*random*value*]',
+                })
+              ).getByText('random*value')
             ).toBeInTheDocument();
           });
         });

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -62,14 +62,20 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
       const items = token.value.items;
 
       if (items.length === 1 && items[0]!.value) {
+        const allContains =
+          items[0]!.value.type === Token.VALUE_TEXT && !!items[0]!.value.wildcard;
+
         return (
           <FilterValueSingleTruncatedValue>
-            {formatFilterValue(items[0]!.value)}
+            {formatFilterValue(items[0]!.value, allContains)}
           </FilterValueSingleTruncatedValue>
         );
       }
 
       const maxItems = size === 'small' ? 1 : 3;
+      const allContains = items.every(
+        item => item?.value?.type === Token.VALUE_TEXT && item.value.wildcard
+      );
 
       return (
         <FilterValueList>
@@ -77,7 +83,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
             <Fragment key={index}>
               <FilterMultiValueTruncated>
                 {/* @ts-expect-error TS(2345): Argument of type '{ type: Token.VALUE_NUMBER; valu... Remove this comment to see the full error message */}
-                {formatFilterValue(item.value)}
+                {formatFilterValue(item.value, allContains)}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
                 <FilterValueOr> or </FilterValueOr>
@@ -95,12 +101,15 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
         <DateTime date={token.value.value} dateOnly={!token.value.time} utc={isUtc} />
       );
     }
-    default:
+    default: {
+      const allContains = token.value.type === Token.VALUE_TEXT && !!token.value.wildcard;
+
       return (
         <FilterValueSingleTruncatedValue>
-          {formatFilterValue(token.value)}
+          {formatFilterValue(token.value, allContains)}
         </FilterValueSingleTruncatedValue>
       );
+    }
   }
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -69,7 +69,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
           <FilterValueSingleTruncatedValue>
             {formatFilterValue({
               token: items[0]!.value,
-              allContains,
+              stripWildcards: allContains,
             })}
           </FilterValueSingleTruncatedValue>
         );
@@ -87,7 +87,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
               <FilterMultiValueTruncated>
                 {formatFilterValue({
                   token: item.value!,
-                  allContains,
+                  stripWildcards: allContains,
                 })}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
@@ -113,7 +113,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
         <FilterValueSingleTruncatedValue>
           {formatFilterValue({
             token: token.value,
-            allContains,
+            stripWildcards: allContains,
           })}
         </FilterValueSingleTruncatedValue>
       );

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -67,7 +67,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
 
         return (
           <FilterValueSingleTruncatedValue>
-            {formatFilterValue(items[0]!.value, allContains)}
+            {formatFilterValue({
+              token: items[0]!.value,
+              allContains,
+            })}
           </FilterValueSingleTruncatedValue>
         );
       }
@@ -82,8 +85,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
           {items.slice(0, maxItems).map((item, index) => (
             <Fragment key={index}>
               <FilterMultiValueTruncated>
-                {/* @ts-expect-error TS(2345): Argument of type '{ type: Token.VALUE_NUMBER; valu... Remove this comment to see the full error message */}
-                {formatFilterValue(item.value, allContains)}
+                {formatFilterValue({
+                  token: item.value!,
+                  allContains,
+                })}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
                 <FilterValueOr> or </FilterValueOr>
@@ -106,7 +111,10 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
 
       return (
         <FilterValueSingleTruncatedValue>
-          {formatFilterValue(token.value, allContains)}
+          {formatFilterValue({
+            token: token.value,
+            allContains,
+          })}
         </FilterValueSingleTruncatedValue>
       );
     }

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -128,14 +128,20 @@ export function unescapeTagValue(value: string): string {
   return value.replace(/\\"/g, '"');
 }
 
-export function formatFilterValue(token: TokenResult<Token.FILTER>['value']): string {
+export function formatFilterValue(
+  token: TokenResult<Token.FILTER>['value'],
+  allContains = false
+): string {
   switch (token.type) {
     case Token.VALUE_TEXT: {
+      const content = token.value ? token.value : token.text;
+      const cleanedContent = allContains ? content.replace(/\*/g, '') : content;
+
       if (!token.value) {
-        return token.text;
+        return cleanedContent;
       }
 
-      return token.quoted ? unescapeTagValue(token.value) : token.text;
+      return token.quoted ? unescapeTagValue(cleanedContent) : cleanedContent;
     }
     case Token.VALUE_RELATIVE_DATE:
       return t('%s', `${token.value}${token.unit} ago`);

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -128,10 +128,13 @@ export function unescapeTagValue(value: string): string {
   return value.replace(/\\"/g, '"');
 }
 
-export function formatFilterValue(
-  token: TokenResult<Token.FILTER>['value'],
-  allContains = false
-): string {
+export function formatFilterValue({
+  token,
+  allContains = false,
+}: {
+  token: TokenResult<Token.FILTER>['value'];
+  allContains?: boolean;
+}): string {
   switch (token.type) {
     case Token.VALUE_TEXT: {
       const content = token.value ? token.value : token.text;

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -138,7 +138,7 @@ export function formatFilterValue({
   switch (token.type) {
     case Token.VALUE_TEXT: {
       const content = token.value ? token.value : token.text;
-      const cleanedContent = allContains ? content.replace(/\*/g, '') : content;
+      const cleanedContent = allContains ? content.replace(/^\*+|\*+$/g, '') : content;
 
       if (!token.value) {
         return cleanedContent;

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -130,15 +130,15 @@ export function unescapeTagValue(value: string): string {
 
 export function formatFilterValue({
   token,
-  allContains = false,
+  stripWildcards = false,
 }: {
   token: TokenResult<Token.FILTER>['value'];
-  allContains?: boolean;
+  stripWildcards?: boolean;
 }): string {
   switch (token.type) {
     case Token.VALUE_TEXT: {
       const content = token.value ? token.value : token.text;
-      const cleanedContent = allContains ? content.replace(/^\*+|\*+$/g, '') : content;
+      const cleanedContent = stripWildcards ? content.replace(/^\*+|\*+$/g, '') : content;
 
       if (!token.value) {
         return cleanedContent;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -904,7 +904,9 @@ export function SearchQueryBuilderValueCombobox({
       ? prettifyTagKey(token.value.text)
       : canSelectMultipleValues
         ? ''
-        : formatFilterValue(token.value);
+        : formatFilterValue({
+            token: token.value,
+          });
 
   return (
     <ValueEditing ref={ref} data-test-id="filter-value-editing">


### PR DESCRIPTION
This PR updates the function that formats values being rendered in the search bar so that they won't render the asterisks when all values are considered to be wildcard'ed values.

Example:

<img width="323" alt="Screenshot 2025-06-18 at 15 13 50" src="https://github.com/user-attachments/assets/ca7e7134-d5fc-46c0-bc1e-93bae4a28fc4" />
