### PR TITLE
fix(replay): Fix summaries not loading due to using wrong `project_id`

### DIFF
--- a/static/app/views/replays/detail/ai/index.tsx
+++ b/static/app/views/replays/detail/ai/index.tsx
@@ -90,9 +90,7 @@ function AiContent({replayRecord}: Props) {
   if (replayRecord?.project_id && !project) {
     return (
       <SummaryContainer>
-        <Alert type="error">
-          {t('Project not found. Unable to load AI summary.')}
-        </Alert>
+        <Alert type="error">{t('Project not found. Unable to load AI summary.')}</Alert>
       </SummaryContainer>
     );
   }

--- a/static/app/views/replays/detail/ai/index.tsx
+++ b/static/app/views/replays/detail/ai/index.tsx
@@ -87,6 +87,16 @@ function AiContent({replayRecord}: Props) {
     );
   }
 
+  if (replayRecord?.project_id && !project) {
+    return (
+      <SummaryContainer>
+        <Alert type="error">
+          {t('Project not found. Unable to load AI summary.')}
+        </Alert>
+      </SummaryContainer>
+    );
+  }
+
   if (isPending || isRefetching) {
     return (
       <LoadingContainer>

--- a/static/app/views/replays/detail/ai/index.tsx
+++ b/static/app/views/replays/detail/ai/index.tsx
@@ -11,8 +11,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {decodeScalar} from 'sentry/utils/queryString';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 import BreadcrumbRow from 'sentry/views/replays/detail/breadcrumbs/breadcrumbRow';
@@ -58,10 +56,7 @@ export default function Ai({replayRecord}: Props) {
 function AiContent({replayRecord}: Props) {
   const {replay} = useReplayContext();
   const organization = useOrganization();
-  const {project: project_id} = useLocationQuery({
-    fields: {project: decodeScalar},
-  });
-  const project = useProjectFromId({project_id});
+  const project = useProjectFromId({project_id: replayRecord?.project_id});
 
   const {
     data: summaryData,


### PR DESCRIPTION
Use `project_id` on the replay record instead of the URL (where it does not always exist).