### PR TITLE
perf(aci): Add back DataCondition evaluation timer

### DIFF
--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -204,7 +204,11 @@ class DataCondition(DefaultFieldsModel):
         should_be_fast = not is_slow_condition(self)
         start_time = time.time()
         try:
-            result = handler.evaluate_value(value, self.comparison)
+            with metrics.timer(
+                "workflow_engine.data_condition.evaluation_duration",
+                tags={"type": self.type, "speed_category": "fast" if should_be_fast else "slow"},
+            ):
+                result = handler.evaluate_value(value, self.comparison)
         except DataConditionEvaluationException as e:
             metrics.incr("workflow_engine.data_condition.evaluation_error")
             logger.info(


### PR DESCRIPTION
This timer was deleted to avoid overloading our span buffer, but now timers no longer generate spans, so we can add it back.
