### PR TITLE
feat(emerge): Create skeleton for preprod (emerge) frontend routes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -689,6 +689,7 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 
 # Preprod build artifact analysis
 /src/sentry/preprod                                   @getsentry/emerge-tools
+/static/app/views/preprod                             @getsentry/emerge-tools
 # End of preprod
 
 ## Frontend Platform (keep last as we want highest specificity)

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2006,6 +2006,12 @@ function buildRoutes() {
     </Route>
   );
 
+  const preprodRoutes = (
+    <Route path="/preprod/" component={make(() => import('sentry/views/preprod/index'))}>
+      <IndexRoute component={make(() => import('sentry/views/preprod/sizeAnalysis'))} />
+    </Route>
+  );
+
   const feedbackV2ChildRoutes = (
     <Fragment>
       <IndexRoute
@@ -2414,6 +2420,7 @@ function buildRoutes() {
       {issueRoutes}
       {alertRoutes}
       {codecovRoutes}
+      {preprodRoutes}
       {replayRoutes}
       {releasesRoutes}
       {statsRoutes}

--- a/static/app/views/preprod/index.tsx
+++ b/static/app/views/preprod/index.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
-  children: React.ReactNode;
+  children: NonNullable<React.ReactNode>;
 };
 
 function PreprodContainer({children}: Props) {

--- a/static/app/views/preprod/index.tsx
+++ b/static/app/views/preprod/index.tsx
@@ -1,0 +1,32 @@
+import Feature from 'sentry/components/acl/feature';
+import {Alert} from 'sentry/components/core/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
+import NoProjectMessage from 'sentry/components/noProjectMessage';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function PreprodContainer({children}: Props) {
+  const organization = useOrganization();
+
+  return (
+    <Feature
+      features={['organizations:preprod-frontend-routes']}
+      organization={organization}
+      renderDisabled={() => (
+        <Layout.Page withPadding>
+          <Alert.Container>
+            <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+          </Alert.Container>
+        </Layout.Page>
+      )}
+    >
+      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
+    </Feature>
+  );
+}
+
+export default PreprodContainer;

--- a/static/app/views/preprod/sizeAnalysis.tsx
+++ b/static/app/views/preprod/sizeAnalysis.tsx
@@ -9,7 +9,7 @@ function SizeAnalysis() {
       <Layout.Header unified>
         <Layout.HeaderContent>
           <Layout.Title>
-            Size analysis <FeatureBadge type="new" />
+            {t('Size analysis')} <FeatureBadge type="new" />
           </Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>

--- a/static/app/views/preprod/sizeAnalysis.tsx
+++ b/static/app/views/preprod/sizeAnalysis.tsx
@@ -1,0 +1,23 @@
+import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+
+function SizeAnalysis() {
+  return (
+    <SentryDocumentTitle title={t('Size analysis')}>
+      <Layout.Header unified>
+        <Layout.HeaderContent>
+          <Layout.Title>
+            Size analysis <FeatureBadge type="new" />
+          </Layout.Title>
+        </Layout.HeaderContent>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main fullWidth>Main content (coming soon)</Layout.Main>
+      </Layout.Body>
+    </SentryDocumentTitle>
+  );
+}
+
+export default SizeAnalysis;


### PR DESCRIPTION
Creates a basic skeleton page at the `/preprod` route path. This page is gated to specific orgs by the `preprod-frontend-routes` feature flag added in https://github.com/getsentry/sentry/pull/94064 & https://github.com/getsentry/sentry-options-automator/pull/4264.

UI with valid org:
<img width="530" alt="Screenshot 2025-06-23 at 4 39 32 PM" src="https://github.com/user-attachments/assets/c9177b6d-d8c4-4469-9f6d-2ea49d3e3683" />

UI with org not in FF:
<img width="643" alt="Screenshot 2025-06-23 at 4 38 32 PM" src="https://github.com/user-attachments/assets/a4f3c61b-fa3c-4dcc-8690-1324ab4652f0" />
