### PR TITLE
fix(grouping): Distinguish between built-in and custom fingerprints in grouping info

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -432,13 +432,17 @@ def get_grouping_variants_for_event(
             additional_variants["built_in_fingerprint"] = BuiltInFingerprintVariant(
                 resolved_fingerprint, fingerprint_info
             )
+            fingerprint_source = "built-in"
         else:
             additional_variants["custom_fingerprint"] = CustomFingerprintVariant(
                 resolved_fingerprint, fingerprint_info
             )
+            fingerprint_source = "custom server" if matched_rule else "custom client"
+
+        hint = f"{fingerprint_source} fingerprint takes precedence"
 
         for variant in strategy_component_variants.values():
-            variant.component.update(contributes=False, hint="custom fingerprint takes precedence")
+            variant.component.update(contributes=False, hint=hint)
 
     elif fingerprint_type == "hybrid":
         for variant_name, variant in strategy_component_variants.items():

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.369457+00:00'
+created: '2025-06-23T19:43:16.010337+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -13,7 +13,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: built-in fingerprint takes precedence
     type: component
   built_in_fingerprint:
     matched_rule: family:"javascript" type:"ChunkLoadError" -> "chunkloaderror"
@@ -23,5 +23,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: built-in fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_abs_path.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.648004+00:00'
+created: '2025-06-23T19:43:16.351532+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ stack.abs_path }}"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_escape_chars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.573246+00:00'
+created: '2025-06-23T19:43:17.269318+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,5 +28,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.088186+00:00'
+created: '2025-06-23T19:43:15.728454+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:17.224512+00:00'
+created: '2025-06-23T19:43:17.957455+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -35,5 +35,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:14.259249+00:00'
+created: '2025-06-23T19:43:14.719522+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -35,5 +35,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.952667+00:00'
+created: '2025-06-23T19:43:17.697024+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: value:"*went wrong*" -> "something-went-wrong{{ error.value }}"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:13.661245+00:00'
+created: '2025-06-23T19:43:14.090880+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.698987+00:00'
+created: '2025-06-23T19:43:17.404401+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,5 +28,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:14.418050+00:00'
+created: '2025-06-23T19:43:14.857909+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: message:"*love*" -> "what-is-love{{ message }}"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.258775+00:00'
+created: '2025-06-23T19:43:15.891338+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:14.833107+00:00'
+created: '2025-06-23T19:43:15.323823+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -22,7 +22,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
@@ -32,5 +32,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:17.372603+00:00'
+created: '2025-06-23T19:43:18.092628+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:14.091914+00:00'
+created: '2025-06-23T19:43:14.552335+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:14.660887+00:00'
+created: '2025-06-23T19:43:15.158256+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:13.370335+00:00'
+created: '2025-06-23T19:43:13.727464+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -24,7 +24,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
@@ -36,5 +36,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.451923+00:00'
+created: '2025-06-23T19:43:17.133621+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -36,5 +36,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:14.537139+00:00'
+created: '2025-06-23T19:43:15.008448+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,5 +25,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.161628+00:00'
+created: '2025-06-23T19:43:16.845801+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,5 +28,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:13.799217+00:00'
+created: '2025-06-23T19:43:14.231203+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,5 +27,5 @@ variants:
   default:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.774925+00:00'
+created: '2025-06-23T19:43:16.489072+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:13.538456+00:00'
+created: '2025-06-23T19:43:13.953461+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,7 +23,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_release.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.904164+00:00'
+created: '2025-06-23T19:43:16.610349+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     client_values:
@@ -33,5 +33,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.826883+00:00'
+created: '2025-06-23T19:43:17.561266+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,7 +26,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
@@ -38,5 +38,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_two_threads.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:15.510987+00:00'
+created: '2025-06-23T19:43:16.156321+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -20,7 +20,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: function:"main" -> "in-main"
@@ -30,5 +30,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-11-08T22:03:16.036167+00:00'
+created: '2025-06-23T19:43:16.724367+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,7 +25,7 @@ variants:
   app:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component
   custom_fingerprint:
     matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
@@ -37,5 +37,5 @@ variants:
   system:
     component:
       contributes: false
-      hint: custom fingerprint takes precedence
+      hint: custom server fingerprint takes precedence
     type: component

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:36.135621+00:00'
+created: '2025-06-23T19:37:51.429139+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -211,7 +211,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:36.080554+00:00'
+created: '2025-06-23T19:37:51.286506+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -211,7 +211,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:36.237342+00:00'
+created: '2025-06-23T19:37:51.568767+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -211,7 +211,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2024-12-17T22:46:41.428253+00:00'
+created: '2025-06-23T19:38:04.708576+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*
@@ -211,7 +211,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:22.816738+00:00'
+created: '2025-06-23T19:37:23.465896+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:22.370588+00:00'
+created: '2025-06-23T19:37:23.295532+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:23.117702+00:00'
+created: '2025-06-23T19:37:23.601410+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:36.289790+00:00'
+created: '2025-06-23T19:37:36.625883+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:48.378124+00:00'
+created: '2025-06-23T19:36:51.306892+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (custom fingerprint takes precedence)
+    app (built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -31,7 +31,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (built-in fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:48.269776+00:00'
+created: '2025-06-23T19:36:51.183909+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (custom fingerprint takes precedence)
+    app (built-in fingerprint takes precedence)
       exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         stacktrace (ignored because it contains no in-app frames)
           frame (marked out of app by the client)
@@ -31,7 +31,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (built-in fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:50.688440+00:00'
+created: '2025-06-23T19:36:53.833205+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom client fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:50.400405+00:00'
+created: '2025-06-23T19:36:53.679648+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:21:50.850828+00:00'
+created: '2025-06-23T19:36:53.989863+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-25T21:22:07.441352+00:00'
+created: '2025-06-23T19:37:07.612460+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: exception
   component:
-    app (custom fingerprint takes precedence)
+    app (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame* (marked in-app by the client)
@@ -177,7 +177,7 @@ system:
   hash: null
   contributing component: exception
   component:
-    system (custom fingerprint takes precedence)
+    system (custom server fingerprint takes precedence)
       exception*
         stacktrace*
           frame*


### PR DESCRIPTION
In the grouping info section on the issue details page, we let people know if normal grouping has been overridden by a custom fingerprint (good), but we fail to tell them what kind of custom fingerprint (not so good). So, for example, if one of our built-in fingerprints has taken precedence, we still say "custom fingerprint takes precedence," which is confusing.

This fixes that by making the hint vary by fingerprint type. It also distinguishes between a custom fingerprint coming from the client and one coming from the application of a fingerprinting rule on the server.

Fixes https://github.com/getsentry/sentry/issues/78745