### PR TITLE
chore(dashboards): Delete old SpanTagsProvider, rename useSpanTags

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -24,7 +24,7 @@ import {
   TraceItemSearchQueryBuilder,
   useSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 import {SpanIndexedField} from 'sentry/views/insights/types';
@@ -192,8 +192,8 @@ function IndexedSpanSearchQueryBuilder({
 }
 
 function EapSpanSearchQueryBuilderWrapper(props: SpanSearchQueryBuilderProps) {
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   return (
     <EAPSpanSearchQueryBuilder

--- a/static/app/views/alerts/rules/metric/eapField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.spec.tsx
@@ -3,9 +3,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import EAPField from 'sentry/views/alerts/rules/metric/eapField';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 describe('EAPField', () => {
   const organization = OrganizationFixture();
@@ -20,9 +20,9 @@ describe('EAPField', () => {
 
   it('renders', () => {
     render(
-      <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
         <EAPField aggregate={'count(span.duration)'} onChange={() => {}} />
-      </SpanTagsProvider>
+      </TraceItemAttributeProvider>
     );
     expect(fieldsMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
@@ -49,9 +49,9 @@ describe('EAPField', () => {
 
   it('renders epm with argument disabled', () => {
     render(
-      <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
         <EAPField aggregate={'epm()'} onChange={() => {}} />
-      </SpanTagsProvider>
+      </TraceItemAttributeProvider>
     );
     expect(fieldsMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
@@ -78,9 +78,9 @@ describe('EAPField', () => {
 
   it('renders failure_rate with argument disabled', () => {
     render(
-      <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
         <EAPField aggregate={'failure_rate()'} onChange={() => {}} />
-      </SpanTagsProvider>
+      </TraceItemAttributeProvider>
     );
     expect(fieldsMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
@@ -108,9 +108,9 @@ describe('EAPField', () => {
   it('should call onChange with the new aggregate string when switching aggregates', async () => {
     const onChange = jest.fn();
     render(
-      <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+      <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
         <EAPField aggregate={'count(span.duration)'} onChange={onChange} />
-      </SpanTagsProvider>
+      </TraceItemAttributeProvider>
     );
     expect(fieldsMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
@@ -133,9 +133,9 @@ describe('EAPField', () => {
     function Component() {
       const [aggregate, setAggregate] = useState('count(span.duration)');
       return (
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <EAPField aggregate={aggregate} onChange={setAggregate} />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       );
     }
 
@@ -162,9 +162,9 @@ describe('EAPField', () => {
     function Component() {
       const [aggregate, setAggregate] = useState('count(span.duration)');
       return (
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <EAPField aggregate={aggregate} onChange={setAggregate} />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       );
     }
 

--- a/static/app/views/alerts/rules/metric/eapField.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.tsx
@@ -17,7 +17,7 @@ import {
   DEFAULT_VISUALIZATION_FIELD,
   updateVisualizeAggregate,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 const DEFAULT_EAP_AGGREGATION = 'count';
 const DEFAULT_EAP_FIELD = 'span.duration';
@@ -48,8 +48,8 @@ function EAPField({aggregate, onChange}: Props) {
     arguments: [field],
   } = parseFunction(aggregate) ?? {arguments: [undefined]};
 
-  const {tags: storedStringTags} = useSpanTags('string');
-  const {tags: storedNumberTags} = useSpanTags('number');
+  const {tags: storedStringTags} = useTraceItemTags('string');
+  const {tags: storedNumberTags} = useTraceItemTags('number');
   const storedTags =
     aggregation === AggregationKey.COUNT_UNIQUE ? storedStringTags : storedNumberTags;
   const numberTags: TagCollection = useMemo(() => {

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -71,7 +71,7 @@ import {
   DEPRECATED_TRANSACTION_ALERTS,
   getSupportedAndOmittedTags,
 } from 'sentry/views/alerts/wizard/options';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {
@@ -775,8 +775,8 @@ function EAPSpanSearchQueryBuilderWithContext({
   onSearch,
   project,
 }: EAPSpanSearchQueryBuilderWithContextProps) {
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
   return (
     <EAPSpanSearchQueryBuilder
       numberTags={numberTags}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -4,9 +4,9 @@ import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {TagValue} from 'sentry/types/group';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import SpansSearchBar from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 // The endpoint seems to just return these fields, but the original TagValue type
 // has extra fields related to user information that we don't seem to need.
@@ -19,9 +19,9 @@ function renderWithProvider({
   onClose,
 }: ComponentProps<typeof SpansSearchBar>) {
   return render(
-    <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} onClose={onClose} />
-    </SpanTagsProvider>
+    </TraceItemAttributeProvider>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -2,7 +2,7 @@ import {EAPSpanSearchQueryBuilder} from 'sentry/components/performance/spanSearc
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import type {WidgetBuilderSearchBarProps} from 'sentry/views/dashboards/datasetConfig/base';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 /**
  * A search bar for exploring tags and values for spans in Dashboards.
@@ -20,8 +20,8 @@ function SpansSearchBar({
   const {
     selection: {projects},
   } = usePageFilters();
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
   return (
     <EAPSpanSearchQueryBuilder
       initialQuery={widgetQuery.conditions}

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.spec.tsx
@@ -2,10 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 const organization = OrganizationFixture({
   features: [],
@@ -22,9 +22,9 @@ describe('WidgetBuilderGroupBySelector', function () {
   it('renders', async function () {
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         organization,
@@ -39,9 +39,9 @@ describe('WidgetBuilderGroupBySelector', function () {
   it('renders the group by field and can function', async function () {
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderGroupBySelector validatedWidgetResponse={{} as any} />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         organization,

--- a/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/groupBySelector.tsx
@@ -13,7 +13,7 @@ import {GroupBySelector} from 'sentry/views/dashboards/widgetBuilder/buildSteps/
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 interface WidgetBuilderGroupBySelectorProps {
   validatedWidgetResponse: UseApiQueryResult<ValidateWidgetResponse, RequestError>;
@@ -27,8 +27,8 @@ function WidgetBuilderGroupBySelector({
   const organization = useOrganization();
 
   let tags: TagCollection = useTags();
-  const {tags: numericSpanTags} = useSpanTags('number');
-  const {tags: stringSpanTags} = useSpanTags('string');
+  const {tags: numericSpanTags} = useTraceItemTags('number');
+  const {tags: stringSpanTags} = useTraceItemTags('string');
   if (state.dataset === WidgetType.SPANS) {
     tags = {...numericSpanTags, ...stringSpanTags};
   }

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -18,7 +18,6 @@ import {space} from 'sentry/styles/space';
 import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {useDimensions} from 'sentry/utils/useDimensions';
@@ -51,7 +50,8 @@ import {
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useNavContext} from 'sentry/views/nav/context';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
@@ -164,8 +164,8 @@ function WidgetBuilderV2({
                   organization={organization}
                   selection={selection}
                 >
-                  <SpanTagsProvider
-                    dataset={DiscoverDatasets.SPANS_EAP}
+                  <TraceItemAttributeProvider
+                    traceItemType={TraceItemDataset.SPANS}
                     enabled={organization.features.includes('visibility-explore-view')}
                   >
                     <ContainerWithoutSidebar
@@ -227,7 +227,7 @@ function WidgetBuilderV2({
                         )}
                       </WidgetBuilderContainer>
                     </ContainerWithoutSidebar>
-                  </SpanTagsProvider>
+                  </TraceItemAttributeProvider>
                 </CustomMeasurementsProvider>
               </WidgetBuilderProvider>
             )}

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -9,7 +9,7 @@ import useCustomMeasurements from 'sentry/utils/useCustomMeasurements';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetBuilderQueryFilterBuilder from 'sentry/views/dashboards/widgetBuilder/components/queryFilterBuilder';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
@@ -21,7 +21,7 @@ describe('QueryFilterBuilder', () => {
       features: [],
     });
     jest.mocked(useCustomMeasurements).mockReturnValue({customMeasurements: {}});
-    jest.mocked(useSpanTags).mockReturnValue({tags: {}, isLoading: false});
+    jest.mocked(useTraceItemTags).mockReturnValue({tags: {}, isLoading: false});
 
     MockApiClient.addMockResponse({url: '/organizations/org-slug/recent-searches/'});
   });

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -5,11 +5,11 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import WidgetBuilderSortBySelector from 'sentry/views/dashboards/widgetBuilder/components/sortBySelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {ELLIPSIS} from 'sentry/views/insights/common/utils/centerTruncate';
 
 jest.mock('sentry/utils/useNavigate', () => ({
@@ -51,9 +51,9 @@ describe('WidgetBuilderSortBySelector', function () {
   it('renders', async function () {
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router,
@@ -79,9 +79,9 @@ describe('WidgetBuilderSortBySelector', function () {
 
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router: tableRouter,
@@ -101,9 +101,9 @@ describe('WidgetBuilderSortBySelector', function () {
 
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router,
@@ -142,9 +142,9 @@ describe('WidgetBuilderSortBySelector', function () {
   it('renders the correct limit options', async function () {
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router,
@@ -169,9 +169,9 @@ describe('WidgetBuilderSortBySelector', function () {
 
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router: moreAggregatesRouter,
@@ -190,9 +190,9 @@ describe('WidgetBuilderSortBySelector', function () {
 
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router,
@@ -250,9 +250,9 @@ describe('WidgetBuilderSortBySelector', function () {
 
     render(
       <WidgetBuilderProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <WidgetBuilderSortBySelector />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </WidgetBuilderProvider>,
       {
         router,

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -25,7 +25,7 @@ import {
   SortDirection,
 } from 'sentry/views/dashboards/widgetBuilder/utils';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 function WidgetBuilderSortBySelector() {
   const {state, dispatch} = useWidgetBuilderContext();
@@ -37,8 +37,8 @@ function WidgetBuilderSortBySelector() {
   const datasetConfig = getDatasetConfig(state.dataset);
 
   let tags: TagCollection = useTags();
-  const {tags: numericSpanTags} = useSpanTags('number');
-  const {tags: stringSpanTags} = useSpanTags('string');
+  const {tags: numericSpanTags} = useTraceItemTags('number');
+  const {tags: stringSpanTags} = useTraceItemTags('string');
   if (state.dataset === WidgetType.SPANS) {
     tags = {...numericSpanTags, ...stringSpanTags};
   }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -11,7 +11,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import Visualize from 'sentry/views/dashboards/widgetBuilder/components/visualize';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
@@ -28,7 +28,7 @@ describe('Visualize', () => {
 
     jest.mocked(useCustomMeasurements).mockReturnValue({customMeasurements: {}});
 
-    jest.mocked(useSpanTags).mockImplementation((type?: 'number' | 'string') => {
+    jest.mocked(useTraceItemTags).mockImplementation((type?: 'number' | 'string') => {
       if (type === 'number') {
         const tags: TagCollection = {
           'span.duration': {
@@ -1247,7 +1247,7 @@ describe('Visualize', () => {
 
   describe('spans', () => {
     beforeEach(() => {
-      jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {
+      jest.mocked(useTraceItemTags).mockImplementation((type?: 'string' | 'number') => {
         if (type === 'number') {
           return {
             tags: {
@@ -1416,7 +1416,7 @@ describe('Visualize', () => {
     });
 
     it('differentiates between function and column values in selection', async () => {
-      jest.mocked(useSpanTags).mockImplementation((type?: 'string' | 'number') => {
+      jest.mocked(useTraceItemTags).mockImplementation((type?: 'string' | 'number') => {
         if (type === 'number') {
           return {
             tags: {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -52,7 +52,7 @@ import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
 import {validateColumnTypes} from 'sentry/views/discover/table/queryField';
 import {type FieldValue, FieldValueKind} from 'sentry/views/discover/table/types';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 export const NONE = 'none';
 
@@ -255,8 +255,8 @@ function Visualize({error, setError}: VisualizeProps) {
     state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER;
   const isBigNumberWidget = state.displayType === DisplayType.BIG_NUMBER;
-  const {tags: numericSpanTags} = useSpanTags('number');
-  const {tags: stringSpanTags} = useSpanTags('string');
+  const {tags: numericSpanTags} = useTraceItemTags('number');
+  const {tags: stringSpanTags} = useTraceItemTags('string');
 
   // Span column options are explicitly defined and bypass all of the
   // fieldOptions filtering and logic used for showing options for

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -18,7 +18,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import WidgetBuilderSlideout from 'sentry/views/dashboards/widgetBuilder/components/widgetBuilderSlideout';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 jest.mock('sentry/utils/useCustomMeasurements');
 jest.mock('sentry/views/explore/contexts/spanTagsContext');
@@ -32,7 +32,7 @@ describe('WidgetBuilderSlideout', () => {
 
     jest.mocked(useCustomMeasurements).mockReturnValue({customMeasurements: {}});
 
-    jest.mocked(useSpanTags).mockReturnValue({tags: {}, isLoading: false});
+    jest.mocked(useTraceItemTags).mockReturnValue({tags: {}, isLoading: false});
 
     jest.mocked(useParams).mockReturnValue({widgetIndex: undefined});
 

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -2,11 +2,11 @@ import Feature from 'sentry/components/acl/feature';
 import {Alert} from 'sentry/components/core/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 import WidgetBuilder from './widgetBuilder';
 
@@ -28,8 +28,8 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
         </Layout.Page>
       )}
     >
-      <SpanTagsProvider
-        dataset={DiscoverDatasets.SPANS_EAP}
+      <TraceItemAttributeProvider
+        traceItemType={TraceItemDataset.SPANS}
         enabled={organization.features.includes('visibility-explore-view')}
       >
         <WidgetBuilder
@@ -43,7 +43,7 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
             })
           }
         />
-      </SpanTagsProvider>
+      </TraceItemAttributeProvider>
     </Feature>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -72,7 +72,7 @@ import {
   DashboardsMEPProvider,
 } from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {MetricsDataSwitcher} from 'sentry/views/performance/landing/metricsDataSwitcher';
 
 import {BuildStep} from './buildSteps/buildStep';
@@ -300,8 +300,8 @@ function WidgetBuilder({
   let tags: TagCollection = useTags();
 
   // HACK: Inject EAP dataset tags when selecting the Spans dataset
-  const {tags: numericSpanTags} = useSpanTags('number');
-  const {tags: stringSpanTags} = useSpanTags('string');
+  const {tags: numericSpanTags} = useTraceItemTags('number');
+  const {tags: stringSpanTags} = useTraceItemTags('string');
   if (state.dataSet === DataSet.SPANS) {
     tags = {...numericSpanTags, ...stringSpanTags};
   }

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -1,43 +1,9 @@
-import type React from 'react';
+import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 
-import type {Project} from 'sentry/types/project';
-import type {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {
-  TraceItemAttributeProvider,
-  useTraceItemAttributes,
-} from 'sentry/views/explore/contexts/traceItemAttributeContext';
-import {TraceItemDataset} from 'sentry/views/explore/types';
-
-interface SpanTagsProviderProps {
-  children: React.ReactNode;
-  dataset: DiscoverDatasets;
-  enabled: boolean;
-  projects?: Project[];
-}
-
-export function SpanTagsProvider({children, enabled, projects}: SpanTagsProviderProps) {
-  return (
-    <TraceItemAttributeProvider
-      traceItemType={TraceItemDataset.SPANS}
-      enabled={enabled}
-      projects={projects}
-    >
-      {children}
-    </TraceItemAttributeProvider>
-  );
-}
-
-export function useSpanTags(type?: 'number' | 'string') {
+export function useTraceItemTags(type?: 'number' | 'string') {
   const {attributes, isLoading} = useTraceItemAttributes(type);
   return {
     tags: attributes,
     isLoading,
   };
-}
-
-export function useSpanTag(key: string) {
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
-
-  return stringTags[key] ?? numberTags[key] ?? null;
 }

--- a/static/app/views/explore/hooks/useSortByFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.spec.tsx
@@ -5,13 +5,13 @@ import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
@@ -23,9 +23,9 @@ function createWrapper(organization: Organization) {
       <QueryClientProvider client={makeTestQueryClient()}>
         <OrganizationContext value={organization}>
           <PageParamsProvider>
-            <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+            <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
               {children}
-            </SpanTagsProvider>
+            </TraceItemAttributeProvider>
           </PageParamsProvider>
         </OrganizationContext>
       </QueryClientProvider>

--- a/static/app/views/explore/hooks/useSortByFields.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.tsx
@@ -5,13 +5,13 @@ import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/field
 import {classifyTagKey, prettifyTagKey} from 'sentry/utils/fields';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 
 type Props = {fields: string[]; groupBys: string[]; mode: Mode; yAxes: string[]};
 
 export function useSortByFields({fields, yAxes, groupBys, mode}: Props) {
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const fieldOptions: Array<SelectOption<string>> = useMemo(() => {
     const uniqueOptions: string[] = [];

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -6,15 +6,13 @@ import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
-import {
-  SpanTagsProvider,
-  useSpanTags,
-} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
@@ -26,9 +24,9 @@ function createWrapper(organization: Organization) {
       <QueryClientProvider client={makeTestQueryClient()}>
         <OrganizationContext value={organization}>
           <PageParamsProvider>
-            <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+            <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
               {children}
-            </SpanTagsProvider>
+            </TraceItemAttributeProvider>
           </PageParamsProvider>
         </OrganizationContext>
       </QueryClientProvider>
@@ -37,8 +35,8 @@ function createWrapper(organization: Organization) {
 }
 
 function useWrapper(yAxis: string) {
-  const {tags: stringTags} = useSpanTags('string');
-  const {tags: numberTags} = useSpanTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
   return useVisualizeFields({
     numberTags,
     stringTags,

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -10,11 +10,11 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {PageParamsProvider} from 'sentry/views/explore/contexts/pageParamsContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {MultiQueryModeContent} from 'sentry/views/explore/multiQueryMode/content';
 import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 jest.mock('sentry/components/lazyRender', () => ({
   LazyRender: ({children}: {children: React.ReactNode}) => children,
@@ -99,9 +99,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -118,9 +118,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -187,9 +187,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -208,9 +208,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -279,9 +279,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -348,9 +348,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -369,9 +369,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -458,9 +458,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -512,9 +512,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -554,9 +554,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -602,9 +602,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -650,9 +650,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -701,9 +701,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -761,9 +761,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -828,9 +828,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -938,9 +938,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -1085,9 +1085,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -1144,9 +1144,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <MultiQueryModeContent />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,
@@ -1226,9 +1226,9 @@ describe('MultiQueryModeContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <MultiQueryModeContent />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,

--- a/static/app/views/explore/multiQueryMode/content.tsx
+++ b/static/app/views/explore/multiQueryMode/content.tsx
@@ -26,9 +26,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
-import {useExploreDataset} from 'sentry/views/explore/contexts/pageParamsContext';
 import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useSaveMultiQuery} from 'sentry/views/explore/hooks/useSaveMultiQuery';
 import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
@@ -37,6 +36,7 @@ import {
   useReadQueriesFromLocation,
 } from 'sentry/views/explore/multiQueryMode/locationUtils';
 import {QueryRow} from 'sentry/views/explore/multiQueryMode/queryRow';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 
 export const MAX_QUERIES_ALLOWED = 5;
@@ -204,11 +204,10 @@ function Content() {
 }
 
 export function MultiQueryModeContent() {
-  const dataset = useExploreDataset();
   return (
-    <SpanTagsProvider dataset={dataset} enabled>
+    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       <Content />
-    </SpanTagsProvider>
+    </TraceItemAttributeProvider>
   );
 }
 

--- a/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/groupBy.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {CompactSelect, type SelectOption} from 'sentry/components/core/compactSelect';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {
   type ReadableExploreQueryParts,
@@ -18,7 +18,7 @@ import {
 type Props = {index: number; query: ReadableExploreQueryParts};
 
 export function GroupBySection({query, index}: Props) {
-  const {tags} = useSpanTags();
+  const {tags} = useTraceItemTags();
 
   const updateGroupBys = useUpdateQueryAtIndex(index);
 

--- a/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
@@ -2,7 +2,7 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import {EAPSpanSearchQueryBuilder} from 'sentry/components/performance/spanSearchQueryBuilder';
 import {t} from 'sentry/locale';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {
   type ReadableExploreQueryParts,
   useUpdateQueryAtIndex,
@@ -17,8 +17,8 @@ type Props = {index: number; query: ReadableExploreQueryParts};
 
 export function SearchBarSection({query, index}: Props) {
   const {selection} = usePageFilters();
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const updateQuerySearch = useUpdateQueryAtIndex(index);
 

--- a/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/visualize.tsx
@@ -10,7 +10,7 @@ import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {updateVisualizeAggregate} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {
   type ReadableExploreQueryParts,
@@ -28,8 +28,8 @@ type Props = {
 };
 
 export function VisualizeSection({query, index}: Props) {
-  const {tags: stringTags} = useSpanTags('string');
-  const {tags: numberTags} = useSpanTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
 
   const parsedFunction = findFirstFunction(query.yAxes);
 

--- a/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
+++ b/static/app/views/explore/multiQueryMode/queryVisualizations/table.tsx
@@ -30,7 +30,7 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {TOP_EVENTS_LIMIT} from 'sentry/views/explore/hooks/useTopEvents';
@@ -95,8 +95,8 @@ function AggregatesTable({
 
   const columns = useMemo(() => eventView.getColumns(), [eventView]);
 
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const tableRef = useRef<HTMLTableElement>(null);
   const {initialTableStyles} = useTableStyles(fields, tableRef, {
@@ -231,8 +231,8 @@ function SpansTable({spansTableResult, query: queryParts, index}: SampleTablePro
     [fields]
   );
 
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const tableRef = useRef<HTMLTableElement>(null);
   const {initialTableStyles} = useTableStyles(visibleFields, tableRef, {

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -19,11 +19,10 @@ import ExploreBreadcrumb from 'sentry/views/explore/components/breadcrumb';
 import {TraceExploreAiQueryProvider} from 'sentry/views/explore/components/traceExploreAiQueryProvider';
 import {
   PageParamsProvider,
-  useExploreDataset,
   useExploreId,
   useExploreTitle,
 } from 'sentry/views/explore/contexts/pageParamsContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
 import {SpansTabContent, SpansTabOnboarding} from 'sentry/views/explore/spans/spansTab';
@@ -35,6 +34,7 @@ import {
   useExploreSpansTourModal,
 } from 'sentry/views/explore/spans/tour';
 import {StarSavedQueryButton} from 'sentry/views/explore/starSavedQueryButton';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
@@ -115,12 +115,10 @@ function SpansTabTourTrigger() {
 }
 
 function ExploreTagsProvider({children}: SpansTabContextProps) {
-  const dataset = useExploreDataset();
-
   return (
-    <SpanTagsProvider dataset={dataset} enabled>
+    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       {children}
-    </SpanTagsProvider>
+    </TraceItemAttributeProvider>
   );
 }
 

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -4,7 +4,6 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {FieldKind} from 'sentry/utils/fields';
 import {
   PageParamsProvider,
@@ -12,8 +11,9 @@ import {
   useExploreGroupBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import * as spanTagsModule from 'sentry/views/explore/contexts/spanTagsContext';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import type {PickableDays} from 'sentry/views/explore/utils';
 
 jest.mock('sentry/utils/analytics');
@@ -93,9 +93,9 @@ describe('SpansTabContent', function () {
   it('should fire analytics once per change', async function () {
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP_RPC} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <SpansTabContent datePageFilterProps={datePageFilterProps} />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {organization}
     );
@@ -139,9 +139,9 @@ describe('SpansTabContent', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP_RPC} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {organization}
     );
@@ -186,7 +186,7 @@ describe('SpansTabContent', function () {
 
     beforeEach(function () {
       const useSpanTagsSpy = jest
-        .spyOn(spanTagsModule, 'useSpanTags')
+        .spyOn(spanTagsModule, 'useTraceItemTags')
         .mockImplementation(type => {
           switch (type) {
             case 'number':

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -53,7 +53,7 @@ import {
   useSetExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {useChartInterval} from 'sentry/views/explore/hooks/useChartInterval';
 import {useExploreAggregatesTable} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
@@ -164,8 +164,8 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
   const query = useExploreQuery();
   const setExplorePageParams = useSetExplorePageParams();
 
-  const {tags: numberTags, isLoading: numberTagsLoading} = useSpanTags('number');
-  const {tags: stringTags, isLoading: stringTagsLoading} = useSpanTags('string');
+  const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
+  const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
 
   const search = useMemo(() => new MutableSearch(query), [query]);
   const oldSearch = usePrevious(search);

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -38,7 +38,7 @@ import {
   useExploreVisualizes,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 import {TOP_EVENTS_LIMIT, useTopEvents} from 'sentry/views/explore/hooks/useTopEvents';
@@ -74,8 +74,8 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
 
   const meta = result.meta ?? {};
 
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const numberOfRowsNeedingColor = Math.min(result.data?.length ?? 0, TOP_EVENTS_LIMIT);
 

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -19,7 +19,7 @@ import {
   useSetExploreMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {AggregatesTableResult} from 'sentry/views/explore/hooks/useExploreAggregatesTable';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import type {TracesTableResult} from 'sentry/views/explore/hooks/useExploreTracesTable';
@@ -54,8 +54,8 @@ export function ExploreTables(props: ExploreTablesProps) {
   const fields = useExploreFields();
   const setFields = useSetExploreFields();
 
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const openColumnEditor = useCallback(() => {
     openModal(

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -27,7 +27,7 @@ import {
   useExploreSortBys,
   useSetExploreSortBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
 
@@ -60,8 +60,8 @@ export function SpansTable({spansTableResult}: SpansTableProps) {
 
   const meta = result.meta ?? {};
 
-  const {tags: numberTags} = useSpanTags('number');
-  const {tags: stringTags} = useSpanTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
 
   const paginationAnalyticsEvent = usePaginationAnalytics(
     'samples',

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -12,7 +12,6 @@ import {
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   PageParamsProvider,
   useExploreFields,
@@ -23,8 +22,9 @@ import {
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 jest.mock('sentry/actionCreators/modal');
 
@@ -58,9 +58,9 @@ describe('ExploreToolbar', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -81,9 +81,9 @@ describe('ExploreToolbar', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -117,9 +117,9 @@ describe('ExploreToolbar', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -144,9 +144,9 @@ describe('ExploreToolbar', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -186,9 +186,9 @@ describe('ExploreToolbar', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -231,9 +231,9 @@ describe('ExploreToolbar', function () {
 
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -295,9 +295,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -347,9 +347,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -376,9 +376,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -401,9 +401,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>
     );
 
@@ -465,9 +465,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,
@@ -505,9 +505,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,
@@ -548,9 +548,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,
@@ -632,9 +632,9 @@ describe('ExploreToolbar', function () {
     }
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,
@@ -659,9 +659,9 @@ describe('ExploreToolbar', function () {
     router.push(router.location);
     render(
       <PageParamsProvider>
-        <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP} enabled>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
           <Component />
-        </SpanTagsProvider>
+        </TraceItemAttributeProvider>
       </PageParamsProvider>,
       {
         router,

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -18,7 +18,7 @@ import {
   useSetExploreGroupBys,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 
@@ -36,7 +36,7 @@ interface ToolbarGroupBy {
 }
 
 export function ToolbarGroupBy({autoSwitchToAggregates}: ToolbarGroupBy) {
-  const {tags} = useSpanTags();
+  const {tags} = useTraceItemTags();
 
   const groupBys = useExploreGroupBys();
   const setGroupBys = useSetExploreGroupBys();

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -21,7 +21,7 @@ import {
   updateVisualizeAggregate,
   Visualize,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
-import {useSpanTags} from 'sentry/views/explore/contexts/spanTagsContext';
+import {useTraceItemTags} from 'sentry/views/explore/contexts/spanTagsContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 
 import {
@@ -136,8 +136,8 @@ function VisualizeDropdown({
   yAxis,
   label,
 }: VisualizeDropdownProps) {
-  const {tags: stringTags} = useSpanTags('string');
-  const {tags: numberTags} = useSpanTags('number');
+  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags} = useTraceItemTags('number');
 
   const parsedFunction = useMemo(() => parseFunction(yAxis), [yAxis]);
 

--- a/static/app/views/insights/pages/insightsSpanTagProvider.tsx
+++ b/static/app/views/insights/pages/insightsSpanTagProvider.tsx
@@ -1,10 +1,10 @@
-import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {SpanTagsProvider} from 'sentry/views/explore/contexts/spanTagsContext';
+import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export function InsightsSpanTagProvider({children}: {children: React.ReactNode}) {
   return (
-    <SpanTagsProvider dataset={DiscoverDatasets.SPANS_EAP_RPC} enabled>
+    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
       {children}
-    </SpanTagsProvider>
+    </TraceItemAttributeProvider>
   );
 }


### PR DESCRIPTION
This provider hardcoded spans, and wasn't needed anymore. Let's move to a logs-inclusive world!