### PR TITLE
fix(demo-mode): doing a proper logout when redirecting from sandbox to welcome page

### DIFF
--- a/src/sentry/middleware/demo_mode_guard.py
+++ b/src/sentry/middleware/demo_mode_guard.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 
+from django.contrib.auth import logout
+from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 
 from sentry import options
+from sentry.auth.providers.saml2.provider import handle_saml_single_logout
 from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.organizations.services.organization import organization_service
 
@@ -43,6 +46,13 @@ class DemoModeGuardMiddleware:
                     logger.debug("Maybe blocking org redirect for org: %s", activeorg)
                     if is_demo_org(_get_org(activeorg)):
                         logger.debug("Org %s is demo org, redirecting to welcome page", activeorg)
+
+                        if options.get("demo-mode.sandbox-redirect-logout"):
+                            # copied from sentry/api/endpoints/auth_index.py
+                            handle_saml_single_logout(request)
+                            logout(request._request)
+                            request.user = AnonymousUser()
+
                         return HttpResponseRedirect("https://sentry.io/welcome")
 
         return self.get_response(request)

--- a/src/sentry/middleware/demo_mode_guard.py
+++ b/src/sentry/middleware/demo_mode_guard.py
@@ -4,12 +4,10 @@ import logging
 from collections.abc import Callable
 
 from django.contrib.auth import logout
-from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 
 from sentry import options
-from sentry.auth.providers.saml2.provider import handle_saml_single_logout
 from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.organizations.services.organization import organization_service
 
@@ -48,10 +46,7 @@ class DemoModeGuardMiddleware:
                         logger.debug("Org %s is demo org, redirecting to welcome page", activeorg)
 
                         if options.get("demo-mode.sandbox-redirect-logout"):
-                            # copied from sentry/api/endpoints/auth_index.py
-                            handle_saml_single_logout(request)
-                            logout(request._request)
-                            request.user = AnonymousUser()
+                            logout(request)
 
                         return HttpResponseRedirect("https://sentry.io/welcome")
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3129,6 +3129,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "demo-mode.sandbox-redirect-logout",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # option for sample size when fetching project tag keys
 register(
     "visibility.tag-key-sample-size",


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/TET-628/sandbox-suppressing-the-redirect-should-be-the-same-as-exit-sandbox