### PR TITLE
fix(taskworker) Extend deadlines for check_auth

### DIFF
--- a/src/sentry/tasks/auth/check_auth.py
+++ b/src/sentry/tasks/auth/check_auth.py
@@ -73,7 +73,9 @@ def check_auth_identity(auth_identity_id: int, **kwargs):
     name="sentry.tasks.check_auth_identities",
     queue="auth.control",
     silo_mode=SiloMode.CONTROL,
-    taskworker_config=TaskworkerConfig(namespace=auth_control_tasks),
+    taskworker_config=TaskworkerConfig(
+        namespace=auth_control_tasks, processing_deadline_duration=60
+    ),
 )
 def check_auth_identities(
     auth_identity_id: int | None = None,


### PR DESCRIPTION
This has been killed a few times.

Refs SENTRY-42M7
