### PR TITLE
feat: Group dynamic sampling reasons into single label

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -102,7 +102,6 @@ describe('getReasonGroupName', function () {
     const testCases: Array<[string, string]> = [
       ['Sampled:1000,1004,1500', 'dynamic sampling'],
       ['Sampled:1000,1500', 'dynamic sampling'],
-      ['Sampled:1000,1500,1004', 'dynamic sampling'],
     ];
 
     testCases.forEach(([input, expected]) => {

--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -97,4 +97,16 @@ describe('getReasonGroupName', function () {
       ClientDiscardReason.QUEUE_OVERFLOW
     );
   });
+
+  it('groups all dynamic sampling reason codes into "dynamic sampling" label', function () {
+    const testCases: Array<[string, string]> = [
+      ['Sampled:1000,1004,1500', 'dynamic sampling'],
+      ['Sampled:1000,1500', 'dynamic sampling'],
+      ['Sampled:1000,1500,1004', 'dynamic sampling'],
+    ];
+
+    testCases.forEach(([input, expected]) => {
+      expect(getReasonGroupName(Outcome.FILTERED, input)).toBe(expected);
+    });
+  });
 });

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -156,6 +156,14 @@ const invalidReasonsGroup: Record<string, DiscardReason[]> = {
   sampling: [DiscardReason.TRANSACTION_SAMPLED],
 };
 
+function getFilteredReasonGroupName(reason: string): string {
+  if (reason.startsWith('Sampled:')) {
+    return 'dynamic sampling';
+  }
+
+  return startCase(reason);
+}
+
 function getInvalidReasonGroupName(reason: string): string {
   // 1. Check if there is a direct match in the `invalidReasonsGroup`
   for (const [group, reasons] of Object.entries(invalidReasonsGroup)) {
@@ -231,7 +239,7 @@ export function getReasonGroupName(outcome: string | number, reason: string): st
     case Outcome.ABUSE:
       return getRateLimitedReasonGroupName(reason as RateLimitedReason);
     case Outcome.FILTERED:
-      return startCase(reason);
+      return getFilteredReasonGroupName(reason);
     case Outcome.CLIENT_DISCARD:
       return getClientDiscardReasonGroupName(reason as ClientDiscardReason);
     default:


### PR DESCRIPTION
In [this PR](https://github.com/getsentry/sentry/pull/83916/files), we initially decided to expose all filtered reasons individually on the stats page. However, we recently encountered a variety of dynamic sampling reasons such as Sampled:500, Sampled:1000, and others, which made it difficult to understand

This PR addresses that by grouping all dynamic sampling-related reasons under a single label: "Dynamic Sampling".