### PR TITLE
fix(nav): Silence isMobile prop warning

### DIFF
--- a/static/app/views/nav/primary/primaryButtonOverlay.tsx
+++ b/static/app/views/nav/primary/primaryButtonOverlay.tsx
@@ -49,7 +49,9 @@ export function PrimaryButtonOverlay({
   );
 }
 
-const ScrollableOverlay = styled(Overlay)<{
+const ScrollableOverlay = styled(Overlay, {
+  shouldForwardProp: prop => prop !== 'isMobile',
+})<{
   isMobile: boolean;
 }>`
   min-height: 150px;


### PR DESCRIPTION
Silences a warning that isMobile is not a valid prop on the child div
