### PR TITLE
chore(member merge): placeholder email for sentry apps

### DIFF
--- a/src/sentry/sentry_apps/logic.py
+++ b/src/sentry/sentry_apps/logic.py
@@ -366,7 +366,11 @@ class SentryAppCreator:
 
     def _create_proxy_user(self, slug: str) -> User:
         # need a proxy user name that will always be unique
-        return User.objects.create(username=f"{slug}-{default_uuid()}", is_sentry_app=True)
+        username = f"{slug}-{default_uuid()}"
+        proxy_user = User.objects.create(
+            username=username, email=f"{username}@proxy-user.sentry.io", is_sentry_app=True
+        )
+        return proxy_user
 
     def _create_api_application(self, proxy: User) -> ApiApplication:
         return ApiApplication.objects.create(

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -187,7 +187,7 @@ class GroupActivityTestCase(TestCase):
                 user=proxy_user,
             )
         )
-        assert data["user"]["name"] == proxy_user.username
+        assert data["user"]["name"] == proxy_user.email
         assert data["sentry_app"]["name"] == sentry_app.name
         assert {
             "avatarType": "default",

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
@@ -11,6 +11,7 @@ from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProjec
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.users.models.user import User
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
 
@@ -141,3 +142,10 @@ class TestCreator(TestCase):
             organization_id=self.org.id,
             sentry_app="nulldb",
         )
+
+    @responses.activate
+    def test_placeholder_email(self):
+        responses.add(responses.POST, "https://example.com/webhook")
+        install = self.run_creator()
+        proxy_user = User.objects.get(id=install.sentry_app.proxy_user.id)
+        assert proxy_user.email == f"{proxy_user.username}@proxy-user.sentry.io"


### PR DESCRIPTION
Redo of #86210 with updated proxy user tests. When creating a Sentry App proxy user, we should set a placeholder email so the field is not null.