### PR TITLE
feat(aci): Modify SimpleTable to support sortable headers and responsive columns

### DIFF
--- a/static/app/components/workflowEngine/simpleTable/index.spec.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.spec.tsx
@@ -1,104 +1,41 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 
-function col(label: string) {
-  return {
-    Header: () => label,
-  };
-}
-function cell(output: string) {
-  return {
-    Header: () => 'header',
-    Cell: ({value}: any) => `${output}: ${value}`,
-  };
-}
-function width(value: string) {
-  return {
-    Header: () => 'header',
-    width: value,
-  };
-}
 describe('SimpleTable component', function () {
-  it('renders cells', function () {
+  it('renders headers andcells', function () {
     render(
-      <SimpleTable
-        data={[
-          {a: 0, b: 1, c: 2},
-          {a: 3, b: 4, c: 5},
-        ]}
-      />
-    );
-
-    expect(screen.getByRole('cell', {name: '0'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '1'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '2'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '3'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '4'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: '5'})).toBeInTheDocument();
-  });
-
-  it('renders headers without config', function () {
-    render(
-      <SimpleTable
-        data={[
-          {a: 0, b: 1, c: 2},
-          {a: 1, b: 2, c: 3},
-        ]}
-      />
-    );
-
-    expect(screen.getByRole('columnheader', {name: 'a'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'b'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'c'})).toBeInTheDocument();
-  });
-
-  it('renders with custom headers', function () {
-    render(
-      <SimpleTable
-        columns={{a: col('A'), b: col('B'), c: col('C')}}
-        data={[
-          {a: 0, b: 1, c: 2},
-          {a: 1, b: 2, c: 3},
-        ]}
-      />
+      <SimpleTable>
+        <SimpleTable.Header>
+          <SimpleTable.HeaderCell name="a">A</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell name="b">B</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell name="c">C</SimpleTable.HeaderCell>
+        </SimpleTable.Header>
+        <SimpleTable.Row data-test-id="row-1">
+          <SimpleTable.RowCell name="a">0</SimpleTable.RowCell>
+          <SimpleTable.RowCell name="b">1</SimpleTable.RowCell>
+          <SimpleTable.RowCell name="c">2</SimpleTable.RowCell>
+        </SimpleTable.Row>
+        <SimpleTable.Row data-test-id="row-2">
+          <SimpleTable.RowCell name="a">3</SimpleTable.RowCell>
+          <SimpleTable.RowCell name="b">4</SimpleTable.RowCell>
+          <SimpleTable.RowCell name="c">5</SimpleTable.RowCell>
+        </SimpleTable.Row>
+      </SimpleTable>
     );
 
     expect(screen.getByRole('columnheader', {name: 'A'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'B'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'C'})).toBeInTheDocument();
-  });
 
-  it('renders with custom cells', function () {
-    render(
-      <SimpleTable
-        columns={{a: cell('test-cell-a'), b: cell('test-cell-b'), c: cell('test-cell-c')}}
-        data={[
-          {a: 0, b: 1, c: 2},
-          {a: 1, b: 2, c: 3},
-        ]}
-      />
-    );
+    const row1 = screen.getByTestId('row-1');
+    expect(within(row1).getByRole('cell', {name: '0'})).toBeInTheDocument();
+    expect(within(row1).getByRole('cell', {name: '1'})).toBeInTheDocument();
+    expect(within(row1).getByRole('cell', {name: '2'})).toBeInTheDocument();
 
-    expect(screen.getByRole('cell', {name: 'test-cell-a: 0'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: 'test-cell-b: 1'})).toBeInTheDocument();
-    expect(screen.getByRole('cell', {name: 'test-cell-c: 2'})).toBeInTheDocument();
-  });
-
-  it('allows custom column widths', function () {
-    render(
-      <SimpleTable
-        columns={{a: width('2fr'), b: width('150px'), c: width('300px')}}
-        data={[
-          {a: 0, b: 1, c: 2},
-          {a: 1, b: 2, c: 3},
-        ]}
-      />
-    );
-
-    expect(screen.getByRole('table')).toBeInTheDocument();
-    expect(screen.getByRole('table')).toHaveStyle(
-      'grid-template-columns: 2fr 150px 300px'
-    );
+    const row2 = screen.getByTestId('row-2');
+    expect(within(row2).getByRole('cell', {name: '3'})).toBeInTheDocument();
+    expect(within(row2).getByRole('cell', {name: '4'})).toBeInTheDocument();
+    expect(within(row2).getByRole('cell', {name: '5'})).toBeInTheDocument();
   });
 });

--- a/static/app/components/workflowEngine/simpleTable/index.stories.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.stories.tsx
@@ -1,8 +1,9 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
-import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
+import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
 
@@ -13,21 +14,8 @@ interface Data {
   name: string;
 }
 
-const columns = defineColumns<Data>({
-  name: {Header: () => t('Name')},
-  monitors: {
-    Header: () => t('Monitors'),
-    Cell: ({value}) => `${value.length} monitors`,
-  },
-  action: {Header: () => t('Action')},
-  lastTriggered: {
-    Header: () => t('Last Triggered'),
-    Cell: ({value}) => <TimeAgoCell date={value} />,
-  },
-});
-
 export default Storybook.story('SimpleTable', story => {
-  story('default', () => {
+  story('Default', () => {
     const data: Data[] = [
       {
         name: 'Row A',
@@ -81,45 +69,68 @@ export default Storybook.story('SimpleTable', story => {
         <p>
           An example <Storybook.JSXNode name="SimpleTable" /> looks like this:
         </p>
-        <SimpleTable columns={columns} data={data} />
+        <SimpleTableWithColumns>
+          <SimpleTable.Header>
+            <SimpleTable.HeaderCell name="name" sortKey="name">
+              Name
+            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell name="monitors" sortKey="monitors">
+              Monitors
+            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell name="action" sortKey="action">
+              Action
+            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell name="lastTriggered" sortKey="lastTriggered">
+              Last Triggered
+            </SimpleTable.HeaderCell>
+          </SimpleTable.Header>
+          {data.map(row => (
+            <SimpleTable.Row key={row.name}>
+              <SimpleTable.RowCell name="name">{row.name}</SimpleTable.RowCell>
+              <SimpleTable.RowCell name="monitors">
+                {t('%s monitors', row.monitors.length)}
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell name="action">{row.action}</SimpleTable.RowCell>
+              <SimpleTable.RowCell name="lastTriggered">
+                <TimeAgoCell date={row.lastTriggered} />
+              </SimpleTable.RowCell>
+            </SimpleTable.Row>
+          ))}
+        </SimpleTableWithColumns>
       </Fragment>
     );
   });
 
-  story('empty', () => {
-    const data: Data[] = [];
-
+  story('Empty states', () => {
     return (
       <Fragment>
         <p>
-          Use the <Storybook.JSXProperty name="fallback" value="message" /> property for
-          empty states
+          Use the <Storybook.JSXNode name="SimpleTable.Empty" /> component for empty
+          states
         </p>
 
-        <SimpleTable
-          columns={columns}
-          data={data}
-          fallback={t('No alerts triggered during given date range')}
-        />
+        <SimpleTableWithColumns>
+          <SimpleTable.Header>
+            <SimpleTable.HeaderCell name="name" sortKey="name">
+              Name
+            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell name="monitors" sortKey="monitors">
+              Monitors
+            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell name="action" sortKey="action">
+              Action
+            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell name="lastTriggered" sortKey="lastTriggered">
+              Last Triggered
+            </SimpleTable.HeaderCell>
+          </SimpleTable.Header>
+          <SimpleTable.Empty>No data</SimpleTable.Empty>
+        </SimpleTableWithColumns>
       </Fragment>
     );
   });
 
-  story('custom widths', () => {
-    const columnsWithWidth = defineColumns<Data>({
-      name: {Header: () => t('Name'), width: '2fr'},
-      monitors: {
-        Header: () => t('Monitors'),
-        Cell: ({value}) => `${value.length} monitors`,
-        width: 'min-content',
-      },
-      action: {Header: () => t('Action')},
-      lastTriggered: {
-        Header: () => t('Last Triggered'),
-        Cell: ({value}) => <TimeAgoCell date={value} />,
-        width: '256px',
-      },
-    });
+  story('Custom widths and hidden columns', () => {
     const data: Data[] = [
       {
         name: 'Row A',
@@ -141,10 +152,67 @@ export default Storybook.story('SimpleTable', story => {
       },
     ];
 
+    const tableContent = (
+      <Fragment>
+        <SimpleTable.Header>
+          <SimpleTable.HeaderCell name="name" sortKey="name">
+            Name
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell name="monitors" sortKey="monitors">
+            Monitors
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell name="action" sortKey="action">
+            Action
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell name="lastTriggered" sortKey="lastTriggered">
+            Last Triggered
+          </SimpleTable.HeaderCell>
+        </SimpleTable.Header>
+        {data.map(row => (
+          <SimpleTable.Row key={row.name}>
+            <SimpleTable.RowCell name="name">{row.name}</SimpleTable.RowCell>
+            <SimpleTable.RowCell name="monitors">
+              {row.monitors.length} monitors
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell name="action">{row.action}</SimpleTable.RowCell>
+            <SimpleTable.RowCell name="lastTriggered">
+              <TimeAgoCell date={row.lastTriggered} />
+            </SimpleTable.RowCell>
+          </SimpleTable.Row>
+        ))}
+      </Fragment>
+    );
+
     return (
       <Fragment>
-        <SimpleTable columns={columnsWithWidth} data={data} />
+        <p>
+          Set custom widths for columns by styling SimpleTable with{' '}
+          <code>grid-template-columns</code>.
+        </p>
+
+        <SimpleTableWithCustomWidths>{tableContent}</SimpleTableWithCustomWidths>
+        <p>
+          You can also hide columns by targeting the column's class name, which is useful
+          for creating responsive tables.
+        </p>
+        <SimpleTableWithHiddenColumns>{tableContent}</SimpleTableWithHiddenColumns>
       </Fragment>
     );
   });
 });
+
+const SimpleTableWithColumns = styled(SimpleTable)`
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+`;
+
+const SimpleTableWithCustomWidths = styled(SimpleTable)`
+  grid-template-columns: 2fr min-content auto 256px;
+`;
+
+const SimpleTableWithHiddenColumns = styled(SimpleTableWithCustomWidths)`
+  grid-template-columns: 2fr min-content auto;
+
+  .lastTriggered {
+    display: none;
+  }
+`;

--- a/static/app/components/workflowEngine/simpleTable/index.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.tsx
@@ -1,91 +1,202 @@
-import type {CSSProperties} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 
-import {
-  Body as Panel,
-  Grid,
-  GridBody,
-  GridBodyCell,
-  GridBodyCellStatus,
-  GridHead,
-  GridHeadCellStatic,
-  GridRow,
-} from 'sentry/components/gridEditable/styles';
+import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
+import Panel from 'sentry/components/panels/panel';
+import {IconArrow} from 'sentry/icons';
+import {space} from 'sentry/styles/space';
+import type {Sort} from 'sentry/utils/discover/fields';
 
-interface ColumnConfig<Cell, Row> {
-  Header: () => React.ReactNode;
-  Cell?: (props: {row: Row; value: Cell}) => React.ReactNode;
-  /** @default 1fr */
-  width?: CSSProperties['gridTemplateColumns'];
+interface TableProps {
+  children: React.ReactNode;
+  className?: string;
 }
 
-interface TableProps<
-  Data extends Record<string, unknown>,
-  ColumnId extends keyof Data = keyof Data,
-> {
-  data: Data[];
-  columns?: {[Property in ColumnId]?: ColumnConfig<Data[Property], Data>};
-  fallback?: React.ReactNode;
-}
-
-export function defineColumns<Data extends {[Property in keyof Data]: unknown}>(columns: {
-  [Property in keyof Data]?: ColumnConfig<Data[Property], Data>;
-}) {
-  return columns;
-}
-
-export function SimpleTable<
-  Data extends Record<string, any>,
-  ColumnId extends keyof Data = keyof Data,
->({columns, data, fallback}: TableProps<Data, ColumnId>) {
-  const columnIds = Object.keys(columns ?? data.at(0) ?? {}) as unknown as ColumnId[];
-  const gridTemplateColumns = columnIds
-    .map(colId => columns?.[colId]?.width ?? 'minmax(0, 1fr)')
-    .join(' ');
-
+export function SimpleTable({className, children}: TableProps) {
   return (
-    <Panel>
-      <Grid
-        /** override grid-template-columns */
-        style={{gridTemplateColumns}}
-      >
-        <GridHead>
-          <GridRow data-row="header">
-            {columnIds.map(colId => {
-              const {Header = () => String(colId)} = columns?.[colId] ?? {};
-              return (
-                <GridHeadCellStatic key={String(colId)} data-column={colId}>
-                  <Header />
-                </GridHeadCellStatic>
-              );
-            })}
-          </GridRow>
-        </GridHead>
-        <GridBody>
-          {data.length > 0 ? (
-            data.map((row, i) => (
-              <GridRow key={i} data-row={i}>
-                {columnIds.map(colId => {
-                  const value = row[colId] as Data[ColumnId];
-                  const {Cell = DefaultCell} = columns?.[colId] ?? {};
-                  return (
-                    <GridBodyCell key={String(colId)} data-column={colId} data-row={i}>
-                      <Cell value={value} row={row} />
-                    </GridBodyCell>
-                  );
-                })}
-              </GridRow>
-            ))
-          ) : (
-            <GridRow>
-              <GridBodyCellStatus>{fallback}</GridBodyCellStatus>
-            </GridRow>
-          )}
-        </GridBody>
-      </Grid>
-    </Panel>
+    <StyledPanel className={className} role="table">
+      {children}
+    </StyledPanel>
   );
 }
 
-function DefaultCell({value}: {value: unknown}) {
-  return typeof value === 'string' ? value : JSON.stringify(value);
+function Header({children}: {children: React.ReactNode}) {
+  return <StyledPanelHeader role="row">{children}</StyledPanelHeader>;
 }
+
+function HeaderCell({
+  children,
+  name,
+  sortKey,
+  sort,
+  handleSortClick,
+}: {
+  children: React.ReactNode;
+  name: string;
+  handleSortClick?: () => void;
+  sort?: Sort;
+  sortKey?: string;
+}) {
+  const isSortedByField = sort?.field === sortKey;
+
+  return (
+    <ColumnHeaderCell
+      className={name}
+      isSorted={isSortedByField}
+      onClick={handleSortClick}
+      role="columnheader"
+      as={sortKey ? 'button' : 'div'}
+    >
+      <HeaderDivider />
+      {sortKey && <InteractionStateLayer />}
+      <HeadingText>{children}</HeadingText>
+      {sortKey && (
+        <SortIndicator
+          aria-hidden
+          size="xs"
+          direction={sort?.kind === 'asc' ? 'up' : 'down'}
+          isSorted={isSortedByField}
+        />
+      )}
+    </ColumnHeaderCell>
+  );
+}
+
+function Row({children, faded}: {children: React.ReactNode; faded?: boolean}) {
+  return (
+    <StyledRow faded={faded} role="row">
+      <InteractionStateLayer />
+      {children}
+    </StyledRow>
+  );
+}
+
+function RowCell({children, name}: {children: React.ReactNode; name: string}) {
+  return (
+    <StyledRowCell className={name} role="cell">
+      {children}
+    </StyledRowCell>
+  );
+}
+
+const StyledPanel = styled(Panel)`
+  display: grid;
+`;
+
+const StyledPanelHeader = styled('div')`
+  background: ${p => p.theme.backgroundSecondary};
+  border-bottom: 1px solid ${p => p.theme.border};
+  border-radius: calc(${p => p.theme.borderRadius} + 1px)
+    calc(${p => p.theme.borderRadius} + 1px) 0 0;
+  justify-content: left;
+  padding: 0;
+  min-height: 40px;
+  align-items: center;
+  text-transform: none;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+`;
+
+const StyledRowCell = styled('div')`
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  padding: ${space(2)};
+`;
+
+const StyledRow = styled('div', {
+  shouldForwardProp: prop => prop !== 'faded',
+})<{faded?: boolean}>`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  position: relative;
+  align-items: center;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  }
+
+  ${p =>
+    p.faded &&
+    css`
+      ${StyledRowCell}, {
+        opacity: 0.8;
+      }
+    `}
+`;
+
+const HeadingText = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const HeaderDivider = styled('div')`
+  position: absolute;
+  left: 0;
+  background-color: ${p => p.theme.gray200};
+  width: 1px;
+  border-radius: ${p => p.theme.borderRadius};
+  height: 14px;
+`;
+
+const ColumnHeaderCell = styled('div')<{isSorted?: boolean}>`
+  background: none;
+  outline: none;
+  border: none;
+  padding: 0 ${space(2)};
+  text-transform: inherit;
+  font-weight: ${p => p.theme.fontWeightBold};
+  text-align: left;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.subText};
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${space(1)};
+  height: 100%;
+
+  &:first-child {
+    ${HeaderDivider} {
+      display: none;
+    }
+  }
+
+  ${p =>
+    p.isSorted &&
+    css`
+      color: ${p.theme.textColor};
+    `}
+`;
+
+const SortIndicator = styled(IconArrow, {
+  shouldForwardProp: prop => prop !== 'isSorted',
+})<{isSorted?: boolean}>`
+  visibility: hidden;
+
+  ${p =>
+    p.isSorted &&
+    css`
+      visibility: visible;
+    `}
+`;
+
+const StyledEmptyMessage = styled('div')`
+  grid-column: 1 / -1;
+  min-height: 200px;
+  padding: ${space(2)};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+SimpleTable.Header = Header;
+SimpleTable.HeaderCell = HeaderCell;
+SimpleTable.Row = Row;
+SimpleTable.RowCell = RowCell;
+SimpleTable.Empty = StyledEmptyMessage;

--- a/static/app/components/workflowEngine/simpleTable/index.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.tsx
@@ -1,3 +1,4 @@
+import type {HTMLAttributes} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -10,6 +11,10 @@ import type {Sort} from 'sentry/utils/discover/fields';
 interface TableProps {
   children: React.ReactNode;
   className?: string;
+}
+
+interface RowProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: 'default' | 'faded';
 }
 
 export function SimpleTable({className, children}: TableProps) {
@@ -62,9 +67,9 @@ function HeaderCell({
   );
 }
 
-function Row({children, faded}: {children: React.ReactNode; faded?: boolean}) {
+function Row({children, variant = 'default', ...props}: RowProps) {
   return (
-    <StyledRow faded={faded} role="row">
+    <StyledRow variant={variant} role="row" {...props}>
       <InteractionStateLayer />
       {children}
     </StyledRow>
@@ -106,8 +111,8 @@ const StyledRowCell = styled('div')`
 `;
 
 const StyledRow = styled('div', {
-  shouldForwardProp: prop => prop !== 'faded',
-})<{faded?: boolean}>`
+  shouldForwardProp: prop => prop !== 'variant',
+})<{variant?: 'default' | 'faded'}>`
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1;
@@ -119,7 +124,7 @@ const StyledRow = styled('div', {
   }
 
   ${p =>
-    p.faded &&
+    p.variant === 'faded' &&
     css`
       ${StyledRowCell}, {
         opacity: 0.8;

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -1,10 +1,11 @@
+import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {DateTime} from 'sentry/components/dateTime';
 import Link from 'sentry/components/links/link';
 import {useTimezone} from 'sentry/components/timezoneProvider';
-import {defineColumns, SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
-import {t, tct} from 'sentry/locale';
+import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
+import {tct} from 'sentry/locale';
 
 interface AutomationHistoryData {
   dateSent: Date;
@@ -16,29 +17,36 @@ type Props = {
   history: AutomationHistoryData[];
 };
 
-const getColumns = (timezone: string) =>
-  defineColumns<AutomationHistoryData>({
-    dateSent: {
-      Header: () =>
-        tct('Time Sent ([timezone])', {timezone: moment.tz(timezone).zoneAbbr()}),
-      Cell: ({value}) => <DateTime date={value} forcedTimezone={timezone} />,
-      width: '1fr',
-    },
-    monitor: {
-      Header: () => t('Monitor'),
-      Cell: ({value}) => <Link to={value.link}>{value.name}</Link>,
-      width: '2fr',
-    },
-    groupId: {
-      Header: () => t('Issue'),
-      Cell: ({value}) => <Link to={`/issues/${value}`}>{`#${value}`}</Link>,
-      width: '2fr',
-    },
-  });
-
 export default function AutomationHistoryList({history}: Props) {
   const timezone = useTimezone();
-  const columns = getColumns(timezone);
 
-  return <SimpleTable columns={columns} data={history} />;
+  return (
+    <SimpleTableWithColumns>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell name="dateSent">
+          {tct('Time Sent ([timezone])', {timezone: moment.tz(timezone).zoneAbbr()})}
+        </SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell name="monitor">Monitor</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell name="groupId">Issue</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      {history.length === 0 && <SimpleTable.Empty>No history found</SimpleTable.Empty>}
+      {history.map((row, index) => (
+        <SimpleTable.Row key={index}>
+          <SimpleTable.RowCell name="dateSent">
+            <DateTime date={row.dateSent} forcedTimezone={timezone} />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell name="monitor">
+            <Link to={row.monitor.link}>{row.monitor.name}</Link>
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell name="groupId">
+            <Link to={`/issues/${row.groupId}`}>{`#${row.groupId}`}</Link>
+          </SimpleTable.RowCell>
+        </SimpleTable.Row>
+      ))}
+    </SimpleTableWithColumns>
+  );
 }
+
+const SimpleTableWithColumns = styled(SimpleTable)`
+  grid-template-columns: 1fr 2fr 2fr;
+`;


### PR DESCRIPTION
- Modified SimpleTable to use composable JSX instead of `columns` and `data` props
- Update styling of table headers to follow new design
- Add clickable headers to allow sorting
- Update existing uses of SimpleTable to use the new componentry

This will enable us to use this component on the list view pages as well.

![CleanShot 2025-06-23 at 09 54 32](https://github.com/user-attachments/assets/3a98499e-fc80-4061-b7dc-0491fe0cdca3)
