### PR TITLE
Revert "chore(header): remove excess bottom margin (#91753)"

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -65,7 +65,14 @@ export const HeaderContent = styled('div')<{unified?: boolean}>`
   display: flex;
   flex-direction: column;
   justify-content: normal;
+  margin-bottom: ${space(1)};
   max-width: 100%;
+
+  ${p =>
+    p.unified &&
+    css`
+      margin-bottom: 0;
+    `}
 `;
 
 /**

--- a/static/app/views/explore/multiQueryMode/index.tsx
+++ b/static/app/views/explore/multiQueryMode/index.tsx
@@ -37,7 +37,7 @@ export default function MultiQueryMode() {
       renderDisabled={NoAccess}
     >
       <SentryDocumentTitle title={t('Compare Queries')} orgSlug={organization.slug}>
-        <Layout.Header unified>
+        <Layout.Header>
           <Layout.HeaderContent>
             <Breadcrumbs
               crumbs={[

--- a/static/app/views/explore/multiQueryMode/index.tsx
+++ b/static/app/views/explore/multiQueryMode/index.tsx
@@ -37,7 +37,7 @@ export default function MultiQueryMode() {
       renderDisabled={NoAccess}
     >
       <SentryDocumentTitle title={t('Compare Queries')} orgSlug={organization.slug}>
-        <Layout.Header>
+        <Layout.Header unified>
           <Layout.HeaderContent>
             <Breadcrumbs
               crumbs={[


### PR DESCRIPTION
This PR partially reverts the changes from https://github.com/getsentry/sentry/pull/91753. 

The reason we cannot do this is because some headers have relied on the margin, and look broken without it. An alternative is to use the unified prop (as done here that sets the margin to 0)


Fixed DE-148