### PR TITLE
feat(trace-eap-waterfall): Adding breadcrumbs section back to eap trace waterfall

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -52,6 +52,7 @@ import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/de
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
 import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {BreadCrumbs} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs';
 import ReplayPreview from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview';
 import {Request} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/request';
 import {
@@ -594,6 +595,10 @@ function EAPSpanNodeDetails({
                         project={project}
                         group={undefined}
                       />
+                    ) : null}
+
+                    {isTransaction ? (
+                      <BreadCrumbs event={eventTransaction} organization={organization} />
                     ) : null}
 
                     {isTransaction && project ? (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs.tsx
@@ -33,7 +33,12 @@ export function BreadCrumbs({
 
   return (
     <ResponsiveBreadcrumbWrapper>
-      <Breadcrumbs data={matchingEntry.data} event={event} organization={organization} />
+      <Breadcrumbs
+        data={matchingEntry.data}
+        event={event}
+        organization={organization}
+        disableCollapsePersistence
+      />
     </ResponsiveBreadcrumbWrapper>
   );
 }


### PR DESCRIPTION
<img width="1432" alt="Screenshot 2025-06-19 at 10 17 49 AM" src="https://github.com/user-attachments/assets/ba7225c7-0c14-4924-9307-c9d0c79ab295" />
