### PR TITLE
fix(replays): Ensure query is scoped to segment rows only

### DIFF
--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -145,8 +145,7 @@ def fetch_rows_matching_pattern(
             Condition(Column("project_id"), Op.EQ, project_id),
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column("timestamp"), Op.GTE, start),
-            # We only match segment rows because those contain the PII we want to delete. This also
-            # means we won't match our is_archived rows putting us in an infinite deletion loop.
+            # We only match segment rows because those contain the PII we want to delete.
             Condition(Column("segment_id"), Op.IS_NOT_NULL),
             *where,
         ],

--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -145,6 +145,9 @@ def fetch_rows_matching_pattern(
             Condition(Column("project_id"), Op.EQ, project_id),
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column("timestamp"), Op.GTE, start),
+            # We only match segment rows because those contain the PII we want to delete. This also
+            # means we won't match our is_archived rows putting us in an infinite deletion loop.
+            Condition(Column("segment_id"), Op.IS_NOT_NULL),
             *where,
         ],
         groupby=[Column("replay_id")],

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -162,6 +162,7 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         replay_id1 = uuid.uuid4().hex
         replay_id2 = uuid.uuid4().hex
         replay_id3 = uuid.uuid4().hex
+        replay_id4 = uuid.uuid4().hex
         self.store_replays(
             mock_replay(t1, self.project.id, replay_id1, segment_id=0, environment="prod")
         )
@@ -170,6 +171,9 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         )
         self.store_replays(
             mock_replay(t1, project.id, replay_id3, segment_id=0, environment="prod")
+        )
+        self.store_replays(
+            mock_replay(t1, self.project.id, replay_id4, segment_id=None, environment="prod")
         )
 
         with TaskRunner():

--- a/tests/sentry/replays/tasks/test_delete_replays_bulk.py
+++ b/tests/sentry/replays/tasks/test_delete_replays_bulk.py
@@ -156,14 +156,20 @@ class TestDeleteReplaysBulk(APITestCase, ReplaysSnubaTestCase):
         )
 
     def test_run_bulk_replay_delete_job_chained_runs(self):
+        project = self.create_project()
+
         t1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
         replay_id1 = uuid.uuid4().hex
         replay_id2 = uuid.uuid4().hex
+        replay_id3 = uuid.uuid4().hex
         self.store_replays(
             mock_replay(t1, self.project.id, replay_id1, segment_id=0, environment="prod")
         )
         self.store_replays(
             mock_replay(t1, self.project.id, replay_id2, segment_id=0, environment="prod")
+        )
+        self.store_replays(
+            mock_replay(t1, project.id, replay_id3, segment_id=0, environment="prod")
         )
 
         with TaskRunner():


### PR DESCRIPTION
Make sure we're only matching PII bearing rows.  Also adds coverage ensuring deletes are scoped to the project.