### PR TITLE
fix(explore): Keep original sample fields in explore drilldown

### DIFF
--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -32,6 +32,7 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {
+  useExploreFields,
   useExploreGroupBys,
   useExploreQuery,
   useExploreSortBys,
@@ -55,9 +56,10 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   const location = useLocation();
   const {projects} = useProjects();
 
-  const {result, eventView, fields} = aggregatesTableResult;
+  const {result, eventView, fields: tableFields} = aggregatesTableResult;
 
   const topEvents = useTopEvents();
+  const fields = useExploreFields();
   const groupBys = useExploreGroupBys();
   const visualizes = useExploreVisualizes();
   const sorts = useExploreSortBys();
@@ -67,7 +69,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
   const columns = useMemo(() => eventView.getColumns(), [eventView]);
 
   const tableRef = useRef<HTMLTableElement>(null);
-  const {initialTableStyles, onResizeMouseDown} = useTableStyles(fields, tableRef, {
+  const {initialTableStyles, onResizeMouseDown} = useTableStyles(tableFields, tableRef, {
     minimumColumnWidth: 50,
     prefixColumnWidth: 'min-content',
   });
@@ -94,7 +96,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
             <TableHeadCell isFirst={false}>
               <TableHeadCellContent />
             </TableHeadCell>
-            {fields.map((field, i) => {
+            {tableFields.map((field, i) => {
               // Hide column names before alignment is determined
               if (result.isPending) {
                 return <TableHeadCell key={i} isFirst={i === 0} />;
@@ -140,7 +142,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
                       />
                     )}
                   </TableHeadCellContent>
-                  {i !== fields.length - 1 && (
+                  {i !== tableFields.length - 1 && (
                     <GridResizer
                       dataRows={
                         !result.isError && !result.isPending && result.data
@@ -169,6 +171,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
               const target = viewSamplesTarget({
                 location,
                 query,
+                fields,
                 groupBys,
                 visualizes,
                 sorts,
@@ -187,7 +190,7 @@ export function AggregatesTable({aggregatesTableResult}: AggregatesTableProps) {
                       </StyledLink>
                     </Tooltip>
                   </TableBodyCell>
-                  {fields.map((field, j) => {
+                  {tableFields.map((field, j) => {
                     return (
                       <TableBodyCell key={j}>
                         <FieldRenderer

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -19,6 +19,7 @@ describe('viewSamplesTarget', function () {
     const target = viewSamplesTarget({
       location,
       query: '',
+      fields: ['foo'],
       groupBys: [],
       visualizes: [visualize],
       sorts: [sort],
@@ -27,7 +28,7 @@ describe('viewSamplesTarget', function () {
     });
     expect(target).toMatchObject({
       query: {
-        field: ['span.duration'],
+        field: ['foo', 'span.duration'],
         mode: 'samples',
         query: '',
         sort: ['-span.duration'],
@@ -40,17 +41,18 @@ describe('viewSamplesTarget', function () {
     const target = viewSamplesTarget({
       location,
       query: '',
-      groupBys: ['foo'],
+      fields: ['foo'],
+      groupBys: ['bar'],
       visualizes: [visualize],
       sorts: [sort],
-      row: {foo: 'foo', 'count(span.duration)': 10},
+      row: {bar: 'bar', 'count(span.duration)': 10},
       projects,
     });
     expect(target).toMatchObject({
       query: {
         field: ['foo', 'span.duration'],
         mode: 'samples',
-        query: 'foo:foo',
+        query: 'bar:bar',
         sort: ['-span.duration'],
       },
     });
@@ -61,11 +63,11 @@ describe('viewSamplesTarget', function () {
     const target = viewSamplesTarget({
       location,
       query: '',
-      groupBys: ['foo', 'bar', 'baz'],
+      fields: ['foo'],
+      groupBys: ['bar', 'baz'],
       visualizes: [visualize],
       sorts: [sort],
       row: {
-        foo: 'foo',
         bar: 'bar',
         baz: 'baz',
         'count(span.duration)': 10,
@@ -74,9 +76,9 @@ describe('viewSamplesTarget', function () {
     });
     expect(target).toMatchObject({
       query: {
-        field: ['foo', 'bar', 'baz', 'span.duration'],
+        field: ['foo', 'span.duration'],
         mode: 'samples',
-        query: 'foo:foo bar:bar baz:baz',
+        query: 'bar:bar baz:baz',
         sort: ['-span.duration'],
       },
     });
@@ -87,6 +89,7 @@ describe('viewSamplesTarget', function () {
     const target = viewSamplesTarget({
       location,
       query: '',
+      fields: ['foo'],
       groupBys: ['environment'],
       visualizes: [visualize],
       sorts: [sort],
@@ -98,7 +101,7 @@ describe('viewSamplesTarget', function () {
     });
     expect(target).toMatchObject({
       query: {
-        field: ['environment', 'span.duration'],
+        field: ['foo', 'span.duration'],
         mode: 'samples',
         query: '',
         environment: 'prod',
@@ -112,6 +115,7 @@ describe('viewSamplesTarget', function () {
     const target = viewSamplesTarget({
       location,
       query: '',
+      fields: ['foo'],
       groupBys: ['project.id'],
       visualizes: [visualize],
       sorts: [sort],
@@ -123,7 +127,7 @@ describe('viewSamplesTarget', function () {
     });
     expect(target).toMatchObject({
       query: {
-        field: ['project.id', 'span.duration'],
+        field: ['foo', 'span.duration'],
         mode: 'samples',
         query: '',
         project: '1',
@@ -137,6 +141,7 @@ describe('viewSamplesTarget', function () {
     const target = viewSamplesTarget({
       location,
       query: '',
+      fields: ['foo'],
       groupBys: ['project'],
       visualizes: [visualize],
       sorts: [sort],
@@ -148,7 +153,7 @@ describe('viewSamplesTarget', function () {
     });
     expect(target).toMatchObject({
       query: {
-        field: ['project', 'span.duration'],
+        field: ['foo', 'span.duration'],
         mode: 'samples',
         query: '',
         project: String(project.id),


### PR DESCRIPTION
Dropping the fields during the dropdown results in a poor experience as those columns can provide a lot of context. This change keeps the fields and removes the group bys because the group by columns are being filtered on and they will always have a single value.