### PR TITLE
feat(cc): add total duration column to table

### DIFF
--- a/src/sentry/codecov/endpoints/TestResults/query.py
+++ b/src/sentry/codecov/endpoints/TestResults/query.py
@@ -25,6 +25,7 @@ query = """query GetTestResults(
               node {
                 updatedAt
                 avgDuration
+                totalDuration
                 lastDuration
                 name
                 failureRate

--- a/src/sentry/codecov/endpoints/TestResults/serializers.py
+++ b/src/sentry/codecov/endpoints/TestResults/serializers.py
@@ -13,6 +13,7 @@ class TestResultNodeSerializer(serializers.Serializer):
 
     updatedAt = serializers.CharField()
     avgDuration = serializers.FloatField()
+    totalDuration = serializers.FloatField()
     name = serializers.CharField()
     failureRate = serializers.FloatField()
     flakeRate = serializers.FloatField()

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -39,6 +39,7 @@ class TestResultsEndpointTest(APITestCase):
                                         "node": {
                                             "updatedAt": "2025-05-22T16:21:18.763951+00:00",
                                             "avgDuration": 0.04066228070175437,
+                                            "totalDuration": 1.0,
                                             "lastDuration": 0.04066228070175437,
                                             "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_no_yaml",
                                             "failureRate": 0.0,
@@ -54,6 +55,7 @@ class TestResultsEndpointTest(APITestCase):
                                         "node": {
                                             "updatedAt": "2025-05-22T16:21:18.763961+00:00",
                                             "avgDuration": 0.034125877192982455,
+                                            "totalDuration": 1.0,
                                             "lastDuration": 0.034125877192982455,
                                             "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_yaml",
                                             "failureRate": 0.0,


### PR DESCRIPTION
- Add totalDuration field to TestResults query and serializer
- Update test fixtures to include totalDuration field
- This allows tracking the total duration of individual test runs