### PR TITLE
chore(seer): optimize scanner rate limiting

### DIFF
--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -176,7 +176,7 @@ def is_seer_scanner_rate_limited(
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False, 0, 0
 
-    limit = options.get("seer.max_num_scanner_autotriggered_per_hour", 2000)
+    limit = options.get("seer.max_num_scanner_autotriggered_per_hour", 2500)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
         key="seer.scanner.auto_triggered",

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -176,7 +176,7 @@ def is_seer_scanner_rate_limited(
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False, 0, 0
 
-    limit = options.get("seer.max_num_scanner_autotriggered_per_hour", 1000)
+    limit = options.get("seer.max_num_scanner_autotriggered_per_hour", 2000)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
         key="seer.scanner.auto_triggered",

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -5,7 +5,7 @@ from typing import Any
 import sentry_sdk
 
 from sentry import features, options
-from sentry.autofix.utils import SeerAutomationSource, is_seer_scanner_rate_limited
+from sentry.autofix.utils import SeerAutomationSource
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.seer.issue_summary import get_issue_summary
@@ -29,17 +29,6 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     if not project.get_option("sentry:seer_scanner_automation"):
         return None
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
-        return None
-
-    is_rate_limited, current, limit = is_seer_scanner_rate_limited(project, group.organization)
-    if is_rate_limited:
-        sentry_sdk.set_tags(
-            {
-                "scanner_run_count": current,
-                "scanner_run_limit": limit,
-            }
-        )
-        logger.error("Seer scanner auto-trigger rate limit hit")
         return None
 
     from sentry import quotas

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -5,7 +5,7 @@ from typing import Any
 import sentry_sdk
 
 from sentry import features, options
-from sentry.autofix.utils import SeerAutomationSource
+from sentry.autofix.utils import SeerAutomationSource, is_seer_scanner_rate_limited
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.seer.issue_summary import get_issue_summary
@@ -29,6 +29,17 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     if not project.get_option("sentry:seer_scanner_automation"):
         return None
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
+        return None
+
+    is_rate_limited, current, limit = is_seer_scanner_rate_limited(project, group.organization)
+    if is_rate_limited:
+        sentry_sdk.set_tags(
+            {
+                "scanner_run_count": current,
+                "scanner_run_limit": limit,
+            }
+        )
+        logger.error("Seer scanner auto-trigger rate limit hit")
         return None
 
     from sentry import quotas

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -603,7 +603,7 @@ register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIA
 register("seer.max_num_autofix_autotriggered_per_hour", default=20, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per hour)
 register(
-    "seer.max_num_scanner_autotriggered_per_hour", default=1000, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "seer.max_num_scanner_autotriggered_per_hour", default=2000, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
 # Codecov Integration

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -603,7 +603,7 @@ register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIA
 register("seer.max_num_autofix_autotriggered_per_hour", default=20, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per hour)
 register(
-    "seer.max_num_scanner_autotriggered_per_hour", default=2000, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "seer.max_num_scanner_autotriggered_per_hour", default=2500, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
 # Codecov Integration


### PR DESCRIPTION
- Bump scanner rate limit to 2500 per hour. Since we now scan existing issues as well, and since we double-count in slack alerts, we're going to be hitting the rate limit a lot more. This is still respectable for budgets, capping at $7.50.
- Only increment and check rate limit _after_ we pass the quota check and are about to start a scanner task. Right now we're logging rate limit exceeded errors for customers without any quota.