### PR TITLE
ref(grouping): Tiny refactors to creating fingerprint variants

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -426,9 +426,6 @@ def get_grouping_variants_for_event(
     # non-contributing. And if it's hybrid, we'll replace the existing variants with "salted"
     # versions which include the fingerprint.
     if fingerprint_type == "custom":
-        for variant in strategy_component_variants.values():
-            variant.component.update(contributes=False, hint="custom fingerprint takes precedence")
-
         if fingerprint_info.get("matched_rule", {}).get("is_builtin") is True:
             additional_variants["built_in_fingerprint"] = BuiltInFingerprintVariant(
                 resolved_fingerprint, fingerprint_info
@@ -437,6 +434,10 @@ def get_grouping_variants_for_event(
             additional_variants["custom_fingerprint"] = CustomFingerprintVariant(
                 resolved_fingerprint, fingerprint_info
             )
+
+        for variant in strategy_component_variants.values():
+            variant.component.update(contributes=False, hint="custom fingerprint takes precedence")
+
     elif fingerprint_type == "hybrid":
         for variant_name, variant in strategy_component_variants.items():
             # Since we're reusing the variant names, when all of the variants are combined, these

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -426,7 +426,9 @@ def get_grouping_variants_for_event(
     # non-contributing. And if it's hybrid, we'll replace the existing variants with "salted"
     # versions which include the fingerprint.
     if fingerprint_type == "custom":
-        if fingerprint_info.get("matched_rule", {}).get("is_builtin") is True:
+        matched_rule = fingerprint_info.get("matched_rule", {})
+
+        if matched_rule and matched_rule.get("is_builtin") is True:
             additional_variants["built_in_fingerprint"] = BuiltInFingerprintVariant(
                 resolved_fingerprint, fingerprint_info
             )


### PR DESCRIPTION
This is a tiny refactor of the code we use to create custom fingerprint variants, to better enable future changes.