### PR TITLE
fix(grouping): Fix buggy chained exception filtering

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -739,9 +739,10 @@ def filter_exceptions_for_exception_groups(
 
     # Traverse the tree recursively from the root exception to get all "top-level exceptions" and sort for consistency.
     top_level_exceptions = []
-    if exception_tree[0].exception:
+    root_node = exception_tree.get(0)
+    if root_node and root_node.exception:
         top_level_exceptions = sorted(
-            get_top_level_exceptions(exception_tree[0].exception),
+            get_top_level_exceptions(root_node.exception),
             key=lambda exception: str(exception.type),
             reverse=True,
         )

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -623,8 +623,8 @@ def chained_exception(
             all_exceptions, exception_components_by_exception, event
         )
     except Exception:
-        # We shouldn't have exceptions here. But if we do, just record it and continue with the original list.
-        # TODO: Except we do, as it turns out. See https://github.com/getsentry/sentry/issues/73592.
+        # We shouldn't have exceptions here. But if we do, just record it and continue with the
+        # original list.
         logging.exception(
             "Failed to filter exceptions for exception groups. Continuing with original list.",
             extra={

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -695,7 +695,11 @@ def filter_exceptions_for_exception_groups(
     exception_tree: dict[int, ExceptionTreeNode] = {}
     for exception in reversed(exceptions):
         mechanism: Mechanism = exception.mechanism
-        if mechanism and mechanism.exception_id is not None:
+        if (
+            mechanism
+            and mechanism.exception_id is not None
+            and mechanism.exception_id != mechanism.parent_id
+        ):
             node = exception_tree.setdefault(
                 mechanism.exception_id, ExceptionTreeNode()
             ).exception = exception
@@ -704,8 +708,9 @@ def filter_exceptions_for_exception_groups(
                 parent_node = exception_tree.setdefault(mechanism.parent_id, ExceptionTreeNode())
                 parent_node.children.append(exception)
         else:
-            # At least one exception is missing mechanism ids, so we can't continue with the filter.
-            # Exit early to not waste perf.
+            # At least one exception's mechanism is either missing an exception id or listing the
+            # exception as its own parent, so we can't continue with the filter. Exit early to not
+            # waste perf.
             return exceptions
 
     # This gets the child exceptions for an exception using the exception_id from the mechanism.

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -700,10 +700,10 @@ def filter_exceptions_for_exception_groups(
             and mechanism.exception_id is not None
             and mechanism.exception_id != mechanism.parent_id
         ):
-            node = exception_tree.setdefault(
-                mechanism.exception_id, ExceptionTreeNode()
-            ).exception = exception
+            node = exception_tree.setdefault(mechanism.exception_id, ExceptionTreeNode())
             node.exception = exception
+            exception.exception = exception
+
             if mechanism.parent_id is not None:
                 parent_node = exception_tree.setdefault(mechanism.parent_id, ExceptionTreeNode())
                 parent_node.children.append(exception)

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-18T22:47:54.553430+00:00'
+created: '2025-06-20T17:24:14.091297+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -22,12 +22,18 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "0809098f9f613b63467605dd1739cc9b"
-    contributing component: exception
+    hash: "93b26686d00504b4e5aa1cb0244d8b37"
+    contributing component: chained-exception
     component:
       app*
-        exception*
-          type*
-            "System.AggregateException"
-          value*
-            "One or more errors occurred."
+        chained-exception*
+          exception*
+            type*
+              "InnerException"
+            value*
+              "Nope"
+          exception*
+            type*
+              "System.AggregateException"
+            value*
+              "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-06-18T22:50:03.158202+00:00'
+created: '2025-06-20T17:23:52.422319+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouphash_metadata.py
 ---
@@ -22,12 +22,18 @@ metrics with tags: {
 ---
 contributing variants:
   app*
-    hash: "0809098f9f613b63467605dd1739cc9b"
-    contributing component: exception
+    hash: "93b26686d00504b4e5aa1cb0244d8b37"
+    contributing component: chained-exception
     component:
       app*
-        exception*
-          type*
-            "System.AggregateException"
-          value*
-            "One or more errors occurred."
+        chained-exception*
+          exception*
+            type*
+              "InnerException"
+            value*
+              "Nope"
+          exception*
+            type*
+              "System.AggregateException"
+            value*
+              "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,15 +1,21 @@
 ---
-created: '2025-06-18T22:38:40.804913+00:00'
+created: '2025-06-20T17:19:29.502421+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "0809098f9f613b63467605dd1739cc9b"
-  contributing component: exception
+  hash: "93b26686d00504b4e5aa1cb0244d8b37"
+  contributing component: chained-exception
   component:
     app*
-      exception*
-        type*
-          "System.AggregateException"
-        value*
-          "One or more errors occurred."
+      chained-exception*
+        exception*
+          type*
+            "InnerException"
+          value*
+            "Nope"
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,15 +1,21 @@
 ---
-created: '2025-06-18T22:40:08.728458+00:00'
+created: '2025-06-20T17:19:55.755505+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "0809098f9f613b63467605dd1739cc9b"
-  contributing component: exception
+  hash: "93b26686d00504b4e5aa1cb0244d8b37"
+  contributing component: chained-exception
   component:
     app*
-      exception*
-        type*
-          "System.AggregateException"
-        value*
-          "One or more errors occurred."
+      chained-exception*
+        exception*
+          type*
+            "InnerException"
+          value*
+            "Nope"
+        exception*
+          type*
+            "System.AggregateException"
+          value*
+            "One or more errors occurred."

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -110,15 +110,7 @@ def _assert_and_snapshot_results(
     # Check that we didn't end up with a caught but unexpected error in any of our `newstyle`
     # strategies
     if not config_name.startswith("legacy"):
-        if input_file not in [
-            "exception-groups-bad-inner-self-parenting-duplicate-id.json",
-            "exception-groups-bad-no-root.json",
-            "exception-groups-bad-root-self-parenting.json",
-        ]:
-            # TODO: An upcoming fix will make this pass for the above inputs
-            assert mock_newstyle_exception_logger.call_count == 0
-        else:
-            assert mock_newstyle_exception_logger.call_count > 0
+        assert mock_newstyle_exception_logger.call_count == 0
 
     lines: list[str] = []
 


### PR DESCRIPTION
This fixes two bugs with the way we handle chained exceptions when grouping. In the first case, we assume that there will always be a root exception (an exception with `exception_id = 0`). In the second, we assume that an exception will never be listed as its own parent. Both of those are reasonable assumptions to make about a well-formed tree, but for some reason, sometimes the data we get doesn't work that way, and we end up hitting an error. 

Though we handle that error gracefully, it would be better if we didn't error out at all. To fix this, this PR checks for those cases explicitly and handles them directly, before they can cause an error. 

The effects of this change can be seen in two places in the tests: We no longer have to exclude certain test cases from our check that no exception has been logged, and one test case which previously was having one of its exceptions wrongly excluded from grouping now includes the full chain.

Fixes https://github.com/getsentry/sentry/issues/73592
Fixes https://sentry.my.sentry.io/organizations/sentry/issues/2293485
Fixes https://sentry.sentry.io/issues/6634847839
Fixes https://sentry.my.sentry.io/organizations/sentry/issues/2293421