### PR TITLE
chore(seer): Make seer automation settings clearer

### DIFF
--- a/static/app/components/events/autofix/autofixHighlightWrapper.tsx
+++ b/static/app/components/events/autofix/autofixHighlightWrapper.tsx
@@ -5,6 +5,7 @@ import {AnimatePresence} from 'framer-motion';
 
 import AutofixHighlightPopup from 'sentry/components/events/autofix/autofixHighlightPopup';
 import {useTextSelection} from 'sentry/components/events/autofix/useTextSelection';
+import {t} from 'sentry/locale';
 
 interface AutofixHighlightWrapperProps {
   children: React.ReactNode;
@@ -54,7 +55,7 @@ export function AutofixHighlightWrapper({
         ref={containerRef}
         className={className}
         isSelected={!!selection}
-        title={selection ? undefined : 'Click to chat about this with Seer'}
+        title={selection ? undefined : t('Click to chat about this with Seer')}
       >
         {children}
       </Wrapper>

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -256,6 +256,7 @@ describe('ProjectSeer', function () {
     const initialProject: Project = {
       ...project,
       autofixAutomationTuning: 'medium', // Start from medium
+      seerScannerAutomation: true,
     };
 
     MockApiClient.addMockResponse({
@@ -344,6 +345,7 @@ describe('ProjectSeer', function () {
     const initialProject: Project = {
       ...project,
       autofixAutomationTuning: 'medium',
+      seerScannerAutomation: true,
     };
 
     MockApiClient.addMockResponse({

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -104,6 +104,7 @@ export const autofixAutomatingTuningField = {
   ],
   saveOnBlur: true,
   saveMessage: t('Automatic Seer settings updated'),
+  visible: ({model}) => model?.getValue('seerScannerAutomation') === true,
 } satisfies FieldObject;
 
 function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
@@ -165,6 +166,9 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
     saveOnBlur: true,
     saveMessage: t('Stopping point updated'),
     onChange: handleStoppingPointChange,
+    visible: ({model}) =>
+      model?.getValue('seerScannerAutomation') === true &&
+      model?.getValue('autofixAutomationTuning') !== 'off',
   } satisfies FieldObject;
 
   const seerFormGroups: JsonFormObject[] = [
@@ -195,49 +199,32 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
         onSubmitSuccess={handleSubmitSuccess}
         additionalFieldProps={{organization}}
       >
-        {({model}) => {
-          const seerScannerAutomation = model.getValue('seerScannerAutomation');
-          const autofixAutomationTuning = model.getValue('autofixAutomationTuning');
-          const showWarning =
-            seerScannerAutomation === false && autofixAutomationTuning !== 'off';
-          return (
-            <JsonForm
-              forms={seerFormGroups}
-              disabled={!canWriteProject}
-              renderHeader={() => (
-                <Fragment>
-                  <Alert type="info" system>
-                    {tct(
-                      "Choose how Seer automates analysis of incoming issues. Automated scans and fixes are charged at the [link:standard billing rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.[break][break]You can also [bulklink:configure automation for other projects].",
-                      {
-                        link: (
-                          <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />
-                        ),
-                        spendlink: (
-                          <Link
-                            to={getPricingDocsLinkForEventType(
-                              DataCategoryExact.SEER_AUTOFIX
-                            )}
-                          />
-                        ),
-                        break: <br />,
-                        bulklink: <Link to={`/settings/${organization.slug}/seer/`} />,
-                      }
-                    )}
-                  </Alert>
-                  <ProjectPermissionAlert project={project} system />
-                  {showWarning && (
-                    <Alert type="warning" system showIcon>
-                      {t(
-                        'Automatic Issue Scans must be enabled for Issue Fixes to be triggered automatically.'
-                      )}
-                    </Alert>
-                  )}
-                </Fragment>
-              )}
-            />
-          );
-        }}
+        <JsonForm
+          forms={seerFormGroups}
+          disabled={!canWriteProject}
+          renderHeader={() => (
+            <Fragment>
+              <Alert type="info" system>
+                {tct(
+                  "Choose how Seer automates analysis of incoming issues. Automated scans and fixes are charged at the [link:standard billing rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.[break][break]You can also [bulklink:configure automation for other projects].",
+                  {
+                    link: <Link to={'https://docs.sentry.io/pricing/#seer-pricing'} />,
+                    spendlink: (
+                      <Link
+                        to={getPricingDocsLinkForEventType(
+                          DataCategoryExact.SEER_AUTOFIX
+                        )}
+                      />
+                    ),
+                    break: <br />,
+                    bulklink: <Link to={`/settings/${organization.slug}/seer/`} />,
+                  }
+                )}
+              </Alert>
+              <ProjectPermissionAlert project={project} system />
+            </Fragment>
+          )}
+        />
       </Form>
     </Fragment>
   );

--- a/static/gsApp/views/seerAutomation/index.spec.tsx
+++ b/static/gsApp/views/seerAutomation/index.spec.tsx
@@ -17,6 +17,7 @@ describe('SeerAutomation', function () {
   it('can update the org default autofix automation tuning setting', async function () {
     const organization = OrganizationFixture({
       features: ['trigger-autofix-on-issue-summary'],
+      defaultSeerScannerAutomation: true,
     });
     const project = ProjectFixture();
     ProjectsStore.loadInitialData([project]);

--- a/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationDefault.tsx
@@ -32,6 +32,7 @@ export function SeerAutomationDefault() {
     ...autofixAutomatingTuningField,
     name: 'defaultAutofixAutomationTuning',
     label: <SeerSelectLabel>{t('Default for Automatic Issue Fixes')}</SeerSelectLabel>,
+    visible: ({model}) => model?.getValue('defaultSeerScannerAutomation') === true,
   } satisfies FieldObject;
 
   const seerFormGroups: JsonFormObject[] = [
@@ -52,39 +53,19 @@ export function SeerAutomationDefault() {
           organization.defaultAutofixAutomationTuning ?? 'off',
       }}
     >
-      {({model}) => {
-        const defaultSeerScannerAutomation = model.getValue(
-          'defaultSeerScannerAutomation'
-        );
-        const defaultAutofixAutomationTuning = model.getValue(
-          'defaultAutofixAutomationTuning'
-        );
-        const showWarning =
-          defaultSeerScannerAutomation === false &&
-          defaultAutofixAutomationTuning !== 'off';
-        return (
-          <JsonForm
-            forms={seerFormGroups}
-            disabled={!canWrite}
-            renderHeader={() => (
-              <React.Fragment>
-                <Alert type="info" system>
-                  {t(
-                    'Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis.'
-                  )}
-                </Alert>
-                {showWarning && (
-                  <Alert type="warning" system showIcon>
-                    {t(
-                      'Automatic Issue Scans must be enabled for Issue Fixes to be triggered automatically.'
-                    )}
-                  </Alert>
-                )}
-              </React.Fragment>
-            )}
-          />
-        );
-      }}
+      <JsonForm
+        forms={seerFormGroups}
+        disabled={!canWrite}
+        renderHeader={() => (
+          <React.Fragment>
+            <Alert type="info" system>
+              {t(
+                'Set the default automation level for newly-created projects. This setting can be overridden on a per-project basis.'
+              )}
+            </Alert>
+          </React.Fragment>
+        )}
+      />
     </Form>
   );
 }

--- a/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomationProjectList.tsx
@@ -67,7 +67,8 @@ function ProjectSeerSetting({project, orgSlug}: {orgSlug: string; project: Proje
       </span>
       {' | '}
       <span>
-        <Subheading>{t('Fixes')}:</Subheading> {getSeerLabel(autofixAutomationTuning)}
+        <Subheading>{t('Fixes')}:</Subheading>{' '}
+        {getSeerLabel(autofixAutomationTuning, seerScannerAutomation)}
       </span>
     </SeerValue>
   );
@@ -81,7 +82,11 @@ const SeerSelectLabel = styled('div')`
   margin-bottom: ${space(0.5)};
 `;
 
-function getSeerLabel(key: string) {
+function getSeerLabel(key: string, seerScannerAutomation: boolean) {
+  if (!seerScannerAutomation) {
+    return t('Off');
+  }
+
   switch (key) {
     case 'off':
       return t('Off');
@@ -220,7 +225,7 @@ export function SeerAutomationProjectList() {
 
   const actionMenuItems = SEER_THRESHOLD_MAP.map(key => ({
     key,
-    label: <SeerSelectLabel>{getSeerLabel(key)}</SeerSelectLabel>,
+    label: <SeerSelectLabel>{getSeerLabel(key, true)}</SeerSelectLabel>,
     onAction: () => updateProjectsSeerValue(key),
   }));
 


### PR DESCRIPTION
Don't show issue fix settings if scan is off, don't show stopping point settings if issue fix is off, etc.

<img width="1187" alt="Screenshot 2025-06-24 at 9 32 09 AM" src="https://github.com/user-attachments/assets/e94413e6-e7c7-44d9-b655-ff826b4efeae" />
<img width="1198" alt="Screenshot 2025-06-24 at 9 32 14 AM" src="https://github.com/user-attachments/assets/a70e6008-574b-410c-9d02-47353738c529" />
<img width="1201" alt="Screenshot 2025-06-24 at 9 32 20 AM" src="https://github.com/user-attachments/assets/286869cc-ae24-4716-b1d2-b3818b5aa1cc" />
