### PR TITLE
ref(explore): Visualize should only have 1 y axis

### DIFF
--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -9,7 +9,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {isTimeSeriesOther} from 'sentry/utils/timeSeries/isTimeSeriesOther';
 import {markDelayedData} from 'sentry/utils/timeSeries/markDelayedData';
@@ -133,7 +132,7 @@ export function ExploreCharts({
 
   const chartInfos = useMemo(() => {
     return visualizes.map((visualize, index) => {
-      const dedupedYAxes = dedupeArray(visualize.yAxes);
+      const dedupedYAxes = [visualize.yAxis];
 
       const formattedYAxes = dedupedYAxes.map(yaxis => {
         const func = parseFunction(yaxis);
@@ -157,7 +156,7 @@ export function ExploreCharts({
         chartType: visualize.chartType,
         stack: visualize.stack,
         label: visualize.label,
-        yAxes: visualize.yAxes,
+        yAxes: [visualize.yAxis],
         formattedYAxes,
         data,
         error,

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -115,7 +115,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateFields: [
           {groupBy: ''},
-          new Visualize(['count(span.duration)'], {label: 'A'}),
+          new Visualize('count(span.duration)', {label: 'A'}),
         ],
       })
     );
@@ -135,7 +135,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -158,7 +158,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'browser.name'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -181,7 +181,7 @@ describe('PageParamsProvider', function () {
         query: '',
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -205,7 +205,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: ''},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -228,7 +228,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -262,7 +262,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateFields: [
           {groupBy: ''},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -310,7 +310,7 @@ describe('PageParamsProvider', function () {
           {groupBy: 'sdk.version'},
           {groupBy: 'span.op'},
           {groupBy: ''},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -333,7 +333,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -356,7 +356,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'id', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -379,7 +379,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'timestamp', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -412,11 +412,11 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'max(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['min(span.self_time)'], {
+          new Visualize('min(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
-          new Visualize(['max(span.duration)'], {
+          new Visualize('max(span.duration)', {
             label: 'B',
             chartType: ChartType.AREA,
           }),
@@ -449,11 +449,11 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['min(span.self_time)'], {
+          new Visualize('min(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
-          new Visualize(['max(span.duration)'], {
+          new Visualize('max(span.duration)', {
             label: 'B',
             chartType: ChartType.AREA,
           }),
@@ -486,7 +486,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'sdk.name', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -519,7 +519,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
@@ -542,7 +542,7 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.duration)'], {label: 'A'}),
+          new Visualize('count(span.duration)', {label: 'A'}),
         ],
       })
     );
@@ -573,15 +573,15 @@ describe('PageParamsProvider', function () {
         sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new Visualize(['count(span.self_time)'], {
+          new Visualize('count(span.self_time)', {
             label: 'A',
             chartType: ChartType.AREA,
           }),
-          new Visualize(['avg(span.duration)'], {
+          new Visualize('avg(span.duration)', {
             label: 'B',
             chartType: ChartType.LINE,
           }),
-          new Visualize(['avg(span.self_time)'], {
+          new Visualize('avg(span.self_time)', {
             label: 'C',
             chartType: ChartType.LINE,
           }),

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -26,6 +26,7 @@ import type {AggregateField, BaseAggregateField, GroupBy} from './aggregateField
 import {
   defaultAggregateFields,
   getAggregateFieldsFromLocation,
+  isBaseVisualize,
   isGroupBy,
   isVisualize,
   updateLocationWithAggregateFields,
@@ -121,7 +122,7 @@ function defaultPageParams(): ReadablePageParams {
   const sortBys = defaultSortBys(
     mode,
     fields,
-    aggregateFields.filter(isVisualize).flatMap(visualize => visualize.yAxes)
+    aggregateFields.filter(isVisualize).map(visualize => visualize.yAxis)
   );
 
   return new ReadablePageParams({
@@ -357,7 +358,7 @@ function findAllFieldRefs(
 
   const readableVisualizeFields = readablePageParams.aggregateFields
     .filter<Visualize>(isVisualize)
-    .flatMap(visualize => visualize.yAxes)
+    .map(visualize => visualize.yAxis)
     .map(yAxis => parseFunction(yAxis)?.arguments?.[0])
     .filter<string>(defined);
 
@@ -371,7 +372,7 @@ function findAllFieldRefs(
     writablePageParams.aggregateFields === null
       ? []
       : writablePageParams.aggregateFields
-          ?.filter<Visualize>(isVisualize)
+          ?.filter<BaseVisualize>(isBaseVisualize)
           ?.flatMap(visualize => visualize.yAxes)
           ?.map(yAxis => parseFunction(yAxis)?.arguments?.[0])
           ?.filter<string>(defined);

--- a/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
@@ -62,7 +62,7 @@ export function getSortBysFromLocation(
       sortBys.every(
         sortBy =>
           groupBys.includes(sortBy.field) ||
-          visualizes.some(visualize => visualize.yAxes.includes(sortBy.field))
+          visualizes.some(visualize => visualize.yAxis === sortBy.field)
       )
     ) {
       return sortBys;
@@ -72,7 +72,7 @@ export function getSortBysFromLocation(
   return defaultSortBys(
     mode,
     fields,
-    visualizes.flatMap(visualize => visualize.yAxes)
+    visualizes.map(visualize => visualize.yAxis)
   );
 }
 

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.spec.tsx
@@ -5,17 +5,11 @@ describe('Visualize', function () {
   it.each(['count(span.duration)', 'count_unique(span.op)', 'sum(span.duration)'])(
     'defaults to bar charts for %s',
     function (yAxis) {
-      const visualize = new Visualize([yAxis]);
+      const visualize = new Visualize(yAxis);
       expect(visualize.chartType).toEqual(ChartType.BAR);
       expect(visualize.stack).toBeDefined();
     }
   );
-
-  it('uses unstacked bar graph', function () {
-    const visualize = new Visualize(['count(span.duration)', 'count_unique(span.op)']);
-    expect(visualize.chartType).toEqual(ChartType.BAR);
-    expect(visualize.stack).toBeUndefined();
-  });
 
   it.each([
     'avg(span.duration)',
@@ -28,72 +22,61 @@ describe('Visualize', function () {
     'min(span.duration)',
     'max(span.duration)',
   ])('defaults to bar charts for %s', function (yAxis) {
-    const visualize = new Visualize([yAxis]);
+    const visualize = new Visualize(yAxis);
     expect(visualize.chartType).toEqual(ChartType.LINE);
     expect(visualize.stack).toBeDefined();
   });
 
   it('uses selected chart type', function () {
-    const visualize = new Visualize(['count(span.duration)'], {
+    const visualize = new Visualize('count(span.duration)', {
       chartType: ChartType.AREA,
     });
     expect(visualize.chartType).toEqual(ChartType.AREA);
     expect(visualize.stack).toBeDefined();
   });
 
-  it('uses the dominant chart type', function () {
-    const visualize = new Visualize([
-      'count(span.duration)',
-      'p50(span.duration)',
-      'p75(span.duration)',
-      'p90(span.duration)',
-    ]);
-    expect(visualize.chartType).toEqual(ChartType.LINE);
-    expect(visualize.stack).toBeDefined();
-  });
-
   it('clones', function () {
-    const vis1 = new Visualize(['count(span.duration)'], {chartType: ChartType.AREA});
+    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
     const vis2 = vis1.clone();
     expect(vis1).toEqual(vis2);
   });
 
   it('replaces yAxes', function () {
-    const vis1 = new Visualize(['count(span.duration)'], {chartType: ChartType.AREA});
-    const vis2 = vis1.replace({yAxes: ['avg(span.duration)']});
+    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
+    const vis2 = vis1.replace({yAxis: 'avg(span.duration)'});
     expect(vis2).toEqual(
-      new Visualize(['avg(span.duration)'], {chartType: ChartType.AREA})
+      new Visualize('avg(span.duration)', {chartType: ChartType.AREA})
     );
   });
 
   it('replaces chart type', function () {
-    const vis1 = new Visualize(['count(span.duration)'], {chartType: ChartType.AREA});
+    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
     const vis2 = vis1.replace({chartType: ChartType.LINE});
     expect(vis2).toEqual(
-      new Visualize(['count(span.duration)'], {chartType: ChartType.LINE})
+      new Visualize('count(span.duration)', {chartType: ChartType.LINE})
     );
   });
 
   it('replaces yAxes and chart type', function () {
-    const vis1 = new Visualize(['count(span.duration)'], {chartType: ChartType.AREA});
+    const vis1 = new Visualize('count(span.duration)', {chartType: ChartType.AREA});
     const vis2 = vis1.replace({
-      yAxes: ['avg(span.duration)'],
+      yAxis: 'avg(span.duration)',
       chartType: ChartType.LINE,
     });
     expect(vis2).toEqual(
-      new Visualize(['avg(span.duration)'], {chartType: ChartType.LINE})
+      new Visualize('avg(span.duration)', {chartType: ChartType.LINE})
     );
   });
 
   it('converts to JSON without chart type', function () {
-    const visualize = new Visualize(['count(span.duration)']);
+    const visualize = new Visualize('count(span.duration)');
     expect(visualize.toJSON()).toEqual({
       yAxes: ['count(span.duration)'],
     });
   });
 
   it('converts to JSON with chart type', function () {
-    const visualize = new Visualize(['count(span.duration)'], {
+    const visualize = new Visualize('count(span.duration)', {
       chartType: ChartType.AREA,
     });
     expect(visualize.toJSON()).toEqual({
@@ -106,7 +89,7 @@ describe('Visualize', function () {
     const visualize = Visualize.fromJSON({
       yAxes: ['count(span.duration)'],
     });
-    expect(visualize).toEqual(new Visualize(['count(span.duration)']));
+    expect(visualize).toEqual([new Visualize('count(span.duration)')]);
   });
 
   it('converts from JSON with chart type', function () {
@@ -114,8 +97,8 @@ describe('Visualize', function () {
       yAxes: ['count(span.duration)'],
       chartType: ChartType.AREA,
     });
-    expect(visualize).toEqual(
-      new Visualize(['count(span.duration)'], {chartType: ChartType.AREA})
-    );
+    expect(visualize).toEqual([
+      new Visualize('count(span.duration)', {chartType: ChartType.AREA}),
+    ]);
   });
 });

--- a/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/visualizes.tsx
@@ -21,7 +21,7 @@ export const DEFAULT_VISUALIZATION_FIELD = ALLOWED_EXPLORE_VISUALIZE_FIELDS[0]!;
 export const DEFAULT_VISUALIZATION = `${DEFAULT_VISUALIZATION_AGGREGATE}(${DEFAULT_VISUALIZATION_FIELD})`;
 
 export function defaultVisualizes(): Visualize[] {
-  return [new Visualize([DEFAULT_VISUALIZATION], {label: 'A'})];
+  return [new Visualize(DEFAULT_VISUALIZATION, {label: 'A'})];
 }
 
 type VisualizeOptions = {
@@ -37,28 +37,27 @@ export interface BaseVisualize {
 export class Visualize {
   chartType: ChartType;
   label: string;
-  yAxes: readonly string[];
+  yAxis: string;
   stack?: string;
   private selectedChartType?: ChartType;
 
-  constructor(yAxes: readonly string[], options?: VisualizeOptions) {
-    this.yAxes = yAxes;
+  constructor(yAxis: string, options?: VisualizeOptions) {
+    this.yAxis = yAxis;
     this.label = options?.label || '';
     this.selectedChartType = options?.chartType;
-    this.chartType = this.selectedChartType ?? determineDefaultChartType(this.yAxes);
-    this.stack =
-      this.chartType === ChartType.BAR && this.yAxes.length > 1 ? undefined : 'all';
+    this.chartType = this.selectedChartType ?? determineDefaultChartType([yAxis]);
+    this.stack = 'all';
   }
 
   clone(): Visualize {
-    return new Visualize(this.yAxes, {
+    return new Visualize(this.yAxis, {
       label: this.label,
       chartType: this.selectedChartType,
     });
   }
 
-  replace({chartType, yAxes}: {chartType?: ChartType; yAxes?: string[]}): Visualize {
-    return new Visualize(yAxes ?? this.yAxes, {
+  replace({chartType, yAxis}: {chartType?: ChartType; yAxis?: string}): Visualize {
+    return new Visualize(yAxis ?? this.yAxis, {
       label: this.label,
       chartType: chartType ?? this.selectedChartType,
     });
@@ -66,7 +65,7 @@ export class Visualize {
 
   toJSON(): BaseVisualize {
     const json: BaseVisualize = {
-      yAxes: this.yAxes,
+      yAxes: [this.yAxis],
     };
 
     if (defined(this.selectedChartType)) {
@@ -76,8 +75,10 @@ export class Visualize {
     return json;
   }
 
-  static fromJSON(json: BaseVisualize): Visualize {
-    return new Visualize(json.yAxes, {label: '', chartType: json.chartType});
+  static fromJSON(json: BaseVisualize): Visualize[] {
+    return json.yAxes.map(
+      yAxis => new Visualize(yAxis, {label: '', chartType: json.chartType})
+    );
   }
 }
 
@@ -97,7 +98,7 @@ export function getVisualizesFromLocation(
   for (const visualize of baseVisualizes) {
     for (const yAxis of visualize.yAxes) {
       visualizes.push(
-        new Visualize([yAxis], {
+        new Visualize(yAxis, {
           label: String.fromCharCode(65 + i), // starts from 'A',
           chartType: visualize.chartType,
         })

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -13,7 +13,6 @@ import {
   DisplayType,
   WidgetType,
 } from 'sentry/views/dashboards/types';
-import {MAX_NUM_Y_AXES} from 'sentry/views/dashboards/widgetBuilder/buildSteps/yAxisStep/yAxisSelector';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
 import {
   useExploreDataset,
@@ -48,14 +47,14 @@ export function useAddToDashboard() {
 
   const getEventView = useCallback(
     (visualizeIndex: number) => {
-      const yAxes = visualizes[visualizeIndex]!.yAxes.slice(0, MAX_NUM_Y_AXES);
+      const yAxis = visualizes[visualizeIndex]!.yAxis;
 
       let fields: any;
       if (mode === Mode.SAMPLES) {
         fields = [];
       } else {
         fields = [
-          ...new Set([...groupBys, ...yAxes, ...sortBys.map(sort => sort.field)]),
+          ...new Set([...groupBys, yAxis, ...sortBys.map(sort => sort.field)]),
         ].filter(Boolean);
       }
 
@@ -68,7 +67,7 @@ export function useAddToDashboard() {
         query: search.formatString(),
         version: 2,
         dataset,
-        yAxis: yAxes,
+        yAxis: [yAxis],
       };
 
       const newEventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -4,7 +4,6 @@ import * as Sentry from '@sentry/react';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -187,7 +186,7 @@ function useTrackAnalytics({
       result_missing_root: 0,
       user_queries: search.formatString(),
       user_queries_count: search.tokens.length,
-      visualizes,
+      visualizes: visualizes.map(visualize => visualize.toJSON()),
       visualizes_count: visualizes.length,
       title: title || '',
       empty_buckets_percentage: computeEmptyBuckets(visualizes, timeseriesResult.data),
@@ -274,7 +273,7 @@ function useTrackAnalytics({
       result_missing_root: resultMissingRoot,
       user_queries: search.formatString(),
       user_queries_count: search.tokens.length,
-      visualizes,
+      visualizes: visualizes.map(visualize => visualize.toJSON()),
       visualizes_count: visualizes.length,
       title: title || '',
       empty_buckets_percentage: computeEmptyBuckets(visualizes, timeseriesResult.data),
@@ -377,8 +376,7 @@ export function useCompareAnalytics({
   const query = queryParts.query;
   const fields = queryParts.fields;
   const visualizes = queryParts.yAxes.map(
-    yAxis =>
-      new Visualize([yAxis], {label: String(index), chartType: queryParts.chartType})
+    yAxis => new Visualize(yAxis, {label: String(index), chartType: queryParts.chartType})
   );
 
   return useTrackAnalytics({
@@ -474,7 +472,7 @@ function computeConfidence(
   data: ReturnType<typeof useSortedTimeSeries>['data']
 ) {
   return visualizes.map(visualize => {
-    const dedupedYAxes = dedupeArray(visualize.yAxes);
+    const dedupedYAxes = [visualize.yAxis];
     const series = dedupedYAxes.flatMap(yAxis => data[yAxis]).filter(defined);
     return String(combineConfidenceForSeries(series));
   });
@@ -495,7 +493,7 @@ function computeEmptyBuckets(
   data: ReturnType<typeof useSortedTimeSeries>['data']
 ) {
   return visualizes.flatMap(visualize => {
-    const dedupedYAxes = dedupeArray(visualize.yAxes);
+    const dedupedYAxes = [visualize.yAxis];
     return dedupedYAxes
       .flatMap(yAxis => data[yAxis])
       .filter(defined)

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.tsx
@@ -75,12 +75,10 @@ function useExploreAggregatesTableImp({
         }
         allFields.push(aggregateField.groupBy);
       } else {
-        for (const yAxis of aggregateField.yAxes) {
-          if (allFields.includes(yAxis)) {
-            continue;
-          }
-          allFields.push(yAxis);
+        if (allFields.includes(aggregateField.yAxis)) {
+          continue;
         }
+        allFields.push(aggregateField.yAxis);
       }
     }
 

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -81,9 +81,7 @@ function useExploreTimeseriesImpl({
       return [];
     }
 
-    return [...groupBys, ...visualizes.flatMap(visualize => visualize.yAxes)].filter(
-      Boolean
-    );
+    return [...groupBys, ...visualizes.map(visualize => visualize.yAxis)].filter(Boolean);
   }, [mode, groupBys, visualizes]);
 
   const orderby: string | string[] | undefined = useMemo(() => {
@@ -95,7 +93,7 @@ function useExploreTimeseriesImpl({
   }, [sortBys]);
 
   const yAxes = useMemo(() => {
-    const deduped = dedupeArray(visualizes.flatMap(visualize => visualize.yAxes));
+    const deduped = dedupeArray(visualizes.map(visualize => visualize.yAxis));
     deduped.sort();
     return deduped;
   }, [visualizes]);
@@ -173,7 +171,7 @@ function _checkCanQueryForMoreData(
   isTopN: boolean
 ) {
   return visualizes.some(visualize => {
-    const dedupedYAxes = dedupeArray(visualize.yAxes);
+    const dedupedYAxes = [visualize.yAxis];
     const series = dedupedYAxes.flatMap(yAxis => data[yAxis]).filter(defined);
     const {dataScanned} = determineSeriesSampleCountAndIsSampled(series, isTopN);
     return dataScanned === 'partial';

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -3,7 +3,6 @@ import {useMemo} from 'react';
 import {
   useExploreGroupBys,
   useExploreMode,
-  useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 
@@ -13,7 +12,6 @@ export const TOP_EVENTS_LIMIT = 5;
 // This hook always returns 5, which can be misleading, but there's no simple way
 // to get the series count without adding more complexity to this hook.
 export function useTopEvents(): number | undefined {
-  const visualizes = useExploreVisualizes();
   const groupBys = useExploreGroupBys();
   const mode = useExploreMode();
 
@@ -25,16 +23,12 @@ export function useTopEvents(): number | undefined {
       return undefined;
     }
 
-    if (visualizes.some(visualize => visualize.yAxes.length > 1)) {
-      return undefined;
-    }
-
     if (groupBys.every(groupBy => groupBy === '')) {
       return undefined;
     }
 
     return TOP_EVENTS_LIMIT;
-  }, [groupBys, mode, visualizes]);
+  }, [groupBys, mode]);
 
   return topEvents;
 }

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -26,7 +26,6 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
-import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {
   type AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
@@ -347,7 +346,7 @@ function SpanTabContentSection({
   const confidences = useMemo(
     () =>
       visualizes.map(visualize => {
-        const dedupedYAxes = dedupeArray(visualize.yAxes);
+        const dedupedYAxes = [visualize.yAxis];
         const series = dedupedYAxes
           .flatMap(yAxis => timeseriesResult.data[yAxis])
           .filter(defined);

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -70,7 +70,7 @@ describe('AggregateColumnEditorModal', function () {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: ''}, new Visualize([DEFAULT_VISUALIZATION])]}
+            columns={[{groupBy: ''}, new Visualize(DEFAULT_VISUALIZATION)]}
             onColumnsChange={() => {}}
             stringTags={stringTags}
             numberTags={numberTags}
@@ -98,8 +98,8 @@ describe('AggregateColumnEditorModal', function () {
             columns={[
               {groupBy: 'geo.country'},
               {groupBy: 'geo.region'},
-              new Visualize(['count(span.duration)']),
-              new Visualize(['avg(span.self_time)']),
+              new Visualize('count(span.duration)'),
+              new Visualize('avg(span.self_time)'),
             ]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
@@ -116,8 +116,8 @@ describe('AggregateColumnEditorModal', function () {
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
       {groupBy: 'geo.region'},
-      new Visualize(['count(span.duration)']),
-      new Visualize(['avg(span.self_time)']),
+      new Visualize('count(span.duration)'),
+      new Visualize('avg(span.self_time)'),
     ]);
 
     await userEvent.click(screen.getAllByLabelText('Remove Column')[0]!);
@@ -125,8 +125,8 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.region'},
-      new Visualize(['count(span.duration)']),
-      new Visualize(['avg(span.self_time)']),
+      new Visualize('count(span.duration)'),
+      new Visualize('avg(span.self_time)'),
     ]);
 
     // only 1 group by remaining, disable the delete option
@@ -137,7 +137,7 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.region'},
-      new Visualize(['avg(span.self_time)']),
+      new Visualize('avg(span.self_time)'),
     ]);
 
     // 1 group by and visualize remaining so both should be disabled
@@ -148,7 +148,7 @@ describe('AggregateColumnEditorModal', function () {
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
     expect(onColumnsChange).toHaveBeenCalledWith([
       {groupBy: 'geo.region'},
-      new Visualize(['avg(span.self_time)']),
+      {yAxes: ['avg(span.self_time)']},
     ]);
   });
 
@@ -162,7 +162,7 @@ describe('AggregateColumnEditorModal', function () {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: 'geo.country'}, new Visualize([DEFAULT_VISUALIZATION])]}
+            columns={[{groupBy: 'geo.country'}, new Visualize(DEFAULT_VISUALIZATION)]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
@@ -177,7 +177,7 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize(['count(span.duration)']),
+      new Visualize('count(span.duration)'),
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
@@ -188,7 +188,7 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize(['count(span.duration)']),
+      new Visualize('count(span.duration)'),
       {groupBy: ''},
     ]);
 
@@ -200,18 +200,18 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize(['count(span.duration)']),
+      new Visualize('count(span.duration)'),
       {groupBy: ''},
-      new Visualize(['count(span.duration)']),
+      new Visualize('count(span.duration)'),
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
 
     expect(onColumnsChange).toHaveBeenCalledWith([
       {groupBy: 'geo.country'},
-      new Visualize(['count(span.duration)']),
+      {yAxes: ['count(span.duration)']},
       {groupBy: ''},
-      new Visualize(['count(span.duration)']),
+      {yAxes: ['count(span.duration)']},
     ]);
   });
 
@@ -225,7 +225,7 @@ describe('AggregateColumnEditorModal', function () {
         modalProps => (
           <AggregateColumnEditorModal
             {...modalProps}
-            columns={[{groupBy: 'geo.country'}, new Visualize([DEFAULT_VISUALIZATION])]}
+            columns={[{groupBy: 'geo.country'}, new Visualize(DEFAULT_VISUALIZATION)]}
             onColumnsChange={onColumnsChange}
             stringTags={stringTags}
             numberTags={numberTags}
@@ -240,7 +240,7 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.country'},
-      new Visualize(['count(span.duration)']),
+      new Visualize('count(span.duration)'),
     ]);
 
     const options: string[] = ['\u2014', 'geo.city', 'geo.country', 'project', 'span.op'];
@@ -254,13 +254,13 @@ describe('AggregateColumnEditorModal', function () {
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.city'},
-      new Visualize(['count(span.duration)']),
+      new Visualize('count(span.duration)'),
     ]);
 
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
     expect(onColumnsChange).toHaveBeenCalledWith([
       {groupBy: 'geo.city'},
-      new Visualize(['count(span.duration)']),
+      {yAxes: ['count(span.duration)']},
     ]);
   });
 });
@@ -279,8 +279,7 @@ function expectRows(rows: HTMLElement[]) {
             new RegExp(`Group By${field.groupBy}`)
           );
         } else {
-          expect(field.yAxes).toHaveLength(1);
-          const parsedFunction = parseFunction(field.yAxes[0]!)!;
+          const parsedFunction = parseFunction(field.yAxis)!;
           expect(parsedFunction).not.toBeNull();
           expect(parsedFunction.arguments.filter(Boolean)).toHaveLength(1);
 
@@ -290,7 +289,7 @@ function expectRows(rows: HTMLElement[]) {
           );
 
           const argsRegexOverride =
-            field.yAxes[0] === 'count(span.duration)' ? /spans/ : undefined;
+            field.yAxis === 'count(span.duration)' ? /spans/ : undefined;
           const argumentElement = within(row).getByTestId('editor-visualize-argument');
           expect(argumentElement).toHaveTextContent(
             argsRegexOverride ?? new RegExp(parsedFunction.arguments[0]!)

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -64,7 +64,7 @@ export function AggregateColumnEditorModal({
   }, [columns]);
 
   const handleApply = useCallback(() => {
-    onColumnsChange(tempColumns);
+    onColumnsChange(tempColumns.map(col => (isVisualize(col) ? col.toJSON() : col)));
     closeModal();
   }, [closeModal, onColumnsChange, tempColumns]);
 
@@ -113,7 +113,7 @@ export function AggregateColumnEditorModal({
                     key: 'add-visualize',
                     label: t('Visualize / Function'),
                     details: t('ex. p50(span.duration)'),
-                    onAction: () => insertColumn(new Visualize([DEFAULT_VISUALIZATION])),
+                    onAction: () => insertColumn(new Visualize(DEFAULT_VISUALIZATION)),
                   },
                 ]}
                 trigger={triggerProps => (
@@ -274,7 +274,7 @@ function VisualizeSelector({
   stringTags,
   visualize,
 }: VisualizeSelectorProps) {
-  const yAxis = visualize.yAxes[0]!;
+  const yAxis = visualize.yAxis;
   const parsedFunction = useMemo(() => parseFunction(yAxis), [yAxis]);
 
   const aggregateOptions: Array<SelectOption<string>> = useMemo(() => {
@@ -300,7 +300,7 @@ function VisualizeSelector({
         oldAggregate: parsedFunction?.name,
         oldArgument: parsedFunction?.arguments[0]!,
       });
-      onChange(visualize.replace({yAxes: [newYAxis]}));
+      onChange(visualize.replace({yAxis: newYAxis}));
     },
     [parsedFunction, onChange, visualize]
   );
@@ -308,7 +308,7 @@ function VisualizeSelector({
   const handleArgumentChange = useCallback(
     (option: SelectOption<SelectKey>) => {
       const newYAxis = `${parsedFunction?.name}(${option.value})`;
-      onChange(visualize.replace({yAxes: [newYAxis]}));
+      onChange(visualize.replace({yAxis: newYAxis}));
     },
     [parsedFunction, onChange, visualize]
   );

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -67,7 +67,7 @@ describe('ExploreToolbar', function () {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
 
     expect(await within(section).findByRole('button', {name: 'spans'})).toBeDisabled();
   });
@@ -90,7 +90,7 @@ describe('ExploreToolbar', function () {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
@@ -100,12 +100,12 @@ describe('ExploreToolbar', function () {
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
 
-    expect(visualizes).toEqual([new Visualize(['avg(span.self_time)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.self_time)', {label: 'A'})]);
 
     await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
     await userEvent.click(within(section).getByRole('option', {name: 'count'}));
 
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
   });
 
   it('disables changing visualize fields for epm', async function () {
@@ -126,7 +126,7 @@ describe('ExploreToolbar', function () {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
 
     // change aggregate to epm
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
@@ -153,7 +153,7 @@ describe('ExploreToolbar', function () {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
@@ -163,18 +163,18 @@ describe('ExploreToolbar', function () {
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
 
-    expect(visualizes).toEqual([new Visualize(['avg(span.self_time)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.self_time)', {label: 'A'})]);
 
     await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
     await userEvent.click(within(section).getByRole('option', {name: 'epm'}));
 
-    expect(visualizes).toEqual([new Visualize(['epm()'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('epm()', {label: 'A'})]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'epm'}));
     await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
 
-    expect(visualizes).toEqual([new Visualize(['avg(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.duration)', {label: 'A'})]);
   });
 
   it('defaults count_unique argument to span.op', async function () {
@@ -195,13 +195,13 @@ describe('ExploreToolbar', function () {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
 
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
     await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
 
-    expect(visualizes).toEqual([new Visualize(['count_unique(span.op)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count_unique(span.op)', {label: 'A'})]);
 
     // try changing the aggregate + field
     await userEvent.click(within(section).getByRole('button', {name: 'count_unique'}));
@@ -211,13 +211,13 @@ describe('ExploreToolbar', function () {
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
 
-    expect(visualizes).toEqual([new Visualize(['avg(span.self_time)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.self_time)', {label: 'A'})]);
     //
     // try changing the aggregate back to count_unique
     await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
     await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
 
-    expect(visualizes).toEqual([new Visualize(['count_unique(span.op)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count_unique(span.op)', {label: 'A'})]);
   });
 
   it('allows changing visualizes', async function () {
@@ -240,7 +240,7 @@ describe('ExploreToolbar', function () {
     const section = screen.getByTestId('section-visualizes');
 
     // this is the default
-    expect(visualizes).toEqual([new Visualize(['count(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('count(span.duration)', {label: 'A'})]);
 
     expect(fields).toEqual([
       'id',
@@ -254,12 +254,12 @@ describe('ExploreToolbar', function () {
     // try changing the aggregate
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
     await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
-    expect(visualizes).toEqual([new Visualize(['avg(span.duration)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.duration)', {label: 'A'})]);
 
     // try changing the field
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
-    expect(visualizes).toEqual([new Visualize(['avg(span.self_time)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.self_time)', {label: 'A'})]);
 
     expect(fields).toEqual([
       'id',
@@ -274,13 +274,13 @@ describe('ExploreToolbar', function () {
     // try adding a new chart
     await userEvent.click(within(section).getByRole('button', {name: 'Add Chart'}));
     expect(visualizes).toEqual([
-      new Visualize(['avg(span.self_time)'], {label: 'A'}),
-      new Visualize(['count(span.duration)'], {label: 'B'}),
+      new Visualize('avg(span.self_time)', {label: 'A'}),
+      new Visualize('count(span.duration)', {label: 'B'}),
     ]);
 
     // delete second chart
     await userEvent.click(within(section).getAllByLabelText('Remove Overlay')[1]!);
-    expect(visualizes).toEqual([new Visualize(['avg(span.self_time)'], {label: 'A'})]);
+    expect(visualizes).toEqual([new Visualize('avg(span.self_time)', {label: 'A'})]);
 
     // only one left so we hide the delete button
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -17,7 +17,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
@@ -59,7 +58,7 @@ export function ToolbarSaveAs() {
   const sortBys = useExploreSortBys();
   const mode = useExploreMode();
   const id = useExploreId();
-  const visualizeYAxes = visualizes.flatMap(v => v.yAxes);
+  const visualizeYAxes = visualizes.map(v => v.yAxis);
 
   const [interval] = useChartInterval();
 
@@ -151,7 +150,7 @@ export function ToolbarSaveAs() {
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
 
   const chartOptions = visualizes.map((chart, index) => {
-    const dedupedYAxes = dedupeArray(chart.yAxes);
+    const dedupedYAxes = [chart.yAxis];
     const formattedYAxes = dedupedYAxes.map(yaxis => {
       const func = parseFunction(yaxis);
       return func ? prettifyParsedFunction(func) : undefined;

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -37,7 +37,7 @@ export function ToolbarSortBy({
 
   const fieldOptions = useSortByFields({
     fields,
-    yAxes: visualizes.flatMap(v => v.yAxes),
+    yAxes: visualizes.map(v => v.yAxis),
     groupBys,
     mode,
   });

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -8,7 +8,7 @@ import {findSuggestedColumns, viewSamplesTarget} from 'sentry/views/explore/util
 describe('viewSamplesTarget', function () {
   const project = ProjectFixture();
   const projects = [project];
-  const visualize = new Visualize(['count(span.duration)']);
+  const visualize = new Visualize('count(span.duration)');
   const sort = {
     field: 'count(span.duration)',
     kind: 'desc' as const,


### PR DESCRIPTION
Previously, explore supported multiple y axis per chart, so each visualize supported multiple y axis. That functionality has since been removed for simplicity so update the types here to match. Keep in mind that saved queries still store them as an array so when serializing/deserializing, we still need to treat it as an array.