### PR TITLE
fix(aci): Fix accidental over-logging

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -580,7 +580,7 @@ def fire_actions_for_groups(
                     extra={
                         "workflow_ids": [workflow.id for workflow in workflows],
                         "actions": [action.id for action in filtered_actions],
-                        "event_data": event_data,
+                        "event_data": workflow_event_data,
                         "event_id": workflow_event_data.event.event_id,
                     },
                 )


### PR DESCRIPTION
Unfortunately, 'event_data' went from being the variable for current event context to being the complete parsed data from Redis, and we continued logging it per group.
That's more data than we should be logging even arguably once, let alone per group.
