### PR TITLE
:wrench: chore: use IntegrationProviderSlug.Github instead of magic str

### DIFF
--- a/src/sentry/api/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/api/endpoints/group_autofix_setup_check.py
@@ -15,6 +15,7 @@ from sentry.api.bases.group import GroupAiEndpoint
 from sentry.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -37,7 +38,7 @@ def get_autofix_integration_setup_problems(
     If there is an issue, returns the reason.
     """
     organization_integrations = integration_service.get_organization_integrations(
-        organization_id=organization.id, providers=["github"]
+        organization_id=organization.id, providers=[IntegrationProviderSlug.GITHUB.value]
     )
 
     # Iterate through all organization integrations to find one with an active integration
@@ -66,7 +67,7 @@ def get_repos_and_access(project: Project) -> list[dict]:
     for repo in repos:
         # We only support github for now.
         provider = repo.get("provider")
-        if provider != "integrations:github" and provider != "github":
+        if provider != "integrations:github" and provider != IntegrationProviderSlug.GITHUB.value:
             continue
 
         body = orjson.dumps(

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -22,6 +22,7 @@ from sentry.api.serializers import Serializer, serialize
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationFeatures
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
 
@@ -182,7 +183,7 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
 
         for integration_provider, integration_ids in integration_provider_to_ids.items():
             # TODO(cathy): allow other integration providers
-            if integration_provider != "github":
+            if integration_provider != IntegrationProviderSlug.GITHUB.value:
                 continue
 
             queryset = _get_missing_organization_members(

--- a/src/sentry/auth/providers/github/provider.py
+++ b/src/sentry/auth/providers/github/provider.py
@@ -8,6 +8,7 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Login, OAuth2Provider
 from sentry.auth.services.auth.model import RpcAuthProvider
 from sentry.auth.view import AuthView
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.authidentity import AuthIdentity
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.base.response import DeferredResponse
@@ -21,7 +22,7 @@ class GitHubOAuth2Provider(OAuth2Provider):
     access_token_url = ACCESS_TOKEN_URL
     authorize_url = AUTHORIZE_URL
     name = "GitHub"
-    key = "github"
+    key = IntegrationProviderSlug.GITHUB.value
 
     def get_client_id(self):
         return CLIENT_ID

--- a/src/sentry/autofix/webhooks.py
+++ b/src/sentry/autofix/webhooks.py
@@ -4,6 +4,7 @@ from django.conf import settings
 
 from sentry import analytics
 from sentry.autofix.utils import AutofixState, get_autofix_state_from_pr_id
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.utils import metrics
 
@@ -43,7 +44,7 @@ def handle_github_pr_webhook_for_autofix(
         analytics.record(
             f"ai.autofix.pr.{analytic_action}",
             organization_id=org.id,
-            integration="github",
+            integration=IntegrationProviderSlug.GITHUB.value,
             **get_webhook_analytics_fields(autofix_state),
         )
         metrics.incr(f"ai.autofix.pr.{analytic_action}")

--- a/src/sentry/codecov/client.py
+++ b/src/sentry/codecov/client.py
@@ -9,6 +9,7 @@ from rest_framework import status
 
 from sentry import options
 from sentry.api.exceptions import SentryAPIException
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.utils import jwt
 
 GitProviderId: TypeAlias = str
@@ -23,7 +24,7 @@ class GitProvider(StrEnum):
     for now.
     """
 
-    GitHub = "github"
+    GitHub = IntegrationProviderSlug.GITHUB
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -2,6 +2,7 @@ from django.core.exceptions import PermissionDenied
 
 from sentry import http, options
 from sentry.identity.oauth2 import OAuth2Provider
+from sentry.integrations.types import IntegrationProviderSlug
 
 
 def get_user_info(access_token):
@@ -24,7 +25,7 @@ def get_user_info(access_token):
 
 
 class GitHubIdentityProvider(OAuth2Provider):
-    key = "github"
+    key = IntegrationProviderSlug.GITHUB.value
     name = "GitHub"
 
     oauth_access_token_url = "https://github.com/login/oauth/access_token"

--- a/src/sentry/integrations/api/endpoints/organization_repositories.py
+++ b/src/sentry/integrations/api/endpoints/organization_repositories.py
@@ -15,12 +15,16 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.repository.model import RpcRepository
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.plugins.base import bindings
 from sentry.ratelimits.config import SENTRY_RATELIMITER_GROUP_DEFAULTS, RateLimitConfig
 from sentry.utils.sdk import capture_exception
 
-UNMIGRATABLE_PROVIDERS = ("bitbucket", "github")
+UNMIGRATABLE_PROVIDERS = (
+    IntegrationProviderSlug.BITBUCKET.value,
+    IntegrationProviderSlug.GITHUB.value,
+)
 
 
 @region_silo_endpoint

--- a/src/sentry/integrations/github/actions/create_ticket.py
+++ b/src/sentry/integrations/github/actions/create_ticket.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.rules.actions import TicketEventAction
 from sentry.utils.http import absolute_uri
 
@@ -10,7 +11,7 @@ class GitHubCreateTicketAction(TicketEventAction):
     ticket_type = "a GitHub issue"
     # TODO(schew2381): Add link to docs once GitHub issue sync is available
     link = None
-    provider = "github"
+    provider = IntegrationProviderSlug.GITHUB.value
 
     def generate_footer(self, rule_url: str) -> str:
         return "\nThis issue was automatically created by Sentry via [{}]({})".format(

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -25,7 +25,7 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.integrations.source_code_management.repo_trees import RepoTreesClient
 from sentry.integrations.source_code_management.repository import RepositoryClient
-from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.integrations.types import EXTERNAL_PROVIDERS, ExternalProviders, IntegrationProviderSlug
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
@@ -243,7 +243,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
     allow_redirects = True
 
     base_url = "https://api.github.com"
-    integration_name = "github"
+    integration_name = IntegrationProviderSlug.GITHUB
     # Github gives us links to navigate, however, let's be safe in case we're fed garbage
     page_number_limit = 50  # With a default of 100 per page -> 5,000 items
 
@@ -555,7 +555,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
     ) -> Sequence[FileBlameInfo]:
         log_info = {
             **extra,
-            "provider": "github",
+            "provider": IntegrationProviderSlug.GITHUB,
             "organization_integration_id": self.org_integration_id,
         }
         metrics.incr("integrations.github.get_blame_for_files")
@@ -572,7 +572,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
                 logger.error(
                     "sentry.integrations.github.get_blame_for_files.rate_limit",
                     extra={
-                        "provider": "github",
+                        "provider": IntegrationProviderSlug.GITHUB,
                         "specific_resource": "graphql",
                         "remaining": rate_limit.remaining,
                         "next_window": rate_limit.next_window(),
@@ -628,7 +628,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
             files=files,
             extra={
                 **extra,
-                "provider": "github",
+                "provider": IntegrationProviderSlug.GITHUB,
                 "organization_integration_id": self.org_integration_id,
             },
         )

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -243,7 +243,7 @@ class GitHubBaseClient(GithubProxyClient, RepositoryClient, CommitContextClient,
     allow_redirects = True
 
     base_url = "https://api.github.com"
-    integration_name = IntegrationProviderSlug.GITHUB
+    integration_name = IntegrationProviderSlug.GITHUB.value
     # Github gives us links to navigate, however, let's be safe in case we're fed garbage
     page_number_limit = 50  # With a default of 100 per page -> 5,000 items
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -212,7 +212,7 @@ def get_document_origin(org) -> str:
 class GitHubIntegration(
     RepositoryIntegration, GitHubIssuesSpec, CommitContextIntegration, RepoTreesIntegration
 ):
-    integration_name = "github"
+    integration_name = IntegrationProviderSlug.GITHUB
 
     codeowners_locations = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
 
@@ -305,7 +305,7 @@ class GitHubIntegration(
         accessible_repo_names = [r["identifier"] for r in accessible_repos]
 
         existing_repos = repository_service.get_repositories(
-            organization_id=self.organization_id, providers=["github"]
+            organization_id=self.organization_id, providers=[IntegrationProviderSlug.GITHUB.value]
         )
 
         return [repo for repo in existing_repos if repo.name not in accessible_repo_names]
@@ -687,7 +687,7 @@ class GitHubIntegrationProvider(IntegrationProvider):
     ) -> None:
         repos = repository_service.get_repositories(
             organization_id=organization.id,
-            providers=["github", "integrations:github"],
+            providers=[IntegrationProviderSlug.GITHUB.value, "integrations:github"],
             has_integration=False,
         )
 
@@ -803,7 +803,10 @@ class OAuthLoginView(IntegrationPipelineViewT):
                 state = pipeline.signature
 
                 redirect_uri = absolute_uri(
-                    reverse("sentry-extension-setup", kwargs={"provider_id": "github"})
+                    reverse(
+                        "sentry-extension-setup",
+                        kwargs={"provider_id": IntegrationProviderSlug.GITHUB.value},
+                    )
                 )
                 return HttpResponseRedirect(
                     f"{ghip.get_oauth_authorize_url()}?client_id={github_client_id}&state={state}&redirect_uri={redirect_uri}"

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -6,6 +6,7 @@ from typing import Any
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
@@ -18,7 +19,7 @@ WEBHOOK_EVENTS = ["push", "pull_request"]
 
 class GitHubRepositoryProvider(IntegrationRepositoryProvider):
     name = "GitHub"
-    repo_provider = "github"
+    repo_provider = IntegrationProviderSlug.GITHUB.value
 
     def _validate_repo(self, client: Any, installation: IntegrationInstallation, repo: str) -> Any:
         try:

--- a/src/sentry/integrations/github/tasks/pr_comment.py
+++ b/src/sentry/integrations/github/tasks/pr_comment.py
@@ -9,6 +9,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.github.constants import RATE_LIMITED_MESSAGE
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.tasks import pr_comment_workflow
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.pullrequest import PullRequestComment
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
@@ -61,7 +62,7 @@ def github_comment_reactions():
 
         # Add check for GitHub provider before proceeding
         # TODO: nuke comment reactions or implement for all providers
-        if repo.provider not in ("github", "integrations:github"):
+        if repo.provider not in (IntegrationProviderSlug.GITHUB.value, "integrations:github"):
             metrics.incr("pr_comment.comment_reactions.skipped_non_github")
             continue
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -30,6 +30,7 @@ from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.services.repository.service import repository_service
 from sentry.integrations.source_code_management.commit_context import CommitContextIntegration
 from sentry.integrations.source_code_management.webhook import SCMWebhook
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent, IntegrationWebhookEventType
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.models.commit import Commit
@@ -74,7 +75,7 @@ class GitHubWebhook(SCMWebhook, ABC):
 
     @property
     def provider(self) -> str:
-        return "github"
+        return IntegrationProviderSlug.GITHUB.value
 
     @abstractmethod
     def _handle(self, integration: RpcIntegration, event: Mapping[str, Any], **kwargs) -> None:
@@ -142,7 +143,7 @@ class GitHubWebhook(SCMWebhook, ABC):
                         "webhook.repository_created",
                         organization_id=org.id,
                         repository_id=repo.id,
-                        integration="github",
+                        integration=IntegrationProviderSlug.GITHUB.value,
                     )
                     metrics.incr("github.webhook.repository_created")
 
@@ -233,7 +234,7 @@ class InstallationEventWebhook(GitHubWebhook):
                 },
             }
             data = GitHubIntegrationProvider().build_integration(state)
-            ensure_integration("github", data)
+            ensure_integration(IntegrationProviderSlug.GITHUB.value, data)
 
         if event["action"] == "deleted":
             external_id = event["installation"]["id"]

--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -1,9 +1,10 @@
 from sentry.integrations.github.client import GitHubBaseClient
 from sentry.integrations.github.utils import get_jwt
+from sentry.integrations.types import IntegrationProviderSlug
 
 
 class GitHubEnterpriseApiClient(GitHubBaseClient):
-    integration_name = "github_enterprise"
+    integration_name = IntegrationProviderSlug.GITHUB_ENTERPRISE.value
 
     def __init__(self, base_url, integration, app_id, private_key, verify_ssl, org_integration_id):
         self.base_url = f"https://{base_url}"

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -40,7 +40,7 @@ from sentry.integrations.slack.utils.escape import (
     escape_slack_text,
 )
 from sentry.integrations.time_utils import get_approx_start_time, time_since
-from sentry.integrations.types import ExternalProviders
+from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
 from sentry.integrations.utils.issue_summary_for_alerts import fetch_issue_summary
 from sentry.issues.endpoints.group_details import get_group_global_count
 from sentry.issues.grouptype import GroupCategory, NotificationContextField
@@ -67,12 +67,12 @@ from sentry.users.services.user.model import RpcUser
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
 SUPPORTED_COMMIT_PROVIDERS = (
-    "github",
+    IntegrationProviderSlug.GITHUB.value,
     "integrations:github",
     "integrations:github_enterprise",
     "integrations:vsts",
     "integrations:gitlab",
-    "bitbucket",
+    IntegrationProviderSlug.BITBUCKET.value,
     "integrations:bitbucket",
 )
 

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -18,6 +18,7 @@ from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionType,
     SourceCodeSearchEndpointHaltReason,
 )
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import RpcOrganization
 
 T = TypeVar("T", bound=SourceCodeIssueIntegration)
