### PR TITLE
chore(seer): Change scanner rate limit to per minute to ease backfills

### DIFF
--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -176,12 +176,12 @@ def is_seer_scanner_rate_limited(
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False, 0, 0
 
-    limit = options.get("seer.max_num_scanner_autotriggered_per_hour", 2500)
+    limit = options.get("seer.max_num_scanner_autotriggered_per_minute", 50)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
         key="seer.scanner.auto_triggered",
         limit=limit,
-        window=60 * 60,  # 1 hour
+        window=60,  # 1 minute
     )
     return is_rate_limited, current, limit
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -601,9 +601,9 @@ register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Issue Summary Auto-trigger rate (max number of autofix runs auto-triggered per project per hour)
 register("seer.max_num_autofix_autotriggered_per_hour", default=20, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per hour)
+# Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per minute)
 register(
-    "seer.max_num_scanner_autotriggered_per_hour", default=2500, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "seer.max_num_scanner_autotriggered_per_minute", default=50, flags=FLAG_AUTOMATOR_MODIFIABLE
 )
 
 # Codecov Integration

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -207,14 +207,14 @@ class TestAutomationRateLimiting(TestCase):
         project = self.create_project()
         organization = project.organization
 
-        mock_is_limited.return_value = (True, 950, None)
+        mock_is_limited.return_value = (True, 45, None)
 
-        with self.options({"seer.max_num_scanner_autotriggered_per_hour": 1000}):
+        with self.options({"seer.max_num_scanner_autotriggered_per_minute": 50}):
             is_rate_limited, current, limit = is_seer_scanner_rate_limited(project, organization)
 
         assert is_rate_limited is True
-        assert current == 950
-        assert limit == 1000
+        assert current == 45
+        assert limit == 50
 
     @with_feature("organizations:unlimited-auto-triggered-autofix-runs")
     def test_autofix_rate_limited_with_unlimited_flag(self):


### PR DESCRIPTION
We were seeing spikes of tons of concurrent requests to Seer at the start of every hour until the 1000/hr rate limit was exhausted. To ease the load on Seer, this PR changes to a 50/min rate limit instead, so the requests are more spread out.