### PR TITLE
feat(search-bar): Allow filter key secondary aliases in search query builder

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -48,6 +48,7 @@ interface SearchQueryBuilderContextData {
   setDisplaySeerResults: (enabled: boolean) => void;
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement | null>;
+  filterKeysSecondaryAliases?: TagCollection;
   placeholder?: string;
   /**
    * The element to render the combobox popovers into.
@@ -92,6 +93,7 @@ export function SearchQueryBuilderProvider({
   getFilterTokenWarning,
   portalTarget,
   replaceRawSearchKeys,
+  filterKeysSecondaryAliases,
 }: SearchQueryBuilderProps & {children: React.ReactNode}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
@@ -112,6 +114,7 @@ export function SearchQueryBuilderProvider({
         disallowWildcard,
         filterKeys,
         invalidMessages,
+        filterKeysSecondaryAliases,
       }),
     [
       disallowFreeText,
@@ -122,6 +125,7 @@ export function SearchQueryBuilderProvider({
       filterKeys,
       getFilterTokenWarning,
       invalidMessages,
+      filterKeysSecondaryAliases,
     ]
   );
   const parsedQuery = useMemo(() => parseQuery(state.query), [parseQuery, state.query]);
@@ -162,12 +166,14 @@ export function SearchQueryBuilderProvider({
       displaySeerResults,
       setDisplaySeerResults,
       replaceRawSearchKeys,
+      filterKeysSecondaryAliases,
     };
   }, [
     state,
     disabled,
     disallowFreeText,
     disallowWildcard,
+    parseQuery,
     parsedQuery,
     filterKeySections,
     filterKeyMenuWidth,
@@ -182,10 +188,10 @@ export function SearchQueryBuilderProvider({
     searchSource,
     size,
     portalTarget,
-    parseQuery,
     displaySeerResults,
     setDisplaySeerResults,
     replaceRawSearchKeys,
+    filterKeysSecondaryAliases,
   ]);
 
   return (

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -48,7 +48,7 @@ interface SearchQueryBuilderContextData {
   setDisplaySeerResults: (enabled: boolean) => void;
   size: 'small' | 'normal';
   wrapperRef: React.RefObject<HTMLDivElement | null>;
-  filterKeysSecondaryAliases?: TagCollection;
+  filterKeyAliases?: TagCollection;
   placeholder?: string;
   /**
    * The element to render the combobox popovers into.
@@ -93,7 +93,7 @@ export function SearchQueryBuilderProvider({
   getFilterTokenWarning,
   portalTarget,
   replaceRawSearchKeys,
-  filterKeysSecondaryAliases,
+  filterKeyAliases,
 }: SearchQueryBuilderProps & {children: React.ReactNode}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const actionBarRef = useRef<HTMLDivElement>(null);
@@ -114,7 +114,7 @@ export function SearchQueryBuilderProvider({
         disallowWildcard,
         filterKeys,
         invalidMessages,
-        filterKeysSecondaryAliases,
+        filterKeyAliases,
       }),
     [
       disallowFreeText,
@@ -125,7 +125,7 @@ export function SearchQueryBuilderProvider({
       filterKeys,
       getFilterTokenWarning,
       invalidMessages,
-      filterKeysSecondaryAliases,
+      filterKeyAliases,
     ]
   );
   const parsedQuery = useMemo(() => parseQuery(state.query), [parseQuery, state.query]);
@@ -166,7 +166,7 @@ export function SearchQueryBuilderProvider({
       displaySeerResults,
       setDisplaySeerResults,
       replaceRawSearchKeys,
-      filterKeysSecondaryAliases,
+      filterKeyAliases,
     };
   }, [
     state,
@@ -191,7 +191,7 @@ export function SearchQueryBuilderProvider({
     displaySeerResults,
     setDisplaySeerResults,
     replaceRawSearchKeys,
-    filterKeysSecondaryAliases,
+    filterKeyAliases,
   ]);
 
   return (

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -26,6 +26,7 @@ export type FormattedQueryProps = {
   className?: string;
   fieldDefinitionGetter?: FieldDefinitionGetter;
   filterKeys?: TagCollection;
+  filterKeysSecondaryAliases?: TagCollection;
 };
 
 type TokenProps = {
@@ -99,10 +100,14 @@ export function FormattedQuery({
   query,
   fieldDefinitionGetter = getFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
+  filterKeysSecondaryAliases = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {
   const parsedQuery = useMemo(() => {
-    return parseQueryBuilderValue(query, fieldDefinitionGetter, {filterKeys});
-  }, [fieldDefinitionGetter, filterKeys, query]);
+    return parseQueryBuilderValue(query, fieldDefinitionGetter, {
+      filterKeys,
+      filterKeysSecondaryAliases,
+    });
+  }, [fieldDefinitionGetter, filterKeys, query, filterKeysSecondaryAliases]);
 
   if (!parsedQuery) {
     return <QueryWrapper className={className} />;
@@ -131,6 +136,7 @@ export function ProvidedFormattedQuery({
   query,
   fieldDefinitionGetter = getFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
+  filterKeysSecondaryAliases = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {
   return (
     <SearchQueryBuilderProvider
@@ -145,6 +151,7 @@ export function ProvidedFormattedQuery({
         query={query}
         fieldDefinitionGetter={fieldDefinitionGetter}
         filterKeys={filterKeys}
+        filterKeysSecondaryAliases={filterKeysSecondaryAliases}
       />
     </SearchQueryBuilderProvider>
   );

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -25,8 +25,8 @@ export type FormattedQueryProps = {
   query: string;
   className?: string;
   fieldDefinitionGetter?: FieldDefinitionGetter;
+  filterKeyAliases?: TagCollection;
   filterKeys?: TagCollection;
-  filterKeysSecondaryAliases?: TagCollection;
 };
 
 type TokenProps = {
@@ -100,14 +100,14 @@ export function FormattedQuery({
   query,
   fieldDefinitionGetter = getFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
-  filterKeysSecondaryAliases = EMPTY_FILTER_KEYS,
+  filterKeyAliases = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {
   const parsedQuery = useMemo(() => {
     return parseQueryBuilderValue(query, fieldDefinitionGetter, {
       filterKeys,
-      filterKeysSecondaryAliases,
+      filterKeyAliases,
     });
-  }, [fieldDefinitionGetter, filterKeys, query, filterKeysSecondaryAliases]);
+  }, [fieldDefinitionGetter, filterKeys, query, filterKeyAliases]);
 
   if (!parsedQuery) {
     return <QueryWrapper className={className} />;
@@ -136,7 +136,7 @@ export function ProvidedFormattedQuery({
   query,
   fieldDefinitionGetter = getFieldDefinition,
   filterKeys = EMPTY_FILTER_KEYS,
-  filterKeysSecondaryAliases = EMPTY_FILTER_KEYS,
+  filterKeyAliases = EMPTY_FILTER_KEYS,
 }: FormattedQueryProps) {
   return (
     <SearchQueryBuilderProvider
@@ -151,7 +151,7 @@ export function ProvidedFormattedQuery({
         query={query}
         fieldDefinitionGetter={fieldDefinitionGetter}
         filterKeys={filterKeys}
-        filterKeysSecondaryAliases={filterKeysSecondaryAliases}
+        filterKeyAliases={filterKeyAliases}
       />
     </SearchQueryBuilderProvider>
   );

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3505,6 +3505,30 @@ describe('SearchQueryBuilder', function () {
         await screen.findByText('Invalid key. "foo" is not a supported search key.')
       ).toBeInTheDocument();
     });
+
+    describe('secondary aliases provided', function () {
+      it('should not mark secondary aliases as invalid', async function () {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            disallowUnsupportedFilters
+            initialQuery="foo:bar"
+            filterKeysSecondaryAliases={{foo: {key: 'foo', name: 'foo'}}}
+          />
+        );
+
+        expect(screen.getByRole('row', {name: 'foo:bar'})).toHaveAttribute(
+          'aria-invalid',
+          'false'
+        );
+
+        await userEvent.click(getLastInput());
+        await userEvent.keyboard('{ArrowLeft}');
+        expect(
+          screen.queryByText('Invalid key. "foo" is not a supported search key.')
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('invalidMessages', function () {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3513,7 +3513,7 @@ describe('SearchQueryBuilder', function () {
             {...defaultProps}
             disallowUnsupportedFilters
             initialQuery="foo:bar"
-            filterKeysSecondaryAliases={{foo: {key: 'foo', name: 'foo'}}}
+            filterKeyAliases={{foo: {key: 'foo', name: 'foo'}}}
           />
         );
 

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -77,6 +77,12 @@ export interface SearchQueryBuilderProps {
    */
   filterKeySections?: FilterKeySection[];
   /**
+   * A mapping of secondary aliases for filter keys.
+   * These are used to ensure that the filter key does not show them as invalid, however
+   * they will not be shown in the filter key dropdown.
+   */
+  filterKeysSecondaryAliases?: TagCollection;
+  /**
    * A function that returns a warning message for a given filter key
    * will only render a warning if the value is truthy
    */
@@ -88,6 +94,7 @@ export interface SearchQueryBuilderProps {
    * known column.
    */
   getSuggestedFilterKey?: (key: string) => string | null;
+
   /**
    * Allows for customization of the invalid token messages.
    */

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -66,6 +66,12 @@ export interface SearchQueryBuilderProps {
    */
   fieldDefinitionGetter?: FieldDefinitionGetter;
   /**
+   * A mapping of secondary aliases for filter keys.
+   * These are used to ensure that the filter key does not show them as invalid, however
+   * they will not be shown in the filter key dropdown.
+   */
+  filterKeyAliases?: TagCollection;
+  /**
    * The width of the filter key menu.
    * Defaults to 360px. May be increased if there are a large number of categories
    * or long filter key names.
@@ -76,12 +82,6 @@ export interface SearchQueryBuilderProps {
    * Sections and filter keys are displayed in the order they are provided.
    */
   filterKeySections?: FilterKeySection[];
-  /**
-   * A mapping of secondary aliases for filter keys.
-   * These are used to ensure that the filter key does not show them as invalid, however
-   * they will not be shown in the filter key dropdown.
-   */
-  filterKeysSecondaryAliases?: TagCollection;
   /**
    * A function that returns a warning message for a given filter key
    * will only render a warning if the value is truthy

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -66,7 +66,7 @@ export interface SearchQueryBuilderProps {
    */
   fieldDefinitionGetter?: FieldDefinitionGetter;
   /**
-   * A mapping of secondary aliases for filter keys.
+   * A mapping of aliases for filter keys.
    * These are used to ensure that the filter key does not show them as invalid, however
    * they will not be shown in the filter key dropdown.
    */

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -32,17 +32,17 @@ function getTokensFromQuery({
   query,
   getFieldDefinition,
   filterKeys,
-  filterKeysSecondaryAliases,
+  filterKeyAliases,
 }: {
   filterKeys: TagCollection;
   getFieldDefinition: FieldDefinitionGetter;
   query: string;
-  filterKeysSecondaryAliases?: TagCollection;
+  filterKeyAliases?: TagCollection;
 }): Array<TokenResult<Token.FILTER>> {
   const parsed = parseQueryBuilderValue(
     query.slice(0, MAX_QUERY_PARSE_LENGTH),
     getFieldDefinition,
-    {filterKeys, filterKeysSecondaryAliases}
+    {filterKeys, filterKeyAliases}
   );
 
   return getFiltersFromParsedQuery(parsed);
@@ -61,13 +61,13 @@ function getFiltersFromRecentSearches(
   {
     parsedCurrentQuery,
     filterKeys,
-    filterKeysSecondaryAliases,
+    filterKeyAliases,
     getFieldDefinition,
   }: {
     filterKeys: TagCollection;
     getFieldDefinition: FieldDefinitionGetter;
     parsedCurrentQuery: ParseResult | null;
-    filterKeysSecondaryAliases?: TagCollection;
+    filterKeyAliases?: TagCollection;
   }
 ): Array<TokenResult<Token.FILTER>> {
   if (!recentSearchesData?.length) {
@@ -83,7 +83,7 @@ function getFiltersFromRecentSearches(
         query: search.query,
         getFieldDefinition,
         filterKeys,
-        filterKeysSecondaryAliases,
+        filterKeyAliases,
       })
     )
     .filter(token => {
@@ -117,7 +117,7 @@ function getFiltersFromRecentSearches(
  * Orders by highest count of filter key occurrences.
  */
 export function useRecentSearchFilters() {
-  const {parsedQuery, filterKeys, getFieldDefinition, filterKeysSecondaryAliases} =
+  const {parsedQuery, filterKeys, getFieldDefinition, filterKeyAliases} =
     useSearchQueryBuilder();
   const {data: recentSearchesData} = useRecentSearches();
 
@@ -127,15 +127,9 @@ export function useRecentSearchFilters() {
         parsedCurrentQuery: parsedQuery,
         filterKeys,
         getFieldDefinition,
-        filterKeysSecondaryAliases,
+        filterKeyAliases,
       }),
-    [
-      filterKeys,
-      getFieldDefinition,
-      parsedQuery,
-      recentSearchesData,
-      filterKeysSecondaryAliases,
-    ]
+    [filterKeys, getFieldDefinition, parsedQuery, recentSearchesData, filterKeyAliases]
   );
 
   return filters;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/useRecentSearchFilters.tsx
@@ -32,17 +32,17 @@ function getTokensFromQuery({
   query,
   getFieldDefinition,
   filterKeys,
+  filterKeysSecondaryAliases,
 }: {
   filterKeys: TagCollection;
   getFieldDefinition: FieldDefinitionGetter;
   query: string;
+  filterKeysSecondaryAliases?: TagCollection;
 }): Array<TokenResult<Token.FILTER>> {
   const parsed = parseQueryBuilderValue(
     query.slice(0, MAX_QUERY_PARSE_LENGTH),
     getFieldDefinition,
-    {
-      filterKeys,
-    }
+    {filterKeys, filterKeysSecondaryAliases}
   );
 
   return getFiltersFromParsedQuery(parsed);
@@ -61,11 +61,13 @@ function getFiltersFromRecentSearches(
   {
     parsedCurrentQuery,
     filterKeys,
+    filterKeysSecondaryAliases,
     getFieldDefinition,
   }: {
     filterKeys: TagCollection;
     getFieldDefinition: FieldDefinitionGetter;
     parsedCurrentQuery: ParseResult | null;
+    filterKeysSecondaryAliases?: TagCollection;
   }
 ): Array<TokenResult<Token.FILTER>> {
   if (!recentSearchesData?.length) {
@@ -77,7 +79,12 @@ function getFiltersFromRecentSearches(
 
   const filterCounts: FilterCounter = recentSearchesData
     .flatMap(search =>
-      getTokensFromQuery({query: search.query, getFieldDefinition, filterKeys})
+      getTokensFromQuery({
+        query: search.query,
+        getFieldDefinition,
+        filterKeys,
+        filterKeysSecondaryAliases,
+      })
     )
     .filter(token => {
       const filter = getKeyName(token.key);
@@ -110,7 +117,8 @@ function getFiltersFromRecentSearches(
  * Orders by highest count of filter key occurrences.
  */
 export function useRecentSearchFilters() {
-  const {parsedQuery, filterKeys, getFieldDefinition} = useSearchQueryBuilder();
+  const {parsedQuery, filterKeys, getFieldDefinition, filterKeysSecondaryAliases} =
+    useSearchQueryBuilder();
   const {data: recentSearchesData} = useRecentSearches();
 
   const filters = useMemo(
@@ -119,8 +127,15 @@ export function useRecentSearchFilters() {
         parsedCurrentQuery: parsedQuery,
         filterKeys,
         getFieldDefinition,
+        filterKeysSecondaryAliases,
       }),
-    [filterKeys, getFieldDefinition, parsedQuery, recentSearchesData]
+    [
+      filterKeys,
+      getFieldDefinition,
+      parsedQuery,
+      recentSearchesData,
+      filterKeysSecondaryAliases,
+    ]
   );
 
   return filters;

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -94,8 +94,12 @@ export function parseQueryBuilderValue(
       disallowParens: options?.disallowLogicalOperators,
       ...getSearchConfigFromKeys(options?.filterKeys ?? {}, getFieldDefinition),
       invalidMessages: options?.invalidMessages,
-      supportedTags: options?.filterKeys,
-      filterKeysSecondaryAliases: options?.filterKeysSecondaryAliases,
+      supportedTags: {
+        ...(options?.filterKeys ? options.filterKeys : {}),
+        ...(options?.filterKeysSecondaryAliases
+          ? options.filterKeysSecondaryAliases
+          : {}),
+      },
     })
   );
 }

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -76,6 +76,7 @@ export function parseQueryBuilderValue(
     disallowLogicalOperators?: boolean;
     disallowUnsupportedFilters?: boolean;
     disallowWildcard?: boolean;
+    filterKeysSecondaryAliases?: TagCollection;
     getFilterTokenWarning?: (key: string) => React.ReactNode;
     invalidMessages?: SearchConfig['invalidMessages'];
   }
@@ -94,6 +95,7 @@ export function parseQueryBuilderValue(
       ...getSearchConfigFromKeys(options?.filterKeys ?? {}, getFieldDefinition),
       invalidMessages: options?.invalidMessages,
       supportedTags: options?.filterKeys,
+      filterKeysSecondaryAliases: options?.filterKeysSecondaryAliases,
     })
   );
 }

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -76,7 +76,7 @@ export function parseQueryBuilderValue(
     disallowLogicalOperators?: boolean;
     disallowUnsupportedFilters?: boolean;
     disallowWildcard?: boolean;
-    filterKeysSecondaryAliases?: TagCollection;
+    filterKeyAliases?: TagCollection;
     getFilterTokenWarning?: (key: string) => React.ReactNode;
     invalidMessages?: SearchConfig['invalidMessages'];
   }
@@ -96,9 +96,7 @@ export function parseQueryBuilderValue(
       invalidMessages: options?.invalidMessages,
       supportedTags: {
         ...(options?.filterKeys ? options.filterKeys : {}),
-        ...(options?.filterKeysSecondaryAliases
-          ? options.filterKeysSecondaryAliases
-          : {}),
+        ...(options?.filterKeyAliases ? options.filterKeyAliases : {}),
       },
     })
   );

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -921,8 +921,7 @@ export class TokenConverter {
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&
-      !this.config.supportedTags[getKeyName(key)] &&
-      !this.config.filterKeysSecondaryAliases?.[getKeyName(key)]
+      !this.config.supportedTags[getKeyName(key)]
     ) {
       return {
         type: InvalidReason.INVALID_KEY,
@@ -1407,12 +1406,6 @@ export type SearchConfig = {
    * Text filter keys we allow to have operators
    */
   textOperatorKeys: Set<string>;
-  /**
-   * A collection of secondary aliases for filter keys.
-   * These are used to ensure that the filter key does not show them as invalid, however
-   * they will not be shown in the filter key dropdown.
-   */
-  filterKeysSecondaryAliases?: TagCollection;
   /**
    * When true, the parser will not parse paren groups and will return individual paren tokens
    */

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -917,7 +917,6 @@ export class TokenConverter {
   ) => {
     // Text filter is the "fall through" filter that will match when other
     // filter predicates fail.
-
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -917,10 +917,12 @@ export class TokenConverter {
   ) => {
     // Text filter is the "fall through" filter that will match when other
     // filter predicates fail.
+
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&
-      !this.config.supportedTags[getKeyName(key)]
+      !this.config.supportedTags[getKeyName(key)] &&
+      !this.config.filterKeysSecondaryAliases?.[getKeyName(key)]
     ) {
       return {
         type: InvalidReason.INVALID_KEY,
@@ -1405,6 +1407,12 @@ export type SearchConfig = {
    * Text filter keys we allow to have operators
    */
   textOperatorKeys: Set<string>;
+  /**
+   * A collection of secondary aliases for filter keys.
+   * These are used to ensure that the filter key does not show them as invalid, however
+   * they will not be shown in the filter key dropdown.
+   */
+  filterKeysSecondaryAliases?: TagCollection;
   /**
    * When true, the parser will not parse paren groups and will return individual paren tokens
    */


### PR DESCRIPTION
This PR PR updates the search query builder to accept a `filterKeysSecondaryAliases` prop that allows the overriding of invalid filter keys, without needed them to show up in the filter key dropdown.

The motivation behind this is to allow users to use previously valid filter keys that are used in saved queries without them showing as invalid.

Ticket: EXP-363

>[!note]
>There will be a follow up PR, bringing this functionality to the traces search bar