### PR TITLE
ref(replay): Extract selected replay index stuff to hooks/helpers to clean props for PlayPauseCell

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -98,11 +98,11 @@ export default function ReplayPreviewPlayer({
       )}
       <HeaderWrapper>
         <StyledReplayCell
-          key="session"
-          replay={replayRecord as ReplayListRecord}
           eventView={eventView}
-          organization={organization}
+          key="session"
           referrer="issue-details-replay-header"
+          replay={replayRecord as ReplayListRecord}
+          rowIndex={0}
         />
         <LinkButton
           size="sm"

--- a/static/app/views/issueDetails/groupReplays/selectedReplayIndexContext.tsx
+++ b/static/app/views/issueDetails/groupReplays/selectedReplayIndexContext.tsx
@@ -1,0 +1,24 @@
+import {createContext, useContext} from 'react';
+
+import {decodeInteger} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+
+const SelectedReplayIndexContext = createContext<number>(0);
+
+export function SelectedReplayIndexProvider({children}: {children: React.ReactNode}) {
+  const {selected_replay_index: selectedReplayIndex} = useLocationQuery({
+    fields: {
+      selected_replay_index: decodeInteger,
+    },
+  });
+
+  return (
+    <SelectedReplayIndexContext.Provider value={selectedReplayIndex ?? 0}>
+      {children}
+    </SelectedReplayIndexContext.Provider>
+  );
+}
+
+export function useSelectedReplayIndex() {
+  return useContext(SelectedReplayIndexContext);
+}

