### PR TITLE
chore(autofix): Better tooltip on code it up

### DIFF
--- a/static/app/components/events/autofix/autofixSolution.spec.tsx
+++ b/static/app/components/events/autofix/autofixSolution.spec.tsx
@@ -44,6 +44,16 @@ describe('AutofixSolution', () => {
       repos: [],
       codebases: {},
     });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/123/',
+      method: 'GET',
+      body: {
+        project: {
+          slug: 'project-slug',
+        },
+      },
+    });
   });
 
   it('enables Code It Up button when all repos are readable', () => {

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -9,6 +9,7 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {Input} from 'sentry/components/core/input';
+import {Tooltip} from 'sentry/components/core/tooltip';
 import {AutofixHighlightWrapper} from 'sentry/components/events/autofix/autofixHighlightWrapper';
 import {SolutionEventItem} from 'sentry/components/events/autofix/autofixSolutionEventItem';
 import {
@@ -22,9 +23,10 @@ import {
   makeAutofixQueryKey,
   useAutofixRepos,
 } from 'sentry/components/events/autofix/useAutofix';
+import Link from 'sentry/components/links/link';
 import {Timeline} from 'sentry/components/timeline';
 import {IconAdd, IconChat, IconFix} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
@@ -33,6 +35,7 @@ import {setApiQueryData, useMutation, useQueryClient} from 'sentry/utils/queryCl
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
 import AutofixHighlightPopup from './autofixHighlightPopup';
 
@@ -330,6 +333,8 @@ function AutofixSolutionDisplay({
   agentCommentThread,
 }: Omit<AutofixSolutionProps, 'repos'>) {
   const organization = useOrganization();
+  const {data: group} = useGroup({groupId});
+  const project = group?.project;
 
   const {repos} = useAutofixRepos(groupId);
   const {mutate: handleContinue, isPending} = useSelectSolution({groupId, runId});
@@ -488,38 +493,49 @@ function AutofixSolutionDisplay({
                 <CopySolutionButton solution={solution} isEditing={isEditing} />
               )}
             </ButtonBar>
-            <ButtonBar merged>
-              <Button
+            <ButtonBar>
+              <Tooltip
+                isHoverable
                 title={
                   hasNoRepos
-                    ? t(
-                        'You need to set up the GitHub integration and configure repository access for Seer to write code for you.'
+                    ? tct(
+                        'Seer needs to be able to access your repos to write code for you. [link:Manage your integration and working repos here.]',
+                        {
+                          link: (
+                            <Link
+                              to={`/settings/${organization.slug}/projects/${project?.slug}/seer/`}
+                            />
+                          ),
+                        }
                       )
                     : cantReadRepos
                       ? t(
-                          "We can't access any of your repos. Check your GitHub integration and configure repository access for Seer to write code for you."
+                          "Seer can't access any of your repos. Check your GitHub integration and configure repository access for Seer to write code for you."
                         )
                       : undefined
                 }
-                size="sm"
-                priority={
-                  !solutionSelected || !valueIsEqual(solutionItems, solution, true)
-                    ? 'primary'
-                    : 'default'
-                }
-                busy={isPending}
-                disabled={hasNoRepos || cantReadRepos}
-                onClick={() => {
-                  handleContinue({
-                    mode: 'fix',
-                    solution: solutionItems,
-                  });
-                }}
-                analyticsEventName="Autofix: Code It Up"
-                analyticsEventKey="autofix.solution.code"
               >
-                {t('Code It Up')}
-              </Button>
+                <Button
+                  size="sm"
+                  priority={
+                    !solutionSelected || !valueIsEqual(solutionItems, solution, true)
+                      ? 'primary'
+                      : 'default'
+                  }
+                  busy={isPending}
+                  disabled={hasNoRepos || cantReadRepos}
+                  onClick={() => {
+                    handleContinue({
+                      mode: 'fix',
+                      solution: solutionItems,
+                    });
+                  }}
+                  analyticsEventName="Autofix: Code It Up"
+                  analyticsEventKey="autofix.solution.code"
+                >
+                  {t('Code It Up')}
+                </Button>
+              </Tooltip>
             </ButtonBar>
           </ButtonBar>
         </HeaderWrapper>

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -88,7 +88,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   // Onboarding conditions
   const needsGithubIntegration = !hasGithubIntegration;
   const needsRepoSelection =
-    hasGithubIntegration &&
     repos.length === 0 &&
     !preference?.repositories?.length &&
     !codeMappingRepos?.length &&


### PR DESCRIPTION
Show a more informative tooltip with a link to settings when we disable "Code It Up" due to not having any selected repos.

<img width="267" alt="Screenshot 2025-06-24 at 10 00 38 AM" src="https://github.com/user-attachments/assets/cc47352d-b27e-4ee5-8ea9-a1f6efa4c11d" />
