### PR TITLE
fix(migrations): Add upper bounds check in 0925

### DIFF
--- a/src/sentry/migrations/0925_backfill_open_periods.py
+++ b/src/sentry/migrations/0925_backfill_open_periods.py
@@ -70,7 +70,7 @@ def get_open_periods_for_group(
     # Since activities can apparently exist from before the start date, we want to ensure the
     # first open period starts at the first_seen date and ends at the first resolution activity after it.
     start_index = 0
-    while activities and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
+    while start_index < len(activities) and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
         start_index += 1
 
     open_periods = []

--- a/src/sentry/migrations/0925_backfill_open_periods.py
+++ b/src/sentry/migrations/0925_backfill_open_periods.py
@@ -71,7 +71,9 @@ def get_open_periods_for_group(
     # first open period starts at the first_seen date and ends at the first resolution activity after it.
     start_index = 0
     activities_len = len(activities)
-    while start_index < activities_len and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
+    while (
+        start_index < activities_len and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES
+    ):
         start_index += 1
 
     open_periods = []

--- a/src/sentry/migrations/0925_backfill_open_periods.py
+++ b/src/sentry/migrations/0925_backfill_open_periods.py
@@ -70,7 +70,8 @@ def get_open_periods_for_group(
     # Since activities can apparently exist from before the start date, we want to ensure the
     # first open period starts at the first_seen date and ends at the first resolution activity after it.
     start_index = 0
-    while start_index < len(activities) and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
+    activities_len = len(activities)
+    while start_index < activities_len and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
         start_index += 1
 
     open_periods = []


### PR DESCRIPTION
Fixes getsentry/self-hosted#3776

An upper bounds check was added to the `while` loop condition within the `get_open_periods_for_group` function in `src/sentry/migrations/0925_backfill_open_periods.py`.

*   **Before**: The loop condition was `while activities and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:`.
*   **After**: The condition was updated to `while start_index < len(activities) and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:`.

This change addresses a potential `IndexError`. Previously, if `start_index` incremented beyond the length of the `activities` list (e.g., when no activities matched `RESOLVED_ACTIVITY_TYPES`), an out-of-bounds access would occur. The added `start_index < len(activities)` check ensures the loop safely terminates before `activities[start_index]` is accessed, preventing the error and resolving related migration failures.