### PR TITLE
chore(sentry-app): Disable installations for github deployment gates

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.tsx
@@ -325,10 +325,13 @@ export default function SentryAppDetailedView() {
       }
 
       if (userHasAccess) {
+        // TODO: @sentaur-athena: Remove hardcoded github-deployment-gates after deleting the code
         return (
           <InstallButton
             data-test-id="install-button"
-            disabled={disabledFromFeatures}
+            disabled={
+              disabledFromFeatures || integrationSlug === 'github-deployment-gates'
+            }
             onClick={() => handleInstall()}
             priority="primary"
             size="sm"


### PR DESCRIPTION
@Christinarlong  did investigation that we don't have a good way for deprecating SentryApps yet without side effects. So for now I disable this one from UI and delete the code in a quick follow-up.