### PR TITLE
fix(agent-insights): Fix joining search values

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -9,6 +9,7 @@ export const AI_RUN_OPS = [
   'ai.run.generateObject',
   'gen_ai.invoke_agent',
   'ai.pipeline.generate_text',
+  'ai.pipeline.stream_text',
 ];
 export const AI_RUN_DESCRIPTIONS = ['ai.generateText', 'generateText'];
 
@@ -20,7 +21,10 @@ export const AI_GENERATION_OPS = [
   'gen_ai.generate_content',
   'gen_ai.generate_text',
   'gen_ai.generate_object',
-  'get_ai.stream_text',
+  'gen_ai.stream_text',
+  'gen_ai.stream_object',
+  'gen_ai.embed',
+  'gen_ai.embed_many',
   'gen_ai.text_completion',
 ];
 export const AI_GENERATION_DESCRIPTIONS = [
@@ -74,7 +78,7 @@ export function getIsAiSpan({
   op?: string;
 }) {
   if (op !== 'default') {
-    return AI_OPS.includes(op);
+    return AI_OPS.includes(op) || op.startsWith('gen_ai.');
   }
   return AI_DESCRIPTIONS.includes(description ?? '');
 }
@@ -98,16 +102,20 @@ export function mapMissingSpanOp({
   return op;
 }
 
+function joinValues(values: string[]) {
+  return values.map(value => `"${value}"`).join(',');
+}
+
 export const getAgentRunsFilter = () => {
-  return `(span.op:[${AI_RUN_OPS.join(',')}] or span.description:[${AI_RUN_DESCRIPTIONS.join(',')}])`;
+  return `(span.op:[${joinValues(AI_RUN_OPS)}] or span.description:[${joinValues(AI_RUN_DESCRIPTIONS)}])`;
 };
 
 export const getAIGenerationsFilter = () => {
-  return `(span.op:[${AI_GENERATION_OPS.join(',')}] or span.description:[${AI_GENERATION_DESCRIPTIONS.join(',')}])`;
+  return `(span.op:[${joinValues(AI_GENERATION_OPS)}] or span.description:[${joinValues(AI_GENERATION_DESCRIPTIONS)}])`;
 };
 
 export const getAIToolCallsFilter = () => {
-  return `(span.op:[${AI_TOOL_CALL_OPS.join(',')}] or span.description:[${AI_TOOL_CALL_DESCRIPTIONS.join(',')}])`;
+  return `(span.op:[${joinValues(AI_TOOL_CALL_OPS)}] or span.description:[${joinValues(AI_TOOL_CALL_DESCRIPTIONS)}])`;
 };
 
 export const getAITracesFilter = () => {


### PR DESCRIPTION
Properly escape query values.
Add missing span ops.
Make ai span detection more lax by checking if ai op starts with `gen_ai.`