### PR TITLE
fix(nav): Fix links to settings pages without customer domain

### DIFF
--- a/static/app/views/nav/orgDropdown.spec.tsx
+++ b/static/app/views/nav/orgDropdown.spec.tsx
@@ -26,14 +26,14 @@ describe('OrgDropdown', function () {
 
     expect(
       screen.getByRole('menuitemradio', {name: 'Organization Settings'})
-    ).toHaveAttribute('href', `/organizations/${organization.slug}/settings/`);
+    ).toHaveAttribute('href', `/settings/${organization.slug}/`);
     expect(screen.getByRole('menuitemradio', {name: 'Members'})).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/settings/members/`
+      `/settings/${organization.slug}/members/`
     );
     expect(screen.getByRole('menuitemradio', {name: 'Teams'})).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/settings/teams/`
+      `/settings/${organization.slug}/teams/`
     );
   });
 

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -131,7 +131,7 @@ export function OrgDropdown({
             {
               key: 'organization-settings',
               label: t('Organization Settings'),
-              to: `/organizations/${organization.slug}/settings/`,
+              to: `/settings/${organization.slug}/`,
               hidden: !hasOrgRead || hideOrgLinks,
             },
             {
@@ -143,19 +143,19 @@ export function OrgDropdown({
             {
               key: 'members',
               label: t('Members'),
-              to: `/organizations/${organization.slug}/settings/members/`,
+              to: `/settings/${organization.slug}/members/`,
               hidden: !hasMemberRead || hideOrgLinks,
             },
             {
               key: 'teams',
               label: t('Teams'),
-              to: `/organizations/${organization.slug}/settings/teams/`,
+              to: `/settings/${organization.slug}/teams/`,
               hidden: !hasTeamRead || hideOrgLinks,
             },
             {
               key: 'billing',
               label: t('Usage & Billing'),
-              to: `/organizations/${organization.slug}/settings/billing/`,
+              to: `/settings/${organization.slug}/billing/`,
               hidden: !hasBillingAccess || hideOrgLinks,
             },
             {

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -59,13 +59,7 @@ function SettingsIndex(props: SettingsIndexProps) {
   // be the organization settings page.
   // When GAing, this page should be removed and the redirect should be moved to routes.tsx.
   if (organization && prefersStackedNav(organization)) {
-    return (
-      <Redirect
-        to={normalizeUrl(
-          `/organizations/${organization.slug}/settings/${organization.slug}/`
-        )}
-      />
-    );
+    return <Redirect to={normalizeUrl(`/settings/${organization.slug}/`)} />;
   }
 
   const myAccount = (


### PR DESCRIPTION
Fixes JAVASCRIPT-2W3P

I was using the wrong way to make links to org settings, but this should work for both non-customer domain and customer domains.