### PR TITLE
fix(insights): Fix timespent tooltip in insights overview tables

### DIFF
--- a/static/app/views/insights/common/components/headerTooltips/headerTooltips.tsx
+++ b/static/app/views/insights/common/components/headerTooltips/headerTooltips.tsx
@@ -20,7 +20,7 @@ export const SPAN_HEADER_TOOLTIPS: Record<string, React.ReactNode> = {
       {t('The total time spent on this span.')}
       <br />
       <ExternalLink
-        href={`${MODULE_PRODUCT_DOC_LINKS[ModuleName.DB]}#what-is-time-spent`}
+        href={`https://docs.sentry.io/product/insights/overview/metrics/#time-spent`}
       >
         {t('How is this calculated?')}
       </ExternalLink>

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -5,8 +5,6 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import type {GridColumnHeader} from 'sentry/components/gridEditable';
 import type {Alignments} from 'sentry/components/gridEditable/sortLink';
 import SortLink from 'sentry/components/gridEditable/sortLink';
-import ExternalLink from 'sentry/components/links/externalLink';
-import {t} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {
   aggregateFunctionOutputType,
@@ -14,9 +12,7 @@ import {
   parseFunction,
 } from 'sentry/utils/discover/fields';
 import type {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
-import {MODULE_PRODUCT_DOC_LINKS} from 'sentry/views/insights/settings';
 import {
-  ModuleName,
   SpanFunction,
   SpanIndexedField,
   SpanMetricsField,
@@ -140,41 +136,12 @@ export const renderHeadCell = ({column, location, sort, sortParameterName}: Opti
     />
   );
 
-  if (
-    hasTooltip &&
-    [
-      'performance_score(measurements.score.total)',
-      'sum_if(span.duration,is_transaction,true)',
-    ].includes(key)
-  ) {
+  if (hasTooltip) {
     const AlignmentContainer = alignment === 'right' ? AlignRight : AlignLeft;
-
-    const title =
-      key === 'performance_score(measurements.score.total)' ? (
-        <span>
-          {t('The overall performance rating of this page.')}
-          <br />
-          <ExternalLink
-            href={`${MODULE_PRODUCT_DOC_LINKS[ModuleName.VITAL]}#performance-score`}
-          >
-            {t('How is this calculated?')}
-          </ExternalLink>
-        </span>
-      ) : (
-        <span>
-          {t('The total time spent on this transaction.')}
-          <br />
-          <ExternalLink
-            href={`https://docs.sentry.io/product/insights/overview/metrics/#time-spent`}
-          >
-            {t('How is this calculated?')}
-          </ExternalLink>
-        </span>
-      );
 
     return (
       <AlignmentContainer>
-        <StyledTooltip isHoverable title={title}>
+        <StyledTooltip isHoverable title={column.tooltip}>
           {sortLink}
         </StyledTooltip>
       </AlignmentContainer>

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -140,25 +140,41 @@ export const renderHeadCell = ({column, location, sort, sortParameterName}: Opti
     />
   );
 
-  if (hasTooltip) {
+  if (
+    hasTooltip &&
+    [
+      'performance_score(measurements.score.total)',
+      'sum_if(span.duration,is_transaction,true)',
+    ].includes(key)
+  ) {
     const AlignmentContainer = alignment === 'right' ? AlignRight : AlignLeft;
+
+    const title =
+      key === 'performance_score(measurements.score.total)' ? (
+        <span>
+          {t('The overall performance rating of this page.')}
+          <br />
+          <ExternalLink
+            href={`${MODULE_PRODUCT_DOC_LINKS[ModuleName.VITAL]}#performance-score`}
+          >
+            {t('How is this calculated?')}
+          </ExternalLink>
+        </span>
+      ) : (
+        <span>
+          {t('The total time spent on this transaction.')}
+          <br />
+          <ExternalLink
+            href={`${MODULE_PRODUCT_DOC_LINKS[ModuleName.DB]}#what-is-time-spent`}
+          >
+            {t('How is this calculated?')}
+          </ExternalLink>
+        </span>
+      );
 
     return (
       <AlignmentContainer>
-        <StyledTooltip
-          isHoverable
-          title={
-            <span>
-              {t('The overall performance rating of this page.')}
-              <br />
-              <ExternalLink
-                href={`${MODULE_PRODUCT_DOC_LINKS[ModuleName.VITAL]}#performance-score`}
-              >
-                {t('How is this calculated?')}
-              </ExternalLink>
-            </span>
-          }
-        >
+        <StyledTooltip isHoverable title={title}>
           {sortLink}
         </StyledTooltip>
       </AlignmentContainer>

--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -165,7 +165,7 @@ export const renderHeadCell = ({column, location, sort, sortParameterName}: Opti
           {t('The total time spent on this transaction.')}
           <br />
           <ExternalLink
-            href={`${MODULE_PRODUCT_DOC_LINKS[ModuleName.DB]}#what-is-time-spent`}
+            href={`https://docs.sentry.io/product/insights/overview/metrics/#time-spent`}
           >
             {t('How is this calculated?')}
           </ExternalLink>


### PR DESCRIPTION
Fixes time spent column displaying incorrect tooltip
![image](https://github.com/user-attachments/assets/dd4d2c81-dd35-48d4-a96e-b5d05d1caadf)