### PR TITLE
fix(symbolication): Better warning/frame indicators on stack traces

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -149,8 +149,8 @@ describe('Native StackTrace', function () {
           function: 'missing()',
         }),
         EventStacktraceFrameFixture({
-          symbolicatorStatus: SymbolicatorStatus.UNKNOWN_IMAGE,
-          function: 'unknown_image()',
+          symbolicatorStatus: SymbolicatorStatus.MISSING_SYMBOL,
+          function: 'missing_symbol()',
         }),
         EventStacktraceFrameFixture({
           symbolicatorStatus: SymbolicatorStatus.SYMBOLICATED,

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -211,8 +211,9 @@ function NativeFrame({
         case SymbolicatorStatus.MISSING:
         case SymbolicatorStatus.MALFORMED:
           return 'error';
-        case SymbolicatorStatus.MISSING_SYMBOL:
         case SymbolicatorStatus.UNKNOWN_IMAGE:
+          return frame.instructionAddr === '0x0' ? 'success' : 'error';
+        case SymbolicatorStatus.MISSING_SYMBOL:
         default:
           return undefined;
       }


### PR DESCRIPTION
Unknown images are not an unknown error, we can show a better message here (same as `missing`), additionally we can special case null pointer access violation frames, there is nothing unexpected or erroneous  about them.