### PR TITLE
fix: Replace date comparison with number of events

### DIFF
--- a/static/app/views/settings/project/projectFilters/groupTombstones.tsx
+++ b/static/app/views/settings/project/projectFilters/groupTombstones.tsx
@@ -55,7 +55,7 @@ function GroupTombstoneRow({data, disabled, onUndiscard}: GroupTombstoneRowProps
           />
         </StyledBox>
         <RightAlignedColumn>
-          {data.lastSeen && data.lastSeen !== data.dateAdded ? (
+          {data.lastSeen && defined(data.timesSeen) && data.timesSeen > 0 ? (
             <TimeSince
               date={data.lastSeen}
               unitStyle="short"


### PR DESCRIPTION
the date comparison wasn't working due to slight format differences. This PR updates the logic to only show the Last Seen column when there are events, since we then have the correct `lastSeen` value


https://github.com/user-attachments/assets/6faae071-9665-48c6-a22e-f9c08e9b1201

