### PR TITLE
fix(dynamic-sampling): CustomDynamicSamplingRule.assign_rule_id

### DIFF
--- a/src/sentry/models/dynamicsampling.py
+++ b/src/sentry/models/dynamicsampling.py
@@ -247,10 +247,8 @@ class CustomDynamicSamplingRule(Model):
         # Get all existing rule_ids for active, non-expired rules in this organization
         existing_rule_ids = set(
             CustomDynamicSamplingRule.objects.filter(
-                organization_id=self.organization.id,
-                end_date__gt=now,
-                is_active=True
-            ).values_list('rule_id', flat=True)
+                organization_id=self.organization.id, end_date__gt=now, is_active=True
+            ).values_list("rule_id", flat=True)
         )
 
         # Find the first available rule_id starting from 1


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry/pull/93854

Closes https://linear.app/getsentry/issue/TET-676/sql-injection-in-getsentrysentry

This PR uses the Django queryset API to get the lowest possible rule_id without the necessity of a round-trip to Python. The query is roughly equivalent to:

```sql
UPDATE custom_dynamic_sampling_rule
SET rule_id = (
    SELECT rule_id + 1
    FROM custom_dynamic_sampling_rule AS b
    WHERE
        b.organization_id = a.organization_id
        AND b.is_active = TRUE
        AND b.end_date > NOW()
        AND (b.rule_id + 1) NOT IN (
            SELECT rule_id
            FROM custom_dynamic_sampling_rule
            WHERE organization_id = a.organization_id
              AND is_active = TRUE
              AND end_date > NOW()
        )
    ORDER BY b.rule_id + 1
    LIMIT 1
)
FROM custom_dynamic_sampling_rule AS a
WHERE a.id = <target_id>
  AND custom_dynamic_sampling_rule.id = a.id;
```