### PR TITLE
feat(uptime): Add producer and start writing uptime result data to EAP

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -451,6 +451,8 @@ def register_temporary_features(manager: FeatureManager):
     # Enable processing uptime results via the detector handler
     manager.add("organizations:uptime-detector-handler", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:uptime-detector-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable sending uptime results to EAP (Events Analytics Platform)
+    manager.add("organizations:uptime-eap-results", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam classification at User Feedback ingest time

--- a/src/sentry/uptime/consumers/eap_producer.py
+++ b/src/sentry/uptime/consumers/eap_producer.py
@@ -1,0 +1,84 @@
+import logging
+
+from arroyo import Topic as ArroyoTopic
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from sentry_kafka_schemas.codecs import Codec
+from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
+from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
+
+from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.models.project import Project
+from sentry.uptime.consumers.eap_converter import convert_uptime_result_to_trace_items
+from sentry.uptime.models import UptimeStatus, UptimeSubscription
+from sentry.uptime.types import IncidentStatus
+from sentry.utils import metrics
+from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
+
+logger = logging.getLogger(__name__)
+
+EAP_ITEMS_CODEC: Codec[TraceItem] = get_topic_codec(Topic.SNUBA_ITEMS)
+
+
+def _get_eap_items_producer() -> KafkaProducer:
+    """Get a Kafka producer for EAP TraceItems."""
+    cluster_name = get_topic_definition(Topic.SNUBA_ITEMS)["cluster"]
+    producer_config = get_kafka_producer_cluster_options(cluster_name)
+    producer_config.pop("compression.type", None)
+    producer_config.pop("message.max.bytes", None)
+    return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+
+
+_eap_items_producer = SingletonProducer(_get_eap_items_producer)
+
+
+def produce_eap_uptime_result(
+    uptime_subscription: UptimeSubscription,
+    project: Project,
+    result: CheckResult,
+    metric_tags: dict[str, str],
+) -> None:
+    """
+    Produces TraceItems to the EAP topic for uptime check results.
+
+    Uses the converter to create TraceItems and publishes them to the
+    snuba-items topic for EAP ingestion.
+    """
+    try:
+        if uptime_subscription.uptime_status == UptimeStatus.FAILED:
+            incident_status = IncidentStatus.IN_INCIDENT
+        else:
+            incident_status = IncidentStatus.NO_INCIDENT
+
+        trace_items = convert_uptime_result_to_trace_items(project, result, incident_status)
+        topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
+
+        for trace_item in trace_items:
+            payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
+            _eap_items_producer.produce(ArroyoTopic(topic), payload)
+
+        metrics.incr(
+            "uptime.result_processor.eap_message_produced",
+            sample_rate=1.0,
+            tags={**metric_tags, "count": str(len(trace_items))},
+        )
+
+        logger.debug(
+            "Produced EAP TraceItems for uptime result",
+            extra={
+                "subscription_id": result["subscription_id"],
+                "check_status": result["status"],
+                "region": result["region"],
+                "project_id": project.id,
+                "trace_item_count": len(trace_items),
+                "incident_status": incident_status.value,
+            },
+        )
+
+    except Exception:
+        logger.exception("Failed to produce EAP TraceItems for uptime result")
+        metrics.incr(
+            "uptime.result_processor.eap_message_failed",
+            sample_rate=1.0,
+            tags=metric_tags,
+        )

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -24,6 +24,7 @@ from sentry.remote_subscriptions.consumers.result_consumer import (
     ResultProcessor,
     ResultsStrategyFactory,
 )
+from sentry.uptime.consumers.eap_producer import produce_eap_uptime_result
 from sentry.uptime.detectors.ranking import _get_cluster
 from sentry.uptime.detectors.result_handler import handle_onboarding_result
 from sentry.uptime.grouptype import UptimePacketValue
@@ -582,6 +583,9 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         # may mutate the UptimeSubscription when we determine we're in an incident
         if options.get("uptime.snuba_uptime_results.enabled"):
             produce_snuba_uptime_result(subscription, detector.project, result, metric_tags.copy())
+
+        if features.has("organizations:uptime-eap-results", detector.project.organization):
+            produce_eap_uptime_result(subscription, detector.project, result, metric_tags.copy())
 
         # Track the last update date to allow deduplication
         cluster.set(

--- a/tests/sentry/uptime/consumers/test_eap_converter.py
+++ b/tests/sentry/uptime/consumers/test_eap_converter.py
@@ -11,6 +11,7 @@ from sentry.uptime.consumers.eap_converter import (
     convert_uptime_result_to_trace_items,
     ms_to_us,
 )
+from sentry.uptime.types import IncidentStatus
 
 
 class TestHelperFunctions(TestCase):
@@ -96,7 +97,7 @@ class TestDenormalizedUptimeConverter(SentryTestCase):
 
         item_id = b"span-789"[:16].ljust(16, b"\x00")
         trace_item = convert_uptime_request_to_trace_item(
-            self.project, result, request_info, 0, item_id
+            self.project, result, request_info, 0, item_id, IncidentStatus.NO_INCIDENT
         )
 
         self._assert_trace_item_base_fields(trace_item)
@@ -132,7 +133,7 @@ class TestDenormalizedUptimeConverter(SentryTestCase):
 
         item_id = b"span-789"[:16].ljust(16, b"\x00")
         trace_item = convert_uptime_request_to_trace_item(
-            self.project, result, request_info, 0, item_id
+            self.project, result, request_info, 0, item_id, IncidentStatus.NO_INCIDENT
         )
 
         self._assert_trace_item_base_fields(trace_item)
@@ -159,7 +160,7 @@ class TestDenormalizedUptimeConverter(SentryTestCase):
 
         item_id = b"span-789"[:16].ljust(16, b"\x00")
         trace_item = convert_uptime_request_to_trace_item(
-            self.project, result, request_info, 0, item_id
+            self.project, result, request_info, 0, item_id, IncidentStatus.NO_INCIDENT
         )
 
         self._assert_trace_item_base_fields(trace_item)
@@ -186,7 +187,7 @@ class TestDenormalizedUptimeConverter(SentryTestCase):
 
         item_id = b"span-789"[:16].ljust(16, b"\x00")
         trace_item = convert_uptime_request_to_trace_item(
-            self.project, result, request_info, 0, item_id
+            self.project, result, request_info, 0, item_id, IncidentStatus.NO_INCIDENT
         )
 
         # Validate exact timestamp conversion
@@ -216,7 +217,7 @@ class TestDenormalizedUptimeConverter(SentryTestCase):
 
         item_id = b"span-789"[:16].ljust(16, b"\x00")
         trace_item = convert_uptime_request_to_trace_item(
-            self.project, result, request_info, 0, item_id
+            self.project, result, request_info, 0, item_id, IncidentStatus.NO_INCIDENT
         )
 
         attributes = trace_item.attributes
@@ -253,7 +254,12 @@ class TestDenormalizedUptimeConverter(SentryTestCase):
 
         item_id = b"span-789"[:16].ljust(16, b"\x00")
         trace_item = convert_uptime_request_to_trace_item(
-            self.project, result, result["request_info_list"][0], 0, item_id
+            self.project,
+            result,
+            result["request_info_list"][0],
+            0,
+            item_id,
+            IncidentStatus.NO_INCIDENT,
         )
 
         attributes = trace_item.attributes
@@ -300,7 +306,9 @@ class TestFullDenormalizedConversion(SentryTestCase):
             ],
         )
 
-        trace_items = convert_uptime_result_to_trace_items(self.project, result)
+        trace_items = convert_uptime_result_to_trace_items(
+            self.project, result, IncidentStatus.NO_INCIDENT
+        )
 
         assert len(trace_items) == 2
 
@@ -338,7 +346,9 @@ class TestFullDenormalizedConversion(SentryTestCase):
             },
         )
 
