### PR TITLE
fix(replay): transform timestamps to be MS in log messages

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
+++ b/src/sentry/replays/endpoints/project_replay_summarize_breadcrumbs.py
@@ -217,10 +217,13 @@ def as_log_message(event: dict[str, Any]) -> str | None:
         case EventType.CONSOLE:
             return f"Logged: {event["data"]["payload"]["message"]} at {timestamp}"
         case EventType.UI_BLUR:
-            return f"User looked away from the tab at {timestamp}"
+            timestamp_ms = timestamp * 1000
+            return f"User looked away from the tab at {timestamp_ms}"
         case EventType.UI_FOCUS:
-            return f"User returned to tab at {timestamp}"
+            timestamp_ms = timestamp * 1000
+            return f"User returned to tab at {timestamp_ms}"
         case EventType.RESOURCE_FETCH:
+            timestamp_ms = timestamp * 1000
             payload = event["data"]["payload"]
             parsed_url = urlparse(payload["description"])
 
@@ -243,19 +246,21 @@ def as_log_message(event: dict[str, Any]) -> str | None:
                 return None
 
             if response_size is None:
-                return f'Application initiated request: "{method} {path} HTTP/2.0" with status code {status_code}; took {duration} milliseconds at {timestamp}'
+                return f'Application initiated request: "{method} {path} HTTP/2.0" with status code {status_code}; took {duration} milliseconds at {timestamp_ms}'
             else:
-                return f'Application initiated request: "{method} {path} HTTP/2.0" with status code {status_code} and response size {response_size}; took {duration} milliseconds at {timestamp}'
+                return f'Application initiated request: "{method} {path} HTTP/2.0" with status code {status_code} and response size {response_size}; took {duration} milliseconds at {timestamp_ms}'
         case EventType.RESOURCE_XHR:
             return None
         case EventType.LCP:
+            timestamp_ms = timestamp * 1000
             duration = event["data"]["payload"]["data"]["size"]
             rating = event["data"]["payload"]["data"]["rating"]
-            return f"Application largest contentful paint: {duration} ms and has a {rating} rating at {timestamp}"
+            return f"Application largest contentful paint: {duration} ms and has a {rating} rating at {timestamp_ms}"
         case EventType.FCP:
+            timestamp_ms = timestamp * 1000
             duration = event["data"]["payload"]["data"]["size"]
             rating = event["data"]["payload"]["data"]["rating"]
-            return f"Application first contentful paint: {duration} ms and has a {rating} rating at {timestamp}"
+            return f"Application first contentful paint: {duration} ms and has a {rating} rating at {timestamp_ms}"
         case EventType.HYDRATION_ERROR:
             return f"There was a hydration error on the page at {timestamp}"
         case EventType.MUTATIONS:


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/REPLAY-442/investigate-why-timestamps-are-still-messed-up

i checked all our log messages and their timestamp units, and here are the units currently:

in seconds:
- blur
- focus
- LCP
- resource fetch

unused but probably also seconds:
- FCP

in milliseconds (good):
- click
- navigated 
- console
- rage click
- dead click
- hydration error
- errors [converted in the endpoint]

this PR transforms the ones in seconds to be in MS instead.

       