### PR TITLE
feat(agents-insights): redirect to prefered AI module

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/features.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/features.tsx
@@ -1,16 +1,8 @@
-import {useEffect} from 'react';
-import {useNavigate} from 'react-router-dom';
-
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
-import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
-import {AGENTS_LANDING_SUB_PATH} from 'sentry/views/insights/pages/agents/settings';
-import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
-import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
-import {ModuleName} from 'sentry/views/insights/types';
 
 type AgentInsightsFeatureProps = Omit<Parameters<typeof Feature>[0], 'features'>;
 
@@ -27,22 +19,6 @@ export function usePreferedAiModule() {
   }
 
   return user.options.prefersAgentsInsightsModule ? 'agents-insights' : 'llm-monitoring';
-}
-
-export function useRedirectToPreferedAiModule() {
-  const preferedAiModule = usePreferedAiModule();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (preferedAiModule === 'llm-monitoring') {
-      navigate(
-        `/${INSIGHTS_BASE_URL}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS[ModuleName.AI]}/`
-      );
-    } else if (preferedAiModule === 'agents-insights') {
-      navigate(`/${INSIGHTS_BASE_URL}/${AGENTS_LANDING_SUB_PATH}/`);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 }
 
 export function AIInsightsFeature(props: AgentInsightsFeatureProps) {

--- a/static/app/views/insights/agentMonitoring/utils/features.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/features.tsx
@@ -1,8 +1,16 @@
+import {useEffect} from 'react';
+import {useNavigate} from 'react-router-dom';
+
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
+import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
+import {AGENTS_LANDING_SUB_PATH} from 'sentry/views/insights/pages/agents/settings';
+import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
+import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
+import {ModuleName} from 'sentry/views/insights/types';
 
 type AgentInsightsFeatureProps = Omit<Parameters<typeof Feature>[0], 'features'>;
 
@@ -19,6 +27,22 @@ export function usePreferedAiModule() {
   }
 
   return user.options.prefersAgentsInsightsModule ? 'agents-insights' : 'llm-monitoring';
+}
+
+export function useRedirectToPreferedAiModule() {
+  const preferedAiModule = usePreferedAiModule();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (preferedAiModule === 'llm-monitoring') {
+      navigate(
+        `/${INSIGHTS_BASE_URL}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS[ModuleName.AI]}/`
+      );
+    } else if (preferedAiModule === 'agents-insights') {
+      navigate(`/${INSIGHTS_BASE_URL}/${AGENTS_LANDING_SUB_PATH}/`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 }
 
 export function AIInsightsFeature(props: AgentInsightsFeatureProps) {

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -8,6 +8,7 @@ import {EnvironmentPageFilter} from 'sentry/components/organizations/environment
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import TransactionNameSearchBar from 'sentry/components/performance/searchBar';
+import Redirect from 'sentry/components/redirect';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -26,7 +27,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/hooks/useActiveTable';
 import {
   AIInsightsFeature,
-  useRedirectToPreferedAiModule,
+  usePreferedAiModule,
 } from 'sentry/views/insights/agentMonitoring/utils/features';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -35,10 +36,13 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget';
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {AgentsPageHeader} from 'sentry/views/insights/pages/agents/agentsPageHeader';
+import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
 import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWidget';
 import {WidgetGrid} from 'sentry/views/insights/pages/platform/shared/styles';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
+import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 
@@ -136,7 +140,15 @@ function AgentsMonitoringPage() {
 }
 
 function PageWithProviders() {
-  useRedirectToPreferedAiModule();
+  const preferedAiModule = usePreferedAiModule();
+
+  if (preferedAiModule === 'llm-monitoring') {
+    return (
+      <Redirect
+        to={`/${INSIGHTS_BASE_URL}/${AI_LANDING_SUB_PATH}/${MODULE_BASE_URLS[ModuleName.AI]}/`}
+      />
+    );
+  }
 
   return (
     <AIInsightsFeature>

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -24,7 +24,10 @@ import {
   TableType,
   useActiveTable,
 } from 'sentry/views/insights/agentMonitoring/hooks/useActiveTable';
-import {AIInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {
+  AIInsightsFeature,
+  useRedirectToPreferedAiModule,
+} from 'sentry/views/insights/agentMonitoring/utils/features';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
@@ -133,6 +136,8 @@ function AgentsMonitoringPage() {
 }
 
 function PageWithProviders() {
+  useRedirectToPreferedAiModule();
+
   return (
     <AIInsightsFeature>
       <ModulePageProviders

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -1,6 +1,7 @@
 import * as Layout from 'sentry/components/layouts/thirds';
+import Redirect from 'sentry/components/redirect';
 import {AiModuleToggleButton} from 'sentry/views/insights/agentMonitoring/components/aiModuleToggleButton';
-import {useRedirectToPreferedAiModule} from 'sentry/views/insights/agentMonitoring/utils/features';
+import {usePreferedAiModule} from 'sentry/views/insights/agentMonitoring/utils/features';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -9,8 +10,10 @@ import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/modu
 import LlmNumberOfPipelinesChartWidget from 'sentry/views/insights/common/components/widgets/llmNumberOfPipelinesChartWidget';
 import LlmPipelineDurationChartWidget from 'sentry/views/insights/common/components/widgets/llmPipelineDurationChartWidget';
 import LlmTotalTokensUsedChart from 'sentry/views/insights/common/components/widgets/llmTotalTokensUsedChartWidget';
+import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {PipelinesTable} from 'sentry/views/insights/llmMonitoring/components/tables/pipelinesTable';
 import {AiHeader} from 'sentry/views/insights/pages/ai/aiPageHeader';
+import {INSIGHTS_BASE_URL} from 'sentry/views/insights/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 function LLMMonitoringPage() {
@@ -47,7 +50,11 @@ function LLMMonitoringPage() {
 }
 
 function PageWithProviders() {
-  useRedirectToPreferedAiModule();
+  const preferedAiModule = usePreferedAiModule();
+
+  if (preferedAiModule === 'agents-insights') {
+    return <Redirect to={`/${INSIGHTS_BASE_URL}/${MODULE_BASE_URLS[ModuleName.AI]}/`} />;
+  }
 
   return (
     <ModulePageProviders moduleName="ai" analyticEventName="insight.page_loads.ai">

--- a/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
+++ b/static/app/views/insights/llmMonitoring/views/llmMonitoringLandingPage.tsx
@@ -1,5 +1,6 @@
 import * as Layout from 'sentry/components/layouts/thirds';
 import {AiModuleToggleButton} from 'sentry/views/insights/agentMonitoring/components/aiModuleToggleButton';
+import {useRedirectToPreferedAiModule} from 'sentry/views/insights/agentMonitoring/utils/features';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
@@ -46,6 +47,8 @@ function LLMMonitoringPage() {
 }
 
 function PageWithProviders() {
+  useRedirectToPreferedAiModule();
+
   return (
     <ModulePageProviders moduleName="ai" analyticEventName="insight.page_loads.ai">
       <LLMMonitoringPage />


### PR DESCRIPTION
Closes [TET-681: Redirect between LLM Monitoring and Agents Insights](https://linear.app/getsentry/issue/TET-681/redirect-between-llm-monitoring-and-agents-insights)

