### PR TITLE
feat(notif-platform): Prototype the template layer

### DIFF
--- a/src/sentry/notifications/platform/README.md
+++ b/src/sentry/notifications/platform/README.md
@@ -1,8 +1,56 @@
 # Notification Platform
 
-TODO(ecosystem): Fill this out
+This module enables Sentry to send standardized notifications across different providers, with rich contents
+like images, calls to action, and dynamic links. It does this through a series of data models and concepts which can be heavily customized,
+but also provides some opinionated defaults to make it easy to get started.
 
-## NotificationProvider
+A quick glossary overview:
+
+- **Notification Service** - the interface to actually send your notifications
+- **Notification Data** - the raw data which is necessary for your notification
+- **Notification Loader** - the function to format your raw data in a readable, user-friendly template
+- **Notification Template** - the standardized format all notifications adhere to prior to being sent
+- **Notification Provider** - the medium to which a notification is sent (e.g. slack, discord)
+- **Notification Provider Renderer** - the adapter to convert templates to provider specific formats (e.g. Slack's BlockKit, HTML for emails)
+- **Notification Target** - the intended recipients of a notification
+- **Notification Strategy** - a standardized pattern for repeatably creating targets
+
+If you're developing a new feature, and wish to notify a Slack channel, Discord direct message, or just send an email,
+refer to the [usage](#usage) instructions ahead. If you're extending the platform, check out [development](#development) instead.
+
+## Usage
+
+For wholly new notifications, you'll have to set up the following:
+
+1. Decide on a `NotificationCategory` (for opt-out) and assign a `NotificationSource` (for logs/metrics) in [types.py](./types.py).
+2. Use the above to create a dataclass (following the `NotificationData` protocol in [types.py](./types.py))
+3. Create a loader (`NotificationTemplateLoader` type) to convert your `NotificationData` to a `NotificationTemplate`.
+4. Create targets from the intended recipients (preferably with a `NotificationStrategy`)
+5. Import the `NotificationService` into your app code, and call `notify()`!
+
+If you're changing the formatting of an existing notification, just update the loader from Step 3.
+If you're sending an existing notification from new code, just import the service from Step 5.
+
+In general, the platform has sensible defaults, and standardized elements to help with consistency across providers and notifications.
+If you find yourself needing more customization, a [custom ProviderRenderer](#notificationproviderrenderer) might be helpful, but consider adding the change to all other providers as well.
+
+### Example
+
+<!-- TODO(ecosystem): Add example here -->
+
+## Development
+
+The following are common areas that owners of the NotificationPlatform may need to extend/improve.
+
+### NotificationStrategy
+
+<!-- TODO(ecosystem): Add guidance here -->
+
+### NotificationProviderRenderer
+
+<!-- TODO(ecosystem): Add guidance here -->
+
+### NotificationProvider
 
 A notification provider is the system which Sentry will trigger in order to notify NotificationTargets, for example; Email or Slack.
 
@@ -14,3 +62,7 @@ To register a new provider:
    - Extend `NotificationProvider` from [`.provider`](./provider.py) and implement its methods/variables.
    - Import `provider_registry` from [`.registry`](./registry.py) and add it via decorator: `@provider_registry.register(<YOUR-KEY-HERE>)`
 4. In [../apps](../apps.py), explicitly import the module to register the provider on initialization.
+
+### NotificationTemplate
+
+<!-- TODO(ecosystem): Add guidance here -->

--- a/src/sentry/notifications/platform/README.md
+++ b/src/sentry/notifications/platform/README.md
@@ -8,8 +8,8 @@ A quick glossary overview:
 
 - **Notification Service** - the interface to actually send your notifications
 - **Notification Data** - the raw data which is necessary for your notification
-- **Notification Loader** - the function to format your raw data in a readable, user-friendly template
-- **Notification Template** - the standardized format all notifications adhere to prior to being sent
+- **Notification Template** - the class which is responsible for processing your raw Notification Data into a user readable format
+- **Notification Rendered Template** - the standardized format all notifications adhere to prior to being sent
 - **Notification Provider** - the medium to which a notification is sent (e.g. slack, discord)
 - **Notification Provider Renderer** - the adapter to convert templates to provider specific formats (e.g. Slack's BlockKit, HTML for emails)
 - **Notification Target** - the intended recipients of a notification
@@ -24,7 +24,7 @@ For wholly new notifications, you'll have to set up the following:
 
 1. Decide on a `NotificationCategory` (for opt-out) and assign a `NotificationSource` (for logs/metrics) in [types.py](./types.py).
 2. Use the above to create a dataclass (following the `NotificationData` protocol in [types.py](./types.py))
-3. Create a loader (`NotificationTemplateLoader` type) to convert your `NotificationData` to a `NotificationTemplate`.
+3. Create a template (`NotificationTemplate` subclass) to convert your `NotificationData` to a `NotificationRenderedTemplate`.
 4. Create targets from the intended recipients (preferably with a `NotificationStrategy`)
 5. Import the `NotificationService` into your app code, and call `notify()`!
 

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -7,9 +7,9 @@ from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationTarget,
     NotificationTargetResourceType,
-    NotificationTemplate,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 
@@ -23,7 +23,7 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate) -> DiscordRenderable:
+    ](cls, *, data: DataT, rendered_template: NotificationRenderedTemplate) -> DiscordRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/discord/provider.py
+++ b/src/sentry/notifications/platform/discord/provider.py
@@ -23,7 +23,7 @@ class DiscordRenderer(NotificationRenderer[DiscordRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate[DataT]) -> DiscordRenderable:
+    ](cls, *, data: DataT, template: NotificationTemplate) -> DiscordRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -23,7 +23,7 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate[DataT]) -> EmailRenderable:
+    ](cls, *, data: DataT, template: NotificationTemplate) -> EmailRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/email/provider.py
+++ b/src/sentry/notifications/platform/email/provider.py
@@ -7,9 +7,9 @@ from sentry.notifications.platform.target import GenericNotificationTarget
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationTarget,
     NotificationTargetResourceType,
