### PR TITLE
ref(relay): Disable cardinality limiter by default

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1171,7 +1171,7 @@ register("relay.span-usage-metric", default=False, flags=FLAG_AUTOMATOR_MODIFIAB
 
 # Killswitch for the Relay cardinality limiter, one of `enabled`, `disabled`, `passive`.
 # In `passive` mode Relay's cardinality limiter is active but it does not enforce the limits.
-register("relay.cardinality-limiter.mode", default="enabled", flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("relay.cardinality-limiter.mode", default="disabled", flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Override to set a list of limits into passive mode by organization.
 #
 # In passive mode Relay's cardinality limiter is active but it does not enforce the limits.
@@ -1186,7 +1186,7 @@ register(
 # Rate needs to be between `0.0` and `1.0`.
 # If set to `1.0` all cardinality limiter rejections will be logged as a Sentry error.
 register(
-    "relay.cardinality-limiter.error-sample-rate", default=0.01, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "relay.cardinality-limiter.error-sample-rate", default=0.00, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 # List of additional cardinality limits and selectors.
 #

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -211,6 +211,16 @@ class CardinalityLimitOption(TypedDict):
 def get_metrics_config(timeout: TimeChecker, project: Project) -> Mapping[str, Any] | None:
     metrics_config = {}
 
+    if cardinality_limits := get_cardinality_limits(timeout, project):
+        metrics_config["cardinalityLimits"] = cardinality_limits
+
+    return metrics_config or None
+
+
+def get_cardinality_limits(timeout: TimeChecker, project: Project) -> list[CardinalityLimit] | None:
+    if options.get("relay.cardinality-limiter.mode") == "disabled":
+        return None
+
     passive_limits = options.get("relay.cardinality-limiter.passive-limits-by-org").get(
         str(project.organization.id), []
     )
@@ -249,7 +259,7 @@ def get_metrics_config(timeout: TimeChecker, project: Project) -> Mapping[str, A
         "relay.cardinality-limiter.limits", []
     )
     option_limit_options: list[CardinalityLimitOption] = options.get(
-        "relay.cardinality-limiter.limits", []
+        "relay.cardinality-limiter.limits"
     )
 
     for clo in project_limit_options + organization_limit_options + option_limit_options:
@@ -272,9 +282,7 @@ def get_metrics_config(timeout: TimeChecker, project: Project) -> Mapping[str, A
         except KeyError:
             pass
 
-    metrics_config["cardinalityLimits"] = cardinality_limits
-
-    return metrics_config or None
+    return cardinality_limits
 
 
 def get_project_config(

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/REGION.pysnap
@@ -155,29 +155,6 @@ config:
   groupingConfig:
     enhancements: KLUv_SAYwQAAkwKRs25ld3N0eWxlOjIwMjMtMDEtMTGQ
     id: newstyle:2023-01-11
-  metrics:
-    cardinalityLimits:
-    - id: transactions
-      limit: 10000
-      namespace: transactions
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
-    - id: sessions
-      limit: 10000
-      namespace: sessions
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
-    - id: spans
-      limit: 10000
-      namespace: spans
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
   performanceScore:
     profiles:
     - condition:

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -1006,6 +1006,7 @@ def test_mobile_performance_calculate_score(default_project):
 @pytest.mark.parametrize("passive", [False, True])
 def test_project_config_cardinality_limits(default_project, insta_snapshot, passive):
     options: dict[Any, Any] = {
+        "relay.cardinality-limiter.mode": "enabled",
         "sentry-metrics.cardinality-limiter.limits.transactions.per-org": [
             {"window_seconds": 1000, "granularity_seconds": 100, "limit": 10}
         ],
@@ -1099,6 +1100,7 @@ def test_project_config_cardinality_limits(default_project, insta_snapshot, pass
 @region_silo_test
 def test_project_config_cardinality_limits_project_options_override_other_options(default_project):
     options: dict[Any, Any] = {
+        "relay.cardinality-limiter.mode": "enabled",
         "sentry-metrics.cardinality-limiter.limits.transactions.per-org": None,
         "sentry-metrics.cardinality-limiter.limits.sessions.per-org": None,
         "sentry-metrics.cardinality-limiter.limits.spans.per-org": None,
@@ -1166,6 +1168,7 @@ def test_project_config_cardinality_limits_project_options_override_other_option
 @region_silo_test
 def test_project_config_cardinality_limits_organization_options_override_options(default_project):
     options: dict[Any, Any] = {
+        "relay.cardinality-limiter.mode": "enabled",
         "sentry-metrics.cardinality-limiter.limits.transactions.per-org": None,
         "sentry-metrics.cardinality-limiter.limits.sessions.per-org": None,
         "sentry-metrics.cardinality-limiter.limits.spans.per-org": None,


### PR DESCRIPTION
Still enabled by default in SaaS with this [PR](https://github.com/getsentry/sentry-options-automator/pull/4278), but switches the default to disabled for self hosted.

Fixes: https://github.com/getsentry/self-hosted/issues/3772