### PR TITLE
chore(autofix): Don't autofocus agent comments

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -363,7 +363,7 @@ function AutofixHighlightPopupContent({
             onChange={e => setComment(e.target.value)}
             maxLength={4096}
             size="sm"
-            autoFocus
+            autoFocus={!isAgentComment}
             maxRows={5}
             autosize
             onKeyDown={e => {


### PR DESCRIPTION
Don't autofocus the text input for agent comment popups. Feels less in-your-face now