### PR TITLE
add consumer_member_id to allowed tags

### DIFF
--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from sentry.metrics.base import MetricsBackend, MutableTags, Tags, TagValue
 
 _BAD_TAGS = frozenset(["event", "project", "group"])
-_NOT_BAD_TAGS = frozenset(["use_case_id"])
+_NOT_BAD_TAGS = frozenset(["use_case_id", "consumer_member_id"])
 _METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
     [
         # snuba related tags


### PR DESCRIPTION
Tag was added in https://github.com/getsentry/arroyo/pull/462 but was blocked as it ended in `_id`, this should fix