### PR TITLE
fix(taskworker) Extend deletion deadlines

### DIFF
--- a/src/sentry/deletions/tasks/scheduled.py
+++ b/src/sentry/deletions/tasks/scheduled.py
@@ -110,6 +110,7 @@ def _run_scheduled_deletions(model_class: type[BaseScheduledDeletion], process_t
     silo_mode=SiloMode.CONTROL,
     taskworker_config=TaskworkerConfig(
         namespace=deletion_control_tasks,
+        processing_deadline_duration=15 * 60,
         retry=Retry(
             times=MAX_RETRIES,
             times_exceeded=LastAction.Discard,
@@ -136,6 +137,7 @@ def run_deletion_control(deletion_id: int, first_pass: bool = True, **kwargs: An
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=deletion_tasks,
+        processing_deadline_duration=15 * 60,
         retry=Retry(
             times=MAX_RETRIES,
             times_exceeded=LastAction.Discard,


### PR DESCRIPTION
deletion tasks can run for 15 minutes (sometimes more). If a deletion is interrupted it will continue on the next deletion cycle.
