### PR TITLE
fix(taskworker): add isolation scope to taskworker execution

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -310,8 +310,8 @@ def child_process(
         )
         with (
             track_memory_usage("taskworker.worker.memory_change"),
-            sentry_sdk.start_transaction(transaction),
             sentry_sdk.isolation_scope(),
+            sentry_sdk.start_transaction(transaction),
         ):
             transaction.set_data(
                 "taskworker-task", {"args": args, "kwargs": kwargs, "id": activation.id}

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -311,6 +311,7 @@ def child_process(
         with (
             track_memory_usage("taskworker.worker.memory_change"),
             sentry_sdk.start_transaction(transaction),
+            sentry_sdk.isolation_scope(),
         ):
             transaction.set_data(
                 "taskworker-task", {"args": args, "kwargs": kwargs, "id": activation.id}


### PR DESCRIPTION
tag pollution between taskworker tasks reported in slack, I _think_ this should fix it?