### PR TITLE
fix(otlp): Remove duplicate alias for `span.name`

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -101,12 +101,6 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
-            public_alias="span.name",
-            internal_name="sentry.op",
-            search_type="string",
-            secondary_alias=True,
-        ),
-        ResolvedAttribute(
             public_alias="span.category",
             internal_name="sentry.category",
             search_type="string",


### PR DESCRIPTION
I missed this in https://github.com/getsentry/sentry/pull/93725, we need to also remove the existing alias.
