### PR TITLE
ref(dashboards): Append `meta` to Issues dataset responses II

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -579,6 +579,7 @@ function WidgetViewerModal(props: Props) {
             }) as (column: GridColumnOrder, columnIndex: number) => React.ReactNode,
             renderBodyCell: renderGridBodyCell({
               location,
+              tableData: tableResults?.[0],
               theme,
               organization,
               selection,

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -32,7 +32,6 @@ import {getCustomEventsFieldRenderer} from 'sentry/views/dashboards/datasetConfi
 import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
-import {ISSUE_FIELDS} from 'sentry/views/dashboards/widgetBuilder/issueWidget/fields';
 import {TransactionLink} from 'sentry/views/discover/table/tableView';
 import {TopResultsIndicator} from 'sentry/views/discover/table/topResultsIndicator';
 import type {TableColumn} from 'sentry/views/discover/table/types';
@@ -196,8 +195,12 @@ export const renderGridBodyCell = ({
     let cell: React.ReactNode;
     switch (widget.widgetType) {
       case WidgetType.ISSUE:
+        if (!tableData || !tableData.meta) {
+          return dataRow[column.key];
+        }
+
         cell = (
-          getIssueFieldRenderer(columnKey) ?? getFieldRenderer(columnKey, ISSUE_FIELDS)
+          getIssueFieldRenderer(columnKey) ?? getFieldRenderer(columnKey, tableData.meta)
         )(dataRow, {organization, location, theme});
         break;
       case WidgetType.DISCOVER:

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -62,6 +62,27 @@ describe('transformIssuesResponseToTable', function () {
             start: '2019-10-09T11:18:59',
           }),
         ],
+        meta: {
+          fields: expect.objectContaining({
+            assignee: 'string',
+            events: 'string',
+            firstSeen: 'date',
+            isBookmarked: 'boolean',
+            isHandled: 'boolean',
+            isSubscribed: 'boolean',
+            issue: 'string',
+            lastSeen: 'date',
+            level: 'string',
+            lifetimeEvents: 'string',
+            lifetimeUsers: 'string',
+            links: 'string',
+            platform: 'string',
+            project: 'string',
+            status: 'string',
+            title: 'string',
+            users: 'string',
+          }),
+        },
       })
     );
   });

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -13,7 +13,10 @@ import type {OnDemandControlContext} from 'sentry/utils/performance/contexts/onD
 import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import {DEFAULT_TABLE_LIMIT, DisplayType} from 'sentry/views/dashboards/types';
 import {IssuesSearchBar} from 'sentry/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar';
-import {ISSUE_FIELD_TO_HEADER_MAP} from 'sentry/views/dashboards/widgetBuilder/issueWidget/fields';
+import {
+  ISSUE_FIELD_TO_HEADER_MAP,
+  ISSUE_FIELDS,
+} from 'sentry/views/dashboards/widgetBuilder/issueWidget/fields';
 import {generateIssueWidgetFieldOptions} from 'sentry/views/dashboards/widgetBuilder/issueWidget/utils';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {
@@ -166,7 +169,11 @@ export function transformIssuesResponseToTable(
       transformedTableResults.push(transformedTableResult);
     }
   );
-  return {data: transformedTableResults} as TableData;
+
+  return {
+    data: transformedTableResults,
+    meta: {fields: ISSUE_FIELDS},
+  };
 }
 
 function getTableRequest(

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.tsx
@@ -9,21 +9,20 @@ import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {Widget} from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {eventViewFromWidget} from 'sentry/views/dashboards/utils';
-import {ISSUE_FIELDS} from 'sentry/views/dashboards/widgetBuilder/issueWidget/fields';
 
 type Props = {
   loading: boolean;
   location: Location;
   selection: PageFilters;
-  transformedResults: TableDataRow[];
   widget: Widget;
   errorMessage?: string;
+  tableResults?: TableData[];
 };
 
 export function IssueWidgetCard({
@@ -31,7 +30,7 @@ export function IssueWidgetCard({
   widget,
   errorMessage,
   loading,
-  transformedResults,
+  tableResults,
   location,
 }: Props) {
   const datasetConfig = getDatasetConfig(WidgetType.ISSUE);
@@ -74,8 +73,8 @@ export function IssueWidgetCard({
       fields={queryFields}
       fieldAliases={fieldAliases}
       loading={loading}
-      metadata={ISSUE_FIELDS}
-      data={transformedResults}
+      metadata={tableResults?.[0]?.meta}
+      data={tableResults?.[0]?.data}
       getCustomFieldRenderer={getCustomFieldRenderer}
       fieldHeaderMap={datasetConfig.getFieldHeaderMap?.()}
       stickyHeaders

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -161,7 +161,7 @@ export function WidgetCardChartContainer({
                 : null}
               <LoadingScreen loading={loading} showLoadingText={showLoadingText} />
               <IssueWidgetCard
-                transformedResults={tableResults?.[0]!.data ?? []}
+                tableResults={tableResults}
                 loading={loading}
                 errorMessage={errorOrEmptyMessage}
                 widget={widget}


### PR DESCRIPTION
Retry of https://github.com/getsentry/sentry/pull/94150, there was a small mistake where the full table data for issues datasets wasn't passed to the cell renderer, so it would always fall back to returning informatted cells.
