### PR TITLE
fix(trace-eap-waterfall-replay): Unable to load span details

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -383,7 +383,7 @@ function EAPSpanNodeDetails({
   } = useTraceItemDetails({
     traceItemId: node.value.event_id,
     projectId: node.value.project_id.toString(),
-    traceId,
+    traceId: node.metadata.replayTraceSlug ?? traceId,
     traceItemType: TraceItemDataset.SPANS,
     referrer: 'api.explore.log-item-details', // TODO: change to span details
     enabled: true,

--- a/static/app/views/replays/detail/trace/useReplayTraces.tsx
+++ b/static/app/views/replays/detail/trace/useReplayTraces.tsx
@@ -53,7 +53,7 @@ export function useReplayTraces({
     return EventView.fromSavedQuery({
       id: undefined,
       name: `Traces in replay ${replayId}`,
-      fields: ['trace', 'count(trace)', 'min(timestamp)'],
+      fields: ['trace', 'min(timestamp)', 'max(transaction.duration)'],
       orderby: 'min_timestamp',
       query: `replayId:${replayId}`,
       projects: [Number(projectId)],
@@ -89,7 +89,7 @@ export function useReplayTraces({
           end,
           limit: 10,
         } as unknown as Location),
-        sort: ['min_timestamp', 'trace'],
+        sort: ['min_timestamp'],
         cursor: cursor.cursor,
       };
 
@@ -102,6 +102,28 @@ export function useReplayTraces({
 
         const parsedData = data
           .filter(row => row.trace) // Filter out items where trace is not truthy
+          .sort((a, b) => {
+            const aDuration = a['max(transaction.duration)'];
+            const bDuration = b['max(transaction.duration)'];
+            const aMinTimestamp = getTimeStampFromTableDateField(a['min(timestamp)']);
+            const bMinTimestamp = getTimeStampFromTableDateField(b['min(timestamp)']);
+
+            if (
+              !aMinTimestamp ||
+              !bMinTimestamp ||
+              typeof aDuration !== 'number' ||
+              typeof bDuration !== 'number'
+            ) {
+              return 0;
+            }
+
+            // We don't have a way to get the min start time of a trace, so we'll use the min timestamp and subtract the max duration
+            // of a transaction in that trace, to make the best guess.
+            const aMinStart = aMinTimestamp - aDuration / 1000;
+            const bMinStart = bMinTimestamp - bDuration / 1000;
+
+            return aMinStart - bMinStart;
+          })
           .map(row => ({
             traceSlug: row.trace!.toString(),
             timestamp: getTimeStampFromTableDateField(row['min(timestamp)']),


### PR DESCRIPTION
- We have multiple traces associated to a replay, and in the replay trace tab we load one trace, and append the rest in batches of three, in to one waterfall.

-  The error below was happening because, we were using the trace_id of the first trace fetched, to fetch the attributes of all the spans in the waterfall using `/trace-item/..../?trace_id={slug}`. Leading to a 404 for spans that are not part of the first trace.
- Instead of concatenating the fetched results from the batch and appending as one tree, we take the results and individually append them to the tree, hence collecting and passing on the correct traceslugs that the drawer uses to fetch eap span attrs. 
<img width="1431" alt="Screenshot 2025-06-19 at 1 08 00 AM" src="https://github.com/user-attachments/assets/271f4fc8-56db-4c3f-97f8-80703984784b" />


- Also fixed the order of traces processed. 