### PR TITLE
fix(seer): do not trigger scanner if it's a page load summary

### DIFF
--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -272,8 +272,11 @@ def _run_automation(
     event: GroupEvent,
     source: SeerAutomationSource,
 ) -> None:
-    if not features.has(
-        "organizations:trigger-autofix-on-issue-summary", group.organization, actor=user
+    if (
+        not features.has(
+            "organizations:trigger-autofix-on-issue-summary", group.organization, actor=user
+        )
+        or source == SeerAutomationSource.ISSUE_DETAILS
     ):
         return
 

--- a/tests/sentry/seer/test_issue_summary.py
+++ b/tests/sentry/seer/test_issue_summary.py
@@ -557,7 +557,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
             group_id=self.group.id,
             event_id="test_event_id",
             user_id=mock_user.id,
-            auto_run_source="issue_summary_fixability",
+            auto_run_source="issue_summary_on_post_process_fixability",
         )
 
         self.group.refresh_from_db()
@@ -627,7 +627,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
                         group_id=self.group.id,
                         event_id="test_event_id",
                         user_id=mock_user.id,
-                        auto_run_source="issue_summary_fixability",
+                        auto_run_source="issue_summary_on_post_process_fixability",
                     )
                 else:
                     mock_trigger_autofix_task.assert_not_called()

--- a/tests/sentry/seer/test_issue_summary.py
+++ b/tests/sentry/seer/test_issue_summary.py
@@ -549,9 +549,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
         self.group.refresh_from_db()
         assert self.group.seer_fixability_score is None
 
-        _run_automation(
-            self.group, mock_user, mock_event, source=SeerAutomationSource.ISSUE_DETAILS
-        )
+        _run_automation(self.group, mock_user, mock_event, source=SeerAutomationSource.POST_PROCESS)
 
         mock_generate_fixability_score.assert_called_once_with(self.group)
 
@@ -617,7 +615,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
             with self.subTest(option=option_value, score=score, should_trigger=should_trigger):
                 self.group.project.update_option("sentry:autofix_automation_tuning", option_value)
                 _run_automation(
-                    self.group, mock_user, mock_event, source=SeerAutomationSource.ISSUE_DETAILS
+                    self.group, mock_user, mock_event, source=SeerAutomationSource.POST_PROCESS
                 )
 
                 mock_generate_fixability_score.assert_called_once_with(self.group)


### PR DESCRIPTION
Do not generate fixability score or automatically trigger autofix if it's a summary generated manually on page load.