### PR TITLE
chore(ui): Group sentry js dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,10 @@ updates:
           - '@babel/*'
       sentry-dependencies:
         patterns:
-          - '@sentry/*'
+          - '@sentry/core'
+          - '@sentry/node'
+          - '@sentry/react'
+          - '@sentry/profiling-node'
       spectrum-dependencies:
         patterns:
           - '@react-stately/*'


### PR DESCRIPTION
@sentry/webpack and stuff isn't really what we're looking to update as a group. Opening those as individual prs is better.
