### PR TITLE
fix(seer): Scan only new issues or issues without scans

### DIFF
--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -392,6 +392,10 @@ def _log_seer_scanner_billing_event(group: Group, source: SeerAutomationSource):
     )
 
 
+def get_issue_summary_cache_key(group_id: int) -> str:
+    return f"ai-group-summary-v2:{group_id}"
+
+
 def get_issue_summary(
     group: Group,
     user: User | RpcUser | AnonymousUser | None = None,
@@ -418,7 +422,7 @@ def get_issue_summary(
     if not get_seer_org_acknowledgement(group.organization.id):
         return {"detail": "AI Autofix has not been acknowledged by the organization."}, 403
 
-    cache_key = f"ai-group-summary-v2:{group.id}"
+    cache_key = get_issue_summary_cache_key(group.id)
     lock_key = f"ai-group-summary-v2-lock:{group.id}"
     lock_duration = 10  # How long the lock is held if acquired (seconds)
     wait_timeout = 4.5  # How long to wait for the lock (seconds)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1561,11 +1561,20 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
+    from sentry.seer.issue_summary import get_issue_summary_cache_key
     from sentry.seer.seer_setup import get_seer_org_acknowledgement
     from sentry.tasks.autofix import start_seer_automation
 
     event = job["event"]
     group = event.group
+
+    # Only run on new issues or issues with no existing summary/scan
+    if (
+        not job["group_state"]["is_new"]
+        and group.seer_fixability_score is not None
+        and cache.get(get_issue_summary_cache_key(group.id))
+    ):
+        return
 
     # check currently supported issue categories for Seer
     if group.issue_category not in [

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2575,6 +2575,113 @@ class KickOffSeerAutomationTestMixin(BasePostProgressGroupMixin):
 
         mock_start_seer_automation.assert_not_called()
 
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    def test_kick_off_seer_automation_skips_existing_summary_and_score(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
+        from sentry.seer.issue_summary import get_issue_summary_cache_key
+
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        event = self.create_event(
+            data={"message": "testing"},
+            project_id=self.project.id,
+        )
+
+        # Set seer_fixability_score on the group
+        group = event.group
+        group.seer_fixability_score = 0.75
+        group.save()
+
+        # Set cached issue summary
+        cache_key = get_issue_summary_cache_key(group.id)
+        cache.set(cache_key, {"summary": "test summary"}, 3600)
+
+        self.call_post_process_group(
+            is_new=False,  # Not a new group
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+
+        mock_start_seer_automation.assert_not_called()
+
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    def test_kick_off_seer_automation_runs_with_missing_fixability_score(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
+        from sentry.seer.issue_summary import get_issue_summary_cache_key
+
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        event = self.create_event(
+            data={"message": "testing"},
+            project_id=self.project.id,
+        )
+
+        # Group has no seer_fixability_score (None by default)
+        group = event.group
+        assert group.seer_fixability_score is None
+
+        # Set cached issue summary
+        cache_key = get_issue_summary_cache_key(group.id)
+        cache.set(cache_key, {"summary": "test summary"}, 3600)
+
+        self.call_post_process_group(
+            is_new=False,  # Not a new group
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+
+        mock_start_seer_automation.assert_called_once_with(group.id)
+
+    @patch(
+        "sentry.seer.seer_setup.get_seer_org_acknowledgement",
+        return_value=True,
+    )
+    @patch("sentry.tasks.autofix.start_seer_automation.delay")
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    def test_kick_off_seer_automation_runs_with_missing_summary_cache(
+        self, mock_start_seer_automation, mock_get_seer_org_acknowledgement
+    ):
+        from sentry.seer.issue_summary import get_issue_summary_cache_key
+
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        event = self.create_event(
+            data={"message": "testing"},
+            project_id=self.project.id,
+        )
+
+        # Set seer_fixability_score on the group
+        group = event.group
+        group.seer_fixability_score = 0.75
+        group.save()
+
+        # No cached issue summary (cache.get will return None)
+        cache_key = get_issue_summary_cache_key(group.id)
+        assert cache.get(cache_key) is None
+
+        self.call_post_process_group(
+            is_new=False,  # Not a new group
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+
+        mock_start_seer_automation.assert_called_once_with(group.id)
+
 
 class PostProcessGroupErrorTest(
     TestCase,


### PR DESCRIPTION
Only allow the scanner job to start if an issue is new or does not have an existing scan + summary.