-    NotificationTemplate,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 
@@ -23,7 +23,7 @@ class EmailRenderer(NotificationRenderer[EmailRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate) -> EmailRenderable:
+    ](cls, *, data: DataT, rendered_template: NotificationRenderedTemplate) -> EmailRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -7,9 +7,9 @@ from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationTarget,
     NotificationTargetResourceType,
-    NotificationTemplate,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 
@@ -23,7 +23,7 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate) -> MSTeamsRenderable:
+    ](cls, *, data: DataT, rendered_template: NotificationRenderedTemplate) -> MSTeamsRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/msteams/provider.py
+++ b/src/sentry/notifications/platform/msteams/provider.py
@@ -23,7 +23,7 @@ class MSTeamsRenderer(NotificationRenderer[MSTeamsRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate[DataT]) -> MSTeamsRenderable:
+    ](cls, *, data: DataT, template: NotificationTemplate) -> MSTeamsRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/provider.py
+++ b/src/sentry/notifications/platform/provider.py
@@ -3,6 +3,7 @@ from typing import Protocol
 from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.types import (
     NotificationCategory,
+    NotificationData,
     NotificationProviderKey,
     NotificationTarget,
     NotificationTargetResourceType,
@@ -51,7 +52,7 @@ class NotificationProvider[RenderableT](Protocol):
 
     @classmethod
     def get_renderer(
-        cls, *, category: NotificationCategory
+        cls, *, data: NotificationData, category: NotificationCategory
     ) -> type[NotificationRenderer[RenderableT]]:
         """
         Returns an instance of a renderer for a given notification, falling back to the default renderer.

--- a/src/sentry/notifications/platform/registry.py
+++ b/src/sentry/notifications/platform/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from sentry.notifications.platform.provider import NotificationProvider
+from sentry.notifications.platform.types import NotificationTemplate
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 from sentry.utils.registry import Registry
 
@@ -33,3 +34,4 @@ class NotificationProviderRegistry(Registry[type[NotificationProvider[Any]]]):
 
 
 provider_registry = NotificationProviderRegistry()
+template_registry = Registry[type[NotificationTemplate[Any]]]()

--- a/src/sentry/notifications/platform/renderer.py
+++ b/src/sentry/notifications/platform/renderer.py
@@ -24,8 +24,11 @@ class NotificationRenderer[RenderableT](Protocol):
         DataT: NotificationData
     ](cls, *, data: DataT, rendered_template: NotificationRenderedTemplate) -> RenderableT:
         """
-        Convert a loader, and data into a renderable object.
-        The loader is run
-        The form of the renderable object is defined by the provider.
+        Convert a rendered template into a renderable object specific to the provider.
+        For example, Slack might output BlockKit JSON, email might output HTML/txt.
+
+        We pass in the data as well since custom renderers may use raw data to modify the output
+        for the provider where the template cannot. For example, custom markdown formatting,
+        provider-specific features like modals, etc.
         """
         ...

--- a/src/sentry/notifications/platform/renderer.py
+++ b/src/sentry/notifications/platform/renderer.py
@@ -3,7 +3,7 @@ from typing import Protocol
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
-    NotificationTemplate,
+    NotificationRenderedTemplate,
 )
 
 
@@ -22,7 +22,7 @@ class NotificationRenderer[RenderableT](Protocol):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate) -> RenderableT:
+    ](cls, *, data: DataT, rendered_template: NotificationRenderedTemplate) -> RenderableT:
         """
         Convert a loader, and data into a renderable object.
         The loader is run

--- a/src/sentry/notifications/platform/renderer.py
+++ b/src/sentry/notifications/platform/renderer.py
@@ -22,9 +22,10 @@ class NotificationRenderer[RenderableT](Protocol):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate[DataT]) -> RenderableT:
+    ](cls, *, data: DataT, template: NotificationTemplate) -> RenderableT:
         """
-        Convert template, and data into a renderable object.
+        Convert a loader, and data into a renderable object.
+        The loader is run
         The form of the renderable object is defined by the provider.
         """
         ...

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -43,10 +43,10 @@ class NotificationService[T: NotificationData]:
         provider.validate_target(target=target)
 
         # Step 4: Render the template
-        template_cls = template_registry.get(self.data.template_key)
+        template_cls = template_registry.get(self.data.source)
         template = template_cls()
         rendered_template = template.render(data=self.data)
