### PR TITLE
feat(router): Indicate which routes require deprecated router props

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -29,7 +29,7 @@ type CustomProps = {
   withOrgPath?: boolean;
 };
 
-interface SentryRouteProps extends React.PropsWithChildren<RouteProps & CustomProps> {}
+type SentryRouteProps = React.PropsWithChildren<RouteProps & CustomProps>;
 
 export function Route(_props: SentryRouteProps) {
   // XXX: These routes are NEVER rendered

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -123,8 +123,15 @@ function buildRoutes() {
 
   const experimentalSpaRoutes = EXPERIMENTAL_SPA ? (
     <Route path="/auth/login/" component={errorHandler(AuthLayout)}>
-      <IndexRoute component={make(() => import('sentry/views/auth/login'))} />
-      <Route path=":orgId/" component={make(() => import('sentry/views/auth/login'))} />
+      <IndexRoute
+        component={make(() => import('sentry/views/auth/login'))}
+        deprecatedRouteProps
+      />
+      <Route
+        path=":orgId/"
+        component={make(() => import('sentry/views/auth/login'))}
+        deprecatedRouteProps
+      />
     </Route>
   ) : null;
 
@@ -132,11 +139,12 @@ function buildRoutes() {
     <Route
       path="trace/:traceSlug/"
       component={make(() => import('sentry/views/performance/traceDetails'))}
+      deprecatedRouteProps
     />
   );
 
   const rootRoutes = (
-    <Route component={errorHandler(AppBodyContent)}>
+    <Route component={errorHandler(AppBodyContent)} deprecatedRouteProps>
       <IndexRoute component={make(() => import('sentry/views/app/root'))} />
       {hook('routes:root')}
       <Route
@@ -151,7 +159,7 @@ function buildRoutes() {
         path="/accept-transfer/"
         component={make(() => import('sentry/views/acceptProjectTransfer'))}
       />
-      <Route component={errorHandler(OrganizationContainer)}>
+      <Route component={errorHandler(OrganizationContainer)} deprecatedRouteProps>
         <Route
           path="/extensions/external-install/:integrationSlug/:installationId"
           component={make(() => import('sentry/views/integrationOrganizationLink'))}
@@ -164,6 +172,7 @@ function buildRoutes() {
       <Route
         path="/sentry-apps/:sentryAppSlug/external-install/"
         component={make(() => import('sentry/views/sentryAppExternalInstallation'))}
+        deprecatedRouteProps
       />
       <Redirect from="/account/" to="/settings/account/details/" />
       <Redirect from="/share/group/:shareId/" to="/share/issue/:shareId/" />
@@ -173,30 +182,36 @@ function buildRoutes() {
       <Route
         path="/share/issue/:shareId/"
         component={make(() => import('sentry/views/sharedGroupDetails'))}
+        deprecatedRouteProps
       />
       <Route
         path="/organizations/:orgId/share/issue/:shareId/"
         component={make(() => import('sentry/views/sharedGroupDetails'))}
+        deprecatedRouteProps
       />
       {USING_CUSTOMER_DOMAIN && (
         <Route
           path="/unsubscribe/project/:id/"
           component={make(() => import('sentry/views/unsubscribe/project'))}
+          deprecatedRouteProps
         />
       )}
       <Route
         path="/unsubscribe/:orgId/project/:id/"
         component={make(() => import('sentry/views/unsubscribe/project'))}
+        deprecatedRouteProps
       />
       {USING_CUSTOMER_DOMAIN && (
         <Route
           path="/unsubscribe/issue/:id/"
           component={make(() => import('sentry/views/unsubscribe/issue'))}
+          deprecatedRouteProps
         />
       )}
       <Route
         path="/unsubscribe/:orgId/issue/:id/"
         component={make(() => import('sentry/views/unsubscribe/issue'))}
+        deprecatedRouteProps
       />
       <Route
         path="/organizations/new/"
@@ -206,23 +221,27 @@ function buildRoutes() {
         path="/data-export/:dataExportId"
         component={make(() => import('sentry/views/dataExport/dataDownload'))}
         withOrgPath
+        deprecatedRouteProps
       />
-      <Route component={errorHandler(OrganizationContainer)}>
+      <Route component={errorHandler(OrganizationContainer)} deprecatedRouteProps>
         <Route
           path="/disabled-member/"
           component={make(() => import('sentry/views/disabledMember'))}
           withOrgPath
+          deprecatedRouteProps
         />
       </Route>
       {USING_CUSTOMER_DOMAIN && (
         <Route
           path="/restore/"
           component={make(() => import('sentry/views/organizationRestore'))}
+          deprecatedRouteProps
         />
       )}
       <Route
         path="/organizations/:orgId/restore/"
         component={make(() => import('sentry/views/organizationRestore'))}
+        deprecatedRouteProps
       />
       {USING_CUSTOMER_DOMAIN && (
         <Route
@@ -231,6 +250,7 @@ function buildRoutes() {
             make(() => import('sentry/views/organizationJoinRequest'))
           )}
           key="orgless-join-request"
+          deprecatedRouteProps
         />
       )}
       <Route
@@ -239,14 +259,20 @@ function buildRoutes() {
           make(() => import('sentry/views/organizationJoinRequest'))
         )}
         key="org-join-request"
+        deprecatedRouteProps
       />
       <Route
         path="/relocation/"
         component={make(() => import('sentry/views/relocation'))}
         key="orgless-relocation"
+        deprecatedRouteProps
       >
         <IndexRedirect to="get-started/" />
-        <Route path=":step/" component={make(() => import('sentry/views/relocation'))} />
+        <Route
+          path=":step/"
+          component={make(() => import('sentry/views/relocation'))}
+          deprecatedRouteProps
+        />
       </Route>
       {USING_CUSTOMER_DOMAIN && (
         <Fragment>
@@ -255,18 +281,26 @@ function buildRoutes() {
             path="/onboarding/:step/"
             component={errorHandler(withDomainRequired(OrganizationContainer))}
             key="orgless-onboarding"
+            deprecatedRouteProps
           >
-            <IndexRoute component={make(() => import('sentry/views/onboarding'))} />
+            <IndexRoute
+              component={make(() => import('sentry/views/onboarding'))}
+              deprecatedRouteProps
+            />
           </Route>
         </Fragment>
       )}
       <Redirect from="/onboarding/:orgId/" to="/onboarding/:orgId/welcome/" />
       <Route
         path="/onboarding/:orgId/:step/"
-        component={withDomainRedirect(errorHandler(OrganizationContainer))}
+        component={errorHandler(withDomainRedirect(OrganizationContainer))}
         key="org-onboarding"
+        deprecatedRouteProps
       >
-        <IndexRoute component={make(() => import('sentry/views/onboarding'))} />
+        <IndexRoute
+          component={make(() => import('sentry/views/onboarding'))}
+          deprecatedRouteProps
+        />
       </Route>
       <Route
         path="/stories/"
@@ -283,6 +317,7 @@ function buildRoutes() {
       component={make(
         () => import('sentry/views/settings/account/accountSettingsLayout')
       )}
+      deprecatedRouteProps
     >
       <IndexRedirect to="details/" />
       <Route
@@ -298,6 +333,7 @@ function buildRoutes() {
                 'sentry/views/settings/account/notifications/notificationSettingsController'
               )
           )}
+          deprecatedRouteProps
         />
         <Route
           path=":fineTuneType/"
@@ -308,6 +344,7 @@ function buildRoutes() {
                 'sentry/views/settings/account/accountNotificationFineTuningController'
               )
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route
@@ -329,11 +366,13 @@ function buildRoutes() {
                 'sentry/views/settings/account/accountSecurity/accountSecurityWrapper'
               )
           )}
+          deprecatedRouteProps
         >
           <IndexRoute
             component={make(
               () => import('sentry/views/settings/account/accountSecurity')
             )}
+            deprecatedRouteProps
           />
           <Route
             path="session-history/"
@@ -341,6 +380,7 @@ function buildRoutes() {
             component={make(
               () => import('sentry/views/settings/account/accountSecurity/sessionHistory')
             )}
+            deprecatedRouteProps
           />
           <Route
             path="mfa/:authId/"
@@ -351,6 +391,7 @@ function buildRoutes() {
                   'sentry/views/settings/account/accountSecurity/accountSecurityDetails'
                 )
             )}
+            deprecatedRouteProps
           />
         </Route>
         <Route
@@ -362,6 +403,7 @@ function buildRoutes() {
                 'sentry/views/settings/account/accountSecurity/accountSecurityEnroll'
               )
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route
@@ -393,6 +435,7 @@ function buildRoutes() {
             component={make(
               () => import('sentry/views/settings/account/apiTokenDetails')
             )}
+            deprecatedRouteProps
           />
         </Route>
         <Route path="applications/" name={t('Applications')}>
@@ -400,6 +443,7 @@ function buildRoutes() {
             component={make(
               () => import('sentry/views/settings/account/apiApplications')
             )}
+            deprecatedRouteProps
           />
           <Route
             path=":appId/"
@@ -425,6 +469,7 @@ function buildRoutes() {
       component={make(
         () => import('sentry/views/settings/project/projectSettingsLayout')
       )}
+      deprecatedRouteProps
     >
       <IndexRoute
         name={t('General')}
@@ -435,14 +480,17 @@ function buildRoutes() {
         path="teams/"
         name={t('Teams')}
         component={make(() => import('sentry/views/settings/project/projectTeams'))}
+        deprecatedRouteProps
       />
       <Route
         path="alerts/"
         name={t('Alerts')}
         component={make(() => import('sentry/views/settings/projectAlerts'))}
+        deprecatedRouteProps
       >
         <IndexRoute
           component={make(() => import('sentry/views/settings/projectAlerts/settings'))}
+          deprecatedRouteProps
         />
         <Redirect from="new/" to="/organizations/:orgId/alerts/:projectId/new/" />
         <Redirect from="rules/" to="/organizations/:orgId/alerts/rules/" />
@@ -466,6 +514,7 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/settings/project/projectEnvironments')
         )}
+        deprecatedRouteProps
       >
         <IndexRoute />
         <Route path="hidden/" />
@@ -474,6 +523,7 @@ function buildRoutes() {
         path="tags/"
         name={t('Tags & Context')}
         component={make(() => import('sentry/views/settings/projectTags'))}
+        deprecatedRouteProps
       />
       <Redirect from="issue-tracking/" to="/settings/:orgId/:projectId/plugins/" />
       <Route
@@ -482,49 +532,58 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/settings/project/projectReleaseTracking')
         )}
+        deprecatedRouteProps
       />
       <Route
         path="ownership/"
         name={t('Ownership Rules')}
         component={make(() => import('sentry/views/settings/project/projectOwnership'))}
+        deprecatedRouteProps
       />
       <Route
         path="data-forwarding/"
         name={t('Data Forwarding')}
         component={make(() => import('sentry/views/settings/projectDataForwarding'))}
+        deprecatedRouteProps
       />
       <Route
         path="seer/"
         name={t('Seer')}
         component={make(() => import('sentry/views/settings/projectSeer/index'))}
+        deprecatedRouteProps
       />
       <Route
         path="user-feedback/"
         name={t('User Feedback')}
         component={make(() => import('sentry/views/settings/projectUserFeedback'))}
+        deprecatedRouteProps
       />
       <Route path="security-and-privacy/" name={t('Security & Privacy')}>
         <IndexRoute
           component={make(
             () => import('sentry/views/settings/projectSecurityAndPrivacy')
           )}
+          deprecatedRouteProps
         />
         <Route
           path="advanced-data-scrubbing/:scrubbingId/"
           component={make(
             () => import('sentry/views/settings/projectSecurityAndPrivacy')
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route
         path="debug-symbols/"
         name={t('Debug Information Files')}
         component={make(() => import('sentry/views/settings/projectDebugFiles'))}
+        deprecatedRouteProps
       />
       <Route
         path="proguard/"
         name={t('ProGuard Mappings')}
         component={make(() => import('sentry/views/settings/projectProguard'))}
+        deprecatedRouteProps
       />
       <Route
         path="performance/"
@@ -536,25 +595,30 @@ function buildRoutes() {
         path="playstation/"
         name={t('PlayStation')}
         component={make(() => import('sentry/views/settings/project/tempest'))}
+        deprecatedRouteProps
       />
       <Route
         path="replays/"
         name={t('Replays')}
         component={make(() => import('sentry/views/settings/project/projectReplays'))}
+        deprecatedRouteProps
       />
       <Route
         path="toolbar/"
         name={t('Developer Toolbar')}
         component={make(() => import('sentry/views/settings/project/projectToolbar'))}
+        deprecatedRouteProps
       />
       <Route path="source-maps/" name={t('Source Maps')}>
         <IndexRoute
           component={make(() => import('sentry/views/settings/projectSourceMaps'))}
+          deprecatedRouteProps
         />
         <Route
           name={t('Source Map Uploads')}
           path=":bundleId/"
           component={make(() => import('sentry/views/settings/projectSourceMaps'))}
+          deprecatedRouteProps
         />
         <Redirect from="source-maps/artifact-bundles/" to="source-maps/" />
         <Redirect from="source-maps/release-bundles/" to="source-maps/" />
@@ -563,6 +627,7 @@ function buildRoutes() {
         path="filters/"
         name={t('Inbound Filters')}
         component={make(() => import('sentry/views/settings/project/projectFilters'))}
+        deprecatedRouteProps
       >
         <IndexRedirect to="data-filters/" />
         <Route path=":filterType/" />
@@ -572,6 +637,7 @@ function buildRoutes() {
         path="issue-grouping/"
         name={t('Issue Grouping')}
         component={make(() => import('sentry/views/settings/projectIssueGrouping'))}
+        deprecatedRouteProps
       />
       <Route
         path="hooks/"
@@ -586,6 +652,7 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/settings/project/projectCreateServiceHook')
         )}
+        deprecatedRouteProps
       />
       <Route
         path="hooks/:hookId/"
@@ -597,6 +664,7 @@ function buildRoutes() {
       <Route path="keys/" name={t('Client Keys')}>
         <IndexRoute
           component={make(() => import('sentry/views/settings/project/projectKeys/list'))}
+          deprecatedRouteProps
         />
         <Route
           path=":keyId/"
@@ -604,12 +672,14 @@ function buildRoutes() {
           component={make(
             () => import('sentry/views/settings/project/projectKeys/details')
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route
         path="loader-script/"
         name={t('Loader Script')}
         component={make(() => import('sentry/views/settings/project/loaderScript'))}
+        deprecatedRouteProps
       />
       <Redirect
         from="csp/"
@@ -644,11 +714,13 @@ function buildRoutes() {
       <Route path="plugins/" name={t('Legacy Integrations')}>
         <IndexRoute
           component={make(() => import('sentry/views/settings/projectPlugins'))}
+          deprecatedRouteProps
         />
         <Route
           path=":pluginId/"
           name={t('Integration Details')}
           component={make(() => import('sentry/views/settings/projectPlugins/details'))}
+          deprecatedRouteProps
         />
       </Route>
     </Route>
@@ -656,28 +728,39 @@ function buildRoutes() {
 
   const statsChildRoutes = (
     <Fragment>
-      <IndexRoute component={make(() => import('sentry/views/organizationStats'))} />
+      <IndexRoute
+        component={make(() => import('sentry/views/organizationStats'))}
+        deprecatedRouteProps
+      />
       <Route
         component={make(() => import('sentry/views/organizationStats/teamInsights'))}
+        deprecatedRouteProps
       >
         <Route
           path="issues/"
           component={make(
             () => import('sentry/views/organizationStats/teamInsights/issues')
           )}
+          deprecatedRouteProps
         />
         <Route
           path="health/"
           component={make(
             () => import('sentry/views/organizationStats/teamInsights/health')
           )}
+          deprecatedRouteProps
         />
       </Route>
     </Fragment>
   );
   const statsRoutes = (
     <Fragment>
-      <Route path="/stats/" withOrgPath component={OrganizationStatsWrapper}>
+      <Route
+        path="/stats/"
+        withOrgPath
+        component={OrganizationStatsWrapper}
+        deprecatedRouteProps
+      >
         {statsChildRoutes}
       </Route>
       <Redirect
@@ -692,6 +775,7 @@ function buildRoutes() {
       component={make(
         () => import('sentry/views/settings/organization/organizationSettingsLayout')
       )}
+      deprecatedRouteProps
     >
       {hook('routes:settings')}
       {!USING_CUSTOMER_DOMAIN && (
@@ -733,6 +817,7 @@ function buildRoutes() {
         path="audit-log/"
         name={t('Audit Log')}
         component={make(() => import('sentry/views/settings/organizationAuditLog'))}
+        deprecatedRouteProps
       />
       <Route
         path="auth/"
@@ -760,6 +845,7 @@ function buildRoutes() {
         path="rate-limits/"
         name={t('Rate Limits')}
         component={make(() => import('sentry/views/settings/organizationRateLimits'))}
+        deprecatedRouteProps
       />
       <Route
         path="relay/"
@@ -793,6 +879,7 @@ function buildRoutes() {
       <Route path="teams/" name={t('Teams')}>
         <IndexRoute
           component={make(() => import('sentry/views/settings/organizationTeams'))}
+          deprecatedRouteProps
         />
         <Route
           path=":teamId/"
@@ -800,6 +887,7 @@ function buildRoutes() {
           component={make(
             () => import('sentry/views/settings/organizationTeams/teamDetails')
           )}
+          deprecatedRouteProps
         >
           <IndexRedirect to="members/" />
           <Route
@@ -808,6 +896,7 @@ function buildRoutes() {
             component={make(
               () => import('sentry/views/settings/organizationTeams/teamMembers')
             )}
+            deprecatedRouteProps
           />
           <Route
             path="notifications/"
@@ -822,6 +911,7 @@ function buildRoutes() {
             component={make(
               () => import('sentry/views/settings/organizationTeams/teamProjects')
             )}
+            deprecatedRouteProps
           />
           <Route
             path="settings/"
@@ -829,6 +919,7 @@ function buildRoutes() {
             component={make(
               () => import('sentry/views/settings/organizationTeams/teamSettings')
             )}
+            deprecatedRouteProps
           />
         </Route>
       </Route>
@@ -897,6 +988,7 @@ function buildRoutes() {
                 'sentry/views/settings/organizationIntegrations/configureIntegration'
               )
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route path="developer-settings/" name={t('Custom Integrations')}>
@@ -914,6 +1006,7 @@ function buildRoutes() {
                 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
               )
           )}
+          deprecatedRouteProps
         />
         <Route
           path="new-internal/"
@@ -924,6 +1017,7 @@ function buildRoutes() {
                 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
               )
           )}
+          deprecatedRouteProps
         />
         <Route
           path=":appSlug/"
@@ -934,6 +1028,7 @@ function buildRoutes() {
                 'sentry/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
               )
           )}
+          deprecatedRouteProps
         />
         <Route
           path=":appSlug/dashboard/"
@@ -963,12 +1058,14 @@ function buildRoutes() {
           component={make(
             () => import('sentry/views/settings/organizationAuthTokens/authTokenDetails')
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route
         path="early-features/"
         name={t('Early Features')}
         component={make(() => import('sentry/views/settings/earlyFeatures'))}
+        deprecatedRouteProps
       />
       <Route
         path="dynamic-sampling/"
@@ -1017,7 +1114,10 @@ function buildRoutes() {
 
   const settingsRoutes = (
     <Route path="/settings/" name={t('Settings')} component={SettingsWrapper}>
-      <IndexRoute component={make(() => import('sentry/views/settings/settingsIndex'))} />
+      <IndexRoute
+        component={make(() => import('sentry/views/settings/settingsIndex'))}
+        deprecatedRouteProps
+      />
       {accountSettingsRoutes}
       <Fragment>
         {USING_CUSTOMER_DOMAIN && (
@@ -1025,6 +1125,7 @@ function buildRoutes() {
             name={t('Organization')}
             component={withDomainRequired(NoOp)}
             key="orgless-settings-route"
+            deprecatedRouteProps
           >
             {orgSettingsRoutes}
             {projectSettingsRoutes}
@@ -1035,6 +1136,7 @@ function buildRoutes() {
           name={t('Organization')}
           component={withDomainRedirect(NoOp)}
           key="org-settings"
+          deprecatedRouteProps
         >
           {orgSettingsRoutes}
           {projectSettingsRoutes}
@@ -1054,14 +1156,17 @@ function buildRoutes() {
       <Route
         path=":projectId/"
         component={make(() => import('sentry/views/projectDetail'))}
+        deprecatedRouteProps
       />
       <Route
         path=":projectId/events/:eventId/"
         component={errorHandler(ProjectEventRedirect)}
+        deprecatedRouteProps
       />
       <Route
         path=":projectId/getting-started/"
         component={make(() => import('sentry/views/projectInstall/gettingStarted'))}
+        deprecatedRouteProps
       />
     </Fragment>
   );
@@ -1070,6 +1175,7 @@ function buildRoutes() {
       path="/projects/"
       component={make(() => import('sentry/views/projects/'))}
       withOrgPath
+      deprecatedRouteProps
     >
       {projectsChildRoutes}
     </Route>
@@ -1083,6 +1189,7 @@ function buildRoutes() {
             path="/dashboards/"
             component={withDomainRequired(make(() => import('sentry/views/dashboards')))}
             key="orgless-dashboards-route"
+            deprecatedRouteProps
           >
             <IndexRoute
               component={make(() => import('sentry/views/dashboards/manage'))}
@@ -1094,6 +1201,7 @@ function buildRoutes() {
           path="/organizations/:orgId/dashboards/"
           component={withDomainRedirect(make(() => import('sentry/views/dashboards')))}
           key="org-dashboards"
+          deprecatedRouteProps
         >
           <IndexRoute component={make(() => import('sentry/views/dashboards/manage'))} />
         </Route>
@@ -1106,25 +1214,30 @@ function buildRoutes() {
               make(() => import('sentry/views/dashboards/create'))
             )}
             key="orgless-dashboards-new-route"
+            deprecatedRouteProps
           >
             {/* New widget builder routes */}
             <Route
               path="widget-builder/widget/:widgetIndex/edit/"
               component={make(() => import('sentry/views/dashboards/view'))}
+              deprecatedRouteProps
             />
             <Route
               path="widget-builder/widget/new/"
               component={make(() => import('sentry/views/dashboards/view'))}
+              deprecatedRouteProps
             />
 
             {/* Old widget builder routes */}
             <Route
               path="widget/:widgetIndex/edit/"
               component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
+              deprecatedRouteProps
             />
             <Route
               path="widget/new/"
               component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
+              deprecatedRouteProps
             />
           </Route>
         )}
@@ -1134,25 +1247,30 @@ function buildRoutes() {
             make(() => import('sentry/views/dashboards/create'))
           )}
           key="org-dashboards-new"
+          deprecatedRouteProps
         >
           {/* New widget builder routes */}
           <Route
             path="widget-builder/widget/:widgetIndex/edit/"
             component={make(() => import('sentry/views/dashboards/view'))}
+            deprecatedRouteProps
           />
           <Route
             path="widget-builder/widget/new/"
             component={make(() => import('sentry/views/dashboards/view'))}
+            deprecatedRouteProps
           />
 
           {/* Old widget builder routes */}
           <Route
             path="widget/:widgetIndex/edit/"
             component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
+            deprecatedRouteProps
           />
           <Route
             path="widget/new/"
             component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
+            deprecatedRouteProps
           />
         </Route>
       </Fragment>
@@ -1164,10 +1282,12 @@ function buildRoutes() {
               make(() => import('sentry/views/dashboards/create'))
             )}
             key="orgless-dashboards-new-template-route"
+            deprecatedRouteProps
           >
             <Route
               path="widget/:widgetId/"
               component={make(() => import('sentry/views/dashboards/create'))}
+              deprecatedRouteProps
             />
           </Route>
         )}
@@ -1177,10 +1297,12 @@ function buildRoutes() {
             make(() => import('sentry/views/dashboards/create'))
           )}
           key="org-dashboards-new-template"
+          deprecatedRouteProps
         >
           <Route
             path="widget/:widgetId/"
             component={make(() => import('sentry/views/dashboards/create'))}
+            deprecatedRouteProps
           />
         </Route>
       </Fragment>
@@ -1195,29 +1317,35 @@ function buildRoutes() {
         path="/dashboard/:dashboardId/"
         component={make(() => import('sentry/views/dashboards/view'))}
         withOrgPath
+        deprecatedRouteProps
       >
         {/* New widget builder routes */}
         <Route
           path="widget-builder/widget/:widgetIndex/edit/"
           component={make(() => import('sentry/views/dashboards/view'))}
+          deprecatedRouteProps
         />
         <Route
           path="widget-builder/widget/new/"
           component={make(() => import('sentry/views/dashboards/view'))}
+          deprecatedRouteProps
         />
 
         {/* Old widget builder routes */}
         <Route
           path="widget/:widgetIndex/edit/"
           component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
+          deprecatedRouteProps
         />
         <Route
           path="widget/new/"
           component={make(() => import('sentry/views/dashboards/widgetBuilder'))}
+          deprecatedRouteProps
         />
         <Route
           path="widget/:widgetId/"
           component={make(() => import('sentry/views/dashboards/view'))}
+          deprecatedRouteProps
         />
       </Route>
     </Route>
@@ -1229,6 +1357,7 @@ function buildRoutes() {
       <Fragment>
         <IndexRoute
           component={make(() => import('sentry/views/alerts/list/incidents'))}
+          deprecatedRouteProps
         />
         <Route path="rules/">
           <IndexRoute
@@ -1239,10 +1368,12 @@ function buildRoutes() {
           <Route
             path="details/:ruleId/"
             component={make(() => import('sentry/views/alerts/rules/metric/details'))}
+            deprecatedRouteProps
           />
           <Route
             path=":projectId/"
             component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+            deprecatedRouteProps
           >
             <IndexRedirect
               to={
@@ -1254,6 +1385,7 @@ function buildRoutes() {
             <Route
               path=":ruleId/"
               component={make(() => import('sentry/views/alerts/edit'))}
+              deprecatedRouteProps
             />
           </Route>
           <Route path=":projectId/:ruleId/details/">
@@ -1261,15 +1393,18 @@ function buildRoutes() {
               component={make(
                 () => import('sentry/views/alerts/rules/issue/details/ruleDetails')
               )}
+              deprecatedRouteProps
             />
           </Route>
           <Route
             path="uptime/"
             component={make(() => import('sentry/views/alerts/rules/uptime'))}
+            deprecatedRouteProps
           >
             <Route
               path=":projectId/:uptimeRuleId/details/"
               component={make(() => import('sentry/views/alerts/rules/uptime/details'))}
+              deprecatedRouteProps
             />
             <Route
               path="existing-or-create/"
@@ -1281,10 +1416,12 @@ function buildRoutes() {
           <Route
             path="crons/"
             component={make(() => import('sentry/views/alerts/rules/crons'))}
+            deprecatedRouteProps
           >
             <Route
               path=":projectId/:monitorSlug/details/"
               component={make(() => import('sentry/views/alerts/rules/crons/details'))}
+              deprecatedRouteProps
             />
           </Route>
         </Route>
@@ -1297,6 +1434,7 @@ function buildRoutes() {
           <Route
             path=":projectId/"
             component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+            deprecatedRouteProps
           >
             <IndexRedirect
               to={
@@ -1308,6 +1446,7 @@ function buildRoutes() {
             <Route
               path=":ruleId/"
               component={make(() => import('sentry/views/alerts/edit'))}
+              deprecatedRouteProps
             />
           </Route>
         </Route>
@@ -1315,10 +1454,12 @@ function buildRoutes() {
           <Route
             path=":projectId/"
             component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+            deprecatedRouteProps
           >
             <Route
               path=":ruleId/"
               component={make(() => import('sentry/views/alerts/edit'))}
+              deprecatedRouteProps
             />
           </Route>
         </Route>
@@ -1326,22 +1467,29 @@ function buildRoutes() {
           <Route
             path=":projectId/"
             component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+            deprecatedRouteProps
           >
             <Route
               path=":monitorSlug/"
               component={make(() => import('sentry/views/alerts/edit'))}
+              deprecatedRouteProps
             />
           </Route>
         </Route>
         <Route
           path="wizard/"
           component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+          deprecatedRouteProps
         >
-          <IndexRoute component={make(() => import('sentry/views/alerts/wizard'))} />
+          <IndexRoute
+            component={make(() => import('sentry/views/alerts/wizard'))}
+            deprecatedRouteProps
+          />
         </Route>
         <Route
           path="new/"
           component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+          deprecatedRouteProps
         >
           <IndexRedirect
             to={
@@ -1353,23 +1501,28 @@ function buildRoutes() {
           <Route
             path=":alertType/"
             component={make(() => import('sentry/views/alerts/create'))}
+            deprecatedRouteProps
           />
         </Route>
         <Route
           path=":alertId/"
           component={make(() => import('sentry/views/alerts/incidentRedirect'))}
+          deprecatedRouteProps
         />
         <Route
           path=":projectId/"
           component={make(() => import('sentry/views/alerts/builder/projectProvider'))}
+          deprecatedRouteProps
         >
           <Route
             path="new/"
             component={make(() => import('sentry/views/alerts/create'))}
+            deprecatedRouteProps
           />
           <Route
             path="wizard/"
             component={make(() => import('sentry/views/alerts/wizard'))}
+            deprecatedRouteProps
           />
         </Route>
       </Fragment>
@@ -1383,6 +1536,7 @@ function buildRoutes() {
           path="/alerts/"
           component={withDomainRequired(make(() => import('sentry/views/alerts')))}
           key="orgless-alerts-route"
+          deprecatedRouteProps
         >
           {alertChildRoutes({forCustomerDomain: true})}
         </Route>
@@ -1391,6 +1545,7 @@ function buildRoutes() {
         path="/organizations/:orgId/alerts/"
         component={withDomainRedirect(make(() => import('sentry/views/alerts')))}
         key="org-alerts"
+        deprecatedRouteProps
       >
         {alertChildRoutes({forCustomerDomain: false})}
       </Route>
@@ -1409,6 +1564,7 @@ function buildRoutes() {
       <Route
         path=":replaySlug/"
         component={make(() => import('sentry/views/replays/details'))}
+        deprecatedRouteProps
       />
     </Fragment>
   );
@@ -1417,6 +1573,7 @@ function buildRoutes() {
       path="/replays/"
       component={make(() => import('sentry/views/replays/index'))}
       withOrgPath
+      deprecatedRouteProps
     >
       {replayChildRoutes}
     </Route>
@@ -1428,6 +1585,7 @@ function buildRoutes() {
       <Route
         path=":release/"
         component={make(() => import('sentry/views/releases/detail'))}
+        deprecatedRouteProps
       >
         <IndexRoute
           component={make(() => import('sentry/views/releases/detail/overview'))}
@@ -1453,6 +1611,7 @@ function buildRoutes() {
         path="/releases/"
         component={make(() => import('sentry/views/releases/index'))}
         withOrgPath
+        deprecatedRouteProps
       >
         {releasesChildRoutes}
       </Route>
@@ -1473,6 +1632,7 @@ function buildRoutes() {
       <Route
         path="homepage/"
         component={make(() => import('sentry/views/discover/homepage'))}
+        deprecatedRouteProps
       />
       {traceViewRoute}
       <Route
@@ -1482,10 +1642,12 @@ function buildRoutes() {
       <Route
         path="results/"
         component={make(() => import('sentry/views/discover/results'))}
+        deprecatedRouteProps
       />
       <Route
         path=":eventSlug/"
         component={make(() => import('sentry/views/discover/eventDetails'))}
+        deprecatedRouteProps
       />
     </Fragment>
   );
@@ -1494,6 +1656,7 @@ function buildRoutes() {
       path="/discover/"
       component={make(() => import('sentry/views/discover'))}
       withOrgPath
+      deprecatedRouteProps
     >
       {discoverChildRoutes}
     </Route>
@@ -1534,6 +1697,7 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/performance/transactionSummary/transactionOverview')
         )}
+        deprecatedRouteProps
       />
       {traceViewRoute}
       <Route
@@ -1547,18 +1711,21 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/performance/transactionSummary/transactionVitals')
         )}
+        deprecatedRouteProps
       />
       <Route
         path="tags/"
         component={make(
           () => import('sentry/views/performance/transactionSummary/transactionTags')
         )}
+        deprecatedRouteProps
       />
       <Route
         path="events/"
         component={make(
           () => import('sentry/views/performance/transactionSummary/transactionEvents')
         )}
+        deprecatedRouteProps
       />
       <Route
         path="profiles/"
@@ -1578,6 +1745,7 @@ function buildRoutes() {
           component={make(
             () => import('sentry/views/performance/transactionSummary/transactionSpans')
           )}
+          deprecatedRouteProps
         />
         <Route
           path=":spanSlug/"
@@ -1587,6 +1755,7 @@ function buildRoutes() {
                 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails'
               )
           )}
+          deprecatedRouteProps
         />
       </Route>
     </Route>
@@ -1695,6 +1864,7 @@ function buildRoutes() {
             () =>
               import('sentry/views/insights/llmMonitoring/views/llmMonitoringDetailsPage')
           )}
+          deprecatedRouteProps
         />
       </Route>
       <Route path={`${MODULE_BASE_URLS[ModuleName.SESSIONS]}/`}>
@@ -1752,7 +1922,11 @@ function buildRoutes() {
         {traceViewRoute}
         {moduleRoutes}
       </Route>
-      <Route path="projects/" component={make(() => import('sentry/views/projects/'))}>
+      <Route
+        path="projects/"
+        component={make(() => import('sentry/views/projects/'))}
+        deprecatedRouteProps
+      >
         {projectsChildRoutes}
       </Route>
       <Redirect from={`${FRONTEND_LANDING_SUB_PATH}/uptime/`} to="/insights/uptime/" />
@@ -1776,12 +1950,17 @@ function buildRoutes() {
       path="/performance/"
       component={make(() => import('sentry/views/performance'))}
       withOrgPath
+      deprecatedRouteProps
     >
-      <IndexRoute component={make(() => import('sentry/views/performance/content'))} />
+      <IndexRoute
+        component={make(() => import('sentry/views/performance/content'))}
+        deprecatedRouteProps
+      />
       {transactionSummaryRoutes}
       <Route
         path="vitaldetail/"
         component={make(() => import('sentry/views/performance/vitalDetail'))}
+        deprecatedRouteProps
       />
       {traceViewRoute}
       {insightsRedirects}
@@ -1800,6 +1979,7 @@ function buildRoutes() {
       <Route
         path=":eventSlug/"
         component={make(() => import('sentry/views/performance/transactionDetails'))}
+        deprecatedRouteProps
       />
     </Route>
   );
@@ -1827,6 +2007,7 @@ function buildRoutes() {
       path="/traces/"
       component={make(() => import('sentry/views/traces'))}
       withOrgPath
+      deprecatedRouteProps
     >
       {tracesChildRoutes}
     </Route>
@@ -1834,10 +2015,14 @@ function buildRoutes() {
 
   const profilingChildRoutes = (
     <Fragment>
-      <IndexRoute component={make(() => import('sentry/views/profiling/content'))} />
+      <IndexRoute
+        component={make(() => import('sentry/views/profiling/content'))}
+        deprecatedRouteProps
+      />
       <Route
         path="summary/:projectId/"
         component={make(() => import('sentry/views/profiling/profileSummary'))}
+        deprecatedRouteProps
       />
       <Route
         path="profile/:projectId/differential-flamegraph/"
@@ -1847,6 +2032,7 @@ function buildRoutes() {
       <Route
         path="profile/:projectId/"
         component={make(() => import('sentry/views/profiling/continuousProfileProvider'))}
+        deprecatedRouteProps
       >
         <Route
           path="flamegraph/"
@@ -1860,6 +2046,7 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/profiling/transactionProfileProvider')
         )}
+        deprecatedRouteProps
       >
         <Route
           path="flamegraph/"
@@ -1872,21 +2059,38 @@ function buildRoutes() {
   const exploreRoutes = (
     <Route path="/explore/" withOrgPath>
       <IndexRoute component={make(() => import('sentry/views/explore/indexRedirect'))} />
-      <Route path="profiling/" component={make(() => import('sentry/views/profiling'))}>
+      <Route
+        path="profiling/"
+        component={make(() => import('sentry/views/profiling'))}
+        deprecatedRouteProps
+      >
         {profilingChildRoutes}
       </Route>
-      <Route path="traces/" component={make(() => import('sentry/views/traces'))}>
+      <Route
+        path="traces/"
+        component={make(() => import('sentry/views/traces'))}
+        deprecatedRouteProps
+      >
         {tracesChildRoutes}
       </Route>
-      <Route path="replays/" component={make(() => import('sentry/views/replays/index'))}>
+      <Route
+        path="replays/"
+        component={make(() => import('sentry/views/replays/index'))}
+        deprecatedRouteProps
+      >
         {replayChildRoutes}
       </Route>
-      <Route path="discover/" component={make(() => import('sentry/views/discover'))}>
+      <Route
+        path="discover/"
+        component={make(() => import('sentry/views/discover'))}
+        deprecatedRouteProps
+      >
         {discoverChildRoutes}
       </Route>
       <Route
         path="releases/"
         component={make(() => import('sentry/views/releases/index'))}
+        deprecatedRouteProps
       >
         {releasesChildRoutes}
       </Route>
@@ -2001,6 +2205,7 @@ function buildRoutes() {
       path="/codecov/"
       withOrgPath
       component={make(() => import('sentry/views/codecov/index'))}
+      deprecatedRouteProps
     >
       {codecovChildrenRoutes}
     </Route>
@@ -2019,6 +2224,7 @@ function buildRoutes() {
       path="/feedback/"
       component={make(() => import('sentry/views/feedback/index'))}
       withOrgPath
+      deprecatedRouteProps
     >
       {feedbackV2ChildRoutes}
     </Route>
@@ -2092,18 +2298,21 @@ function buildRoutes() {
 
   const issueRoutes = (
     <Route path="/issues/" withOrgPath>
-      <IndexRoute component={errorHandler(OverviewWrapper)} />
+      <IndexRoute component={errorHandler(OverviewWrapper)} deprecatedRouteProps />
       <Route
         path={`${IssueTaxonomy.ERRORS_AND_OUTAGES}/`}
         component={make(() => import('sentry/views/issueList/pages/errorsOutages'))}
+        deprecatedRouteProps
       />
       <Route
         path={`${IssueTaxonomy.BREACHED_METRICS}/`}
         component={make(() => import('sentry/views/issueList/pages/breachedMetrics'))}
+        deprecatedRouteProps
       />
       <Route
         path={`${IssueTaxonomy.WARNINGS}/`}
         component={make(() => import('sentry/views/issueList/pages/warnings'))}
+        deprecatedRouteProps
       />
       <Route
         path="views/"
@@ -2111,8 +2320,16 @@ function buildRoutes() {
           () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')
         )}
       />
-      <Route path="views/:viewId/" component={errorHandler(OverviewWrapper)} />
-      <Route path="searches/:searchId/" component={errorHandler(OverviewWrapper)} />
+      <Route
+        path="views/:viewId/"
+        component={errorHandler(OverviewWrapper)}
+        deprecatedRouteProps
+      />
+      <Route
+        path="searches/:searchId/"
+        component={errorHandler(OverviewWrapper)}
+        deprecatedRouteProps
+      />
 
       {/* Redirects for legacy tags route. */}
       <Redirect
@@ -2136,6 +2353,7 @@ function buildRoutes() {
         path=":groupId/"
         component={make(() => import('sentry/views/issueDetails/groupDetails'))}
         key="org-issues-group-id"
+        deprecatedRouteProps
       >
         {issueTabs}
         <Route path={`${TabPaths[Tab.EVENTS]}:eventId/`}>{issueTabs}</Route>
@@ -2143,10 +2361,15 @@ function buildRoutes() {
       <Route
         path="feedback/"
         component={make(() => import('sentry/views/feedback/index'))}
+        deprecatedRouteProps
       >
         {feedbackV2ChildRoutes}
       </Route>
-      <Route path="alerts/" component={make(() => import('sentry/views/alerts'))}>
+      <Route
+        path="alerts/"
+        component={make(() => import('sentry/views/alerts'))}
+        deprecatedRouteProps
+      >
         {alertChildRoutes({forCustomerDomain: true})}
       </Route>
       {traceViewRoute}
@@ -2161,27 +2384,33 @@ function buildRoutes() {
     <Route
       path="/manage/"
       component={make(() => import('sentry/views/admin/adminLayout'))}
+      deprecatedRouteProps
     >
       <IndexRoute component={make(() => import('sentry/views/admin/adminOverview'))} />
       <Route
         path="buffer/"
         component={make(() => import('sentry/views/admin/adminBuffer'))}
+        deprecatedRouteProps
       />
       <Route
         path="relays/"
         component={make(() => import('sentry/views/admin/adminRelays'))}
+        deprecatedRouteProps
       />
       <Route
         path="organizations/"
         component={make(() => import('sentry/views/admin/adminOrganizations'))}
+        deprecatedRouteProps
       />
       <Route
         path="projects/"
         component={make(() => import('sentry/views/admin/adminProjects'))}
+        deprecatedRouteProps
       />
       <Route
         path="queue/"
         component={make(() => import('sentry/views/admin/adminQueue'))}
+        deprecatedRouteProps
       />
       <Route
         path="quotas/"
@@ -2192,7 +2421,10 @@ function buildRoutes() {
         component={make(() => import('sentry/views/admin/adminSettings'))}
       />
       <Route path="users/">
-        <IndexRoute component={make(() => import('sentry/views/admin/adminUsers'))} />
+        <IndexRoute
+          component={make(() => import('sentry/views/admin/adminUsers'))}
+          deprecatedRouteProps
+        />
         <Route
           path=":id"
           component={make(() => import('sentry/views/admin/adminUserEdit'))}
@@ -2281,20 +2513,27 @@ function buildRoutes() {
       path="/profiling/"
       component={make(() => import('sentry/views/profiling'))}
       withOrgPath
+      deprecatedRouteProps
     >
-      <IndexRoute component={make(() => import('sentry/views/profiling/content'))} />
+      <IndexRoute
+        component={make(() => import('sentry/views/profiling/content'))}
+        deprecatedRouteProps
+      />
       <Route
         path="summary/:projectId/"
         component={make(() => import('sentry/views/profiling/profileSummary'))}
+        deprecatedRouteProps
       />
       <Route
         path="profile/:projectId/differential-flamegraph/"
         component={make(() => import('sentry/views/profiling/differentialFlamegraph'))}
+        deprecatedRouteProps
       />
       {traceViewRoute}
       <Route
         path="profile/:projectId/"
         component={make(() => import('sentry/views/profiling/continuousProfileProvider'))}
+        deprecatedRouteProps
       >
         <Route
           path="flamegraph/"
@@ -2308,6 +2547,7 @@ function buildRoutes() {
         component={make(
           () => import('sentry/views/profiling/transactionProfileProvider')
         )}
+        deprecatedRouteProps
       >
         <Route
           path="flamegraph/"
@@ -2330,6 +2570,7 @@ function buildRoutes() {
             ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="issues/"
@@ -2338,6 +2579,7 @@ function buildRoutes() {
             ({orgId, projectId}) => `/organizations/${orgId}/issues/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="dashboard/"
@@ -2347,6 +2589,7 @@ function buildRoutes() {
               `/organizations/${orgId}/dashboards/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="user-feedback/"
@@ -2356,6 +2599,7 @@ function buildRoutes() {
               `/organizations/${orgId}/feedback/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="releases/"
@@ -2365,6 +2609,7 @@ function buildRoutes() {
               `/organizations/${orgId}/releases/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="releases/:version/"
@@ -2374,6 +2619,7 @@ function buildRoutes() {
               `/organizations/${orgId}/releases/${router.params.version}/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="releases/:version/new-events/"
@@ -2383,6 +2629,7 @@ function buildRoutes() {
               `/organizations/${orgId}/releases/${router.params.version}/new-events/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="releases/:version/all-events/"
@@ -2392,6 +2639,7 @@ function buildRoutes() {
               `/organizations/${orgId}/releases/${router.params.version}/all-events/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
       <Route
         path="releases/:version/commits/"
@@ -2401,6 +2649,7 @@ function buildRoutes() {
               `/organizations/${orgId}/releases/${router.params.version}/commits/?project=${projectId}`
           )
         )}
+        deprecatedRouteProps
       />
     </Route>
   );
@@ -2551,19 +2800,20 @@ function buildRoutes() {
       <Route
         path=":projectId/events/:eventId/"
         component={errorHandler(ProjectEventRedirect)}
+        deprecatedRouteProps
       />
     </Route>
   );
 
   const appRoutes = (
     <ProvideAriaRouter>
-      <Route>
+      <Route deprecatedRouteProps>
         {experimentalSpaRoutes}
-        <Route path="/" component={errorHandler(App)}>
+        <Route path="/" component={errorHandler(App)} deprecatedRouteProps>
           {rootRoutes}
           {organizationRoutes}
           {legacyRedirectRoutes}
-          <Route path="*" component={errorHandler(RouteNotFound)} />
+          <Route path="*" component={errorHandler(RouteNotFound)} deprecatedRouteProps />
         </Route>
       </Route>
     </ProvideAriaRouter>

--- a/static/app/types/legacyReactRouter.tsx
+++ b/static/app/types/legacyReactRouter.tsx
@@ -3,92 +3,67 @@
  *
  * Once we've fully migrated to react-router 6 we can drop these types
  */
-import type {
-  Href,
-  Location,
-  LocationDescriptor,
-  LocationState,
-  Path,
-  Pathname,
-  Query,
-} from 'history';
-
-type Params = Record<string, string>;
+import type {Href, Location, LocationDescriptor, Path, Query} from 'history';
 
 type RoutePattern = string;
-export type RouteComponent = React.ComponentClass<any> | React.FunctionComponent<any>;
 
-type RouteComponents = Record<string, RouteComponent>;
+type NoRouteProps = {
+  [key: string | number | symbol]: any;
+  children?: never;
+  location?: never;
+  params?: never;
+  route?: never;
+  routeParams?: never;
+  router?: never;
+  routes?: never;
+};
 
-interface RouterState<Q = any> {
-  components: RouteComponent[];
-  location: Location<Q>;
-  params: Params;
-  routes: PlainRoute[];
-}
+export type NoRoutePropsRouteComponent = React.ComponentType<NoRouteProps>;
 
-interface RedirectFunction {
-  (location: LocationDescriptor): void;
-  (state: LocationState, pathname: Pathname | Path, query?: Query): void;
-}
-
-type AnyFunction = (...args: any[]) => any;
-
-type EnterHook = (
-  nextState: RouterState,
-  replace: RedirectFunction,
-  callback?: AnyFunction
-) => any;
-
-type LeaveHook = (prevState: RouterState) => any;
-
-type ChangeHook = (
-  prevState: RouterState,
-  nextState: RouterState,
-  replace: RedirectFunction,
-  callback?: AnyFunction
-) => any;
+// Create a branded type to distinguish legacy route components
+export type LegacyRouteComponent = React.ComponentType<
+  RouteComponentProps<any, any, any>
+> & {
+  __isLegacyRouteComponent?: true;
+};
+export type RouteComponent = LegacyRouteComponent;
 
 type RouteHook = (nextLocation?: Location) => any;
 
-type ComponentCallback = (err: any, component: RouteComponent) => any;
-type ComponentsCallback = (err: any, components: RouteComponents) => any;
+export type IndexRouteProps =
+  | {
+      component?: NoRoutePropsRouteComponent | undefined;
+    }
+  | {
+      component: React.ComponentType<any>;
+      /**
+       * Wrap component in props (router, routes, params, location)
+       * Also injects the props from the outlet context and outlet as a children
+       * See withReactRouter3Props for implementation
+       *
+       * @deprecated
+       */
+      deprecatedRouteProps: true;
+    };
 
-export interface IndexRouteProps<Props = any> {
-  component?: RouteComponent | undefined;
-  components?: RouteComponents | undefined;
-  getComponent?(nextState: RouterState, callback: ComponentCallback): void;
-  getComponents?(nextState: RouterState, callback: ComponentsCallback): void;
-  onChange?: ChangeHook | undefined;
-  onEnter?: EnterHook | undefined;
-  onLeave?: LeaveHook | undefined;
-  props?: Props | undefined;
-}
-
-export interface RouteProps<Props = any> extends IndexRouteProps<Props> {
+export type RouteProps = IndexRouteProps & {
   children?: React.ReactNode;
   path?: RoutePattern | undefined;
-}
+};
 
-type RouteCallback = (err: any, route: PlainRoute) => void;
-type RoutesCallback = (err: any, routesArray: PlainRoute[]) => void;
-
-export interface PlainRoute<Props = any> extends RouteProps<Props> {
+export type PlainRoute = RouteProps & {
   childRoutes?: PlainRoute[] | undefined;
-  getChildRoutes?(partialNextState: LocationState, callback: RoutesCallback): void;
-  getIndexRoute?(partialNextState: LocationState, callback: RouteCallback): void;
   indexRoute?: PlainRoute | undefined;
-}
+};
 
 export interface RouteComponentProps<
   P = Record<string, string | undefined>,
   R = Record<string, string | undefined>,
-  ComponentProps = any,
   Q = any,
 > {
   location: Location<Q>;
   params: P;
-  route: PlainRoute<ComponentProps>;
+  route: PlainRoute;
   routeParams: R;
   router: InjectedRouter;
   routes: PlainRoute[];

--- a/static/app/types/legacyReactRouter.tsx
+++ b/static/app/types/legacyReactRouter.tsx
@@ -18,15 +18,7 @@ type NoRouteProps = {
   routes?: never;
 };
 
-export type NoRoutePropsRouteComponent = React.ComponentType<NoRouteProps>;
-
-// Create a branded type to distinguish legacy route components
-export type LegacyRouteComponent = React.ComponentType<
-  RouteComponentProps<any, any, any>
-> & {
-  __isLegacyRouteComponent?: true;
-};
-export type RouteComponent = LegacyRouteComponent;
+type NoRoutePropsRouteComponent = React.ComponentType<NoRouteProps>;
 
 type RouteHook = (nextLocation?: Location) => any;
 

--- a/static/app/utils/errorHandler.tsx
+++ b/static/app/utils/errorHandler.tsx
@@ -7,7 +7,9 @@ type State = {
   hasError: boolean;
 };
 
-export default function errorHandler<P>(WrappedComponent: React.ComponentType<P>) {
+export default function errorHandler<P>(
+  WrappedComponent: React.ComponentType<P>
+): React.ComponentType<P> {
   class ErrorHandler extends Component<P, State> {
     static getDerivedStateFromError(error: Error) {
       // Update state so the next render will show the fallback UI.

--- a/static/app/utils/useRoutes.tsx
+++ b/static/app/utils/useRoutes.tsx
@@ -5,7 +5,7 @@ import type {PlainRoute} from 'sentry/types/legacyReactRouter';
 
 import {useTestRouteContext} from './useRouteContext';
 
-export function useRoutes(): Array<PlainRoute<any>> {
+export function useRoutes(): PlainRoute[] {
   // When running in test mode we still read from the legacy route context to
   // keep test compatability while we fully migrate to react router 6
   const testRouteContext = useTestRouteContext();

--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -87,7 +87,9 @@ describe('withDomainRedirect', function () {
         routes={router.routes}
         routeParams={router.params}
         route={{}}
-      />
+      >
+        <div />
+      </WrappedComponent>
     );
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();
@@ -118,7 +120,9 @@ describe('withDomainRedirect', function () {
           routes={router.routes}
           routeParams={router.params}
           route={{}}
-        />
+        >
+          <div />
+        </WrappedComponent>
       </OrganizationContext>
     );
 
@@ -152,7 +156,9 @@ describe('withDomainRedirect', function () {
           routes={router.routes}
           routeParams={router.params}
           route={{}}
-        />
+        >
+          <div />
+        </WrappedComponent>
       </OrganizationContext>
     );
 
@@ -191,7 +197,9 @@ describe('withDomainRedirect', function () {
           routes={router.routes}
           routeParams={router.params}
           route={{}}
-        />
+        >
+          <div />
+        </WrappedComponent>
       </OrganizationContext>
     );
 
@@ -234,7 +242,9 @@ describe('withDomainRedirect', function () {
           routes={router.routes}
           routeParams={router.params}
           route={{}}
-        />
+        >
+          <div />
+        </WrappedComponent>
       </OrganizationContext>
     );
 
@@ -274,7 +284,9 @@ describe('withDomainRedirect', function () {
           routes={router.routes}
           routeParams={router.params}
           route={{}}
-        />
+        >
+          <div />
+        </WrappedComponent>
       </OrganizationContext>
     );
 

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -5,7 +5,7 @@ import trimStart from 'lodash/trimStart';
 
 import Redirect from 'sentry/components/redirect';
 import ConfigStore from 'sentry/stores/configStore';
-import type {RouteComponent, RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
@@ -30,9 +30,9 @@ import useOrganization from './useOrganization';
  * If either a customer domain is not being used, or if :orgId is not present in the route path, then WrappedComponent
  * is rendered.
  */
-function withDomainRedirect<P extends RouteComponentProps>(
-  WrappedComponent: RouteComponent
-) {
+function withDomainRedirect<
+  P extends Omit<RouteComponentProps<any, any, any>, 'children'> & {children: any},
+>(WrappedComponent: React.ComponentType<P>): React.ComponentType<P> {
   return function WithDomainRedirectWrapper(props: P) {
     const {customerDomain, links, features} = ConfigStore.getState();
     const {sentryUrl} = links;
@@ -67,7 +67,7 @@ function withDomainRedirect<P extends RouteComponentProps>(
 
       if (orglessSlugRoute === fullRoute) {
         // :orgId is not present in the route, so we do not need to perform a redirect here.
-        return <WrappedComponent {...props} />;
+        return <WrappedComponent {...(props as any)} />;
       }
 
       const orglessRedirectPath = generatePath(orglessSlugRoute, params);
@@ -79,7 +79,7 @@ function withDomainRedirect<P extends RouteComponentProps>(
       return <Redirect to={redirectOrgURL} router={props.router} />;
     }
 
-    return <WrappedComponent {...props} />;
+    return <WrappedComponent {...(props as any)} />;
   };
 }
 

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -84,7 +84,9 @@ describe('withDomainRequired', function () {
         routes={router.routes}
         routeParams={router.params}
         route={{}}
-      />
+      >
+        <div />
+      </WrappedComponent>
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -133,7 +135,9 @@ describe('withDomainRequired', function () {
         routes={router.routes}
         routeParams={router.params}
         route={{}}
-      />
+      >
+        <div />
+      </WrappedComponent>
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -182,7 +186,9 @@ describe('withDomainRequired', function () {
         routes={router.routes}
         routeParams={router.params}
         route={{}}
-      />
+      >
+        <div />
+      </WrappedComponent>
     );
 
     expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -2,7 +2,7 @@ import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
 
 import ConfigStore from 'sentry/stores/configStore';
-import type {RouteComponent, RouteComponentProps} from 'sentry/types/legacyReactRouter';
+import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 
 /**
  * withDomainRequired is a higher-order component (HOC) meant to be used with <Route /> components within
@@ -28,9 +28,9 @@ import type {RouteComponent, RouteComponentProps} from 'sentry/types/legacyReact
  *
  * Whenever https://orgslug.sentry.io/ is accessed in the browser, then both conditions above will be satisfied.
  */
-export default function withDomainRequired<P extends RouteComponentProps>(
-  WrappedComponent: RouteComponent
-) {
+export default function withDomainRequired<
+  P extends Omit<RouteComponentProps<any, any, any>, 'children'> & {children: any},
+>(WrappedComponent: React.ComponentType<P>): React.ComponentType<P> {
   return function withDomainRequiredWrapper(props: P) {
     const {params} = props;
     const {features, customerDomain, links} = ConfigStore.getState();
@@ -52,6 +52,6 @@ export default function withDomainRequired<P extends RouteComponentProps>(
       orgId: customerDomain.subdomain,
     };
 
-    return <WrappedComponent {...props} params={newParams} />;
+    return <WrappedComponent {...(props as any)} params={newParams} />;
   };
 }

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -49,7 +49,7 @@ jest.mock('sentry/utils/analytics', () => ({
   trackAnalytics: jest.fn(),
 }));
 
-const projectAlertRuleDetailsRoutes: Array<PlainRoute<any>> = [
+const projectAlertRuleDetailsRoutes: PlainRoute[] = [
   {
     path: '/',
   },

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -51,7 +51,7 @@ type Query = {
   aggregate?: string;
 };
 
-type Props = RouteComponentProps<{groupId: string}, Record<string, unknown>, any, Query>;
+type Props = RouteComponentProps<{groupId: string}, Record<string, unknown>, Query>;
 
 export function DatabaseSpanSummaryPage({params}: Props) {
   const location = useLocation<Query>();

--- a/static/app/views/organizationLayout/index.spec.tsx
+++ b/static/app/views/organizationLayout/index.spec.tsx
@@ -47,14 +47,9 @@ describe('OrganizationLayout', function () {
       });
       OrganizationStore.onUpdate(organization);
 
-      render(
-        <OrganizationLayout>
-          <div />
-        </OrganizationLayout>,
-        {
-          organization,
-        }
-      );
+      render(<OrganizationLayout />, {
+        organization,
+      });
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
       expect(screen.getByLabelText('Restore Organization')).toBeInTheDocument();
@@ -75,14 +70,9 @@ describe('OrganizationLayout', function () {
       });
       OrganizationStore.onUpdate(organization);
 
-      render(
-        <OrganizationLayout>
-          <div />
-        </OrganizationLayout>,
-        {
-          organization,
-        }
-      );
+      render(<OrganizationLayout />, {
+        organization,
+      });
 
       expect(await screen.findByText('Deletion Scheduled')).toBeInTheDocument();
 
@@ -104,14 +94,9 @@ describe('OrganizationLayout', function () {
     });
     OrganizationStore.onUpdate(organization);
 
-    render(
-      <OrganizationLayout>
-        <div />
-      </OrganizationLayout>,
-      {
-        organization,
-      }
-    );
+    render(<OrganizationLayout />, {
+      organization,
+    });
 
     const inProgress = await screen.findByText(
       'currently in the process of being deleted from Sentry.',
@@ -132,11 +117,7 @@ describe('OrganizationLayout', function () {
       url: '/internal/health/',
     });
 
-    render(
-      <OrganizationLayout>
-        <div />
-      </OrganizationLayout>
-    );
+    render(<OrganizationLayout />);
 
     expect(
       await screen.findByText(/Celery workers have not checked in/)
@@ -168,9 +149,7 @@ describe('OrganizationLayout', function () {
 
       render(
         <OrganizationContext.Provider value={null}>
-          <OrganizationLayout>
-            <div />
-          </OrganizationLayout>
+          <OrganizationLayout />
         </OrganizationContext.Provider>
       );
 

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -1,4 +1,4 @@
-import {ScrollRestoration} from 'react-router-dom';
+import {Outlet, ScrollRestoration} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import DemoHeader from 'sentry/components/demo/demoHeader';
@@ -34,7 +34,7 @@ const OrganizationHeader = HookOrDefault({
   hookName: 'component:organization-header',
 });
 
-function OrganizationLayout({children}: Props) {
+function OrganizationLayout() {
   useRouteAnalyticsHookSetup();
 
   // XXX(epurkhiser): The OrganizationContainer is responsible for ensuring the
@@ -54,7 +54,9 @@ function OrganizationLayout({children}: Props) {
     <SentryDocumentTitle noSuffix title={organization?.name ?? 'Sentry'}>
       <OrganizationContainer>
         <GlobalDrawer>
-          <App organization={organization}>{children}</App>
+          <App organization={organization}>
+            <Outlet />
+          </App>
         </GlobalDrawer>
       </OrganizationContainer>
       <ScrollRestoration getKey={location => location.pathname} />

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -226,7 +226,7 @@ export function generateProfileLink() {
   };
 }
 
-export function generateReplayLink(routes: Array<PlainRoute<any>>) {
+export function generateReplayLink(routes: PlainRoute[]) {
   const referrer = getRouteStringFromRoutes(routes);
 
   return (

--- a/static/app/views/settings/components/settingsWrapper.tsx
+++ b/static/app/views/settings/components/settingsWrapper.tsx
@@ -1,24 +1,24 @@
+import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import {useLocation} from 'sentry/utils/useLocation';
 import useScrollToTop from 'sentry/utils/useScrollToTop';
 import {BreadcrumbProvider} from 'sentry/views/settings/components/settingsBreadcrumb/context';
-
-type Props = {
-  children: React.ReactNode;
-  location: Location;
-};
 
 function scrollDisable(newLocation: Location, prevLocation: Location) {
   return newLocation.pathname === prevLocation.pathname;
 }
 
-function SettingsWrapper({location, children}: Props) {
+function SettingsWrapper() {
+  const location = useLocation();
   useScrollToTop({location, disable: scrollDisable});
 
   return (
     <StyledSettingsWrapper>
-      <BreadcrumbProvider>{children}</BreadcrumbProvider>
+      <BreadcrumbProvider>
+        <Outlet />
+      </BreadcrumbProvider>
     </StyledSettingsWrapper>
   );
 }

--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -40,21 +40,21 @@ import Users from 'admin/views/users';
 
 function buildRoutes() {
   return (
-    <Route path="/_admin/" component={Layout}>
-      <IndexRoute component={Home} />
+    <Route path="/_admin/" component={Layout} deprecatedRouteProps>
+      <IndexRoute component={Home} deprecatedRouteProps />
 
       <Route path="beacons/">
-        <IndexRoute component={Beacons} />
-        <Route path=":beaconId/" component={BeaconDetails} />
+        <IndexRoute component={Beacons} deprecatedRouteProps />
+        <Route path=":beaconId/" component={BeaconDetails} deprecatedRouteProps />
       </Route>
 
       <Route path="broadcasts/">
-        <IndexRoute component={Broadcasts} />
-        <Route path=":broadcastId/" component={BroadcastDetails} />
+        <IndexRoute component={Broadcasts} deprecatedRouteProps />
+        <Route path=":broadcastId/" component={BroadcastDetails} deprecatedRouteProps />
       </Route>
 
       <Route path="customers/">
-        <IndexRoute component={Customers} />
+        <IndexRoute component={Customers} deprecatedRouteProps />
         <Route path=":orgId/">
           <IndexRoute component={CustomerDetails} />
           <Route path="upgrade-request/" component={CustomerUpgradeRequest} />
@@ -64,15 +64,15 @@ function buildRoutes() {
       </Route>
 
       <Route path="doc-integrations/">
-        <IndexRoute component={DocIntegrations} />
+        <IndexRoute component={DocIntegrations} deprecatedRouteProps />
         <Route path=":docIntegrationSlug/" component={DocIntegrationDetails} />
       </Route>
       <Route path="debugging-tools/">
         <IndexRoute component={DebuggingTools} />
       </Route>
       <Route path="policies/">
-        <IndexRoute component={Policies} />
-        <Route path=":policySlug" component={PolicyDetails} />
+        <IndexRoute component={Policies} deprecatedRouteProps />
+        <Route path=":policySlug" component={PolicyDetails} deprecatedRouteProps />
       </Route>
 
       <Route path="private-apis/">
@@ -80,7 +80,7 @@ function buildRoutes() {
       </Route>
 
       <Route path="relocations/">
-        <IndexRoute component={Relocations} />
+        <IndexRoute component={Relocations} deprecatedRouteProps />
         <Route path="new/" component={RelocationCreate} />
         <Route path=":regionName/:relocationUuid/" component={RelocationDetails} />
         <Route
@@ -90,32 +90,32 @@ function buildRoutes() {
       </Route>
 
       <Route path="employees/">
-        <IndexRoute component={SentryEmployees} />
+        <IndexRoute component={SentryEmployees} deprecatedRouteProps />
       </Route>
 
       <Route path="promocodes/">
-        <IndexRoute component={PromoCodes} />
+        <IndexRoute component={PromoCodes} deprecatedRouteProps />
         <Route path=":codeId/" component={PromoCodeDetails} />
       </Route>
 
       <Route path="sentry-apps/">
-        <IndexRoute component={SentryApps} />
+        <IndexRoute component={SentryApps} deprecatedRouteProps />
         <Route path=":sentryAppSlug/" component={SentryAppDetails} />
       </Route>
 
       <Route path="users/">
-        <IndexRoute component={Users} />
+        <IndexRoute component={Users} deprecatedRouteProps />
         <Route path=":userId/" component={UserDetails} />
       </Route>
 
       <Route path="options/">
-        <IndexRoute component={Options} />
+        <IndexRoute component={Options} deprecatedRouteProps />
       </Route>
-      <Route path="data-requests/" component={DataRequests} />
-      <Route path="billingadmins/" component={BillingAdmins} />
+      <Route path="data-requests/" component={DataRequests} deprecatedRouteProps />
+      <Route path="billingadmins/" component={BillingAdmins} deprecatedRouteProps />
 
       <Route path="invoices/">
-        <IndexRoute component={Invoices} />
+        <IndexRoute component={Invoices} deprecatedRouteProps />
         <Route path=":invoiceId/" component={InvoiceDetails} />
       </Route>
 

--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -18,48 +18,70 @@ const settingsRoutes = () =>
           path="checkout/"
           name="Change"
           component={errorHandler(SubscriptionContext)}
+          deprecatedRouteProps
         >
-          <IndexRoute component={make(() => import('../views/decideCheckout'))} />
+          <IndexRoute
+            component={make(() => import('../views/decideCheckout'))}
+            deprecatedRouteProps
+          />
         </Route>
-        <Route path="cancel/" name="Cancel" component={errorHandler(SubscriptionContext)}>
-          <IndexRoute component={make(() => import('../views/cancelSubscription'))} />
+        <Route
+          path="cancel/"
+          name="Cancel"
+          component={errorHandler(SubscriptionContext)}
+          deprecatedRouteProps
+        >
+          <IndexRoute
+            component={make(() => import('../views/cancelSubscription'))}
+            deprecatedRouteProps
+          />
         </Route>
         <Route
           path="overview/"
           name="Overview"
           component={make(() => import('../views/subscriptionPage/overview'))}
+          deprecatedRouteProps
         />
         <Route
           path="usage/"
           name="Usage History"
           component={make(() => import('../views/subscriptionPage/usageHistory'))}
+          deprecatedRouteProps
         />
         <Route
           path="receipts/"
           name="Receipts"
           component={make(() => import('../views/subscriptionPage/paymentHistory'))}
+          deprecatedRouteProps
         />
         <Route
           path="notifications/"
           name="Notifications"
           component={make(() => import('../views/subscriptionPage/notifications'))}
+          deprecatedRouteProps
         />
         <Route
           path="details/"
           name="Billing Details"
           component={make(() => import('../views/subscriptionPage/billingDetails'))}
+          deprecatedRouteProps
         />
         <Route
           path="usage-log/"
           name="Usage Log"
           component={make(() => import('../views/subscriptionPage/usageLog'))}
+          deprecatedRouteProps
         />
         <Route
           path="receipts/:invoiceGuid/"
           name="Invoice Details"
           component={errorHandler(SubscriptionContext)}
+          deprecatedRouteProps
         >
-          <IndexRoute component={make(() => import('../views/invoiceDetails'))} />
+          <IndexRoute
+            component={make(() => import('../views/invoiceDetails'))}
+            deprecatedRouteProps
+          />
         </Route>
       </Route>
 
@@ -67,29 +89,34 @@ const settingsRoutes = () =>
         path="spike-protection/"
         name="Spike Protection"
         component={make(() => import('../views/spikeProtection'))}
+        deprecatedRouteProps
       />
       <Route
         path="seer/"
         name="Seer Automation"
         component={make(() => import('../views/seerAutomation'))}
+        deprecatedRouteProps
       />
 
       <Route
         path="subscription/spend-allocations/"
         name="Spend Allocations"
         component={make(() => import('../views/spendAllocations'))}
+        deprecatedRouteProps
       />
 
       <Route
         path="subscription/redeem-code/"
         name="Redeem Promotional Code"
         component={make(() => import('../views/redeemPromoCode'))}
+        deprecatedRouteProps
       />
 
       <Route
         path="legal/"
         name="Legal & Compliance"
         component={make(() => import('../views/legalAndCompliance/legalAndCompliance'))}
+        deprecatedRouteProps
       />
 
       <Route

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -11,9 +11,9 @@ import type {
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 
-interface RouteWithName extends PlainRoute {
+type RouteWithName = PlainRoute & {
   name?: string;
-}
+};
 
 interface PartialInjectedRouter<P>
   extends Partial<Omit<InjectedRouter<P>, 'location' | 'routes'>> {
@@ -64,7 +64,7 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
    * initializeOrg({router: {params: {alertId: '123'}}})
    * ```
    */
-  const routerProps: RouteComponentProps<RouterParams> = {
+  const routerProps: Omit<RouteComponentProps<RouterParams>, 'children'> = {
     params: router.params as any,
     routeParams: router.params as any,
     router,


### PR DESCRIPTION
Wasn't able to completely remove all route props, but we can start reducing the number of props passed into components and it will help with removing the complexity of the legacy route props

possibly scary if all the right routes aren't marked with `deprecatedRouteProps`