### PR TITLE
fix(browser_reports): Do not require destination and attempts

### DIFF
--- a/src/sentry/issues/endpoints/browser_reporting_collector.py
+++ b/src/sentry/issues/endpoints/browser_reporting_collector.py
@@ -40,8 +40,8 @@ class BrowserReportSerializer(serializers.Serializer[Any]):
     type = serializers.ChoiceField(choices=BROWSER_REPORT_TYPES)
     url = serializers.URLField()
     user_agent = serializers.CharField()
-    destination = serializers.CharField()
-    attempts = serializers.IntegerField(min_value=1)
+    destination = serializers.CharField(required=False)
+    attempts = serializers.IntegerField(required=False, min_value=1)
     # Fields that do not overlap between specs
     # We need to support both specs
     age = serializers.IntegerField(required=False)

--- a/tests/sentry/api/endpoints/test_browser_reporting_collector.py
+++ b/tests/sentry/api/endpoints/test_browser_reporting_collector.py
@@ -140,8 +140,8 @@ class BrowserReportingCollectorEndpointTest(APITestCase):
         )
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
-    def test_accepts_optional_fields(self) -> None:
-        """Test that optional fields are accepted"""
+    def test_optional_fields_not_required(self) -> None:
+        """Test that reports missing the optional fields are accepted"""
         report = deepcopy(DEPRECATION_REPORT)
         del report["destination"]
         del report["attempts"]

--- a/tests/sentry/api/endpoints/test_browser_reporting_collector.py
+++ b/tests/sentry/api/endpoints/test_browser_reporting_collector.py
@@ -140,6 +140,15 @@ class BrowserReportingCollectorEndpointTest(APITestCase):
         )
 
     @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
+    def test_accepts_optional_fields(self) -> None:
+        """Test that optional fields are accepted"""
+        report = deepcopy(DEPRECATION_REPORT)
+        del report["destination"]
+        del report["attempts"]
+        response = self.client.post(self.url, [report])
+        assert response.status_code == status.HTTP_200_OK
+
+    @override_options({"issues.browser_reporting.collector_endpoint_enabled": True})
     def test_rejects_invalid_attempts(self) -> None:
         """Test that invalid attempts values are rejected"""
         report = deepcopy(DEPRECATION_REPORT)


### PR DESCRIPTION
Even though the specs require them. We can see many reports not including them.