-        renderer = provider.get_renderer(category=template.category)
+        renderer = provider.get_renderer(data=self.data, category=template.category)
         renderable = renderer.render(data=self.data, rendered_template=rendered_template)
 
         # Step 5: Send the notification

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -5,9 +5,9 @@ from sentry.notifications.platform.registry import provider_registry
 from sentry.notifications.platform.target import prepare_targets
 from sentry.notifications.platform.types import (
     NotificationData,
-    NotificationLoader,
     NotificationStrategy,
     NotificationTarget,
+    NotificationTemplateLoader,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,11 +21,12 @@ class NotificationService[T: NotificationData]:
     def __init__(self, *, data: T):
         self.data: Final[T] = data
 
+    # TODO(ecosystem): Eventually this should be converted to spawn a task with the business logic below
     def notify_prepared_target(
         self,
         *,
         target: NotificationTarget,
-        loader: NotificationLoader[T],
+        loader: NotificationTemplateLoader[T],
     ) -> None:
         """
         Send a notification directly to a prepared target.
@@ -60,7 +61,7 @@ class NotificationService[T: NotificationData]:
         *,
         strategy: NotificationStrategy | None = None,
         targets: list[NotificationTarget] | None = None,
-        loader: NotificationLoader[T],
+        loader: NotificationTemplateLoader[T],
     ) -> None:
 
         if not strategy and not targets:

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -1,13 +1,12 @@
 import logging
 from typing import Final
 
-from sentry.notifications.platform.registry import provider_registry
+from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.target import prepare_targets
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationStrategy,
     NotificationTarget,
-    NotificationTemplate,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,12 +21,7 @@ class NotificationService[T: NotificationData]:
         self.data: Final[T] = data
 
     # TODO(ecosystem): Eventually this should be converted to spawn a task with the business logic below
-    def notify_prepared_target(
-        self,
-        *,
-        target: NotificationTarget,
-        template: NotificationTemplate[T],
-    ) -> None:
+    def notify_prepared_target(self, *, target: NotificationTarget) -> None:
         """
         Send a notification directly to a prepared target.
         NOTE: This method ignores notification settings. When possible, consider using a strategy instead of
@@ -49,6 +43,8 @@ class NotificationService[T: NotificationData]:
         provider.validate_target(target=target)
 
         # Step 4: Render the template
+        template_cls = template_registry.get(self.data.template_key)
+        template = template_cls()
         rendered_template = template.render(data=self.data)
         renderer = provider.get_renderer(category=template.category)
         renderable = renderer.render(data=self.data, rendered_template=rendered_template)
@@ -61,7 +57,6 @@ class NotificationService[T: NotificationData]:
         *,
         strategy: NotificationStrategy | None = None,
         targets: list[NotificationTarget] | None = None,
-        template: NotificationTemplate[T],
     ) -> None:
         if not strategy and not targets:
             raise NotificationServiceError(
@@ -81,4 +76,4 @@ class NotificationService[T: NotificationData]:
         prepare_targets(targets=targets)
 
         for target in targets:
-            self.notify_prepared_target(target=target, template=template)
+            self.notify_prepared_target(target=target)

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -7,7 +7,7 @@ from sentry.notifications.platform.types import (
     NotificationData,
     NotificationStrategy,
     NotificationTarget,
-    NotificationTemplateLoader,
+    NotificationTemplate,
 )
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class NotificationService[T: NotificationData]:
         self,
         *,
         target: NotificationTarget,
-        loader: NotificationTemplateLoader[T],
+        template: NotificationTemplate[T],
     ) -> None:
         """
         Send a notification directly to a prepared target.
@@ -49,9 +49,9 @@ class NotificationService[T: NotificationData]:
         provider.validate_target(target=target)
 
         # Step 4: Render the template
-        renderer = provider.get_renderer(category=self.data.category)
-        template = loader(self.data)
-        renderable = renderer.render(data=self.data, template=template)
+        rendered_template = template.render(data=self.data)
+        renderer = provider.get_renderer(category=template.category)
+        renderable = renderer.render(data=self.data, rendered_template=rendered_template)
 
         # Step 5: Send the notification
         provider.send(target=target, renderable=renderable)
@@ -61,9 +61,8 @@ class NotificationService[T: NotificationData]:
         *,
         strategy: NotificationStrategy | None = None,
         targets: list[NotificationTarget] | None = None,
-        loader: NotificationTemplateLoader[T],
+        template: NotificationTemplate[T],
     ) -> None:
-
         if not strategy and not targets:
             raise NotificationServiceError(
                 "Must provide either a strategy or targets. Strategy is preferred."
@@ -82,4 +81,4 @@ class NotificationService[T: NotificationData]:
         prepare_targets(targets=targets)
 
         for target in targets:
-            self.notify_prepared_target(target=target, loader=loader)
+            self.notify_prepared_target(target=target, template=template)

--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -5,9 +5,9 @@ from sentry.notifications.platform.registry import provider_registry
 from sentry.notifications.platform.target import prepare_targets
 from sentry.notifications.platform.types import (
     NotificationData,
+    NotificationLoader,
     NotificationStrategy,
     NotificationTarget,
-    NotificationTemplate,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ class NotificationService[T: NotificationData]:
         self,
         *,
         target: NotificationTarget,
-        template: NotificationTemplate[T],
+        loader: NotificationLoader[T],
     ) -> None:
         """
         Send a notification directly to a prepared target.
@@ -49,6 +49,7 @@ class NotificationService[T: NotificationData]:
 
         # Step 4: Render the template
         renderer = provider.get_renderer(category=self.data.category)
+        template = loader(self.data)
         renderable = renderer.render(data=self.data, template=template)
 
         # Step 5: Send the notification
@@ -59,7 +60,7 @@ class NotificationService[T: NotificationData]:
         *,
         strategy: NotificationStrategy | None = None,
         targets: list[NotificationTarget] | None = None,
-        template: NotificationTemplate[T],
+        loader: NotificationLoader[T],
     ) -> None:
 
         if not strategy and not targets:
@@ -80,4 +81,4 @@ class NotificationService[T: NotificationData]:
         prepare_targets(targets=targets)
 
         for target in targets:
-            self.notify_prepared_target(target=target, template=template)
+            self.notify_prepared_target(target=target, loader=loader)

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -23,7 +23,7 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate[DataT]) -> SlackRenderable:
+    ](cls, *, data: DataT, template: NotificationTemplate) -> SlackRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/slack/provider.py
+++ b/src/sentry/notifications/platform/slack/provider.py
@@ -7,9 +7,9 @@ from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
     NotificationData,
     NotificationProviderKey,
+    NotificationRenderedTemplate,
     NotificationTarget,
     NotificationTargetResourceType,
-    NotificationTemplate,
 )
 from sentry.organizations.services.organization.model import RpcOrganizationSummary
 
@@ -23,7 +23,7 @@ class SlackRenderer(NotificationRenderer[SlackRenderable]):
     @classmethod
     def render[
         DataT: NotificationData
-    ](cls, *, data: DataT, template: NotificationTemplate) -> SlackRenderable:
+    ](cls, *, data: DataT, rendered_template: NotificationRenderedTemplate) -> SlackRenderable:
         return {}
 
 

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -21,8 +21,7 @@ class NotificationCategory(StrEnum):
 
 class NotificationSource(StrEnum):
     """
-    An unique identifier for each notification. Each source should map to one way a notification
-    can be sent.
+    An unique identifier for each notification.
     """
 
     TEST = "test"
