### PR TITLE
dashboards: use xs size

### DIFF
--- a/static/app/views/dashboards/manage/dashboardCard.tsx
+++ b/static/app/views/dashboards/manage/dashboardCard.tsx
@@ -95,9 +95,9 @@ function DashboardCard({
               aria-label={favorited ? t('UnFavorite') : t('Favorite')}
             />
           }
-          size="zero"
           borderless
           aria-label={t('Dashboards Favorite')}
+          size="xs"
           onClick={async () => {
             try {
               setFavorited(!favorited);


### PR DESCRIPTION
Fixes the menu alignment in Chonk mode. The change has no impact on current UI (verified by toggling the theme).

![CleanShot 2025-06-25 at 14 39 48@2x](https://github.com/user-attachments/assets/166e2ee1-93d5-47c4-a735-90d831509692)
