### PR TITLE
fix(migrations): Fix and index and data error in 0925

### DIFF
--- a/src/sentry/migrations/0925_backfill_open_periods.py
+++ b/src/sentry/migrations/0925_backfill_open_periods.py
@@ -70,7 +70,7 @@ def get_open_periods_for_group(
     # Since activities can apparently exist from before the start date, we want to ensure the
     # first open period starts at the first_seen date and ends at the first resolution activity after it.
     start_index = 0
-    while activities and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
+    while start_index < len(activities) and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:
         start_index += 1
 
     open_periods = []


### PR DESCRIPTION
Fixes getsentry/self-hosted#3751

A migration error in `src/sentry/migrations/0925_backfill_open_periods.py` was addressed to prevent an `IndexError` during upgrades.

*   The `while` loop within the `get_open_periods_for_group` function was updated on line 73.
    *   **Before**: `while activities and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:`
    *   **After**: `while start_index < len(activities) and activities[start_index].type not in RESOLVED_ACTIVITY_TYPES:`
    *   This change adds an upper bounds check, preventing `start_index` from exceeding the list length when all activities are of non-resolution types, which previously caused an `IndexError`.

*   A new test case, `"group_with_only_non_resolution_activities"`, was added to `tests/sentry/migrations/test_0925_backfill_open_periods.py`.
    *   This test specifically covers the edge case where a group contains only `SET_IGNORED` and `SET_UNRESOLVED` activities, validating the fix for the `IndexError`.

These changes resolve the `backfill_open_period` migration failure, ensuring successful upgrades from version 25.5.1 to 25.6.1.