### PR TITLE
fix(taskworker) Fix units on queue latency

### DIFF
--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -150,7 +150,6 @@ class TaskNamespace:
             name=activation.taskname,
             origin="taskworker",
         ) as span:
-            # TODO(taskworker) add monitor headers
             span.set_data(SPANDATA.MESSAGING_DESTINATION_NAME, activation.namespace)
             span.set_data(SPANDATA.MESSAGING_MESSAGE_ID, activation.id)
             span.set_data(SPANDATA.MESSAGING_SYSTEM, "taskworker")

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -325,7 +325,8 @@ def child_process(
                 "taskworker-task", {"args": args, "kwargs": kwargs, "id": activation.id}
             )
             task_added_time = activation.received_at.ToDatetime().timestamp()
-            latency = time.time() - task_added_time
+            # latency attribute needs to be in milliseconds
+            latency = (time.time() - task_added_time) * 1000
 
             with sentry_sdk.start_span(
                 op=OP.QUEUE_PROCESS,


### PR DESCRIPTION
This attribute is expected to be in milliseconds, not seconds like the docs indicate.
