### PR TITLE
feat(replay): Allow jetpack compose warning to be dismissable

### DIFF
--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -15,6 +15,7 @@ import TextCopyInput from 'sentry/components/textCopyInput';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MIN_JETPACK_COMPOSE_VIEW_HIERARCHY_PII_FIX} from 'sentry/utils/replays/sdkVersions';
+import useOrganization from 'sentry/utils/useOrganization';
 import {semverCompare} from 'sentry/utils/versions/semverCompare';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
@@ -31,6 +32,7 @@ type Props = {
 
 function ReplayView({toggleFullscreen, isLoading}: Props) {
   const isFullscreen = useIsFullscreen();
+  const organization = useOrganization();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const {isFetching, replay} = useReplayContext();
   const isVideoReplay = replay?.isVideoReplay();
@@ -86,6 +88,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
           ) : (
             <FluidHeight>
               {isVideoReplay &&
+              organization.slug !== 'demo' &&
               replay?.getReplay()?.sdk.name === 'sentry.java.android' &&
               semverCompare(
                 replay?.getReplay()?.sdk.version || '',

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -14,14 +14,14 @@ import {ReplaySidebarToggleButton} from 'sentry/components/replays/replaySidebar
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {MIN_JETPACK_COMPOSE_VIEW_HIERARCHY_PII_FIX} from 'sentry/utils/replays/sdkVersions';
-import useOrganization from 'sentry/utils/useOrganization';
-import {semverCompare} from 'sentry/utils/versions/semverCompare';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import BrowserOSIcons from 'sentry/views/replays/detail/browserOSIcons';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
-import {JetpackComposePiiNotice} from 'sentry/views/replays/jetpackComposePiiNotice';
+import {
+  JetpackComposePiiNotice,
+  useNeedsJetpackComposePiiNotice,
+} from 'sentry/views/replays/jetpackComposePiiNotice';
 
 import {CanvasSupportNotice} from './canvasSupportNotice';
 
@@ -32,10 +32,12 @@ type Props = {
 
 function ReplayView({toggleFullscreen, isLoading}: Props) {
   const isFullscreen = useIsFullscreen();
-  const organization = useOrganization();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const {isFetching, replay} = useReplayContext();
   const isVideoReplay = replay?.isVideoReplay();
+  const needsJetpackComposePiiWarning = useNeedsJetpackComposePiiNotice({
+    replays: replay ? [replay.getReplay()] : [],
+  });
 
   return (
     <Fragment>
@@ -87,13 +89,7 @@ function ReplayView({toggleFullscreen, isLoading}: Props) {
             <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
             <FluidHeight>
-              {isVideoReplay &&
-              organization.slug !== 'demo' &&
-              replay?.getReplay()?.sdk.name === 'sentry.java.android' &&
-              semverCompare(
-                replay?.getReplay()?.sdk.version || '',
-                MIN_JETPACK_COMPOSE_VIEW_HIERARCHY_PII_FIX.minVersion
-              ) === -1 ? (
+              {isVideoReplay && needsJetpackComposePiiWarning ? (
                 <JetpackComposePiiNotice />
               ) : null}
               <CanvasSupportNotice />

--- a/static/app/views/replays/jetpackComposePiiNotice.tsx
+++ b/static/app/views/replays/jetpackComposePiiNotice.tsx
@@ -2,6 +2,7 @@ import {Alert} from 'sentry/components/core/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {tct} from 'sentry/locale';
 import {MIN_JETPACK_COMPOSE_VIEW_HIERARCHY_PII_FIX} from 'sentry/utils/replays/sdkVersions';
+import useOrganization from 'sentry/utils/useOrganization';
 import {semverCompare} from 'sentry/utils/versions/semverCompare';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
 
@@ -31,6 +32,10 @@ export function useNeedsJetpackComposePiiNotice({
 }: {
   replays: undefined | ReplayListRecord[];
 }) {
+  const organization = useOrganization();
+  if (organization.slug === 'demo') {
+    return false;
+  }
   const needsJetpackComposePiiWarning = replays?.find(replay => {
     return (
       replay?.sdk.name === 'sentry.java.android' &&

--- a/static/app/views/replays/jetpackComposePiiNotice.tsx
+++ b/static/app/views/replays/jetpackComposePiiNotice.tsx
@@ -1,15 +1,36 @@
 import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {tct} from 'sentry/locale';
+import {IconClose} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import {MIN_JETPACK_COMPOSE_VIEW_HIERARCHY_PII_FIX} from 'sentry/utils/replays/sdkVersions';
-import useOrganization from 'sentry/utils/useOrganization';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
 import {semverCompare} from 'sentry/utils/versions/semverCompare';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
 
 export function JetpackComposePiiNotice() {
+  const LOCAL_STORAGE_KEY = 'jetpack-compose-pii-warning-dismissed';
+  const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
+
+  if (isDismissed) {
+    return null;
+  }
+
   return (
     <Alert.Container>
-      <Alert type="error" showIcon>
+      <Alert
+        type="error"
+        showIcon
+        trailingItems={
+          <Button
+            aria-label={t('Dismiss')}
+            icon={<IconClose />}
+            onClick={dismiss}
+            size="zero"
+            borderless
+          />
+        }
+      >
         {tct(
           'There is a [advisory:known PII/masking issue] with [jetpack:Jetpack Compose versions 1.8 and above]. [link:Update your Sentry SDK to version 8.14.0 or later] to ensure replays are properly masked.',
           {
@@ -32,10 +53,6 @@ export function useNeedsJetpackComposePiiNotice({
 }: {
   replays: undefined | ReplayListRecord[];
 }) {
-  const organization = useOrganization();
-  if (organization.slug === 'demo') {
-    return false;
-  }
   const needsJetpackComposePiiWarning = replays?.find(replay => {
     return (
       replay?.sdk.name === 'sentry.java.android' &&

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -92,7 +92,6 @@ function ReplaysList() {
 
   const needsJetpackComposePiiWarning = useNeedsJetpackComposePiiNotice({
     replays,
-    organization,
   });
 
   return (

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -90,7 +90,10 @@ function ReplaysList() {
         ReplayColumn.ACTIVITY,
       ];
 
-  const needsJetpackComposePiiWarning = useNeedsJetpackComposePiiNotice({replays});
+  const needsJetpackComposePiiWarning = useNeedsJetpackComposePiiNotice({
+    replays,
+    organization,
+  });
 
   return (
     <Fragment>


### PR DESCRIPTION
This allows the jetpack compose alert to be dismissable since the warning notice is so broad reaching, it should allow affect a pretty small amount of our android SDK users.
