### PR TITLE
chore(discover): add deprecation for creating new discover queries

### DIFF
--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -16,13 +16,15 @@ import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
 import {Input} from 'sentry/components/core/input';
 import {Flex} from 'sentry/components/core/layout';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {Hovercard} from 'sentry/components/hovercard';
+import Link from 'sentry/components/links/link';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {IconBookmark, IconDelete, IconEllipsis, IconStar} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
@@ -44,6 +46,7 @@ import {
   handleAddQueryToDashboard,
   SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
 } from 'sentry/views/discover/utils';
+import {getExploreUrl} from 'sentry/views/explore/utils';
 import {deprecateTransactionAlerts} from 'sentry/views/insights/common/utils/hasEAPAlerts';
 
 import {
@@ -349,13 +352,42 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
   renderButtonSaveAs(disabled: boolean) {
     const {queryName} = this.state;
+    const {organization, location, savedQuery} = this.props;
+    const currentDataset = getDatasetFromLocationOrSavedQueryDataset(
+      location,
+      savedQuery?.queryDataset
+    );
+
+    const deprecatingSaveAs =
+      currentDataset === DiscoverDatasets.TRANSACTIONS &&
+      organization.features.includes('discover-saved-queries-deprecation');
+
+    const tracesUrl = getExploreUrl({
+      organization,
+      query: 'is_transaction:true',
+    });
+
     return (
-      <SaveAsDropdown
-        queryName={queryName}
-        onChangeInput={this.onChangeInput}
-        modifiedHandleCreateQuery={this.handleCreateQuery}
-        disabled={disabled}
-      />
+      <Tooltip
+        disabled={
+          currentDataset !== DiscoverDatasets.TRANSACTIONS ||
+          !organization.features.includes('discover-saved-queries-deprecation')
+        }
+        isHoverable
+        title={tct(
+          'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please save any transaction related queries from [traces:Explore\u2192Traces]',
+          {
+            traces: <Link to={tracesUrl} />,
+          }
+        )}
+      >
+        <SaveAsDropdown
+          queryName={queryName}
+          onChangeInput={this.onChangeInput}
+          modifiedHandleCreateQuery={this.handleCreateQuery}
+          disabled={disabled || deprecatingSaveAs}
+        />
+      </Tooltip>
     );
   }
 

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -617,12 +617,35 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     const {organization, eventView, savedQuery, yAxis, router, location, isHomepage} =
       this.props;
 
+    const currentDataset = getDatasetFromLocationOrSavedQueryDataset(
+      location,
+      savedQuery?.queryDataset
+    );
+
+    const deprecatingAddToDashboard =
+      currentDataset === DiscoverDatasets.TRANSACTIONS &&
+      organization.features.includes('discover-saved-queries-deprecation');
+
     const contextMenuItems: MenuItemProps[] = [];
+
+    const tracesUrl = getExploreUrl({
+      organization,
+      query: 'is_transaction:true',
+    });
 
     if (organization.features.includes('dashboards-edit')) {
       contextMenuItems.push({
         key: 'add-to-dashboard',
         label: t('Add to Dashboard'),
+        disabled: deprecatingAddToDashboard,
+        tooltip:
+          deprecatingAddToDashboard &&
+          tct(
+            'Discover\u2192Transactions is going to be merged into Explore\u2192Traces soon. Please save any transaction related queries from [traces:Explore\u2192Traces]',
+            {
+              traces: <Link to={tracesUrl} />,
+            }
+          ),
         onAction: () => {
           handleAddQueryToDashboard({
             organization,


### PR DESCRIPTION
Deprecating saving new discover queries behind the `discover-saved-queries-deprecation` feature flag. I've disabled the "Save as..." button in the discover header actions and added a tooltip directing users to explore->traces.
