### PR TITLE
fix(billing): Hide test ent/free/trial plans from Change Plan

### DIFF
--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -11,6 +11,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
@@ -60,11 +61,22 @@ describe('ChangePlanAction', () => {
         {events: 25000, price: 5000},
       ],
     },
-    userSelectable: true,
+    userSelectable: false,
+    isTestPlan: true,
+  });
+
+  const freeTestPlan = PlanFixture({
+    id: 'free_test_monthly',
+    name: 'TEST Tier Free Test Plan',
+    price: 0,
+    basePrice: 0,
+    billingInterval: 'monthly',
+    userSelectable: false,
     isTestPlan: true,
   });
 
   BILLING_CONFIG.planList.push(testPlan);
+  BILLING_CONFIG.planList.push(freeTestPlan);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -308,10 +320,15 @@ describe('ChangePlanAction', () => {
     const testTierTab = screen.getByRole('tab', {name: 'TEST'});
     await userEvent.click(testTierTab);
 
-    // Verify TEST tier plans are shown after clicking the TEST tier tab
+    // Verify >$0 TEST tier plans are shown after clicking the TEST tier tab
     await waitFor(() => {
-      const testPlans = screen.queryAllByTestId('change-plan-label-test_test_monthly');
-      expect(testPlans.length).toBeGreaterThan(0);
+      const testPlans = screen.queryAllByTestId(/_test_monthly/);
+      expect(testPlans).toHaveLength(1);
+
+      testPlans.forEach(planLabel => {
+        expect(within(planLabel).getByText('$50 / monthly')).toBeInTheDocument();
+        expect(within(planLabel).queryByText('$0 / monthly')).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -108,6 +108,7 @@ function ChangePlanAction({
       return planList.filter(
         plan =>
           plan.isTestPlan &&
+          plan.price !== 0 && // filter out enterprise, trial, and free test plans
           plan.billingInterval === billingInterval &&
           plan.contractInterval === contractInterval
       );


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-809/remove-enterprise-test-plans-from-the-change-plan-list

I also hid the test free and trial plans since you can't use the Change Plan action on those without getting a 500.