### PR TITLE
fix(billing): Use correct icons for plans

### DIFF
--- a/static/gsApp/components/labelWithPowerIcon.tsx
+++ b/static/gsApp/components/labelWithPowerIcon.tsx
@@ -74,7 +74,7 @@ function LabelWithPowerIcon({children, id, subscription}: Props) {
     return children as React.ReactElement;
   }
 
-  if (!subscription?.plan || isEnterprise(subscription)) {
+  if (!subscription?.plan || isEnterprise(subscription.plan)) {
     return children as React.ReactElement;
   }
 

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -304,7 +304,7 @@ function ContinuousProfilingBetaAlertBannerInner({
               '[bold:Profiling Beta Ending Soon:] Your free access ends May 19, 2025. Profiling will require a pay-as-you-go budget after this date. To avoid disruptions, upgrade to a paid plan.',
               {bold: <b />}
             )
-        : isEnterprise(subscription)
+        : isEnterprise(subscription.plan)
           ? tct(
               '[bold:Profiling Beta Ending Soon:] Your free access ends May 19, 2025. To avoid disruptions, contact your account manager before then to add it to your plan.',
               {bold: <b />}

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -18,6 +18,7 @@ import {
   hasPerformance,
   isBizPlanFamily,
   isDeveloperPlan,
+  isEnterprise,
   isNewPayingCustomer,
   isTeamPlanFamily,
   MILLISECONDS_IN_HOUR,
@@ -881,5 +882,22 @@ describe('getOnDemandCategories', function () {
     });
     expect(categories).toHaveLength(plan.onDemandCategories.length);
     expect(categories).toEqual(plan.onDemandCategories);
+  });
+});
+
+describe('isEnterprise', function () {
+  it('returns true for enterprise plans', function () {
+    expect(isEnterprise('e1')).toBe(true);
+    expect(isEnterprise('enterprise')).toBe(true);
+    expect(isEnterprise('am1_business_ent')).toBe(true);
+    expect(isEnterprise('am2_team_ent_auf')).toBe(true);
+    expect(isEnterprise('am3_business_ent_ds_auf')).toBe(true);
+  });
+
+  it('returns false for non-enterprise plans', function () {
+    expect(isEnterprise('_e1')).toBe(false);
+    expect(isEnterprise('_enterprise')).toBe(false);
+    expect(isEnterprise('am1_business')).toBe(false);
+    expect(isEnterprise('am2_team')).toBe(false);
   });
 });

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -278,8 +278,8 @@ function displayNumber(n: number, fractionDigits = 0) {
 /**
  * Utility functions for Pricing Plans
  */
-export const isEnterprise = (subscription: Subscription) =>
-  ['e1', 'enterprise'].some(p => subscription.plan.startsWith(p));
+export const isEnterprise = (plan: string) =>
+  ['e1', 'enterprise'].some(p => plan.startsWith(p)) || isAmEnterprisePlan(plan);
 
 export const isTrialPlan = (plan: string) => TRIAL_PLANS.includes(plan);
 
@@ -329,14 +329,11 @@ export function isAm3DsPlan(planId?: string) {
 }
 
 export function isAmEnterprisePlan(planId?: string) {
-  return (
-    typeof planId === 'string' &&
-    planId.startsWith('am') &&
-    (planId.endsWith('_ent') ||
-      planId.endsWith('_ent_auf') ||
-      planId.endsWith('_ent_ds') ||
-      planId.endsWith('_ent_ds_auf'))
-  );
+  if (typeof planId !== 'string' || !isAmPlan(planId)) {
+    return false;
+  }
+
+  return planId.includes('_ent');
 }
 
 export function hasJustStartedPlanTrial(subscription: Subscription) {

--- a/static/gsApp/views/subscriptionPage/headerCards/subscriptionCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/subscriptionCard.tsx
@@ -28,12 +28,12 @@ function PlanImage({subscription}: {subscription: Subscription}) {
   }
 
   let tierImage: any | null = null;
-  if (isEnterprise(subscription)) {
-    tierImage = BusinessBundleArt;
+  if (isEnterprise(subscription.plan)) {
+    tierImage = CustomBundleArt;
   } else if (isTeamPlan(subscription.plan)) {
     tierImage = TeamBundleArt;
   } else {
-    tierImage = CustomBundleArt;
+    tierImage = BusinessBundleArt;
   }
 
   return (


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1007/business-plan-icon-is-wrong

- Fixes the icon displayed on the subscription page for Business plans
- corrects `isEnterprise` checks which previously only took into account legacy enterprise plans

# before -- business plan incorrectly used the enterprise plan icon
![image](https://github.com/user-attachments/assets/de136842-99d3-40b8-918e-fbbb050ec06b)


# after -- business plan uses the business plan icon
![Screenshot 2025-06-25 at 9 52 28 AM](https://github.com/user-attachments/assets/38753f88-c8ba-4c79-a09f-b6cc87a62fdf)
