### PR TITLE
fix(billing): hide pending changes for the same reserved budgets

### DIFF
--- a/static/gsAdmin/components/customers/pendingChanges.spec.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.spec.tsx
@@ -2,6 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {PlanMigrationFixture} from 'getsentry-test/fixtures/planMigration';
+import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
 import {
   Am3DsEnterpriseSubscriptionFixture,
   SubscriptionFixture,
@@ -373,6 +374,39 @@ describe('PendingChanges', function () {
     );
     expect(container).toHaveTextContent(
       'Reserved budgets — $100,000.00 for spans budget → $50,000.00 for spans budget'
+    );
+  });
+
+  it('does not render reserved budgets with mocked values', function () {
+    const subscription = SubscriptionFixture({
+      organization: OrganizationFixture(),
+      reservedBudgets: [
+        SeerReservedBudgetFixture({
+          id: '0',
+          reservedBudget: 0,
+        }),
+      ],
+      pendingChanges: PendingChangesFixture({
+        planDetails: PlanDetailsLookupFixture('am3_business_ent'),
+        plan: 'am3_business_ent',
+        planName: 'Business',
+        reserved: {
+          spans: 0,
+          spansIndexed: 0,
+        },
+        reservedBudgets: [
+          {
+            reservedBudget: 0,
+            categories: {seerAutofix: true, seerScanner: true},
+          },
+        ],
+      }),
+    });
+
+    const {container} = render(<PendingChanges subscription={subscription} />);
+
+    expect(container).not.toHaveTextContent(
+      'Reserved budgets — $0.00 for seer budget → $0.00 for seer budget'
     );
   });
 

--- a/static/gsAdmin/components/customers/pendingChanges.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.tsx
@@ -271,11 +271,11 @@ function getRegularChanges(subscription: Subscription) {
   });
 
   if (oldBudgetsChanges.length > 0 || newBudgetsChanges.length > 0) {
-    changes.push(
-      `Reserved budgets — ${
-        oldBudgetsChanges.length > 0 ? oldBudgetsChanges.join(', ') : 'None'
-      } → ${newBudgetsChanges.length > 0 ? newBudgetsChanges.join(', ') : 'None'}`
-    );
+    const before = oldBudgetsChanges.length > 0 ? oldBudgetsChanges.join(', ') : 'None';
+    const after = newBudgetsChanges.length > 0 ? newBudgetsChanges.join(', ') : 'None';
+    if (before !== after) {
+      changes.push(`Reserved budgets — ${before} → ${after}`);
+    }
   }
 
   return changes;


### PR DESCRIPTION
part of https://linear.app/getsentry/issue/RTC-1045/enterprise-org-who-didnt-purchase-seer-has-pending-change-to-remove-it

Prevents the following from happening
<img width="485" alt="Screenshot 2025-06-18 at 1 21 12 PM" src="https://github.com/user-attachments/assets/79e8f562-0c40-490a-982d-fb68ac924d7a" />
