### PR TITLE
fix(agents-insights): drawer width

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -93,7 +93,7 @@ export function useTraceViewDrawer({onClose = undefined}: UseTraceViewDrawerProp
           drawerWidth: `${DRAWER_WIDTH}px`,
           resizable: true,
           traceSlug,
-          drawerKey: 'abbreviated-trace-view-drawer-2',
+          drawerKey: 'abbreviated-trace-view-drawer',
         }
       ),
     [openDrawer, onClose, closeDrawer]

--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -20,7 +20,7 @@ import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHe
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
-const LEFT_PANEL_WIDTH = 300;
+const LEFT_PANEL_WIDTH = 400;
 const RIGHT_PANEL_WIDTH = 400;
 const DRAWER_WIDTH = LEFT_PANEL_WIDTH + RIGHT_PANEL_WIDTH;
 
@@ -93,7 +93,7 @@ export function useTraceViewDrawer({onClose = undefined}: UseTraceViewDrawerProp
           drawerWidth: `${DRAWER_WIDTH}px`,
           resizable: true,
           traceSlug,
-          drawerKey: 'abbreviated-trace-view-drawer',
+          drawerKey: 'abbreviated-trace-view-drawer-2',
         }
       ),
     [openDrawer, onClose, closeDrawer]

--- a/static/app/views/insights/agentMonitoring/components/drawer.tsx
+++ b/static/app/views/insights/agentMonitoring/components/drawer.tsx
@@ -20,6 +20,10 @@ import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHe
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
+const LEFT_PANEL_WIDTH = 300;
+const RIGHT_PANEL_WIDTH = 400;
+const DRAWER_WIDTH = LEFT_PANEL_WIDTH + RIGHT_PANEL_WIDTH;
+
 interface UseTraceViewDrawerProps {
   onClose?: () => void;
 }
@@ -86,7 +90,7 @@ export function useTraceViewDrawer({onClose = undefined}: UseTraceViewDrawerProp
           ariaLabel: t('Abbreviated Trace'),
           onClose,
           shouldCloseOnInteractOutside: () => true,
-          drawerWidth: '40%',
+          drawerWidth: `${DRAWER_WIDTH}px`,
           resizable: true,
           traceSlug,
           drawerKey: 'abbreviated-trace-view-drawer',
@@ -181,7 +185,7 @@ const SplitContainer = styled('div')`
 
 const LeftPanel = styled('div')`
   flex: 1;
-  min-width: 300px;
+  min-width: ${LEFT_PANEL_WIDTH}px;
   min-height: 0;
   padding: ${space(2)};
   border-right: 1px solid ${p => p.theme.border};
@@ -191,7 +195,7 @@ const LeftPanel = styled('div')`
 `;
 
 const RightPanel = styled('div')`
-  min-width: 400px;
+  min-width: ${RIGHT_PANEL_WIDTH}px;
   flex: 1;
   min-height: 0;
   background-color: ${p => p.theme.background};


### PR DESCRIPTION
Closes [TET-711: Drawer initial width is too small](https://linear.app/getsentry/issue/TET-711/drawer-initial-width-is-too-small)