### PR TITLE
ref(uptime): Rename ProjectUptimeSubscriptionMode -> UptimeMonitorMode

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -73,7 +73,7 @@ from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.snuba.dataset import Dataset
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeStatus
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils.cursors import Cursor, StringCursor
 from sentry.workflow_engine.models import Detector
 
@@ -275,8 +275,8 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         uptime_rules = ProjectUptimeSubscription.objects.filter(
             project__in=projects,
             mode__in=(
-                ProjectUptimeSubscriptionMode.MANUAL,
-                ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                UptimeMonitorMode.MANUAL,
+                UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             ),
         )
         crons_rules = (

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -159,7 +159,7 @@ from sentry.uptime.models import (
     UptimeSubscription,
     UptimeSubscriptionRegion,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.users.models.user import User
 from sentry.users.models.user_avatar import UserAvatar
@@ -2023,7 +2023,7 @@ class Factories:
         env: Environment | None,
         uptime_subscription: UptimeSubscription,
         status: int,
-        mode: ProjectUptimeSubscriptionMode,
+        mode: UptimeMonitorMode,
         name: str | None,
         owner: Actor | None,
         id: int | None,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -52,7 +52,7 @@ from sentry.uptime.models import (
     UptimeSubscriptionRegion,
     create_detector_from_project_subscription,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.users.models.identity import Identity, IdentityProvider
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -756,7 +756,7 @@ class Fixtures:
         env: Environment | None = None,
         uptime_subscription: UptimeSubscription | None = None,
         status: int = ObjectStatus.ACTIVE,
-        mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+        mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         name: str | None = None,
         owner: User | Team | None = None,
         uptime_status=UptimeStatus.OK,

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -44,11 +44,7 @@ from sentry.uptime.subscriptions.tasks import (
     send_uptime_config_deletion,
     update_remote_uptime_subscription,
 )
-from sentry.uptime.types import (
-    DATA_SOURCE_UPTIME_SUBSCRIPTION,
-    IncidentStatus,
-    ProjectUptimeSubscriptionMode,
-)
+from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, IncidentStatus, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
@@ -472,7 +468,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
             metrics.incr("uptime.result_processor.dropped_no_feature")
             return
 
-        mode_name = ProjectUptimeSubscriptionMode(detector.config["mode"]).name.lower()
+        mode_name = UptimeMonitorMode(detector.config["mode"]).name.lower()
 
         status_reason = "none"
         if result["status_reason"]:
@@ -567,7 +563,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
         # measurement of delay/duration.
         record_check_metrics(result, detector, {"mode": mode_name, **metric_tags})
 
-        Mode = ProjectUptimeSubscriptionMode
+        Mode = UptimeMonitorMode
         try:
             match detector.config["mode"]:
                 case Mode.AUTO_DETECTED_ONBOARDING:

--- a/src/sentry/uptime/detectors/result_handler.py
+++ b/src/sentry/uptime/detectors/result_handler.py
@@ -17,7 +17,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     delete_uptime_detector,
     update_project_uptime_subscription,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
 from sentry.workflow_engine.models.detector import Detector
@@ -31,7 +31,7 @@ ONBOARDING_MONITOR_PERIOD = timedelta(days=3)
 ONBOARDING_FAILURE_THRESHOLD = 3
 
 # The TTL of the redis key used to track the failure counts for a subscription in
-# `ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING` mode. Must be >= the
+# `UptimeMonitorMode.AUTO_DETECTED_ONBOARDING` mode. Must be >= the
 # ONBOARDING_MONITOR_PERIOD.
 ONBOARDING_FAILURE_REDIS_TTL = ONBOARDING_MONITOR_PERIOD
 
@@ -90,7 +90,7 @@ def handle_onboarding_result(
             update_project_uptime_subscription(
                 project_subscription,
                 interval_seconds=int(AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL.total_seconds()),
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
                 ensure_assignment=True,
             )
             create_system_audit_entry(

--- a/src/sentry/uptime/detectors/tasks.py
+++ b/src/sentry/uptime/detectors/tasks.py
@@ -32,7 +32,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     get_auto_monitored_detectors_for_project,
     is_url_auto_monitored_for_project,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 from sentry.utils.locking import UnableToAcquireLock
@@ -265,7 +265,7 @@ def monitor_url_for_project(project: Project, url: str) -> ProjectUptimeSubscrip
         url=url,
         interval_seconds=ONBOARDING_SUBSCRIPTION_INTERVAL_SECONDS,
         timeout_ms=ONBOARDING_SUBSCRIPTION_TIMEOUT_MS,
-        mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+        mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
     )
 
 

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -21,7 +21,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     create_project_uptime_subscription,
     update_project_uptime_subscription,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils.audit import create_audit_entry
 
 """
@@ -170,11 +170,10 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
         if not is_active_superuser(self.context["request"]):
             raise serializers.ValidationError("Only superusers can modify `mode`")
         try:
-            return ProjectUptimeSubscriptionMode(mode)
+            return UptimeMonitorMode(mode)
         except ValueError:
             raise serializers.ValidationError(
-                "Invalid mode, valid values are %s"
-                % [item.value for item in ProjectUptimeSubscriptionMode]
+                "Invalid mode, valid values are %s" % [item.value for item in UptimeMonitorMode]
             )
 
     def create(self, validated_data):
@@ -198,7 +197,7 @@ class UptimeMonitorValidator(CamelSnakeSerializer):
                 timeout_ms=validated_data["timeout_ms"],
                 name=validated_data["name"],
                 status=validated_data.get("status"),
-                mode=validated_data.get("mode", ProjectUptimeSubscriptionMode.MANUAL),
+                mode=validated_data.get("mode", UptimeMonitorMode.MANUAL),
                 owner=validated_data.get("owner"),
                 trace_sampling=validated_data.get("trace_sampling", False),
                 **method_headers_body,

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -15,10 +15,7 @@ from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.types.group import PriorityLevel
 from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_project_subscription
-from sentry.uptime.types import (
-    GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
-    ProjectUptimeSubscriptionMode,
-)
+from sentry.uptime.types import GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.workflow_engine.handlers.detector.base import DetectorOccurrence, EventData
 from sentry.workflow_engine.handlers.detector.stateful import (
@@ -307,7 +304,7 @@ class UptimeDomainCheckFailure(GroupType):
             "properties": {
                 "mode": {
                     "type": ["integer"],
-                    "enum": [mode.value for mode in ProjectUptimeSubscriptionMode],
+                    "enum": [mode.value for mode in UptimeMonitorMode],
                 },
                 "environment": {"type": ["string", "null"]},
             },

--- a/src/sentry/uptime/models.py
+++ b/src/sentry/uptime/models.py
@@ -31,7 +31,7 @@ from sentry.types.actor import Actor
 from sentry.uptime.types import (
     DATA_SOURCE_UPTIME_SUBSCRIPTION,
     GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
-    ProjectUptimeSubscriptionMode,
+    UptimeMonitorMode,
 )
 from sentry.utils.function_cache import cache_func, cache_func_for_models
 from sentry.utils.json import JSONEncoder
@@ -184,8 +184,8 @@ class ProjectUptimeSubscription(DefaultFieldsModelExisting):
         choices=ObjectStatus.as_choices(), db_default=ObjectStatus.ACTIVE
     )
     mode = models.SmallIntegerField(
-        default=ProjectUptimeSubscriptionMode.MANUAL.value,
-        db_default=ProjectUptimeSubscriptionMode.MANUAL.value,
+        default=UptimeMonitorMode.MANUAL.value,
+        db_default=UptimeMonitorMode.MANUAL.value,
     )
     # Date of the last time we updated the status for this monitor
     name = models.TextField()
@@ -211,15 +211,15 @@ class ProjectUptimeSubscription(DefaultFieldsModelExisting):
             models.UniqueConstraint(
                 fields=["project_id", "uptime_subscription"],
                 name="uptime_projectuptimesubscription_unique_manual_project_subscription",
-                condition=Q(mode=ProjectUptimeSubscriptionMode.MANUAL.value),
+                condition=Q(mode=UptimeMonitorMode.MANUAL.value),
             ),
             models.UniqueConstraint(
                 fields=["project_id", "uptime_subscription"],
                 name="uptime_projectuptimesubscription_unique_auto_project_subscription",
                 condition=Q(
                     mode__in=(
-                        ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
-                        ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE.value,
+                        UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
+                        UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value,
                     )
                 ),
             ),
@@ -254,8 +254,8 @@ def get_active_auto_monitor_count_for_org(organization: Organization) -> int:
         type=GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE,
         project__organization=organization,
         config__mode__in=[
-            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
-            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
+            UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         ],
     ).count()
 

--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -18,7 +18,7 @@ from sentry.uptime.models import (
     UptimeSubscriptionRegion,
     get_detector,
 )
-from sentry.uptime.types import CheckConfig, ProjectUptimeSubscriptionMode
+from sentry.uptime.types import CheckConfig, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -231,7 +231,7 @@ def broken_monitor_checker(**kwargs):
     ):
         detector = get_detector(uptime_subscription)
         assert detector
-        if detector.config["mode"] == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE:
+        if detector.config["mode"] == UptimeMonitorMode.AUTO_DETECTED_ACTIVE:
             disable_uptime_detector(detector)
             count += 1
 

--- a/src/sentry/uptime/types.py
+++ b/src/sentry/uptime/types.py
@@ -125,10 +125,14 @@ class EapCheckEntry:
     region: str
 
 
-class ProjectUptimeSubscriptionMode(enum.IntEnum):
+class UptimeMonitorMode(enum.IntEnum):
     # Manually created by a user
     MANUAL = 1
     # Auto-detected by our system and in the onboarding stage
     AUTO_DETECTED_ONBOARDING = 2
     # Auto-detected by our system and actively monitoring
     AUTO_DETECTED_ACTIVE = 3
+
+
+# TODO(epurkhiser): interop with getsentry
+ProjectUptimeSubscriptionMode = UptimeMonitorMode

--- a/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
+++ b/tests/sentry/incidents/endpoints/test_organization_combined_rule_index_endpoint.py
@@ -13,7 +13,7 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.types.actor import Actor
 from sentry.uptime.models import UptimeStatus
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from tests.sentry.incidents.endpoints.serializers.test_alert_rule import BaseAlertRuleSerializerTest
 
 
@@ -1124,7 +1124,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         self.create_project_uptime_subscription(
             name="Onboarding Uptime monitor",
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
         )
 
         request_data = {"name": "Uptime", "project": [self.project.id]}
@@ -1146,7 +1146,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         )
         self.create_project_uptime_subscription(
             name="Onboarding Uptime monitor",
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
         )
 
         request_data = {"project": [self.project.id], "sort": "name"}

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -47,7 +47,7 @@ from sentry.uptime.models import (
     UptimeSubscriptionRegion,
     get_detector,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils import json
 from tests.sentry.uptime.subscriptions.test_tasks import ConfigPusherTestMixin
 
@@ -841,13 +841,11 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             "organizations:uptime-create-issues",
             "organizations:uptime-detector-handler",
         ]
-        self.project_subscription.update(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
-        )
+        self.project_subscription.update(mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING)
         self.detector.update(
             config={
                 **self.detector.config,
-                "mode": ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+                "mode": UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
             }
         )
 
@@ -961,13 +959,13 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             "organizations:uptime-detector-handler",
         ]
         self.project_subscription.update(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
             date_added=datetime.now(timezone.utc) - timedelta(minutes=5),
         )
         self.detector.update(
             config={
                 **self.detector.config,
-                "mode": ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+                "mode": UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
             },
             date_added=datetime.now(timezone.utc)
             - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
@@ -1014,14 +1012,14 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             "organizations:uptime-detector-handler",
         ]
         self.project_subscription.update(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
             date_added=datetime.now(timezone.utc)
             - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
         )
         self.detector.update(
             config={
                 **self.detector.config,
-                "mode": ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING.value,
+                "mode": UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
             },
             date_added=datetime.now(timezone.utc)
             - (ONBOARDING_MONITOR_PERIOD + timedelta(minutes=5)),
@@ -1079,7 +1077,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
         self.project_subscription.refresh_from_db()
-        assert self.project_subscription.mode == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        assert self.project_subscription.mode == UptimeMonitorMode.AUTO_DETECTED_ACTIVE
         uptime_subscription.refresh_from_db()
         assert uptime_subscription.interval_seconds == int(
             AUTO_DETECTED_ACTIVE_SUBSCRIPTION_INTERVAL.total_seconds()

--- a/tests/sentry/uptime/detectors/test_tasks.py
+++ b/tests/sentry/uptime/detectors/test_tasks.py
@@ -39,7 +39,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     get_auto_monitored_detectors_for_project,
     is_url_auto_monitored_for_project,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 
 
 @freeze_time()
@@ -364,13 +364,13 @@ class TestMonitorUrlForProject(UptimeTestCase):
         manual_url = "https://sentry.io"
         self.create_project_uptime_subscription(
             uptime_subscription=self.create_uptime_subscription(url=manual_url),
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
         )
         url = "http://santry.io"
         monitor_url_for_project(self.project, url)
         assert is_url_auto_monitored_for_project(self.project, url)
         assert ProjectUptimeSubscription.objects.filter(
             project=self.project,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
             uptime_subscription__url=manual_url,
         ).exists()

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_index.py
@@ -7,7 +7,7 @@ from sentry.models.environment import Environment
 from sentry.quotas.base import SeatAssignmentResult
 from sentry.uptime.endpoints.validators import MAX_REQUEST_SIZE_BYTES
 from sentry.uptime.models import ProjectUptimeSubscription
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
 
 
@@ -38,7 +38,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
         )
         assert uptime_monitor.owner_user_id == self.user.id
         assert uptime_monitor.owner_team_id is None
-        assert uptime_monitor.mode == ProjectUptimeSubscriptionMode.MANUAL
+        assert uptime_monitor.mode == UptimeMonitorMode.MANUAL
         assert uptime_subscription.url == "http://sentry.io"
         assert uptime_subscription.interval_seconds == 60
         assert uptime_subscription.timeout_ms == 1500
@@ -115,7 +115,7 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             url="http://sentry.io",
             interval_seconds=60,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             status_code=400,
         )
         assert resp.data == {
@@ -133,14 +133,14 @@ class ProjectUptimeAlertIndexPostEndpointTest(ProjectUptimeAlertIndexBaseEndpoin
             url="http://sentry.io",
             interval_seconds=60,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         uptime_monitor = ProjectUptimeSubscription.objects.get(id=resp.data["id"])
         uptime_subscription = uptime_monitor.uptime_subscription
         assert uptime_monitor.name == "test"
         assert uptime_monitor.owner_user_id == self.user.id
         assert uptime_monitor.owner_team_id is None
-        assert uptime_monitor.mode == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+        assert uptime_monitor.mode == UptimeMonitorMode.AUTO_DETECTED_ACTIVE
         assert uptime_subscription.url == "http://sentry.io"
         assert uptime_subscription.interval_seconds == 60
         assert uptime_subscription.timeout_ms == 1000

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -41,7 +41,7 @@ from sentry.uptime.subscriptions.subscriptions import (
     update_project_uptime_subscription,
     update_uptime_subscription,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils.outcomes import Outcome
 from sentry.workflow_engine.models.detector import Detector
 
@@ -203,19 +203,19 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         assert ProjectUptimeSubscription.objects.filter(
             project=self.project,
             uptime_subscription__url="https://sentry.io",
             uptime_subscription__interval_seconds=3600,
             uptime_subscription__timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         ).exists()
 
         detector = get_detector(uptime_monitor.uptime_subscription)
         assert detector
-        assert detector.config["mode"] == ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE.value
+        assert detector.config["mode"] == UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value
         assert detector.config["environment"] == self.environment.name
         assert detector.project == self.project
         assert detector.owner_user_id is None
@@ -228,7 +228,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         assert create_project_uptime_subscription(
             self.project,
@@ -236,7 +236,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
 
         assert (
@@ -245,7 +245,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 uptime_subscription__url="https://sentry.io",
                 uptime_subscription__interval_seconds=3600,
                 uptime_subscription__timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             ).count()
             == 2
         )
@@ -260,7 +260,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
             with pytest.raises(MaxManualUptimeSubscriptionsReached):
                 assert create_project_uptime_subscription(
@@ -269,7 +269,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                     url="https://santry.io",
                     interval_seconds=3600,
                     timeout_ms=1000,
-                    mode=ProjectUptimeSubscriptionMode.MANUAL,
+                    mode=UptimeMonitorMode.MANUAL,
                 )
 
     def test_override_max_proj_subs(self):
@@ -282,7 +282,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
             with pytest.raises(MaxManualUptimeSubscriptionsReached):
                 create_project_uptime_subscription(
@@ -291,7 +291,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                     url="https://santry.io",
                     interval_seconds=3600,
                     timeout_ms=1000,
-                    mode=ProjectUptimeSubscriptionMode.MANUAL,
+                    mode=UptimeMonitorMode.MANUAL,
                     override_manual_org_limit=False,
                 )
             assert create_project_uptime_subscription(
@@ -300,7 +300,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://santry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
                 override_manual_org_limit=True,
             )
 
@@ -353,7 +353,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             status=ObjectStatus.DISABLED,
         )
         mock_disable_uptime_detector.assert_called()
@@ -366,7 +366,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
             status=ObjectStatus.DISABLED,
         )
         mock_disable_uptime_detector.assert_not_called()
@@ -380,7 +380,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.ACTIVE,
             )
             detector = get_detector(proj_sub.uptime_subscription)
@@ -396,7 +396,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
                 status=ObjectStatus.ACTIVE,
             )
             mock_enable_uptime_detector.assert_not_called()
@@ -413,7 +413,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.ACTIVE,
             )
 
@@ -433,7 +433,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING,
         )
         assert self.organization.get_option("sentry:uptime_autodetection")
 
@@ -443,7 +443,7 @@ class CreateProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io/manual",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
         )
         assert not self.organization.get_option("sentry:uptime_autodetection")
         with pytest.raises(ProjectUptimeSubscription.DoesNotExist):
@@ -459,7 +459,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             )
             prev_uptime_subscription = proj_sub.uptime_subscription
             prev_uptime_subscription.refresh_from_db()
@@ -482,7 +482,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
         assert proj_sub.name == "New name"
         assert proj_sub.owner_user_id == self.user.id
         assert proj_sub.owner_team_id is None
-        assert proj_sub.mode == ProjectUptimeSubscriptionMode.MANUAL
+        assert proj_sub.mode == UptimeMonitorMode.MANUAL
         prev_uptime_subscription.refresh_from_db()
         assert prev_uptime_subscription.url == "https://santry.io"
         assert prev_uptime_subscription.interval_seconds == 60
@@ -505,7 +505,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
             other_proj_sub = create_project_uptime_subscription(
                 self.project,
@@ -513,7 +513,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://santry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
 
             update_project_uptime_subscription(
@@ -536,7 +536,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 uptime_subscription__url="https://sentry.io",
                 uptime_subscription__interval_seconds=3600,
                 uptime_subscription__timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             ).count()
             == 1
         )
@@ -546,7 +546,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 uptime_subscription__url="https://santry.io",
                 uptime_subscription__interval_seconds=3600,
                 uptime_subscription__timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             ).count()
             == 1
         )
@@ -560,7 +560,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             )
             update_project_uptime_subscription(
                 proj_sub,
@@ -587,7 +587,7 @@ class UpdateProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+                mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
                 status=ObjectStatus.DISABLED,
             )
             update_project_uptime_subscription(
@@ -618,7 +618,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         other_sub = create_project_uptime_subscription(
             other_project,
@@ -626,7 +626,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         detector = get_detector(proj_sub.uptime_subscription)
         assert detector
@@ -654,7 +654,7 @@ class DeleteProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         detector = get_detector(proj_sub.uptime_subscription)
         assert detector
@@ -686,7 +686,7 @@ class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
 
         with self.tasks():
@@ -698,16 +698,14 @@ class RemoveUptimeSubscriptionIfUnusedTest(UptimeTestCase):
 class IsUrlMonitoredForProjectTest(UptimeTestCase):
     def test_not_monitored(self):
         assert not is_url_auto_monitored_for_project(self.project, "https://sentry.io")
-        subscription = self.create_project_uptime_subscription(
-            mode=ProjectUptimeSubscriptionMode.MANUAL
-        )
+        subscription = self.create_project_uptime_subscription(mode=UptimeMonitorMode.MANUAL)
         assert not is_url_auto_monitored_for_project(
             self.project, subscription.uptime_subscription.url
         )
 
     def test_monitored(self):
         subscription = self.create_project_uptime_subscription(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE
         )
         assert is_url_auto_monitored_for_project(self.project, subscription.uptime_subscription.url)
 
@@ -715,7 +713,7 @@ class IsUrlMonitoredForProjectTest(UptimeTestCase):
         other_project = self.create_project()
         subscription = self.create_project_uptime_subscription(
             project=self.project,
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
         )
         assert is_url_auto_monitored_for_project(self.project, subscription.uptime_subscription.url)
         assert not is_url_auto_monitored_for_project(
@@ -729,15 +727,15 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
 
     def test(self):
         subscription = self.create_project_uptime_subscription(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
+            mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE
         )
         detector = get_detector(subscription.uptime_subscription)
         assert get_auto_monitored_detectors_for_project(self.project) == [detector]
         other_subscription = self.create_project_uptime_subscription(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ONBOARDING
+            mode=UptimeMonitorMode.AUTO_DETECTED_ONBOARDING
         )
         other_detector = get_detector(other_subscription.uptime_subscription)
-        self.create_project_uptime_subscription(mode=ProjectUptimeSubscriptionMode.MANUAL)
+        self.create_project_uptime_subscription(mode=UptimeMonitorMode.MANUAL)
         assert set(get_auto_monitored_detectors_for_project(self.project)) == {
             detector,
             other_detector,
@@ -745,9 +743,7 @@ class GetAutoMonitoredSubscriptionsForProjectTest(UptimeTestCase):
 
     def test_other_project(self):
         other_project = self.create_project()
-        self.create_project_uptime_subscription(
-            mode=ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE
-        )
+        self.create_project_uptime_subscription(mode=UptimeMonitorMode.AUTO_DETECTED_ACTIVE)
         assert get_auto_monitored_detectors_for_project(other_project) == []
 
 
@@ -760,7 +756,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
         )
         detector = get_detector(proj_sub.uptime_subscription)
         assert detector
@@ -788,7 +784,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
                 uptime_status=UptimeStatus.FAILED,
             )
             detector = get_detector(proj_sub.uptime_subscription)
@@ -827,7 +823,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
         )
         detector = get_detector(proj_sub.uptime_subscription)
         assert detector
@@ -847,7 +843,7 @@ class DisableProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
         )
         detector = get_detector(proj_sub.uptime_subscription)
         assert detector
@@ -883,7 +879,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
             detector = get_detector(proj_sub.uptime_subscription)
             assert detector
@@ -937,7 +933,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
             detector = get_detector(proj_sub.uptime_subscription)
             assert detector
@@ -967,7 +963,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
             url="https://sentry.io",
             interval_seconds=3600,
             timeout_ms=1000,
-            mode=ProjectUptimeSubscriptionMode.MANUAL,
+            mode=UptimeMonitorMode.MANUAL,
         )
         detector = get_detector(proj_sub.uptime_subscription)
         assert detector
@@ -999,7 +995,7 @@ class EnableProjectUptimeSubscriptionTest(UptimeTestCase):
                 url="https://sentry.io",
                 interval_seconds=3600,
                 timeout_ms=1000,
-                mode=ProjectUptimeSubscriptionMode.MANUAL,
+                mode=UptimeMonitorMode.MANUAL,
             )
             detector = get_detector(proj_sub.uptime_subscription)
             assert detector

--- a/tests/sentry/uptime/subscriptions/test_tasks.py
+++ b/tests/sentry/uptime/subscriptions/test_tasks.py
@@ -38,7 +38,7 @@ from sentry.uptime.subscriptions.tasks import (
     update_remote_uptime_subscription,
     uptime_subscription_to_check_config,
 )
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils import redis
 
 pytestmark = [requires_kafka]
@@ -471,7 +471,7 @@ class UpdateUptimeSubscriptionTaskTest(BaseUptimeSubscriptionTaskTest):
 class BrokenMonitorCheckerTest(UptimeTestCase):
     def test(self):
         self.run_test(
-            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             UptimeStatus.FAILED,
             timezone.now() - timedelta(days=8),
             ObjectStatus.DISABLED,
@@ -480,7 +480,7 @@ class BrokenMonitorCheckerTest(UptimeTestCase):
 
     def test_manual(self):
         self.run_test(
-            ProjectUptimeSubscriptionMode.MANUAL,
+            UptimeMonitorMode.MANUAL,
             UptimeStatus.FAILED,
             timezone.now() - timedelta(days=8),
             ObjectStatus.ACTIVE,
@@ -489,7 +489,7 @@ class BrokenMonitorCheckerTest(UptimeTestCase):
 
     def test_auto_young(self):
         self.run_test(
-            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             UptimeStatus.FAILED,
             timezone.now() - timedelta(days=4),
             ObjectStatus.ACTIVE,
@@ -498,7 +498,7 @@ class BrokenMonitorCheckerTest(UptimeTestCase):
 
     def test_auto_not_failed(self):
         self.run_test(
-            ProjectUptimeSubscriptionMode.AUTO_DETECTED_ACTIVE,
+            UptimeMonitorMode.AUTO_DETECTED_ACTIVE,
             UptimeStatus.OK,
             timezone.now() - timedelta(days=8),
             ObjectStatus.ACTIVE,
@@ -507,7 +507,7 @@ class BrokenMonitorCheckerTest(UptimeTestCase):
 
     def run_test(
         self,
-        mode: ProjectUptimeSubscriptionMode,
+        mode: UptimeMonitorMode,
         uptime_status: UptimeStatus,
         update_date: datetime,
         expected_status: int,

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -18,7 +18,7 @@ from sentry.uptime.grouptype import (
     build_fingerprint,
 )
 from sentry.uptime.models import UptimeStatus, UptimeSubscription, get_detector
-from sentry.uptime.types import ProjectUptimeSubscriptionMode
+from sentry.uptime.types import UptimeMonitorMode
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -229,7 +229,7 @@ class TestUptimeDomainCheckFailureDetectorConfig(TestCase):
             project_id=self.project.id,
             type=UptimeDomainCheckFailure.slug,
             config={
-                "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                "mode": UptimeMonitorMode.MANUAL,
                 "environment": "hi",
             },
         )
@@ -260,7 +260,7 @@ class TestUptimeDomainCheckFailureDetectorConfig(TestCase):
                 project_id=self.project.id,
                 type=UptimeDomainCheckFailure.slug,
                 config={
-                    "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "mode": UptimeMonitorMode.MANUAL,
                     "environment": 1,
                 },
             )
@@ -281,7 +281,7 @@ class TestUptimeDomainCheckFailureDetectorConfig(TestCase):
                 project_id=self.project.id,
                 type=UptimeDomainCheckFailure.slug,
                 config={
-                    "bad_mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "bad_mode": UptimeMonitorMode.MANUAL,
                     "environment": "hi",
                 },
             )
@@ -291,7 +291,7 @@ class TestUptimeDomainCheckFailureDetectorConfig(TestCase):
                 project_id=self.project.id,
                 type=UptimeDomainCheckFailure.slug,
                 config={
-                    "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "mode": UptimeMonitorMode.MANUAL,
                     "environment": "hi",
                     "junk": "hi",
                 },
@@ -319,7 +319,7 @@ class TestUptimeDomainCheckFailureDetectorConfig(TestCase):
                 project_id=self.project.id,
                 type=UptimeDomainCheckFailure.slug,
                 config={
-                    "mode": ProjectUptimeSubscriptionMode.MANUAL,
+                    "mode": UptimeMonitorMode.MANUAL,
                 },
             )
 

--- a/tests/sentry/uptime/test_models.py
+++ b/tests/sentry/uptime/test_models.py
@@ -13,7 +13,7 @@ from sentry.uptime.models import (
     get_detector,
     get_top_hosting_provider_names,
 )
-from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, ProjectUptimeSubscriptionMode
+from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, UptimeMonitorMode
 from sentry.workflow_engine.models import Condition, DataSourceDetector
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
@@ -105,7 +105,7 @@ class GetDetectorTest(UptimeTestCase):
             name="My Uptime Monitor",
             config={
                 "environment": "production",
-                "mode": ProjectUptimeSubscriptionMode.MANUAL.value,
+                "mode": UptimeMonitorMode.MANUAL.value,
             },
         )
         DataSourceDetector.objects.create(data_source=data_source, detector=detector)


### PR DESCRIPTION
Since we're removing ProjectUptimeSubscriptionMode in the future we
should rename this appropriately.

Needs https://github.com/getsentry/getsentry/pull/17807