### PR TITLE
feat(aci): serialize Detector in WorkflowGroupHistory endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -425,6 +425,7 @@ class WorkflowGroupHistory:
     count: int
     last_triggered: datetime
     event_id: str
+    detector: Detector | None
 
 
 class WorkflowFireHistoryResponse(TypedDict):
@@ -432,6 +433,7 @@ class WorkflowFireHistoryResponse(TypedDict):
     count: int
     lastTriggered: datetime
     eventId: str
+    detector: NotRequired[dict[str, Any]]
 
 
 class _Result(TypedDict):
@@ -439,13 +441,26 @@ class _Result(TypedDict):
     count: int
     last_triggered: datetime
     event_id: str
+    detector_id: int | None
 
 
 def convert_results(results: Sequence[_Result]) -> Sequence[WorkflowGroupHistory]:
     group_lookup = {g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])}
+
+    detector_ids = [r["detector_id"] for r in results if r["detector_id"] is not None]
+    detector_lookup = {}
+    if detector_ids:
+        detector_lookup = {d.id: d for d in Detector.objects.filter(id__in=detector_ids)}
+
     return [
         WorkflowGroupHistory(
-            group_lookup[r["group"]], r["count"], r["last_triggered"], r["event_id"]
+            group=group_lookup[r["group"]],
+            count=r["count"],
+            last_triggered=r["last_triggered"],
+            event_id=r["event_id"],
+            detector=(
+                detector_lookup.get(r["detector_id"]) if r["detector_id"] is not None else None
+            ),
         )
         for r in results
     ]
@@ -467,11 +482,12 @@ def fetch_workflow_groups_paginated(
     # subquery that retrieves row with the largest date in a group
     group_max_dates = filtered_history.filter(group=OuterRef("group")).order_by("-date_added")[:1]
     qs = (
-        filtered_history.select_related("group")
+        filtered_history.select_related("group", "detector")
         .values("group")
         .annotate(count=Count("group"))
         .annotate(event_id=Subquery(group_max_dates.values("event_id")))
         .annotate(last_triggered=Max("date_added"))
+        .annotate(detector_id=Subquery(group_max_dates.values("detector_id")))
     )
 
     return cast(
@@ -510,24 +526,45 @@ def fetch_workflow_hourly_stats(
 
 class WorkflowGroupHistorySerializer(Serializer):
     def get_attrs(
-        self, item_list: Sequence[WorkflowFireHistory], user: Any, **kwargs: Any
+        self, item_list: Sequence[WorkflowGroupHistory], user: Any, **kwargs: Any
     ) -> MutableMapping[Any, Any]:
         serialized_groups = {
             g["id"]: g for g in serialize([item.group for item in item_list], user)
         }
-        return {
-            history: {"group": serialized_groups[str(history.group.id)]} for history in item_list
-        }
+
+        # Get detectors that are not None
+        detectors = [item.detector for item in item_list if item.detector is not None]
+        serialized_detectors = {}
+        if detectors:
+            serialized_detectors = {
+                str(d.id): serialized
+                for d, serialized in zip(detectors, serialize(detectors, user))
+            }
+
+        attrs = {}
+        for history in item_list:
+            item_attrs = {"group": serialized_groups[str(history.group.id)]}
+            if history.detector:
+                item_attrs["detector"] = serialized_detectors[str(history.detector.id)]
+
+            attrs[history] = item_attrs
+
+        return attrs
 
     def serialize(
         self, obj: WorkflowGroupHistory, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
     ) -> WorkflowFireHistoryResponse:
-        return {
+        result: WorkflowFireHistoryResponse = {
             "group": attrs["group"],
             "count": obj.count,
             "lastTriggered": obj.last_triggered,
             "eventId": obj.event_id,
         }
+
+        if "detector" in attrs:
+            result["detector"] = attrs["detector"]
+
+        return result
 
 
 class TimeSeriesValueResponse(TypedDict):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_group_history.py
@@ -55,10 +55,14 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group, 3, self.base_triggered_date, self.history[0].event_id
+                    self.group, 3, self.base_triggered_date, self.history[0].event_id, detector=None
                 ),
                 WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                    self.group_2,
+                    1,
+                    self.base_triggered_date,
+                    self.history[-1].event_id,
+                    detector=None,
                 ),
             ],
             self.user,
@@ -76,7 +80,7 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group, 3, self.base_triggered_date, self.history[0].event_id
+                    self.group, 3, self.base_triggered_date, self.history[0].event_id, detector=None
                 )
             ],
             self.user,
