### PR TITLE
ref(aci): use enqueue time to query Snuba in delayed workflow

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -392,7 +392,7 @@ def get_condition_query_groups(
     event_data: EventRedisData,
     workflows_to_envs: Mapping[WorkflowId, int | None],
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
-) -> dict[UniqueConditionQuery, set[GroupId]]:
+) -> dict[UniqueConditionQuery, GroupQueryParams]:
     """
     Map unique condition queries to the group IDs that need to checked for that query.
     """

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -241,12 +241,12 @@ class GroupQueryParams:
     group_ids: set[GroupId] = field(default_factory=set)
     timestamp: datetime | None = None
 
-    def update(self, group_id: GroupId, timestamp: datetime | None) -> None:
+    def update(self, group_ids: set[GroupId], timestamp: datetime | None) -> None:
         """
         Use the latest timestamp for a set of group IDs with the same Snuba query.
         We will query backwards in time from this point.
         """
-        self.group_ids.add(group_id)
+        self.group_ids.update(group_ids)
 
         if timestamp is not None:
             self.timestamp = timestamp if self.timestamp is None else max(timestamp, self.timestamp)
@@ -408,7 +408,7 @@ def get_condition_query_groups(
         for condition in slow_conditions:
             for condition_query in generate_unique_queries(condition, workflow_env):
                 condition_groups[condition_query].update(
-                    group_id=event_data.dcg_to_groups[dcg.id], timestamp=timestamp
+                    group_ids=event_data.dcg_to_groups[dcg.id], timestamp=timestamp
                 )
     return condition_groups
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
-from datetime import timedelta
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from functools import cached_property
 from typing import Any, TypeAlias
 
@@ -79,6 +79,7 @@ WorkflowId: TypeAlias = int
 class EventInstance(BaseModel):
     event_id: str
     occurrence_id: str | None = None
+    timestamp: datetime | None = None
 
     class Config:
         # Ignore unknown fields; we'd like to be able to add new fields easily.
@@ -211,6 +212,39 @@ class EventRedisData:
     @cached_property
     def group_ids(self) -> set[GroupId]:
         return {key.group_id for key in self.events}
+
+    @cached_property
+    def dcg_to_timestamp(self) -> dict[int, datetime | None]:
+        # Uses the latest timestamp each DataConditionGroup was enqueued with
+        result: dict[int, datetime | None] = defaultdict(lambda: None)
+
+        for key, instance in self.events.items():
+            timestamp = instance.timestamp
+            for dcg_id in key.dcg_ids:
+                existing_timestamp = result[dcg_id]
+                if timestamp is None:
+                    continue
+                elif existing_timestamp is not None and timestamp > existing_timestamp:
+                    result[dcg_id] = timestamp
+        return result
+
+
+@dataclass
+class TimeAndGroups:
+    """
+    Represents a collection of group IDs and the timestamp of the latest enqueued event for a group in the set. Used to query Snuba for a UniqueConditionQuery.
+    """
+
+    group_ids: set[GroupId] = field(default_factory=set)
+    timestamp: datetime | None = None
+
+    def update_timestamp(self, timestamp: datetime | None) -> None:
+        """
+        Use the latest timestamp for a set of group IDs with the same Snuba query.
+        We will query backwards in time from this point.
+        """
+        if self.timestamp is None or (timestamp is not None and timestamp > self.timestamp):
+            self.timestamp = timestamp
 
 
 @dataclass(frozen=True)
@@ -359,14 +393,17 @@ def get_condition_query_groups(
     """
     Map unique condition queries to the group IDs that need to checked for that query.
     """
-    condition_groups: dict[UniqueConditionQuery, set[GroupId]] = defaultdict(set)
+    condition_groups: dict[UniqueConditionQuery, TimeAndGroups] = defaultdict(TimeAndGroups)
+
     for dcg in data_condition_groups:
         slow_conditions = dcg_to_slow_conditions[dcg.id]
         workflow_id = event_data.dcg_to_workflow.get(dcg.id)
         workflow_env = workflows_to_envs[workflow_id] if workflow_id else None
+        timestamp = event_data.dcg_to_timestamp[dcg.id]
         for condition in slow_conditions:
             for condition_query in generate_unique_queries(condition, workflow_env):
-                condition_groups[condition_query].update(event_data.dcg_to_groups[dcg.id])
+                condition_groups[condition_query].group_ids.update(event_data.dcg_to_groups[dcg.id])
+                condition_groups[condition_query].update_timestamp(timestamp)
     return condition_groups
 
 
@@ -376,13 +413,15 @@ def get_condition_query_groups(
     sample_rate=1.0,
 )
 def get_condition_group_results(
-    queries_to_groups: dict[UniqueConditionQuery, set[GroupId]],
+    queries_to_groups: dict[UniqueConditionQuery, TimeAndGroups],
 ) -> dict[UniqueConditionQuery, QueryResult]:
     condition_group_results = {}
     current_time = timezone.now()
 
-    for unique_condition, group_ids in queries_to_groups.items():
+    for unique_condition, time_and_groups in queries_to_groups.items():
         handler = unique_condition.handler()
+        group_ids = time_and_groups.group_ids
+        time = time_and_groups.timestamp or current_time
 
         _, duration = handler.intervals[unique_condition.interval]
 
@@ -396,7 +435,7 @@ def get_condition_group_results(
             duration=duration,
             group_ids=group_ids,
             environment_id=unique_condition.environment_id,
-            current_time=current_time,
+            current_time=time,
             comparison_interval=comparison_interval,
             filters=unique_condition.filters,
         )

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -215,7 +215,10 @@ class EventRedisData:
 
     @cached_property
     def dcg_to_timestamp(self) -> dict[int, datetime | None]:
-        # Uses the latest timestamp each DataConditionGroup was enqueued with
+        """
+        Uses the latest timestamp each DataConditionGroup was enqueued with
+        All groups enqueued for a DataConditionGroup will have the same query, hence the same max timestamp.
+        """
         result: dict[int, datetime | None] = defaultdict(lambda: None)
 
         for key, instance in self.events.items():

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -76,9 +76,10 @@ class DelayedWorkflowItem:
     delayed_conditions: list[DataCondition]
     event: GroupEvent
     source: WorkflowDataConditionGroupType
-    timestamp: (
-        datetime  # time the item was created for enqueue. used in delayed workflow Snuba query
-    )
+
+    # Used to pick the end of the time window in snuba querying.
+    # Should be close to when fast conditions were evaluated to try to be consistent.
+    timestamp: datetime
 
     def buffer_key(self) -> str:
         condition_group_set = {

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -76,7 +76,9 @@ class DelayedWorkflowItem:
     delayed_conditions: list[DataCondition]
     event: GroupEvent
     source: WorkflowDataConditionGroupType
-    timestamp: datetime
+    timestamp: (
+        datetime  # time the item was created for enqueue. used in delayed workflow Snuba query
+    )
 
     def buffer_key(self) -> str:
         condition_group_set = {

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -47,7 +47,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     EventInstance,
     EventKey,
     EventRedisData,
-    TimeAndGroups,
+    GroupQueryParams,
     UniqueConditionQuery,
     bulk_fetch_events,
     cleanup_redis_buffer,
@@ -486,8 +486,8 @@ class TestGetSnubaResults(BaseWorkflowTest):
 
     def create_condition_groups(
         self, data_conditions: list[DataCondition], timestamp: datetime | None = None
-    ) -> tuple[dict[UniqueConditionQuery, TimeAndGroups], int, list[UniqueConditionQuery]]:
-        condition_groups: dict[UniqueConditionQuery, TimeAndGroups] = {}
+    ) -> tuple[dict[UniqueConditionQuery, GroupQueryParams], int, list[UniqueConditionQuery]]:
+        condition_groups: dict[UniqueConditionQuery, GroupQueryParams] = {}
         all_unique_queries = []
         for data_condition in data_conditions:
             unique_queries = generate_unique_queries(data_condition, self.environment.id)
@@ -501,7 +501,7 @@ class TestGetSnubaResults(BaseWorkflowTest):
             group = event.group
             condition_groups.update(
                 {
-                    query: TimeAndGroups(group_ids={event.group.id}, timestamp=timestamp)
+                    query: GroupQueryParams(group_ids={event.group.id}, timestamp=timestamp)
                     for query in unique_queries
                 }
             )
@@ -600,7 +600,7 @@ class TestGetSnubaResults(BaseWorkflowTest):
         )
 
         condition_groups = {
-            unique_query: TimeAndGroups(group_ids={1}, timestamp=None)
+            unique_query: GroupQueryParams(group_ids={1}, timestamp=None)
         }  # One group ID to query
 
         with pytest.raises(ValueError, match="Escaping exception"):

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1,8 +1,9 @@
 from dataclasses import asdict
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import ANY, Mock, call, patch
 
 import pytest
+from django.utils import timezone
 
 from sentry import buffer
 from sentry.eventstore.models import Event
@@ -46,6 +47,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     EventInstance,
     EventKey,
     EventRedisData,
+    TimeAndGroups,
     UniqueConditionQuery,
     bulk_fetch_events,
     cleanup_redis_buffer,
@@ -399,12 +401,20 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
             self.workflow_filters.id: self.workflow.id,
             other_workflow_filters.id: self.workflow.id,
         }
+        current_time = timezone.now()
+        dcg_to_timestamp = {
+            self.workflow_triggers.id: current_time,
+            self.workflow_filters.id: current_time + timedelta(minutes=1),
+            other_workflow_filters.id: current_time + timedelta(minutes=2),
+            detector_dcg.id: current_time + timedelta(minutes=3),
+        }
         workflows_to_envs: dict[int, int | None] = {self.workflow.id: None}
 
         # Create mock event data with just the required properties
         mock_event_data = Mock(spec=EventRedisData)
         mock_event_data.dcg_to_groups = dcg_to_groups
         mock_event_data.dcg_to_workflow = dcg_to_workflow
+        mock_event_data.dcg_to_timestamp = dcg_to_timestamp
 
         dcg_to_slow_conditions = get_slow_conditions_for_groups(list(dcg_to_groups.keys()))
         result = get_condition_query_groups(
@@ -415,9 +425,17 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
         percent_only_query = generate_unique_queries(self.percent_dc, None)[1]
         different_query = generate_unique_queries(other_condition, None)[0]
 
-        assert result[count_query] == {self.group.id, group2.id}  # count and percent condition
-        assert result[percent_only_query] == {self.group.id}
-        assert result[different_query] == {group3.id, group4.id}
+        assert result[count_query].group_ids == {
+            self.group.id,
+            group2.id,
+        }  # count and percent condition
+        assert result[count_query].timestamp == current_time + timedelta(
+            minutes=1
+        )  # uses latest timestamp
+        assert result[percent_only_query].group_ids == {self.group.id}
+        assert result[percent_only_query].timestamp == current_time
+        assert result[different_query].group_ids == {group3.id, group4.id}
+        assert result[different_query].timestamp == current_time + timedelta(minutes=3)
 
 
 @freeze_time(FROZEN_TIME)
@@ -440,9 +458,9 @@ class TestGetSnubaResults(BaseWorkflowTest):
         return event
 
     def create_condition_groups(
-        self, data_conditions: list[DataCondition]
-    ) -> tuple[dict[UniqueConditionQuery, set[int]], int, list[UniqueConditionQuery]]:
-        condition_groups = {}
+        self, data_conditions: list[DataCondition], timestamp: datetime | None = None
+    ) -> tuple[dict[UniqueConditionQuery, TimeAndGroups], int, list[UniqueConditionQuery]]:
+        condition_groups: dict[UniqueConditionQuery, TimeAndGroups] = {}
         all_unique_queries = []
         for data_condition in data_conditions:
             unique_queries = generate_unique_queries(data_condition, self.environment.id)
@@ -454,7 +472,12 @@ class TestGetSnubaResults(BaseWorkflowTest):
             event = self.create_events(comparison_type)
             assert event.group
             group = event.group
-            condition_groups.update({query: {event.group.id} for query in unique_queries})
+            condition_groups.update(
+                {
+                    query: TimeAndGroups(group_ids={event.group.id}, timestamp=timestamp)
+                    for query in unique_queries
+                }
+            )
             all_unique_queries.extend(unique_queries)
         return condition_groups, group.id, all_unique_queries
 
@@ -485,6 +508,18 @@ class TestGetSnubaResults(BaseWorkflowTest):
         results = get_condition_group_results(condition_groups)
         assert results == {
             unique_queries[0]: {group_id: 2},
+        }
+
+    def test_with_enqueue_time(self):
+        dc = self.create_event_frequency_condition()
+        condition_groups, group_id, unique_queries = self.create_condition_groups(
+            [dc], timestamp=timezone.now() - timedelta(minutes=1)
+        )
+
+        # events created at timezone.now(), querying for 1 minute before should return no events
+        results = get_condition_group_results(condition_groups)
+        assert results == {
+            unique_queries[0]: {group_id: 0},
         }
 
     def test_percent_comparison_condition(self):
@@ -537,7 +572,9 @@ class TestGetSnubaResults(BaseWorkflowTest):
             environment_id=None,
         )
 
