### PR TITLE
chore(issues): Fix kitchen date parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -123,7 +123,7 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (\d{4}-?[01]\d-?[0-3]\d\s[0-2]\d:[0-5]\d:[0-5]\d)(\.\d+)?
             |
             # Kitchen
-            (\d{1,2}:\d{2}(:\d{2})?(?: [aApP][Mm])?)
+            ([1-9]\d?:\d{2}(:\d{2})?(?: [aApP][Mm])?)
             |
             # Date
             (\d{4}-[01]\d-[0-3]\d)

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -121,6 +121,11 @@ def parameterizer():
             """traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01""",
             """traceparent: <traceparent>""",
         ),
+        (
+            "int - with separator",
+            """blah 0:17502 had a problem""",
+            """blah <int>:<int> had a problem""",
+        ),
         ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
         ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
         (


### PR DESCRIPTION
Kitchen format will never begin with "0:".

Previously `0:17502` was parameterized as `<date>502` and not `<int>:<int>`.