### PR TITLE
chore(oauth): change missing state to halt

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -383,7 +383,7 @@ class OAuth2CallbackView(IdentityPipelineViewT):
                     "pipeline_state": pipeline.fetch_state("state"),
                     "code": code,
                 }
-                lifecycle.record_failure(
+                lifecycle.record_halt(
                     IntegrationPipelineErrorReason.TOKEN_EXCHANGE_MISMATCHED_STATE, extra=extra
                 )
                 return pipeline.error(ERR_INVALID_STATE)


### PR DESCRIPTION
Resolves - https://sentry.sentry.io/issues/3146776098/events/46a49be5baa046e1bab7fb3b5574d389/?project=1&query=&referrer=previous-event 

at least for GitLab......

From what I could see in the logs & requests, the state was not being sent to the pipeline so we would fail. Seems like a user tampering or error, unless I'm missing some failure mode :hides: