### PR TITLE
feat(agent-insights): Render response object in ai output

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -73,6 +73,7 @@ export const legacyAttributeKeys = new Map<string, string[]>([
   ['gen_ai.request.messages', ['ai.prompt.messages']],
   ['gen_ai.response.tool_calls', ['ai.response.toolCalls']],
   ['gen_ai.response.text', ['ai.response.text']],
+  ['gen_ai.response.object', ['ai.response.object']],
   ['gen_ai.tool.name', ['ai.toolCall.name']],
 ]);
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 
-import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -15,14 +14,6 @@ import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
-
-function tryParseJson(value: any) {
-  try {
-    return JSON.parse(value);
-  } catch (error) {
-    return value;
-  }
-}
 
 export function AIOutputSection({
   node,
@@ -51,8 +42,14 @@ export function AIOutputSection({
     attributes
   );
   const toolOutput = getTraceNodeAttribute('gen_ai.tool.output', node, event, attributes);
+  const responseObject = getTraceNodeAttribute(
+    'gen_ai.response.object',
+    node,
+    event,
+    attributes
+  );
 
-  if (!responseText && !toolCalls && !toolOutput) {
+  if (!responseText && !responseObject && !toolCalls && !toolOutput) {
     return null;
   }
 
@@ -72,18 +69,23 @@ export function AIOutputSection({
           </TraceDrawerComponents.MultilineText>
         </Fragment>
       )}
+      {responseObject && (
+        <Fragment>
+          <TraceDrawerComponents.MultilineTextLabel>
+            {t('Response Object')}
+          </TraceDrawerComponents.MultilineTextLabel>
+          <TraceDrawerComponents.MultilineJSON
+            value={responseObject}
+            maxDefaultDepth={2}
+          />
+        </Fragment>
+      )}
       {toolCalls && (
         <Fragment>
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Tool Calls')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <TraceDrawerComponents.MultilineText>
-            <StructuredData
-              value={tryParseJson(toolCalls)}
-              maxDefaultDepth={2}
-              withAnnotatedText
-            />
-          </TraceDrawerComponents.MultilineText>
+          <TraceDrawerComponents.MultilineJSON value={toolCalls} maxDefaultDepth={2} />
         </Fragment>
       )}
       {toolOutput ? (


### PR DESCRIPTION
Render `gen_ai.response.object` as interactive JSON in the ai output section.
Register `ai.response.object` as fallback attribute.

- closes [TET-725: render response object](https://linear.app/getsentry/issue/TET-725/render-response-object)