### PR TITLE
ref(process-spans): Fetch killswitch config only once

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -232,10 +232,10 @@ ALL_KILLSWITCH_OPTIONS = {
 
 
 def validate_user_input(killswitch_name: str, option_value: Any) -> KillswitchConfig:
-    return normalize_value(killswitch_name, option_value, strict=True)
+    return normalize_config(killswitch_name, option_value, strict=True)
 
 
-def normalize_value(
+def normalize_config(
     killswitch_name: str, option_value: Any, strict: bool = False
 ) -> KillswitchConfig:
     rv: KillswitchConfig = []
@@ -261,28 +261,25 @@ def normalize_value(
     return rv
 
 
-def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=True) -> bool:
+def get_killswitch_value(killswitch_name: str) -> KillswitchConfig:
     assert killswitch_name in ALL_KILLSWITCH_OPTIONS
+    raw_option_value = options.get(killswitch_name)
+    return normalize_config(killswitch_name, raw_option_value)
+
+
+def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=True) -> bool:
+    option_value = get_killswitch_value(killswitch_name)
     assert set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields) == set(context)
-    option_value = options.get(killswitch_name)
-    rv = _value_matches(killswitch_name, option_value, context)
-
-    if emit_metrics:
-        # metrics can have a meaningful performance impact, so allow caller to opt out
-        # TODO: re-evaluate after we make metric collection aysnc.
-        metrics.incr(
-            "killswitches.run",
-            tags={"killswitch_name": killswitch_name, "decision": "matched" if rv else "passed"},
-        )
-
-    return rv
+    return value_matches(killswitch_name, option_value, context, emit_metrics)
 
 
-def _value_matches(
-    killswitch_name: str, raw_option_value: LegacyKillswitchConfig, context: Context
+def value_matches(
+    killswitch_name: str,
+    option_value: KillswitchConfig,
+    context: Context,
+    emit_metrics=True,
 ) -> bool:
-    option_value = normalize_value(killswitch_name, raw_option_value)
-
+    decision = False
     for condition in option_value:
         for field, matching_value in condition.items():
             if matching_value is None:
@@ -295,13 +292,25 @@ def _value_matches(
             if str(value) != matching_value:
                 break
         else:
-            return True
+            decision = True
+            break
 
-    return False
+    if emit_metrics:
+        # metrics can have a meaningful performance impact, so allow caller to opt out
+        # TODO: re-evaluate after we make metric collection aysnc.
+        metrics.incr(
+            "killswitches.run",
+            tags={
+                "killswitch_name": killswitch_name,
+                "decision": "matched" if decision else "passed",
+            },
+        )
+
+    return decision
 
 
 def print_conditions(killswitch_name: str, raw_option_value: LegacyKillswitchConfig) -> str:
-    option_value = normalize_value(killswitch_name, raw_option_value)
+    option_value = normalize_config(killswitch_name, raw_option_value)
     if not option_value:
         return "<disabled entirely>"
 

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -232,10 +232,10 @@ ALL_KILLSWITCH_OPTIONS = {
 
 
 def validate_user_input(killswitch_name: str, option_value: Any) -> KillswitchConfig:
-    return normalize_config(killswitch_name, option_value, strict=True)
+    return normalize_value(killswitch_name, option_value, strict=True)
 
 
-def normalize_config(
+def normalize_value(
     killswitch_name: str, option_value: Any, strict: bool = False
 ) -> KillswitchConfig:
     rv: KillswitchConfig = []
@@ -264,7 +264,7 @@ def normalize_config(
 def get_killswitch_value(killswitch_name: str) -> KillswitchConfig:
     assert killswitch_name in ALL_KILLSWITCH_OPTIONS
     raw_option_value = options.get(killswitch_name)
-    return normalize_config(killswitch_name, raw_option_value)
+    return normalize_value(killswitch_name, raw_option_value)
 
 
 def killswitch_matches_context(killswitch_name: str, context: Context, emit_metrics=True) -> bool:
@@ -310,7 +310,7 @@ def value_matches(
 
 
 def print_conditions(killswitch_name: str, raw_option_value: LegacyKillswitchConfig) -> str:
-    option_value = normalize_config(killswitch_name, raw_option_value)
+    option_value = normalize_value(killswitch_name, raw_option_value)
     if not option_value:
         return "<disabled entirely>"
 

--- a/tests/sentry/test_killswitches.py
+++ b/tests/sentry/test_killswitches.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import pytest
 
-from sentry.killswitches import normalize_config, value_matches
+from sentry.killswitches import normalize_value, value_matches
 
 
-def test_normalize_config():
-    assert normalize_config("store.load-shed-group-creation-projects", [1, 2, 3]) == [
+def test_normalize_value():
+    assert normalize_value("store.load-shed-group-creation-projects", [1, 2, 3]) == [
         {"project_id": "1", "platform": None},
         {"project_id": "2", "platform": None},
         {"project_id": "3", "platform": None},
     ]
 
-    assert normalize_config("store.load-shed-group-creation-projects", [{"project_id": 123}]) == [
+    assert normalize_value("store.load-shed-group-creation-projects", [{"project_id": 123}]) == [
         {"project_id": "123", "platform": None},  # match any platform
     ]
 
@@ -63,7 +63,7 @@ def test_normalize_config():
     ),
 )
 def test_value_matches_positive(cfg, value):
-    cfg = normalize_config("store.load-shed-group-creation-projects", cfg)
+    cfg = normalize_value("store.load-shed-group-creation-projects", cfg)
     assert value_matches("store.load-shed-group-creation-projects", cfg, value)
 
 
@@ -97,5 +97,5 @@ def test_value_matches_positive(cfg, value):
     ),
 )
 def test_value_matches_negative(cfg, value):
-    cfg = normalize_config("store.load-shed-group-creation-projects", cfg)
+    cfg = normalize_value("store.load-shed-group-creation-projects", cfg)
     assert not value_matches("store.load-shed-group-creation-projects", cfg, value)

--- a/tests/sentry/test_killswitches.py
+++ b/tests/sentry/test_killswitches.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import pytest
 
-from sentry.killswitches import _value_matches, normalize_value
+from sentry.killswitches import normalize_config, value_matches
 
 
-def test_normalize_value():
-    assert normalize_value("store.load-shed-group-creation-projects", [1, 2, 3]) == [
+def test_normalize_config():
+    assert normalize_config("store.load-shed-group-creation-projects", [1, 2, 3]) == [
         {"project_id": "1", "platform": None},
         {"project_id": "2", "platform": None},
         {"project_id": "3", "platform": None},
     ]
 
-    assert normalize_value("store.load-shed-group-creation-projects", [{"project_id": 123}]) == [
+    assert normalize_config("store.load-shed-group-creation-projects", [{"project_id": 123}]) == [
         {"project_id": "123", "platform": None},  # match any platform
     ]
 
@@ -63,7 +63,8 @@ def test_normalize_value():
     ),
 )
 def test_value_matches_positive(cfg, value):
-    assert _value_matches("store.load-shed-group-creation-projects", cfg, value)
+    cfg = normalize_config("store.load-shed-group-creation-projects", cfg)
+    assert value_matches("store.load-shed-group-creation-projects", cfg, value)
 
 
 @pytest.mark.parametrize(
@@ -96,4 +97,5 @@ def test_value_matches_positive(cfg, value):
     ),
 )
 def test_value_matches_negative(cfg, value):
-    assert not _value_matches("store.load-shed-group-creation-projects", cfg, value)
+    cfg = normalize_config("store.load-shed-group-creation-projects", cfg)
+    assert not value_matches("store.load-shed-group-creation-projects", cfg, value)


### PR DESCRIPTION
We have a batch of N messages, and need to apply the killswitch to each
of them individually. We don't want to fetch the killswitch value for
every single message though.

Split up the killswitches API to allow for fetching the killswitch once,
then applying it many times. Don't introduce any new namedtuples or
dataclasses to avoid any sort of performance overhead. We can achieve
type safety with just type aliases.

Also, rename normalize_value to normalize_config, and disable metrics on
the killswitch for extra performance.
