### PR TITLE
feat(autofix): Collapse insights in automated runs by default

### DIFF
--- a/static/app/components/events/autofix/autofixInsightCards.tsx
+++ b/static/app/components/events/autofix/autofixInsightCards.tsx
@@ -295,6 +295,7 @@ interface AutofixInsightCardsProps {
   insights: AutofixInsight[];
   runId: string;
   stepIndex: number;
+  shouldCollapseByDefault?: boolean;
 }
 
 interface CollapsibleChainLinkProps {
@@ -455,8 +456,9 @@ function AutofixInsightCards({
   stepIndex,
   groupId,
   runId,
+  shouldCollapseByDefault,
 }: AutofixInsightCardsProps) {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(shouldCollapseByDefault ?? false);
   const [expandedCardIndex, setExpandedCardIndex] = useState<number | null>(null);
   const previousInsightsRef = useRef<AutofixInsight[]>([]);
   const [newInsightIndices, setNewInsightIndices] = useState<number[]>([]);

--- a/static/app/components/events/autofix/autofixSteps.tsx
+++ b/static/app/components/events/autofix/autofixSteps.tsx
@@ -34,6 +34,7 @@ interface StepProps {
   hasStepBelow: boolean;
   runId: string;
   step: AutofixStep;
+  isAutoTriggeredRun?: boolean;
   isChangesFirstAppearance?: boolean;
   isRootCauseFirstAppearance?: boolean;
   isSolutionFirstAppearance?: boolean;
@@ -66,6 +67,7 @@ function Step({
   isRootCauseFirstAppearance,
   isSolutionFirstAppearance,
   isChangesFirstAppearance,
+  isAutoTriggeredRun,
 }: StepProps) {
   return (
     <StepCard id={`autofix-step-${step.id}`} data-step-type={step.type}>
@@ -86,6 +88,7 @@ function Step({
                   stepIndex={step.index}
                   groupId={groupId}
                   runId={runId}
+                  shouldCollapseByDefault={isAutoTriggeredRun && hasStepBelow}
                 />
               )}
               {step.type === AutofixStepType.ROOT_CAUSE_ANALYSIS && (
@@ -164,6 +167,8 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
   const errorMessage = getAutofixRunErrorMessage(data);
   const shouldShowStandaloneError = errorMessage && !shouldShowOutputStream;
 
+  const isAutoTriggeredRun = !!data.request.options?.auto_run_source;
+
   return (
     <div>
       {steps.map((step, index) => {
@@ -224,6 +229,7 @@ export function AutofixSteps({data, groupId, runId}: AutofixStepsProps) {
               isChangesFirstAppearance={
                 step.type === AutofixStepType.CHANGES && !isInitialMount
               }
+              isAutoTriggeredRun={isAutoTriggeredRun}
             />
           </div>
         );

--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -50,6 +50,9 @@ export type AutofixData = {
   last_triggered_at: string;
   request: {
     repos: SeerRepoDefinition[];
+    options?: {
+      auto_run_source?: string | null;
+    };
   };
   run_id: string;
   status: AutofixStatus;


### PR DESCRIPTION
To make automated runs more welcoming when you first open them, collapses insight cards by default _only for auto-triggered runs._