### PR TITLE
fix(ui): change width to min-width to avoid shrinking of table

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -109,7 +109,7 @@ export const Grid = styled('table')<{
         `
       : ''}
 
-  width: ${p => p.fit}
+  min-width: ${p => p.fit}
 `;
 
 /**


### PR DESCRIPTION
### Change
Made a mistake [on the PR](https://github.com/getsentry/sentry/pull/93704) I added this prop. Should be `min-width` and not `width`

### Before
![image](https://github.com/user-attachments/assets/1d65989f-780b-450a-bfa2-2a0e19cce382)

### After
![Screenshot 2025-06-23 at 11 49 54 AM](https://github.com/user-attachments/assets/73dff1ea-1028-4924-8f39-69f1f74ef280)

