### PR TITLE
chore(seer rpc): Reformat fields return

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -281,7 +281,7 @@ def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: st
 
 def get_attribute_values(
     *,
-    fields: dict[str, list[str]],
+    fields: dict[list[str]],
     org_id: int,
     project_ids: list[int],
     stats_period: str,

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -267,7 +267,7 @@ def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: st
         parsed_fields = [
             as_attribute_key(
                 attr.name,
-                type_str,
+                "string" if attr_type == AttributeKey.Type.TYPE_STRING else "number",
                 SupportedTraceItemType.SPANS,
             )["name"]
             for attr in fields_resp.attributes

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -245,7 +245,7 @@ def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: st
     end_time_proto = ProtobufTimestamp()
     end_time_proto.FromDatetime(end)
 
-    fields = {type_str: [] for type_str in type_mapping.values()}
+    fields: dict[str, list[str]] = {type_str: [] for type_str in type_mapping.values()}
 
     for attr_type, type_str in type_mapping.items():
         req = TraceItemAttributeNamesRequest(

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -281,7 +281,7 @@ def get_attribute_names(*, org_id: int, project_ids: list[int], stats_period: st
 
 def get_attribute_values(
     *,
-    fields: dict[list[str]],
+    fields: list[str],
     org_id: int,
     project_ids: list[int],
     stats_period: str,

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -36,14 +36,15 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             project_ids=[self.project.id],
             stats_period="7d",
         )
-        result["fields"] = result["fields"].sort()
         assert result == {
-            "fields": [
-                "span.description",
-                "transaction",
-                "project",
-                "span.duration",
-            ].sort(),
+            "fields": {
+                "string": [
+                    "span.description",
+                    "project",
+                    "transaction",
+                ],
+                "number": ["span.duration"],
+            },
         }
 
     def test_get_attribute_values(self):
@@ -69,7 +70,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
 
         result = get_attribute_values(
-            fields=attribute_names["fields"],
+            fields=attribute_names["fields"]["string"],
             org_id=self.organization.id,
             project_ids=[self.project.id],
             stats_period="7d",


### PR DESCRIPTION
- Reformat fields rpc to return dictionary of lists corresponding to the relevant datatype
- Improves context for LLM and makes it easier to split up data for future requests
- Return attributes by their `name` value. Previously there was no meaningful difference, but now tags are displayed to the user as their 'name' value instead of the 'key' value which led to incorrect LLM outputs