### PR TITLE
fix(nav): Fix default explore route when discover is the top option

### DIFF
--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -416,7 +416,7 @@ export function getDefaultExploreRoute(organization: Organization) {
   }
 
   if (organization.features.includes('discover-basic')) {
-    return 'discover';
+    return 'discover/homepage';
   }
 
   if (organization.features.includes('performance-profiling')) {


### PR DESCRIPTION
The default route should be `/discover/homepage/`, not just `/discover/`. This really only affects plans that don't have Traces.