### PR TITLE
fix(migrations): Fix broken org to group search migration

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,5 +1,8 @@
 {
   "mcpServers": {
-
+    "sentry": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@latest", "https://mcp.sentry.dev/sse"]
+    }
   }
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,5 @@
 {
   "mcpServers": {
-    "sentry": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://mcp.sentry.dev/sse"]
-    }
+
   }
 }

--- a/src/sentry/migrations/0917_convert_org_saved_searches_to_views.py
+++ b/src/sentry/migrations/0917_convert_org_saved_searches_to_views.py
@@ -19,6 +19,10 @@ def convert_org_saved_searches_to_views(
     org_saved_searches = SavedSearch.objects.filter(visibility=Visibility.ORGANIZATION)
 
     for saved_search in RangeQuerySetWrapperWithProgressBar(org_saved_searches):
+        # Skip saved searches that don't have an owner_id, as GroupSearchView requires a user_id
+        if saved_search.owner_id is None:
+            continue
+
         GroupSearchView.objects.update_or_create(
             organization=saved_search.organization,
             user_id=saved_search.owner_id,


### PR DESCRIPTION
This should fix getsentry/self-hosted#3766. That said it will cause data loss for the people who encountered the error as it will skip over the searches without an id. Not sure if this is the best approach as I'm not familiar with the issue.
