### PR TITLE
chore: cleanup unused `ReleaseFileCache` class

### DIFF
--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -89,7 +89,6 @@ class ReleaseFileDetailsMixin:
     def download_from_archive(release, entry):
         archive_ident = entry["archive_ident"]
 
-        # Do not use ReleaseFileCache here, we view download as a singular event
         archive_file = ReleaseFile.objects.get(release_id=release.id, ident=archive_ident)
         archive_file_fp = archive_file.file.getfile()
         fp = ZipFile(archive_file_fp).open(entry["filename"])

--- a/src/sentry/bgtasks/clean_releasefilecache.py
+++ b/src/sentry/bgtasks/clean_releasefilecache.py
@@ -1,7 +1,0 @@
-from sentry.bgtasks.api import bgtask
-from sentry.models.releasefile import ReleaseFile
-
-
-@bgtask()
-def clean_releasefilecache() -> None:
-    ReleaseFile.cache.clear_old_entries()

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1380,10 +1380,6 @@ TIMEDELTA_ALLOW_LIST = {
 
 BGTASKS: dict[str, BgTaskConfig] = {
     "sentry.bgtasks.clean_dsymcache:clean_dsymcache": {"interval": 5 * 60, "roles": ["worker"]},
-    "sentry.bgtasks.clean_releasefilecache:clean_releasefilecache": {
-        "interval": 5 * 60,
-        "roles": ["worker"],
-    },
 }
 
 #######################

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -288,17 +288,14 @@ class _ArtifactIndexGuard:
         self._ident = ReleaseFile.get_ident(ARTIFACT_INDEX_FILENAME, dist and dist.name)
         self._filter_args = filter_args  # Extra constraints on artifact index release file
 
-    def readable_data(self, use_cache: bool) -> dict | None:
+    def readable_data(self) -> dict | None:
         """Simple read, no synchronization necessary"""
         try:
             releasefile = self._releasefile_qs()[0]
         except IndexError:
             return None
         else:
-            if use_cache:
-                fp = ReleaseFile.cache.getfile(releasefile)
-            else:
-                fp = releasefile.file.getfile()
+            fp = releasefile.file.getfile()
             with fp:
                 return json.load(fp)
 
@@ -384,12 +381,10 @@ class _ArtifactIndexGuard:
 
 
 @sentry_sdk.tracing.trace
-def read_artifact_index(
-    release: Release, dist: Distribution | None, use_cache: bool = False, **filter_args
-) -> dict | None:
+def read_artifact_index(release: Release, dist: Distribution | None, **filter_args) -> dict | None:
     """Get index data"""
     guard = _ArtifactIndexGuard(release, dist, **filter_args)
-    return guard.readable_data(use_cache)
+    return guard.readable_data()
 
 
 def _compute_sha1(archive: ReleaseArchive, url: str) -> str:

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import errno
 import logging
-import os
 import zipfile
 from contextlib import contextmanager
 from hashlib import sha1
@@ -12,10 +10,8 @@ from typing import IO, ClassVar, Self
 from urllib.parse import urlunsplit
 
 import sentry_sdk
-from django.core.files.base import File as FileObj
 from django.db import models, router
 
-from sentry import options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -28,9 +24,8 @@ from sentry.db.models import (
 from sentry.db.models.manager.base import BaseManager
 from sentry.models.distribution import Distribution
 from sentry.models.files.file import File
-from sentry.models.files.utils import clear_cached_files
 from sentry.models.release import Release
-from sentry.utils import json, metrics
+from sentry.utils import json
 from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import sha1_text
 from sentry.utils.urls import urlsplit_best_effort
@@ -90,8 +85,6 @@ class ReleaseFile(Model):
     objects: ClassVar[BaseManager[Self]] = BaseManager()  # The default manager.
     public_objects: ClassVar[PublicReleaseFileManager] = PublicReleaseFileManager()
 
-    cache: ClassVar[ReleaseFileCache]
-
     class Meta:
         unique_together = (("release_id", "ident"),)
         indexes = (models.Index(fields=("release_id", "name")),)
@@ -150,48 +143,6 @@ class ReleaseFile(Model):
         if query:
             urls.append("~" + urlunsplit(uri_relative_without_query))
         return urls
-
-
-class ReleaseFileCache:
-    @property
-    def cache_path(self):
-        return options.get("releasefile.cache-path")
-
-    def getfile(self, releasefile):
-        cutoff = options.get("releasefile.cache-limit")
-        file_size = releasefile.file.size
-        if file_size < cutoff:
-            metrics.distribution(
-                "release_file.cache.get.size", file_size, tags={"cutoff": True}, unit="byte"
-            )
-            return releasefile.file.getfile()
-
-        file_id = str(releasefile.file.id)
-        organization_id = str(releasefile.organization_id)
-        file_path = os.path.join(self.cache_path, organization_id, file_id)
-
-        hit = True
-        try:
-            os.stat(file_path)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
-            releasefile.file.save_to(file_path)
-            hit = False
-
-        metrics.distribution(
-            "release_file.cache.get.size",
-            file_size,
-            tags={"hit": hit, "cutoff": False},
-            unit="byte",
-        )
-        return FileObj(open(file_path, "rb"))
-
-    def clear_old_entries(self):
-        clear_cached_files(self.cache_path)
-
-
-ReleaseFile.cache = ReleaseFileCache()
 
 
 class ReleaseArchive:

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -1,5 +1,3 @@
-import errno
-import os
 from datetime import datetime, timezone
 from io import BytesIO
 from threading import Thread
@@ -8,7 +6,6 @@ from zipfile import ZipFile
 
 import pytest
 
-from sentry import options
 from sentry.models.distribution import Distribution
 from sentry.models.files.file import File
 from sentry.models.releasefile import (
@@ -72,56 +69,6 @@ class ReleaseFileTestCase(TestCase):
             )
 
         assert self.release.count_artifacts() == 5
-
-
-class ReleaseFileCacheTest(TestCase):
-    def test_getfile_fs_cache(self):
-        file_content = b"this is a test"
-
-        file = self.create_file(name="dummy.txt")
-        file.putfile(BytesIO(file_content))
-        release_file = self.create_release_file(file=file)
-
-        expected_path = os.path.join(
-            options.get("releasefile.cache-path"),
-            str(self.organization.id),
-            str(file.id),
-        )
-
-        # Set the threshold to zero to force caching on the file system
-        options.set("releasefile.cache-limit", 0)
-        with ReleaseFile.cache.getfile(release_file) as f:
-            assert f.read() == file_content
-            assert f.name == expected_path
-
-        # Check that the file was cached
-        os.stat(expected_path)
-
-    def test_getfile_streaming(self):
-        file_content = b"this is a test"
-
-        file = self.create_file(name="dummy.txt")
-        file.putfile(BytesIO(file_content))
-        release_file = self.create_release_file(file=file)
-
-        expected_path = os.path.join(
-            options.get("releasefile.cache-path"),
-            str(self.organization.id),
-            str(file.id),
-        )
-
-        # Set the threshold larger than the file size to force streaming
-        options.set("releasefile.cache-limit", 1024)
-        with ReleaseFile.cache.getfile(release_file) as f:
-            assert f.read() == file_content
-
-        # Check that the file was not cached
-        try:
-            os.stat(expected_path)
-        except OSError as e:
-            assert e.errno == errno.ENOENT
-        else:
-            assert False, "file should not exist"
 
 
 class ReleaseArchiveTestCase(TestCase):


### PR DESCRIPTION
The last usage of this class was removed here:
https://github.com/getsentry/sentry/pull/59090/files#diff-5649208c3eac2367f8d3130a299d7c3cd3020aa4c1a21f1d4ea57b80de38ef34L439

with the last invocation of `read_artifact_index` with `use_cache=True`