@@ -63,7 +64,11 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
     def record_event(self, event: SCMIntegrationInteractionType):
         # XXX (mifu67): self.integration_provider is None for the GithubSharedSearchEndpoint,
         # which is used by both GitHub and GitHub Enterprise.
-        provider_name = "github" if self.integration_provider is None else self.integration_provider
+        provider_name = (
+            IntegrationProviderSlug.GITHUB.value
+            if self.integration_provider is None
+            else self.integration_provider
+        )
         return SCMIntegrationInteractionEvent(
             interaction_type=event,
             provider_key=provider_name,

--- a/src/sentry/integrations/utils/codecov.py
+++ b/src/sentry/integrations/utils/codecov.py
@@ -11,6 +11,7 @@ from sentry_sdk import Scope
 
 from sentry import options
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.stacktrace_link import RepositoryLinkOutcome
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -45,7 +46,7 @@ def has_codecov_integration(organization: Organization) -> tuple[bool, str | Non
     Returns a tuple of (has_codecov_integration, error_message)
     """
     integrations = integration_service.get_integrations(
-        organization_id=organization.id, providers=["github"]
+        organization_id=organization.id, providers=[IntegrationProviderSlug.GITHUB.value]
     )
     if not integrations:
         logger.info(
@@ -64,7 +65,9 @@ def has_codecov_integration(organization: Organization) -> tuple[bool, str | Non
             continue
 
         owner_username, _ = repos[0].get("full_name").split("/")
-        url = CODECOV_REPOS_URL.format(service="github", owner_username=owner_username)
+        url = CODECOV_REPOS_URL.format(
+            service=IntegrationProviderSlug.GITHUB.value, owner_username=owner_username
+        )
         response = requests.get(url)
         if response.status_code == 200:
             logger.info(
@@ -91,7 +94,7 @@ def get_codecov_data(repo: str, service: str, path: str) -> tuple[LineCoverage |
         return None, None
 
     owner_username, repo_name = repo.split("/")
-    service = "gh" if service == "github" else service
+    service = "gh" if service == IntegrationProviderSlug.GITHUB.value else service
 
     path = path.lstrip("/")
     url = CODECOV_REPORT_URL.format(

--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from sentry.integrations.types import IntegrationProviderSlug
+
 METRIC_PREFIX = "auto_source_code_config"
 DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
-SUPPORTED_INTEGRATIONS = ["github"]
+SUPPORTED_INTEGRATIONS = [IntegrationProviderSlug.GITHUB.value]
 STACK_ROOT_MAX_LEVEL = 4
 # Stacktrace roots that match one of these will have three levels of granularity
 # com.au, co.uk, org.uk, gov.uk, net.uk, edu.uk, ct.uk

--- a/src/sentry/notifications/notifications/missing_members_nudge.py
+++ b/src/sentry/notifications/notifications/missing_members_nudge.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import Any
 
 from sentry.db.models.base import Model
-from sentry.integrations.types import ExternalProviders
+from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
@@ -13,7 +13,7 @@ from sentry.notifications.notifications.strategies.member_write_role_recipient_s
 from sentry.notifications.types import NotificationSettingEnum
 from sentry.types.actor import Actor
 
-PROVIDER_TO_URL = {"github": "https://github.com/"}
+PROVIDER_TO_URL = {IntegrationProviderSlug.GITHUB.value: "https://github.com/"}
 
 
 class MissingMembersNudgeNotification(BaseNotification):

--- a/src/sentry/seer/services/test_generation/impl.py
+++ b/src/sentry/seer/services/test_generation/impl.py
@@ -2,6 +2,7 @@ import orjson
 import requests
 from django.conf import settings
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.seer.services.test_generation.model import CreateUnitTestResponse
 from sentry.seer.services.test_generation.service import TestGenerationService
 
@@ -14,7 +15,7 @@ class RegionBackedTestGenerationService(TestGenerationService):
         body = orjson.dumps(
             {
                 "repo": {
-                    "provider": "github",
+                    "provider": IntegrationProviderSlug.GITHUB.value,
                     "owner": github_org,
                     "name": repo,
                     "external_id": external_id,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -15,6 +15,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.grouprelease import GroupRelease
@@ -142,7 +143,7 @@ class Fixtures:
     @assume_test_silo_mode(SiloMode.CONTROL)
     def integration(self):
         integration = Integration.objects.create(
-            provider="github",
+            provider=IntegrationProviderSlug.GITHUB.value,
             name="GitHub",
             external_id="github:1",
             metadata={

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -29,6 +29,7 @@ from sentry.ingest.consumer.processors import (
     process_attachment_chunk,
     process_individual_attachment,
 )
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.activity import Activity
 from sentry.models.broadcast import Broadcast
 from sentry.models.commit import Commit
@@ -484,7 +485,7 @@ def create_repository(organization: Organization) -> Repository:
         # upgrade to the new integration
         repo = Repository.objects.get(
             organization_id=organization.id,
-            provider="github",
+            provider=IntegrationProviderSlug.GITHUB.value,
             external_id="example/example",
             name="Example Repo",
         )

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.utils.http import absolute_uri, create_redirect_url
 from sentry.web.frontend.base import BaseView
@@ -35,7 +36,7 @@ class PipelineAdvancerView(BaseView):
         # they will redirect here *without* being in the pipeline. If that happens
         # redirect to the integration install org picker.
         if (
-            provider_id == "github"
+            provider_id == IntegrationProviderSlug.GITHUB.value
             and request.GET.get("setup_action") == "install"
             and pipeline is None
         ):

--- a/src/social_auth/backends/github.py
+++ b/src/social_auth/backends/github.py
@@ -16,6 +16,7 @@ from urllib.request import Request
 
 from django.conf import settings
 
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.utils import json
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.exceptions import AuthFailed
@@ -35,7 +36,7 @@ GITHUB_ORGANIZATION_MEMBER_OF_URL = "https://%s/orgs/{org}/members/{username}" %
 class GithubBackend(OAuthBackend):
     """Github OAuth authentication backend"""
 
-    name = "github"
+    name = IntegrationProviderSlug.GITHUB.value
     # Default extra data to store
     EXTRA_DATA = [("id", "id"), ("expires", "expires")]
 
@@ -120,4 +121,4 @@ class GithubAuth(BaseOAuth2):
 
 
 # Backend definition
-BACKENDS = {"github": GithubAuth}
+BACKENDS = {IntegrationProviderSlug.GITHUB.value: GithubAuth}


### PR DESCRIPTION
working on standardizing references to integration slugs

continues work from https://github.com/getsentry/sentry/pull/92208

contributes to ECO-541