### PR TITLE
chore(seer): Add seer automation alert on subscription page after checkout

### DIFF
--- a/static/gsApp/views/amCheckout/steps/reviewAndConfirm.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reviewAndConfirm.spec.tsx
@@ -279,7 +279,7 @@ describe('AmCheckout > ReviewAndConfirm', function () {
       expect(router.location).toEqual(
         expect.objectContaining({
           pathname: `/settings/${organization.slug}/billing/overview/`,
-          query: {referrer: 'billing'},
+          query: {referrer: 'billing', showSeerAutomationAlert: 'true'},
         })
       )
     );

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -625,7 +625,14 @@ export async function submitCheckout(
     addSuccessMessage(t('Success'));
     recordAnalytics(organization, subscription, data, isMigratingPartnerAccount);
 
-    const justBoughtSeer = data.seer;
+    const alreadyHasSeer =
+      !isTrialPlan(subscription.plan) &&
+      subscription.reservedBudgets?.some(
+        budget =>
+          (budget.apiName as string as SelectableProduct) === SelectableProduct.SEER &&
+          budget.reservedBudget > 0
+      );
+    const justBoughtSeer = data.seer && !alreadyHasSeer;
 
     // refresh org and subscription state
     // useApi cancels open requests on unmount by default, so we create a new Client to ensure this

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -625,6 +625,8 @@ export async function submitCheckout(
     addSuccessMessage(t('Success'));
     recordAnalytics(organization, subscription, data, isMigratingPartnerAccount);
 
+    const justBoughtSeer = data.seer;
+
     // refresh org and subscription state
     // useApi cancels open requests on unmount by default, so we create a new Client to ensure this
     // request doesn't get cancelled
@@ -632,7 +634,9 @@ export async function submitCheckout(
     SubscriptionStore.loadData(organization.slug);
     browserHistory.push(
       normalizeUrl(
-        `/settings/${organization.slug}/billing/overview/?referrer=${referrer}`
+        `/settings/${organization.slug}/billing/overview/?referrer=${referrer}${
+          justBoughtSeer ? '&showSeerAutomationAlert=true' : ''
+        }`
       )
     );
   } catch (error) {

--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -6,6 +6,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 
 import type {Subscription} from 'getsentry/types';
+import SeerAutomationAlert from 'getsentry/views/subscriptionPage/seerAutomationAlert';
 
 import {SubscriptionCard} from './subscriptionCard';
 import {UsageCard} from './usageCard';
@@ -18,6 +19,7 @@ interface HeaderCardsProps {
 export function HeaderCards({organization, subscription}: HeaderCardsProps) {
   return (
     <ErrorBoundary mini>
+      <SeerAutomationAlert organization={organization} />
       <HeaderCardWrapper>
         <SubscriptionCard organization={organization} subscription={subscription} />
         <UsageCard organization={organization} subscription={subscription} />

--- a/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
@@ -15,7 +15,7 @@ const mockUseLocation = jest.mocked(useLocation);
 
 describe('SeerAutomationAlert', function () {
   const defaultOrganization = OrganizationFixture({
-    features: ['seer-added'],
+    features: ['seer-added', 'trigger-autofix-on-issue-summary'],
     slug: 'test-org',
   });
 
@@ -135,7 +135,7 @@ describe('SeerAutomationAlert', function () {
 
     expect(
       screen.getByText(
-        'Seer issue scans and fixes are running automatically at low settings'
+        'Seer issue scans and fixes run automatically at low settings by default'
       )
     ).toBeInTheDocument();
   });

--- a/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
@@ -46,7 +46,7 @@ describe('SeerAutomationAlert', function () {
 
     expect(
       screen.getByText(
-        'Seer issue scans and fixes are running automatically at low settings'
+        'Seer issue scans and fixes run automatically at low settings by default'
       )
     ).toBeInTheDocument();
     expect(

--- a/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
@@ -1,0 +1,150 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import {useLocation} from 'sentry/utils/useLocation';
+
+import SeerAutomationAlert from 'getsentry/views/subscriptionPage/seerAutomationAlert';
+
+jest.mock('sentry/utils/useDismissAlert');
+jest.mock('sentry/utils/useLocation');
+
+const mockUseDismissAlert = jest.mocked(useDismissAlert);
+const mockUseLocation = jest.mocked(useLocation);
+
+describe('SeerAutomationAlert', function () {
+  const defaultOrganization = OrganizationFixture({
+    features: ['seer-added'],
+    slug: 'test-org',
+  });
+
+  beforeEach(() => {
+    // Default mocks
+    mockUseDismissAlert.mockImplementation(() => ({
+      dismiss: jest.fn(),
+      isDismissed: false,
+    }));
+
+    mockUseLocation.mockImplementation(() => ({
+      query: {referrer: 'billing'},
+      pathname: '/settings/test-org/billing/overview/',
+      search: '?referrer=billing',
+      hash: '',
+      state: null,
+      key: 'test',
+      action: 'PUSH',
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders when all conditions are met', function () {
+    render(<SeerAutomationAlert organization={defaultOrganization} />);
+
+    expect(
+      screen.getByText(
+        'Seer issue scans and fixes are running automatically at low settings'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'You can configure how these work across all of your projects, including the threshold. Changing the threshold will affect how often they run and may impact your bill.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Manage Seer Automation Settings')).toBeInTheDocument();
+  });
+
+  it('has correct link to seer automation settings', function () {
+    render(<SeerAutomationAlert organization={defaultOrganization} />);
+
+    const link = screen.getByText('Manage Seer Automation Settings');
+    expect(link.closest('a')).toHaveAttribute('href', '/settings/test-org/seer/');
+  });
+
+  it('calls dismiss when close button is clicked', async function () {
+    const dismiss = jest.fn();
+    mockUseDismissAlert.mockImplementation(() => ({
+      dismiss,
+      isDismissed: false,
+    }));
+
+    render(<SeerAutomationAlert organization={defaultOrganization} />);
+
+    const dismissButton = screen.getByLabelText('Dismiss banner');
+    await userEvent.click(dismissButton);
+
+    expect(dismiss).toHaveBeenCalled();
+  });
+
+  it('does not render when dismissed', function () {
+    mockUseDismissAlert.mockImplementation(() => ({
+      dismiss: jest.fn(),
+      isDismissed: true,
+    }));
+
+    const {container} = render(
+      <SeerAutomationAlert organization={defaultOrganization} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when organization does not have seer-added feature', function () {
+    const organizationWithoutSeer = OrganizationFixture({
+      features: [], // No seer-added feature
+      slug: 'test-org',
+    });
+
+    const {container} = render(
+      <SeerAutomationAlert organization={organizationWithoutSeer} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when there is no referrer query parameter', function () {
+    mockUseLocation.mockImplementation(() => ({
+      query: {}, // No referrer
+      pathname: '/settings/test-org/billing/overview/',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'test',
+      action: 'PUSH',
+    }));
+
+    const {container} = render(
+      <SeerAutomationAlert organization={defaultOrganization} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders when there is any referrer query parameter', function () {
+    mockUseLocation.mockImplementation(() => ({
+      query: {referrer: 'checkout'},
+      pathname: '/settings/test-org/billing/overview/',
+      search: '?referrer=checkout',
+      hash: '',
+      state: null,
+      key: 'test',
+      action: 'PUSH',
+    }));
+
+    render(<SeerAutomationAlert organization={defaultOrganization} />);
+
+    expect(
+      screen.getByText(
+        'Seer issue scans and fixes are running automatically at low settings'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('uses correct dismiss key with organization id', function () {
+    render(<SeerAutomationAlert organization={defaultOrganization} />);
+
+    expect(mockUseDismissAlert).toHaveBeenCalledWith({
+      key: `${defaultOrganization.id}:seer-automation-billing-alert`,
+    });
+  });
+});

--- a/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/seerAutomationAlert.spec.tsx
@@ -27,9 +27,9 @@ describe('SeerAutomationAlert', function () {
     }));
 
     mockUseLocation.mockImplementation(() => ({
-      query: {referrer: 'billing'},
+      query: {showSeerAutomationAlert: 'true'},
       pathname: '/settings/test-org/billing/overview/',
-      search: '?referrer=billing',
+      search: '?showSeerAutomationAlert=true',
       hash: '',
       state: null,
       key: 'test',
@@ -103,9 +103,9 @@ describe('SeerAutomationAlert', function () {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('does not render when there is no referrer query parameter', function () {
+  it('does not render when there is no showSeerAutomationAlert query parameter', function () {
     mockUseLocation.mockImplementation(() => ({
-      query: {}, // No referrer
+      query: {}, // No showSeerAutomationAlert
       pathname: '/settings/test-org/billing/overview/',
       search: '',
       hash: '',
@@ -120,11 +120,11 @@ describe('SeerAutomationAlert', function () {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders when there is any referrer query parameter', function () {
+  it('renders when there is a showSeerAutomationAlert query parameter', function () {
     mockUseLocation.mockImplementation(() => ({
-      query: {referrer: 'checkout'},
+      query: {showSeerAutomationAlert: 'true'},
       pathname: '/settings/test-org/billing/overview/',
-      search: '?referrer=checkout',
+      search: '?showSeerAutomationAlert=true',
       hash: '',
       state: null,
       key: 'test',

--- a/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
@@ -25,6 +25,7 @@ export default function SeerAutomationAlert({organization}: SeerAutomationAlertP
   if (
     isDismissed ||
     !organization.features.includes('seer-added') ||
+    !organization.features.includes('trigger-autofix-on-issue-summary') ||
     !isCheckoutRedirect
   ) {
     return null;

--- a/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
@@ -16,7 +16,7 @@ interface SeerAutomationAlertProps {
 
 export default function SeerAutomationAlert({organization}: SeerAutomationAlertProps) {
   const location = useLocation();
-  const isCheckoutRedirect = !!location.query.referrer; // only show this alert when redirected to this page, such as from the checkout page
+  const isRedirectedFromCheckout = !!location.query.showSeerAutomationAlert;
 
   const {dismiss, isDismissed} = useDismissAlert({
     key: `${organization.id}:seer-automation-billing-alert`,
@@ -26,7 +26,7 @@ export default function SeerAutomationAlert({organization}: SeerAutomationAlertP
     isDismissed ||
     !organization.features.includes('seer-added') ||
     !organization.features.includes('trigger-autofix-on-issue-summary') ||
-    !isCheckoutRedirect
+    !isRedirectedFromCheckout
   ) {
     return null;
   }

--- a/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import Link from 'sentry/components/links/link';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import {useLocation} from 'sentry/utils/useLocation';
+
+interface SeerAutomationAlertProps {
+  organization: Organization;
+}
+
+export default function SeerAutomationAlert({organization}: SeerAutomationAlertProps) {
+  const location = useLocation();
+  const isCheckoutRedirect = !!location.query.referrer; // only show this alert when redirected to this page, such as from the checkout page
+
+  const {dismiss, isDismissed} = useDismissAlert({
+    key: `${organization.id}:seer-automation-billing-alert`,
+  });
+
+  if (
+    isDismissed ||
+    !organization.features.includes('seer-added') ||
+    !isCheckoutRedirect
+  ) {
+    return null;
+  }
+
+  return (
+    <Alert.Container>
+      <Alert
+        type="info"
+        showIcon
+        trailingItems={
+          <Button
+            icon={<IconClose />}
+            onClick={dismiss}
+            size="zero"
+            borderless
+            aria-label={t('Dismiss banner')}
+          />
+        }
+      >
+        <AlertContent>
+          <AlertHeader>
+            {t('Seer issue scans and fixes are running automatically at low settings')}
+          </AlertHeader>
+          <div>
+            {t(
+              'You can configure how these work across all of your projects, including the threshold. Changing the threshold will affect how often they run and may impact your bill.'
+            )}
+          </div>
+          <Link to={`/settings/${organization.slug}/seer/`}>
+            {t('Manage Seer Automation Settings')}
+          </Link>
+        </AlertContent>
+      </Alert>
+    </Alert.Container>
+  );
+}
+
+const AlertContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+`;
+
+const AlertHeader = styled('div')`
+  font-weight: ${p => p.theme.fontWeightBold};
+  font-size: ${p => p.theme.fontSizeLarge};
+`;

--- a/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
@@ -47,7 +47,7 @@ export default function SeerAutomationAlert({organization}: SeerAutomationAlertP
       >
         <AlertContent>
           <AlertHeader>
-            {t('Seer issue scans and fixes are running automatically at low settings')}
+            {t('Seer issue scans and fixes run automatically at low settings by default')}
           </AlertHeader>
           <div>
             {t(


### PR DESCRIPTION
Adds a dismissible alert banner at the top of the subscription page that shows when being redirected there post-checkout with Seer purchased. It notifies the user that Seer automation is on and offers a link to settings.

I did not use the custom colors in the design because the Alert component did not play nicely with them. I also did not put the exact settings status because that would require making a network request for each project in an org. I tweaked the copy to make sense given that constraint.

<img width="1196" alt="Screenshot 2025-06-20 at 7 24 54 AM" src="https://github.com/user-attachments/assets/7ac28359-95a4-4c54-a345-5565bc870455" />
