### PR TITLE
fix(dashboards): Remove waiting for animation on chart zoom

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -69,10 +69,6 @@ type Props = {
   xAxisIndex?: number | number[];
 };
 
-type State = {
-  zooming: (() => void) | null;
-};
-
 /**
  * This is a very opinionated component that takes a render prop through `children`. It
  * will provide props to be passed to `BaseChart` to enable support of zooming without
@@ -81,7 +77,7 @@ type State = {
  * This also is very tightly coupled with the Global Selection Header. We can make it more
  * generic if need be in the future.
  */
-class ChartZoom extends Component<Props, State> {
+class ChartZoom extends Component<Props> {
   constructor(props: Props) {
     super(props);
 
@@ -91,10 +87,6 @@ class ChartZoom extends Component<Props, State> {
     // Initialize current period instance state for zoom history
     this.saveCurrentPeriod(props);
   }
-
-  state = {
-    zooming: null,
-  };
 
   componentDidUpdate() {
     if (this.props.disabled) {

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -134,12 +134,6 @@ export function useChartZoom({
   const router = useRouter();
 
   /**
-   * Used to store the date update function so that we can call it after the chart
-   * animation is complete
-   */
-  const zooming = useRef<(() => void) | null>(null);
-
-  /**
    * Sets the new period due to a zoom related action
    *
    * Saves the current period to an instance property so that we
@@ -165,34 +159,32 @@ export function useChartZoom({
         end: getQueryTime(newPeriod.end),
       });
 
-      zooming.current = () => {
-        if (usePageDate) {
-          const newQuery = {
-            ...location.query,
-            pageStart: startFormatted,
-            pageEnd: endFormatted,
-            pageStatsPeriod: newPeriod.period ?? undefined,
-          };
+      if (usePageDate) {
+        const newQuery = {
+          ...location.query,
+          pageStart: startFormatted,
+          pageEnd: endFormatted,
+          pageStatsPeriod: newPeriod.period ?? undefined,
+        };
 
-          // Only push new location if query params has changed because this will cause a heavy re-render
-          if (qs.stringify(newQuery) !== qs.stringify(location.query)) {
-            navigate({
-              pathname: location.pathname,
-              query: newQuery,
-            });
-          }
-        } else {
-          updateDateTime(
-            {
-              period: newPeriod.period,
-              start: startFormatted,
-              end: endFormatted,
-            },
-            router,
-            {save: saveOnZoom}
-          );
+        // Only push new location if query params has changed because this will cause a heavy re-render
+        if (qs.stringify(newQuery) !== qs.stringify(location.query)) {
+          navigate({
+            pathname: location.pathname,
+            query: newQuery,
+          });
         }
-      };
+      } else {
+        updateDateTime(
+          {
+            period: newPeriod.period,
+            start: startFormatted,
+            end: endFormatted,
+          },
+          router,
+          {save: saveOnZoom}
+        );
+      }
     },
     [onZoom, navigate, location, router, saveOnZoom, usePageDate]
   );
@@ -231,11 +223,6 @@ export function useChartZoom({
    * before we update URL state and re-render
    */
   const handleChartFinished = useCallback<EChartFinishedHandler>((_props, chart) => {
-    if (typeof zooming.current === 'function') {
-      zooming.current();
-      zooming.current = null;
-    }
-
     // This attempts to activate the area zoom toolbox feature
     const zoom = (chart as any)._componentsViews?.find((c: any) => c._features?.dataZoom);
     if (zoom && !zoom._features.dataZoom._isZoomActive) {


### PR DESCRIPTION
This is causing zooming issues where the finish handler isn't triggering and flushing the queued up time range changes (i.e. updating the URL params so the remaining charts and page filters can update).

We've decided to immediately trigger the state changes because we know the chart zoom callback consistently triggers