@@ -109,7 +108,6 @@ class NotificationRenderedAction(TypedDict):
 
 @dataclass(frozen=True)
 class NotificationTemplate:
-
     subject: str
     """
     The subject or title of the notification. It's expected that the receiver understand the
@@ -153,7 +151,7 @@ class NotificationTemplate:
     """
 
 
-type NotificationLoader[DataT: NotificationData] = Callable[[DataT], NotificationTemplate]
+type NotificationTemplateLoader[DataT: NotificationData] = Callable[[DataT], NotificationTemplate]
 """
 A loader is a function which takes in NotificationData and returns a valid NotificationTemplate.
 """

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -38,6 +38,14 @@ class NotificationProviderKey(StrEnum):
     DISCORD = ExternalProviderEnum.DISCORD
 
 
+class NotificationTemplateKey(StrEnum):
+    """
+    The unique keys for each registered notification template.
+    """
+
+    DEBUG = "debug"
+
+
 class NotificationTargetResourceType(StrEnum):
     """
     Avenues for a notification to be sent to that can be understood by a provider.
@@ -77,6 +85,11 @@ class NotificationData(Protocol):
     """
     The source is uniquely attributable to the way this notification was sent. It will be tracked in
     metrics/analytics to determine the egress from a given code-path or service.
+    """
+
+    template_key: NotificationTemplateKey
+    """
+    The key of the template that will be used to render this notification.
     """
 
 
@@ -168,7 +181,7 @@ class NotificationTemplate[T: NotificationData](abc.ABC):
         ...
 
     @abc.abstractmethod
-    def render(cls, data: T) -> NotificationRenderedTemplate:
+    def render(self, data: T) -> NotificationRenderedTemplate:
         """
         Produce a rendered template given the notification data. Usually, this will involve
         formatting the data into user-friendly strings of text.

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationData,
+    NotificationRenderedTemplate,
     NotificationSource,
     NotificationStrategy,
     NotificationTarget,
@@ -12,23 +13,25 @@ from sentry.notifications.platform.types import (
 
 @dataclass(kw_only=True, frozen=True)
 class MockNotification(NotificationData):
-    category = NotificationCategory.DEBUG
     source = NotificationSource.TEST
     message: str
 
 
-def mock_notification_loader(data: MockNotification) -> NotificationTemplate:
-    return NotificationTemplate(
-        subject="Mock Notification",
-        body=data.message,
-        actions=[
-            {
-                "label": "Visit Sentry",
-                "link": "https://www.sentry.io",
-            }
-        ],
-        footer="This is a mock footer",
-    )
+class MockNotificationTemplate(NotificationTemplate[MockNotification]):
+    category = NotificationCategory.DEBUG
+
+    def render(cls, data: MockNotification) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject="Mock Notification",
+            body=data.message,
+            actions=[
+                {
+                    "label": "Visit Sentry",
+                    "link": "https://www.sentry.io",
+                }
+            ],
+            footer="This is a mock footer",
+        )
 
 
 class MockStrategy(NotificationStrategy):

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationData,
@@ -8,19 +9,22 @@ from sentry.notifications.platform.types import (
     NotificationStrategy,
     NotificationTarget,
     NotificationTemplate,
+    NotificationTemplateKey,
 )
 
 
 @dataclass(kw_only=True, frozen=True)
 class MockNotification(NotificationData):
     source = NotificationSource.TEST
+    template_key = NotificationTemplateKey.DEBUG
     message: str
 
 
+@template_registry.register(NotificationTemplateKey.DEBUG)
 class MockNotificationTemplate(NotificationTemplate[MockNotification]):
     category = NotificationCategory.DEBUG
 
-    def render(cls, data: MockNotification) -> NotificationRenderedTemplate:
+    def render(self, data: MockNotification) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
             subject="Mock Notification",
             body=data.message,

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -5,22 +5,19 @@ from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationData,
     NotificationRenderedTemplate,
-    NotificationSource,
     NotificationStrategy,
     NotificationTarget,
     NotificationTemplate,
-    NotificationTemplateKey,
 )
 
 
 @dataclass(kw_only=True, frozen=True)
 class MockNotification(NotificationData):
-    source = NotificationSource.TEST
-    template_key = NotificationTemplateKey.DEBUG
+    source = "test"
     message: str
 
 
-@template_registry.register(NotificationTemplateKey.DEBUG)
+@template_registry.register(MockNotification.source)
 class MockNotificationTemplate(NotificationTemplate[MockNotification]):
     category = NotificationCategory.DEBUG
 
@@ -28,12 +25,15 @@ class MockNotificationTemplate(NotificationTemplate[MockNotification]):
         return NotificationRenderedTemplate(
             subject="Mock Notification",
             body=data.message,
-            actions=[
-                {
-                    "label": "Visit Sentry",
-                    "link": "https://www.sentry.io",
-                }
-            ],
+            actions=[{"label": "Visit Sentry", "link": "https://www.sentry.io"}],
+            footer="This is a mock footer",
+        )
+
+    def render_example(self) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject="Mock Notification",
+            body="This is a mock notification",
+            actions=[{"label": "Visit Sentry", "link": "https://www.sentry.io"}],
             footer="This is a mock footer",
         )
 