-        condition_groups = {unique_query: {1}}  # One group ID to query
+        condition_groups = {
+            unique_query: TimeAndGroups(group_ids={1}, timestamp=None)
+        }  # One group ID to query
 
         with pytest.raises(ValueError, match="Escaping exception"):
             get_condition_group_results(condition_groups)
@@ -791,6 +828,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
             self.detector,
         )
 
+    @freeze_time()
     @patch("sentry.workflow_engine.processors.workflow.enqueue_workflows")
     def test_fire_actions_for_groups__enqueue(self, mock_enqueue):
         # enqueue the IF DCGs with slow conditions!
@@ -815,6 +853,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
                                 delayed_conditions=[self.workflow1_dcgs[1].conditions.all()[0]],
                                 event=self.event1.for_group(self.group1),
                                 source=WorkflowDataConditionGroupType.ACTION_FILTER,
+                                timestamp=timezone.now(),
                             ),
                         ],
                     }
@@ -827,6 +866,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
                                 delayed_conditions=[self.workflow2_dcgs[1].conditions.all()[0]],
                                 event=self.event2.for_group(self.group2),
                                 source=WorkflowDataConditionGroupType.ACTION_FILTER,
+                                timestamp=timezone.now(),
                             ),
                         ],
                     }

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django.utils import timezone
 
 from sentry import buffer
 from sentry.eventstream.base import GroupState
