### PR TITLE
feat(agents-insights): Add open in AI focus button

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -57,6 +57,7 @@ export function SpanDescription({
   project,
   attributes,
   avgSpanDuration,
+  hideNodeActions,
 }: {
   attributes: TraceItemResponseAttribute[];
   avgSpanDuration: number | undefined;
@@ -64,6 +65,7 @@ export function SpanDescription({
   node: TraceTreeNode<TraceTree.EAPSpan>;
   organization: Organization;
   project: Project | undefined;
+  hideNodeActions?: boolean;
 }) {
   const {data: event} = useEventDetails({
     eventId: node.event?.eventID,
@@ -212,6 +214,7 @@ export function SpanDescription({
       avgDuration={avgSpanDuration ? avgSpanDuration / 1000 : undefined}
       headerContent={value}
       bodyContent={actions}
+      hideNodeActions={hideNodeActions}
       highlightedAttributes={getHighlightedSpanAttributes({
         organization,
         attributes,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -274,6 +274,7 @@ export function SpanNodeDetails(
                     project={project}
                     organization={organization}
                     location={location}
+                    hideNodeActions={props.hideNodeActions}
                   />
                   <AIInputSection node={node} />
                   <AIOutputSection node={node} />
@@ -454,6 +455,7 @@ function EAPSpanNodeDetails({
                       location={location}
                       attributes={attributes}
                       avgSpanDuration={avgSpanDuration}
+                      hideNodeActions={hideNodeActions}
                     />
                     <AIInputSection node={node} attributes={attributes} />
                     <AIOutputSection node={node} attributes={attributes} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -53,11 +53,13 @@ export function SpanDescription({
   organization,
   location,
   project,
+  hideNodeActions,
 }: {
   location: Location;
   node: TraceTreeNode<TraceTree.Span>;
   organization: Organization;
   project: Project | undefined;
+  hideNodeActions?: boolean;
 }) {
   const {data: event} = useEventDetails({
     eventId: node.event?.eventID,
@@ -219,6 +221,7 @@ export function SpanDescription({
       avgDuration={averageSpanDuration ? averageSpanDuration / 1000 : undefined}
       headerContent={value}
       bodyContent={actions}
+      hideNodeActions={hideNodeActions}
       highlightedAttributes={getHighlightedSpanAttributes({
         organization,
         attributes: span.data,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -75,6 +75,7 @@ import {
   useTraceStateDispatch,
 } from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 import {traceGridCssVariables} from 'sentry/views/performance/newTraceDetails/traceWaterfallStyles';
+import {TraceLayoutTabKeys} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
 
 import type {KeyValueActionParams, TraceDrawerActionKind} from './utils';
 import {getTraceKeyValueActions, TraceDrawerActionValueKind} from './utils';
@@ -413,6 +414,7 @@ type HighlightProps = {
   node: TraceTreeNode<TraceTree.NodeValue>;
   project: Project | undefined;
   transaction: EventTransaction | undefined;
+  hideNodeActions?: boolean;
   highlightedAttributes?: Array<{name: string; value: React.ReactNode}>;
 };
 
@@ -424,7 +426,9 @@ function Highlights({
   headerContent,
   bodyContent,
   highlightedAttributes,
+  hideNodeActions,
 }: HighlightProps) {
+  const location = useLocation();
   const dispatch = useTraceStateDispatch();
   const organization = useOrganization();
 
@@ -491,7 +495,22 @@ function Highlights({
               ))}
             </HighlightedAttributesWrapper>
           ) : null}
-          {isAiNode && hasAgentInsightsFeature(organization) ? null : (
+          {isAiNode && hasAgentInsightsFeature(organization) ? (
+            hideNodeActions ? null : (
+              <OpenInAIFocusButton
+                size="xs"
+                to={{
+                  ...location,
+                  query: {
+                    ...location.query,
+                    tab: TraceLayoutTabKeys.AI_SPANS,
+                  },
+                }}
+              >
+                {t('Open in AI Focus')}
+              </OpenInAIFocusButton>
+            )
+          ) : (
             <Fragment>
               <StyledPanel>
                 <StyledPanelHeader>{headerContent}</StyledPanelHeader>
@@ -688,6 +707,10 @@ const HighlightedAttributesWrapper = styled('div')`
 
 const HighlightedAttributeName = styled('div')`
   color: ${p => p.theme.subText};
+`;
+
+const OpenInAIFocusButton = styled(LinkButton)`
+  width: max-content;
 `;
 
 const StyledPanelHeader = styled(PanelHeader)`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -507,7 +507,7 @@ function Highlights({
                   },
                 }}
               >
-                {t('Open in AI Focus')}
+                {t('Open in AI View')}
               </OpenInAIFocusButton>
             )
           ) : (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -164,6 +164,7 @@ export function TransactionNodeDetails({
           node={node}
           project={project}
           organization={organization}
+          hideNodeActions={hideNodeActions}
         />
 
         <AIInputSection node={node} event={event} />

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/highlights.tsx
@@ -25,6 +25,7 @@ type HighlightProps = {
   node: TraceTreeNode<TraceTree.Transaction>;
   organization: Organization;
   project: Project | undefined;
+  hideNodeActions?: boolean;
 };
 
 export function TransactionHighlights(props: HighlightProps) {
@@ -86,6 +87,7 @@ export function TransactionHighlights(props: HighlightProps) {
       avgDuration={avgDurationInSeconds}
       headerContent={headerContent}
       bodyContent={bodyContent}
+      hideNodeActions={props.hideNodeActions}
       highlightedAttributes={getHighlightedSpanAttributes({
         organization: props.organization,
         attributes: props.event.contexts.trace?.data,


### PR DESCRIPTION
Add `Open in AI Focus` button in span details of AI spans inside trace waterfall.
On click the tab switches to `AI Spans` with the respective span selected.
<img width="347" alt="Screenshot 2025-06-25 at 09 55 37" src="https://github.com/user-attachments/assets/a0e94092-e9a5-4139-a13c-3c72d4251167" />

Fixed loading of attributes in ai span list.

- closes [TET-680: Trace view: Add button to open in ai spans](https://linear.app/getsentry/issue/TET-680/trace-view-add-button-to-open-in-ai-spans)
- closes [TET-713: validate that tool name, model and tokens are visible in AI Spans trace list](https://linear.app/getsentry/issue/TET-713/validate-that-tool-name-model-and-tokens-are-visible-in-ai-spans-trace)