### PR TITLE
feat(spans): Limit segment size during insert

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -20,14 +20,15 @@ local num_spans = ARGV[1]
 local parent_span_id = ARGV[2]
 local has_root_span = ARGV[3] == "true"
 local set_timeout = tonumber(ARGV[4])
-local NUM_ARGS = 4
+local max_spans = tonumber(ARGV[5])
+local NUM_ARGS = 5
 
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
 local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
 
-for i = 0, 10000 do  -- theoretically this limit means that segment trees of depth 10k may not be joined together correctly.
+for i = 0, max_spans do
     local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
     redirect_depth = i
     if not new_set_span or new_set_span == set_span_id then
@@ -37,8 +38,8 @@ for i = 0, 10000 do  -- theoretically this limit means that segment trees of dep
     set_span_id = new_set_span
 end
 
-local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
-local parent_key = string.format("span-buf:s:{%s}:%s", project_and_trace, parent_span_id)
+local set_key = string.format("span-buf:z:{%s}:%s", project_and_trace, set_span_id)
+local parent_key = string.format("span-buf:z:{%s}:%s", project_and_trace, parent_span_id)
 
 local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
 has_root_span = has_root_span or redis.call("get", has_root_span_key) == "1"
@@ -49,7 +50,7 @@ end
 local hset_args = {}
 local sunionstore_args = {}
 
-if set_span_id ~= parent_span_id and redis.call("scard", parent_key) > 0 then
+if set_span_id ~= parent_span_id and redis.call("zcard", parent_key) > 0 then
     table.insert(sunionstore_args, parent_key)
 end
 
@@ -61,7 +62,7 @@ for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     table.insert(hset_args, set_span_id)
 
     if not is_root_span then
-        local span_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
+        local span_key = string.format("span-buf:z:{%s}:%s", project_and_trace, span_id)
         table.insert(sunionstore_args, span_key)
     end
 end
@@ -70,8 +71,12 @@ redis.call("hset", main_redirect_key, unpack(hset_args))
 redis.call("expire", main_redirect_key, set_timeout)
 
 if #sunionstore_args > 0 then
