### PR TITLE
feat(aci): Report when bulk snuba results appear incomplete

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -443,6 +443,12 @@ def get_condition_group_results(
             comparison_interval=comparison_interval,
             filters=unique_condition.filters,
         )
+        absent_group_ids = group_ids - set(result.keys())
+        if absent_group_ids:
+            logger.warning(
+                "workflow_engine.delayed_workflow.absent_group_ids",
+                extra={"group_ids": absent_group_ids, "unique_condition": unique_condition},
+            )
         condition_group_results[unique_condition] = result
 
     return condition_group_results


### PR DESCRIPTION
We've observed some cases in logs showing groups to be present in data before we query Snuba, but not after.
Given that we're currently assuming consistency here, we add logs to show when our assumption is wrong.
