### PR TITLE
ref(ACI): Remove unnecessary enable/disable code

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2133,46 +2133,36 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
 
 class EnableDisableAlertRuleTest(TestCase, BaseIncidentsTest):
     def setUp(self):
-        self.detector = self.create_detector()
         self.alert_rule = self.create_alert_rule()
-        self.create_alert_rule_detector(alert_rule_id=self.alert_rule.id, detector=self.detector)
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_enable(self):
         with self.tasks():
             disable_alert_rule(self.alert_rule)
-            self.detector.refresh_from_db()
             alert_rule = AlertRule.objects.get(id=self.alert_rule.id)
             assert alert_rule.status == AlertRuleStatus.DISABLED.value
             for subscription in alert_rule.snuba_query.subscriptions.all():
                 assert subscription.status == QuerySubscription.Status.DISABLED.value
-            assert self.detector.status == ObjectStatus.DISABLED
 
             enable_alert_rule(self.alert_rule)
-            self.detector.refresh_from_db()
             alert_rule = AlertRule.objects.get(id=self.alert_rule.id)
             assert alert_rule.status == AlertRuleStatus.PENDING.value
             for subscription in alert_rule.snuba_query.subscriptions.all():
                 assert subscription.status == QuerySubscription.Status.ACTIVE.value
-            assert self.detector.status == ObjectStatus.ACTIVE
 
     @with_feature("organizations:workflow-engine-metric-alert-dual-write")
     def test_disable(self):
         with self.tasks():
             disable_alert_rule(self.alert_rule)
-            self.detector.refresh_from_db()
             alert_rule = AlertRule.objects.get(id=self.alert_rule.id)
             assert alert_rule.status == AlertRuleStatus.DISABLED.value
             for subscription in alert_rule.snuba_query.subscriptions.all():
                 assert subscription.status == QuerySubscription.Status.DISABLED.value
-            assert self.detector.status == ObjectStatus.DISABLED
 
 
 class EnableDisableDetectorTest(TestCase, BaseIncidentsTest):
     def setUp(self):
         self.detector = self.create_detector()
-        self.alert_rule = self.create_alert_rule()
-        self.create_alert_rule_detector(alert_rule_id=self.alert_rule.id, detector=self.detector)
 
         with self.tasks():
             self.snuba_query = create_snuba_query(


### PR DESCRIPTION
After https://github.com/getsentry/getsentry/pull/17739 is merged we don't need this code anymore as the receiver will handle detectors separately using `update_detector`. 