@@ -94,7 +98,11 @@ class WorkflowGroupHistoryEndpointTest(APITestCase):
         assert resp.data == serialize(
             [
                 WorkflowGroupHistory(
-                    self.group_2, 1, self.base_triggered_date, self.history[-1].event_id
+                    self.group_2,
+                    1,
+                    self.base_triggered_date,
+                    self.history[-1].event_id,
+                    detector=None,
                 )
             ],
             self.user,

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -517,26 +517,60 @@ class WorkflowGroupsPaginatedTest(TestCase):
 
         self.history: list[WorkflowFireHistory] = []
         self.workflow = self.create_workflow(organization=self.organization)
+
+        self.detector_1 = self.create_detector(
+            project_id=self.project.id,
+            type=MetricIssue.slug,
+        )
         for i in range(3):
             self.history.append(
-                WorkflowFireHistory(workflow=self.workflow, group=self.group, event_id=uuid4().hex)
+                WorkflowFireHistory(
+                    detector=self.detector_1,
+                    workflow=self.workflow,
+                    group=self.group,
+                    event_id=uuid4().hex,
+                )
             )
         self.group_2 = self.create_group()
+        self.detector_2 = self.create_detector(
+            project_id=self.project.id,
+            type=MetricIssue.slug,
+        )
         self.history.append(
-            WorkflowFireHistory(workflow=self.workflow, group=self.group_2, event_id=uuid4().hex)
+            WorkflowFireHistory(
+                detector=self.detector_2,
+                workflow=self.workflow,
+                group=self.group_2,
+                event_id=uuid4().hex,
+            )
         )
         self.group_3 = self.create_group()
+        self.detector_3 = self.create_detector(
+            project_id=self.project.id,
+            type=MetricIssue.slug,
+        )
         for i in range(2):
             self.history.append(
                 WorkflowFireHistory(
+                    detector=self.detector_3,
                     workflow=self.workflow,
                     group=self.group_3,
                     event_id=uuid4().hex,
                 )
             )
+        # this will be ordered after the WFH with self.detector_1
+        self.detector_4 = self.create_detector(
+            project_id=self.project.id,
+            type=MetricIssue.slug,
+        )
         self.workflow_2 = self.create_workflow(organization=self.organization)
         self.history.append(
-            WorkflowFireHistory(workflow=self.workflow_2, group=self.group, event_id=uuid4().hex)
+            WorkflowFireHistory(
+                detector=self.detector_4,
+                workflow=self.workflow_2,
+                group=self.group,
+                event_id=uuid4().hex,
+            )
         )
 
         histories: list[WorkflowFireHistory] = WorkflowFireHistory.objects.bulk_create(self.history)
@@ -571,18 +605,21 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     count=3,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[0].event_id,
+                    detector=self.detector_1,
                 ),
                 WorkflowGroupHistory(
                     self.group_3,
                     count=2,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[4].event_id,
+                    detector=self.detector_3,
                 ),
                 WorkflowGroupHistory(
                     self.group_2,
                     count=1,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[3].event_id,
+                    detector=self.detector_2,
                 ),
             ],
         )
@@ -598,6 +635,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     count=3,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[0].event_id,
+                    detector=self.detector_1,
                 ),
             ],
             per_page=1,
@@ -613,6 +651,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     count=2,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[4].event_id,
+                    detector=self.detector_3,
                 ),
             ],
             cursor=result.next,
@@ -629,6 +668,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     count=1,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[3].event_id,
+                    detector=self.detector_2,
                 ),
             ],
             cursor=result.next,
@@ -647,18 +687,21 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     count=1,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[0].event_id,
+                    detector=self.detector_1,
                 ),
                 WorkflowGroupHistory(
                     self.group_2,
                     count=1,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[3].event_id,
+                    detector=self.detector_2,
                 ),
                 WorkflowGroupHistory(
                     self.group_3,
                     count=1,
                     last_triggered=self.base_triggered_date,
                     event_id=self.history[4].event_id,
+                    detector=self.detector_3,
                 ),
             ],
         )
@@ -674,6 +717,7 @@ class WorkflowGroupsPaginatedTest(TestCase):
                     count=1,
                     last_triggered=self.base_triggered_date - timedelta(days=2),
                     event_id=self.history[2].event_id,
+                    detector=self.detector_1,
                 ),
             ],
         )


### PR DESCRIPTION
We are tracking detectors that fire a workflow as of https://github.com/getsentry/sentry/pull/94136 in `WorkflowFireHistory.detector`. We want to return these detectors to the FE to build the chart for when a group was last fired + by what detector. Note that a detector can also be deleted but we don't delete the `WorkflowFireHistory` entry until the 90 day retention period is up.