### PR TITLE
fix(explore): fix user avatars on saved explore queries table not displaying correctly

### DIFF
--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -9,7 +9,7 @@ import {
 } from 'sentry/actionCreators/indicator';
 import {openSaveQueryModal} from 'sentry/actionCreators/modal';
 import {ActivityAvatar} from 'sentry/components/activity/item/avatar';
-import {ActorAvatar} from 'sentry/components/core/avatar/actorAvatar';
+import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import Pagination, {type CursorHandler} from 'sentry/components/pagination';
 import {SavedEntityTable} from 'sentry/components/savedEntityTable';
@@ -222,11 +222,7 @@ export function SavedQueriesTable({
                   <ActivityAvatar type="system" size={20} />
                 </Tooltip>
               ) : query.createdBy ? (
-                <ActorAvatar
-                  actor={query.createdBy}
-                  tooltip={query.createdBy.name}
-                  hasTooltip
-                />
+                <UserAvatar user={query.createdBy} hasTooltip />
               ) : null}
             </SavedEntityTable.Cell>
             <SavedEntityTable.Cell data-column="last-visited">


### PR DESCRIPTION
Previous `Avatar` component was deprecated and changed to `ActorAvatar`. However `ActorAvatar` doesn't work because we're missing an attribute to distinguish between user vs team actors. Update to use `UserAvatar` instead which suits our purpose better and matches the saved Issues View table.