### PR TITLE
fix: Remove browserTracing integration code by using getSdkInitSnippe…

### DIFF
--- a/static/app/gettingStartedDocs/node/node.tsx
+++ b/static/app/gettingStartedDocs/node/node.tsx
@@ -315,24 +315,7 @@ const performanceOnboarding: OnboardingConfig = {
               value: 'javascript',
               filename: 'instrument.(js|mjs)',
               language: 'javascript',
-              code: `
-const Sentry = require("@sentry/node");
-
-// Ensure to call this before requiring any other modules!
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  integrations: [Sentry.browserTracingIntegration()],
-
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-
-  // Setting this option to true will send default PII data to Sentry.
-  // For example, automatic IP address collection on events
-  sendDefaultPii: true,
-});
-`,
+              code: getSdkInitSnippet(params, 'node'),
             },
           ],
           additionalInfo: tct(


### PR DESCRIPTION
**Before**
![Screenshot 2025-06-23 at 13 15 23](https://github.com/user-attachments/assets/f03c009f-1a11-42c0-9161-472c4d71914e)


**After**

![image](https://github.com/user-attachments/assets/b9dfc4ec-0ce2-4f60-8dc6-11c41bc2701d)


closes https://linear.app/getsentry/issue/TET-624/typeerror-sentrybrowsertracingintegration-is-not-a-function