-        trace_items = convert_uptime_result_to_trace_items(self.project, result)
+        trace_items = convert_uptime_result_to_trace_items(
+            self.project, result, IncidentStatus.NO_INCIDENT
+        )
 
         assert len(trace_items) == 1
         trace_item = trace_items[0]
@@ -356,7 +366,9 @@ class TestFullDenormalizedConversion(SentryTestCase):
         """Test conversion when there are no requests to convert (e.g., missed_window status)."""
         result = self._create_base_result()  # Has request_info=None and no request_info_list
 
-        trace_items = convert_uptime_result_to_trace_items(self.project, result)
+        trace_items = convert_uptime_result_to_trace_items(
+            self.project, result, IncidentStatus.NO_INCIDENT
+        )
 
         # Should return empty list when there are legitimately no requests to convert
         assert len(trace_items) == 0

--- a/tests/sentry/uptime/consumers/test_eap_producer.py
+++ b/tests/sentry/uptime/consumers/test_eap_producer.py
@@ -1,0 +1,121 @@
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from sentry_kafka_schemas.schema_types.uptime_results_v1 import CheckResult
+
+from sentry.conf.types.kafka_definition import Topic, get_topic_codec
+from sentry.testutils.cases import TestCase
+from sentry.uptime.consumers.eap_converter import convert_uptime_result_to_trace_items
+from sentry.uptime.consumers.eap_producer import produce_eap_uptime_result
+from sentry.uptime.types import IncidentStatus
+
+
+class EAPProducerIntegrationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.subscription = self.create_uptime_subscription(subscription_id=str(uuid.uuid4()))
+
+    def create_check_result(self) -> CheckResult:
+        """Create a sample CheckResult for testing."""
+        base_time = datetime.now(timezone.utc)
+        result: CheckResult = {
+            "guid": str(uuid.uuid4()),
+            "subscription_id": str(self.subscription.subscription_id),
+            "status": "success",
+            "status_reason": None,
+            "trace_id": str(uuid.uuid4()),
+            "span_id": str(uuid.uuid4()),
+            "region": "us-east-1",
+            "scheduled_check_time_ms": int(base_time.timestamp() * 1000),
+            "actual_check_time_ms": int(base_time.timestamp() * 1000) + 1000,
+            "duration_ms": 150,
+            "request_info": {
+                "http_status_code": 200,
+                "request_type": "GET",
+                "url": "https://example.com",
+            },
+        }
+        return result
+
+    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.get_topic_definition")
+    def test_produce_eap_uptime_result_success(self, mock_get_topic, mock_producer):
+        mock_get_topic.return_value = {"real_topic_name": "test-eap-items"}
+        mock_producer_instance = MagicMock()
+        mock_producer.produce = mock_producer_instance
+
+        result = self.create_check_result()
+        metric_tags = {"status": "success", "region": "us-east-1"}
+
+        produce_eap_uptime_result(
+            uptime_subscription=self.subscription,
+            project=self.project,
+            result=result,
+            metric_tags=metric_tags,
+        )
+
+        mock_producer_instance.assert_called_once()
+        call_args = mock_producer_instance.call_args
+        topic, payload = call_args[0]
+
+        assert topic.name == "test-eap-items"
+        assert payload.key is None
+        assert len(payload.value) > 0
+        assert payload.headers == []
+        expected_trace_items = convert_uptime_result_to_trace_items(
+            self.project, result, IncidentStatus.NO_INCIDENT
+        )
+        codec = get_topic_codec(Topic.SNUBA_ITEMS)
+        assert [codec.decode(payload.value)] == expected_trace_items
+
+    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    @patch("sentry.uptime.consumers.eap_producer.logger")
+    def test_produce_eap_uptime_result_error_handling(self, mock_logger, mock_producer):
+        mock_producer.produce.side_effect = Exception("Kafka error")
+        result = self.create_check_result()
+        metric_tags = {"status": "success", "region": "us-east-1"}
+        produce_eap_uptime_result(
+            uptime_subscription=self.subscription,
+            project=self.project,
+            result=result,
+            metric_tags=metric_tags,
+        )
+        mock_logger.exception.assert_called_once_with(
+            "Failed to produce EAP TraceItems for uptime result"
+        )
+
+    @patch("sentry.uptime.consumers.eap_producer.metrics")
+    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    def test_metrics_tracking(self, mock_producer, mock_metrics):
+        result = self.create_check_result()
+        metric_tags = {"status": "success", "region": "us-east-1"}
+        produce_eap_uptime_result(
+            uptime_subscription=self.subscription,
+            project=self.project,
+            result=result,
+            metric_tags=metric_tags,
+        )
+        mock_metrics.incr.assert_called_with(
+            "uptime.result_processor.eap_message_produced",
+            sample_rate=1.0,
+            tags={**metric_tags, "count": "1"},
+        )
+
+    @patch("sentry.uptime.consumers.eap_producer.metrics")
+    @patch("sentry.uptime.consumers.eap_producer._eap_items_producer")
+    def test_error_metrics_tracking(self, mock_producer, mock_metrics):
+        mock_producer.produce.side_effect = Exception("Kafka error")
+        result = self.create_check_result()
+        metric_tags = {"status": "success", "region": "us-east-1"}
+        produce_eap_uptime_result(
+            uptime_subscription=self.subscription,
+            project=self.project,
+            result=result,
+            metric_tags=metric_tags,
+        )
+        mock_metrics.incr.assert_called_with(
+            "uptime.result_processor.eap_message_failed",
+            sample_rate=1.0,
+            tags=metric_tags,
+        )


### PR DESCRIPTION
This hooks up to the conversion function from https://github.com/getsentry/sentry/pull/94146, gets `TraceItems` and produces them to EAP.
