### PR TITLE
fix(issues): Allow a wider screenshot modal

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -193,17 +193,19 @@ export default function ScreenshotModal({
 }
 
 const AttachmentComponentWrapper = styled('div')`
-  & > * {
-    padding: 0;
-    border: none;
+  & > img,
+  & > video {
+    max-width: 100%;
     max-height: calc(100vh - 300px);
-    box-sizing: border-box;
+    width: auto;
+    height: auto;
+    object-fit: contain;
   }
 `;
 
 export const modalCss = css`
   width: auto;
   height: 100%;
-  max-width: 700px;
+  max-width: min(90vw, 1500px);
   margin-top: 0 !important;
 `;


### PR DESCRIPTION
Clamp max width, preserve image aspect ratio on tall images

tall image
![image](https://github.com/user-attachments/assets/643c8764-b655-4e92-a292-ae7158ce392c)

wide image
![image](https://github.com/user-attachments/assets/4f845bcd-c155-49e3-aab8-55b05bf94315)

fixes #93839