### PR TITLE
feat(agent-insights): persist drawer state in url

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import EmptyMessage from 'sentry/components/emptyMessage';
-import useDrawer from 'sentry/components/globalDrawer';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -12,6 +11,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/agentMonitoring/components/aiSpanList';
 import {useAITrace} from 'sentry/views/insights/agentMonitoring/hooks/useAITrace';
 import {useNodeDetailsLink} from 'sentry/views/insights/agentMonitoring/hooks/useNodeDetailsLink';
+import {useUrlTraceDrawer} from 'sentry/views/insights/agentMonitoring/hooks/useUrlTraceDrawer';
 import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
@@ -75,18 +75,27 @@ function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
 }
 
 export function useTraceViewDrawer({onClose = undefined}: UseTraceViewDrawerProps) {
-  const {openDrawer, isDrawerOpen} = useDrawer();
+  const {openDrawer, isDrawerOpen, drawerUrlState} = useUrlTraceDrawer();
 
-  const openTraceViewDrawer = (traceSlug: string) =>
-    openDrawer(() => <TraceViewDrawer traceSlug={traceSlug} />, {
-      ariaLabel: t('Abbreviated Trace'),
-      onClose,
-      shouldCloseOnInteractOutside: () => true,
-      drawerWidth: '40%',
-      resizable: true,
+  const openTraceViewDrawer = useCallback(
+    (traceSlug: string) =>
+      openDrawer(() => <TraceViewDrawer traceSlug={traceSlug} />, {
+        ariaLabel: t('Abbreviated Trace'),
+        onClose,
+        shouldCloseOnInteractOutside: () => true,
+        drawerWidth: '40%',
+        resizable: true,
+        traceSlug,
+        drawerKey: 'abbreviated-trace-view-drawer',
+      }),
+    [openDrawer, onClose]
+  );
 
-      drawerKey: 'abbreviated-trace-view-drawer',
-    });
+  useEffect(() => {
+    if (drawerUrlState.trace && !isDrawerOpen) {
+      openTraceViewDrawer(drawerUrlState.trace);
+    }
+  }, [drawerUrlState.trace, isDrawerOpen, openTraceViewDrawer]);
 
   return {
     openTraceViewDrawer,

--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -23,7 +23,13 @@ interface UseTraceViewDrawerProps {
   onClose?: () => void;
 }
 
-function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
+function TraceViewDrawer({
+  traceSlug,
+  closeDrawer,
+}: {
+  closeDrawer: () => void;
+  traceSlug: string;
+}) {
   const {nodes, isLoading, error} = useAITrace(traceSlug);
   const [selectedNodeKey, setSelectedNodeKey] = useState<string | null>(null);
 
@@ -53,7 +59,7 @@ function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
       <StyledDrawerHeader>
         <HeaderContent>
           {t('Abbreviated Trace')}
-          <LinkButton size="xs" to={nodeDetailsLink}>
+          <LinkButton size="xs" onMouseDown={closeDrawer} to={nodeDetailsLink}>
             {t('View in Full Trace')}
           </LinkButton>
         </HeaderContent>
@@ -75,20 +81,23 @@ function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
 }
 
 export function useTraceViewDrawer({onClose = undefined}: UseTraceViewDrawerProps) {
-  const {openDrawer, isDrawerOpen, drawerUrlState} = useUrlTraceDrawer();
+  const {openDrawer, isDrawerOpen, drawerUrlState, closeDrawer} = useUrlTraceDrawer();
 
   const openTraceViewDrawer = useCallback(
     (traceSlug: string) =>
-      openDrawer(() => <TraceViewDrawer traceSlug={traceSlug} />, {
-        ariaLabel: t('Abbreviated Trace'),
-        onClose,
-        shouldCloseOnInteractOutside: () => true,
-        drawerWidth: '40%',
-        resizable: true,
-        traceSlug,
-        drawerKey: 'abbreviated-trace-view-drawer',
-      }),
-    [openDrawer, onClose]
+      openDrawer(
+        () => <TraceViewDrawer traceSlug={traceSlug} closeDrawer={closeDrawer} />,
+        {
+          ariaLabel: t('Abbreviated Trace'),
+          onClose,
+          shouldCloseOnInteractOutside: () => true,
+          drawerWidth: '40%',
+          resizable: true,
+          traceSlug,
+          drawerKey: 'abbreviated-trace-view-drawer',
+        }
+      ),
+    [openDrawer, onClose, closeDrawer]
   );
 
   useEffect(() => {

--- a/static/app/views/insights/agentMonitoring/hooks/useUrlTraceDrawer.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useUrlTraceDrawer.tsx
@@ -1,0 +1,106 @@
+import {useMemo} from 'react';
+import omit from 'lodash/omit';
+
+import useDrawer from 'sentry/components/globalDrawer';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+enum TraceDrawerFields {
+  DRAWER = 'drawer',
+  TRACE_SLUG = 'trace',
+}
+
+const TRACE_DRAWER_FIELD_MAP = {
+  [TraceDrawerFields.DRAWER]: decodeScalar,
+  [TraceDrawerFields.TRACE_SLUG]: decodeScalar,
+};
+
+const TRACE_DRAWER_FIELD_KEYS = Object.keys(TRACE_DRAWER_FIELD_MAP);
+
+export function useUrlTraceDrawer() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const {
+    openDrawer: baseOpenDrawer,
+    closeDrawer: baseCloseDrawer,
+    isDrawerOpen,
+    panelRef,
+  } = useDrawer();
+
+  const {drawer, trace} = useLocationQuery({
+    fields: TRACE_DRAWER_FIELD_MAP,
+  });
+
+  const openDrawer = useMemo(() => {
+    return (
+      renderer: Parameters<typeof baseOpenDrawer>[0],
+      options?: Parameters<typeof baseOpenDrawer>[1] & {traceSlug?: string}
+    ) => {
+      const {traceSlug, onClose, ariaLabel, ...rest} = options || {};
+
+      if (traceSlug) {
+        navigate(
+          {
+            pathname: location.pathname,
+            query: {
+              ...location.query,
+              [TraceDrawerFields.DRAWER]: 'open',
+              [TraceDrawerFields.TRACE_SLUG]: traceSlug,
+            },
+          },
+          {replace: true}
+        );
+      }
+
+      return baseOpenDrawer(renderer, {
+        ...rest,
+        ariaLabel: ariaLabel || t('Trace Drawer'),
+        shouldCloseOnLocationChange: nextLocation => {
+          // Don't close if we're just updating the drawer state in URL
+          return nextLocation.query[TraceDrawerFields.DRAWER] !== 'open';
+        },
+        onClose: () => {
+          navigate(
+            {
+              pathname: location.pathname,
+              query: omit(location.query, TRACE_DRAWER_FIELD_KEYS),
+            },
+            {replace: true}
+          );
+
+          onClose?.();
+        },
+      });
+    };
+  }, [baseOpenDrawer, navigate, location]);
+
+  const closeDrawer = useMemo(() => {
+    return () => {
+      navigate(
+        {
+          pathname: location.pathname,
+          query: omit(location.query, TRACE_DRAWER_FIELD_KEYS),
+        },
+        {replace: true}
+      );
+
+      return baseCloseDrawer();
+    };
+  }, [baseCloseDrawer, navigate, location]);
+
+  const drawerUrlState = {
+    drawer,
+    trace,
+  };
+
+  return {
+    openDrawer,
+    closeDrawer,
+    isDrawerOpen,
+    panelRef,
+    drawerUrlState,
+  };
+}

--- a/static/app/views/insights/agentMonitoring/hooks/useUrlTraceDrawer.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useUrlTraceDrawer.tsx
@@ -53,12 +53,7 @@ export function useUrlTraceDrawer() {
       renderer: Parameters<typeof baseOpenDrawer>[0],
       options?: Parameters<typeof baseOpenDrawer>[1] & {traceSlug?: string}
     ) => {
-      const {
-        traceSlug: optionsTraceSlug,
-        onClose,
-        ariaLabel,
-        ...restOptions
-      } = options || {};
+      const {traceSlug: optionsTraceSlug, onClose, ariaLabel, ...rest} = options || {};
 
       if (optionsTraceSlug) {
         navigate(
@@ -75,7 +70,7 @@ export function useUrlTraceDrawer() {
       }
 
       return baseOpenDrawer(renderer, {
-        ...restOptions,
+        ...rest,
         ariaLabel: ariaLabel || 'Trace Drawer',
         shouldCloseOnLocationChange: nextLocation => {
           return nextLocation.query[TraceDrawerFields.DRAWER_OPEN] !== 'open';

--- a/static/app/views/insights/agentMonitoring/hooks/useUrlTraceDrawer.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useUrlTraceDrawer.tsx
@@ -7,17 +7,7 @@ import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
-enum TraceDrawerFields {
-  DRAWER_OPEN = 'drawerOpen',
-  TRACE_SLUG = 'trace',
-}
-
-const AI_TRACE_DRAWER_FIELD_MAP = {
-  [TraceDrawerFields.DRAWER_OPEN]: decodeScalar,
-  [TraceDrawerFields.TRACE_SLUG]: decodeScalar,
-};
-
-const AI_TRACE_DRAWER_FIELD_KEYS = Object.keys(AI_TRACE_DRAWER_FIELD_MAP);
+const DRAWER_TRACE_SLUG = 'trace';
 
 export function useUrlTraceDrawer() {
   const location = useLocation();
@@ -29,15 +19,17 @@ export function useUrlTraceDrawer() {
     panelRef,
   } = useDrawer();
 
-  const {drawerOpen, trace} = useLocationQuery({
-    fields: AI_TRACE_DRAWER_FIELD_MAP,
+  const {trace} = useLocationQuery({
+    fields: {
+      [DRAWER_TRACE_SLUG]: decodeScalar,
+    },
   });
 
   const removeQueryParams = useCallback(() => {
     navigate(
       {
         pathname: location.pathname,
-        query: omit(location.query, AI_TRACE_DRAWER_FIELD_KEYS),
+        query: omit(location.query, DRAWER_TRACE_SLUG),
       },
       {replace: true}
     );
@@ -61,8 +53,7 @@ export function useUrlTraceDrawer() {
             pathname: location.pathname,
             query: {
               ...location.query,
-              [TraceDrawerFields.DRAWER_OPEN]: 'open',
-              [TraceDrawerFields.TRACE_SLUG]: optionsTraceSlug,
+              [DRAWER_TRACE_SLUG]: optionsTraceSlug,
             },
           },
           {replace: true}
@@ -73,7 +64,7 @@ export function useUrlTraceDrawer() {
         ...rest,
         ariaLabel: ariaLabel || 'Trace Drawer',
         shouldCloseOnLocationChange: nextLocation => {
-          return nextLocation.query[TraceDrawerFields.DRAWER_OPEN] !== 'open';
+          return !nextLocation.query[DRAWER_TRACE_SLUG];
         },
         onClose: () => {
           removeQueryParams();
@@ -89,6 +80,6 @@ export function useUrlTraceDrawer() {
     closeDrawer,
     isDrawerOpen,
     panelRef,
-    drawerUrlState: {drawerOpen, trace},
+    drawerUrlState: {trace},
   };
 }


### PR DESCRIPTION
Closes [TET-646: Drawer state should be in URL so that when you go to full trace and go back it stays open with the right trace (and span)](https://linear.app/getsentry/issue/TET-646/drawer-state-should-be-in-url-so-that-when-you-go-to-full-trace-and-go)