### PR TITLE
chore(integrations): Record bitbucket 404s as halts

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -20,7 +20,7 @@ from sentry.users.services.user import RpcUser
 
 # Generated based on the response from the Bitbucket API
 # Example: {"type": "error", "error": {"message": "Repository has no issue tracker."}}
-BITBUCKET_HALT_ERROR_CODES = ["Repository has no issue tracker."]
+BITBUCKET_HALT_ERROR_CODES = ["Repository has no issue tracker.", "Resource not found"]
 
 
 ISSUE_TYPES = (

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -50,6 +50,7 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
             try:
                 response = installation.search_issues(query=full_query, repo=repo)
             except ApiError as e:
+
                 if "no issue tracker" in str(e):
                     lifecycle.record_halt(str(SourceCodeSearchEndpointHaltReason.NO_ISSUE_TRACKER))
                     logger.info(
@@ -59,6 +60,15 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
                     return Response(
                         {"detail": "Bitbucket Repository has no issue tracker."}, status=400
                     )
+                elif "resource not found" in str(e):
+                    lifecycle.record_halt(
+                        str(SourceCodeSearchEndpointHaltReason.MISSING_REPOSITORY_OR_NO_ACCESS)
+                    )
+                    logger.info(
+                        "bitbucket.issue-search-resource-not-found",
+                        extra={"installation_id": installation.model.id, "repo": repo},
+                    )
+                    return Response({"detail": "Bitbucket Repository not found."}, status=400)
                 raise
 
             assert isinstance(response, dict)

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -53,20 +53,12 @@ class BitbucketSearchEndpoint(SourceCodeSearchEndpoint):
 
                 if "no issue tracker" in str(e):
                     lifecycle.record_halt(str(SourceCodeSearchEndpointHaltReason.NO_ISSUE_TRACKER))
-                    logger.info(
-                        "bitbucket.issue-search-no-issue-tracker",
-                        extra={"installation_id": installation.model.id, "repo": repo},
-                    )
                     return Response(
                         {"detail": "Bitbucket Repository has no issue tracker."}, status=400
                     )
                 elif "resource not found" in str(e):
                     lifecycle.record_halt(
                         str(SourceCodeSearchEndpointHaltReason.MISSING_REPOSITORY_OR_NO_ACCESS)
-                    )
-                    logger.info(
-                        "bitbucket.issue-search-resource-not-found",
-                        extra={"installation_id": installation.model.id, "repo": repo},
                     )
                     return Response({"detail": "Bitbucket Repository not found."}, status=400)
                 raise


### PR DESCRIPTION
When the integrations attempts to create/search for a repo and doesn't find it, don't record an error, just halt. We can't action on the permission issues for the bitbucket app, or if the repo has been renamed/deleted and must be set up again.