### PR TITLE
Fix overlapping empty flamegraph

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -166,7 +166,7 @@ export function TransactionProfilesContent(props: TransactionProfilesContentProp
                   <RequestStateMessageContainer>
                     {t('There was an error loading the flamegraph.')}
                   </RequestStateMessageContainer>
-                ) : isEmpty(data) ? (
+                ) : isEmpty(data) && visualization !== 'flamegraph' ? (
                   <RequestStateMessageContainer>
                     {t('No profiling data found')}
                   </RequestStateMessageContainer>


### PR DESCRIPTION
When profiling data is empty this UI was a bit overlapping 

Before:
![Screenshot 2025-06-25 at 11 39 24 AM](https://github.com/user-attachments/assets/847a60b4-2096-4f61-a020-e9b732f42339)
After:
![Screenshot 2025-06-25 at 3 31 18 PM](https://github.com/user-attachments/assets/61e9bc7e-86c7-4126-a282-6d017afd8512)
