### PR TITLE
fix(insights): Fix insights frontend overview perf score chart colors

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -64,7 +64,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
   const weightedTimeseriesData = applyStaticWeightsToTimeseries(timeseriesData);
 
   const getAreaChart = () => {
-    const segmentColors = theme.chart.getColorPalette(3).slice(0, 5);
+    const segmentColors = theme.chart.getColorPalette(4).slice(0, 5);
     return (
       <Chart
         stacked


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0b49dade-c5b5-4999-98fb-fb0d55c37228)

After:
![image](https://github.com/user-attachments/assets/2ffe26dd-136b-4f86-8085-04c75ff364b2)
