### PR TITLE
chore(issues): Improve parameterization tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,6 +472,7 @@ module = [
     "tests.sentry.grouping.seer_similarity.test_seer_eligibility",
     "tests.sentry.grouping.test_fingerprinting",
     "tests.sentry.grouping.test_hashing",
+    "tests.sentry.grouping.test_parameterization",
     "tests.sentry.hybridcloud.*",
     "tests.sentry.incidents.serializers.*",
     "tests.sentry.integrations.msteams.webhook.*",

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -5,7 +5,7 @@ from sentry.grouping.strategies.message import REGEX_PATTERN_KEYS
 
 
 @pytest.fixture
-def parameterizer():
+def parameterizer() -> Parameterizer:
     return Parameterizer(regex_pattern_keys=REGEX_PATTERN_KEYS)
 
 
@@ -83,7 +83,9 @@ def parameterizer():
         ("Multiple - ip:port", "0.0.0.0:80", "<ip>:<int>"),
     ],
 )
-def test_parameterize_standard(name, input, expected, parameterizer):
+def test_parameterize_standard(
+    name: str, input: str, expected: str, parameterizer: Parameterizer
+) -> None:
     assert expected == parameterizer.parameterize_all(input), f"{name} failed"
     assert (
         f"prefix {expected}" == f"prefix {parameterizer.parameterize_all(input)}"
@@ -108,7 +110,9 @@ def test_parameterize_standard(name, input, expected, parameterizer):
         ),
     ],
 )
-def test_fail_parameterize(name, input, expected, parameterizer):
+def test_fail_parameterize(
+    name: str, input: str, expected: str, parameterizer: Parameterizer
+) -> None:
     assert expected == parameterizer.parameterize_all(input), f"Case {name} Failed"
 
 
@@ -120,5 +124,7 @@ def test_fail_parameterize(name, input, expected, parameterizer):
         ("Not an Int", "Encoding: utf-8", "Encoding: utf-8"),  # produces "Encoding: utf<int>"
     ],
 )
