### PR TITLE
feat(browser-reports): Validate both browser report formats

### DIFF
--- a/src/sentry/issues/endpoints/browser_reporting_collector.py
+++ b/src/sentry/issues/endpoints/browser_reporting_collector.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
-from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework import serializers
 from rest_framework.parsers import JSONParser
 from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK, HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY
 
 from sentry import options
 from sentry.api.api_owners import ApiOwner
@@ -17,30 +18,46 @@ from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
-# Known browser report types as defined by the Browser Reporting API specification
-BrowserReportType = Literal[
-    # Core report types (always sent to 'default' endpoint)
-    "deprecation",  # Deprecated API usage
-    "intervention",  # Browser interventions/blocks
-    "crash",  # Browser crashes
-    # Policy violation report types (can be sent to named endpoints)
-    "csp-violation",  # Content Security Policy violations
-    "coep",  # Cross-Origin-Embedder-Policy violations
-    "coop",  # Cross-Origin-Opener-Policy violations
-    "document-policy-violation",  # Document Policy violations
-    "permissions-policy",  # Permissions Policy violations
+BROWSER_REPORT_TYPES = [
+    "deprecation",
+    "intervention",
+    "crash",
+    "csp-violation",
+    "coep",
+    "coop",
+    "document-policy-violation",
+    "permissions-policy",
 ]
 
 
-@dataclass
-class BrowserReport:
-    body: dict[str, Any]
-    type: BrowserReportType
-    url: str
-    user_agent: str
-    destination: str
-    timestamp: int
-    attempts: int
+# Working Draft https://www.w3.org/TR/reporting-1/#concept-reports
+# Editor's Draft https://w3c.github.io/reporting/#concept-reports
+# We need to support both
+class BrowserReportSerializer(serializers.Serializer[Any]):
+    """Serializer for validating browser report data structure."""
+
+    body = serializers.DictField()
+    type = serializers.ChoiceField(choices=BROWSER_REPORT_TYPES)
+    url = serializers.URLField()
+    user_agent = serializers.CharField()
+    destination = serializers.CharField()
+    attempts = serializers.IntegerField(min_value=1)
+    # Fields that do not overlap between specs
+    # We need to support both specs
+    age = serializers.IntegerField(required=False)
+    timestamp = serializers.IntegerField(required=False, min_value=0)
+
+    def validate_timestamp(self, value: int) -> int:
+        """Validate that age is absent, but timestamp is present."""
+        if self.initial_data.get("age"):
+            raise serializers.ValidationError("If timestamp is present, age must be absent")
+        return value
+
+    def validate_age(self, value: int) -> int:
+        """Validate that age is present, but not timestamp."""
+        if self.initial_data.get("timestamp"):
+            raise serializers.ValidationError("If age is present, timestamp must be absent")
+        return value
 
 
 class BrowserReportsJSONParser(JSONParser):
@@ -63,17 +80,15 @@ class BrowserReportingCollectorEndpoint(Endpoint):
     permission_classes = ()
     # Support both standard JSON and browser reporting API content types
     parser_classes = [BrowserReportsJSONParser, JSONParser]
-    publish_status = {
-        "POST": ApiPublishStatus.PRIVATE,
-    }
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
     owner = ApiOwner.ISSUES
 
     # CSRF exemption and CORS support required for Browser Reporting API
     @csrf_exempt
     @allow_cors_options
-    def post(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         if not options.get("issues.browser_reporting.collector_endpoint_enabled"):
-            return HttpResponse(status=404)
+            return Response(status=HTTP_404_NOT_FOUND)
 
         logger.info("browser_report_received", extra={"request_body": request.data})
 
@@ -86,14 +101,30 @@ class BrowserReportingCollectorEndpoint(Endpoint):
                 "browser_report_invalid_format",
                 extra={"data_type": type(raw_data).__name__, "data": raw_data},
             )
-            return HttpResponse(status=422)
+            return Response(status=HTTP_422_UNPROCESSABLE_ENTITY)
 
+        # Validate each report in the array
+        validated_reports = []
         for report in raw_data:
-            browser_report = BrowserReport(**report)
+            serializer = BrowserReportSerializer(data=report)
+            if not serializer.is_valid():
+                logger.warning(
+                    "browser_report_validation_failed",
+                    extra={"validation_errors": serializer.errors, "raw_report": report},
+                )
+                return Response(
+                    {"error": "Invalid report data", "details": serializer.errors},
+                    status=HTTP_422_UNPROCESSABLE_ENTITY,
+                )
+
+            validated_reports.append(serializer.validated_data)
+
+        # Process all validated reports
+        for browser_report in validated_reports:
             metrics.incr(
                 "browser_reporting.raw_report_received",
-                tags={"browser_report_type": browser_report.type},
+                tags={"browser_report_type": str(browser_report["type"])},
                 sample_rate=1.0,  # XXX: Remove this once we have a ballpark figure
             )
 
-        return HttpResponse(status=200)
+        return Response(status=HTTP_200_OK)

--- a/tests/sentry/api/endpoints/test_browser_reporting_collector.py
+++ b/tests/sentry/api/endpoints/test_browser_reporting_collector.py
@@ -1,7 +1,9 @@
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.response import Response
 
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
@@ -49,16 +51,20 @@ class BrowserReportingCollectorEndpointTest(APITestCase):
         self.url = reverse(self.endpoint)
         self.report_data = [DEPRECATION_REPORT]
 
+    def assert_invalid_report_data(self, response: Response, details: dict[str, list[str]]) -> None:
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        response_data = response.json()  # type: ignore[attr-defined]
+        assert response_data["error"] == "Invalid report data"
+        assert response_data["details"] == details
+
     def test_404s_by_default(self) -> None:
         response = self.client.post(self.url, self.report_data)
-
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     @patch("sentry.issues.endpoints.browser_reporting_collector.metrics.incr")
-    def test_logs_request_data_if_option_enabled(self, mock_metrics_incr: MagicMock) -> None:
+    def test_basic(self, mock_metrics_incr: MagicMock) -> None:
         response = self.client.post(self.url, self.report_data)
-
         assert response.status_code == status.HTTP_200_OK
         mock_metrics_incr.assert_any_call(
             "browser_reporting.raw_report_received",
@@ -71,7 +77,6 @@ class BrowserReportingCollectorEndpointTest(APITestCase):
     def test_rejects_invalid_content_type(self, mock_metrics_incr: MagicMock) -> None:
         """Test that the endpoint rejects invalid content type and does not call the browser reporting metric"""
         response = self.client.post(self.url, self.report_data, content_type="bad/type/json")
-
         assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
         # Verify that the browser_reporting.raw_report_received metric was not called
         # Check that none of the calls were for the browser_reporting.raw_report_received metric
@@ -83,9 +88,7 @@ class BrowserReportingCollectorEndpointTest(APITestCase):
     def test_handles_multiple_reports_both_specs(self, mock_metrics_incr: MagicMock) -> None:
         """Test that the endpoint handles multiple reports in a single request"""
         multiple_reports = [DEPRECATION_REPORT, INTERVENTION_REPORT]
-
         response = self.client.post(self.url, multiple_reports)
-
         assert response.status_code == status.HTTP_200_OK
         # Should record metrics for each report type
         mock_metrics_incr.assert_any_call(
@@ -102,167 +105,71 @@ class BrowserReportingCollectorEndpointTest(APITestCase):
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_missing_required_fields(self) -> None:
         """Test that missing required fields are properly validated"""
-        # Missing required fields: url, user_agent, destination, attempts
-        invalid_report = [{"body": {"message": "test"}, "type": "deprecation"}]
-
-        response = self.client.post(self.url, invalid_report)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-
-        assert response_data["details"] == {
-            "url": ["This field is required."],
-            "user_agent": ["This field is required."],
-            "destination": ["This field is required."],
-            "attempts": ["This field is required."],
-        }
+        report = deepcopy(DEPRECATION_REPORT)
+        del report["user_agent"]
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(response, {"user_agent": ["This field is required."]})
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_invalid_report_type(self) -> None:
         """Test that invalid report types are rejected"""
-        invalid_report = [
-            {
-                "body": {"message": "test"},
-                "type": "invalid-type",  # Invalid type
-                "url": "https://example.com",
-                "user_agent": "Mozilla/5.0",
-                "destination": "default",
-                "timestamp": 1640995200000,
-                "attempts": 1,
-            }
-        ]
-
-        response = self.client.post(self.url, invalid_report)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-        assert response_data["details"] == {"type": ['"invalid-type" is not a valid choice.']}
+        report = deepcopy(DEPRECATION_REPORT)
+        report["type"] = "invalid-type"
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(
+            response,
+            {"type": ['"invalid-type" is not a valid choice.']},
+        )
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_invalid_url(self) -> None:
         """Test that invalid URLs are rejected"""
-        invalid_report = [
-            {
-                "body": {"message": "test"},
-                "type": "deprecation",
-                "url": "not-a-valid-url",  # Invalid URL
-                "user_agent": "Mozilla/5.0",
-                "destination": "default",
-                "timestamp": 1640995200000,
-                "attempts": 1,
-            }
-        ]
-
-        response = self.client.post(self.url, invalid_report)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-        assert response_data["details"] == {
-            "url": ["Enter a valid URL."],
-        }
+        report = deepcopy(DEPRECATION_REPORT)
+        report["url"] = "not-a-valid-url"
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(response, {"url": ["Enter a valid URL."]})
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_invalid_timestamp(self) -> None:
         """Test that invalid timestamps are rejected"""
-        invalid_report = [
-            {
-                "body": {"message": "test"},
-                "type": "deprecation",
-                "url": "https://example.com",
-                "user_agent": "Mozilla/5.0",
-                "destination": "default",
-                "timestamp": -1,  # Negative timestamp
-                "attempts": 1,
-            }
-        ]
-
-        response = self.client.post(self.url, invalid_report)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-        assert response_data["details"] == {
-            "timestamp": ["Timestamp must be non-negative"],
-        }
+        report = deepcopy(DEPRECATION_REPORT)
+        report["timestamp"] = -1
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(
+            response, {"timestamp": ["Ensure this value is greater than or equal to 0."]}
+        )
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_invalid_attempts(self) -> None:
         """Test that invalid attempts values are rejected"""
-        invalid_report = [
-            {
-                "body": {"message": "test"},
-                "type": "deprecation",
-                "url": "https://example.com",
-                "user_agent": "Mozilla/5.0",
-                "destination": "default",
-                "timestamp": 1640995200000,
-                "attempts": 0,  # Must be at least 1
-            }
-        ]
-
-        response = self.client.post(self.url, invalid_report)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-        assert response_data["details"] == {
-            "attempts": ["Ensure this value is greater than or equal to 1."],
-        }
+        report = deepcopy(DEPRECATION_REPORT)
+        report["attempts"] = 0
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(
+            response, {"attempts": ["Ensure this value is greater than or equal to 1."]}
+        )
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_non_dict_body(self) -> None:
         """Test that non-dict body values are rejected"""
-        invalid_report = [
-            {
-                "body": "not-a-dict",  # Body must be a dict
-                "type": "deprecation",
-                "url": "https://example.com",
-                "user_agent": "Mozilla/5.0",
-                "destination": "default",
-                "timestamp": 1640995200000,
-                "attempts": 1,
-            }
-        ]
-
-        response = self.client.post(self.url, invalid_report)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-        assert response_data["details"] == {
-            "body": ['Expected a dictionary of items but got type "str".']
-        }
+        report = deepcopy(DEPRECATION_REPORT)
+        report["body"] = "not-a-dict"
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(
+            response,
+            {"body": ['Expected a dictionary of items but got type "str".']},
+        )
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
-    def test_validates_second_report_in_array(self) -> None:
-        """Test that validation errors in the second report are properly handled"""
-        invalid_reports = [
-            DEPRECATION_REPORT,
-            # This report has an invalid type
+    def test_mixed_fields(self) -> None:
+        """Test that mixed fields are rejected"""
+        report = deepcopy(DEPRECATION_REPORT)
+        report["age"] = 1
+        response = self.client.post(self.url, [report])
+        self.assert_invalid_report_data(
+            response,
             {
-                "body": {"message": "test"},
-                "type": "invalid-type",  # Invalid type
-                "url": "https://example.com",
-                "user_agent": "Mozilla/5.0",
-                "destination": "default",
-                "timestamp": 1640995200000,
-                "attempts": 1,
+                "age": ["If age is present, timestamp must be absent"],
+                "timestamp": ["If timestamp is present, age must be absent"],
             },
-        ]
-
-        response = self.client.post(self.url, invalid_reports)
-
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-        response_data = response.json()
-        assert response_data["error"] == "Invalid report data"
-        assert response_data["details"] == {"type": ['"invalid-type" is not a valid choice.']}
+        )


### PR DESCRIPTION
This validates both the [Working Draft](https://www.w3.org/TR/reporting-1/#concept-reports) and the [Editor's Draft](https://w3c.github.io/reporting/#concept-reports) formats.

Fixes [ID-730 - Accept current and upcoming data model](https://linear.app/getsentry/issue/ID-730/accept-current-and-upcoming-data-model).