### PR TITLE
ref(issues): Standardize fingerprint value display styling in grouping info panel

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -44,13 +44,18 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
     ]);
   }
   if ('values' in variant) {
-    data.push([t('Fingerprint values'), variant.values]);
+    data.push([
+      t('Fingerprint values'),
+      <TextWithQuestionTooltip key="fingerprint-values">
+        {variant.values?.join(', ') || ''}
+      </TextWithQuestionTooltip>,
+    ]);
   }
   if ('client_values' in variant) {
     data.push([
       t('Client fingerprint values'),
       <TextWithQuestionTooltip key="type">
-        {variant.client_values}
+        {variant.client_values?.join(', ') || ''}
         {'matched_rule' in variant && ( // Only display override tooltip if overriding actually happened
           <QuestionTooltip
             size="xs"


### PR DESCRIPTION
<!-- Describe your PR here. -->
Make "Fingerprint values" and "Client fingerprint values" visually consistent by wrapping both in TextWithQuestionTooltip component, ensuring uniform appearance across all fingerprint fields in the grouping variant table.

before
![Screenshot 2025-06-24 at 2 42 24 PM](https://github.com/user-attachments/assets/75d39c3e-3acd-4ac8-ad76-247a812e28d1)

after
![Screenshot 2025-06-24 at 3 18 58 PM](https://github.com/user-attachments/assets/9d8f54ff-2d50-4a60-843f-9935ea00720b)

after with more than 1 item in the array
![Screenshot 2025-06-24 at 3 25 05 PM](https://github.com/user-attachments/assets/8d9f8466-b5ad-421c-b6fc-d30d0bdefc9b)

https://github.com/getsentry/sentry/issues/72290
