### PR TITLE
feat(ACI): Handle anomaly detection data condition in validator

### DIFF
--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -39,6 +39,21 @@ class MetricIssueComparisonConditionValidator(
 
         return type
 
+    def validate_comparison(self, value: float | int | str) -> float:
+        if isinstance(value, (float, int)):
+            try:
+                value = float(value)
+            except ValueError:
+                raise serializers.ValidationError("A valid number is required.")
+
+        elif isinstance(value, dict):
+            value = super().validate_comparison(value)
+
+        else:
+            raise serializers.ValidationError("A valid number or dict is required.")
+
+        return value
+
     def validate_condition_result(self, value: str) -> DetectorPriorityLevel:
         try:
             result = DetectorPriorityLevel(int(value))

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -18,9 +18,7 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel, SnubaQueryDataSourceType
 
 
-class MetricIssueComparisonConditionValidator(
-    BaseDataConditionValidator[float, DetectorPriorityLevel]
-):
+class MetricIssueComparisonConditionValidator(BaseDataConditionValidator):
     supported_conditions = frozenset(
         (Condition.GREATER, Condition.LESS, Condition.ANOMALY_DETECTION)
     )
@@ -39,20 +37,19 @@ class MetricIssueComparisonConditionValidator(
 
         return type
 
-    def validate_comparison(self, value: float | int | str) -> float:
+    def validate_comparison(self, value: dict | float | int | str) -> float | dict:
         if isinstance(value, (float, int)):
             try:
                 value = float(value)
             except ValueError:
                 raise serializers.ValidationError("A valid number is required.")
+            return value
 
         elif isinstance(value, dict):
-            value = super().validate_comparison(value)
+            return super().validate_comparison(value)
 
         else:
             raise serializers.ValidationError("A valid number or dict is required.")
-
-        return value
 
     def validate_condition_result(self, value: str) -> DetectorPriorityLevel:
         try:

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -69,7 +69,7 @@ class MetricIssueConditionGroupValidator(BaseDataConditionGroupValidator):
 
 class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
     data_source = SnubaQueryValidator(required=True, timeWindowSeconds=True)
-    condition_group = MetricIssueConditionGroupValidator(required=True)
+    condition_group = BaseDataConditionGroupValidator(required=True)
 
     def validate(self, attrs):
         attrs = super().validate(attrs)

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
@@ -40,20 +40,23 @@ class AbstractDataConditionValidator(
 class BaseDataConditionValidator(
     AbstractDataConditionValidator[Any, Any],
 ):
+
+    @property
+    def condition_type(self) -> Condition:
+        condition_type = self.initial_data[0].get("type")
+        return condition_type
+
     def _get_handler(self) -> type[DataConditionHandler] | None:
         if self._is_operator_condition():
             return None
 
-        condition_type = self.initial_data.get("type")
-
         try:
-            return condition_handler_registry.get(condition_type)
+            return condition_handler_registry.get(self.condition_type)
         except NoRegistrationExistsError:
-            raise serializers.ValidationError(f"Invalid condition type: {condition_type}")
+            raise serializers.ValidationError(f"Invalid condition type: {self.condition_type}")
 
     def _is_operator_condition(self) -> bool:
-        condition_type = self.initial_data.get("type")
-        return condition_type in CONDITION_OPS
+        return self.condition_type in CONDITION_OPS
 
     def validate_comparison(self, value: Any) -> Any:
         """

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
@@ -43,8 +43,10 @@ class BaseDataConditionValidator(
 
     @property
     def condition_type(self) -> Condition:
-        condition_type = self.initial_data[0].get("type")
-        return condition_type
+        if isinstance(self.initial_data, list) and self.initial_data:
+            return self.initial_data[0].get("type")
+
+        return self.initial_data.get("type")
 
     def _get_handler(self) -> type[DataConditionHandler] | None:
         if self._is_operator_condition():
@@ -63,7 +65,6 @@ class BaseDataConditionValidator(
         Validate the comparison field. Get the schema configuration for the type, if
         there is no schema configuration, then we assume the comparison field is a primitive value.
         """
-
         handler = self._get_handler()
 
         if not handler:

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -128,13 +128,13 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
             "name": "Test Detector",
             "type": MetricIssue.slug,
             "dataSource": {
-                "query_type": SnubaQuery.Type.ERROR.value,
+                "queryType": SnubaQuery.Type.ERROR.value,
                 "dataset": Dataset.Events.value,
                 "query": "test query",
                 "aggregate": "count()",
-                "time_window": 3600,
+                "timeWindow": 3600,
                 "environment": self.environment.name,
-                "event_types": [SnubaQueryEventType.EventType.ERROR.name.lower()],
+                "eventTypes": [SnubaQueryEventType.EventType.ERROR.name.lower()],
             },
             "conditionGroup": {
                 "id": self.data_condition_group.id,
@@ -150,8 +150,8 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
                 ],
             },
             "config": {
-                "threshold_period": 1,
-                "detection_type": AlertRuleDetectionType.STATIC.value,
+                "thresholdPeriod": 1,
+                "detectionType": AlertRuleDetectionType.STATIC.value,
             },
         }
 


### PR DESCRIPTION
Update the metric issue validator to handle anomaly detection data condition input - the main difference with these is that `comparison` is a dictionary rather than a number.