### PR TITLE
fix(aci): add All Environments option in automation builder

### DIFF
--- a/static/app/components/workflowEngine/form/environmentSelector.spec.tsx
+++ b/static/app/components/workflowEngine/form/environmentSelector.spec.tsx
@@ -19,9 +19,12 @@ describe('EnvironmentSelector', function () {
     render(<EnvironmentSelector value={''} onChange={mockOnChange} />);
 
     // Open list
-    await userEvent.click(screen.getByRole('button', {name: 'Environment None'}));
+    await userEvent.click(screen.getByRole('button', {name: 'All Environments'}));
 
     // Get groups
+    const allEnvironments = screen.getByRole('group', {
+      name: 'All Environments',
+    });
     const userProjectEnvironments = screen.getByRole('group', {
       name: 'Environments in My Projects',
     });
@@ -30,6 +33,9 @@ describe('EnvironmentSelector', function () {
     });
 
     // Environments are correctly grouped
+    expect(
+      within(allEnvironments).getByRole('option', {name: 'All Environments'})
+    ).toBeInTheDocument();
     expect(
       within(userProjectEnvironments).getByRole('option', {name: 'prod'})
     ).toBeInTheDocument();
@@ -48,7 +54,7 @@ describe('EnvironmentSelector', function () {
     await userEvent.click(screen.getByRole('option', {name: 'prod'}));
 
     // Trigger label is updated
-    expect(screen.getByRole('button', {name: 'Environment prod'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'prod'})).toBeInTheDocument();
     expect(mockOnChange).toHaveBeenCalledWith('prod');
   });
 });

--- a/static/app/components/workflowEngine/form/environmentSelector.tsx
+++ b/static/app/components/workflowEngine/form/environmentSelector.tsx
@@ -30,6 +30,11 @@ export function EnvironmentSelector({value, onChange}: EnvironmentSelectorProps)
 
     return [
       {
+        key: 'all-environments',
+        label: t('All Environments'),
+        options: [{value: '', label: t('All Environments')}],
+      },
+      {
         key: 'my-projects',
         label: t('Environments in My Projects'),
         options: setToOptions(userEnvs),
@@ -45,11 +50,10 @@ export function EnvironmentSelector({value, onChange}: EnvironmentSelectorProps)
   return (
     <CompactSelect<string>
       size="md"
-      triggerProps={{prefix: t('Environment')}}
       options={options}
       searchable
       disabled={!projectsLoaded}
-      sizeLimit={10}
+      sizeLimit={20}
       multiple={false}
       value={value}
       onChange={selected => onChange(selected.value)}

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -76,6 +76,10 @@ export default function AutomationForm({model}: {model: FormModel}) {
   };
 
   const [environment, setEnvironment] = useState<string>('');
+  const updateEnvironment = (env: string) => {
+    setEnvironment(env);
+    model.setValue('environment', env || null);
+  };
 
   return (
     <Flex direction="column" gap={space(1.5)}>
@@ -103,7 +107,7 @@ export default function AutomationForm({model}: {model: FormModel}) {
             )}
           </Description>
         </Flex>
-        <EnvironmentSelector value={environment} onChange={setEnvironment} />
+        <EnvironmentSelector value={environment} onChange={updateEnvironment} />
       </Card>
       <Card>
         <Heading>{t('Automation Builder')}</Heading>

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -82,7 +82,11 @@ function EditableAutomationName() {
   );
 }
 
-const initialData = {...flattie(initialAutomationBuilderState), frequency: '1440'};
+const initialData = {
+  ...flattie(initialAutomationBuilderState),
+  environment: null,
+  frequency: '1440',
+};
 
 export default function AutomationNewSettings() {
   const navigate = useNavigate();


### PR DESCRIPTION
a workflow's `environment` can be `null` which represents "any environment"