--- a/src/sentry/testutils/notifications/platform.py
+++ b/src/sentry/testutils/notifications/platform.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from sentry.notifications.platform.types import (
     NotificationCategory,
     NotificationData,
-    NotificationRenderedTemplate,
     NotificationSource,
     NotificationStrategy,
     NotificationTarget,
@@ -18,9 +17,18 @@ class MockNotification(NotificationData):
     message: str
 
 
-class MockNotificationTemplate(NotificationTemplate[MockNotification]):
-    def process(self, *, data: MockNotification) -> NotificationRenderedTemplate:
-        return data.message
+def mock_notification_loader(data: MockNotification) -> NotificationTemplate:
+    return NotificationTemplate(
+        subject="Mock Notification",
+        body=data.message,
+        actions=[
+            {
+                "label": "Visit Sentry",
+                "link": "https://www.sentry.io",
+            }
+        ],
+        footer="This is a mock footer",
+    )
 
 
 class MockStrategy(NotificationStrategy):

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -6,15 +6,16 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
+from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 class DiscordRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = DiscordNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
-        template = mock_notification_loader(data)
-        assert renderer.render(data=data, template=template) == {}
+        template = MockNotificationTemplate()
+        rendered_template = template.render(data)
+        assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 
 class DiscordNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -11,10 +11,12 @@ from sentry.testutils.notifications.platform import MockNotification, MockNotifi
 
 class DiscordRendererTest(TestCase):
     def test_default_renderer(self):
-        renderer = DiscordNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
         rendered_template = template.render(data)
+        renderer = DiscordNotificationProvider.get_renderer(
+            data=data, category=NotificationCategory.DEBUG
+        )
         assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 

--- a/tests/sentry/notifications/platform/discord/test_provider.py
+++ b/tests/sentry/notifications/platform/discord/test_provider.py
@@ -6,19 +6,15 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
+from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
 
 
 class DiscordRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = DiscordNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
-        # TODO(ecosystem): Replace this with a real data blob, template and renderable
-        assert (
-            renderer.render(
-                data=MockNotification(message="test"), template=MockNotificationTemplate()
-            )
-            == {}
-        )
+        data = MockNotification(message="test")
+        template = mock_notification_loader(data)
+        assert renderer.render(data=data, template=template) == {}
 
 
 class DiscordNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -6,19 +6,15 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
+from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
 
 
 class EmailRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = EmailNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
-        # TODO(ecosystem): Replace this with a real data blob, template and renderable
-        assert (
-            renderer.render(
-                data=MockNotification(message="test"), template=MockNotificationTemplate()
-            )
-            == {}
-        )
+        data = MockNotification(message="test")
+        template = mock_notification_loader(data)
+        assert renderer.render(data=data, template=template) == {}
 
 
 class EmailNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -11,10 +11,12 @@ from sentry.testutils.notifications.platform import MockNotification, MockNotifi
 
 class EmailRendererTest(TestCase):
     def test_default_renderer(self):
-        renderer = EmailNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
         rendered_template = template.render(data)
+        renderer = EmailNotificationProvider.get_renderer(
+            data=data, category=NotificationCategory.DEBUG
+        )
         assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 

--- a/tests/sentry/notifications/platform/email/test_provider.py
+++ b/tests/sentry/notifications/platform/email/test_provider.py
@@ -6,15 +6,16 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
+from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 class EmailRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = EmailNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
-        template = mock_notification_loader(data)
-        assert renderer.render(data=data, template=template) == {}
+        template = MockNotificationTemplate()
+        rendered_template = template.render(data)
+        assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 
 class EmailNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -6,15 +6,16 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
+from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 class MSTeamsRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = MSTeamsNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
-        template = mock_notification_loader(data)
-        assert renderer.render(data=data, template=template) == {}
+        template = MockNotificationTemplate()
+        rendered_template = template.render(data)
+        assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 
 class MSTeamsNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -11,10 +11,12 @@ from sentry.testutils.notifications.platform import MockNotification, MockNotifi
 
 class MSTeamsRendererTest(TestCase):
     def test_default_renderer(self):
-        renderer = MSTeamsNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
         rendered_template = template.render(data)
+        renderer = MSTeamsNotificationProvider.get_renderer(
+            data=data, category=NotificationCategory.DEBUG
+        )
         assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 

--- a/tests/sentry/notifications/platform/msteams/test_provider.py
+++ b/tests/sentry/notifications/platform/msteams/test_provider.py
@@ -6,19 +6,15 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
+from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
 
 
 class MSTeamsRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = MSTeamsNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
-        # TODO(ecosystem): Replace this with a real data blob, template and renderable
-        assert (
-            renderer.render(
-                data=MockNotification(message="test"), template=MockNotificationTemplate()
-            )
-            == {}
-        )
+        data = MockNotification(message="test")
+        template = mock_notification_loader(data)
+        assert renderer.render(data=data, template=template) == {}
 
 
 class MSTeamsNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -11,10 +11,12 @@ from sentry.testutils.notifications.platform import MockNotification, MockNotifi
 
 class SlackRendererTest(TestCase):
     def test_default_renderer(self):
-        renderer = SlackNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
         template = MockNotificationTemplate()
         rendered_template = template.render(data)
+        renderer = SlackNotificationProvider.get_renderer(
+            data=data, category=NotificationCategory.DEBUG
+        )
         assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -6,19 +6,15 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
+from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
 
 
 class SlackRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = SlackNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
-        # TODO(ecosystem): Replace this with a real data blob, template and renderable
-        assert (
-            renderer.render(
-                data=MockNotification(message="test"), template=MockNotificationTemplate()
-            )
-            == {}
-        )
+        data = MockNotification(message="test")
+        template = mock_notification_loader(data)
+        assert renderer.render(data=data, template=template) == {}
 
 
 class SlackNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/slack/test_provider.py
+++ b/tests/sentry/notifications/platform/slack/test_provider.py
@@ -6,15 +6,16 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.notifications.platform import MockNotification, mock_notification_loader
+from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 
 
 class SlackRendererTest(TestCase):
     def test_default_renderer(self):
         renderer = SlackNotificationProvider.get_renderer(category=NotificationCategory.DEBUG)
         data = MockNotification(message="test")
-        template = mock_notification_loader(data)
-        assert renderer.render(data=data, template=template) == {}
+        template = MockNotificationTemplate()
+        rendered_template = template.render(data)
+        assert renderer.render(data=data, rendered_template=rendered_template) == {}
 
 
 class SlackNotificationProviderTest(TestCase):

--- a/tests/sentry/notifications/platform/test_provider.py
+++ b/tests/sentry/notifications/platform/test_provider.py
@@ -15,10 +15,12 @@ from sentry.notifications.platform.types import (
 )
 from sentry.organizations.services.organization.serial import serialize_organization_summary
 from sentry.testutils.cases import TestCase
+from sentry.testutils.notifications.platform import MockNotification
 
 
 class NotificationProviderTest(TestCase):
     def setUp(self):
+        self.data = MockNotification(message="test")
         self.slack_integration = self.create_integration(
             organization=self.organization, provider="slack", external_id="ext-123"
         )
@@ -37,7 +39,7 @@ class NotificationProviderTest(TestCase):
                 assert resource_type in NotificationTargetResourceType
             # Ensures the default renderer links back to its connected provider key
             assert provider.default_renderer == provider.get_renderer(
-                category=NotificationCategory.DEBUG
+                data=self.data, category=NotificationCategory.DEBUG
             )
             assert isinstance(provider.is_available(), bool)
             assert isinstance(

--- a/tests/sentry/notifications/platform/test_registry.py
+++ b/tests/sentry/notifications/platform/test_registry.py
@@ -3,7 +3,6 @@ from sentry.notifications.platform.email.provider import EmailNotificationProvid
 from sentry.notifications.platform.msteams.provider import MSTeamsNotificationProvider
 from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
-from sentry.notifications.platform.types import NotificationTemplateKey
 from sentry.testutils.cases import TestCase
 
 
@@ -31,26 +30,16 @@ class NotificationProviderRegistryTest(TestCase):
 
 
 class NotificationTemplateRegistryTest(TestCase):
-    debug_template_keys = {NotificationTemplateKey.DEBUG}
-
-    def test_no_unknown_registration_keys(self):
-        for template_key, template in template_registry.registrations.items():
-            assert template_key in NotificationTemplateKey, (
-                f"Template {template!r} was registered with an unknown key ({template_key})\n"
-                "use NotificationTemplateKey within @template_registry.register() to fix this test."
+    def test_template_categories(self):
+        for template in template_registry.registrations.values():
+            assert template.category, (
+                f"Template {template!r} was registered without a category!\n"
+                "Use NotificationCategory within the class to fix this test"
             )
 
-    def test_no_unused_production_keys(self):
-        unused_keys: set[str] = set(NotificationTemplateKey)
-        for template_key in template_registry.registrations.keys():
-            if template_key in unused_keys:
-                unused_keys.remove(template_key)
-
-        # Remove the debug template keys, these are permitted to be unused in production.
-        unused_production_keys = unused_keys - set(self.debug_template_keys)
-
-        if unused_production_keys:
-            raise AssertionError(
-                f"Known NotificationTemplateKey(s) have no associated template registered: '{', '.join(unused_production_keys)}'\n"
-                "Use @template_registry.register() to register them, or explicitly exclude these keys within this test."
+    def test_template_source_matches_categories(self):
+        for source, template in template_registry.registrations.items():
+            assert source in template.category.get_sources(), (
+                f"Template {template!r} was registered with an unknown source ({source})\n"
+                f"Add the '{source}' to NOTIFICATION_SOURCE_MAP on '{template.category.value}' to fix this test."
             )

--- a/tests/sentry/notifications/platform/test_registry.py
+++ b/tests/sentry/notifications/platform/test_registry.py
@@ -1,8 +1,9 @@
 from sentry.notifications.platform.discord.provider import DiscordNotificationProvider
 from sentry.notifications.platform.email.provider import EmailNotificationProvider
 from sentry.notifications.platform.msteams.provider import MSTeamsNotificationProvider
-from sentry.notifications.platform.registry import provider_registry
+from sentry.notifications.platform.registry import provider_registry, template_registry
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
+from sentry.notifications.platform.types import NotificationTemplateKey
 from sentry.testutils.cases import TestCase
 
 
@@ -27,3 +28,29 @@ class NotificationProviderRegistryTest(TestCase):
         assert len(providers) == len(expected_providers)
         for provider in expected_providers:
             assert provider in providers
+
+
+class NotificationTemplateRegistryTest(TestCase):
+    debug_template_keys = {NotificationTemplateKey.DEBUG}
+
+    def test_no_unknown_registration_keys(self):
+        for template_key, template in template_registry.registrations.items():
+            assert template_key in NotificationTemplateKey, (
+                f"Template {template!r} was registered with an unknown key ({template_key})\n"
+                "use NotificationTemplateKey within @template_registry.register() to fix this test."
+            )
+
+    def test_no_unused_production_keys(self):
+        unused_keys: set[str] = set(NotificationTemplateKey)
+        for template_key in template_registry.registrations.keys():
+            if template_key in unused_keys:
+                unused_keys.remove(template_key)
+
+        # Remove the debug template keys, these are permitted to be unused in production.
+        unused_production_keys = unused_keys - set(self.debug_template_keys)
+
+        if unused_production_keys:
+            raise AssertionError(
+                f"Known NotificationTemplateKey(s) have no associated template registered: '{', '.join(unused_production_keys)}'\n"
+                "Use @template_registry.register() to register them, or explicitly exclude these keys within this test."
+            )

--- a/tests/sentry/notifications/platform/test_service.py
+++ b/tests/sentry/notifications/platform/test_service.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any
 from unittest import mock
 
@@ -7,37 +6,15 @@ import pytest
 from sentry.notifications.platform.service import NotificationService, NotificationServiceError
 from sentry.notifications.platform.target import GenericNotificationTarget, prepare_targets
 from sentry.notifications.platform.types import (
-    NotificationCategory,
-    NotificationData,
     NotificationProviderKey,
-    NotificationRenderedTemplate,
-    NotificationSource,
-    NotificationStrategy,
-    NotificationTarget,
     NotificationTargetResourceType,
-    NotificationTemplate,
 )
 from sentry.testutils.cases import TestCase
-
-
-@dataclass(kw_only=True, frozen=True)
-class MockNotification(NotificationData):
-    category = NotificationCategory.DEBUG
-    source = NotificationSource.TEST
-    message: str
-
-
-class MockNotificationTemplate(NotificationTemplate[MockNotification]):
-    def process(self, *, data: MockNotification) -> NotificationRenderedTemplate:
-        return data.message
-
-
-class MockStrategy(NotificationStrategy):
-    def __init__(self, *, targets: list[NotificationTarget]):
-        self.targets = targets
-
-    def get_targets(self) -> list[NotificationTarget]:
-        return self.targets
+from sentry.testutils.notifications.platform import (
+    MockNotification,
+    MockStrategy,
+    mock_notification_loader,
+)
 
 
 class NotificationServiceTest(TestCase):
@@ -47,14 +24,11 @@ class NotificationServiceTest(TestCase):
             resource_type=NotificationTargetResourceType.EMAIL,
             resource_id="test@example.com",
         )
-        self.template = MockNotificationTemplate()
+        self.loader = mock_notification_loader
 
     def test_basic_notify(self):
         service = NotificationService(data=MockNotification(message="this is a test notification"))
-        service.notify(
-            targets=[self.target],
-            template=self.template,
-        )
+        service.notify(targets=[self.target], loader=self.loader)
 
     @mock.patch("sentry.notifications.platform.service.logger")
     def test_validation_on_notify(self, mock_logger):
@@ -63,16 +37,16 @@ class NotificationServiceTest(TestCase):
             NotificationServiceError,
             match="Must provide either a strategy or targets. Strategy is preferred.",
         ):
-            service.notify(template=self.template)
+            service.notify(loader=self.loader)
 
         strategy = MockStrategy(targets=[])
         with pytest.raises(
             NotificationServiceError,
             match="Cannot provide both strategy and targets, only one is permitted. Strategy is preferred.",
         ):
-            service.notify(strategy=strategy, targets=[self.target], template=self.template)
+            service.notify(strategy=strategy, targets=[self.target], loader=self.loader)
 
-        service.notify(strategy=strategy, template=self.template)
+        service.notify(strategy=strategy, loader=self.loader)
         mock_logger.info.assert_called_once_with(
             "Strategy '%s' did not yield targets", strategy.__class__.__name__
         )
@@ -80,10 +54,7 @@ class NotificationServiceTest(TestCase):
     def test_basic_notify_prepared_target(self):
         service = NotificationService(data=MockNotification(message="this is a test notification"))
         prepare_targets([self.target])
-        service.notify_prepared_target(
-            target=self.target,
-            template=self.template,
-        )
+        service.notify_prepared_target(target=self.target, loader=self.loader)
 
     def test_validation_on_notify_prepared_target(self):
         empty_data_service: NotificationService[Any] = NotificationService(data=None)
@@ -91,14 +62,11 @@ class NotificationServiceTest(TestCase):
             NotificationServiceError,
             match="Notification service must be initialized with data before sending!",
         ):
-            empty_data_service.notify_prepared_target(target=self.target, template=self.template)
+            empty_data_service.notify_prepared_target(target=self.target, loader=self.loader)
 
         service = NotificationService(data=MockNotification(message="this is a test notification"))
         with pytest.raises(
             NotificationServiceError,
             match="Target must have `prepare_targets` called prior to sending",
         ):
-            service.notify_prepared_target(
-                target=self.target,
-                template=self.template,
-            )
+            service.notify_prepared_target(target=self.target, loader=self.loader)

--- a/tests/sentry/notifications/platform/test_service.py
+++ b/tests/sentry/notifications/platform/test_service.py
@@ -12,8 +12,8 @@ from sentry.notifications.platform.types import (
 from sentry.testutils.cases import TestCase
 from sentry.testutils.notifications.platform import (
     MockNotification,
+    MockNotificationTemplate,
     MockStrategy,
-    mock_notification_loader,
 )
 
 
@@ -24,11 +24,11 @@ class NotificationServiceTest(TestCase):
             resource_type=NotificationTargetResourceType.EMAIL,
             resource_id="test@example.com",
         )
-        self.loader = mock_notification_loader
+        self.template = MockNotificationTemplate()
 
     def test_basic_notify(self):
         service = NotificationService(data=MockNotification(message="this is a test notification"))
-        service.notify(targets=[self.target], loader=self.loader)
+        service.notify(targets=[self.target], template=self.template)
 
     @mock.patch("sentry.notifications.platform.service.logger")
     def test_validation_on_notify(self, mock_logger):
@@ -37,16 +37,16 @@ class NotificationServiceTest(TestCase):
             NotificationServiceError,
             match="Must provide either a strategy or targets. Strategy is preferred.",
         ):
