### PR TITLE
fix(search): allow issue searches over multiple wild card terms

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -455,6 +455,23 @@ class SearchValue(NamedTuple):
             return False
         return _is_wildcard(self.raw_value)
 
+    def is_str_sequence(self) -> bool:
+        return isinstance(self.raw_value, list) and all(isinstance(e, str) for e in self.raw_value)
+
+    def split_wildcards(self) -> tuple[list[str], list[str]] | None:
+        if not self.is_str_sequence():
+            return None
+        wildcards = []
+        non_wildcards = []
+        assert isinstance(self.raw_value, list)
+        for s in self.raw_value:
+            assert isinstance(s, str)
+            if _is_wildcard(s) is True:
+                wildcards.append(s)
+            else:
+                non_wildcards.append(s)
+        return (non_wildcards, wildcards)
+
     def classify_and_format_wildcard(
         self,
     ) -> (

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1277,6 +1277,35 @@ class BaseQueryBuilder:
         operator = search_filter.operator
         value = search_filter.value.value
 
+        strs = search_filter.value.split_wildcards()
+        if strs is not None and len(strs[1]) > 0:
+            # If we have a mixture of wildcards and non-wildcards in a [] set, we must
+            # group them into their own sets to apply the appropriate operators, and
+            # then 'OR' them together.
+            (non_wildcards, wildcards) = strs
+            operator = "="
+            if operator == "NOT IN":
+                operator = "!="
+            filters = [
+                self.default_filter_converter(
+                    event_search.SearchFilter(
+                        search_filter.key, operator, event_search.SearchValue(wc)
+                    )
+                )
+                for wc in wildcards
+            ]
+            if len(non_wildcards) > 0:
+                lhs = self.default_filter_converter(
+                    event_search.SearchFilter(
+                        search_filter.key,
+                        search_filter.operator,
+                        event_search.SearchValue(non_wildcards),
+                    )
+                )
+                filters.append(lhs)
+
+            return Or(filters)
+
         # Some fields aren't valid queries
         if name in constants.SKIP_FILTER_RESOLUTION:
             name = f"tags[{name}]"

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -114,6 +114,29 @@ class DiscoverQueryBuilderTest(TestCase):
             )
             bulk_snuba_queries([query.get_snql_query()], referrer=Referrer.TESTING_TEST.value)
 
+    def test_multiple_wildcards(self):
+        query = DiscoverQueryBuilder(
+            Dataset.Discover, self.params, query='title:["*A", "*B", "C", "D"]'
+        )
+
+        expected = Or(
+            [
+                Condition(
+                    Function("match", [Column("title"), "(?i)^.*A$"]),
+                    Op.EQ,
+                    1,
+                ),
+                Condition(
+                    Function("match", [Column("title"), "(?i)^.*B$"]),
+                    Op.EQ,
+                    1,
+                ),
+                Condition(Column("title"), Op.IN, ["C", "D"]),
+            ]
+        )
+
+        self.assertCountEqual(query.where[0].conditions, expected.conditions)
+
     def test_simple_orderby(self):
         query = DiscoverQueryBuilder(
             Dataset.Discover,


### PR DESCRIPTION
Enable both issue search and discover search to allow multiple wildcard fields in the comma "implicit OR" form.

Right now, "title: A*,B*" does not work in either issue or discover search, and while discover search has the explicit OR form for fallback, issue search does not.  Enable this in both for a more consistent experience (and thus allowing issue search to perform multiple wildcard searches at all.)
