### PR TITLE
ref(counter): remove old way of incrementing project counter

### DIFF
--- a/bin/split-silo-database
+++ b/bin/split-silo-database
@@ -75,28 +75,6 @@ def split_database(tables: list[str], source: str, destination: str, reset: bool
             click.echo(f">> Running {' '.join(import_command)}")
         exec_run(postgres, import_command)
 
-        if destination == "region" and reset:
-            click.echo(">> Cloning stored procedures")
-            function_dump = [
-                "psql",
-                "-U",
-                "postgres",
-                source,
-                "-c",
-                "'\\sf sentry_increment_project_counter'",
-            ]
-            function_sql = exec_run(postgres, function_dump)
-
-            import_function = [
-                "psql",
-                "-U",
-                "postgres",
-                destination,
-                "-c",
-                "'" + function_sql.decode("utf8") + "'",
-            ]
-            exec_run(postgres, import_function)
-
 
 def revise_organization_mappings(legacy_region_name: str):
     if settings.SENTRY_MONOLITH_REGION == legacy_region_name:

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -1,7 +1,6 @@
 import sentry_sdk
 from django.conf import settings
 from django.db import connections, transaction
-from django.db.models.signals import post_migrate
 
 from sentry import features
 from sentry.backup.scopes import RelocationScope
@@ -9,14 +8,11 @@ from sentry.db.models import (
     BoundedBigIntegerField,
     FlexibleForeignKey,
     Model,
-    get_model_if_available,
     region_silo_model,
     sane_repr,
 )
 from sentry.locks import locks
-from sentry.options.rollout import in_random_rollout
 from sentry.silo.base import SiloMode
-from sentry.silo.safety import unguarded_write
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.config import TaskworkerConfig
 from sentry.taskworker.namespaces import ingest_errors_tasks
@@ -97,8 +93,6 @@ def increment_project_counter_in_database(project, delta=1, using="default") -> 
     if delta <= 0:
         raise ValueError("There is only one way, and that's up.")
 
-    modern_upsert = in_random_rollout("store.projectcounter-modern-upsert-sample-rate")
-
     # To prevent the statement_timeout leaking into the session we need to use
     # set local which can be used only within a transaction
     with transaction.atomic(using=using):
@@ -114,21 +108,15 @@ def increment_project_counter_in_database(project, delta=1, using="default") -> 
                     [settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT],
                 )
 
-            if modern_upsert:
-                # Our postgres wrapper thing does not allow for named arguments
-                cur.execute(
-                    "insert into sentry_projectcounter (project_id, value) "
-                    "values (%s, %s) "
-                    "on conflict (project_id) do update "
-                    "set value = sentry_projectcounter.value + %s "
-                    "returning value",
-                    [project.id, delta, delta],
-                )
-            else:
-                cur.execute(
-                    "select sentry_increment_project_counter(%s, %s)",
-                    [project.id, delta],
-                )
+            # Our postgres wrapper thing does not allow for named arguments
+            cur.execute(
+                "insert into sentry_projectcounter (project_id, value) "
+                "values (%s, %s) "
+                "on conflict (project_id) do update "
+                "set value = sentry_projectcounter.value + %s "
+                "returning value",
+                [project.id, delta, delta],
+            )
 
             project_counter = cur.fetchone()[0]
 
@@ -139,50 +127,6 @@ def increment_project_counter_in_database(project, delta=1, using="default") -> 
                 )
 
             return project_counter
-
-
-# this must be idempotent because it seems to execute twice
-# (at least during test runs)
-def create_counter_function(app_config, using, **kwargs) -> None:
-    if app_config and app_config.name != "sentry":
-        return
-
-    if not get_model_if_available(app_config, "Counter"):
-        return
-
-    if SiloMode.get_current_mode() == SiloMode.CONTROL:
-        return
-
-    with unguarded_write(using), connections[using].cursor() as cursor:
-        cursor.execute(
-            """
-            create or replace function sentry_increment_project_counter(
-                project bigint, delta int) returns int as $$
-            declare
-            new_val int;
-            begin
-            loop
-                update sentry_projectcounter set value = value + delta
-                where project_id = project
-                returning value into new_val;
-                if found then
-                return new_val;
-                end if;
-                begin
-                insert into sentry_projectcounter(project_id, value)
-                    values (project, delta)
-                    returning value into new_val;
-                return new_val;
-                exception when unique_violation then
-                end;
-            end loop;
-            end
-            $$ language plpgsql;
-        """
-        )
-
-
-post_migrate.connect(create_counter_function, dispatch_uid="create_counter_function", weak=False)
 
 
 @instrumented_task(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1164,11 +1164,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Switch for more performant project counter incr
-register(
-    "store.projectcounter-modern-upsert-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
-)
-
 # Run an experimental grouping config in background for performance analysis
 register("store.background-grouping-config-id", default=None, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -5,7 +5,6 @@ import pytest
 from django.db import IntegrityError
 from django.test import override_settings
 
-from sentry import options
 from sentry.locks import locks
 from sentry.models.counter import (
     LOW_WATER_RATIO,
@@ -23,10 +22,7 @@ from sentry.utils.redis import redis_clusters
 
 
 @django_db_all
-@pytest.mark.parametrize("upsert_sample_rate", [0, 1])
-def test_increment(default_project, upsert_sample_rate):
-    options.set("store.projectcounter-modern-upsert-sample-rate", upsert_sample_rate)
-
+def test_increment(default_project):
     assert Counter.increment(default_project) == 1
     assert Counter.increment(default_project) == 2
 


### PR DESCRIPTION
removes code relating to the old way of doing project counter incrementing with a postgres function. these values have been set to 1 in us/de for a long time, so i believe we can remove the previous way.