### PR TITLE
feat(feedback): update frontend for AI summary panel

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -438,13 +438,13 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:uptime-detector-handler", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:uptime-detector-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam filtering at User Feedback ingest time, if spam-ingest is also enabled
     manager.add("organizations:user-feedback-spam-filter-actions", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable User Feedback v2 UI
-    manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # User Feedback Error Link Ingestion Changes
     manager.add("organizations:user-feedback-event-link-ingestion-changes", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable view hierarchies options

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -438,13 +438,13 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:uptime-detector-handler", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:uptime-detector-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
+    manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam filtering at User Feedback ingest time, if spam-ingest is also enabled
     manager.add("organizations:user-feedback-spam-filter-actions", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable User Feedback v2 UI
-    manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
+    manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # User Feedback Error Link Ingestion Changes
     manager.add("organizations:user-feedback-event-link-ingestion-changes", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=False)
     # Enable view hierarchies options

--- a/static/app/components/feedback/feedbackSummary.tsx
+++ b/static/app/components/feedback/feedbackSummary.tsx
@@ -12,7 +12,7 @@ export default function FeedbackSummary() {
 
   const organization = useOrganization();
 
-  if (!organization.features.includes('user-feedback-ai-summaries') || isError) {
+  if (!organization.features.includes('user-feedback-ai-summaries')) {
     return null;
   }
 
@@ -23,13 +23,15 @@ export default function FeedbackSummary() {
         <SummaryHeader>{t('Feedback Summary')}</SummaryHeader>
         {isPending ? (
           <LoadingContainer>
-            <LoadingIndicator style={{margin: 0, marginTop: space(0.5)}} size={24} />
-            <SummaryContent>Summarizing feedback received...</SummaryContent>
+            <StyledLoadingIndicator size={24} />
+            <SummaryContent>{t('Summarizing feedback received...')}</SummaryContent>
           </LoadingContainer>
         ) : tooFewFeedbacks ? (
           <SummaryContent>
             {t('Bummer... Not enough feedback to summarize (yet).')}
           </SummaryContent>
+        ) : isError ? (
+          <SummaryContent>{t('Error summarizing feedback.')}</SummaryContent>
         ) : (
           <SummaryContent>{summary}</SummaryContent>
         )}
@@ -37,6 +39,10 @@ export default function FeedbackSummary() {
     </SummaryIconContainer>
   );
 }
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: ${space(0.5)} 0 0 0;
+`;
 
 const LoadingContainer = styled('div')`
   display: flex;

--- a/static/app/components/feedback/feedbackSummary.tsx
+++ b/static/app/components/feedback/feedbackSummary.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import useFeedbackSummary from 'sentry/components/feedback/list/useFeedbackSummary';
-import Placeholder from 'sentry/components/placeholder';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconSeer} from 'sentry/icons/iconSeer';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -12,16 +12,8 @@ export default function FeedbackSummary() {
 
   const organization = useOrganization();
 
-  if (
-    !organization.features.includes('user-feedback-ai-summaries') ||
-    tooFewFeedbacks ||
-    isError
-  ) {
+  if (!organization.features.includes('user-feedback-ai-summaries') || isError) {
     return null;
-  }
-
-  if (isPending) {
-    return <Placeholder height="100px" />;
   }
 
   return (
@@ -29,11 +21,29 @@ export default function FeedbackSummary() {
       <IconSeer size="xs" />
       <SummaryContainer>
         <SummaryHeader>{t('Feedback Summary')}</SummaryHeader>
-        <SummaryContent>{summary}</SummaryContent>
+        {isPending ? (
+          <LoadingContainer>
+            <LoadingIndicator style={{margin: 0, marginTop: space(0.5)}} size={24} />
+            <SummaryContent>Summarizing feedback received...</SummaryContent>
+          </LoadingContainer>
+        ) : tooFewFeedbacks ? (
+          <SummaryContent>
+            {t('Bummer... Not enough feedback to summarize (yet).')}
+          </SummaryContent>
+        ) : (
+          <SummaryContent>{summary}</SummaryContent>
+        )}
       </SummaryContainer>
     </SummaryIconContainer>
   );
 }
+
+const LoadingContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  align-items: center;
+`;
 
 const SummaryContainer = styled('div')`
   display: flex;


### PR DESCRIPTION
Updated based on designs
- Error state was not updated, right now it just hides the box, should we surface an error to the user if there is one?

Loading state:
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/6a2a9419-69e2-4121-9734-cc8017f28e98" />

Too few feedback state:
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/7afe48fc-bd7e-4b79-a731-cb73a1388c09" />
- Since, for now, there is no way to hide/collapse the box, removed the text that was below what we have now in the designs