### PR TITLE
feat(aci): Add sorting to automations list

### DIFF
--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -50,7 +50,7 @@ function HeaderCell({
       sort && isSortedByField ? `${sort.kind === 'asc' ? '-' : ''}${sortKey}` : sortKey;
     navigate({
       pathname: location.pathname,
-      query: {...location.query, sort: newSort},
+      query: {...location.query, sort: newSort, cursor: undefined},
     });
   };
 

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -4,6 +4,9 @@ import LoadingError from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/workflowEngine/simpleTable';
 import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {
   AutomationListRow,
   AutomationListRowSkeleton,
@@ -15,6 +18,7 @@ type AutomationListTableProps = {
   isError: boolean;
   isPending: boolean;
   isSuccess: boolean;
+  sort: Sort | undefined;
 };
 
 function LoadingSkeletons() {
@@ -23,24 +27,70 @@ function LoadingSkeletons() {
   ));
 }
 
+function HeaderCell({
+  children,
+  name,
+  sortKey,
+  sort,
+}: {
+  children: React.ReactNode;
+  name: string;
+  sort: Sort | undefined;
+  divider?: boolean;
+  sortKey?: string;
+}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isSortedByField = sort?.field === sortKey;
+  const handleSort = () => {
+    if (!sortKey) {
+      return;
+    }
+    const newSort =
+      sort && isSortedByField ? `${sort.kind === 'asc' ? '-' : ''}${sortKey}` : sortKey;
+    navigate({
+      pathname: location.pathname,
+      query: {...location.query, sort: newSort},
+    });
+  };
+
+  return (
+    <SimpleTable.HeaderCell
+      name={name}
+      sort={sort}
+      sortKey={sortKey}
+      handleSortClick={handleSort}
+    >
+      {children}
+    </SimpleTable.HeaderCell>
+  );
+}
+
 function AutomationListTable({
   automations,
   isPending,
   isError,
   isSuccess,
+  sort,
 }: AutomationListTableProps) {
   return (
     <AutomationsSimpleTable>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell name="name">{t('Name')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell name="last-triggered">
+        <HeaderCell name="name" sort={sort} sortKey="name">
+          {t('Name')}
+        </HeaderCell>
+        <HeaderCell name="last-triggered" sort={sort}>
           {t('Last Triggered')}
-        </SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell name="action">{t('Actions')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell name="projects">{t('Projects')}</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell name="connected-monitors">
+        </HeaderCell>
+        <HeaderCell name="action" sort={sort} sortKey="actions">
+          {t('Actions')}
+        </HeaderCell>
+        <HeaderCell name="projects" sort={sort}>
+          {t('Projects')}
+        </HeaderCell>
+        <HeaderCell name="connected-monitors" sort={sort} sortKey="connectedDetectors">
           {t('Monitors')}
-        </SimpleTable.HeaderCell>
+        </HeaderCell>
       </SimpleTable.Header>
       {isSuccess && automations.length === 0 && (
         <SimpleTable.Empty>{t('No automations found')}</SimpleTable.Empty>

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -14,7 +14,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 const makeAutomationsQueryKey = ({
   orgSlug,
   query,
-  sort,
+  sortBy,
   ids,
   limit,
   cursor,
@@ -26,10 +26,10 @@ const makeAutomationsQueryKey = ({
   limit?: number;
   projects?: number[];
   query?: string;
-  sort?: string;
+  sortBy?: string;
 }): ApiQueryKey => [
   `/organizations/${orgSlug}/workflows/`,
-  {query: {query, sort, id: ids, per_page: limit, cursor, project: projects}},
+  {query: {query, sortBy, id: ids, per_page: limit, cursor, project: projects}},
 ];
 
 const makeAutomationQueryKey = (orgSlug: string, automationId: string): ApiQueryKey => [
@@ -42,7 +42,7 @@ interface UseAutomationsQueryOptions {
   limit?: number;
   projects?: number[];
   query?: string;
-  sort?: string;
+  sortBy?: string;
 }
 export function useAutomationsQuery(
   options: UseAutomationsQueryOptions = {},

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -12,6 +12,8 @@ import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/use
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -29,10 +31,18 @@ export default function AutomationsList() {
   const navigate = useNavigate();
   const {selection} = usePageFilters();
 
-  const query =
-    typeof location.query.query === 'string' ? location.query.query : undefined;
-  const cursor =
-    typeof location.query.cursor === 'string' ? location.query.cursor : undefined;
+  const {
+    sort: sorts,
+    query,
+    cursor,
+  } = useLocationQuery({
+    fields: {
+      sort: decodeSorts,
+      query: decodeScalar,
+      cursor: decodeScalar,
+    },
+  });
+  const sort = sorts[0] ?? {kind: 'desc', field: 'connectedDetectors'};
 
   const {
     data: automations,
@@ -43,6 +53,7 @@ export default function AutomationsList() {
   } = useAutomationsQuery({
     cursor,
     query,
+    sortBy: sort ? `${sort?.kind === 'asc' ? '' : '-'}${sort?.field}` : undefined,
     projects: selection.projects,
     limit: AUTOMATION_LIST_PAGE_LIMIT,
   });
@@ -59,6 +70,7 @@ export default function AutomationsList() {
                 isPending={isPending}
                 isError={isError}
                 isSuccess={isSuccess}
+                sort={sort}
               />
               <Pagination
                 pageLinks={getResponseHeader?.('Link')}

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -50,7 +50,7 @@ function HeaderCell({
       sort && isSortedByField ? `${sort.kind === 'asc' ? '-' : ''}${sortKey}` : sortKey;
     navigate({
       pathname: location.pathname,
-      query: {...location.query, sort: newSort},
+      query: {...location.query, sort: newSort, cursor: undefined},
     });
   };
 


### PR DESCRIPTION
Similar to the monitor list, adds supported sorts to the table headers