### PR TITLE
chore(seer): Don't run seer scanner if something is already generating a summary

### DIFF
--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -399,6 +399,10 @@ def get_issue_summary_cache_key(group_id: int) -> str:
     return f"ai-group-summary-v2:{group_id}"
 
 
+def get_issue_summary_lock_key(group_id: int) -> tuple[str, str]:
+    return (f"ai-group-summary-v2-lock:{group_id}", "get_issue_summary")
+
+
 def get_issue_summary(
     group: Group,
     user: User | RpcUser | AnonymousUser | None = None,
@@ -426,7 +430,7 @@ def get_issue_summary(
         return {"detail": "AI Autofix has not been acknowledged by the organization."}, 403
 
     cache_key = get_issue_summary_cache_key(group.id)
-    lock_key = f"ai-group-summary-v2-lock:{group.id}"
+    lock_key, lock_name = get_issue_summary_lock_key(group.id)
     lock_duration = 10  # How long the lock is held if acquired (seconds)
     wait_timeout = 4.5  # How long to wait for the lock (seconds)
 
@@ -445,9 +449,9 @@ def get_issue_summary(
     # 2. Try to acquire lock
     try:
         # Acquire lock context manager. This will poll and wait.
-        with locks.get(
-            key=lock_key, duration=lock_duration, name="get_issue_summary"
-        ).blocking_acquire(initial_delay=0.25, timeout=wait_timeout):
+        with locks.get(key=lock_key, duration=lock_duration, name=lock_name).blocking_acquire(
+            initial_delay=0.25, timeout=wait_timeout
+        ):
             # Re-check cache after acquiring lock, in case another process finished
             # while we were waiting for the lock.
             if cached_summary := cache.get(cache_key):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1558,7 +1558,7 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
-    from sentry.seer.issue_summary import get_issue_summary_cache_key
+    from sentry.seer.issue_summary import get_issue_summary_cache_key, get_issue_summary_lock_key
     from sentry.seer.seer_setup import get_seer_org_acknowledgement
     from sentry.tasks.autofix import start_seer_automation
 
@@ -1571,6 +1571,12 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         and group.seer_fixability_score is not None
         and cache.get(get_issue_summary_cache_key(group.id))
     ):
+        return
+
+    # Check if there's already a task in progress for this issue
+    lock_key, lock_name = get_issue_summary_lock_key(group.id)
+    lock = locks.get(lock_key, duration=0.01, name=lock_name)
+    if lock.locked():
         return
 
     # check currently supported issue categories for Seer

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1575,7 +1575,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
 
     # Check if there's already a task in progress for this issue
     lock_key, lock_name = get_issue_summary_lock_key(group.id)
-    lock = locks.get(lock_key, duration=0.01, name=lock_name)
+    lock = locks.get(lock_key, duration=1, name=lock_name)
     if lock.locked():
         return
 


### PR DESCRIPTION
Another optimization: if a lock is already held for an in-progress issue summary, we return early and avoid creating another scanner task.