--- a/static/app/views/issueDetails/groupReplays/useSelectReplayIndex.tsx
+++ b/static/app/views/issueDetails/groupReplays/useSelectReplayIndex.tsx
@@ -1,0 +1,23 @@
+import {useCallback} from 'react';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+export default function useSelectReplayIndex() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return {
+    select: useCallback(
+      (index: number) => {
+        navigate(
+          {
+            pathname: location.pathname,
+            query: {...location.query, selected_replay_index: index},
+          },
+          {replace: true, preventScrollReset: true}
+        );
+      },
+      [location, navigate]
+    ),
+  };
+}

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -87,13 +87,13 @@ export default function ExampleReplaysList({
         replays?.map(r => {
           return (
             <ReplayCell
-              key={r.id}
-              replay={r}
               eventView={eventView}
-              organization={organization}
+              isWidget
+              key={r.id}
               referrer={referrer}
               referrerTable="selector-widget"
-              isWidget
+              replay={r}
+              rowIndex={0}
             />
           );
         })

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -13,7 +13,7 @@ import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
-import useUrlParams from 'sentry/utils/useUrlParams';
+import {useSelectedReplayIndex} from 'sentry/views/issueDetails/groupReplays/selectedReplayIndexContext';
 import type {ReplayListRecordWithTx} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData';
 import HeaderCell from 'sentry/views/replays/replayTable/headerCell';
 import {
@@ -39,7 +39,7 @@ type Props = {
   visibleColumns: ReplayColumn[];
   emptyMessage?: ReactNode;
   gridRows?: string;
-  onClickPlay?: (index: number) => void;
+  onClickRow?: (index: number) => void;
   referrerLocation?: string;
   showDropdownFilters?: boolean;
 };
@@ -71,20 +71,14 @@ function ReplayTable({
   emptyMessage,
   gridRows,
   showDropdownFilters,
-  onClickPlay,
+  onClickRow,
   referrerLocation,
 }: Props) {
   const routes = useRoutes();
   const location = useLocation();
   const organization = useOrganization();
 
-  // we may have a selected replay index in the URLs
-  const urlParams = useUrlParams();
-  const rawReplayIndex = urlParams.getParamValue('selected_replay_index');
-  const selectedReplayIndex = parseInt(
-    typeof rawReplayIndex === 'string' ? rawReplayIndex : '0',
-    10
-  );
+  const selectedReplayIndex = useSelectedReplayIndex();
 
   const tableHeaders = visibleColumns
     .filter(Boolean)
@@ -129,8 +123,8 @@ function ReplayTable({
             <Row
               key={replay.id}
               isPlaying={index === selectedReplayIndex && referrerLocation !== 'replay'}
-              onClick={() => onClickPlay?.(index)}
-              showCursor={onClickPlay !== undefined}
+              onClick={() => onClickRow?.(index)}
+              showCursor={onClickRow !== undefined}
               referrerLocation={referrerLocation}
             >
               {visibleColumns.map(column => {
@@ -140,6 +134,7 @@ function ReplayTable({
                       <ActivityCell
                         key="activity"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -149,6 +144,7 @@ function ReplayTable({
                       <BrowserCell
                         key="browser"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -158,6 +154,7 @@ function ReplayTable({
                       <DeadClickCountCell
                         key="countDeadClicks"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -167,6 +164,7 @@ function ReplayTable({
                       <ErrorCountCell
                         key="countErrors"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -176,6 +174,7 @@ function ReplayTable({
                       <RageClickCountCell
                         key="countRageClicks"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -185,6 +184,7 @@ function ReplayTable({
                       <DurationCell
                         key="duration"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -194,6 +194,7 @@ function ReplayTable({
                       <OSCell
                         key="os"
                         replay={replay}
+                        rowIndex={index}
                         showDropdownFilters={showDropdownFilters}
                       />
                     );
@@ -203,6 +204,7 @@ function ReplayTable({
                       <ReplayCell
                         key="session"
                         replay={replay}
+                        rowIndex={index}
                         eventView={eventView}
                         organization={organization}
                         referrer={referrer}
@@ -211,19 +213,14 @@ function ReplayTable({
                     );
 
                   case ReplayColumn.PLAY_PAUSE:
-                    return (
-                      <PlayPauseCell
-                        key="play"
-                        isSelected={selectedReplayIndex === index}
-                        handleClick={() => onClickPlay?.(index)}
-                      />
-                    );
+                    return <PlayPauseCell key="play" replay={replay} rowIndex={index} />;
 
                   case ReplayColumn.SLOWEST_TRANSACTION:
                     return (
                       <TransactionCell
                         key="slowestTransaction"
                         replay={replay}
+                        rowIndex={index}
                         organization={organization}
                       />
                     );

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -11,7 +11,6 @@ import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {useSelectedReplayIndex} from 'sentry/views/issueDetails/groupReplays/selectedReplayIndexContext';
 import type {ReplayListRecordWithTx} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData';
@@ -76,7 +75,6 @@ function ReplayTable({
 }: Props) {
   const routes = useRoutes();
   const location = useLocation();
-  const organization = useOrganization();
 
   const selectedReplayIndex = useSelectedReplayIndex();
 
@@ -206,7 +204,6 @@ function ReplayTable({
                         replay={replay}
                         rowIndex={index}
                         eventView={eventView}
-                        organization={organization}
                         referrer={referrer}
                         referrerTable="main"
                       />
@@ -221,7 +218,6 @@ function ReplayTable({
                         key="slowestTransaction"
                         replay={replay}
                         rowIndex={index}
-                        organization={organization}
                       />
                     );
 

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -26,7 +26,6 @@ import {
 import {t, tct} from 'sentry/locale';
 import type {ValidSize} from 'sentry/styles/space';
 import {space} from 'sentry/styles/space';
-import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import {spanOperationRelativeBreakdownRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -36,6 +35,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useSelectedReplayIndex} from 'sentry/views/issueDetails/groupReplays/selectedReplayIndexContext';
 import useSelectReplayIndex from 'sentry/views/issueDetails/groupReplays/useSelectReplayIndex';
@@ -306,7 +306,6 @@ function getUserBadgeUser(replay: Props['replay']) {
 
 export function ReplayCell({
   eventView,
-  organization,
   referrer,
   replay,
   referrerTable,
@@ -314,12 +313,12 @@ export function ReplayCell({
   className,
 }: Props & {
   eventView: EventView;
-  organization: Organization;
   referrer: string;
   className?: string;
   isWidget?: boolean;
   referrerTable?: ReferrerTableType;
 }) {
+  const organization = useOrganization();
   const {projects} = useProjects();
   const project = projects.find(p => p.id === replay.project_id);
 
@@ -451,10 +450,8 @@ const SubText = styled('div')`
   gap: ${space(0.25)};
 `;
 
-export function TransactionCell({
-  organization,
-  replay,
-}: Props & {organization: Organization}) {
+export function TransactionCell({replay}: Props) {
+  const organization = useOrganization();
   const location = useLocation();
   const theme = useTheme();
 

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -37,12 +37,15 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useProjects from 'sentry/utils/useProjects';
+import {useSelectedReplayIndex} from 'sentry/views/issueDetails/groupReplays/selectedReplayIndexContext';
+import useSelectReplayIndex from 'sentry/views/issueDetails/groupReplays/useSelectReplayIndex';
 import type {ReplayListRecordWithTx} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData';
 import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
 import type {ReplayListLocationQuery, ReplayListRecord} from 'sentry/views/replays/types';
 
 type Props = {
   replay: ReplayListRecord | ReplayListRecordWithTx;
+  rowIndex: number;
   showDropdownFilters?: boolean;
 };
 
@@ -663,27 +666,24 @@ export function ActivityCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-export function PlayPauseCell({
-  isSelected,
-  handleClick,
-}: {
-  handleClick: () => void;
-  isSelected: boolean;
-}) {
-  const inner = isSelected ? (
-    <ReplayPlayPauseButton size="sm" priority="default" borderless />
-  ) : (
-    <Button
-      title={t('Play')}
-      aria-label={t('Play')}
-      icon={<IconPlay size="sm" />}
-      onClick={handleClick}
-      data-test-id="replay-table-play-button"
-      borderless
-      size="sm"
-      priority="default"
-    />
-  );
+export function PlayPauseCell({rowIndex}: Props) {
+  const selectedReplayIndex = useSelectedReplayIndex();
+  const {select: setSelectedReplayIndex} = useSelectReplayIndex();
+  const inner =
+    rowIndex === selectedReplayIndex ? (
+      <ReplayPlayPauseButton size="sm" priority="default" borderless />
+    ) : (
+      <Button
+        title={t('Play')}
+        aria-label={t('Play')}
+        icon={<IconPlay size="sm" />}
+        onClick={() => setSelectedReplayIndex(rowIndex)}
+        data-test-id="replay-table-play-button"
+        borderless
+        size="sm"
+        priority="default"
+      />
+    );
   return <Item>{inner}</Item>;
 }
 


### PR DESCRIPTION
We used to pass around the `setSelectedReplayIndex` callback, and (mostly) pass around the `selectedReplayIndex` variable.
Both of these now have helpers, so we can read the current `selectedReplayIndex` from `location` whenever we want. We can also set the location as needed, with fewer props passed around.

This has the benefit that we don't need to drill random stuff down into `<PlayPauseCell>` anymore, which will make it easier to re-use.