### PR TITLE
feat(trace-view): Sync waterfall and AI spans selection

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -9,6 +9,7 @@ import {IconSpeechBubble} from 'sentry/icons/iconSpeechBubble';
 import {IconTool} from 'sentry/icons/iconTool';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import {
   AI_AGENT_NAME_ATTRIBUTE,
   AI_GENERATION_DESCRIPTIONS,
@@ -80,7 +81,7 @@ export function AISpanList({
           transactionBounds = getTransactionBounds(node);
         }
 
-        const uniqueKey = node.metadata.event_id;
+        const uniqueKey = getNodeId(node);
         return (
           <TraceListItem
             key={uniqueKey}

--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -12,6 +12,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/agentMonitoring/components/aiSpanList';
 import {useAITrace} from 'sentry/views/insights/agentMonitoring/hooks/useAITrace';
 import {useNodeDetailsLink} from 'sentry/views/insights/agentMonitoring/hooks/useNodeDetailsLink';
+import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
@@ -22,17 +23,12 @@ interface UseTraceViewDrawerProps {
   onClose?: () => void;
 }
 
-function getUniqueKey(node: AITraceSpanNode) {
-  // types are not precise enough here. For AITraceSpanNode, event_id is always defined.
-  return node.metadata.event_id as string;
-}
-
 function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
   const {nodes, isLoading, error} = useAITrace(traceSlug);
   const [selectedNodeKey, setSelectedNodeKey] = useState<string | null>(null);
 
   const handleSelectNode = useCallback((node: AITraceSpanNode) => {
-    const uniqueKey = getUniqueKey(node);
+    const uniqueKey = getNodeId(node);
     setSelectedNodeKey(uniqueKey);
   }, []);
 
@@ -43,7 +39,7 @@ function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
   }, [handleSelectNode, nodes, selectedNodeKey]);
 
   const selectedNode = selectedNodeKey
-    ? nodes.find(node => getUniqueKey(node) === selectedNodeKey) || nodes[0]
+    ? nodes.find(node => getNodeId(node) === selectedNodeKey) || nodes[0]
     : nodes[0];
 
   const nodeDetailsLink = useNodeDetailsLink({
@@ -136,7 +132,7 @@ function AITraceView({
         <SpansHeader>{t('AI Spans')}</SpansHeader>
         <AISpanList
           nodes={nodes}
-          selectedNodeKey={getUniqueKey(selectedNode!)}
+          selectedNodeKey={getNodeId(selectedNode!)}
           onSelectNode={onSelectNode}
         />
       </LeftPanel>

--- a/static/app/views/insights/agentMonitoring/utils/getNodeId.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/getNodeId.tsx
@@ -1,0 +1,22 @@
+import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
+import {
+  isEAPSpanNode,
+  isSpanNode,
+  isTransactionNode,
+} from 'sentry/views/performance/newTraceDetails/traceGuards';
+
+export function getNodeId(node: AITraceSpanNode): string {
+  if (isEAPSpanNode(node)) {
+    return node.metadata.event_id as string;
+  }
+  if (isTransactionNode(node)) {
+    return node.value.event_id;
+  }
+
+  if (isSpanNode(node)) {
+    return node.value.span_id;
+  }
+
+  // We should never reach this point as AITraceSpanNode only contains the above node types
+  throw new Error('Invalid node type');
+}

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -149,6 +149,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
                 hideIfNoData={hideTraceWaterfallIfEmpty}
                 traceWaterfallScrollHandlers={traceWaterfallScroll}
                 traceWaterfallModels={traceWaterfallModels}
+                isVisible={currentTab === TraceLayoutTabKeys.WATERFALL}
               />
             </TabsWaterfallWrapper>
             {currentTab === TraceLayoutTabKeys.TAGS ||

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -1,15 +1,22 @@
-import {useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {LinkButton} from 'sentry/components/core/button/linkButton';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/agentMonitoring/components/aiSpanList';
 import {useAITrace} from 'sentry/views/insights/agentMonitoring/hooks/useAITrace';
+import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {VirtualizedViewManager} from 'sentry/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager';
+import {TraceLayoutTabKeys} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
+import {getScrollToPath} from 'sentry/views/performance/newTraceDetails/useTraceScrollToPath';
 
 function TraceAiSpans({
   traceSlug,
@@ -18,11 +25,42 @@ function TraceAiSpans({
   viewManager: VirtualizedViewManager;
 }) {
   const organization = useOrganization();
+  const navigate = useNavigate();
+  const location = useLocation();
   const {nodes, isLoading, error} = useAITrace(traceSlug);
-  const [selectedNodeKey, setSelectedNodeKey] = useState<string | null>(null);
+  const [selectedNodeKey, setSelectedNodeKey] = useState<string | null>(() => {
+    const path = getScrollToPath()?.path;
+    const lastSpan = path?.findLast(item => item.startsWith('span-'));
+    return lastSpan?.replace('span-', '') ?? null;
+  });
+
   const selectedNode = useMemo(() => {
     return nodes.find(node => node.metadata.event_id === selectedNodeKey) || nodes[0];
   }, [nodes, selectedNodeKey]);
+
+  const handleSelectNode = useCallback(
+    (node: AITraceSpanNode) => {
+      const eventId = node.metadata.event_id;
+      if (!eventId) {
+        return;
+      }
+      setSelectedNodeKey(eventId);
+
+      // Update the node path url param to keep the trace waterfal in sync
+      const nodeIdentifier: TraceTree.NodePath = `span-${eventId}`;
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            node: nodeIdentifier,
+          },
+        },
+        {replace: true}
+      );
+    },
+    [location, navigate]
+  );
 
   if (isLoading) {
     return <LoadingIndicator />;
@@ -39,12 +77,24 @@ function TraceAiSpans({
   return (
     <Wrapper>
       <HeaderCell>{t('Abbreviated Trace')}</HeaderCell>
-      <HeaderCell>{/* TODO: tabs for spans */}</HeaderCell>
+      <HeaderCell align={'right'}>
+        <LinkButton
+          size="xs"
+          to={{
+            ...location,
+            query: {
+              tab: TraceLayoutTabKeys.WATERFALL,
+            },
+          }}
+        >
+          {t('View in Full Trace')}
+        </LinkButton>
+      </HeaderCell>
       <LeftPanel>
         <SpansHeader>{t('AI Spans')}</SpansHeader>
         <AISpanList
           nodes={nodes}
-          onSelectNode={node => setSelectedNodeKey(node.metadata.event_id as string)}
+          onSelectNode={handleSelectNode}
           selectedNodeKey={selectedNode?.metadata.event_id ?? null}
         />
       </LeftPanel>
@@ -86,13 +136,14 @@ const SpansHeader = styled('h6')`
   margin-left: ${space(1)};
 `;
 
-const HeaderCell = styled('div')`
+const HeaderCell = styled('div')<{align?: 'left' | 'right'}>`
   padding: 0 ${space(2)};
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.subText};
   border-bottom: 1px solid ${p => p.theme.border};
   display: flex;
   align-items: center;
+  justify-content: ${p => (p.align === 'right' ? 'flex-end' : 'flex-start')};
 `;
 
 const LeftPanel = styled('div')`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -84,6 +84,7 @@ function TraceAiSpans({
           to={{
             ...location,
             query: {
+              ...location.query,
               tab: TraceLayoutTabKeys.WATERFALL,
             },
           }}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -11,6 +11,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/agentMonitoring/components/aiSpanList';
 import {useAITrace} from 'sentry/views/insights/agentMonitoring/hooks/useAITrace';
+import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -35,12 +36,12 @@ function TraceAiSpans({
   });
 
   const selectedNode = useMemo(() => {
-    return nodes.find(node => node.metadata.event_id === selectedNodeKey) || nodes[0];
+    return nodes.find(node => getNodeId(node) === selectedNodeKey) || nodes[0];
   }, [nodes, selectedNodeKey]);
 
   const handleSelectNode = useCallback(
     (node: AITraceSpanNode) => {
-      const eventId = node.metadata.event_id;
+      const eventId = getNodeId(node);
       if (!eventId) {
         return;
       }
@@ -95,7 +96,7 @@ function TraceAiSpans({
         <AISpanList
           nodes={nodes}
           onSelectNode={handleSelectNode}
-          selectedNodeKey={selectedNode?.metadata.event_id ?? null}
+          selectedNodeKey={getNodeId(selectedNode!)}
         />
       </LeftPanel>
       <RightPanel>

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -31,6 +31,7 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import type {DispatchingReducerMiddleware} from 'sentry/utils/useDispatchingReducer';
+import {useIsMountedRef} from 'sentry/utils/useIsMountedRef';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -529,8 +530,9 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
 
   // We re-init the view to sync back with URL params
   // as they might have changed while the waterfall was hidden
-  useEffect(() => {
-    if (props.isVisible) {
+  const isMountedRef = useIsMountedRef();
+  useLayoutEffect(() => {
+    if (props.isVisible && isMountedRef.current) {
       scrollQueueRef.current = getScrollToPath();
       onTraceLoad();
     }

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -528,13 +528,14 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   ]);
 
   // We re-init the view to sync back with URL params
-  // which might have changed while the waterfall was hidden
+  // as they might have changed while the waterfall was hidden
   useEffect(() => {
     if (props.isVisible) {
       scrollQueueRef.current = getScrollToPath();
       onTraceLoad();
     }
 
+    // Only run if isVisible changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.isVisible]);
 

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -82,7 +82,7 @@ import TraceTypeWarnings from './traceTypeWarnings';
 import {TraceWaterfallState} from './traceWaterfallState';
 import {useTraceOnLoad} from './useTraceOnLoad';
 import {useTraceQueryParamStateSync} from './useTraceQueryParamStateSync';
-import {useTraceScrollToPath} from './useTraceScrollToPath';
+import {getScrollToPath, useTraceScrollToPath} from './useTraceScrollToPath';
 import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
 
 const TRACE_TAB: TraceReducerState['tabs']['tabs'][0] = {
@@ -104,6 +104,7 @@ export interface TraceWaterfallProps {
   tree: TraceTree;
   // If set to true, the entire waterfall will not render if it is empty.
   hideIfNoData?: boolean;
+  isVisible?: boolean;
   replayTraces?: ReplayTrace[];
 }
 
@@ -131,7 +132,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   const projectsRef = useRef<Project[]>(projects);
   projectsRef.current = projects;
 
-  const scrollQueueRef = useTraceScrollToPath(undefined);
+  const scrollQueueRef = useTraceScrollToPath();
   const forceRerender = useCallback(() => {
     flushSync(rerender);
   }, []);
@@ -525,6 +526,17 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     hasExceededPerformanceUsageLimit,
     source,
   ]);
+
+  // We re-init the view to sync back with URL params
+  // which might have changed while the waterfall was hidden
+  useEffect(() => {
+    if (props.isVisible) {
+      scrollQueueRef.current = getScrollToPath();
+      onTraceLoad();
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.isVisible]);
 
   // Setup the middleware for the trace reducer
   useLayoutEffect(() => {

--- a/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceScrollToPath.tsx
@@ -20,34 +20,31 @@ type UseTraceScrollToPath =
   | null
   | undefined;
 
-export function useTraceScrollToPath(
-  path: UseTraceScrollToPath
-): React.MutableRefObject<UseTraceScrollToPath> {
+export function getScrollToPath(): UseTraceScrollToPath {
+  const queryParams = qs.parse(location.search);
+  const scrollToNode = {
+    eventId: (queryParams.eventId ?? queryParams.targetId) as string | undefined,
+    path: decodeScrollQueue(queryParams.node) as TraceTree.NodePath[] | undefined,
+  };
+
+  if (scrollToNode && (scrollToNode.path || scrollToNode.eventId)) {
+    return {
+      eventId: scrollToNode.eventId as string,
+      path: scrollToNode.path,
+    };
+  }
+
+  return null;
+}
+
+export function useTraceScrollToPath(): React.MutableRefObject<UseTraceScrollToPath> {
   const scrollQueueRef = useRef<
     {eventId?: string; path?: TraceTree.NodePath[]} | null | undefined
   >(undefined);
 
   // If we havent decoded anything yet, then decode the path
   if (scrollQueueRef.current === undefined) {
-    let scrollToNode: UseTraceScrollToPath = path;
-
-    if (!path) {
-      const queryParams = qs.parse(location.search);
-
-      scrollToNode = {
-        eventId: (queryParams.eventId ?? queryParams.targetId) as string | undefined,
-        path: decodeScrollQueue(queryParams.node) as TraceTree.NodePath[] | undefined,
-      };
-    }
-
-    if (scrollToNode && (scrollToNode.path || scrollToNode.eventId)) {
-      scrollQueueRef.current = {
-        eventId: scrollToNode.eventId as string,
-        path: scrollToNode.path,
-      };
-    } else {
-      scrollQueueRef.current = null;
-    }
+    scrollQueueRef.current = getScrollToPath();
   }
 
   return scrollQueueRef;


### PR DESCRIPTION
Sync selected span via URL params between trace waterfall and AI spans tab.
Add button to link back to trace waterfall.
Fix selection logic (`getNodeId`) for old trace data format.

- closes [TET-675: Trace View: Sync waterfall and ai span selection](https://linear.app/getsentry/issue/TET-675/trace-view-sync-waterfall-and-ai-span-selection)