### PR TITLE
:wrench: chore(aci): disable firing notifications from the old system under FF

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1034,10 +1034,12 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
-        # TODO(cathy): add opposite of the FF organizations:workflow-engine-trigger-actions
-        for callback, futures in callback_and_futures:
-            has_alert = True
-            safe_execute(callback, group_event, futures)
+        if not features.has(
+            "organizations:workflow-engine-trigger-actions", group_event.project.organization
+        ):
+            for callback, futures in callback_and_futures:
+                has_alert = True
+                safe_execute(callback, group_event, futures)
 
     job["has_alert"] = has_alert
     return


### PR DESCRIPTION
we only fire actions from the legacy system if the `organizations:workflow-engine-trigger-actions` is disabled.