### PR TITLE
feat(trace-suspect-tags): Multiple chart interactions

### DIFF
--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -8,6 +8,7 @@ import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 type RegistrationFunction = (chart: EChartsType) => void;
 
 interface WidgetSyncContext {
+  groupName: string;
   register: RegistrationFunction;
 }
 
@@ -35,6 +36,7 @@ export function WidgetSyncContextProvider({
     <_WidgetSyncProvider
       value={{
         register,
+        groupName,
       }}
     >
       {children}
@@ -49,6 +51,7 @@ export function useWidgetSyncContext(): WidgetSyncContext {
     // The provider was not registered, return a dummy function
     return {
       register: (_p: any) => null,
+      groupName: '',
     };
   }
 

--- a/static/app/views/explore/charts/index.tsx
+++ b/static/app/views/explore/charts/index.tsx
@@ -108,8 +108,6 @@ export function ExploreCharts({
   const [interval, setInterval, intervalOptions] = useChartInterval();
   const topEvents = useTopEvents();
   const isTopN = defined(topEvents) && topEvents > 0;
-  const chartWrapperRef = useRef<HTMLDivElement>(null);
-
   const previousTimeseriesResult = usePrevious(timeseriesResult);
 
   const getSeries = useCallback(
@@ -262,8 +260,8 @@ export function ExploreCharts({
   );
 
   return (
-    <ChartList ref={chartWrapperRef}>
-      <WidgetSyncContextProvider>
+    <ChartList>
+      <WidgetSyncContextProvider groupName={EXPLORE_CHART_GROUP}>
         {chartInfos.map((chartInfo, index) => {
           return (
             <Chart
@@ -279,7 +277,6 @@ export function ExploreCharts({
               hideContextMenu={hideContextMenu}
               samplingMode={samplingMode}
               topEvents={topEvents}
-              chartWrapperRef={chartWrapperRef}
             />
           );
         })}
@@ -290,7 +287,6 @@ export function ExploreCharts({
 
 interface ChartProps {
   chartInfo: ChartInfo;
-  chartWrapperRef: React.RefObject<HTMLDivElement | null>;
   handleChartTypeChange: (chartType: ChartType, index: number) => void;
   index: number;
   interval: string;
@@ -315,7 +311,6 @@ function Chart({
   hideContextMenu,
   samplingMode,
   topEvents,
-  chartWrapperRef,
 }: ChartProps) {
   const theme = useTheme();
   const [visible, setVisible] = useState(true);
@@ -324,6 +319,7 @@ function Chart({
 
   const chartRef = useRef<ReactEchartsRef>(null);
   const triggerWrapperRef = useRef<HTMLDivElement | null>(null);
+  const chartWrapperRef = useRef<HTMLDivElement | null>(null);
 
   const boxSelectOptions = useChartBoxSelect({
     chartRef,
@@ -479,7 +475,7 @@ function Chart({
         : Bars;
 
   return (
-    <ChartWrapper>
+    <ChartWrapper ref={chartWrapperRef}>
       <Widget
         key={index}
         height={chartHeight}
@@ -491,6 +487,7 @@ function Chart({
             ref={chartRef}
             brush={boxSelectOptions.brush}
             onBrushEnd={boxSelectOptions.onBrushEnd}
+            onBrushStart={boxSelectOptions.onBrushStart}
             toolBox={boxSelectOptions.toolBox}
             plottables={chartInfo.data.map(timeSeries => {
               return new DataPlottableConstructor(


### PR DESCRIPTION
This PR polishes box selection across multiple charts:
- Adjusts the position of the 'floating trigger' with vertical scroll on the page. 
- Ensures that clicking dropdowns outside the charts, acts as outside clicks. 
- Makes box selection chart specific, we can draw boxes on charts individually. Having shared boxes leads to problems like, unit mismatch when we plot different types of aggrs on the charts. 
<img width="1088" alt="Screenshot 2025-06-25 at 4 56 45 PM" src="https://github.com/user-attachments/assets/c11f9f43-7a13-4284-b98a-dba601a50aff" />
