### PR TITLE
feat(replay): log when input tokens exceeds 100k in summary endpoint

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -181,6 +181,14 @@ def analyze_recording_segments(
     # Combine breadcrumbs and error details
     request_data = json.dumps({"logs": get_request_data(iter_segment_data(segments), error_events)})
 
+    # Log when the input tokens are too large. This is potential for timeout.
+    tokens = len(request_data) / 4
+    if tokens > 100000:
+        logger.info(
+            "Replay AI summary: input tokens exceeded 100k.",
+            extra={"request_len": len(request_data), "num_tokens": len(request_data) / 4},
+        )
+
     # XXX: I have to deserialize this request so it can be "automatically" reserialized by the
     # paginate method. This is less than ideal.
     return json.loads(make_seer_request(request_data).decode("utf-8"))


### PR DESCRIPTION
1 token ~~ 4 chars
 closes https://linear.app/getsentry/issue/REPLAY-441/add-metrics-to-track-when-input-is-greater-than-x