### PR TITLE
chore(span-buffer): Count and tag the amount of rebalancing

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -43,6 +43,8 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     ):
         super().__init__()
 
+        self.rebalancing_count = 0
+
         # config
         self.max_batch_size = max_batch_size
         self.max_batch_time = max_batch_time
@@ -60,6 +62,8 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
+        self.rebalancing_count += 1
+        sentry_sdk.set_tag("sentry_spans_rebalancing_count", str(self.rebalancing_count))
         sentry_sdk.set_tag("sentry_spans_buffer_component", "consumer")
 
         committer = CommitOffsets(commit)


### PR DESCRIPTION
We are debugging a consumer crash "broker handle destroyed" and are
fishing for any correlation to pod lifetime or whether this happens
during shutdown or startup.
