### PR TITLE
Upgrade @sentry/status-page-list to version 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@sentry/node": "9.30.0",
     "@sentry/react": "9.30.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/status-page-list": "0.6.1",
+    "@sentry/status-page-list": "^0.6.1",
     "@sentry/toolbar": "1.0.0-beta.16",
     "@sentry/webpack-plugin": "^3.4.0",
     "@swc/plugin-emotion": "9.0.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@sentry/node": "9.30.0",
     "@sentry/react": "9.30.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/status-page-list": "^0.6.0",
+    "@sentry/status-page-list": "0.6.1",
     "@sentry/toolbar": "1.0.0-beta.16",
     "@sentry/webpack-plugin": "^3.4.0",
     "@swc/plugin-emotion": "9.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       '@sentry/status-page-list':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: 0.6.1
+        version: 0.6.1
       '@sentry/toolbar':
         specifier: 1.0.0-beta.16
         version: 1.0.0-beta.16(react@19.1.0)
@@ -2847,8 +2847,8 @@ packages:
   '@sentry/release-parser@1.3.1':
     resolution: {integrity: sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==}
 
-  '@sentry/status-page-list@0.6.0':
-    resolution: {integrity: sha512-umFIGPsFo8wjT5xLSraUd69GDJhBv8a8YgpAt8zE23SlkFNiWZcDP+Wr6yif2EQvB6Z6i3TmnQcz3mBN1j1kNA==}
+  '@sentry/status-page-list@0.6.1':
+    resolution: {integrity: sha512-MCDLIEvzFKeDae1rSEU30O8QpcWqSECvDQaViW3eeGGLzxhr9rEI7rdKuHmouWT9hXCmYEK1W1DWKE534+Vv1g==}
     engines: {node: '>=14'}
 
   '@sentry/toolbar@1.0.0-beta.16':
@@ -11060,7 +11060,7 @@ snapshots:
 
   '@sentry/release-parser@1.3.1': {}
 
-  '@sentry/status-page-list@0.6.0': {}
+  '@sentry/status-page-list@0.6.1': {}
 
   '@sentry/toolbar@1.0.0-beta.16(react@19.1.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       '@sentry/status-page-list':
-        specifier: 0.6.1
+        specifier: ^0.6.1
         version: 0.6.1
       '@sentry/toolbar':
         specifier: 1.0.0-beta.16


### PR DESCRIPTION
The `@sentry/status-page-list` package was upgraded to `^0.6.1` in `package.json`.

https://github.com/getsentry/status-page-list/releases/tag/0.6.1