### PR TITLE
fix(profiling): fix profile functions metrics payload

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1354,7 +1354,7 @@ def build_chunk_functions_kafka_message(
     chunk: vroomrs.ProfileChunk, functions: list[vroomrs.CallTreeFunction]
 ) -> KafkaPayload:
     data = {
-        "environment": chunk.get_environment(),
+        "environment": chunk.get_environment() or "",
         "functions": [
             {
                 "fingerprint": f.get_fingerprint(),
@@ -1370,7 +1370,7 @@ def build_chunk_functions_kafka_message(
         "platform": chunk.get_platform(),
         "project_id": chunk.get_project_id(),
         "received": int(chunk.get_received()),
-        "release": chunk.get_release(),
+        "release": chunk.get_release() or "",
         "retention_days": chunk.get_retention_days(),
         "timestamp": int(chunk.start_timestamp()),
         "start_timestamp": chunk.start_timestamp(),


### PR DESCRIPTION
`get_environment` and `get_release`, might return None.

While the rust _Snuba_ consumer is able to handle it properly, the kafka schema validation that occurs before the `process_message` expect a string, in case those fields are present.

With this we'll set them to an empty string in case the returned value was `None`.