### PR TITLE
[ft] Allow verifying an org by name in Seer RPC

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -201,7 +201,7 @@ def get_organization_seer_consent_by_org_name(
     *, org_name: str, provider: str = "github"
 ) -> dict[str, bool]:
     org_integrations = integration_service.get_organization_integrations(
-        provider=provider, name=org_name
+        providers=[provider], name=org_name
     )
 
     for org_integration in org_integrations:

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -206,7 +206,7 @@ def get_organization_seer_consent_by_org_name(
 
     for org_integration in org_integrations:
         try:
-            org: Organization = Organization.objects.get(id=org_integration.organization_id)
+            org = Organization.objects.get(id=org_integration.organization_id)
             seer_org_acknowledgement = get_seer_org_acknowledgement(org_id=org.id)
             github_extension_enabled = org.id in options.get("github-extension.enabled-orgs")
 

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -34,6 +34,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.organization_trace_item_attributes import as_attribute_key
 from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
+from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
@@ -194,6 +195,28 @@ def get_organization_autofix_consent(*, org_id: int) -> dict:
     return {
         "consent": seer_org_acknowledgement or github_extension_enabled,
     }
+
+
+def get_organization_seer_consent_by_org_name(
+    *, org_name: str, provider: str = "github"
+) -> dict[str, bool]:
+    org_integrations = integration_service.get_organization_integrations(
+        provider=provider, name=org_name
+    )
+
+    for org_integration in org_integrations:
+        try:
+            org: Organization = Organization.objects.get(id=org_integration.organization_id)
+            seer_org_acknowledgement = get_seer_org_acknowledgement(org_id=org.id)
+            github_extension_enabled = org.id in options.get("github-extension.enabled-orgs")
+
+            if seer_org_acknowledgement or github_extension_enabled:
+                return {"consent": True}
+
+        except Organization.DoesNotExist:
+            continue
+
+    return {"consent": False}
 
 
 def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: str) -> dict:
