### PR TITLE
fix(eap-migration): Add `percentile` to the translation layer

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -1,3 +1,4 @@
+import re
 from typing import TypedDict
 
 from parsimonious import NodeVisitor
@@ -12,6 +13,34 @@ class QueryParts(TypedDict):
     query: str
     equations: list[str] | None
     orderby: list[str] | None
+
+
+PERCENTILE_REGEX = r"percentile\(.*\)"
+
+
+def format_percentile_term(term):
+    function, args, alias = fields.parse_function(term)
+
+    percentile_replacement_function = {
+        0.5: "p50",
+        0.75: "p75",
+        0.90: "p90",
+        0.95: "p95",
+        0.99: "p99",
+        1.0: "p100",
+    }
+    try:
+        translated_column = column_switcheroo(args[0])[0]
+        percentile_value = args[1]
+        numeric_percentile_value = float(percentile_value)
+        new_function = percentile_replacement_function.get(numeric_percentile_value, function)
+    except (IndexError, ValueError):
+        return term
+
+    if new_function == function:
+        return term
+
+    return f"{new_function}({translated_column})"
 
 
 def apply_is_segment_condition(query: str) -> str:
@@ -50,6 +79,8 @@ def function_switcheroo(term):
     swapped_term = term
     if term == "count()":
         swapped_term = "count(span.duration)"
+    elif re.match(PERCENTILE_REGEX, term):
+        swapped_term = format_percentile_term(term)
 
     return swapped_term, swapped_term != term
 

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -1,4 +1,3 @@
-import re
 from typing import TypedDict
 
 from parsimonious import NodeVisitor
@@ -13,9 +12,6 @@ class QueryParts(TypedDict):
     query: str
     equations: list[str] | None
     orderby: list[str] | None
-
-
-PERCENTILE_REGEX = r"percentile\(.*\)"
 
 
 def format_percentile_term(term):
@@ -79,7 +75,7 @@ def function_switcheroo(term):
     swapped_term = term
     if term == "count()":
         swapped_term = "count(span.duration)"
-    elif re.match(PERCENTILE_REGEX, term):
+    elif term.startswith("percentile("):
         swapped_term = format_percentile_term(term)
 
     return swapped_term, swapped_term != term

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -89,6 +89,10 @@ def test_mep_to_eap_simple_query(input: str, expected: str):
             ["avgIf(transaction.duration,greater,300)"],
             ["avgIf(span.duration,greater,300)"],
         ),
+        pytest.param(
+            ["percentile(transaction.duration,0.5000)", "percentile(transaction.duration,0.94)"],
+            ["p50(span.duration)", "percentile(span.duration,0.94)"],
+        ),
     ],
 )
 def test_mep_to_eap_simple_selected_columns(input: list[str], expected: list[str]):

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -46,6 +46,10 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "title:tasks.spike_protection.run_spike_projection",
             "(transaction:tasks.spike_protection.run_spike_projection) AND is_transaction:1",
         ),
+        pytest.param(
+            "geo.country_code:US AND geo.city:San Francisco",
+            "(user.geo.country_code:US AND user.geo.city:San Francisco) AND is_transaction:1",
+        ),
     ],
 )
 def test_mep_to_eap_simple_query(input: str, expected: str):
@@ -66,6 +70,16 @@ def test_mep_to_eap_simple_query(input: str, expected: str):
         pytest.param(
             ["transaction.duration"],
             ["span.duration"],
+        ),
+        pytest.param(
+            ["geo.country_code", "geo.city", "geo.region", "geo.subdivision", "geo.subregion"],
+            [
+                "user.geo.country_code",
+                "user.geo.city",
+                "user.geo.region",
+                "user.geo.subdivision",
+                "user.geo.subregion",
+            ],
         ),
         pytest.param(
             ["count()", "avg(transaction.duration)"],

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -50,6 +50,10 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "geo.country_code:US AND geo.city:San Francisco",
             "(user.geo.country_code:US AND user.geo.city:San Francisco) AND is_transaction:1",
         ),
+        pytest.param(
+            "percentile(transaction.duration,0.5000):>100 AND percentile(transaction.duration, 0.25):>20",
+            "(p50(span.duration):>100 AND percentile(span.duration, 0.25):>20) AND is_transaction:1",
+        ),
     ],
 )
 def test_mep_to_eap_simple_query(input: str, expected: str):


### PR DESCRIPTION
added a translation for common percentile functions that we support. Also added tests for the geo -> user.geo mappings and the percentile translations