-            service.notify(loader=self.loader)
+            service.notify(template=self.template)
 
         strategy = MockStrategy(targets=[])
         with pytest.raises(
             NotificationServiceError,
             match="Cannot provide both strategy and targets, only one is permitted. Strategy is preferred.",
         ):
-            service.notify(strategy=strategy, targets=[self.target], loader=self.loader)
+            service.notify(strategy=strategy, targets=[self.target], template=self.template)
 
-        service.notify(strategy=strategy, loader=self.loader)
+        service.notify(strategy=strategy, template=self.template)
         mock_logger.info.assert_called_once_with(
             "Strategy '%s' did not yield targets", strategy.__class__.__name__
         )
@@ -54,7 +54,7 @@ class NotificationServiceTest(TestCase):
     def test_basic_notify_prepared_target(self):
         service = NotificationService(data=MockNotification(message="this is a test notification"))
         prepare_targets([self.target])
-        service.notify_prepared_target(target=self.target, loader=self.loader)
+        service.notify_prepared_target(target=self.target, template=self.template)
 
     def test_validation_on_notify_prepared_target(self):
         empty_data_service: NotificationService[Any] = NotificationService(data=None)
@@ -62,11 +62,11 @@ class NotificationServiceTest(TestCase):
             NotificationServiceError,
             match="Notification service must be initialized with data before sending!",
         ):
