### PR TITLE
ref(post-process): remove unecessary try catch

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1168,21 +1168,18 @@ def handle_auto_assignment(job: PostProcessJob) -> None:
     from sentry.models.projectownership import ProjectOwnership
 
     event = job["event"]
-    try:
-        ProjectOwnership.handle_auto_assignment(
-            project_id=event.project_id,
-            organization_id=event.project.organization_id,
-            event=event,
-            logging_extra={
-                "event_id": event.event_id,
-                "group_id": str(event.group_id),
-                "project_id": str(event.project_id),
-                "organization_id": event.project.organization_id,
-                "source": "post_process",
-            },
-        )
-    except Exception:
-        logger.exception("Failed to set auto-assignment")
+    ProjectOwnership.handle_auto_assignment(
+        project_id=event.project_id,
+        organization_id=event.project.organization_id,
+        event=event,
+        logging_extra={
+            "event_id": event.event_id,
+            "group_id": str(event.group_id),
+            "project_id": str(event.project_id),
+            "organization_id": event.project.organization_id,
+            "source": "post_process",
+        },
+    )
 
 
 def process_service_hooks(job: PostProcessJob) -> None:


### PR DESCRIPTION
all post process jobs are already wrapped in try catch, so one inside this function is redundant. https://github.com/getsentry/sentry/blob/31b8a0c441d69fd8a9dd57c13b2e7f63a2a082df/src/sentry/tasks/post_process.py#L681