### PR TITLE
feat(agents-insights): Add indent to ai span list

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -1,7 +1,8 @@
-import {useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/core/layout';
 import Placeholder from 'sentry/components/placeholder';
 import {IconChevron, IconCode} from 'sentry/icons';
 import {IconBot} from 'sentry/icons/iconBot';
@@ -9,7 +10,9 @@ import {IconSpeechBubble} from 'sentry/icons/iconSpeechBubble';
 import {IconTool} from 'sentry/icons/iconTool';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import getDuration from 'sentry/utils/duration/getDuration';
 import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
+import {getIsAiRunNode} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import {
   AI_AGENT_NAME_ATTRIBUTE,
   AI_GENERATION_DESCRIPTIONS,
@@ -34,8 +37,38 @@ import {
   isTransactionNode,
   isTransactionNodeEquivalent,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
-import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+function getTimeBounds(transactionNode: AITraceSpanNode | null) {
+  if (!transactionNode?.value) return {startTime: 0, endTime: 0, duration: 0};
+
+  const startTime = transactionNode.value.start_timestamp;
+  let endTime = 0;
+  if (isTransactionNode(transactionNode) || isSpanNode(transactionNode)) {
+    endTime = transactionNode.value.timestamp;
+  } else if (isEAPSpanNode(transactionNode)) {
+    endTime = transactionNode.value.end_timestamp;
+  }
+
+  if (endTime === 0) return {startTime: 0, endTime: 0, duration: 0};
+
+  return {
+    startTime,
+    endTime,
+    duration: endTime - startTime,
+  };
+}
+
+function getClosestAiRunNode<T extends AITraceSpanNode>(
+  node: AITraceSpanNode,
+  predicate: (node: TraceTreeNode) => node is T
+): T {
+  if (predicate(node)) {
+    return node;
+  }
+  return TraceTree.ParentNode(node, predicate) as T;
+}
 
 export function AISpanList({
   nodes,
@@ -48,58 +81,57 @@ export function AISpanList({
 }) {
   const theme = useTheme();
   const colors = theme.chart.getColorPalette(5);
-  let transactionBounds = {startTime: 0, endTime: 0, duration: 0};
-
-  const getTransactionBounds = (
-    transactionNode: TraceTreeNode<TraceTree.Transaction | TraceTree.EAPSpan>
-  ) => {
-    if (!transactionNode?.value) return {startTime: 0, endTime: 0, duration: 0};
-
-    const startTime = transactionNode.value.start_timestamp;
-    let endTime = 0;
-    if (isTransactionNode(transactionNode)) {
-      endTime = transactionNode.value.timestamp;
-    } else if (isEAPSpanNode(transactionNode)) {
-      endTime = transactionNode.value.end_timestamp;
-    }
-
-    if (endTime === 0) return {startTime: 0, endTime: 0, duration: 0};
-
-    return {
-      startTime,
-      endTime,
-      duration: endTime - startTime,
-    };
-  };
 
   const spanAttributesRequest = useEAPSpanAttributes(nodes);
+  let currentTransaction: TraceTreeNode<
+    TraceTree.Transaction | TraceTree.EAPSpan
+  > | null = null;
+  let currentAiRunNode: AITraceSpanNode | null = null;
 
   return (
     <TraceListContainer>
       {nodes.map(node => {
-        const isTransaction = isTransactionNodeEquivalent(node);
-        if (isTransaction) {
-          transactionBounds = getTransactionBounds(node);
+        // find the closest transaction node
+        const transactionNode = getClosestAiRunNode(node, isTransactionNodeEquivalent);
+        const aiRunNode = getClosestAiRunNode(node, getIsAiRunNode);
+
+        if (aiRunNode !== currentAiRunNode) {
+          currentAiRunNode = aiRunNode;
+        }
+
+        let transactionName: string | null = null;
+        if (transactionNode !== currentTransaction) {
+          currentTransaction = transactionNode;
+          if (
+            transactionNode &&
+            (isTransactionNode(transactionNode) || isEAPSpanNode(transactionNode))
+          ) {
+            transactionName = transactionNode.value.transaction;
+          }
         }
 
         const uniqueKey = getNodeId(node);
         return (
-          <TraceListItem
-            key={uniqueKey}
-            node={node}
-            traceBounds={transactionBounds}
-            onClick={() => onSelectNode(node)}
-            isSelected={uniqueKey === selectedNodeKey}
-            colors={colors}
-            isLoadingAttributes={
-              isEAPSpanNode(node) ? spanAttributesRequest.isPending : false
-            }
-            spanAttributes={
-              isEAPSpanNode(node)
-                ? spanAttributesRequest.data[node.value.event_id]
-                : undefined
-            }
-          />
+          <Fragment key={uniqueKey}>
+            {transactionName && <TransactionItem>{transactionName}</TransactionItem>}
+            <TraceListItem
+              indent={aiRunNode === node ? 0 : 1}
+              traceBounds={getTimeBounds(currentAiRunNode)}
+              key={uniqueKey}
+              node={node}
+              onClick={() => onSelectNode(node)}
+              isSelected={uniqueKey === selectedNodeKey}
+              colors={colors}
+              isLoadingAttributes={
+                isEAPSpanNode(node) ? spanAttributesRequest.isPending : false
+              }
+              spanAttributes={
+                isEAPSpanNode(node)
+                  ? spanAttributesRequest.data[node.value.event_id]
+                  : undefined
+              }
+            />
+          </Fragment>
         );
       })}
     </TraceListContainer>
@@ -110,36 +142,39 @@ function TraceListItem({
   node,
   onClick,
   isSelected,
-  traceBounds,
   colors,
   spanAttributes = {},
   isLoadingAttributes = false,
+  traceBounds,
+  indent,
 }: {
   colors: readonly string[];
+  indent: number;
   isSelected: boolean;
   node: AITraceSpanNode;
   onClick: () => void;
   spanAttributes: Record<string, string> | undefined;
-  traceBounds: {duration: number; endTime: number; startTime: number};
+  traceBounds: TraceBounds;
   isLoadingAttributes?: boolean;
 }) {
   const {icon, title, subtitle, color} = getNodeInfo(node, colors, spanAttributes);
-
   const safeColor = color || colors[0] || '#9ca3af';
-
   const relativeTiming = calculateRelativeTiming(node, traceBounds);
+  const duration = getTimeBounds(node).duration;
 
   return (
-    <ListItemContainer isSelected={isSelected} onClick={onClick}>
+    <ListItemContainer isSelected={isSelected} onClick={onClick} indent={indent}>
       <ListItemIcon color={safeColor}>{icon}</ListItemIcon>
       <ListItemContent>
-        <ListItemHeader>
+        <ListItemHeader align="center" gap={space(0.5)}>
           <ListItemTitle>{title}</ListItemTitle>
           {isLoadingAttributes ? (
             <Placeholder height="12px" width="60px" />
           ) : (
             subtitle && <ListItemSubtitle>- {subtitle}</ListItemSubtitle>
           )}
+          <FlexSpacer />
+          <DurationText>{getDuration(duration, 2, true, true)}</DurationText>
         </ListItemHeader>
         <DurationBar color={safeColor} relativeTiming={relativeTiming} />
       </ListItemContent>
@@ -299,6 +334,9 @@ function getNodeInfo(
     description: node.value?.description,
   });
 
+  const truncatedOp = op.startsWith('gen_ai.') ? op.slice(7) : op;
+  nodeInfo.title = truncatedOp;
+
   if (
     AI_RUN_OPS.includes(op) ||
     AI_RUN_DESCRIPTIONS.includes(node.value.description ?? '')
@@ -306,7 +344,6 @@ function getNodeInfo(
     const agentName = getNodeAttribute(AI_AGENT_NAME_ATTRIBUTE) || '';
     const model = getNodeAttribute(AI_MODEL_ID_ATTRIBUTE) || '';
     nodeInfo.icon = <IconBot size="md" />;
-    nodeInfo.title = op;
     nodeInfo.subtitle = `${agentName}${model ? ` (${model})` : ''}`;
     nodeInfo.color = colors[0];
   } else if (
@@ -315,7 +352,6 @@ function getNodeInfo(
   ) {
     const tokens = getNodeAttribute(AI_TOTAL_TOKENS_ATTRIBUTE);
     nodeInfo.icon = <IconSpeechBubble size="md" />;
-    nodeInfo.title = op;
     nodeInfo.subtitle = tokens ? ` ${tokens} Tokens` : '';
     nodeInfo.color = colors[2];
   } else if (
@@ -323,16 +359,13 @@ function getNodeInfo(
     AI_TOOL_CALL_DESCRIPTIONS.includes(node.value.description ?? '')
   ) {
     nodeInfo.icon = <IconTool size="md" />;
-    nodeInfo.title = op || 'gen_ai.toolCall';
     nodeInfo.subtitle = getNodeAttribute(AI_TOOL_NAME_ATTRIBUTE) || '';
     nodeInfo.color = colors[5];
   } else if (AI_HANDOFF_OPS.includes(op)) {
     nodeInfo.icon = <IconChevron size="md" isDouble direction="right" />;
-    nodeInfo.title = op;
     nodeInfo.subtitle = node.value.description || '';
     nodeInfo.color = colors[4];
   } else {
-    nodeInfo.title = op || 'Span';
     nodeInfo.subtitle = node.value.description || '';
   }
   return nodeInfo;
@@ -346,10 +379,11 @@ const TraceListContainer = styled('div')`
   overflow: hidden;
 `;
 
-const ListItemContainer = styled('div')<{isSelected: boolean}>`
+const ListItemContainer = styled('div')<{indent: number; isSelected: boolean}>`
   display: flex;
   align-items: center;
   padding: ${space(1)} ${space(0.5)};
+  padding-left: ${p => (p.indent ? p.indent * 16 : 4)}px;
   border-radius: ${p => p.theme.borderRadius};
   cursor: pointer;
   background-color: ${p =>
@@ -373,9 +407,7 @@ const ListItemContent = styled('div')`
   min-width: 0;
 `;
 
-const ListItemHeader = styled('div')`
-  display: flex;
-  align-items: center;
+const ListItemHeader = styled(Flex)`
   margin-bottom: ${space(0.5)};
 `;
 
@@ -384,9 +416,8 @@ const ListItemTitle = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.textColor};
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+  flex-basis: max-content;
+  flex-shrink: 0;
 `;
 
 const ListItemSubtitle = styled('span')`
@@ -397,7 +428,7 @@ const ListItemSubtitle = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
   flex: 1;
-  min-width: 0;
+  flex-basis: max-content;
 `;
 
 const DurationBar = styled('div')<{
@@ -420,4 +451,29 @@ const DurationBar = styled('div')<{
     background-color: ${p => p.color};
     border-radius: 2px;
   }
+`;
+
+const DurationText = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  color: ${p => p.theme.subText};
+`;
+
+const TransactionItem = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+  padding: ${space(2)} ${space(0.5)} 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  min-width: 0;
+  &:first-child {
+    padding-top: 0;
+  }
+`;
+
+const FlexSpacer = styled('div')`
+  flex-grow: 1;
+  min-width: 0;
+  flex-basis: 0;
 `;

--- a/static/app/views/insights/agentMonitoring/hooks/useAITrace.tsx
+++ b/static/app/views/insights/agentMonitoring/hooks/useAITrace.tsx
@@ -79,12 +79,12 @@ export function useAITrace(traceSlug: string): UseAITraceResult {
 
         // Keep only transactions that include AI spans and the AI spans themselves
         const flattenedNodes = TraceTree.FindAll(tree.root, node => {
-          if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
+          if (
+            !isTransactionNodeEquivalent(node) &&
+            !isSpanNode(node) &&
+            !isEAPSpanNode(node)
+          ) {
             return false;
-          }
-
-          if (isTransactionNodeEquivalent(node)) {
-            return TraceTree.Find(node, child => getIsAiNode(child)) !== null;
           }
 
           return getIsAiNode(node);

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -7,9 +7,11 @@ import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAt
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
 import {
+  getIsAiRunSpan,
   getIsAiSpan,
   legacyAttributeKeys,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
+import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
 import {
   isEAPSpanNode,
   isSpanNode,
@@ -146,7 +148,9 @@ export function getTraceNodeAttribute(
   return undefined;
 }
 
-export function getIsAiNode(node: TraceTreeNode<TraceTree.NodeValue>) {
+export function getIsAiNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): node is AITraceSpanNode {
   if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
     return false;
   }
@@ -159,4 +163,18 @@ export function getIsAiNode(node: TraceTreeNode<TraceTree.NodeValue>) {
   }
 
   return getIsAiSpan(node.value);
+}
+
+export function getIsAiRunNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): node is AITraceSpanNode {
+  if (!isTransactionNode(node) && !isSpanNode(node) && !isEAPSpanNode(node)) {
+    return false;
+  }
+
+  if (isTransactionNode(node)) {
+    return getIsAiRunSpan({op: node.value['transaction.op']});
+  }
+
+  return getIsAiRunSpan({op: node.value.op});
 }

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -9,7 +9,9 @@ export const AI_RUN_OPS = [
   'ai.run.generateObject',
   'gen_ai.invoke_agent',
   'ai.pipeline.generate_text',
+  'ai.pipeline.generate_object',
   'ai.pipeline.stream_text',
+  'ai.pipeline.stream_object',
 ];
 export const AI_RUN_DESCRIPTIONS = ['ai.generateText', 'generateText'];
 
@@ -83,6 +85,10 @@ export function getIsAiSpan({
     return AI_OPS.includes(op) || op.startsWith('gen_ai.');
   }
   return AI_DESCRIPTIONS.includes(description ?? '');
+}
+
+export function getIsAiRunSpan({op = 'default'}: {op?: string}) {
+  return AI_RUN_OPS.includes(op);
 }
 
 // TODO: Remove once tool spans have their own op


### PR DESCRIPTION
<img width="970" alt="Screenshot 2025-06-25 at 14 42 52" src="https://github.com/user-attachments/assets/a25d05b3-da0b-4acc-9ea3-d14d4d96094d" />

- closes [TET-722: Get rid of `gen_ai` prefix in trace](https://linear.app/getsentry/issue/TET-722/get-rid-of-gen-ai-prefix-in-trace)
- closes [TET-688: Add duration to AI spans list](https://linear.app/getsentry/issue/TET-688/add-duration-to-ai-spans-list)
- closes [TET-714: don't want to see `http.server` spans in AI traces](https://linear.app/getsentry/issue/TET-714/dont-want-to-see-httpserver-spans-in-ai-traces)
- part of [TET-716: add time and cost to spans where it makes sense](https://linear.app/getsentry/issue/TET-716/add-time-and-cost-to-spans-where-it-makes-sense)