-    redis.call("sunionstore", set_key, set_key, unpack(sunionstore_args))
+    local span_count = redis.call("zunionstore", set_key, #sunionstore_args + 1, set_key, unpack(sunionstore_args))
     redis.call("unlink", unpack(sunionstore_args))
+
+    if span_count > max_spans then
+        redis.call("zpopmin", set_key, 0, span_count - max_spans)
+    end
 end
 
 redis.call("expire", set_key, set_timeout)

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -202,7 +202,7 @@ class SpansBuffer:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
                     set_key = self._get_span_key(project_and_trace, parent_span_id)
                     prepared = self._prepare_payloads(subsegment)
-                    p.zadd(set_key, *prepared)
+                    p.zadd(set_key, prepared)
 
                 p.execute()
 
@@ -326,7 +326,7 @@ class SpansBuffer:
 
         return trees
 
-    def _prepare_payloads(self, spans: list[Span]) -> list[bytes]:
+    def _prepare_payloads(self, spans: list[Span]) -> dict[bytes, float]:
         if self._zstd_compressor is None:
             return {span.payload: span.end_timestamp_precise for span in spans}
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -326,7 +326,7 @@ class SpansBuffer:
 
         return trees
 
-    def _prepare_payloads(self, spans: list[Span]) -> dict[bytes, float]:
+    def _prepare_payloads(self, spans: list[Span]) -> dict[str | bytes, float]:
         if self._zstd_compressor is None:
             return {span.payload: span.end_timestamp_precise for span in spans}
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -34,7 +34,7 @@ Now how does that look like in Redis? For each incoming span, we:
 
 1. Try to figure out what the name of the respective span buffer is (`set_key` in `add-buffer.lua`)
   a. We look up any "redirects" from the span buffer's parent_span_id (hashmap at "span-buf:sr:{project_id:trace_id}") to another key.
-  b. Otherwise we use "span-buf:s:{project_id:trace_id}:span_id"
+  b. Otherwise we use "span-buf:z:{project_id:trace_id}:span_id"
 2. Rename any span buffers keyed under the span's own span ID to `set_key`, merging their contents.
 3. Add the ingested span's payload to the set under `set_key`.
 4. To a "global queue", we write the set's key, sorted by timeout.
@@ -55,10 +55,10 @@ than the original topic.
 
 Glossary for types of keys:
 
-    * span-buf:s:* -- the actual set keys, containing span payloads. Each key contains all data for a segment. The most memory-intensive kind of key.
+    * span-buf:z:* -- the actual set keys, containing span payloads. Each key contains all data for a segment. The most memory-intensive kind of key.
     * span-buf:q:* -- the priority queue, used to determine which segments are ready to be flushed.
     * span-buf:hrs:* -- simple bool key to flag a segment as "has root span" (HRS)
-    * span-buf:sr:* -- redirect mappings so that each incoming span ID can be mapped to the right span-buf:s: set.
+    * span-buf:sr:* -- redirect mappings so that each incoming span ID can be mapped to the right span-buf:z: set.
 """
 
 from __future__ import annotations
@@ -81,7 +81,7 @@ from sentry.utils import metrics, redis
 
 # SegmentKey is an internal identifier used by the redis buffer that is also
 # directly used as raw redis key. the format is
-# "span-buf:s:{project_id:trace_id}:span_id", and the type is bytes because our
+# "span-buf:z:{project_id:trace_id}:span_id", and the type is bytes because our
 # redis client is bytes.
 #
 # The segment ID in the Kafka protocol is only the span ID.
@@ -128,6 +128,7 @@ class Span(NamedTuple):
     parent_span_id: str | None
     project_id: int
     payload: bytes
+    end_timestamp_precise: float
     is_segment_span: bool = False
 
     def effective_parent_id(self):
@@ -167,7 +168,7 @@ class SpansBuffer:
         return (SpansBuffer, (self.assigned_shards,))
 
     def _get_span_key(self, project_and_trace: str, span_id: str) -> bytes:
-        return f"span-buf:s:{{{project_and_trace}}}:{span_id}".encode("ascii")
+        return f"span-buf:z:{{{project_and_trace}}}:{span_id}".encode("ascii")
 
     def process_spans(self, spans: Sequence[Span], now: int):
         """
@@ -187,6 +188,7 @@ class SpansBuffer:
         redis_ttl = options.get("spans.buffer.redis-ttl")
         timeout = options.get("spans.buffer.timeout")
         root_timeout = options.get("spans.buffer.root-timeout")
+        max_segment_spans = options.get("spans.buffer.max-segment-spans")
 
         result_meta = []
         is_root_span_count = 0
@@ -199,10 +201,8 @@ class SpansBuffer:
             with self.client.pipeline(transaction=False) as p:
                 for (project_and_trace, parent_span_id), subsegment in trees.items():
                     set_key = self._get_span_key(project_and_trace, parent_span_id)
-                    payloads = [span.payload for span in subsegment]
-
-                    compressed = self._compress_span_payloads(payloads)
-                    p.sadd(set_key, *compressed)
+                    prepared = self._prepare_payloads(subsegment)
+                    p.zadd(set_key, *prepared)
 
                 p.execute()
 
@@ -223,6 +223,7 @@ class SpansBuffer:
                         parent_span_id,
                         "true" if any(span.is_segment_span for span in subsegment) else "false",
                         redis_ttl,
+                        max_segment_spans,
                         *[span.span_id for span in subsegment],
                     )
 
@@ -325,12 +326,12 @@ class SpansBuffer:
 
         return trees
 
