### PR TITLE
fix(agents) Fix scheduling error for ai_agent_monitoring task

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3451,6 +3451,11 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "taskworker.ai_agent_monitoring.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Flags for taskworker scheduler rollout
 register(


### PR DESCRIPTION
A rollout option is required per namespace. Without a rollout option tasks cannot be scheduled.

Fixes SENTRY-435B
