### PR TITLE
feat(issues): Add hex parameterization experiment

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -180,8 +180,36 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
     ),
 ]
 
+EXPERIMENT_PARAMETERIZATION_REGEXES = [
+    (
+        ParameterizationRegex(
+            name="hex",
+            raw_pattern=r"""
+                # Hex value with 0x or 0X prefix
+                (\b0[xX][0-9a-fA-F]+\b) |
+
+                # Hex value without 0x or 0X prefix exactly 4 or 8 bytes long.
+                #
+                # We don't need to lookahead for a-f since we if it contains at
+                # least one number it must contain at least one a-f otherwise it
+                # would have matched "int".
+                #
+                # (?=.*[0-9]):  At least one 0-9 is in the 16 match.
+                # [0-9a-f]{16}: Exactly 16 hex characters (0-9, a-f).
+                (\b(?=.*[0-9])[0-9a-f]{8,16}\b)
+            """,
+        )
+        if r.name == "hex"
+        else r
+    )
+    for r in DEFAULT_PARAMETERIZATION_REGEXES.copy()
+]
+
 
 DEFAULT_PARAMETERIZATION_REGEXES_MAP = {r.name: r.pattern for r in DEFAULT_PARAMETERIZATION_REGEXES}
+EXPERIMENT_PARAMETERIZATION_REGEXES_MAP = {
+    r.name: r.pattern for r in EXPERIMENT_PARAMETERIZATION_REGEXES
+}
 
 
 @dataclasses.dataclass
@@ -273,14 +301,15 @@ class Parameterizer:
         self,
         regex_pattern_keys: Sequence[str],
         experiments: Sequence[ParameterizationExperiment] = (),
+        enable_regex_experiments: bool = False,
     ):
+        self._enable_regex_experiments = enable_regex_experiments
         self._parameterization_regex = self._make_regex_from_patterns(regex_pattern_keys)
         self._experiments = experiments
 
         self.matches_counter: defaultdict[str, int] = defaultdict(int)
 
-    @staticmethod
-    def _make_regex_from_patterns(pattern_keys: Sequence[str]) -> re.Pattern[str]:
+    def _make_regex_from_patterns(self, pattern_keys: Sequence[str]) -> re.Pattern[str]:
         """
         Takes list of pattern keys and returns a compiled regex pattern that matches any of them.
 
@@ -292,9 +321,14 @@ class Parameterizer:
         so we can use newlines and indentation for better legibility in patterns above.
         """
 
-        return re.compile(
-            rf"(?x){'|'.join(DEFAULT_PARAMETERIZATION_REGEXES_MAP[k] for k in pattern_keys)}"
-        )
+        if self._enable_regex_experiments:
+            return re.compile(
+                rf"(?x){'|'.join(EXPERIMENT_PARAMETERIZATION_REGEXES_MAP[k] for k in pattern_keys)}"
+            )
+        else:
+            return re.compile(
+                rf"(?x){'|'.join(DEFAULT_PARAMETERIZATION_REGEXES_MAP[k] for k in pattern_keys)}"
+            )
 
     def parametrize_w_regex(self, content: str) -> str:
         """

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -194,9 +194,10 @@ EXPERIMENT_PARAMETERIZATION_REGEXES = [
                 # least one number it must contain at least one a-f otherwise it
                 # would have matched "int".
                 #
-                # (?=.*[0-9]):  At least one 0-9 is in the 16 match.
-                # [0-9a-f]{16}: Exactly 16 hex characters (0-9, a-f).
-                (\b(?=.*[0-9])[0-9a-f]{8,16}\b)
+                # (?=.*[0-9]):    At least one 0-9 is in the match.
+                # [0-9a-f]{8/16}: Exactly 8 or 16 hex characters (0-9, a-f).
+                (\b(?=.*[0-9])[0-9a-f]{8}\b) |
+                (\b(?=.*[0-9])[0-9a-f]{16}\b)
             """,
         )
         if r.name == "hex"

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -85,7 +85,9 @@ def normalize_message_for_grouping(message: str, event: Event, share_analytics: 
         )
 
     parameterizer = Parameterizer(
-        regex_pattern_keys=REGEX_PATTERN_KEYS, experiments=(UniqueIdExperiment,)
+        regex_pattern_keys=REGEX_PATTERN_KEYS,
+        experiments=(UniqueIdExperiment,),
+        enable_regex_experiments=_should_run_experiment("regex"),
     )
 
     normalized = parameterizer.parameterize_all(trimmed, _should_run_experiment)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2629,6 +2629,11 @@ register(
     default=0.0,
     flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
 )
