### PR TITLE
fix(replay): Add handling for null max_segment_id

### DIFF
--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -84,6 +84,11 @@ def _delete_if_exists(filename: str) -> None:
 
 
 def _make_recording_filenames(project_id: int, row: MatchedRow) -> list[str]:
+    # Null segment_ids can cause this to fail. If no segments were ingested then we can skip
+    # deleting the segements.
+    if row["max_segment_id"] is None:
+        return []
+
     # We assume every segment between 0 and the max_segment_id exists. Its a waste of time to
     # delete a non-existent segment but its not so significant that we'd want to query ClickHouse
     # to verify it exists.
@@ -104,7 +109,7 @@ def _make_recording_filenames(project_id: int, row: MatchedRow) -> list[str]:
 class MatchedRow(TypedDict):
     retention_days: int
     replay_id: str
-    max_segment_id: int
+    max_segment_id: int | None
     platform: str
 
 

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -94,7 +94,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
                 {
                     "retention_days": 90,
                     "replay_id": "b",
-                    "max_segment_id": 0,
+                    "max_segment_id": None,
                     "platform": "javascript",
                 },
             ],


### PR DESCRIPTION
When the max segment ID is null the process fails.  We should exit early since if there aren't any segments to delete there's nothing to do.