### PR TITLE
fix(usage stats): add chartTransform param to EnhancedUsageStatsOrganization

### DIFF
--- a/static/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx
+++ b/static/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx
@@ -15,7 +15,6 @@ import withRouteAnalytics from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import withProjects from 'sentry/utils/withProjects';
 import type {UsageSeries} from 'sentry/views/organizationStats/types';
-import type {ChartDataTransform} from 'sentry/views/organizationStats/usageChart';
 import type {UsageStatsOrganizationProps} from 'sentry/views/organizationStats/usageStatsOrg';
 import UsageStatsOrganization, {
   getChartProps,
@@ -211,7 +210,7 @@ interface EnhancedUsageStatsOrganizationProps
   isSingleProject: boolean;
   projects: Project[];
   subscription: Subscription;
-  chartTransform?: ChartDataTransform;
+  chartTransform?: string;
   spikeCursor?: string;
 }
 /**

--- a/static/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx
+++ b/static/gsApp/hooks/spendVisibility/enhancedUsageStatsOrganization.tsx
@@ -15,6 +15,7 @@ import withRouteAnalytics from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import withProjects from 'sentry/utils/withProjects';
 import type {UsageSeries} from 'sentry/views/organizationStats/types';
+import type {ChartDataTransform} from 'sentry/views/organizationStats/usageChart';
 import type {UsageStatsOrganizationProps} from 'sentry/views/organizationStats/usageStatsOrg';
 import UsageStatsOrganization, {
   getChartProps,
@@ -210,6 +211,7 @@ interface EnhancedUsageStatsOrganizationProps
   isSingleProject: boolean;
   projects: Project[];
   subscription: Subscription;
+  chartTransform?: ChartDataTransform;
   spikeCursor?: string;
 }
 /**
@@ -233,6 +235,7 @@ function EnhancedUsageStatsOrganization({
   spikeCursor,
   clientDiscard,
   handleChangeState,
+  chartTransform,
 }: EnhancedUsageStatsOrganizationProps) {
   const project = projects.find(p => p.id === `${projectIds[0]}`);
   const endpointQueryDatetime = getEndpointQueryDatetime(dataDatetime);
@@ -342,6 +345,7 @@ function EnhancedUsageStatsOrganization({
       endpointQuery={newEndpointQuery}
       handleChangeState={handleChangeState}
       clientDiscard={clientDiscard}
+      chartTransform={chartTransform}
     >
       {usageStats => {
         const loadingStatuses = [usageStats.orgStats.isPending];


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/RTC-1058/stats-graph-does-not-update-when-switching-from-periodic-to-cumulative

<img width="1408" alt="Screenshot 2025-06-25 at 12 43 57 PM" src="https://github.com/user-attachments/assets/55023ad8-1ab8-4c69-9b17-6e8fd66fecd8" />
