### PR TITLE
feat(ACI): Enable/disable detectors via API

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -100,6 +100,7 @@ from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry_from_user
 from sentry.utils.not_set import NOT_SET, NotSet
 from sentry.utils.snuba import is_measurement
+from sentry.workflow_engine.endpoints.validators.utils import toggle_detector
 from sentry.workflow_engine.models.detector import Detector
 
 # We can return an incident as "windowed" which returns a range of points around the start of the incident
@@ -1039,12 +1040,6 @@ def disable_alert_rule(alert_rule: AlertRule) -> None:
     update_dual_written_detector(alert_rule=alert_rule, enabled=False)
 
 
-def enable_disable_detector(detector: Detector, enabled: bool) -> None:
-    updated_detector_status = ObjectStatus.ACTIVE if enabled else ObjectStatus.DISABLED
-    detector.update(status=updated_detector_status)
-    detector.update(enabled=enabled)
-
-
 def enable_disable_subscriptions(
     query_subscriptions: BaseQuerySet[QuerySubscription], enabled: bool
 ) -> None:
@@ -1056,7 +1051,7 @@ def enable_disable_subscriptions(
 
 def update_detector(detector: Detector, enabled: bool) -> None:
     with transaction.atomic(router.db_for_write(Detector)):
-        enable_disable_detector(detector, enabled)
+        toggle_detector(detector, enabled)
 
         query_subscriptions = QuerySubscription.objects.filter(
             id__in=[data_source.source_id for data_source in detector.data_sources.all()]

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -21,6 +21,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.auth.access import SystemAccess
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, ObjectStatus
 from sentry.db.models import Model
+from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents import tasks
 from sentry.incidents.models.alert_rule import (
@@ -1045,7 +1046,7 @@ def enable_disable_detector(detector: Detector, enabled: bool) -> None:
 
 
 def enable_disable_subscriptions(
-    query_subscriptions: list[QuerySubscription], enabled: bool
+    query_subscriptions: BaseQuerySet[QuerySubscription], enabled: bool
 ) -> None:
     if enabled:
         bulk_enable_snuba_subscriptions(query_subscriptions)

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from rest_framework import serializers
 
+from sentry.incidents.logic import enable_disable_subscriptions
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.snuba_query_validator import SnubaQueryValidator
 from sentry.snuba.subscriptions import update_snuba_query
@@ -115,6 +116,15 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
 
     def update(self, instance: Detector, validated_data: dict[str, Any]):
         super().update(instance, validated_data)
+
+        # Handle enable/disable query subscriptions
+        if "enabled" in validated_data:
+            enabled = validated_data.get("enabled")
+            query_subscriptions = QuerySubscription.objects.filter(
+                id__in=[data_source.source_id for data_source in instance.data_sources.all()]
+            )
+            if query_subscriptions:
+                enable_disable_subscriptions(query_subscriptions, enabled)
 
         data_source: SnubaQueryDataSourceType = validated_data.pop("data_source")
         if data_source:

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -120,6 +120,8 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
         # Handle enable/disable query subscriptions
         if "enabled" in validated_data:
             enabled = validated_data.get("enabled")
+            assert isinstance(enabled, bool)
+
             query_subscriptions = QuerySubscription.objects.filter(
                 id__in=[data_source.source_id for data_source in instance.data_sources.all()]
             )

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -68,6 +68,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         # Handle enable/disable detector
         if "enabled" in validated_data:
             enabled = validated_data.get("enabled")
+            assert isinstance(enabled, bool)
             enable_disable_detector(instance, enabled)
 
         # Handle owner field update

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from sentry import audit_log
 from sentry.api.fields.actor import ActorField
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
-from sentry.incidents.logic import enable_disable_detector
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.utils.audit import create_audit_entry
@@ -16,7 +15,10 @@ from sentry.workflow_engine.endpoints.validators.base import (
     BaseDataConditionValidator,
     BaseDataSourceValidator,
 )
-from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detector_type_error
+from sentry.workflow_engine.endpoints.validators.utils import (
+    get_unknown_detector_type_error,
+    toggle_detector,
+)
 from sentry.workflow_engine.models import (
     DataConditionGroup,
     DataSource,
@@ -69,7 +71,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer):
         if "enabled" in validated_data:
             enabled = validated_data.get("enabled")
             assert isinstance(enabled, bool)
-            enable_disable_detector(instance, enabled)
+            toggle_detector(instance, enabled)
 
         # Handle owner field update
         if "owner" in validated_data:

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -4,8 +4,16 @@ from django.forms import ValidationError
 from jsonschema import ValidationError as JsonValidationError
 from jsonschema import validate
 
+from sentry.constants import ObjectStatus
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
+from sentry.workflow_engine.models.detector import Detector
+
+
+def toggle_detector(detector: Detector, enabled: bool) -> None:
+    updated_detector_status = ObjectStatus.ACTIVE if enabled else ObjectStatus.DISABLED
+    detector.update(status=updated_detector_status)
+    detector.update(enabled=enabled)
 
 
 def validate_json_schema(value, schema):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -330,6 +330,46 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         # Verify serialized response shows no owner
         assert response.data["owner"] is None
 
+    def test_disable_detector(self):
+        assert self.detector.enabled is True
+        assert self.detector.status == ObjectStatus.ACTIVE
+
+        data = {
+            **self.valid_data,
+            "enabled": False,
+        }
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **data,
+                status_code=200,
+            )
+
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.enabled is False
+        assert detector.status == ObjectStatus.DISABLED
+
+    def test_enable_detector(self):
+        self.detector.update(enabled=False)
+        self.detector.update(status=ObjectStatus.DISABLED)
+
+        data = {
+            **self.valid_data,
+            "enabled": True,
+        }
+        with self.tasks():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **data,
+                status_code=200,
+            )
+
+        detector = Detector.objects.get(id=response.data["id"])
+        assert detector.enabled is True
+        assert detector.status == ObjectStatus.ACTIVE
+
 
 @region_silo_test
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):


### PR DESCRIPTION
Add support for passing `enabled` via the api to toggle a detector. For metric issue detectors we also disable the query subscription. 