### PR TITLE
ref(spans): Use orjson across the entire buffer

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -69,7 +69,7 @@ import math
 from collections.abc import Generator, MutableMapping, Sequence
 from typing import Any, NamedTuple
 
-import rapidjson
+import orjson
 import zstandard
 from django.conf import settings
 from django.utils.functional import cached_property
@@ -418,7 +418,7 @@ class SpansBuffer:
             has_root_span = False
             metrics.timing("spans.buffer.flush_segments.num_spans_per_segment", len(segment))
             for payload in segment:
-                val = rapidjson.loads(payload)
+                val = orjson.loads(payload)
                 old_segment_id = val.get("segment_id")
                 outcome = "same" if old_segment_id == segment_span_id else "different"
 

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Mapping
 from functools import partial
 from typing import cast
 
-import rapidjson
+import orjson
 import sentry_sdk
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.dlq import InvalidMessage
@@ -139,7 +139,7 @@ def process_batch(
                 min_timestamp = timestamp
 
             with metrics.timer("spans.buffer.process_batch.decode"):
-                val = cast(SpanEvent, rapidjson.loads(payload.value))
+                val = cast(SpanEvent, orjson.loads(payload.value))
 
             if killswitches.killswitch_matches_context(
                 "spans.drop-in-buffer",

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -1,8 +1,8 @@
 import time
 from datetime import datetime
 
+import orjson
 import pytest
-import rapidjson
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
@@ -40,14 +40,14 @@ def test_basic(monkeypatch):
                 offset=1,
                 payload=KafkaPayload(
                     None,
-                    rapidjson.dumps(
+                    orjson.dumps(
                         {
                             "project_id": 12,
                             "span_id": "a" * 16,
                             "trace_id": "b" * 32,
                             "end_timestamp_precise": 1700000000.0,
                         }
-                    ).encode("ascii"),
+                    ),
                     [],
                 ),
                 timestamp=datetime.now(),
@@ -66,7 +66,7 @@ def test_basic(monkeypatch):
 
     (msg,) = messages
 
-    assert rapidjson.loads(msg.value) == {
+    assert orjson.loads(msg.value) == {
         "spans": [
             {
                 "data": {

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -1,7 +1,7 @@
 import time
 from time import sleep
 
-import rapidjson
+import orjson
 from arroyo.processing.strategies.noop import Noop
 
 from sentry.spans.buffer import Span, SpansBuffer
@@ -10,8 +10,8 @@ from sentry.testutils.helpers.options import override_options
 from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
 
 
-def _payload(span_id: bytes) -> bytes:
-    return rapidjson.dumps({"span_id": span_id}).encode("ascii")
+def _payload(span_id: str) -> bytes:
+    return orjson.dumps({"span_id": span_id})
 
 
 @override_options({**DEFAULT_OPTIONS, "spans.buffer.max-flush-segments": 1})
@@ -39,7 +39,7 @@ def test_backpressure(monkeypatch):
 
         spans = [
             Span(
-                payload=_payload(b"a" * 16),
+                payload=_payload("a" * 16),
                 trace_id=trace_id,
                 span_id="a" * 16,
                 parent_span_id="b" * 16,
@@ -47,7 +47,7 @@ def test_backpressure(monkeypatch):
                 end_timestamp_precise=now,
             ),
             Span(
-                payload=_payload(b"d" * 16),
+                payload=_payload("d" * 16),
                 trace_id=trace_id,
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
@@ -55,7 +55,7 @@ def test_backpressure(monkeypatch):
                 end_timestamp_precise=now,
             ),
             Span(
-                payload=_payload(b"c" * 16),
+                payload=_payload("c" * 16),
                 trace_id=trace_id,
                 span_id="c" * 16,
                 parent_span_id="b" * 16,
@@ -63,7 +63,7 @@ def test_backpressure(monkeypatch):
                 end_timestamp_precise=now,
             ),
             Span(
-                payload=_payload(b"b" * 16),
+                payload=_payload("b" * 16),
                 trace_id=trace_id,
                 span_id="b" * 16,
                 parent_span_id=None,

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -4,8 +4,8 @@ import itertools
 from collections.abc import Sequence
 from unittest import mock
 
+import orjson
 import pytest
-import rapidjson
 from sentry_redis_tools.clients import StrictRedis
 
 from sentry.spans.buffer import FlushedSegment, OutputSpan, SegmentKey, Span, SpansBuffer
@@ -38,8 +38,8 @@ def _segment_id(project_id: int, trace_id: str, span_id: str) -> SegmentKey:
     return f"span-buf:z:{{{project_id}:{trace_id}}}:{span_id}".encode("ascii")
 
 
-def _payload(span_id: bytes) -> bytes:
-    return rapidjson.dumps({"span_id": span_id}).encode("ascii")
+def _payload(span_id: str) -> bytes:
+    return orjson.dumps({"span_id": span_id})
 
 
 def _output_segment(span_id: bytes, segment_id: bytes, is_segment: bool) -> OutputSpan:
@@ -134,7 +134,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
         itertools.permutations(
             [
                 Span(
-                    payload=_payload(b"a" * 16),
+                    payload=_payload("a" * 16),
                     trace_id="a" * 32,
                     span_id="a" * 16,
                     parent_span_id="b" * 16,
@@ -142,7 +142,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"d" * 16),
+                    payload=_payload("d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
@@ -150,7 +150,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"c" * 16),
+                    payload=_payload("c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
@@ -158,7 +158,7 @@ def process_spans(spans: Sequence[Span | _SplitBatch], buffer: SpansBuffer, now)
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"b" * 16),
+                    payload=_payload("b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
                     parent_span_id=None,
@@ -203,7 +203,7 @@ def test_basic(buffer: SpansBuffer, spans):
         itertools.permutations(
             [
                 Span(
-                    payload=_payload(b"d" * 16),
+                    payload=_payload("d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
@@ -212,7 +212,7 @@ def test_basic(buffer: SpansBuffer, spans):
                 ),
                 _SplitBatch(),
                 Span(
-                    payload=_payload(b"b" * 16),
+                    payload=_payload("b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
                     parent_span_id="a" * 16,
@@ -220,7 +220,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"a" * 16),
+                    payload=_payload("a" * 16),
                     trace_id="a" * 32,
                     span_id="a" * 16,
                     parent_span_id=None,
@@ -229,7 +229,7 @@ def test_basic(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"c" * 16),
+                    payload=_payload("c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
@@ -273,7 +273,7 @@ def test_deep(buffer: SpansBuffer, spans):
         itertools.permutations(
             [
                 Span(
-                    payload=_payload(b"e" * 16),
+                    payload=_payload("e" * 16),
                     trace_id="a" * 32,
                     span_id="e" * 16,
                     parent_span_id="d" * 16,
@@ -281,7 +281,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"d" * 16),
+                    payload=_payload("d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
@@ -289,7 +289,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"b" * 16),
+                    payload=_payload("b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
                     parent_span_id="c" * 16,
@@ -297,7 +297,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"c" * 16),
+                    payload=_payload("c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
                     parent_span_id="a" * 16,
@@ -305,7 +305,7 @@ def test_deep(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"a" * 16),
+                    payload=_payload("a" * 16),
                     trace_id="a" * 32,
                     span_id="a" * 16,
                     parent_span_id=None,
@@ -351,7 +351,7 @@ def test_deep2(buffer: SpansBuffer, spans):
         itertools.permutations(
             [
                 Span(
-                    payload=_payload(b"c" * 16),
+                    payload=_payload("c" * 16),
                     trace_id="a" * 32,
                     span_id="c" * 16,
                     parent_span_id="b" * 16,
@@ -359,7 +359,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"d" * 16),
+                    payload=_payload("d" * 16),
                     trace_id="a" * 32,
                     span_id="d" * 16,
                     parent_span_id="b" * 16,
@@ -367,7 +367,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"e" * 16),
+                    payload=_payload("e" * 16),
                     trace_id="a" * 32,
                     span_id="e" * 16,
                     parent_span_id="b" * 16,
@@ -375,7 +375,7 @@ def test_deep2(buffer: SpansBuffer, spans):
                     end_timestamp_precise=1700000000.0,
                 ),
                 Span(
-                    payload=_payload(b"b" * 16),
+                    payload=_payload("b" * 16),
                     trace_id="a" * 32,
                     span_id="b" * 16,
                     parent_span_id=None,
@@ -427,7 +427,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
     shallow_permutations(
         [
             Span(
-                payload=_payload(b"c" * 16),
+                payload=_payload("c" * 16),
                 trace_id="a" * 32,
                 span_id="c" * 16,
                 parent_span_id="d" * 16,
@@ -436,7 +436,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 end_timestamp_precise=1700000000.0,
             ),
             Span(
-                payload=_payload(b"d" * 16),
+                payload=_payload("d" * 16),
                 trace_id="a" * 32,
                 span_id="d" * 16,
                 parent_span_id="b" * 16,
@@ -444,7 +444,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 end_timestamp_precise=1700000000.0,
             ),
             Span(
-                payload=_payload(b"e" * 16),
+                payload=_payload("e" * 16),
                 trace_id="a" * 32,
                 span_id="e" * 16,
                 parent_span_id="b" * 16,
@@ -452,7 +452,7 @@ def test_parent_in_other_project(buffer: SpansBuffer, spans):
                 end_timestamp_precise=1700000000.0,
             ),
             Span(
-                payload=_payload(b"b" * 16),
+                payload=_payload("b" * 16),
                 trace_id="a" * 32,
                 span_id="b" * 16,
                 parent_span_id=None,
@@ -507,7 +507,7 @@ def test_parent_in_other_project_and_nested_is_segment_span(buffer: SpansBuffer,
 def test_flush_rebalance(buffer: SpansBuffer):
     spans = [
         Span(
-            payload=_payload(b"a" * 16),
+            payload=_payload("a" * 16),
             trace_id="a" * 32,
             span_id="a" * 16,
             parent_span_id=None,
@@ -545,14 +545,14 @@ def test_compression_functionality(compression_level):
         buffer = SpansBuffer(assigned_shards=list(range(32)))
 
         def make_payload(span_id: str):
-            return rapidjson.dumps(
+            return orjson.dumps(
                 {
                     "span_id": span_id,
                     "trace_id": "a" * 32,
                     "data": {"message": "x" * 1000},
                     "extra_data": {"field": "y" * 500},
                 }
-            ).encode("ascii")
+            )
 
         spans = [
             Span(


### PR DESCRIPTION
Switches to `orjson` like the rest of the codebase.
