### PR TITLE
feat(logs): Add a wip sentry meta

### DIFF
--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -26,7 +26,7 @@ from sentry.search.eap.utils import (
     translate_to_sentry_conventions,
 )
 from sentry.snuba.referrer import Referrer
-from sentry.utils import snuba_rpc
+from sentry.utils import json, snuba_rpc
 
 
 def convert_rpc_attribute_to_json(
@@ -39,6 +39,8 @@ def convert_rpc_attribute_to_json(
     for attribute in attributes:
         internal_name = attribute["name"]
         if internal_name in PRIVATE_ATTRIBUTES.get(trace_item_type, []):
+            continue
+        if internal_name.startswith("sentry._meta"):
             continue
         source = attribute["value"]
         if len(source) == 0:
@@ -92,6 +94,24 @@ def convert_rpc_attribute_to_json(
                 )
 
     return sorted(result, key=lambda x: (x["type"], x["name"]))
+
+
+def serialize_meta(
+    attributes: list[dict],
+    trace_item_type: SupportedTraceItemType,
+) -> dict:
+    for attribute in attributes:
+        internal_name = attribute["name"]
+        if internal_name.startswith("sentry._meta"):
+            break
+
+    if not internal_name.startswith("sentry._meta") or "valStr" not in attribute["value"]:
+        return {}
+
+    try:
+        return json.loads(attribute["value"]["valStr"])
+    except json.JSONDecodeError:
+        return {}
 
 
 def serialize_item_id(item_id: str, trace_item_type: SupportedTraceItemType) -> str:
@@ -180,6 +200,7 @@ class ProjectTraceItemDetailsEndpoint(ProjectEndpoint):
             "attributes": convert_rpc_attribute_to_json(
                 resp["attributes"], item_type, use_sentry_conventions
             ),
+            "meta": serialize_meta(resp["attributes"], item_type),
         }
 
         return Response(resp_dict)

--- a/src/sentry/api/endpoints/project_trace_item_details.py
+++ b/src/sentry/api/endpoints/project_trace_item_details.py
@@ -100,6 +100,8 @@ def serialize_meta(
     attributes: list[dict],
     trace_item_type: SupportedTraceItemType,
 ) -> dict:
+    internal_name = ""
+    attribute = {}
     for attribute in attributes:
         internal_name = attribute["name"]
         if internal_name.startswith("sentry._meta"):
@@ -126,11 +128,8 @@ def serialize_meta(
                 external_name = translate_internal_to_public_alias(key, item_type, trace_item_type)
                 if external_name:
                     key = external_name
-                else:
-                    if item_type == "number":
-                        key = f"tags[{key},number]"
-                    else:
-                        key = internal_name
+                elif item_type == "number":
+                    key = f"tags[{key},number]"
             mapped_result[key] = value
         return mapped_result
     except json.JSONDecodeError:

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -212,6 +212,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                 {"name": "str_attr", "type": "str", "value": "1"},
                 {"name": "trace", "type": "str", "value": self.trace_uuid},
             ],
+            "meta": {},
             "itemId": item_id,
             "timestamp": self.one_min_ago.replace(
                 microsecond=0,
@@ -353,3 +354,99 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
             trace_details_response.data["timestamp"]
             == self.one_min_ago.replace(microsecond=0, tzinfo=None).isoformat() + "Z"
         )
+
+    def test_logs_with_a_meta_key(self):
+        logs = [
+            self.create_ourlog(
+                {
+                    "body": "[Filtered]",
+                    "trace_id": self.trace_uuid,
+                },
+                attributes={
+                    "str_attr": {
+                        "string_value": "1",
+                    },
+                    # This is a guess on how this will look, the key & storage may change at some point
+                    "sentry._meta.fields.attributes": '{"sentry.body": {"length": 300, "reason": "value too long"}}',
+                    "int_attr": {"int_value": 2},
+                    "float_attr": {
+                        "double_value": 3.0,
+                    },
+                    "bool_attr": {
+                        "bool_value": True,
+                    },
+                },
+                timestamp=self.one_min_ago,
+            ),
+        ]
+        self.store_ourlogs(logs)
+        item_list_url = reverse(
+            "sentry-api-0-organization-events",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+            },
+        )
+        with self.feature(self.features):
+            item_list_response = self.client.get(
+                item_list_url,
+                {
+                    "field": ["message", "sentry.item_id", "sentry.trace_id"],
+                    "query": "",
+                    "orderby": "sentry.item_id",
+                    "project": self.project.id,
+                    "dataset": "ourlogs",
+                },
+            )
+        assert item_list_response.data is not None
+        item_id = item_list_response.data["data"][0]["sentry.item_id"]
+
+        trace_details_response = self.do_request("logs", item_id)
+
+        assert trace_details_response.status_code == 200, trace_details_response.content
+
+        timestamp_nanos = int(self.one_min_ago.timestamp() * 1_000_000_000)
+        assert trace_details_response.data == {
+            "attributes": [
+                {"name": "bool_attr", "type": "bool", "value": True},
+                {"name": "severity_number", "type": "float", "value": 0.0},
+                {"name": "tags[bool_attr,number]", "type": "float", "value": 1.0},
+                {"name": "tags[float_attr,number]", "type": "float", "value": 3.0},
+                {"name": "tags[int_attr,number]", "type": "float", "value": 2.0},
+                {
+                    "name": "tags[sentry.timestamp_nanos,number]",
+                    "type": "float",
+                    "value": pytest.approx(float(timestamp_nanos), abs=1e12),
+                },
+                # this is stored as a float for searching, so it is not actually very precise
+                {
+                    "name": "tags[sentry.timestamp_precise,number]",
+                    "type": "float",
+                    "value": pytest.approx(float(timestamp_nanos), abs=1e12),
+                },
+                {"name": "project_id", "type": "int", "value": str(self.project.id)},
+                {"name": "severity_number", "type": "int", "value": "0"},
+                {"name": "tags[int_attr,number]", "type": "int", "value": "2"},
+                {
+                    "name": "tags[sentry.timestamp_nanos,number]",
+                    "type": "int",
+                    "value": str(timestamp_nanos),
+                },
+                # this is the precise one
+                {
+                    "name": "tags[sentry.timestamp_precise,number]",
+                    "type": "int",
+                    "value": str(timestamp_nanos),
+                },
+                {"name": "message", "type": "str", "value": "[Filtered]"},
+                {"name": "severity", "type": "str", "value": "INFO"},
+                {"name": "str_attr", "type": "str", "value": "1"},
+                {"name": "trace", "type": "str", "value": self.trace_uuid},
+            ],
+            "meta": {"sentry.body": {"length": 300, "reason": "value too long"}},
+            "itemId": item_id,
+            "timestamp": self.one_min_ago.replace(
+                microsecond=0,
+                tzinfo=None,
+            ).isoformat()
+            + "Z",
+        }

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -367,7 +367,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                         "string_value": "1",
                     },
                     # This is a guess on how this will look, the key & storage may change at some point
-                    "sentry._meta.fields.attributes": '{"sentry.body": {"length": 300, "reason": "value too long"}}',
+                    "sentry._meta.fields.attributes": '{"sentry.body": {"length": 300, "reason": "value too long"}, "float_attr": {"unit": "float"}}',
                     "int_attr": {"int_value": 2},
                     "float_attr": {
                         "double_value": 3.0,
@@ -442,7 +442,10 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase, OurLogTestCase, SpanTe
                 {"name": "str_attr", "type": "str", "value": "1"},
                 {"name": "trace", "type": "str", "value": self.trace_uuid},
             ],
-            "meta": {"sentry.body": {"length": 300, "reason": "value too long"}},
+            "meta": {
+                "message": {"length": 300, "reason": "value too long"},
+                "tags[float_attr,number]": {"unit": "float"},
+            },
             "itemId": item_id,
             "timestamp": self.one_min_ago.replace(
                 microsecond=0,


### PR DESCRIPTION
- This is some code that's just assuming how the sentry meta will look like and returning it as expected for the project trace item details
- This also will make sure we exclude the meta from the actual attributes if that's how we end up storing it