### PR TITLE
:wrench: chore(sentry apps): increase `clear_region_cache` processing deadline

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -489,6 +489,7 @@ def installation_webhook(installation_id: int, user_id: int, *args: Any, **kwarg
             times=3,
             delay=60 * 5,
         ),
+        processing_deadline_duration=30,
     ),
     **CONTROL_TASK_OPTIONS,
 )


### PR DESCRIPTION
resolves [SENTRY-43D0](https://sentry.sentry.io/issues/6708494666/events/9e969cf4c14a4d45a0350fcc186c346b/)