### PR TITLE
chore: bump eap max allowed buckets to 2689

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -93,7 +93,7 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
 
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
 # The RPC limits us to 2688 points per timeseries
-MAX_ROLLUP_POINTS = 2688
+MAX_ROLLUP_POINTS = 2689
 # Copied from snuba, a number of total seconds
 VALID_GRANULARITIES = frozenset(
     {

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -93,6 +93,7 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
 
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
 # The RPC limits us to 2689 points per timeseries
+# MAX 15 minute granularity over 28 days (2688 buckets) + 1 bucket to allow for partial time buckets on
 MAX_ROLLUP_POINTS = 2689
 # Copied from snuba, a number of total seconds
 VALID_GRANULARITIES = frozenset(

--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -92,7 +92,7 @@ TYPE_MAP: dict[SearchType, AttributeKey.Type.ValueType] = {
 }
 
 # https://github.com/getsentry/snuba/blob/master/snuba/web/rpc/v1/endpoint_time_series.py
-# The RPC limits us to 2688 points per timeseries
+# The RPC limits us to 2689 points per timeseries
 MAX_ROLLUP_POINTS = 2689
 # Copied from snuba, a number of total seconds
 VALID_GRANULARITIES = frozenset(


### PR DESCRIPTION
Requires https://github.com/getsentry/snuba/pull/7246