### PR TITLE
slideout: remove shadow

### DIFF
--- a/static/app/components/slideOverPanel.tsx
+++ b/static/app/components/slideOverPanel.tsx
@@ -107,7 +107,7 @@ const _SlideOverPanel = styled(motion.div, {
 
   z-index: ${p => p.theme.zIndex.modal - 1};
 
-  box-shadow: ${p => p.theme.dropShadowHeavy};
+  box-shadow: ${p => (p.theme.isChonk ? undefined : p.theme.dropShadowHeavy)};
   background: ${p => p.theme.background};
   color: ${p => p.theme.textColor};
 


### PR DESCRIPTION
Chonk doesn't use shadows to indicate elevation, so 🔪 it