### PR TITLE
ref(aci): Use SimpleTable for automation and detector list pages

### DIFF
--- a/static/app/components/workflowEngine/gridCell/titleCell.tsx
+++ b/static/app/components/workflowEngine/gridCell/titleCell.tsx
@@ -6,6 +6,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
 import {IconSentry} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
 import useProjectFromId from 'sentry/utils/useProjectFromId';
 
 export type TitleCellProps = {
@@ -37,26 +38,28 @@ export function TitleCell({
         )}
         {disabled && <span>&mdash; Disabled</span>}
       </Name>
-      <DetailsWrapper>
-        {project && (
-          <StyledProjectBadge
-            css={css`
-              && img {
-                box-shadow: none;
-              }
-            `}
-            project={project}
-            avatarSize={16}
-            disableLink
-          />
-        )}
-        {details?.map((detail, index) => (
-          <Fragment key={index}>
-            <Separator />
-            {detail}
-          </Fragment>
-        ))}
-      </DetailsWrapper>
+      {(defined(project) || (details && details.length > 0)) && (
+        <DetailsWrapper>
+          {project && (
+            <StyledProjectBadge
+              css={css`
+                && img {
+                  box-shadow: none;
+                }
+              `}
+              project={project}
+              avatarSize={16}
+              disableLink
+            />
+          )}
+          {details?.map((detail, index) => (
+            <Fragment key={index}>
+              <Separator />
+              {detail}
+            </Fragment>
+          ))}
+        </DetailsWrapper>
+      )}
     </TitleWrapper>
   );
 }

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -1,12 +1,8 @@
 import styled from '@emotion/styled';
 
-import {Flex} from 'sentry/components/core/layout';
 import LoadingError from 'sentry/components/loadingError';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
+import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import {
   AutomationListRow,
@@ -18,6 +14,7 @@ type AutomationListTableProps = {
   automations: Automation[];
   isError: boolean;
   isPending: boolean;
+  isSuccess: boolean;
 };
 
 function LoadingSkeletons() {
@@ -26,68 +23,39 @@ function LoadingSkeletons() {
   ));
 }
 