+register(
+    "grouping.experiments.parameterization.regex",
+    default=0.0,
+    flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE | FLAG_RATE,
+)
 
 # TODO: For now, only a small number of projects are going through a grouping config transition at
 # any given time, so we're sampling at 100% in order to be able to get good signal. Once we've fully

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -9,6 +9,7 @@ def parameterizer():
     return Parameterizer(
         regex_pattern_keys=REGEX_PATTERN_KEYS,
         experiments=(UniqueIdExperiment,),
+        enable_regex_experiments=True,
     )
 
 
@@ -108,6 +109,8 @@ def parameterizer():
             """blah <date> had a problem""",
         ),
         ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
+        ("hex", """blah 9af8c3b0 had a problem""", """blah <hex> had a problem"""),
+        ("hex", """blah 9af8c3b09af8c3b0 had a problem""", """blah <hex> had a problem"""),
         ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
         ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
         (
@@ -146,6 +149,11 @@ def parameterizer():
             "Nothing to replace",
             """A quick brown fox jumped over the lazy dog""",
             """A quick brown fox jumped over the lazy dog""",
+        ),
+        (
+            "Not confidently a hex",
+            """blah aaffccbb had a problem""",
+            """blah aaffccbb had a problem""",
         ),
     ],
 )

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -111,6 +111,16 @@ def parameterizer():
         ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
         ("hex", """blah 9af8c3b0 had a problem""", """blah <hex> had a problem"""),
         ("hex", """blah 9af8c3b09af8c3b0 had a problem""", """blah <hex> had a problem"""),
+        (
+            "hex - missing numbers",
+            """blah aaffccbb had a problem""",
+            """blah aaffccbb had a problem""",
+        ),
+        (
+            "hex - not 4 or 8 bytes",
+            """blah 4aaa 9aaaaaaaa 10aaaaaaaa 15aaaaaaaaaaaaa 17aaaaaaaaaaaaaaa had a problem""",
+            """blah 4aaa 9aaaaaaaa 10aaaaaaaa 15aaaaaaaaaaaaa 17aaaaaaaaaaaaaaa had a problem""",
+        ),
         ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
         ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
         (
@@ -149,11 +159,6 @@ def parameterizer():
             "Nothing to replace",
             """A quick brown fox jumped over the lazy dog""",
             """A quick brown fox jumped over the lazy dog""",
-        ),
-        (
-            "Not confidently a hex",
-            """blah aaffccbb had a problem""",
-            """blah aaffccbb had a problem""",
         ),
     ],
 )


### PR DESCRIPTION
Our existing hex parameterization supports hex values of any length however they must begin with either `0x` or `0X`. We frequently see hex values in messages which do not have this prefix (ex: trace ids or span ids).

This adds support for hex values which do not have the `0x` prefix. To ensure it does not over-parameterize the following requirements:
- Must be exactly 4 or 8 bytes (8 or 16 characters)
- Must contain both a number and a letter
- Must use lowercase letters (anecdotally I've never seen examples where uppercase would be beneficial)

We're replacing the `hex` pattern in place in the experiment so that when this is rolled out it doesn't trigger a rehash.

The addition of `EXPERIMENT_PARAMETERIZATION_REGEXES_MAP` and other parameters will all be removed once the rollout of this is completed.