### PR TITLE
chore(performance): Remove spans tab from transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -188,28 +188,4 @@ describe('Performance > Transaction Summary Header', function () {
 
     expect(screen.queryByRole('tab', {name: 'Web Vitals'})).not.toBeInTheDocument();
   });
-
-  it('should render spans tab with feature', async function () {
-    const {project, organization, router, eventView} = initializeData({});
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-has-measurements/',
-      body: {measurements: true},
-    });
-
-    render(
-      <TransactionHeader
-        eventView={eventView}
-        location={router.location}
-        organization={organization}
-        projects={[project]}
-        projectId={project.id}
-        transactionName="transaction_name"
-        currentTab={Tab.TRANSACTION_SUMMARY}
-        hasWebVitals="yes"
-      />
-    );
-
-    expect(await screen.findByRole('tab', {name: 'Spans'})).toBeInTheDocument();
-  });
 });

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -211,9 +211,6 @@ function TransactionHeader({
             <TabList.Item key={Tab.TRANSACTION_SUMMARY}>{t('Overview')}</TabList.Item>
             <TabList.Item key={Tab.EVENTS}>{t('Sampled Events')}</TabList.Item>
             <TabList.Item key={Tab.TAGS}>{t('Tags')}</TabList.Item>
-            <TabList.Item key={Tab.SPANS} hidden>
-              {t('Spans')}
-            </TabList.Item>
             <TabList.Item
               key={Tab.WEB_VITALS}
               textValue={t('Web Vitals')}
@@ -412,7 +409,6 @@ function TransactionHeader({
               <TabList.Item key={Tab.TRANSACTION_SUMMARY}>{t('Overview')}</TabList.Item>
               <TabList.Item key={Tab.EVENTS}>{t('Sampled Events')}</TabList.Item>
               <TabList.Item key={Tab.TAGS}>{t('Tags')}</TabList.Item>
-              <TabList.Item key={Tab.SPANS}>{t('Spans')}</TabList.Item>
               <TabList.Item
                 key={Tab.WEB_VITALS}
                 textValue={t('Web Vitals')}


### PR DESCRIPTION
This tab was originally hidden back in #87890. However it was only hidden in the insights version of the page. If they came from discover for example, the spans tab was still accessible.