### PR TITLE
fix(issue-views): Fix color for save button chevron when there are changes

### DIFF
--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -135,7 +135,12 @@ function SegmentedIssueViewSaveButton({
               <DropdownTrigger
                 {...props}
                 disabled={!hasFeature || isSaving}
-                icon={<IconChevron direction="down" color="subText" />}
+                icon={
+                  <IconChevron
+                    direction="down"
+                    color={buttonPriority === 'primary' ? undefined : 'subText'}
+                  />
+                }
                 aria-label={t('More save options')}
                 priority={buttonPriority}
               />


### PR DESCRIPTION
This was the issue:

![CleanShot 2025-06-24 at 09 38 30](https://github.com/user-attachments/assets/1ec10695-4b1b-47a2-ae0e-1b001c968d83)