-            empty_data_service.notify_prepared_target(target=self.target, loader=self.loader)
+            empty_data_service.notify_prepared_target(target=self.target, template=self.template)
 
         service = NotificationService(data=MockNotification(message="this is a test notification"))
         with pytest.raises(
             NotificationServiceError,
             match="Target must have `prepare_targets` called prior to sending",
         ):
-            service.notify_prepared_target(target=self.target, loader=self.loader)
+            service.notify_prepared_target(target=self.target, template=self.template)

--- a/tests/sentry/notifications/platform/test_service.py
+++ b/tests/sentry/notifications/platform/test_service.py
@@ -28,7 +28,7 @@ class NotificationServiceTest(TestCase):
 
     def test_basic_notify(self):
         service = NotificationService(data=MockNotification(message="this is a test notification"))
-        service.notify(targets=[self.target], template=self.template)
+        service.notify(targets=[self.target])
 
     @mock.patch("sentry.notifications.platform.service.logger")
     def test_validation_on_notify(self, mock_logger):
@@ -37,16 +37,16 @@ class NotificationServiceTest(TestCase):
             NotificationServiceError,
             match="Must provide either a strategy or targets. Strategy is preferred.",
         ):
-            service.notify(template=self.template)
+            service.notify()
 
         strategy = MockStrategy(targets=[])
         with pytest.raises(
             NotificationServiceError,
             match="Cannot provide both strategy and targets, only one is permitted. Strategy is preferred.",
         ):