-    def _compress_span_payloads(self, payloads: list[bytes]) -> list[bytes]:
-        combined = b"\x00".join(payloads)
-        original_size = len(combined)
-
+    def _prepare_payloads(self, spans: list[Span]) -> list[bytes]:
         if self._zstd_compressor is None:
-            return payloads
+            return {span.payload: span.end_timestamp_precise for span in spans}
+
+        combined = b"\x00".join(span.payload for span in spans)
+        original_size = len(combined)
 
         with metrics.timer("spans.buffer.compression.cpu_time"):
             compressed = self._zstd_compressor.compress(combined)
@@ -342,7 +343,8 @@ class SpansBuffer:
         metrics.timing("spans.buffer.compression.compressed_size", compressed_size)
         metrics.timing("spans.buffer.compression.compression_ratio", compression_ratio)
 
-        return [compressed]
+        min_timestamp = min(span.end_timestamp_precise for span in spans)
+        return {compressed: min_timestamp}
 
     def _decompress_batch(self, compressed_data: bytes) -> list[bytes]:
         # Check for zstd magic header (0xFD2FB528 in little-endian) --
@@ -466,7 +468,6 @@ class SpansBuffer:
 
         page_size = options.get("spans.buffer.segment-page-size")
         max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
-        max_segment_spans = options.get("spans.buffer.max-segment-spans")
 
         payloads: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
         cursors = {key: 0 for key in segment_keys}
@@ -501,14 +502,6 @@ class SpansBuffer:
                     continue
 
                 payloads[key].extend(decompressed_spans)
-                if len(payloads[key]) > max_segment_spans:
-                    metrics.incr("spans.buffer.flush_segments.segment_span_count_exceeded")
-                    logger.warning("Skipping too large segment, span count %s", len(payloads[key]))
-
-                    del payloads[key]
-                    del cursors[key]
-                    continue
-
                 if cursor == 0:
                     del cursors[key]
                 else:

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -2,6 +2,7 @@ import logging
 import time
 from collections.abc import Callable, Mapping
 from functools import partial
+from typing import cast
 
 import rapidjson
 import sentry_sdk
@@ -12,6 +13,7 @@ from arroyo.processing.strategies.batching import BatchStep, ValuesBatch
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import BrokerValue, Commit, FilteredPayload, Message, Partition
+from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 from sentry import killswitches
 from sentry.spans.buffer import Span, SpansBuffer
@@ -134,7 +136,7 @@ def process_batch(
             if min_timestamp is None or timestamp < min_timestamp:
                 min_timestamp = timestamp
 
-            val = rapidjson.loads(payload.value)
+            val = cast(SpanEvent, rapidjson.loads(payload.value))
 
             partition_id = value.partition.index
 
@@ -155,6 +157,7 @@ def process_batch(
                 parent_span_id=val.get("parent_span_id"),
                 project_id=val["project_id"],
                 payload=payload.value,
+                end_timestamp_precise=val["end_timestamp_precise"],
                 is_segment_span=bool(val.get("parent_span_id") is None or val.get("is_remote")),
             )
             spans.append(span)

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -45,6 +45,7 @@ def test_basic(monkeypatch):
                             "project_id": 12,
                             "span_id": "a" * 16,
                             "trace_id": "b" * 32,
+                            "end_timestamp_precise": 1700000000.0,
                         }
                     ).encode("ascii"),
                     [],
@@ -76,6 +77,7 @@ def test_basic(monkeypatch):
                 "segment_id": "aaaaaaaaaaaaaaaa",
                 "span_id": "aaaaaaaaaaaaaaaa",
                 "trace_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "end_timestamp_precise": 1700000000.0,
             },
         ],
     }

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -44,6 +44,7 @@ def test_backpressure(monkeypatch):
                 span_id="a" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"d" * 16),
