### PR TITLE
perf(aci): Prefetch Workflow.environment

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -239,7 +239,9 @@ def _get_associated_workflows(
             (Q(environment_id=None) | Q(environment_id=environment.id)),
             detectorworkflow__detector_id=detector.id,
             enabled=True,
-        ).distinct()
+        )
+        .select_related("environment")
+        .distinct()
     )
 
     if workflows:


### PR DESCRIPTION
Normally we don't want to optimize by distant `selected_related`; but in this case we're selecting the Workflow to call `evaluate_trigger_conditions` on them, a method that access the Environment on the Workflow.
We are filtering by env, so we could pass it directly, and we also have an Env cache we could be using to avoid this sneaky optimization, but both of those approaches seem messier, and given that this isn't a critical optimization, this seems tolerable.

In terms of data, we have cases where of ~1s of `process_workflows` time, 95% is spent loading presumably the same environment over and over.
Ideally, we'd be able to annotate our foreign keys to say "use the cache", but that's not the case.
