### PR TITLE
chore(issues): Remove regex parameterization experiment

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -11,7 +11,6 @@ __all__ = [
     "ParameterizationCallableExperiment",
     "ParameterizationExperiment",
     "ParameterizationRegex",
-    "ParameterizationRegexExperiment",
     "Parameterizer",
     "UniqueIdExperiment",
 ]
@@ -206,15 +205,6 @@ class ParameterizationCallableExperiment(ParameterizationCallable):
         return content
 
 
-class ParameterizationRegexExperiment(ParameterizationRegex):
-    def run(
-        self,
-        content: str,
-        callback: Callable[[re.Match[str]], str],
-    ) -> str:
-        return self.compiled_pattern.sub(callback, content)
-
-
 class _UniqueId:
     # just a namespace for the uniq_id logic, no need to instantiate
 
@@ -275,7 +265,7 @@ UniqueIdExperiment = ParameterizationCallableExperiment(
 )
 
 
-ParameterizationExperiment = ParameterizationCallableExperiment | ParameterizationRegexExperiment
+ParameterizationExperiment = ParameterizationCallableExperiment
 
 
 class Parameterizer:
@@ -355,10 +345,8 @@ class Parameterizer:
         for experiment in self._experiments:
             if not should_run(experiment.name):
                 continue
-            if isinstance(experiment, ParameterizationCallableExperiment):
-                content = experiment.run(content, _incr_counter)
-            else:
-                content = experiment.run(content, _handle_regex_match)
+
+            content = experiment.run(content, _incr_counter)
 
         return content
 

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -1,12 +1,6 @@
-from unittest import mock
-
 import pytest
 
-from sentry.grouping.parameterization import (
-    ParameterizationRegexExperiment,
-    Parameterizer,
-    UniqueIdExperiment,
-)
+from sentry.grouping.parameterization import Parameterizer, UniqueIdExperiment
 from sentry.grouping.strategies.message import REGEX_PATTERN_KEYS
 
 
@@ -225,43 +219,6 @@ def test_parameterize_experiment(name, input, expected, parameterizer):
         experiments = parameterizer.get_successful_experiments()
         assert len(experiments) == 1
         assert experiments[0] == UniqueIdExperiment
-
-
-def test_parameterize_regex_experiment():
-    """
-    We don't have any of these yet, but we need to test that they work
-    """
-    FooExperiment = ParameterizationRegexExperiment(name="foo", raw_pattern=r"f[oO]{2}")
-
-    parameterizer = Parameterizer(
-        regex_pattern_keys=(),
-        experiments=(FooExperiment,),
-    )
-    input_str = "blah foobarbaz fooooo"
-    normalized = parameterizer.parameterize_all(input_str)
-    assert normalized == "blah <foo>barbaz <foo>ooo"
-    assert len(parameterizer.get_successful_experiments()) == 1
-    assert parameterizer.get_successful_experiments()[0] == FooExperiment
-
-
-def test_parameterize_regex_experiment_cached_compiled():
-
-    with mock.patch.object(
-        ParameterizationRegexExperiment,
-        "pattern",
-        new_callable=mock.PropertyMock,
-        return_value=r"(?P<foo>f[oO]{2})",
-    ) as mocked_pattern:
-        FooExperiment = ParameterizationRegexExperiment(name="foo", raw_pattern=r"f[oO]{2}")
-        parameterizer = Parameterizer(
-            regex_pattern_keys=(),
-            experiments=(FooExperiment,),
-        )
-        input_str = "blah foobarbaz fooooo"
-        _ = parameterizer.parameterize_all(input_str)
-        _ = parameterizer.parameterize_all(input_str)
-
-    mocked_pattern.assert_called_once()
 
 
 # These are test cases that we should fix


### PR DESCRIPTION
This is unused and most regex experiments have required broader changes to ensure that regexes are evaluated in a specific order (ex: traceparent). Removing this for now to simplify the code and very slightly improve runtime performance.