### PR TITLE
tabs: remove default border on Chonk Tabs

### DIFF
--- a/static/app/components/core/tabs/tabList.chonk.tsx
+++ b/static/app/components/core/tabs/tabList.chonk.tsx
@@ -26,15 +26,11 @@ export const ChonkStyledTabListWrap = chonkStyled('ul', {
       ? css`
           grid-auto-flow: column;
           justify-content: start;
-          ${p.variant === 'flat' &&
-          `border-bottom: solid 1px ${p.theme.tokens.border.primary};`}
         `
       : css`
           height: 100%;
           grid-auto-flow: row;
           align-content: start;
           padding-right: ${space(0.5)};
-          ${p.variant === 'flat' &&
-          `border-right: solid 1px ${p.theme.tokens.border.primary};`}
         `};
 `;

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -128,8 +128,7 @@ export interface TabListProps {
   children: TabListStateOptions<TabListItemProps>['children'];
   /**
    * @deprecated
-   * With chonk, `flat` variants always have a border and `floating` variants never do.
-   * Whether to hide the bottom border of the tab list.
+   * In chonk, tabs never have a border.
    * Defaults to `false`.
    */
   hideBorder?: boolean;
@@ -322,7 +321,7 @@ const TabListWrap = withChonk(
             grid-auto-flow: column;
             justify-content: start;
             gap: ${p.variant === 'floating' ? 0 : space(2)};
-            ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
+            border-bottom: ${p.hideBorder ? 'undefined' : `solid 1px ${p.theme.border}`};
           `
         : css`
             height: 100%;
@@ -330,7 +329,7 @@ const TabListWrap = withChonk(
             align-content: start;
             gap: 1px;
             padding-right: ${space(2)};
-            ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
+            border-right: ${p.hideBorder ? 'undefined' : `solid 1px ${p.theme.border}`};
           `};
   `,
   ChonkStyledTabListWrap

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -128,7 +128,8 @@ export interface TabListProps {
   children: TabListStateOptions<TabListItemProps>['children'];
   /**
    * @deprecated
-   * In chonk, tabs never have a border.
+   * With chonk, tabs never have a border.
+   * Whether to hide the bottom border of the tab list.
    * Defaults to `false`.
    */
   hideBorder?: boolean;
@@ -321,7 +322,7 @@ const TabListWrap = withChonk(
             grid-auto-flow: column;
             justify-content: start;
             gap: ${p.variant === 'floating' ? 0 : space(2)};
-            border-bottom: ${p.hideBorder ? 'undefined' : `solid 1px ${p.theme.border}`};
+            ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
           `
         : css`
             height: 100%;
@@ -329,7 +330,7 @@ const TabListWrap = withChonk(
             align-content: start;
             gap: 1px;
             padding-right: ${space(2)};
-            border-right: ${p.hideBorder ? 'undefined' : `solid 1px ${p.theme.border}`};
+            ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
           `};
   `,
   ChonkStyledTabListWrap


### PR DESCRIPTION
This is causing stacking border issues, so it is getting removed. cc @Jesse-Box 