### PR TITLE
fix(ui): Style hover state on webhook subscriptions

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -85,6 +85,7 @@ export default withOrganization(SubscriptionBox);
 const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   background: ${p => p.theme.backgroundSecondary};
   opacity: ${p => (p.disabled ? 0.6 : 1)};
   border-radius: ${p => p.theme.borderRadius};


### PR DESCRIPTION
The interaction state layer needed some additional CSS to apply properly
Resolves https://github.com/getsentry/sentry/issues/93883


**Before**
<img width="118" alt="image" src="https://github.com/user-attachments/assets/d48913dd-b475-4bd4-8fc0-0412e114a630" />

**After**
<img width="91" alt="image" src="https://github.com/user-attachments/assets/a8b00d93-3726-47f6-8a5b-6c163d0a6987" />

