### PR TITLE
feat(agents-insights): beta badge

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -391,6 +391,7 @@ function Sidebar() {
             to={`/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${AGENTS_LANDING_SUB_PATH}/${MODULE_BASE_URLS[AGENTS_LANDING_SUB_PATH]}/`}
             id="performance-domains-agents"
             icon={<SubitemDot collapsed />}
+            isBeta
           />
         </AIInsightsFeature>
         <SidebarItem

--- a/static/app/views/insights/pages/agents/settings.ts
+++ b/static/app/views/insights/pages/agents/settings.ts
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const AGENTS_LANDING_SUB_PATH = 'agents';
-export const AGENTS_LANDING_TITLE = t('Agents');
-export const AGENTS_SIDEBAR_LABEL = t('Agents');
+export const AGENTS_LANDING_TITLE = t('AI Agents');
+export const AGENTS_SIDEBAR_LABEL = t('AI Agents');
 
 export const MODULES = [ModuleName.AGENTS];

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -2,10 +2,8 @@ import {Fragment, useMemo} from 'react';
 import partition from 'lodash/partition';
 
 import Feature from 'sentry/components/acl/feature';
-import {Badge} from 'sentry/components/core/badge';
-import {Flex} from 'sentry/components/core/layout';
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {AIInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
@@ -92,11 +90,9 @@ export function InsightsSecondaryNav() {
             <SecondaryNav.Item
               to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
               analyticsItemName="insights_agents"
+              trailingItems={<FeatureBadge type="beta" />}
             >
-              <Flex align="center" gap={space(0.5)}>
-                {AGENTS_SIDEBAR_LABEL}
-                <Badge type="beta">beta</Badge>
-              </Flex>
+              {AGENTS_SIDEBAR_LABEL}
             </SecondaryNav.Item>
           </AIInsightsFeature>
         </SecondaryNav.Section>

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -2,7 +2,10 @@ import {Fragment, useMemo} from 'react';
 import partition from 'lodash/partition';
 
 import Feature from 'sentry/components/acl/feature';
+import {Badge} from 'sentry/components/core/badge';
+import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {AIInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
@@ -90,7 +93,10 @@ export function InsightsSecondaryNav() {
               to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
               analyticsItemName="insights_agents"
             >
-              {AGENTS_SIDEBAR_LABEL}
+              <Flex align="center" gap={space(0.5)}>
+                {AGENTS_SIDEBAR_LABEL}
+                <Badge type="beta">beta</Badge>
+              </Flex>
             </SecondaryNav.Item>
           </AIInsightsFeature>
         </SecondaryNav.Section>


### PR DESCRIPTION
Closes: [TET-667: Add beta badge to nav item](https://linear.app/getsentry/issue/TET-667/add-beta-badge-to-nav-item)

New nav:
![image](https://github.com/user-attachments/assets/47567816-7f67-458f-b64f-46a2d40cc5df)

Old nav: 
![image](https://github.com/user-attachments/assets/c37c47f8-037b-43af-8c1b-d05a7f4d7866)

