### PR TITLE
fix(grouping): Improve handling of known React 19 errors

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -635,10 +635,6 @@ def chained_exception(
         )
         exceptions = all_exceptions
 
-    main_exception_id = determine_main_exception_id(exceptions)
-    if main_exception_id:
-        event.data["main_exception_id"] = main_exception_id
-
     # Cases 1 and 2: Either this never was a chained exception (this is our entry point for single
     # exceptions, too), or this is a chained exception consisting solely of an exception group and a
     # single inner exception. In the former case, all we have is the single exception component, so
@@ -650,6 +646,12 @@ def chained_exception(
     # Case 3: This is either a chained exception or an exception group containing at least two inner
     # exceptions. Either way, we need to wrap our exception components in a chained exception component.
     exception_components_by_variant: dict[str, list[ExceptionGroupingComponent]] = {}
+
+    # Check for cases in which we want to switch the `main_exception_id` in order to use a different
+    # exception than normal for the event title
+    main_exception_id = determine_main_exception_id(exceptions)
+    if main_exception_id:
+        event.data["main_exception_id"] = main_exception_id
 
     for exception in exceptions:
         for variant_name, component in exception_components_by_exception[id(exception)].items():

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -860,6 +860,7 @@ def react_error_with_cause(exceptions: list[SingleException]) -> int | None:
     if (
         exceptions[0].type == "Error"
         and exceptions[0].value in REACT_ERRORS_WITH_CAUSE
+        and exceptions[-1].mechanism
         and exceptions[-1].mechanism.source == "cause"
     ):
         main_exception_id = exceptions[-1].mechanism.exception_id

--- a/tests/sentry/grouping/grouping_inputs/react-concurrent-rendering-no-cause.json
+++ b/tests/sentry/grouping/grouping_inputs/react-concurrent-rendering-no-cause.json
@@ -1,0 +1,15 @@
+{
+  "exception": {
+    "values": [
+      {
+        "type": "Error",
+        "value": "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.",
+        "mechanism": {
+          "type": "generic",
+          "handled": true,
+          "exception_id": 0
+        }
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/grouping_inputs/react-concurrent-rendering-no-mechanism.json
+++ b/tests/sentry/grouping/grouping_inputs/react-concurrent-rendering-no-mechanism.json
@@ -1,0 +1,14 @@
+{
+  "exception": {
+    "values": [
+      {
+        "type": "TypeError",
+        "value": "Load failed"
+      },
+      {
+        "type": "Error",
+        "value": "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/grouping_inputs/react-concurrent-rendering.json
+++ b/tests/sentry/grouping/grouping_inputs/react-concurrent-rendering.json
@@ -1,0 +1,26 @@
+{
+  "exception": {
+    "values": [
+      {
+        "type": "TypeError",
+        "value": "Load failed",
+        "mechanism": {
+          "type": "onerror",
+          "handled": false,
+          "source": "cause",
+          "exception_id": 1,
+          "parent_id": 0
+        }
+      },
+      {
+        "type": "Error",
+        "value": "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root.",
+        "mechanism": {
+          "type": "generic",
+          "handled": true,
+          "exception_id": 0
+        }
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/react_concurrent_rendering.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-06-20T20:35:46.856234+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "5f209162115f576bedbaf6f0ad30e5aa"
+    contributing component: chained-exception
+    component:
+      system*
+        chained-exception*
+          exception*
+            type*
+              "TypeError"
+            value*
+              "Load failed"
+          exception*
+            type*
+              "Error"
+            value*
+              "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/react_concurrent_rendering_no_cause.pysnap
@@ -1,0 +1,33 @@
+---
+created: '2025-06-20T20:35:46.587353+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "70dd09f56349dcce62a74137b00bb571"
+    contributing component: exception
+    component:
+      system*
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/legacy@2019_03_12/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-06-20T20:35:46.737882+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  system*
+    hash: "5f209162115f576bedbaf6f0ad30e5aa"
+    contributing component: chained-exception
+    component:
+      system*
+        chained-exception*
+          exception*
+            type*
+              "TypeError"
+            value*
+              "Load failed"
+          exception*
+            type*
+              "Error"
+            value*
+              "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_concurrent_rendering.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-06-20T20:36:28.761540+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "11e6467c8358a9366c6538f95dcd7bd4"
+    contributing component: chained-exception
+    component:
+      app*
+        chained-exception*
+          exception*
+            type*
+              "Error"
+            value*
+              "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+          exception*
+            type*
+              "TypeError"
+            value*
+              "Load failed"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_concurrent_rendering_no_cause.pysnap
@@ -1,0 +1,33 @@
+---
+created: '2025-06-20T20:36:28.580970+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "70dd09f56349dcce62a74137b00bb571"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2019_05_08/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-06-20T20:36:28.668969+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "5f209162115f576bedbaf6f0ad30e5aa"
+    contributing component: chained-exception
+    component:
+      app*
+        chained-exception*
+          exception*
+            type*
+              "TypeError"
+            value*
+              "Load failed"
+          exception*
+            type*
+              "Error"
+            value*
+              "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-06-20T20:36:08.247077+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "11e6467c8358a9366c6538f95dcd7bd4"
+    contributing component: chained-exception
+    component:
+      app*
+        chained-exception*
+          exception*
+            type*
+              "Error"
+            value*
+              "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+          exception*
+            type*
+              "TypeError"
+            value*
+              "Load failed"

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,0 +1,33 @@
+---
+created: '2025-06-20T20:36:08.028421+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "70dd09f56349dcce62a74137b00bb571"
+    contributing component: exception
+    component:
+      app*
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/test_grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2025-06-20T20:36:08.117220+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_grouphash_metadata.py
+---
+hash_basis: message
+hashing_metadata: {
+  "message_parameterized": false,
+  "message_source": "exception"
+}
+---
+metrics with tags: {
+  "grouping.grouphashmetadata.event_hash_basis": {
+    "hash_basis": "message",
+    "is_hybrid_fingerprint": "False"
+  },
+  "grouping.grouphashmetadata.event_hashing_metadata.message": {
+    "message_parameterized": "False",
+    "message_source": "exception"
+  }
+}
+---
+contributing variants:
+  app*
+    hash: "5f209162115f576bedbaf6f0ad30e5aa"
+    contributing component: chained-exception
+    component:
+      app*
+        chained-exception*
+          exception*
+            type*
+              "TypeError"
+            value*
+              "Load failed"
+          exception*
+            type*
+              "Error"
+            value*
+              "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_concurrent_rendering.pysnap
@@ -1,0 +1,38 @@
+---
+created: '2025-06-20T20:33:47.832026+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  component:
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+--------------------------------------------------------------------------
+system:
+  hash: "5f209162115f576bedbaf6f0ad30e5aa"
+  contributing component: chained-exception
+  component:
+    system*
+      chained-exception*
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_concurrent_rendering_no_cause.pysnap
@@ -1,0 +1,26 @@
+---
+created: '2025-06-20T20:33:47.441907+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        type*
+          "Error"
+        value*
+          "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+--------------------------------------------------------------------------
+system:
+  hash: "70dd09f56349dcce62a74137b00bb571"
+  contributing component: exception
+  component:
+    system*
+      exception*
+        type*
+          "Error"
+        value*
+          "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,0 +1,38 @@
+---
+created: '2025-06-20T20:33:47.656868+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  contributing component: null
+  component:
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+--------------------------------------------------------------------------
+system:
+  hash: "5f209162115f576bedbaf6f0ad30e5aa"
+  contributing component: chained-exception
+  component:
+    system*
+      chained-exception*
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_concurrent_rendering.pysnap
@@ -1,0 +1,21 @@
+---
+created: '2025-06-20T20:33:22.438396+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "11e6467c8358a9366c6538f95dcd7bd4"
+  contributing component: chained-exception
+  component:
+    app*
+      chained-exception*
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_concurrent_rendering_no_cause.pysnap
@@ -1,0 +1,15 @@
+---
+created: '2025-06-20T20:33:22.254536+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "70dd09f56349dcce62a74137b00bb571"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        type*
+          "Error"
+        value*
+          "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,0 +1,21 @@
+---
+created: '2025-06-20T20:33:22.347146+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "5f209162115f576bedbaf6f0ad30e5aa"
+  contributing component: chained-exception
+  component:
+    app*
+      chained-exception*
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,0 +1,21 @@
+---
+created: '2025-06-20T20:34:12.428309+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "11e6467c8358a9366c6538f95dcd7bd4"
+  contributing component: chained-exception
+  component:
+    app*
+      chained-exception*
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,0 +1,15 @@
+---
+created: '2025-06-20T20:34:12.234791+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "70dd09f56349dcce62a74137b00bb571"
+  contributing component: exception
+  component:
+    app*
+      exception*
+        type*
+          "Error"
+        value*
+          "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,0 +1,21 @@
+---
+created: '2025-06-20T20:34:12.329464+00:00'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "5f209162115f576bedbaf6f0ad30e5aa"
+  contributing component: chained-exception
+  component:
+    app*
+      chained-exception*
+        exception*
+          type*
+            "TypeError"
+          value*
+            "Load failed"
+        exception*
+          type*
+            "Error"
+          value*
+            "There was an error during concurrent rendering but React was able to recover by instead synchronously rendering the entire root."


### PR DESCRIPTION
There are cases in which we override the value of `main_exception_id` in order to change which error in an exception chain we use for titling an event. In a well-formed chain, this works fine, but sometimes we see events which either a) have the root of a known chain but with nothing attached, or b) have a known chain root without a `mechanism` value, and we don't handle those cases gracefully.

This fixes that by a) only attempting the override if the event is in fact a chain, and b) checking for the `mechanism` value before trying to look at it. It also adds some test cases illustrating that even if we see degenerate cases, the algorithm doesn’t crash.

Fixes https://github.com/getsentry/sentry/issues/93983
Fixes https://sentry.sentry.io/issues/6691472122