-            service.notify(strategy=strategy, targets=[self.target], template=self.template)
+            service.notify(strategy=strategy, targets=[self.target])
 
-        service.notify(strategy=strategy, template=self.template)
+        service.notify(strategy=strategy)
         mock_logger.info.assert_called_once_with(
             "Strategy '%s' did not yield targets", strategy.__class__.__name__
         )
@@ -54,7 +54,7 @@ class NotificationServiceTest(TestCase):
     def test_basic_notify_prepared_target(self):
         service = NotificationService(data=MockNotification(message="this is a test notification"))
         prepare_targets([self.target])
-        service.notify_prepared_target(target=self.target, template=self.template)
+        service.notify_prepared_target(target=self.target)
 
     def test_validation_on_notify_prepared_target(self):
         empty_data_service: NotificationService[Any] = NotificationService(data=None)
@@ -62,11 +62,11 @@ class NotificationServiceTest(TestCase):
             NotificationServiceError,
             match="Notification service must be initialized with data before sending!",
         ):
-            empty_data_service.notify_prepared_target(target=self.target, template=self.template)
+            empty_data_service.notify_prepared_target(target=self.target)
 
         service = NotificationService(data=MockNotification(message="this is a test notification"))
         with pytest.raises(
             NotificationServiceError,
             match="Target must have `prepare_targets` called prior to sending",
         ):
-            service.notify_prepared_target(target=self.target, template=self.template)
+            service.notify_prepared_target(target=self.target)


### PR DESCRIPTION
This PR introduces some more structure around templates, including a template registry. I've also added some tests to ensure developer interface with it correctly. 

For example, registering with an unknown key:

```
@template_registry.register('some-unknown-key')
MyTemplate(...): ...
```
will yield:
```
tests/sentry/notifications/platform/test_registry.py:40: in test_no_unknown_registration_keys
    assert (
E   AssertionError: Template <class 'sentry.notifications.platform.registry.DemoNotificationTemplate'> was registered with an unknown key (some-unknown-key)
E
E   assert 'some-unknown-key' in NotificationTemplateKey
```
and forgetting a template, but adding to NotificationTemplateKey

```
tests/sentry/notifications/platform/test_registry.py:55: in test_no_unused_production_keys
    raise AssertionError(
E   AssertionError: Known NotificationTemplateKey(s) have no associated template registered: 'my_new_template'
E   Use @template_registry.register() to register them, or explicitly exclude them within this test.

```

We've discussed this below block offline, it's the way forward for now so collapsing it for legibility
  <details> 
  <summary>Explanation of NotificationRenderedTemplate</summary>
  
  This has a few things to consider though: 
  - For email, we have flexibility, we can just pass the existing django templates and get whatever level of customization we want by modifying the templates. 
  - For integrations though, `body` (for example) is just a `str`. So if a notification wanted bold the text of a slack message, it'd have to be signaled within the `str` to bold somehow, likely from a shared templating language (e.g. markdown `**`s), which is idealistic. This would have to be understood by all providers; which is reasonable for MSTeams/Slack/Discord, but might not work for future providers(?) if they don't parse markdown, or do so differently (e.g notion uses `| text` for quotes, md uses `> text` even though most other syntax is md-like)
    - If we allow markdown in the `str` attributes, it's likely we'd get bugs as soon as someone tries a provider specific md formatting (e.g. imagine like `f"[John](@john)"` or something)
    - Onboarding new providers would also become a minefield if there is syntax assumed to be understood by all that is done differently for other integrations (e.g. if jira uses [img:link](...) but slack uses ![link](...)) -- If a new provider needs a new format, it means every notify call must now be updated to include the new syntax :(
  
    
  The only way around this I can see is restricting to top level building blocks (e.g. `subject`, `body`, `action`, `chart`) that explicitly will not allow custom formatting, and deferring to renderers to do all non-standard elements. Pros: Consistency out of the box, and devs never need to learn slack markdown vs discord markdown. Cons: If a dev wants to bold text, they need a custom renderer for each provider 🙃 
  </details>
