### PR TITLE
chore(seer rpc): Bulk fetch all values

### DIFF
--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -4,6 +4,7 @@ from sentry.api.endpoints.seer_rpc import (
     get_attribute_names,
     get_attribute_values,
     get_attribute_values_with_substring,
+    get_attributes_and_values,
 )
 from sentry.testutils.cases import BaseSpansTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -126,4 +127,57 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             "values": {
                 "transaction": {"bar", "baz"},
             }
+        }
+
+    def test_get_attributes_and_values(self):
+        for tag_value in ["foo", "bar", "baz"]:
+            self.store_segment(
+                self.project.id,
+                uuid4().hex,
+                uuid4().hex,
+                span_id=uuid4().hex[:16],
+                organization_id=self.organization.id,
+                parent_span_id=None,
+                timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+                tags={"test_tag": tag_value},
+                duration=100,
+                exclusive_time=100,
+                is_eap=True,
+            )
+
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            span_id=uuid4().hex[:16],
+            organization_id=self.organization.id,
+            parent_span_id=None,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            tags={"another_tag": "another_value"},
+            duration=100,
+            exclusive_time=100,
+            is_eap=True,
+        )
+
+        result = get_attributes_and_values(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            stats_period="7d",
+        )
+
+        assert result == {
+            "attributes_and_values": [
+                {
+                    "test_tag": [
+                        {"value": "foo", "count": 1.0},
+                        {"value": "baz", "count": 1.0},
+                        {"value": "bar", "count": 1.0},
+                    ],
+                },
+                {
+                    "another_tag": [
+                        {"value": "another_value", "count": 1.0},
+                    ],
+                },
+            ]
         }


### PR DESCRIPTION
- Bulk fetch all values with `TraceItemStats` endpoint
- Formatted and returned as the following:
```json
"attributes_and_values": [
      {
          "field_1": [
              {"value": "foo", "count": 10.0},
              {"value": "bar", "count": 5.0},
          ],
      },
      {
          "field_2": [
              {"value": "another_value", "count": 1.0},
          ],
      },
  ]
```