### PR TITLE
chore(urls): Use more of build_url

### DIFF
--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -94,10 +94,7 @@ def organization_absolute_url(
 def api_absolute_url(
     *, slug: str, path: str, query: str | None = None, fragment: str | None = None
 ) -> str:
-    if path.startswith("/"):
-        path = path.lstrip("/")
-
-    full_path = f"/api/0/organizations/{slug}/{path}/"
+    full_path = f"/api/0/organizations/{slug}/{path.lstrip('/')}/"
     uri = absolute_uri(full_path)
     parts = construct_url_parts(uri=uri, query=query, fragment=fragment)
     return "".join(parts)

--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -97,7 +97,7 @@ def api_absolute_url(
     if path.startswith("/"):
         path = path.lstrip("/")
 
-    full_path = f"/api/0/organizations/{slug}/{path}"
+    full_path = f"/api/0/organizations/{slug}/{path}/"
     uri = absolute_uri(full_path)
     parts = construct_url_parts(uri=uri, query=query, fragment=fragment)
     return "".join(parts)

--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -94,10 +94,11 @@ def organization_absolute_url(
 def api_absolute_url(
     *, slug: str, path: str, query: str | None = None, fragment: str | None = None
 ) -> str:
-    if path and path[0] != "/":
-        path = f"/{path}"
-    path = f"/api/0/organizations/{slug}{path}"
-    uri = absolute_uri(path)
+    if path.startswith("/"):
+        path = path.lstrip("/")
+
+    full_path = f"/api/0/organizations/{slug}/{path}"
+    uri = absolute_uri(full_path)
     parts = construct_url_parts(uri=uri, query=query, fragment=fragment)
     return "".join(parts)
 

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -268,6 +268,19 @@ class GroupTest(TestCase, SnubaTestCase):
         expected = f"http://{org.slug}.testserver/issues/{group.id}/"
         assert expected == group.get_absolute_url()
 
+    def test_get_absolute_api_url(self):
+        project = self.create_project()
+        event = self.store_event(
+            data={"fingerprint": ["group1"], "timestamp": self.min_ago}, project_id=project.id
+        )
+        org = self.organization
+        group = event.group
+
+        assert (
+            group.get_absolute_api_url()
+            == f"http://testserver/api/0/organizations/{org.slug}/issues/{group.id}/"
+        )
+
     def test_get_releases(self):
         now = timezone.now().replace(microsecond=0)
         project = self.create_project()

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -442,6 +442,28 @@ class Require2fa(TestCase, HybridCloudTestMixin):
         url = org.absolute_api_url("/issues/", query="project=123", fragment="ref")
         assert url == "http://testserver/api/0/organizations/acme/issues/?project=123#ref"
 
+    def test_absolute_api_url_mising_slashes(self):
+        org = self.create_organization(owner=self.user, slug="acme")
+        url = org.absolute_api_url("restore")
+        assert url == "http://testserver/api/0/organizations/acme/restore/"
+
+        url = org.absolute_api_url("/issues", query="project=123", fragment="ref")
+        assert url == "http://testserver/api/0/organizations/acme/issues/?project=123#ref"
+
+        url = org.absolute_api_url("issues/", query="project=123", fragment="ref")
+        assert url == "http://testserver/api/0/organizations/acme/issues/?project=123#ref"
+
+    def test_absolute_api_url_extraneous_slashes(self):
+        org = self.create_organization(owner=self.user, slug="acme")
+        url = org.absolute_api_url("/////restore/////")
+        assert url == "http://testserver/api/0/organizations/acme/restore/"
+
+        url = org.absolute_api_url("////issues", query="project=123", fragment="ref")
+        assert url == "http://testserver/api/0/organizations/acme/issues/?project=123#ref"
+
+        url = org.absolute_api_url("issues////", query="project=123", fragment="ref")
+        assert url == "http://testserver/api/0/organizations/acme/issues/?project=123#ref"
+
     def test_get_bulk_owner_profiles(self):
         u1, u2, u3 = (self.create_user() for _ in range(3))
         o1, o2, o3 = (self.create_organization(owner=u) for u in (u1, u2, u3))


### PR DESCRIPTION
I forgot to incorporate build_url into the issue urls PR. Looking at build_url it assumes you have some base_url from the integration which we accomplish with [absolute_uri](https://github.com/getsentry/sentry/blob/crl/build-url/src/sentry/utils/http.py#L22) so I think the most relevant part is stripping of the / from the path instead of prepending