### PR TITLE
feat(agent-insights): Select first AI span as default

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -12,6 +12,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/agentMonitoring/components/aiSpanList';
 import {useAITrace} from 'sentry/views/insights/agentMonitoring/hooks/useAITrace';
 import {useNodeDetailsLink} from 'sentry/views/insights/agentMonitoring/hooks/useNodeDetailsLink';
+import {getDefaultSelectedNode} from 'sentry/views/insights/agentMonitoring/utils/getDefaultSelectedNode';
 import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
@@ -32,15 +33,9 @@ function TraceViewDrawer({traceSlug}: {traceSlug: string}) {
     setSelectedNodeKey(uniqueKey);
   }, []);
 
-  useEffect(() => {
-    if (nodes.length > 0 && !selectedNodeKey && nodes[0]) {
-      handleSelectNode(nodes[0]);
-    }
-  }, [handleSelectNode, nodes, selectedNodeKey]);
-
-  const selectedNode = selectedNodeKey
-    ? nodes.find(node => getNodeId(node) === selectedNodeKey) || nodes[0]
-    : nodes[0];
+  const selectedNode =
+    (selectedNodeKey && nodes.find(node => getNodeId(node) === selectedNodeKey)) ||
+    getDefaultSelectedNode(nodes);
 
   const nodeDetailsLink = useNodeDetailsLink({
     node: selectedNode,

--- a/static/app/views/insights/agentMonitoring/utils/getDefaultSelectedNode.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/getDefaultSelectedNode.tsx
@@ -1,0 +1,7 @@
+import {getIsAiNode} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
+import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
+
+export function getDefaultSelectedNode(nodes: AITraceSpanNode[]) {
+  const firstAiSpan = nodes.find(getIsAiNode);
+  return firstAiSpan ?? nodes[0];
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -11,6 +11,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/agentMonitoring/components/aiSpanList';
 import {useAITrace} from 'sentry/views/insights/agentMonitoring/hooks/useAITrace';
+import {getDefaultSelectedNode} from 'sentry/views/insights/agentMonitoring/utils/getDefaultSelectedNode';
 import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {TraceTreeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
@@ -36,7 +37,10 @@ function TraceAiSpans({
   });
 
   const selectedNode = useMemo(() => {
-    return nodes.find(node => getNodeId(node) === selectedNodeKey) || nodes[0];
+    return (
+      nodes.find(node => getNodeId(node) === selectedNodeKey) ||
+      getDefaultSelectedNode(nodes)
+    );
   }, [nodes, selectedNodeKey]);
 
   const handleSelectNode = useCallback(


### PR DESCRIPTION
- closes [TET-703: AI trace: select first ai span as default](https://linear.app/getsentry/issue/TET-703/ai-trace-select-first-ai-span-as-default)