-function TableHeader() {
-  return (
-    <StyledPanelHeader>
-      <Flex className="name">
-        <Heading>{t('Name')}</Heading>
-      </Flex>
-      <Flex className="last-triggered">
-        <Heading>{t('Last Triggered')}</Heading>
-      </Flex>
-      <Flex className="action">
-        <HeaderDivider />
-        <Heading>{t('Actions')}</Heading>
-      </Flex>
-      <Flex className="projects">
-        <HeaderDivider />
-        <Heading>{t('Projects')}</Heading>
-      </Flex>
-      <Flex className="connected-monitors">
-        <HeaderDivider />
-        <Heading>{t('Monitors')}</Heading>
-      </Flex>
-    </StyledPanelHeader>
-  );
-}
-
 function AutomationListTable({
   automations,
   isPending,
   isError,
+  isSuccess,
 }: AutomationListTableProps) {
-  if (isError) {
-    return (
-      <PanelGrid>
-        <TableHeader />
-        <PanelBody>
-          <LoadingError />
-        </PanelBody>
-      </PanelGrid>
-    );
-  }
-
-  if (isPending) {
-    return (
-      <PanelGrid>
-        <TableHeader />
-        <LoadingSkeletons />
-      </PanelGrid>
-    );
-  }
-
   return (
-    <PanelGrid>
-      <TableHeader />
-      {automations.map(automation => (
-        <AutomationListRow key={automation.id} automation={automation} />
-      ))}
-    </PanelGrid>
+    <AutomationsSimpleTable>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell name="name">{t('Name')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell name="last-triggered">
+          {t('Last Triggered')}
+        </SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell name="action">{t('Actions')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell name="projects">{t('Projects')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell name="connected-monitors">
+          {t('Monitors')}
+        </SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      {isSuccess && automations.length === 0 && (
+        <SimpleTable.Empty>{t('No automations found')}</SimpleTable.Empty>
+      )}
+      {isError && <LoadingError message={t('Error loading automations')} />}
+      {isPending && <LoadingSkeletons />}
+      {isSuccess &&
+        automations.map(automation => (
+          <AutomationListRow key={automation.id} automation={automation} />
+        ))}
+    </AutomationsSimpleTable>
   );
 }
 
-const PanelGrid = styled(Panel)`
-  display: grid;
+const AutomationsSimpleTable = styled(SimpleTable)`
   grid-template-columns: 1fr;
 
   .last-triggered,
@@ -128,31 +96,6 @@ const PanelGrid = styled(Panel)`
       display: flex;
     }
   }
-`;
-
-const HeaderDivider = styled('div')`
-  background-color: ${p => p.theme.gray200};
-  width: 1px;
-  border-radius: ${p => p.theme.borderRadius};
-`;
-
-const Heading = styled('div')`
-  display: flex;
-  padding: 0 ${space(2)};
-  color: ${p => p.theme.subText};
-  align-items: center;
-`;
-
-const StyledPanelHeader = styled(PanelHeader)`
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-column: 1/-1;
-
-  justify-content: left;
-  padding: ${space(0.75)} ${space(2)};
-  min-height: 40px;
-  align-items: center;
-  text-transform: none;
 `;
 
 export default AutomationListTable;

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -1,15 +1,12 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Checkbox} from 'sentry/components/core/checkbox';
-import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import Placeholder from 'sentry/components/placeholder';
 import {ProjectList} from 'sentry/components/projectList';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import AutomationTitleCell from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
+import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AutomationListConnectedDetectors} from 'sentry/views/automations/components/automationListTable/conenctedDetectors';
@@ -32,91 +29,55 @@ export function AutomationListRow({automation}: AutomationListRowProps) {
     projectId => ProjectsStore.getById(projectId)?.slug
   ) as string[];
   return (
-    <RowWrapper disabled={disabled} data-test-id="automation-list-row">
-      <InteractionStateLayer />
-      <CellWrapper>
+    <AutomationSimpleTableRow
+      variant={disabled ? 'faded' : 'default'}
+      data-test-id="automation-list-row"
+    >
+      <SimpleTable.RowCell name="name">
         <AutomationTitleCell
           name={name}
           href={makeAutomationDetailsPathname(organization.slug, id)}
           createdBy={createdBy}
         />
-      </CellWrapper>
-      <CellWrapper className="last-triggered">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="last-triggered">
         <TimeAgoCell date={lastTriggered} />
-      </CellWrapper>
-      <CellWrapper className="action">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="action">
         <ActionCell actions={actions} disabled={disabled} />
-      </CellWrapper>
-      <CellWrapper className="projects">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="projects">
         <ProjectList projectSlugs={projectSlugs} />
-      </CellWrapper>
-      <CellWrapper className="connected-monitors">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="connected-monitors">
         <AutomationListConnectedDetectors detectorIds={detectorIds} />
-      </CellWrapper>
-    </RowWrapper>
+      </SimpleTable.RowCell>
+    </AutomationSimpleTableRow>
   );
 }
 
 export function AutomationListRowSkeleton() {
   return (
-    <RowWrapper>
-      <CellWrapper>
+    <AutomationSimpleTableRow>
+      <SimpleTable.RowCell name="name">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="last-triggered">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="last-triggered">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="action">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="action">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="projects">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="projects">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="connected-monitors">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="connected-monitors">
         <Placeholder height="20px" />
-      </CellWrapper>
-    </RowWrapper>
+      </SimpleTable.RowCell>
+    </AutomationSimpleTableRow>
   );
 }
 
