### PR TITLE
feat(aci): Remove title editing from detector step 1, rearrange

### DIFF
--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -10,7 +10,6 @@ import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
-import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 
 function getDefaultProject(projects: Project[]) {
@@ -20,32 +19,31 @@ function getDefaultProject(projects: Project[]) {
 export function DetectorTypeForm() {
   return (
     <FormContainer>
-      <Header>
-        <h3>{t('Project and Environment')}</h3>
-      </Header>
-      <Flex>
-        <ProjectField />
-        <EnvironmentField />
-      </Flex>
-      <Header>
-        <h3>{t('Monitor type')}</h3>
-        <p>
-          {t("Monitor type can't be edited once the monitor has been created.")}{' '}
-          <a href="#">{t('Learn more about monitor types.')}</a>
-        </p>
-      </Header>
-      <MonitorTypeField />
+      <div>
+        <Header>
+          <h3>{t('Monitor type')}</h3>
+          <p>
+            {t("Monitor type can't be edited once the monitor has been created.")}{' '}
+            <a href="#">{t('Learn more about monitor types.')}</a>
+          </p>
+        </Header>
+        <MonitorTypeField />
+      </div>
+      <div>
+        <Header>
+          <h3>{t('Project and Environment')}</h3>
+        </Header>
+        <Flex>
+          <ProjectField />
+          <EnvironmentField />
+        </Flex>
+      </div>
     </FormContainer>
   );
 }
 
 function ProjectField() {
-  const location = useLocation();
   const {projects, fetching} = useProjects();
-  const queryProjectId = location.query.project as string | undefined;
-  const currentProject = queryProjectId
-    ? projects.find(p => p.id === queryProjectId)
-    : getDefaultProject(projects);
 
   return (
     <StyledProjectField
@@ -58,7 +56,6 @@ function ProjectField() {
         {key: 'member', label: t('My Projects')},
         {key: 'all', label: t('All Projects')},
       ]}
-      value={currentProject?.id}
       name="project"
       placeholder={t('Project')}
       aria-label={t('Select Project')}
@@ -93,15 +90,11 @@ function EnvironmentField() {
 }
 
 function MonitorTypeField() {
-  const location = useLocation();
-  const queryType = location.query.detectorType as string | undefined;
-
   return (
     <StyledRadioField
       inline={false}
       flexibleControlStateSize
       name="detectorType"
-      value={queryType}
       choices={[
         [
           'metric',

--- a/static/app/views/detectors/new.spec.tsx
+++ b/static/app/views/detectors/new.spec.tsx
@@ -20,7 +20,7 @@ describe('DetectorNew', function () {
     ProjectsStore.loadInitialData(projects);
   });
 
-  it('sets query parameters for title, project, environment, and detectorType', async function () {
+  it('sets query parameters for project, environment, and detectorType', async function () {
     const {router} = render(<DetectorNew />);
 
     // Set detectorType
@@ -34,10 +34,6 @@ describe('DetectorNew', function () {
     await userEvent.click(screen.getByRole('textbox', {name: 'Select Environment'}));
     await userEvent.click(await screen.findByText('prod-2'));
 
-    // Set title
-    await userEvent.click(screen.getAllByText('New Monitor')[1]!);
-    await userEvent.type(await screen.findByRole('textbox', {name: ''}), 'test-title');
-
     await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
     expect(router.location).toEqual(
@@ -47,7 +43,6 @@ describe('DetectorNew', function () {
           detectorType: 'uptime',
           project: '2',
           environment: 'prod-2',
-          name: 'test-title',
         },
       })
     );

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -20,6 +20,12 @@ import useProjects from 'sentry/utils/useProjects';
 import {DetectorTypeForm} from 'sentry/views/detectors/components/detectorTypeForm';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 
+interface NewDetectorFormData {
+  detectorType: string;
+  environment: string;
+  project: string;
+}
+
 export default function DetectorNew() {
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -28,35 +34,41 @@ export default function DetectorNew() {
 
   const defaultProject = projects.find(p => p.isMember) ?? projects[0];
 
+  const newMonitorName = t('New Monitor');
   return (
     <FullHeightForm
-      onSubmit={data => {
+      onSubmit={formData => {
+        // Form doesn't allow type to be defined, cast to the expected shape
+        const data = formData as NewDetectorFormData;
         navigate({
           pathname: `${makeMonitorBasePathname(organization.slug)}new/settings/`,
-          // Filter out empty values
-          query: Object.fromEntries(
-            Object.entries(data).filter(([_, value]) => value !== '')
-          ),
+          query: {
+            detectorType: data.detectorType,
+            project: data.project,
+            environment: data.environment,
+          },
         });
       }}
       hideFooter
-      initialData={{
-        detectorType: 'metric',
-        project: defaultProject?.id,
-        environment: '',
-      }}
+      initialData={
+        {
+          detectorType: 'metric',
+          project: defaultProject?.id ?? '',
+          environment: '',
+        } satisfies NewDetectorFormData
+      }
     >
-      <SentryDocumentTitle title={t('New Monitor')} />
+      <SentryDocumentTitle title={newMonitorName} />
       <Layout.Page>
         <StyledLayoutHeader>
           <Layout.HeaderContent>
             <Breadcrumbs
               crumbs={[
                 {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
-                {label: t('New Monitor')},
+                {label: newMonitorName},
               ]}
             />
-            <Layout.Title>{t('New Monitor')}</Layout.Title>
+            <Layout.Title>{newMonitorName}</Layout.Title>
           </Layout.HeaderContent>
         </StyledLayoutHeader>
         <Layout.Body>

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -7,7 +7,6 @@ import {Flex} from 'sentry/components/core/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
-import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {
   StickyFooter,
   StickyFooterLabel,
@@ -19,26 +18,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {DetectorTypeForm} from 'sentry/views/detectors/components/detectorTypeForm';
-import {EditableDetectorName} from 'sentry/views/detectors/components/forms/editableDetectorName';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
-
-function NewDetectorBreadcrumbs() {
-  const title = useFormField<string>('title');
-  const organization = useOrganization();
-  return (
-    <Breadcrumbs
-      crumbs={[
-        {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
-        {label: title ? title : t('New Monitor')},
-      ]}
-    />
-  );
-}
-
-function NewDetectorDocumentTitle() {
-  const title = useFormField<string>('title');
-  return <SentryDocumentTitle title={title ? title : t('New Monitor')} />;
-}
 
 export default function DetectorNew() {
   const navigate = useNavigate();
@@ -63,18 +43,20 @@ export default function DetectorNew() {
       initialData={{
         detectorType: 'metric',
         project: defaultProject?.id,
-        name: '',
         environment: '',
       }}
     >
-      <NewDetectorDocumentTitle />
+      <SentryDocumentTitle title={t('New Monitor')} />
       <Layout.Page>
         <StyledLayoutHeader>
           <Layout.HeaderContent>
-            <NewDetectorBreadcrumbs />
-            <Layout.Title>
-              <EditableDetectorName />
-            </Layout.Title>
+            <Breadcrumbs
+              crumbs={[
+                {label: t('Monitors'), to: makeMonitorBasePathname(organization.slug)},
+                {label: t('New Monitor')},
+              ]}
+            />
+            <Layout.Title>{t('New Monitor')}</Layout.Title>
           </Layout.HeaderContent>
         </StyledLayoutHeader>
         <Layout.Body>


### PR DESCRIPTION
Removes some logic that is no longer being used. Removes the editable title and switches the order of the form.

![image](https://github.com/user-attachments/assets/fc818af0-c9a2-46e3-9481-66c3753445c9)