@@ -371,6 +394,7 @@ def get_attribute_values_with_substring(
 seer_method_registry: dict[str, Callable[..., dict[str, Any]]] = {
     "get_organization_slug": get_organization_slug,
     "get_organization_autofix_consent": get_organization_autofix_consent,
+    "get_organization_seer_consent_by_org_name": get_organization_seer_consent_by_org_name,
     "get_issues_related_to_file_patches": get_issues_related_to_file_patches,
     "get_issues_related_to_function_names": get_issues_related_to_function_names,
     "get_issues_related_to_exception_type": get_issues_related_to_exception_type,

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -172,6 +172,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         has_grace_period: bool | None = None,
         grace_period_expired: bool | None = None,
         limit: int | None = None,
+        name: str | None = None,
     ) -> list[RpcOrganizationIntegration]:
         oi_kwargs: dict[str, Any] = {}
         if org_integration_ids is not None:
@@ -191,6 +192,8 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if grace_period_expired:
             # Used by getsentry
             oi_kwargs["grace_period_end__lte"] = timezone.now()
+        if name is not None:
+            oi_kwargs["integration__name"] = name
 
         if not oi_kwargs:
             return []

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -99,6 +99,7 @@ class IntegrationService(RpcService):
         has_grace_period: bool | None = None,
         grace_period_expired: bool | None = None,
         limit: int | None = None,
+        name: str | None = None,
     ) -> list[RpcOrganizationIntegration]:
         """
         Returns all RpcOrganizationIntegrations from the matching kwargs.

--- a/tests/sentry/api/endpoints/test_seer_rpc.py
+++ b/tests/sentry/api/endpoints/test_seer_rpc.py
@@ -47,128 +47,138 @@ class TestSeerRpcMethods(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.organization = self.create_organization()
+        self.organization = self.create_organization(owner=self.user)
 
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
-    def test_get_organization_seer_consent_by_org_name_no_integrations(self, mock_get_integrations):
+    def _create_options_get_side_effect(self, enabled_orgs=None):
+        """Helper to create a side effect function for options.get mock"""
+
+        def side_effect(key):
+            if key == "github-extension.enabled-orgs":
+                return enabled_orgs or []
+            return []
+
+        return side_effect
+
+    def test_get_organization_seer_consent_by_org_name_no_integrations(self):
         """Test when no organization integrations are found"""
-        mock_get_integrations.return_value = []
-
-        result = get_organization_seer_consent_by_org_name(org_name="test-org")
-
+        # Test with a non-existent organization name
+        result = get_organization_seer_consent_by_org_name(org_name="non-existent-org")
         assert result == {"consent": False}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
 
     @patch("sentry.api.endpoints.seer_rpc.options.get")
     @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
     def test_get_organization_seer_consent_by_org_name_no_consent(
-        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+        self, mock_get_acknowledgement, mock_options_get
     ):
         """Test when organization exists but has no consent"""
-        from unittest.mock import Mock
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org",
+        )
 
-        mock_integration = Mock()
-        mock_integration.organization_id = self.organization.id
-        mock_get_integrations.return_value = [mock_integration]
         mock_get_acknowledgement.return_value = False
         mock_options_get.return_value = []  # No orgs in github-extension.enabled-orgs
 
         result = get_organization_seer_consent_by_org_name(org_name="test-org")
 
         assert result == {"consent": False}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
-        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
-        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+        mock_get_acknowledgement.assert_called_with(org_id=self.organization.id)
+        mock_options_get.assert_any_call("github-extension.enabled-orgs")
 
     @patch("sentry.api.endpoints.seer_rpc.options.get")
     @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
     def test_get_organization_seer_consent_by_org_name_with_seer_acknowledgement(
-        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+        self, mock_get_acknowledgement, mock_options_get
     ):
         """Test when organization has seer acknowledgement"""
-        from unittest.mock import Mock
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org",
+        )
 
-        mock_integration = Mock()
-        mock_integration.organization_id = self.organization.id
-        mock_get_integrations.return_value = [mock_integration]
         mock_get_acknowledgement.return_value = True
         mock_options_get.return_value = []  # No orgs in github-extension.enabled-orgs
 
         result = get_organization_seer_consent_by_org_name(org_name="test-org")
 
         assert result == {"consent": True}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
-        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
-        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+        mock_get_acknowledgement.assert_called_with(org_id=self.organization.id)
+        mock_options_get.assert_any_call("github-extension.enabled-orgs")
 
     @patch("sentry.api.endpoints.seer_rpc.options.get")
     @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
     def test_get_organization_seer_consent_by_org_name_with_github_extension(
-        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+        self, mock_get_acknowledgement, mock_options_get
     ):
         """Test when organization has github extension enabled"""
-        from unittest.mock import Mock
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org",
+        )
 
-        mock_integration = Mock()
-        mock_integration.organization_id = self.organization.id
-        mock_get_integrations.return_value = [mock_integration]
         mock_get_acknowledgement.return_value = False
-        mock_options_get.return_value = [
-            self.organization.id
-        ]  # Org in github-extension.enabled-orgs
+        mock_options_get.side_effect = self._create_options_get_side_effect(
+            enabled_orgs=[self.organization.id]
+        )
 
         result = get_organization_seer_consent_by_org_name(org_name="test-org")
 
         assert result == {"consent": True}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
-        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
-        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+        mock_get_acknowledgement.assert_called_with(org_id=self.organization.id)
+        mock_options_get.assert_any_call("github-extension.enabled-orgs")
 
     @patch("sentry.api.endpoints.seer_rpc.options.get")
     @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
     def test_get_organization_seer_consent_by_org_name_with_both_consents(
-        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+        self, mock_get_acknowledgement, mock_options_get
     ):
         """Test when organization has both seer acknowledgement and github extension enabled"""
-        from unittest.mock import Mock
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org",
+        )
 
-        mock_integration = Mock()
-        mock_integration.organization_id = self.organization.id
-        mock_get_integrations.return_value = [mock_integration]
         mock_get_acknowledgement.return_value = True
-        mock_options_get.return_value = [
-            self.organization.id
-        ]  # Org in github-extension.enabled-orgs
+        mock_options_get.side_effect = self._create_options_get_side_effect(
+            enabled_orgs=[self.organization.id]
+        )
 
         result = get_organization_seer_consent_by_org_name(org_name="test-org")
 
         assert result == {"consent": True}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
-        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
-        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+        mock_get_acknowledgement.assert_called_with(org_id=self.organization.id)
+        mock_options_get.assert_any_call("github-extension.enabled-orgs")
 
     @patch("sentry.api.endpoints.seer_rpc.options.get")
     @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
     def test_get_organization_seer_consent_by_org_name_multiple_orgs_one_with_consent(
-        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+        self, mock_get_acknowledgement, mock_options_get
     ):
         """Test when multiple organizations exist, one with consent"""
-        from unittest.mock import Mock
+        org_without_consent = self.create_organization(owner=self.user)
+        org_with_consent = self.create_organization(owner=self.user)
 
-        org_without_consent = self.create_organization()
-        org_with_consent = self.create_organization()
-
-        mock_integration_1 = Mock()
-        mock_integration_1.organization_id = org_without_consent.id
-        mock_integration_2 = Mock()
-        mock_integration_2.organization_id = org_with_consent.id
-
-        mock_get_integrations.return_value = [mock_integration_1, mock_integration_2]
+        # Create integrations for both organizations with the same name
+        self.create_integration(
+            organization=org_without_consent,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org-1",
+        )
+        self.create_integration(
+            organization=org_with_consent,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org-2",
+        )
 
         # First org has no consent, second org has seer acknowledgement
         mock_get_acknowledgement.side_effect = [False, True]
@@ -177,52 +187,41 @@ class TestSeerRpcMethods(APITestCase):
         result = get_organization_seer_consent_by_org_name(org_name="test-org")
 
         assert result == {"consent": True}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
         # Should stop after finding first org with consent
         assert mock_get_acknowledgement.call_count == 2
 
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
-    def test_get_organization_seer_consent_by_org_name_custom_provider(self, mock_get_integrations):
-        """Test with custom provider"""
-        mock_get_integrations.return_value = []
-
-        result = get_organization_seer_consent_by_org_name(org_name="test-org", provider="gitlab")
-
-        assert result == {"consent": False}
-        mock_get_integrations.assert_called_once_with(provider="gitlab", name="test-org")
-
     @patch("sentry.api.endpoints.seer_rpc.options.get")
     @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
-    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
     def test_get_organization_seer_consent_by_org_name_mixed_scenarios(
-        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+        self, mock_get_acknowledgement, mock_options_get
     ):
-        """Test mixed scenario with non-existent org, org without consent, and org with consent"""
-        from unittest.mock import Mock
+        """Test mixed scenario with org without consent and org with consent"""
+        org_without_consent = self.create_organization(owner=self.user)
+        org_with_consent = self.create_organization(owner=self.user)
 
-        org_without_consent = self.create_organization()
-        org_with_consent = self.create_organization()
+        # Create integrations for both organizations with the same name
+        self.create_integration(
+            organization=org_without_consent,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org-1",
+        )
 
-        mock_integration_1 = Mock()
-        mock_integration_1.organization_id = 99999  # Non-existent org
-        mock_integration_2 = Mock()
-        mock_integration_2.organization_id = org_without_consent.id
-        mock_integration_3 = Mock()
-        mock_integration_3.organization_id = org_with_consent.id
+        self.create_integration(
+            organization=org_with_consent,
+            provider="github",
+            name="test-org",
+            external_id="github:test-org-2",
+        )
 
-        mock_get_integrations.return_value = [
-            mock_integration_1,
-            mock_integration_2,
-            mock_integration_3,
-        ]
-
-        # Second org has no consent, third org has github extension enabled
+        # First org has no consent, second org has github extension enabled
         mock_get_acknowledgement.side_effect = [False, False]
-        mock_options_get.return_value = [org_with_consent.id]
+        mock_options_get.side_effect = self._create_options_get_side_effect(
+            enabled_orgs=[org_with_consent.id]
+        )
 
         result = get_organization_seer_consent_by_org_name(org_name="test-org")
 
         assert result == {"consent": True}
-        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
-        # Should be called twice (skips non-existent org, checks two existing orgs)
+        # Should be called twice (checks both existing orgs)
         assert mock_get_acknowledgement.call_count == 2

--- a/tests/sentry/api/endpoints/test_seer_rpc.py
+++ b/tests/sentry/api/endpoints/test_seer_rpc.py
@@ -1,10 +1,14 @@
 from typing import Any
+from unittest.mock import patch
 
 import orjson
 from django.test import override_settings
 from django.urls import reverse
 
-from sentry.api.endpoints.seer_rpc import generate_request_signature
+from sentry.api.endpoints.seer_rpc import (
+    generate_request_signature,
+    get_organization_seer_consent_by_org_name,
+)
 from sentry.testutils.cases import APITestCase
 
 
@@ -36,3 +40,189 @@ class TestSeerRpc(APITestCase):
             path, data=data, HTTP_AUTHORIZATION=self.auth_header(path, data)
         )
         assert response.status_code == 404
+
+
+class TestSeerRpcMethods(APITestCase):
+    """Test individual RPC methods"""
+
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_no_integrations(self, mock_get_integrations):
+        """Test when no organization integrations are found"""
+        mock_get_integrations.return_value = []
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": False}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+
+    @patch("sentry.api.endpoints.seer_rpc.options.get")
+    @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_no_consent(
+        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+    ):
+        """Test when organization exists but has no consent"""
+        from unittest.mock import Mock
+
+        mock_integration = Mock()
+        mock_integration.organization_id = self.organization.id
+        mock_get_integrations.return_value = [mock_integration]
+        mock_get_acknowledgement.return_value = False
+        mock_options_get.return_value = []  # No orgs in github-extension.enabled-orgs
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": False}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
+        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+
+    @patch("sentry.api.endpoints.seer_rpc.options.get")
+    @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_with_seer_acknowledgement(
+        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+    ):
+        """Test when organization has seer acknowledgement"""
+        from unittest.mock import Mock
+
+        mock_integration = Mock()
+        mock_integration.organization_id = self.organization.id
+        mock_get_integrations.return_value = [mock_integration]
+        mock_get_acknowledgement.return_value = True
+        mock_options_get.return_value = []  # No orgs in github-extension.enabled-orgs
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": True}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
+        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+
+    @patch("sentry.api.endpoints.seer_rpc.options.get")
+    @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_with_github_extension(
+        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+    ):
+        """Test when organization has github extension enabled"""
+        from unittest.mock import Mock
+
+        mock_integration = Mock()
+        mock_integration.organization_id = self.organization.id
+        mock_get_integrations.return_value = [mock_integration]
+        mock_get_acknowledgement.return_value = False
+        mock_options_get.return_value = [
+            self.organization.id
+        ]  # Org in github-extension.enabled-orgs
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": True}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
+        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+
+    @patch("sentry.api.endpoints.seer_rpc.options.get")
+    @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_with_both_consents(
+        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+    ):
+        """Test when organization has both seer acknowledgement and github extension enabled"""
+        from unittest.mock import Mock
+
+        mock_integration = Mock()
+        mock_integration.organization_id = self.organization.id
+        mock_get_integrations.return_value = [mock_integration]
+        mock_get_acknowledgement.return_value = True
+        mock_options_get.return_value = [
+            self.organization.id
+        ]  # Org in github-extension.enabled-orgs
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": True}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+        mock_get_acknowledgement.assert_called_once_with(org_id=self.organization.id)
+        mock_options_get.assert_called_once_with("github-extension.enabled-orgs")
+
+    @patch("sentry.api.endpoints.seer_rpc.options.get")
+    @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_multiple_orgs_one_with_consent(
+        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+    ):
+        """Test when multiple organizations exist, one with consent"""
+        from unittest.mock import Mock
+
+        org_without_consent = self.create_organization()
+        org_with_consent = self.create_organization()
+
+        mock_integration_1 = Mock()
+        mock_integration_1.organization_id = org_without_consent.id
+        mock_integration_2 = Mock()
+        mock_integration_2.organization_id = org_with_consent.id
+
+        mock_get_integrations.return_value = [mock_integration_1, mock_integration_2]
+
+        # First org has no consent, second org has seer acknowledgement
+        mock_get_acknowledgement.side_effect = [False, True]
+        mock_options_get.return_value = []  # No orgs in github-extension.enabled-orgs
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": True}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+        # Should stop after finding first org with consent
+        assert mock_get_acknowledgement.call_count == 2
+
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_custom_provider(self, mock_get_integrations):
+        """Test with custom provider"""
+        mock_get_integrations.return_value = []
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org", provider="gitlab")
+
+        assert result == {"consent": False}
+        mock_get_integrations.assert_called_once_with(provider="gitlab", name="test-org")
+
+    @patch("sentry.api.endpoints.seer_rpc.options.get")
+    @patch("sentry.api.endpoints.seer_rpc.get_seer_org_acknowledgement")
+    @patch("sentry.api.endpoints.seer_rpc.integration_service.get_organization_integrations")
+    def test_get_organization_seer_consent_by_org_name_mixed_scenarios(
+        self, mock_get_integrations, mock_get_acknowledgement, mock_options_get
+    ):
+        """Test mixed scenario with non-existent org, org without consent, and org with consent"""
+        from unittest.mock import Mock
+
+        org_without_consent = self.create_organization()
+        org_with_consent = self.create_organization()
+
+        mock_integration_1 = Mock()
+        mock_integration_1.organization_id = 99999  # Non-existent org
+        mock_integration_2 = Mock()
+        mock_integration_2.organization_id = org_without_consent.id
+        mock_integration_3 = Mock()
+        mock_integration_3.organization_id = org_with_consent.id
+
+        mock_get_integrations.return_value = [
+            mock_integration_1,
+            mock_integration_2,
+            mock_integration_3,
+        ]
+
+        # Second org has no consent, third org has github extension enabled
+        mock_get_acknowledgement.side_effect = [False, False]
+        mock_options_get.return_value = [org_with_consent.id]
+
+        result = get_organization_seer_consent_by_org_name(org_name="test-org")
+
+        assert result == {"consent": True}
+        mock_get_integrations.assert_called_once_with(provider="github", name="test-org")
+        # Should be called twice (skips non-existent org, checks two existing orgs)
+        assert mock_get_acknowledgement.call_count == 2


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adds the `get_organization_seer_consent_by_org_name` to verify AI PR review and AI test gen requests. Since the install flow is via a GitHub app, we cannot be certain that an org exists within Sentry for the GitHub user. We call this function from Seer to verify that the user is able to run certain AI functionalities from there. 

Related: https://github.com/getsentry/seer/pull/2814

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
