### PR TITLE
filters: remove .5 opacity on checkbox

### DIFF
--- a/static/app/components/organizations/hybridFilter.tsx
+++ b/static/app/components/organizations/hybridFilter.tsx
@@ -445,7 +445,7 @@ const CheckWrap = styled('div')<{visible: boolean}>`
   display: flex;
   justify-content: center;
   align-items: center;
-  opacity: ${p => (p.visible ? 1 : 0.5)};
+  opacity: ${p => (p.theme.isChonk ? undefined : p.visible ? 1 : 0.5)};
   padding: ${space(0.25)} 0 ${space(0.25)} ${space(0.25)};
 `;
 


### PR DESCRIPTION
Remove opacity change in Chonk because it makes the checkbox nearly invisible. I am not removing this for the current UI because it is not clear to me why this logic has to exist or what is the intent that it is signaling