### PR TITLE
feat(aci): connect automation creation form to API

### DIFF
--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -1,6 +1,6 @@
 export interface Action {
   config: {
-    target_type: ActionTarget;
+    target_type: ActionTarget | null;
     sentry_app_identifier?: SentryAppIdentifier;
     target_display?: string;
     target_identifier?: string;

--- a/static/app/types/workflowEngine/automations.tsx
+++ b/static/app/types/workflowEngine/automations.tsx
@@ -1,10 +1,10 @@
 import type {DataConditionGroup} from 'sentry/types/workflowEngine/dataConditions';
 
-interface NewAutomation {
+export interface NewAutomation {
   actionFilters: DataConditionGroup[];
   config: {frequency?: number};
   detectorIds: string[];
-  environment: string;
+  environment: string | null;
   name: string;
   triggers: DataConditionGroup;
   disabled?: boolean;

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -66,7 +66,7 @@ export interface DataCondition {
   comparison: any;
   id: string;
   type: DataConditionType;
-  conditionResult?: DetectorPriorityLevel;
+  conditionResult?: any;
 }
 
 export interface DataConditionGroup {

--- a/static/app/views/automations/components/actionFilters/ageComparison.tsx
+++ b/static/app/views/automations/components/actionFilters/ageComparison.tsx
@@ -9,15 +9,17 @@ import {
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 enum TimeUnit {
-  MINUTES = 'minutes',
-  HOURS = 'hours',
-  DAYS = 'days',
+  MINUTES = 'minute',
+  HOURS = 'hour',
+  DAYS = 'day',
+  WEEKS = 'week',
 }
 
 const TIME_CHOICES = [
   {value: TimeUnit.MINUTES, label: 'minute(s)'},
   {value: TimeUnit.HOURS, label: 'hour(s)'},
   {value: TimeUnit.DAYS, label: 'day(s)'},
+  {value: TimeUnit.WEEKS, label: 'week(s)'},
 ];
 
 interface AgeComparisonDetailsProps {
@@ -54,7 +56,7 @@ function ComparisonField() {
       options={AGE_COMPARISON_CHOICES}
       onChange={(value: AgeComparison) => {
         onUpdate({
-          type: value,
+          comparison_type: value,
         });
       }}
     />

--- a/static/app/views/automations/components/actions/email.tsx
+++ b/static/app/views/automations/components/actions/email.tsx
@@ -95,7 +95,7 @@ function IdentifierField() {
           name={`${actionId}.config.target_identifier`}
           value={action.config.target_identifier}
           onChange={(value: any) =>
-            onUpdate({config: {target_identifier: value.actor.id}})
+            onUpdate({config: {target_identifier: value.actor.id}, data: {}})
           }
           useId
           styles={selectControlStyles}
@@ -111,7 +111,7 @@ function IdentifierField() {
           key={`${actionId}.config.target_identifier`}
           value={action.config.target_identifier}
           onChange={(value: any) =>
-            onUpdate({config: {target_identifier: value.actor.id}})
+            onUpdate({config: {target_identifier: value.actor.id}, data: {}})
           }
           styles={selectControlStyles}
         />

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -135,7 +135,7 @@ export function useAutomationBuilderReducer() {
   return {state, actions};
 }
 
-interface AutomationBuilderState {
+export interface AutomationBuilderState {
   actionFilters: DataConditionGroup[];
   triggers: DataConditionGroup;
 }
@@ -322,7 +322,8 @@ function addWhenCondition(
         {
           id: uuid4(),
           type: action.conditionType,
-          comparison: {},
+          comparison: true,
+          conditionResult: true,
         },
       ],
     },
@@ -419,7 +420,8 @@ function addIfCondition(
           {
             id: uuid4(),
             type: conditionType,
-            comparison: {},
+            comparison: true,
+            conditionResult: true,
           },
         ],
       };
@@ -488,8 +490,10 @@ function updateIfCondition(
   };
 }
 
-function getActionTargetType(actionType: ActionType): ActionTarget {
+function getActionTargetType(actionType: ActionType): ActionTarget | null {
   switch (actionType) {
+    case ActionType.PLUGIN:
+      return null;
     case ActionType.EMAIL:
       return ActionTarget.ISSUE_OWNERS;
     case ActionType.SENTRY_APP:

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -59,6 +59,10 @@ export default function AutomationForm({model}: {model: FormModel}) {
   });
   const connectedMonitors = monitors.filter(monitor => connectedIds.has(monitor.id));
 
+  useEffect(() => {
+    model.setValue('detectorIds', Array.from(connectedIds));
+  }, [connectedIds, model]);
+
   const {openDrawer, isDrawerOpen, closeDrawer} = useDrawer();
 
   const showEditMonitorsDrawer = () => {

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -10,11 +10,11 @@ import useDrawer from 'sentry/components/globalDrawer';
 import {useDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {DebugForm} from 'sentry/components/workflowEngine/form/debug';
 import {EnvironmentSelector} from 'sentry/components/workflowEngine/form/environmentSelector';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {Card} from 'sentry/components/workflowEngine/ui/card';
 import {IconAdd, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import AutomationBuilder from 'sentry/views/automations/components/automationBuilder';
 import ConnectedMonitorsList from 'sentry/views/automations/components/connectedMonitorsList';
@@ -35,7 +35,6 @@ const FREQUENCY_OPTIONS = [
 ];
 
 export default function AutomationForm({model}: {model: FormModel}) {
-  const location = useLocation();
   const organization = useOrganization();
   const title = useDocumentTitle();
 
@@ -44,24 +43,15 @@ export default function AutomationForm({model}: {model: FormModel}) {
   }, [title, model]);
 
   const {data: monitors = []} = useDetectorsQuery();
-  const [connectedIds, setConnectedIds] = useState<Set<string>>(() => {
-    const connectedIdsQuery = location.query.connectedIds as
-      | string
-      | string[]
-      | undefined;
-    if (!connectedIdsQuery) {
-      return new Set<string>();
-    }
-    const connectedIdsArray = Array.isArray(connectedIdsQuery)
-      ? connectedIdsQuery
-      : [connectedIdsQuery];
-    return new Set(connectedIdsArray);
-  });
+  const initialConnectedIds = useFormField('detectorIds');
+  const [connectedIds, setConnectedIds] = useState<Set<string>>(
+    initialConnectedIds ? new Set(initialConnectedIds) : new Set<string>()
+  );
   const connectedMonitors = monitors.filter(monitor => connectedIds.has(monitor.id));
-
-  useEffect(() => {
-    model.setValue('detectorIds', Array.from(connectedIds));
-  }, [connectedIds, model]);
+  const updateConnectedIds = (ids: Set<string>) => {
+    setConnectedIds(ids);
+    model.setValue('detectorIds', Array.from(ids));
+  };
 
   const {openDrawer, isDrawerOpen, closeDrawer} = useDrawer();
 
@@ -72,7 +62,7 @@ export default function AutomationForm({model}: {model: FormModel}) {
           <EditConnectedMonitorsDrawer
             initialIds={connectedIds}
             onSave={ids => {
-              setConnectedIds(ids);
+              updateConnectedIds(ids);
               closeDrawer();
             }}
           />
@@ -91,11 +81,7 @@ export default function AutomationForm({model}: {model: FormModel}) {
     <Flex direction="column" gap={space(1.5)}>
       <Card>
         <Heading>{t('Connect Monitors')}</Heading>
-        <ConnectedMonitorsList
-          monitors={connectedMonitors}
-          connectedIds={connectedIds}
-          setConnectedIds={setConnectedIds}
-        />
+        <ConnectedMonitorsList monitors={connectedMonitors} />
         <ButtonWrapper justify="space-between">
           <LinkButton
             icon={<IconAdd />}

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -1,0 +1,45 @@
+import type {NewAutomation} from 'sentry/types/workflowEngine/automations';
+import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
+
+export interface AutomationFormData {
+  detectorIds: string[];
+  environment: string | null;
+  frequency: string | null;
+  name: string;
+}
+
+export function getNewAutomationData(
+  data: AutomationFormData,
+  state: AutomationBuilderState
+): NewAutomation {
+  const stripDataConditionIds = (condition: any) => {
+    const {id: _id, ...conditionWithoutId} = condition;
+    return conditionWithoutId;
+  };
+
+  const stripActionIds = (action: any) => {
+    const {id: _id, ...actionWithoutId} = action;
+    return actionWithoutId;
+  };
+
+  const stripDataConditionGroupIds = (group: any) => {
+    const {id: _id, ...groupWithoutId} = group;
+    return {
+      ...groupWithoutId,
+      conditions: group.conditions?.map(stripDataConditionIds) || [],
+      actions: group.actions?.map(stripActionIds) || [],
+    };
+  };
+
+  const result = {
+    name: data.name,
+    triggers: stripDataConditionGroupIds(state.triggers),
+    environment: data.environment,
+    actionFilters: state.actionFilters.map(stripDataConditionGroupIds),
+    config: {
+      frequency: data.frequency ? parseInt(data.frequency, 10) : undefined,
+    },
+    detectorIds: data.detectorIds,
+  };
+  return result;
+}

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -1,11 +1,14 @@
+import {t} from 'sentry/locale';
+import AlertStore from 'sentry/stores/alertStore';
 import type {ActionHandler} from 'sentry/types/workflowEngine/actions';
-import type {Automation} from 'sentry/types/workflowEngine/automations';
+import type {Automation, NewAutomation} from 'sentry/types/workflowEngine/automations';
 import type {
   DataConditionHandler,
   DataConditionHandlerGroupType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {ApiQueryKey, UseApiQueryOptions} from 'sentry/utils/queryClient';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const makeAutomationsQueryKey = ({
@@ -81,5 +84,27 @@ export function useAvailableActionsQuery() {
   return useApiQuery<ActionHandler[]>([`/organizations/${slug}/available-actions/`], {
     staleTime: Infinity,
     retry: false,
+  });
+}
+
+export function useCreateAutomation() {
+  const org = useOrganization();
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  return useMutation<Automation, void, NewAutomation>({
+    mutationFn: data =>
+      api.requestPromise(`/organizations/${org.slug}/workflows/`, {
+        method: 'POST',
+        data,
+      }),
+    onSuccess: _ => {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${org.slug}/workflows/`],
+      });
+    },
+    onError: _ => {
+      AlertStore.addAlert({type: 'error', message: t('Unable to create automation')});
+    },
   });
 }

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -124,6 +124,7 @@ export default function AutomationNewSettings() {
       hideFooter
       initialData={{...initialData, detectorIds: initialConnectedIds}}
       onSubmit={handleSubmit}
+      model={model}
     >
       <AutomationDocumentTitle />
       <Layout.Page>

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -21,6 +21,7 @@ import {
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -85,10 +86,25 @@ const initialData = {...flattie(initialAutomationBuilderState), frequency: '1440
 
 export default function AutomationNewSettings() {
   const navigate = useNavigate();
+  const location = useLocation();
   const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
+
+  const initialConnectedIds = useMemo(() => {
+    const connectedIdsQuery = location.query.connectedIds as
+      | string
+      | string[]
+      | undefined;
+    if (!connectedIdsQuery) {
+      return [];
+    }
+    const connectedIds = Array.isArray(connectedIdsQuery)
+      ? connectedIdsQuery
+      : [connectedIdsQuery];
+    return connectedIds;
+  }, [location.query.connectedIds]);
 
   const {mutateAsync: createAutomation} = useCreateAutomation();
 
@@ -104,7 +120,11 @@ export default function AutomationNewSettings() {
   );
 
   return (
-    <FullHeightForm hideFooter initialData={initialData} onSubmit={handleSubmit}>
+    <FullHeightForm
+      hideFooter
+      initialData={{...initialData, detectorIds: initialConnectedIds}}
+      onSubmit={handleSubmit}
+    >
       <AutomationDocumentTitle />
       <Layout.Page>
         <StyledLayoutHeader>

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {flattie} from 'flattie';
 
@@ -9,6 +9,7 @@ import {Flex} from 'sentry/components/core/layout';
 import EditableText from 'sentry/components/editableText';
 import FormField from 'sentry/components/forms/formField';
 import FormModel from 'sentry/components/forms/model';
+import type {OnSubmitCallback} from 'sentry/components/forms/types';
 import * as Layout from 'sentry/components/layouts/thirds';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
@@ -20,6 +21,7 @@ import {
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   AutomationBuilderContext,
@@ -27,7 +29,13 @@ import {
   useAutomationBuilderReducer,
 } from 'sentry/views/automations/components/automationBuilderContext';
 import AutomationForm from 'sentry/views/automations/components/automationForm';
-import {makeAutomationBasePathname} from 'sentry/views/automations/pathnames';
+import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
+import {getNewAutomationData} from 'sentry/views/automations/components/automationFormData';
+import {useCreateAutomation} from 'sentry/views/automations/hooks';
+import {
+  makeAutomationBasePathname,
+  makeAutomationDetailsPathname,
+} from 'sentry/views/automations/pathnames';
 
 function AutomationDocumentTitle() {
   const title = useFormField('name');
@@ -76,13 +84,27 @@ function EditableAutomationName() {
 const initialData = {...flattie(initialAutomationBuilderState), frequency: '1440'};
 
 export default function AutomationNewSettings() {
+  const navigate = useNavigate();
   const organization = useOrganization();
   useWorkflowEngineFeatureGate({redirect: true});
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
 
+  const {mutateAsync: createAutomation} = useCreateAutomation();
+
+  const handleSubmit = useCallback<OnSubmitCallback>(
+    async (data, _, __, ___, ____) => {
+      // TODO: add form validation
+      const automation = await createAutomation(
+        getNewAutomationData(data as AutomationFormData, state)
+      );
+      navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
+    },
+    [createAutomation, state, navigate, organization.slug]
+  );
+
   return (
-    <FullHeightForm hideFooter initialData={initialData}>
+    <FullHeightForm hideFooter initialData={initialData} onSubmit={handleSubmit}>
       <AutomationDocumentTitle />
       <Layout.Page>
         <StyledLayoutHeader>
@@ -110,7 +132,9 @@ export default function AutomationNewSettings() {
           >
             {t('Back')}
           </LinkButton>
-          <Button priority="primary">{t('Create Automation')}</Button>
+          <Button priority="primary" type="submit">
+            {t('Create Automation')}
+          </Button>
         </Flex>
       </StickyFooter>
     </FullHeightForm>


### PR DESCRIPTION
connected automation form to the API with a new `createAutomation()` hook and a `getNewAutomationData()` helper that combines the form data and automation builder state into the request type that the API expects
