### PR TITLE
feat(dashboards): Backfill positions when requested in starred endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/api/endpoints/organization_dashboards_starred.py
@@ -46,6 +46,15 @@ class OrganizationDashboardsStarredEndpoint(OrganizationEndpoint):
             organization=organization, user_id=request.user.id
         ).select_related("dashboard")
 
+        if favorites.filter(position__isnull=True).exists():
+            # Commit the order of the dashboards of this current response if there are any
+            # that don't have a position assigned
+            DashboardFavoriteUser.objects.reorder_favorite_dashboards(
+                organization=organization,
+                user_id=request.user.id,
+                new_dashboard_positions=[favorite.dashboard.id for favorite in favorites],
+            )
+
         def data_fn(offset, limit):
             return [favorite.dashboard for favorite in favorites[offset : offset + limit]]
 


### PR DESCRIPTION
If any of the dashboards that are requested have position unset, then take the order and commit them so the position is backfilled

There shouldn't be a scenario where there are positioned dashboards and unpositioned dashboards, but the test case shows that it can be handled. This is meant to fill in data for a user's first visit. When we see that the data is all backfilled we can remove the code related to this check.