### PR TITLE
chore(issues): Lightly deprecate project issues endpoint

### DIFF
--- a/api-docs/paths/events/project-issues.json
+++ b/api-docs/paths/events/project-issues.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "tags": ["Events"],
-    "description": "Return a list of issues (groups) bound to a project.  All parameters are supplied as query string parameters. \n\n A default query of ``is:unresolved`` is applied. To return results with other statuses send an new query value (i.e. ``?query=`` for all results).\n\nThe ``statsPeriod`` parameter can be used to select the timeline stats which should be present. Possible values are: ``\"\"`` (disable),``\"24h\"`` (default), ``\"14d\"``\n\nUser feedback items from the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-feedback-widget) are built off the issue platform, so to return a list of user feedback items for a specific project, filter for `issue.category:feedback`.",
+    "description": "**Deprecated**: This endpoint has been replaced with the [Organization Issues endpoint](/api/events/list-an-organizations-issues/) which\nsupports filtering on project and additional functionality.\n\nReturn a list of issues (groups) bound to a project.  All parameters are supplied as query string parameters. \n\n A default query of ``is:unresolved`` is applied. To return results with other statuses send an new query value (i.e. ``?query=`` for all results).\n\nThe ``statsPeriod`` parameter can be used to select the timeline stats which should be present. Possible values are: ``\"\"`` (disable),``\"24h\"`` (default), ``\"14d\"``\n\nUser feedback items from the [User Feedback Widget](https://docs.sentry.io/product/user-feedback/#user-feedback-widget) are built off the issue platform, so to return a list of user feedback items for a specific project, filter for `issue.category:feedback`.",
     "operationId": "List a Project's Issues",
     "parameters": [
       {

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -56,6 +56,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         """
         List a Project's Issues
         ```````````````````````
+        **Deprecated**: This endpoint has been replaced with the [Organization
+        Issues](/api/events/list-an-organizations-issues/) endpoint which
+        supports filtering on project and additional functionality.
 
         Return a list of issues (groups) bound to a project.  All parameters are
         supplied as query string parameters.

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -57,7 +57,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         List a Project's Issues
         ```````````````````````
         **Deprecated**: This endpoint has been replaced with the [Organization
-        Issues](/api/events/list-an-organizations-issues/) endpoint which
+        Issues endpoint](/api/events/list-an-organizations-issues/) which
         supports filtering on project and additional functionality.
 
         Return a list of issues (groups) bound to a project.  All parameters are


### PR DESCRIPTION
This does not yet use our more heavy-handed deprecation tools given how much usage this endpoint receives. The intent here is simply to guide users to the recommended endpoint for now.