### PR TITLE
ref(issues): Remove redundant Type row from Event Grouping Information table

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -100,68 +100,19 @@ function GroupingVariant({event, showGroupingConfig, variant}: GroupingVariantPr
     switch (variant.type) {
       case EventGroupVariantType.COMPONENT:
         component = variant.component;
-        data.push([
-          t('Type'),
-          <TextWithQuestionTooltip key="type">
-            {variant.type}
-            <QuestionTooltip
-              size="xs"
-              position="top"
-              title={t(
-                'Uses a complex grouping algorithm taking event data into account'
-              )}
-            />
-          </TextWithQuestionTooltip>,
-        ]);
+
         if (showGroupingConfig && variant.config?.id) {
           data.push([t('Grouping Config'), variant.config.id]);
         }
         break;
       case EventGroupVariantType.CUSTOM_FINGERPRINT:
-        data.push([
-          t('Type'),
-          <TextWithQuestionTooltip key="type">
-            {variant.type}
-            <QuestionTooltip
-              size="xs"
-              position="top"
-              title={t('Overrides the default grouping by a custom fingerprinting rule')}
-            />
-          </TextWithQuestionTooltip>,
-        ]);
         addFingerprintInfo(data, variant);
         break;
       case EventGroupVariantType.BUILT_IN_FINGERPRINT:
-        data.push([
-          t('Type'),
-          <TextWithQuestionTooltip key="type">
-            {variant.type}
-            <QuestionTooltip
-              size="xs"
-              position="top"
-              title={t(
-                'Overrides the default grouping by a Sentry defined fingerprinting rule'
-              )}
-            />
-          </TextWithQuestionTooltip>,
-        ]);
         addFingerprintInfo(data, variant);
         break;
       case EventGroupVariantType.SALTED_COMPONENT:
         component = variant.component;
-        data.push([
-          t('Type'),
-          <TextWithQuestionTooltip key="type">
-            {variant.type}
-            <QuestionTooltip
-              size="xs"
-              position="top"
-              title={t(
-                'Uses a complex grouping algorithm taking event data and a fingerprint into account'
-              )}
-            />
-          </TextWithQuestionTooltip>,
-        ]);
         addFingerprintInfo(data, variant);
         if (showGroupingConfig && variant.config?.id) {
           data.push([t('Grouping Config'), variant.config.id]);
@@ -173,19 +124,6 @@ function GroupingVariant({event, showGroupingConfig, variant}: GroupingVariantPr
             .find((c): c is EntrySpans => c.type === 'spans')
             ?.data?.map((span: RawSpanType) => [span.span_id, span.hash]) ?? []
         );
-        data.push([
-          t('Type'),
-          <TextWithQuestionTooltip key="type">
-            {variant.type}
-            <QuestionTooltip
-              size="xs"
-              position="top"
-              title={t(
-                'Uses the evidence from performance issue detection to generate a fingerprint.'
-              )}
-            />
-          </TextWithQuestionTooltip>,
-        ]);
 
         data.push(['Performance Issue Type', variant.key]);
         data.push(['Span Operation', variant.evidence.op]);


### PR DESCRIPTION
<!-- Describe your PR here. -->
[ticket](https://linear.app/getsentry/issue/ID-156/grouping-info-remove-type-field-from-ui)
The Type field in the Grouping Info section of the issue details page was redundant.
This removes the Type row from all variant types while keeping the underlying data structure intact.

before
![Screenshot 2025-06-20 at 12 00 54 PM](https://github.com/user-attachments/assets/97ca72da-0a52-4446-9825-cd4fcb505adf)

after
![Screenshot 2025-06-20 at 11 59 29 AM](https://github.com/user-attachments/assets/a4284d2b-c9f5-442f-b010-7fe72a598e39)
