### PR TITLE
feat(ai): Set up new queue and namespace for AI agent monitoring tasks

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -989,6 +989,7 @@ CELERY_QUEUES_REGION = [
     Queue("stats", routing_key="stats"),
     Queue("subscriptions", routing_key="subscriptions"),
     Queue("tempest", routing_key="tempest"),
+    Queue("ai_agent_monitoring", routing_key="ai_agent_monitoring"),
     Queue("unmerge", routing_key="unmerge"),
     Queue("update", routing_key="update"),
     Queue("uptime", routing_key="uptime"),

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -34,6 +34,10 @@ deletion_control_tasks = taskregistry.create_namespace(
 
 demomode_tasks = taskregistry.create_namespace("demomode", app_feature="shared")
 
+ai_agent_monitoring_tasks = taskregistry.create_namespace(
+    "ai_agent_monitoring", app_feature="ai_agent_monitoring"
+)
+
 digests_tasks = taskregistry.create_namespace("digests", app_feature="shared")
 
 export_tasks = taskregistry.create_namespace(


### PR DESCRIPTION
Sets up new RabbitMQ queue (will be used for a bit longer), and a namespace for future task related to AI Agent monitoring.

For now, we only plan to run 1 periodic task once every 30 minutes (task duration is ~1s).

Periodic task will be assigned to the queue and namespace in a follow up PR