-def test_too_aggressive_parameterize(name, input, expected, parameterizer):
+def test_too_aggressive_parameterize(
+    name: str, input: str, expected: str, parameterizer: Parameterizer
+) -> None:
     assert expected == parameterizer.parameterize_all(input), f"Case {name} Failed"

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -12,154 +12,88 @@ def parameterizer():
 @pytest.mark.parametrize(
     ("name", "input", "expected"),
     [
-        ("email", """blah test@email.com had a problem""", """blah <email> had a problem"""),
-        ("url", """blah http://some.email.com had a problem""", """blah <url> had a problem"""),
-        (
-            "url - existing behavior",
-            """blah tcp://user:pass@email.com:10 had a problem""",
-            """blah tcp://user:<email>:<int> had a problem""",
-        ),
-        ("ip", """blah 0.0.0.0 had a problem""", """blah <ip> had a problem"""),
-        (
-            "UUID",
-            """blah 7c1811ed-e98f-4c9c-a9f9-58c757ff494f had a problem""",
-            """blah <uuid> had a problem""",
-        ),
-        (
-            "UUID",
-            """blah bea691f2-2e25-4bec-6838-e0c44b03d60a/7c1811ed-e98f-4c9c-a9f9-58c757ff494f had a problem""",
-            """blah <uuid>/<uuid> had a problem""",
-        ),
-        (
-            "SHA1",
-            """blah 5fc35719b9cf96ec602dbc748ff31c587a46961d had a problem""",
-            """blah <sha1> had a problem""",
-        ),
-        (
-            "MD5",
-            """blah 0751007cd28df267e8e051b51f918c60 had a problem""",
-            """blah <md5> had a problem""",
-        ),
-        (
-            "Date",
-            """blah 2024-02-20T22:16:36 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC822",
-            """blah Mon, 02 Jan 06 15:04 MST had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC822Z",
-            """blah Mon, 02 Jan 06 15:04 -0700 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC850",
-            """blah Monday, 02-Jan-06 15:04:05 MST had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC1123",
-            """blah Mon, 02 Jan 2006 15:04:05 MST had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC1123Z",
-            """blah Mon, 02 Jan 2006 15:04:05 -0700 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC3339",
-            """blah 2006-01-02T15:04:05Z07:00 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Date RFC3339Nano",
-            """blah 2006-01-02T15:04:05.999999999Z07:00 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        ("Date - plain", """blah 2006-01-02 had a problem""", """blah <date> had a problem"""),
-        ("Date - long", """blah Jan 18, 2019 had a problem""", """blah <date> had a problem"""),
-        (
-            "Date - Datetime",
-            """blah 2006-01-02 15:04:05 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        ("Date - Kitchen", """blah 3:04PM had a problem""", """blah <date> had a problem"""),
-        ("Date - Time", """blah 15:04:05 had a problem""", """blah <date> had a problem"""),
-        (
-            "Date - basic",
-            """blah Mon Jan 02, 1999 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Datetime - compressed",
-            """blah 20240220 11:55:33.546593 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        (
-            "Datetime - datestamp",
-            """blah 2024-02-23 02:13:53.418 had a problem""",
-            """blah <date> had a problem""",
-        ),
-        ("hex", """blah 0x9af8c3b had a problem""", """blah <hex> had a problem"""),
-        ("hex", """blah 9af8c3b0 had a problem""", """blah <hex> had a problem"""),
-        ("hex", """blah 9af8c3b09af8c3b0 had a problem""", """blah <hex> had a problem"""),
-        (
-            "hex - missing numbers",
-            """blah aaffccbb had a problem""",
-            """blah aaffccbb had a problem""",
-        ),
-        (
-            "hex - not 4 or 8 bytes",
-            """blah 4aaa 9aaaaaaaa 10aaaaaaaa 15aaaaaaaaaaaaa 17aaaaaaaaaaaaaaa had a problem""",
-            """blah 4aaa 9aaaaaaaa 10aaaaaaaa 15aaaaaaaaaaaaa 17aaaaaaaaaaaaaaa had a problem""",
-        ),
-        ("float", """blah 0.23 had a problem""", """blah <float> had a problem"""),
-        ("int", """blah 23 had a problem""", """blah <int> had a problem"""),
+        ("email", "test@email.com", "<email>"),
+        ("url", "http://some.email.com", "<url>"),
+        ("url - existing behavior", "tcp://user:pass@email.com:10", "tcp://user:<email>:<int>"),
+        ("hostname - tld", "example.com", "<hostname>"),
+        ("hostname - subdomain", "www.example.net", "<hostname>"),
+        ("ip", "0.0.0.0", "<ip>"),
         (
             "traceparent",
-            """traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01""",
-            """traceparent: <traceparent>""",
+            "traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "traceparent: <traceparent>",
         ),
+        ("uuid", "7c1811ed-e98f-4c9c-a9f9-58c757ff494f", "<uuid>"),
         (
-            "int - with separator",
-            """blah 0:17502 had a problem""",
-            """blah <int>:<int> had a problem""",
+            "uuid - multiple",
+            "bea691f2-2e25-4bec-6838-e0c44b03d60a/7c1811ed-e98f-4c9c-a9f9-58c757ff494f",
+            "<uuid>/<uuid>",
         ),
-        ("quoted str", """blah b="1" had a problem""", """blah b=<quoted_str> had a problem"""),
-        ("bool", """blah a=true had a problem""", """blah a=<bool> had a problem"""),
+        ("sha1", "5fc35719b9cf96ec602dbc748ff31c587a46961d", "<sha1>"),
+        ("md5", "0751007cd28df267e8e051b51f918c60", "<md5>"),
+        ("date", "2024-02-20T22:16:36", "<date>"),
+        ("date - RFC822", "Mon, 02 Jan 06 15:04 MST", "<date>"),
+        ("date - RFC822Z", "Mon, 02 Jan 06 15:04 -0700", "<date>"),
+        ("date - RFC850", "Monday, 02-Jan-06 15:04:05 MST", "<date>"),
+        ("date - RFC1123", "Mon, 02 Jan 2006 15:04:05 MST", "<date>"),
+        ("date - RFC1123Z", "Mon, 02 Jan 2006 15:04:05 -0700", "<date>"),
+        ("date - RFC3339", "2006-01-02T15:04:05Z07:00", "<date>"),
+        ("date - RFC3339 without offset", "2006-01-02T15:04:05Z", "<date>"),
+        ("date - RFC3339Nano", "2006-01-02T15:04:05.999999999Z07:00", "<date>"),
+        ("date - RFC3339Nano without offset", "2006-01-02T15:04:05.999999999Z", "<date>"),
+        ("date - plain", "2006-01-02", "<date>"),
+        ("date - long", "Jan 18, 2019", "<date>"),
+        ("date - datetime", "2006-01-02 15:04:05", "<date>"),
+        ("date - kitchen", "3:04PM", "<date>"),
+        ("date - time", "15:04:05", "<date>"),
+        ("date - basic", "Mon Jan 02, 1999", "<date>"),
+        ("date - compressed", "20240220 11:55:33.546593", "<date>"),
+        ("date - datestamp", "2024-02-23 02:13:53.418", "<date>"),
+        ("date - datetime", "datetime.datetime(2025, 6, 24, 18, 33, 0, 447640)", "<date>"),
+        ("duration - 0ms", "0ms", "<duration>"),
+        ("duration - 1ms", "1ms", "<duration>"),
+        ("duration - 10ms", "10ms", "<duration>"),
+        ("duration - 1000000ms", "1000000ms", "<duration>"),
+        ("duration - 0s", "0s", "<duration>"),
+        ("duration - 0.100s", "0.100s", "<duration>"),
+        ("duration - 1.234s", "1.234s", "<duration>"),
+        ("duration - 10s", "10s", "<duration>"),
+        ("duration - 100.0000s", "100.0000s", "<duration>"),
+        ("hex", "0x9af8c3b", "<hex>"),
+        ("hex", "9af8c3b0", "<hex>"),
+        ("hex", "9af8c3b09af8c3b0", "<hex>"),
+        ("hex - missing numbers", "aaffccbb", "aaffccbb"),
         (
-            "Duration - ms",
-            """connection failed after 1ms 23ms 4567890ms""",
-            """connection failed after <duration> <duration> <duration>""",
+            "hex - not 4 or 8 bytes",
+            "4aaa 9aaaaaaaa 10aaaaaaaa 15aaaaaaaaaaaaa 17aaaaaaaaaaaaaaa",
+            "4aaa 9aaaaaaaa 10aaaaaaaa 15aaaaaaaaaaaaa 17aaaaaaaaaaaaaaa",
         ),
-        (
-            "Duration - s",
-            """connection failed after 1.234s 56s 78.90s""",
-            """connection failed after <duration> <duration> <duration>""",
-        ),
-        (
-            "Hostname - 2 levels",
-            """Blocked 'connect' from 'gggggggdasdwefwewqqqfefwef.com'""",
-            """Blocked 'connect' from '<hostname>'""",
-        ),
-        (
-            "Hostname - 3 levels",
-            """Blocked 'font' from 'www.time.co'""",
-            """Blocked 'font' from '<hostname>'""",
-        ),
-        (
-            "Nothing to replace",
-            """A quick brown fox jumped over the lazy dog""",
-            """A quick brown fox jumped over the lazy dog""",
-        ),
+        ("float", "0.23", "<float>"),
+        ("int", "23", "<int>"),
+        ("int - separator", "0:17502", "<int>:<int>"),
+        ("int - parens", '{"msg" => "(#239323)', '{"msg" => "(#<int>)'),
+        ("quoted_str - single", "b='1'", "b=<quoted_str>"),
+        ("quoted_str - double", 'b="1"', "b=<quoted_str>"),
+        ("quoted_str - mismatch", "b='value\"", "b='value\""),
+        ("quoted_str - mismatch", "b=\"value'", "b=\"value'"),
+        ("bool", "a=false", "a=<bool>"),
+        ("bool", "a=true", "a=<bool>"),
+        ("bool - missing equal", "true", "true"),
+        ("None", "A quick brown fox", "A quick brown fox"),
+        ("Multiple - ip:port", "0.0.0.0:80", "<ip>:<int>"),
     ],
 )
 def test_parameterize_standard(name, input, expected, parameterizer):
-    assert expected == parameterizer.parameterize_all(input), f"Case {name} Failed"
+    assert expected == parameterizer.parameterize_all(input), f"{name} failed"
+    assert (
+        f"prefix {expected}" == f"prefix {parameterizer.parameterize_all(input)}"
+    ), f"{name} with prefix failed"
+    assert (
+        f"{expected} suffix" == f"{parameterizer.parameterize_all(input)} suffix"
+    ), f"{name} with suffix failed"
+    assert (
+        f"prefix {expected} suffix" == f"prefix {parameterizer.parameterize_all(input)} suffix"
+    ), f"{name} with prefix and suffix failed"
 
 
 # These are test cases that we should fix
@@ -171,12 +105,6 @@ def test_parameterize_standard(name, input, expected, parameterizer):
             "URL - non-http protocol user/pass/port",
             """blah tcp://user:pass@email.com:10 had a problem""",
             """blah <url> had a problem""",
-        ),
-        ("URL - IP w/ port", """blah 0.0.0.0:10 had a problem""", """blah <ip> had a problem"""),
-        (
-            "Int - parens",
-            """Tb.Worker {"msg" => "(#239323) Received ...""",
-            """Tb.Worker {"msg" => "(#<int>) Received ...""",
         ),
     ],
 )

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -86,16 +86,10 @@ def parameterizer() -> Parameterizer:
 def test_parameterize_standard(
     name: str, input: str, expected: str, parameterizer: Parameterizer
 ) -> None:
-    assert expected == parameterizer.parameterize_all(input), f"{name} failed"
-    assert (
-        f"prefix {expected}" == f"prefix {parameterizer.parameterize_all(input)}"
-    ), f"{name} with prefix failed"
-    assert (
-        f"{expected} suffix" == f"{parameterizer.parameterize_all(input)} suffix"
-    ), f"{name} with suffix failed"
-    assert (
-        f"prefix {expected} suffix" == f"prefix {parameterizer.parameterize_all(input)} suffix"
-    ), f"{name} with prefix and suffix failed"
+    assert expected == parameterizer.parameterize_all(input)
+    assert f"prefix {expected}" == f"prefix {parameterizer.parameterize_all(input)}"
+    assert f"{expected} suffix" == f"{parameterizer.parameterize_all(input)} suffix"
+    assert f"prefix {expected} suffix" == f"prefix {parameterizer.parameterize_all(input)} suffix"
 
 
 # These are test cases that we should fix


### PR DESCRIPTION
This moves the prefix/suffix verification into the actual test case so that the examples are a lot cleaner and also adds some additional cases. The primary motivation here is to make it easier to add new parameterization in the future.

No functionality changes and no existing tests were removed.