### PR TITLE
fix(workflow_engine): Correct threshold trigger logic

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -90,8 +90,7 @@ class DetectorStateManager:
         Resets the counter values for the detector.
         This method is to reset the counters when the detector is resolved.
         """
-        for counter in self.counter_names:
-            self.counter_updates[group_key][counter] = None
+        self.counter_updates[group_key] = {key: None for key in self.counter_names}
 
     def enqueue_counter_update(
         self, group_key: DetectorGroupKey, counter_updates: DetectorCounters
@@ -324,35 +323,43 @@ class StatefulDetectorHandler(
 
             self.state_manager.enqueue_dedupe_update(group_key, dedupe_value)
 
-            evaluated_priority, condition_results = self._evaluate_value(
-                group_data_values[group_key],
-                state_data,
+            condition_results, evaluated_priority = self._evaluation_detector_conditions(
+                group_data_values[group_key]
             )
 
-            if evaluated_priority is None or condition_results is None:
+            if condition_results is None:
+                # Invalid condition result, nothing we can do
+                continue
+
+            if state_data.status == evaluated_priority:
+                # evaluated priority is equal to current detector state.
+                # Nothing to do and no thresholds to increment
+
+                # Reset counters if any were incremented while evaluating a
+                # different priority (but not reaching thresholds)
+                if any(state_data.counter_updates.values()):
+                    self.state_manager.enqueue_counter_reset()
+
                 continue
 
             updated_threshold_counts = self._increment_detector_thresholds(
                 state_data, evaluated_priority, group_key
             )
 
-            # XXX(epurkhiser): Doing some debugging to understand why it
-            # apperas the thresholds are reached immediately for uptime results
-            if self.detector.type == "uptime_domain_failure":
-                logger.info(
-                    "uptime_debug_logging",
-                    extra={
-                        "packet": data_packet,
-                        "state_data": state_data,
-                        "threshold_counts": updated_threshold_counts,
-                        "thresholds": self._thresholds,
-                    },
-                )
-
             new_priority = self._has_breached_threshold(updated_threshold_counts)
+
             if new_priority is None:
-                # We haven't met any thresholds yet, so continue checking
+                # We haven't met any thresholds yet
                 continue
+
+            if state_data.status == new_priority:
+                # breached threshold priority matches existing threshold, do
+                # not report an occurrence.
+                continue
+
+            # OK counts are reset
+            if new_priority == DetectorPriorityLevel.OK:
+                self.state_manager.enqueue_counter_reset(group_key)
 
             self.state_manager.enqueue_state_update(
                 group_key,
@@ -421,7 +428,6 @@ class StatefulDetectorHandler(
         if new_priority == DetectorPriorityLevel.OK:
             # Call the `create_resolve_message` method to create the status change.
             detector_result = self._create_resolve_message(group_key)
-            self.state_manager.enqueue_counter_reset(group_key)
         else:
             # Call the `create_occurrence` method to create the detector occurrence.
             detector_occurrence, event_data = self.create_occurrence(
@@ -460,19 +466,6 @@ class StatefulDetectorHandler(
 
         # Check if all keys are DetectorGroupKey instances
         return all(isinstance(key, DetectorGroupKey) for key in value.keys())
-
-    def _evaluate_value(
-        self,
-        value: DataPacketEvaluationType,
-        state: DetectorStateData,
-    ) -> tuple[DetectorPriorityLevel | None, ProcessedDataConditionGroup | None]:
-        condition_results, new_priority = self._evaluation_detector_conditions(value)
-
-        is_status_changed = state.status != new_priority
-        if not is_status_changed or condition_results is None:
-            return None, condition_results
-
-        return new_priority, condition_results
 
     def _get_configured_detector_levels(self) -> list[DetectorPriorityLevel]:
         priority_levels: list[DetectorPriorityLevel] = [level for level in DetectorPriorityLevel]


### PR DESCRIPTION
The adds a fair number of new tests to validate that the threshold breaching works as expected. A number of these tests were not passing so I adjusted the logic for when to increment thresholds and reset thresholds in the evaluate.