### PR TITLE
fix(search-bar): Remove Title Attribute

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKey.tsx
@@ -69,7 +69,6 @@ export function FilterKey({item, state, token, onActiveChange}: FilterKeyProps) 
           onActiveChange(true);
         }}
         disabled={disabled}
-        title="hello"
         {...filterButtonProps}
       >
         <InteractionStateLayer />


### PR DESCRIPTION
This PR removes a `title` attribute from the `KeyButton` component in the `FilterKey` component, fixing this bug:


![image (2)](https://github.com/user-attachments/assets/cd9e983b-5e0a-4f73-835d-277c55f17040)
