### PR TITLE
chore(uptime): Bump `sentry-kafka-schemas` to 1.3.13

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -64,7 +64,7 @@ rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.25.0
-sentry-kafka-schemas>=1.3.11
+sentry-kafka-schemas>=1.3.13
 sentry-ophio>=1.1.3
 sentry-protos==0.2.1
 sentry-redis-tools>=0.5.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -185,7 +185,7 @@ sentry-devenv==1.21.0
 sentry-forked-django-stubs==5.2.1.post3
 sentry-forked-djangorestframework-stubs==3.16.0.post1
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.11
+sentry-kafka-schemas==1.3.13
 sentry-ophio==1.1.3
 sentry-protos==0.2.1
 sentry-redis-tools==0.5.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -123,7 +123,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.25.0
 sentry-forked-email-reply-parser==0.5.12.post1
-sentry-kafka-schemas==1.3.11
+sentry-kafka-schemas==1.3.13
 sentry-ophio==1.1.3
 sentry-protos==0.2.1
 sentry-redis-tools==0.5.0


### PR DESCRIPTION
Getting the latest changes for our results schema

<!-- Describe your PR here. -->