@@ -51,6 +52,7 @@ def test_backpressure(monkeypatch):
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"c" * 16),
@@ -58,6 +60,7 @@ def test_backpressure(monkeypatch):
                 span_id="c" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
             Span(
                 payload=_payload(b"b" * 16),
@@ -66,6 +69,7 @@ def test_backpressure(monkeypatch):
                 parent_span_id=None,
                 is_segment_span=True,
                 project_id=1,
+                end_timestamp_precise=now,
             ),
         ]
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -35,7 +35,7 @@ def shallow_permutations(spans: list[Span]) -> list[list[Span]]:
 
 
 def _segment_id(project_id: int, trace_id: str, span_id: str) -> SegmentKey:
-    return f"span-buf:s:{{{project_id}:{trace_id}}}:{span_id}".encode("ascii")
+    return f"span-buf:z:{{{project_id}:{trace_id}}}:{span_id}".encode("ascii")
 
 
 def _payload(span_id: bytes) -> bytes:
@@ -139,6 +139,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="a" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -146,6 +147,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -153,6 +155,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -161,6 +164,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -204,6 +208,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 _SplitBatch(),
                 Span(
@@ -212,6 +217,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="b" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"a" * 16),
@@ -220,6 +226,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -227,6 +234,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -270,6 +278,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="e" * 16,
                     parent_span_id="d" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -277,6 +286,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -284,6 +294,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="b" * 16,
                     parent_span_id="c" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"c" * 16),
@@ -291,6 +302,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"a" * 16),
@@ -299,6 +311,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -343,6 +356,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"d" * 16),
@@ -350,6 +364,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"e" * 16),
@@ -357,6 +372,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     span_id="e" * 16,
                     parent_span_id="b" * 16,
                     project_id=1,
+                    end_timestamp_precise=1700000000.0,
                 ),
                 Span(
                     payload=_payload(b"b" * 16),
@@ -365,6 +381,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     parent_span_id=None,
                     is_segment_span=True,
                     project_id=2,
+                    end_timestamp_precise=1700000000.0,
                 ),
             ]
         )
@@ -416,6 +433,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 parent_span_id="d" * 16,
                 project_id=1,
                 is_segment_span=True,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"d" * 16),
@@ -423,6 +441,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"e" * 16),
@@ -430,6 +449,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 span_id="e" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=_payload(b"b" * 16),
@@ -438,6 +458,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 parent_span_id=None,
                 is_segment_span=True,
                 project_id=2,
+                end_timestamp_precise=1700000000.0,
             ),
         ]
     ),
@@ -492,6 +513,7 @@ def test_flush_rebalance(buffer: SpansBuffer):
             parent_span_id=None,
             project_id=1,
             is_segment_span=True,
+            end_timestamp_precise=1700000000.0,
         )
     ]
 
@@ -540,6 +562,7 @@ def test_compression_functionality(compression_level):
                 parent_span_id=None,
                 project_id=1,
                 is_segment_span=True,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=make_payload("a" * 16),
@@ -547,6 +570,7 @@ def test_compression_functionality(compression_level):
                 span_id="a" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=1700000000.0,
             ),
             Span(
                 payload=make_payload("c" * 16),
@@ -554,6 +578,7 @@ def test_compression_functionality(compression_level):
                 span_id="c" * 16,
                 parent_span_id="b" * 16,
                 project_id=1,
+                end_timestamp_precise=1700000000.0,
             ),
         ]
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -585,7 +585,7 @@ def test_compression_functionality(compression_level):
         buffer.process_spans(spans, now=0)
 
         segment_key = _segment_id(1, "a" * 32, "b" * 16)
-        stored_data = buffer.client.smembers(segment_key)
+        stored_data = buffer.client.zrange(segment_key, 0, -1, withscores=False)
         assert len(stored_data) > 0
 
         segments = buffer.flush_segments(now=11)


### PR DESCRIPTION
A proof of concept that limits the number of spans per segment during insertion. Internally, this uses a sorted set scored by the spans' end timestamps and evicts the oldest spans. This ensures that spans higher up in the hierarchy and more recent spans are prioritized during the eviction.

Closes STREAM-162