-const StyledCheckbox = styled(Checkbox)<{checked?: boolean}>`
-  visibility: ${p => (p.checked ? 'visible' : 'hidden')};
-  align-self: flex-start;
-  opacity: 1;
-`;
-
-const CellWrapper = styled('div')`
-  justify-content: start;
-  padding: 0 ${space(2)};
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  width: 100%;
-  min-width: 0;
-`;
-
-const RowWrapper = styled('div')<{disabled?: boolean}>`
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-column: 1/-1;
-
-  position: relative;
-  align-items: center;
-  padding: ${space(2)};
-
-  min-height: 60px;
-
-  ${p =>
-    p.disabled &&
-    css`
-      ${CellWrapper} {
-        opacity: 0.6;
-      }
-    `}
-
-  &:hover {
-    ${StyledCheckbox} {
-      visibility: visible;
-    }
-  }
+const AutomationSimpleTableRow = styled(SimpleTable.Row)`
+  min-height: 54px;
 `;

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -53,21 +53,23 @@ export default function AutomationsList() {
         <ActionsProvider actions={<Actions />}>
           <ListLayout>
             <TableHeader />
-            <AutomationListTable
-              automations={automations ?? []}
-              isPending={isPending}
-              isError={isError}
-              isSuccess={isSuccess}
-            />
-            <Pagination
-              pageLinks={getResponseHeader?.('Link')}
-              onCursor={newCursor => {
-                navigate({
-                  pathname: location.pathname,
-                  query: {...location.query, cursor: newCursor},
-                });
-              }}
-            />
+            <div>
+              <AutomationListTable
+                automations={automations ?? []}
+                isPending={isPending}
+                isError={isError}
+                isSuccess={isSuccess}
+              />
+              <Pagination
+                pageLinks={getResponseHeader?.('Link')}
+                onCursor={newCursor => {
+                  navigate({
+                    pathname: location.pathname,
+                    query: {...location.query, cursor: newCursor},
+                  });
+                }}
+              />
+            </div>
           </ListLayout>
         </ActionsProvider>
       </PageFiltersContainer>

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -38,6 +38,7 @@ export default function AutomationsList() {
     data: automations,
     isPending,
     isError,
+    isSuccess,
     getResponseHeader,
   } = useAutomationsQuery({
     cursor,
@@ -56,6 +57,7 @@ export default function AutomationsList() {
               automations={automations ?? []}
               isPending={isPending}
               isError={isError}
+              isSuccess={isSuccess}
             />
             <Pagination
               pageLinks={getResponseHeader?.('Link')}

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -1,11 +1,8 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
-import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
-import {space} from 'sentry/styles/space';
+import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import type {Group} from 'sentry/types/group';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {DetectorLink} from 'sentry/views/detectors/components/detectorLink';
@@ -23,9 +20,11 @@ export function DetectorListRow({
   const issues: Group[] = [];
 
   return (
-    <RowWrapper disabled={disabled} data-test-id="detector-list-row">
-      <InteractionStateLayer />
-      <CellWrapper>
+    <DetectorSimpleTableRow
+      variant={disabled ? 'faded' : 'default'}
+      data-test-id="detector-list-row"
+    >
+      <SimpleTable.RowCell name="name">
         <DetectorLink
           detectorId={id}
           name={name}
@@ -33,76 +32,48 @@ export function DetectorListRow({
           projectId={projectId}
           disabled={disabled}
         />
-      </CellWrapper>
-      <CellWrapper className="type">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="type">
         <DetectorTypeCell type={type} />
-      </CellWrapper>
-      <CellWrapper className="last-issue">
-        <StyledIssueCell group={issues.length > 0 ? issues[0] : undefined} />
-      </CellWrapper>
-      <CellWrapper className="assignee">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="last-issue">
+        <IssueCell group={issues.length > 0 ? issues[0] : undefined} />
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="assignee">
         <DetectorAssigneeCell assignee={owner} />
-      </CellWrapper>
-      <CellWrapper className="connected-automations">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="connected-automations">
         <DetectorListConnectedAutomations automationIds={workflowIds} />
-      </CellWrapper>
-    </RowWrapper>
+      </SimpleTable.RowCell>
+    </DetectorSimpleTableRow>
   );
 }
 
 export function DetectorListRowSkeleton() {
   return (
-    <RowWrapper>
-      <CellWrapper>
+    <DetectorSimpleTableRow>
+      <SimpleTable.RowCell name="name">
         <div style={{width: '100%'}}>
           <Placeholder height="20px" width="50%" style={{marginBottom: '4px'}} />
           <Placeholder height="16px" width="20%" />
         </div>
-      </CellWrapper>
-      <CellWrapper className="type">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="type">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="last-issue">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="last-issue">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="creator">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="assignee">
         <Placeholder height="20px" />
-      </CellWrapper>
-      <CellWrapper className="connected-automations">
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell name="connected-automations">
         <Placeholder height="20px" />
-      </CellWrapper>
-    </RowWrapper>
+      </SimpleTable.RowCell>
+    </DetectorSimpleTableRow>
   );
 }
 
-const CellWrapper = styled(Flex)`
-  padding: 0 ${space(2)};
-  flex: 1;
-  overflow: hidden;
-`;
-
-const StyledIssueCell = styled(IssueCell)`
-  padding: ${space(2)};
-  margin: -${space(2)};
-`;
-
-const RowWrapper = styled('div')<{disabled?: boolean}>`
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-column: 1 / -1;
-  position: relative;
-  align-items: center;
-  padding: ${space(2)};
-
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
-  }
-
-  ${p =>
-    p.disabled &&
-    css`
-      ${CellWrapper}, {
-        opacity: 0.8;
-      }
-    `}
+const DetectorSimpleTableRow = styled(SimpleTable.Row)`
+  min-height: 76px;
 `;

--- a/static/app/views/detectors/list.tsx
+++ b/static/app/views/detectors/list.tsx
@@ -46,6 +46,8 @@ export default function DetectorsList() {
   const {
     data: detectors,
     isPending,
+    isError,
+    isSuccess,
     getResponseHeader,
   } = useDetectorsQuery({
     cursor,
@@ -64,6 +66,8 @@ export default function DetectorsList() {
               <DetectorListTable
                 detectors={detectors ?? []}
                 isPending={isPending}
+                isError={isError}
+                isSuccess={isSuccess}
                 sort={sort}
               />
               <Pagination


### PR DESCRIPTION
Automation list and monitor list pages now use SimpleTable. Deletes a lot of code and keeps things consistent.