### PR TITLE
Migrate sampling_context to use SDK 3.0 attributes

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -178,8 +178,8 @@ def get_project_key():
 
 
 def traces_sampler(sampling_context):
-    wsgi_path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
-    if wsgi_path and wsgi_path in SAMPLED_ROUTES:
+    wsgi_path = sampling_context.get("url.path")
+    if wsgi_path in SAMPLED_ROUTES:
         return SAMPLED_ROUTES[wsgi_path]
 
     # Apply sample_rate from custom_sampling_context
@@ -192,8 +192,7 @@ def traces_sampler(sampling_context):
         return sampling_context["parent_sampled"]
 
     if "celery_job" in sampling_context:
-        task_name = sampling_context["celery_job"].get("task")
-
+        task_name = sampling_context.get("celery.job.task")
         if task_name in SAMPLED_TASKS:
             return SAMPLED_TASKS[task_name]
 


### PR DESCRIPTION
See the Celery and WSGI sections [in the migration guide](https://docs.sentry.io/platforms/python/migration/2.x-to-3.x#sampling)

Closes https://github.com/getsentry/sentry-python/issues/4505