### PR TITLE
feat(replay): update logging in sentry for large input length

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -182,9 +182,9 @@ def analyze_recording_segments(
     request_data = json.dumps({"logs": get_request_data(iter_segment_data(segments), error_events)})
 
     # Log when the input string is too large. This is potential for timeout.
-    if len(request_data) > 200000:
+    if len(request_data) > 120000:
         logger.info(
-            "Replay AI summary: input length exceeds 200k.",
+            "Replay AI summary: input length exceeds 120k.",
             extra={"request_len": len(request_data)},
         )
 

--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -181,14 +181,6 @@ def analyze_recording_segments(
     # Combine breadcrumbs and error details
     request_data = json.dumps({"logs": get_request_data(iter_segment_data(segments), error_events)})
 
-    # Log when the input tokens are too large. This is potential for timeout.
-    tokens = len(request_data) / 4
-    if tokens > 100000:
-        logger.info(
-            "Replay AI summary: input tokens exceeded 100k.",
-            extra={"request_len": len(request_data), "num_tokens": len(request_data) / 4},
-        )
-
     # XXX: I have to deserialize this request so it can be "automatically" reserialized by the
     # paginate method. This is less than ideal.
     return json.loads(make_seer_request(request_data).decode("utf-8"))

--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -181,6 +181,13 @@ def analyze_recording_segments(
     # Combine breadcrumbs and error details
     request_data = json.dumps({"logs": get_request_data(iter_segment_data(segments), error_events)})
 
+    # Log when the input string is too large. This is potential for timeout.
+    if len(request_data) > 200000:
+        logger.info(
+            "Replay AI summary: input length exceeds 200k.",
+            extra={"request_len": len(request_data)},
+        )
+
     # XXX: I have to deserialize this request so it can be "automatically" reserialized by the
     # paginate method. This is less than ideal.
     return json.loads(make_seer_request(request_data).decode("utf-8"))


### PR DESCRIPTION
the way we were measuring tokens was not accurate, so let's just use the length of the input string instead.

based on langfuse traces, 60k input chars takes about 30s. we want to measure timeout around 1min.