### PR TITLE
chore(demo-mode): remove option `lookback_days`

### DIFF
--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -44,7 +44,7 @@ def sync_debug_artifacts():
 
     target_org = get_demo_org()
 
-    lookback_days = options.get("sentry.demo_mode.sync_debug_artifacts.lookback_days")
+    lookback_days = 3
     cutoff_date = timezone.now() - timedelta(days=lookback_days)
 
     _sync_artifact_bundles(source_org, target_org, cutoff_date)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3192,11 +3192,6 @@ register(
     type=Int,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "sentry.demo_mode.sync_debug_artifacts.lookback_days",
-    default=3,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # Taskbroker flags
 register(


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-616/discuss-lookback-days-option-for-sandbox-sync