### PR TITLE
fix(aci): Use contextual logger in workflow processor

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Collection, Mapping
 from dataclasses import asdict, dataclass, replace
 from enum import StrEnum
@@ -33,7 +32,7 @@ from sentry.workflow_engine.types import WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 from sentry.workflow_engine.utils.metrics import metrics_incr
 
-logger = logging.getLogger(__name__)
+logger = log_context.get_logger(__name__)
 
 WORKFLOW_ENGINE_BUFFER_LIST_KEY = "workflow_engine_delayed_processing_buffer"
 


### PR DESCRIPTION
Missed in the initial commit, leading to some relevant logs being unannotated.