### PR TITLE
fix(agent-insights): Trim input and output messages

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -24,7 +24,7 @@ function renderTextMessages(content: any) {
   }
   return content
     .filter((part: any) => part.type === 'text')
-    .map((part: any) => part.text)
+    .map((part: any) => part.text.trim())
     .join('\n');
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -68,7 +68,7 @@ export function AIOutputSection({
             {t('Response')}
           </TraceDrawerComponents.MultilineTextLabel>
           <TraceDrawerComponents.MultilineText>
-            {responseText}
+            {responseText.trim()}
           </TraceDrawerComponents.MultilineText>
         </Fragment>
       )}


### PR DESCRIPTION
- closes [TET-697: span details: Trim messages](https://linear.app/getsentry/issue/TET-697/span-details-trim-messages)