### PR TITLE
ref(spans): Debounce the decode timing once per batch

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -134,7 +134,9 @@ def process_batch(
 ) -> int:
     killswitch_config = killswitches.get_killswitch_value("spans.drop-in-buffer")
     min_timestamp = None
+    decode_time = 0
     spans = []
+
     for value in values.payload:
         assert isinstance(value, BrokerValue)
 
@@ -143,8 +145,9 @@ def process_batch(
             if min_timestamp is None or timestamp < min_timestamp:
                 min_timestamp = timestamp
 
-            with metrics.timer("spans.buffer.process_batch.decode"):
-                val = cast(SpanEvent, orjson.loads(payload.value))
+            decode_start = time.monotonic()
+            val = cast(SpanEvent, orjson.loads(payload.value))
+            decode_time += time.monotonic() - decode_start
 
             if killswitches.value_matches(
                 "spans.drop-in-buffer",
@@ -184,6 +187,10 @@ def process_batch(
             # in those situations it's better to halt the consumer as we're
             # otherwise very likely to just DLQ everything anyway.
             raise InvalidMessage(value.partition, value.offset)
+
+    # This timing is not tracked in case of an exception. This is desired
+    # because otherwise the ratio with other batch metrics is out of sync.
+    metrics.timing("spans.buffer.process_batch.decode", decode_time)
 
     assert min_timestamp is not None
     buffer.process_spans(spans, now=min_timestamp)

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -134,7 +134,7 @@ def process_batch(
 ) -> int:
     killswitch_config = killswitches.get_killswitch_value("spans.drop-in-buffer")
     min_timestamp = None
-    decode_time = 0
+    decode_time = 0.0
     spans = []
 
     for value in values.payload:


### PR DESCRIPTION
In #94270 we theorize that capturing timing metrics per message (span) is expensive. This debounces the metric and tracks it once per batch.