### PR TITLE
fix(explore): Stop propagation of escape key from input

### DIFF
--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -147,6 +147,7 @@ export function ComboBox({
       onKeyDown?.(evt);
       switch (evt.key) {
         case 'Escape':
+          evt.stopPropagation();
           state.close();
           state.setFocused(false);
           onInputEscape?.();


### PR DESCRIPTION
When used in a modal, allowing the escape key to propagate closes the modal.