### PR TITLE
feat: Return the reason for check_permission() failures

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -23,6 +23,7 @@ Required context variables:
       (function() {
         const referrer = '{{ referrer|escapejs }}';
         const state = '{{ state|escapejs }}'; // enum of: logged-out, missing-project, invalid-domain, logged-in
+            // The reason: {{ reason|escapejs }}
         const logging = '{{ logging|escapejs }}';
         const organizationSlug = '{{ organization_slug|escapejs }}';
         const projectIdOrSlug = '{{ project_id_or_slug|escapejs }}';

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -533,6 +533,7 @@ class AbstractOrganizationView(BaseView, abc.ABC):
         self,
         request: HttpRequest,
         organization: RpcOrganization | Organization | None,
+        reason: str = "",
         *args: Any,
         **kwargs: Any,
     ) -> tuple[bool, str]:

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -877,17 +877,16 @@ urlpatterns += [
     ),
     # Dev toolbar
     re_path(
-        r"^toolbar/",
+        r"^toolbar/(?P<organization_slug>[\w_-]+)/(?P<project_id_or_slug>[\w_-]+)/",
         include(
             [
-                # Although the pattern looks project-scoped, these are OrganizationViews (auth and perms are org-scoped).
                 re_path(
-                    r"^(?P<organization_slug>[^/\.]+)/(?P<project_id_or_slug>[^/\.]+)/iframe/$",
+                    r"^iframe/$",
                     IframeView.as_view(),
                     name="sentry-toolbar-iframe",
                 ),
                 re_path(
-                    r"^(?P<organization_slug>[^/\.]+)/(?P<project_id_or_slug>[^/\.]+)/login-success/$",
+                    r"^login-success/$",
                     LoginSuccessView.as_view(),
                     name="sentry-toolbar-login-success",
                 ),


### PR DESCRIPTION
Right now it's really opaque when a `missing-project` error happens while logging into the toolbar. This will help reveal the specific case that's causing unexpected results. 
Printing these reasons should not reveal anything dangerous because we're already dealing with a logged-in user at this point.