### PR TITLE
fix(taskworker) Extend deadline for migrate_repo task

### DIFF
--- a/src/sentry/integrations/tasks/migrate_repo.py
+++ b/src/sentry/integrations/tasks/migrate_repo.py
@@ -25,6 +25,7 @@ from sentry.taskworker.retry import Retry
             times=5,
             delay=60 * 5,
         ),
+        processing_deadline_duration=60,
     ),
 )
 @retry(exclude=(Integration.DoesNotExist, Repository.DoesNotExist, Organization.DoesNotExist))

--- a/src/sentry/notifications/utils/tasks.py
+++ b/src/sentry/notifications/utils/tasks.py
@@ -106,7 +106,7 @@ def async_send_notification(
     silo_mode=SiloMode.REGION,
     queue="notifications",
     taskworker_config=TaskworkerConfig(
-        namespace=notifications_tasks, processing_deadline_duration=20
+        namespace=notifications_tasks, processing_deadline_duration=30
     ),
 )
 def _send_notification(notification_class_name: str, arg_list: Iterable[Mapping[str, Any]]) -> None:


### PR DESCRIPTION
Fixes SENTRY-41WA
