### PR TITLE
deps(ui): Bump moment-timezone to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "mobx": "^6.8.0",
     "mobx-react": "~7.6.0",
     "mockdate": "3.0.5",
-    "moment-timezone": "0.5.44",
+    "moment-timezone": "0.6.0",
     "papaparse": "^5.3.2",
     "peggy": "^4.1.1",
     "platformicons": "^8.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,8 +412,8 @@ importers:
         specifier: 3.0.5
         version: 3.0.5
       moment-timezone:
-        specifier: 0.5.44
-        version: 0.5.44
+        specifier: 0.6.0
+        version: 0.6.0
       papaparse:
         specifier: ^5.3.2
         version: 5.3.2
@@ -6209,8 +6209,8 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  moment-timezone@0.5.44:
-    resolution: {integrity: sha512-nv3YpzI/8lkQn0U6RkLd+f0W/zy/JnoR5/EyPz/dNkPTBjA2jNLCVxaiQ8QpeLymhSZvX0wCL5s27NQWdOPwAw==}
+  moment-timezone@0.6.0:
+    resolution: {integrity: sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==}
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
@@ -15379,7 +15379,7 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  moment-timezone@0.5.44:
+  moment-timezone@0.6.0:
     dependencies:
       moment: 2.30.1
 


### PR DESCRIPTION
We bump up a few TZDB versions and some type fixes https://github.com/moment/moment-timezone/blob/develop/changelog.md