@@ -650,6 +651,7 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
                         [self.condition],
                         self.group_event,
                         WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
+                        timestamp=timezone.now(),
                     )
                 ]
             }
@@ -665,6 +667,7 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
     def test_enqueue_workflow__adds_to_workflow_engine_set(
         self, mock_push_to_hash_bulk, mock_push_to_sorted_set
     ):
+        current_time = timezone.now()
         condition2 = self.create_data_condition(condition_group=self.create_data_condition_group())
         condition3 = self.create_data_condition(condition_group=self.create_data_condition_group())
         enqueue_workflows(
@@ -675,6 +678,7 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
                         [self.condition, condition2, condition3],
                         self.group_event,
                         WorkflowDataConditionGroupType.WORKFLOW_TRIGGER,
+                        timestamp=current_time,
                     )
                 ]
             }
@@ -692,6 +696,7 @@ class TestEnqueueWorkflows(BaseWorkflowTest):
                     {
                         "event_id": self.event.event_id,
                         "occurrence_id": self.group_event.occurrence_id,
+                        "timestamp": current_time,
                     }
                 )
             },


### PR DESCRIPTION
For a slow alert condition (e.g. "> 10 events in the past 1 minute"), we always use the time the query is being made as the time to start looking backwards from. This is not optimal in the case where:
- A task needs to be rerun
- There is a backlog in the delayed workflow queue
- Because we flush the buffer every minute, here is an edge case where the time period is 1 minute: events come in at 11:00:02 am, are dispatched in a task at ~11:01:00am, the query is run at 11:01:03am or later, which would mean those events aren't picked up in the result

A better solution would be to use the _**time the event is enqueued**_ into the delayed workflow buffer!

However, we also batch queries such that all alerts that end up making the same queries are grouped together, and we run a single query for multiple groups. For example:
- Two events for two different groups come in a different times within the same minute, are both processed by alert A
- We will make a single Snuba query for group A with the two groups

In the above case, we'll need to decide which enqueue time to use. We should use the _**latest enqueue time**_ out of a list of groups as it will cover all groups being queried for in the Snuba query.