### PR TITLE
chore(api): add rate limits for project-related endpoints

### DIFF
--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -21,6 +21,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.loader.dynamic_sdk_options import get_default_loader_data
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus, UseCase
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 @extend_schema(tags=["Projects"])
@@ -29,6 +30,19 @@ class ProjectKeysEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
+    }
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+        },
+        "POST": {
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+        },
     }
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -10,12 +10,21 @@ from sentry.api.helpers.environments import get_environment_id
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.models.environment import Environment
 from sentry.tsdb.base import TSDBModel
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 @region_silo_endpoint
 class ProjectStatsEndpoint(ProjectEndpoint, StatsMixin):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
+    }
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+        },
     }
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -18,6 +18,7 @@ from sentry.api.utils import get_date_range_from_params
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class GroupEventDetailsResponse(IssueEventSerializerResponse):
@@ -88,6 +89,14 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=5, window=1),
+            RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+        },
     }
 
     def get(self, request: Request, project: Project, event_id: str) -> Response:


### PR DESCRIPTION
From https://linear.app/getsentry/issue/RTC-678/first-api-request-to-an-endpoint-is-failing-with-429-code, we see a steady stream of users hitting rate-limits for endpoints that are in the default rate-limit bucket.  This generates some confusing messages for users, since they might see an error for and endpoint that isn't being hit much.  I went through logs to collect the top endpoints hitting default limits, and am assigning each their own rate-limit group.

I don't know if these are ideal values for your endpoints; these values are quite prevalent in the codebase.