### PR TITLE
feat(equations): This adds support for equations with one term

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -296,6 +296,7 @@ def parse_arithmetic(
     equation: str,
     max_operators: int | None = None,
     custom_measurements: set[str] | None = None,
+    validate_single_operator: bool = False,
 ) -> tuple[Operation, list[str], list[str]]:
     """Given a string equation try to parse it into a set of Operations"""
     try:
@@ -314,9 +315,7 @@ def parse_arithmetic(
         return result, list(visitor.fields), list(visitor.functions)
     if len(visitor.fields) > 0 and len(visitor.functions) > 0:
         raise ArithmeticValidationError("Cannot mix functions and fields in arithmetic")
-    if visitor.terms <= 1:
-        raise ArithmeticValidationError("Arithmetic expression must contain at least 2 terms")
-    if visitor.operators == 0:
+    if validate_single_operator and visitor.operators == 0:
         raise ArithmeticValidationError("Arithmetic expression must contain at least 1 operator")
     return result, list(visitor.fields), list(visitor.functions)
 
@@ -341,7 +340,9 @@ def resolve_equation_list(
     parsed_equations: list[ParsedEquation] = []
     resolved_columns: list[str] = selected_columns[:]
     for index, equation in enumerate(equations):
-        parsed_equation, fields, functions = parse_arithmetic(equation, None, custom_measurements)
+        parsed_equation, fields, functions = parse_arithmetic(
+            equation, None, custom_measurements, validate_single_operator=True
+        )
 
         if (len(fields) == 0 and len(functions) == 0) and not plain_math:
             raise InvalidSearchQuery("Equations need to include a field or function")

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -8,6 +8,7 @@ from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
     AttributeConditionalAggregation,
 )
 from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column
+from sentry_protos.snuba.v1.formula_pb2 import Literal as LiteralValue
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
     AttributeAggregation,
@@ -77,6 +78,21 @@ class ResolvedColumn:
             return self.internal_type
         else:
             return constants.TYPE_MAP[self.search_type]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ResolvedLiteral(ResolvedColumn):
+    value: float
+    is_aggregate: bool = False
+
+    @property
+    def proto_definition(self) -> Column.BinaryFormula:
+        """rpc doesn't understand a bare literal, so we return a no-op formula"""
+        return Column.BinaryFormula(
+            op=constants.ARITHMETIC_OPERATOR_MAP["plus"],
+            left=Column(literal=LiteralValue(val_double=self.value)),
+            right=Column(literal=LiteralValue(val_double=0)),
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -455,6 +471,17 @@ def project_term_resolver(
         return [int(val) for val in raw_value]
     else:
         return int(raw_value)
+
+
+# Any of the resolved attributes, mostly to clean typing up so there's not this giant list all over the code
+AnyResolved = (
+    ResolvedAttribute
+    | ResolvedAggregate
+    | ResolvedConditionalAggregate
+    | ResolvedFormula
+    | ResolvedEquation
+    | ResolvedLiteral
+)
 
 
 @dataclass(frozen=True)

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -42,6 +42,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     AggregateDefinition,
+    AnyResolved,
     AttributeArgumentDefinition,
     ColumnDefinitions,
     ConditionalAggregateDefinition,
@@ -51,6 +52,7 @@ from sentry.search.eap.columns import (
     ResolvedConditionalAggregate,
     ResolvedEquation,
     ResolvedFormula,
+    ResolvedLiteral,
     VirtualColumnDefinition,
 )
 from sentry.search.eap.spans.attributes import SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS
@@ -757,7 +759,9 @@ class SearchResolver:
 
         return resolved_columns, resolved_contexts
 
-    def resolve_column(self, column: str, match: Match | None = None) -> tuple[
+    def resolve_column(
+        self, column: str, match: Match | None = None, public_alias_override: str | None = None
+    ) -> tuple[
         ResolvedAttribute | ResolvedAggregate | ResolvedConditionalAggregate | ResolvedFormula,
         VirtualColumnDefinition | None,
     ]:
@@ -765,9 +769,9 @@ class SearchResolver:
         resolve function"""
         match = fields.is_function(column)
         if match:
-            return self.resolve_function(column, match)
+            return self.resolve_function(column, match, public_alias_override)
         else:
-            return self.resolve_attribute(column)
+            return self.resolve_attribute(column, public_alias_override)
 
     def get_field_type(self, column: str) -> str:
         resolved_column, _ = self.resolve_column(column)
@@ -787,17 +791,22 @@ class SearchResolver:
         return resolved_columns, resolved_contexts
 
     def resolve_attribute(
-        self, column: str
+        self, column: str, public_alias_override: str | None = None
     ) -> tuple[ResolvedAttribute, VirtualColumnDefinition | None]:
         """Attributes are columns that aren't 'functions' or 'aggregates', usually this means string or numeric
         attributes (aka. tags), but can also refer to fields like span.description"""
         # If a virtual context is defined the column definition is always the same
         if column in self._resolved_attribute_cache:
             return self._resolved_attribute_cache[column]
+
+        alias = column
+        if public_alias_override is not None:
+            alias = public_alias_override
+
         if column in self.definitions.contexts:
             column_context = self.definitions.contexts[column]
             column_definition = ResolvedAttribute(
-                public_alias=column,
+                public_alias=alias,
                 internal_name=column,
                 search_type="string",
                 processor=column_context.processor,
@@ -807,6 +816,13 @@ class SearchResolver:
             column_definition = self.definitions.columns[column]
             if column_definition.private and column not in self.config.fields_acl.attributes:
                 raise InvalidSearchQuery(f"The field {column} is not allowed for this query")
+            # Need to override the RA entirely
+            if public_alias_override:
+                column_definition = ResolvedAttribute(
+                    public_alias=public_alias_override,
+                    internal_name=column_definition.internal_name,
+                    search_type=column_definition.search_type,
+                )
         else:
             if len(column) > qb_constants.MAX_TAG_KEY_LENGTH:
                 raise InvalidSearchQuery(
@@ -835,7 +851,7 @@ class SearchResolver:
 
             search_type = cast(constants.SearchType, field_type)
             column_definition = ResolvedAttribute(
-                public_alias=column, internal_name=field, search_type=search_type
+                public_alias=alias, internal_name=field, search_type=search_type
             )
             column_context = None
 
@@ -858,7 +874,9 @@ class SearchResolver:
             resolved_contexts.append(context)
         return resolved_functions, resolved_contexts
 
-    def resolve_function(self, column: str, match: Match | None = None) -> tuple[
+    def resolve_function(
+        self, column: str, match: Match | None = None, public_alias_override: str | None = None
+    ) -> tuple[
         ResolvedFormula | ResolvedAggregate | ResolvedConditionalAggregate,
         VirtualColumnDefinition | None,
     ]:
@@ -874,6 +892,8 @@ class SearchResolver:
         columns = match.group("columns")
         # Alias defaults to the name of the function
         alias = match.group("alias") or column
+        if public_alias_override is not None:
+            alias = public_alias_override
 
         function_definition = self.get_function_definition(function_name)
         if function_definition.private and function_name not in self.config.fields_acl.functions:
@@ -979,7 +999,7 @@ class SearchResolver:
         return self._resolved_function_cache[column]
 
     def resolve_equations(self, equations: list[str]) -> tuple[
-        list[ResolvedEquation],
+        list[AnyResolved],
         list[VirtualColumnDefinition],
     ]:
         formulas = []
@@ -991,13 +1011,27 @@ class SearchResolver:
         return formulas, contexts
 
     def resolve_equation(self, equation: str) -> tuple[
-        ResolvedEquation,
+        AnyResolved,
         list[VirtualColumnDefinition],
     ]:
         """Resolve an equation creating a ResolvedEquation object, we don't just return a Column.BinaryFormula since
         it'll help callers with extra information, like the existence of aggregates and the search type
         """
         operation, fields, functions = arithmetic.parse_arithmetic(equation)
+        # Handle the case where the equation is just a single term
+        if isinstance(operation, str):
+            # Resolve the column, and turn it into a RPC Column so it can be used in a BinaryFormula
+            col, context = self.resolve_column(
+                operation, public_alias_override=f"equation|{equation}"
+            )
+            return col, [context] if context else []
+        elif isinstance(operation, float):
+            return (
+                ResolvedLiteral(
+                    public_alias=f"equation|{equation}", search_type="number", value=operation
+                ),
+                [],
+            )
         lhs, lhs_contexts = self._resolve_operation(operation.lhs) if operation.lhs else (None, [])
         rhs, rhs_contexts = self._resolve_operation(operation.rhs) if operation.rhs else (None, [])
         has_aggregates = False

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -816,7 +816,7 @@ class SearchResolver:
             column_definition = self.definitions.columns[column]
             if column_definition.private and column not in self.config.fields_acl.attributes:
                 raise InvalidSearchQuery(f"The field {column} is not allowed for this query")
-            # Need to override the RA entirely
+            # Need to override the ResolvedAttribute entirely
             if public_alias_override:
                 column_definition = ResolvedAttribute(
                     public_alias=public_alias_override,

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -31,11 +31,13 @@ from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.discover import arithmetic
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.columns import (
+    AnyResolved,
     ResolvedAggregate,
     ResolvedAttribute,
     ResolvedConditionalAggregate,
     ResolvedEquation,
     ResolvedFormula,
+    ResolvedLiteral,
 )
 from sentry.search.eap.constants import DOUBLE, MAX_ROLLUP_POINTS, VALID_GRANULARITIES
 from sentry.search.eap.resolver import SearchResolver
@@ -86,26 +88,21 @@ def process_timeseries_list(timeseries_list: list[TimeSeries]) -> ProcessedTimes
 
 
 def categorize_column(
-    column: (
-        ResolvedAttribute
-        | ResolvedAggregate
-        | ResolvedConditionalAggregate
-        | ResolvedFormula
-        | ResolvedEquation
-    ),
+    column: AnyResolved,
 ) -> Column:
-    if isinstance(column, (ResolvedFormula, ResolvedEquation)):
+    # Can't do bare literals, so they're actually formulas with +0
+    if isinstance(column, (ResolvedFormula, ResolvedEquation, ResolvedLiteral)):
         return Column(formula=column.proto_definition, label=column.public_alias)
-    if isinstance(column, ResolvedAggregate):
+    elif isinstance(column, ResolvedAggregate):
         return Column(aggregation=column.proto_definition, label=column.public_alias)
-    if isinstance(column, ResolvedConditionalAggregate):
+    elif isinstance(column, ResolvedConditionalAggregate):
         return Column(conditional_aggregation=column.proto_definition, label=column.public_alias)
     else:
         return Column(key=column.proto_definition, label=column.public_alias)
 
 
 def categorize_aggregate(
-    column: ResolvedAggregate | ResolvedConditionalAggregate | ResolvedFormula | ResolvedEquation,
+    column: AnyResolved,
 ) -> Expression:
     if isinstance(column, (ResolvedFormula, ResolvedEquation)):
         # TODO: Remove when https://github.com/getsentry/eap-planning/issues/206 is merged, since we can use formulas in both APIs at that point
@@ -192,7 +189,7 @@ def get_timeseries_query(
     extra_conditions: TraceItemFilter | None = None,
 ) -> tuple[
     TimeSeriesRequest,
-    list[ResolvedFormula | ResolvedAggregate | ResolvedConditionalAggregate | ResolvedEquation],
+    list[AnyResolved],
     list[ResolvedAttribute],
 ]:
     timeseries_filter, params = update_timestamps(params, search_resolver)
@@ -277,13 +274,7 @@ class TableRequest:
     """Container for rpc requests"""
 
     rpc_request: TraceItemTableRequest
-    columns: list[
-        ResolvedAttribute
-        | ResolvedAggregate
-        | ResolvedConditionalAggregate
-        | ResolvedFormula
-        | ResolvedEquation
-    ]
+    columns: list[AnyResolved]
 
 
 @sentry_sdk.trace
@@ -313,6 +304,8 @@ def get_table_rpc_request(query: TableQuery) -> TableRequest:
     sentry_sdk.set_tag("query.sampling_mode", query.sampling_mode)
     meta = resolver.resolve_meta(referrer=query.referrer, sampling_mode=query.sampling_mode)
     where, having, query_contexts = resolver.resolve_query(query.query_string)
+
+    all_columns: list[AnyResolved] = []
     equations, equation_contexts = resolver.resolve_equations(
         query.equations if query.equations else []
     )
@@ -320,11 +313,12 @@ def get_table_rpc_request(query: TableQuery) -> TableRequest:
         query.selected_columns,
         has_aggregates=any(equation for equation in equations if equation.is_aggregate),
     )
+    all_columns = columns + equations
     contexts = resolver.resolve_contexts(query_contexts + column_contexts)
     # We allow orderby function_aliases if they're a selected_column
     # eg. can orderby sum_span_self_time, assuming sum(span.self_time) is selected
     orderby_aliases = {
-        resolved_column.public_alias: resolved_column for resolved_column in columns + equations
+        resolved_column.public_alias: resolved_column for resolved_column in all_columns
     }
     for alias_column in columns:
         orderby_aliases[get_function_alias(alias_column.public_alias)] = alias_column
@@ -348,7 +342,17 @@ def get_table_rpc_request(query: TableQuery) -> TableRequest:
         col for col in equations if col.is_aggregate
     )
 
-    labeled_columns = [categorize_column(col) for col in columns + equations]
+    labeled_columns = [categorize_column(col) for col in all_columns]
+    if has_aggregations:
+        group_by = []
+        for col in equations:
+            if isinstance(col, ResolvedAttribute) and not col.is_aggregate:
+                group_by.append(col.proto_definition)
+        for col in columns:
+            if isinstance(col.proto_definition, AttributeKey):
+                group_by.append(col.proto_definition)
+    else:
+        group_by = []
 
     return TableRequest(
         TraceItemTableRequest(
@@ -356,21 +360,13 @@ def get_table_rpc_request(query: TableQuery) -> TableRequest:
             filter=where,
             aggregation_filter=having,
             columns=labeled_columns,
-            group_by=(
-                [
-                    col.proto_definition
-                    for col in columns
-                    if isinstance(col.proto_definition, AttributeKey)
-                ]
-                if has_aggregations
-                else []
-            ),
+            group_by=group_by,
             order_by=resolved_orderby,
             limit=query.limit,
             page_token=PageToken(offset=query.offset),
             virtual_column_contexts=[context for context in contexts if context is not None],
         ),
-        columns + equations,
+        all_columns,
     )
 
 

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -289,4 +289,4 @@ def test_unparseable_arithmetic(equation):
 )
 def test_invalid_arithmetic(equation):
     with pytest.raises(ArithmeticValidationError):
-        parse_arithmetic(equation)
+        parse_arithmetic(equation, validate_single_operator=True)

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5010,6 +5010,156 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert meta["dataset"] == self.dataset
         assert meta["fields"][equation] == "number"
 
+    def test_equation_single_function_term(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {"description": "bar", "sentry_tags": {"status": "invalid_argument"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        equation = "equation|count()"
+        response = self.do_request(
+            {
+                "field": ["span.status", "description", equation],
+                "query": "",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {
+                "span.status": "invalid_argument",
+                "description": "bar",
+                equation: 1,
+            },
+            {
+                "span.status": "success",
+                "description": "foo",
+                equation: 1,
+            },
+        ]
+        assert meta["dataset"] == self.dataset
+        assert meta["fields"][equation] == "integer"
+
+    def test_equation_single_field_term(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "measurements": {"lcp": {"value": 1}},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "success"},
+                        "measurements": {"lcp": {"value": 1}},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        equation = "equation|measurements.lcp"
+        response = self.do_request(
+            {
+                "field": ["span.status", "description", equation, "count()"],
+                "query": "",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {
+                "span.status": "success",
+                "description": "bar",
+                "count()": 1,
+                equation: 1,
+            },
+            {
+                "span.status": "success",
+                "description": "foo",
+                "count()": 1,
+                equation: 1,
+            },
+        ]
+        assert meta["dataset"] == self.dataset
+        assert meta["fields"][equation] == "duration"
+
+    def test_equation_single_literal(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "success"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        equation = "equation|3.14159"
+        response = self.do_request(
+            {
+                "field": ["span.status", "description", equation, "count()"],
+                "query": "",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 2
+        assert data == [
+            {
+                "span.status": "success",
+                "description": "bar",
+                "count()": 1,
+                equation: 3.14159,
+            },
+            {
+                "span.status": "success",
+                "description": "foo",
+                "count()": 1,
+                equation: 3.14159,
+            },
+        ]
+        assert meta["dataset"] == self.dataset
+        assert meta["fields"][equation] == "number"
+
     @pytest.mark.xfail(reason="Confidence isn't being returned by the RPC currently")
     def test_equation_with_extrapolation(self):
         """Extrapolation only changes the number when there's a sample rate"""


### PR DESCRIPTION
- This updates equations on RPC to support only one term something like `equation|count()`. This will still error for equations built on QueryBuilders cause that would require a lot more work and they're being deprecated
- Needed to do a small hack when the equation was a single literal since the rpc doesn't understand that so creating a no-op formula
- This also fixes a bug on equations without any functions where the groupby would be created incorrectly