### PR TITLE
chore(insights): redirects /performance to /insights/frontend

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1777,7 +1777,7 @@ function buildRoutes() {
       component={make(() => import('sentry/views/performance'))}
       withOrgPath
     >
-      <IndexRedirect to="/insights/backend/" />
+      <IndexRedirect to="/insights/frontend/" />
       {transactionSummaryRoutes}
       <Route
         path="vitaldetail/"

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1777,7 +1777,7 @@ function buildRoutes() {
       component={make(() => import('sentry/views/performance'))}
       withOrgPath
     >
-      <IndexRoute component={make(() => import('sentry/views/performance/content'))} />
+      <IndexRedirect to="/insights/backend/" />
       {transactionSummaryRoutes}
       <Route
         path="vitaldetail/"


### PR DESCRIPTION
The `/performance` page is old and broken now that we are on EAP. Redirect to ` /insights/frontend`