### PR TITLE
chore(autofix): Dynamic auto-autofix rate limit

### DIFF
--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -208,13 +208,13 @@ def is_seer_autotriggered_autofix_rate_limited(
     # while allowing big projects with reasonable settings to run more often.
     option = project.get_option("sentry:autofix_automation_tuning")
     if option == "off":
-        limit *= 16
+        limit *= 10
     elif option == "super_low":
-        limit *= 16
+        limit *= 10
     elif option == "low":
         limit *= 8
     elif option == "medium":
-        limit *= 4
+        limit *= 6
     elif option == "high":
         limit *= 2
     elif option == "always":

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -208,13 +208,13 @@ def is_seer_autotriggered_autofix_rate_limited(
     # while allowing big projects with reasonable settings to run more often.
     option = project.get_option("sentry:autofix_automation_tuning")
     if option == "off":
-        limit *= 10
+        limit *= 5
     elif option == "super_low":
-        limit *= 10
+        limit *= 5
     elif option == "low":
-        limit *= 8
+        limit *= 4
     elif option == "medium":
-        limit *= 6
+        limit *= 3
     elif option == "high":
         limit *= 2
     elif option == "always":

--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -186,6 +186,17 @@ def is_seer_scanner_rate_limited(
     return is_rate_limited, current, limit
 
 
+AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS = {
+    "off": 5,
+    "super_low": 5,
+    "low": 4,
+    "medium": 3,
+    "high": 2,
+    "always": 1,
+    None: 1,  # default if option is not set
+}
+
+
 def is_seer_autotriggered_autofix_rate_limited(
     project: Project, organization: Organization
 ) -> tuple[bool, int, int]:
@@ -207,18 +218,8 @@ def is_seer_autotriggered_autofix_rate_limited(
     # This is to protect projects with extreme settings from starting too many runs
     # while allowing big projects with reasonable settings to run more often.
     option = project.get_option("sentry:autofix_automation_tuning")
-    if option == "off":
-        limit *= 5
-    elif option == "super_low":
-        limit *= 5
-    elif option == "low":
-        limit *= 4
-    elif option == "medium":
-        limit *= 3
-    elif option == "high":
-        limit *= 2
-    elif option == "always":
-        limit *= 1
+    multiplier = AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS.get(option, 1)
+    limit *= multiplier
 
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -258,10 +258,10 @@ class TestAutomationRateLimiting(TestCase):
 
         base_limit = 20
         option_multipliers = {
-            "off": 10,
-            "super_low": 10,
-            "low": 8,
-            "medium": 6,
+            "off": 5,
+            "super_low": 5,
+            "low": 4,
+            "medium": 3,
             "high": 2,
             "always": 1,
             None: 1,  # default if option is not set

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 from django.conf import settings
 
 from sentry.autofix.utils import (
+    AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS,
     AutofixState,
     AutofixStatus,
     get_autofix_repos_from_project_code_mappings,
@@ -257,17 +258,8 @@ class TestAutomationRateLimiting(TestCase):
         mock_is_limited.return_value = (False, 0, None)
 
         base_limit = 20
-        option_multipliers = {
-            "off": 5,
-            "super_low": 5,
-            "low": 4,
-            "medium": 3,
-            "high": 2,
-            "always": 1,
-            None: 1,  # default if option is not set
-        }
 
-        for option, multiplier in option_multipliers.items():
+        for option, multiplier in AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS.items():
             with self.options({"seer.max_num_autofix_autotriggered_per_hour": base_limit}):
                 project.update_option("sentry:autofix_automation_tuning", option)
                 is_seer_autotriggered_autofix_rate_limited(project, organization)

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -258,10 +258,10 @@ class TestAutomationRateLimiting(TestCase):
 
         base_limit = 20
         option_multipliers = {
-            "off": 16,
-            "super_low": 16,
+            "off": 10,
+            "super_low": 10,
             "low": 8,
-            "medium": 4,
+            "medium": 6,
             "high": 2,
             "always": 1,
             None: 1,  # default if option is not set


### PR DESCRIPTION
Increases the rate limit for auto-triggered Autofix as your automation setting becomes more strict. The goal of this logic is to enable high usage for large orgs with reasonable settings, while protecting small orgs with extreme settings from surprise bills.