### PR TITLE
feat(seer): Add org-wide setup check endpoint for seer

### DIFF
--- a/src/sentry/api/endpoints/organization_seer_setup_check.py
+++ b/src/sentry/api/endpoints/organization_seer_setup_check.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import quotas
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.constants import DataCategory
+from sentry.models.organization import Organization
+from sentry.seer.seer_setup import get_seer_org_acknowledgement, get_seer_user_acknowledgement
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class OrganizationSeerSetupCheck(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=200, window=60, concurrent_limit=20),
+            RateLimitCategory.USER: RateLimit(limit=100, window=60, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=1000, window=60, concurrent_limit=100),
+        }
+    }
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        Checks Seer product setup status for the organization including quotas and acknowledgements/consent.
+        """
+        if not request.user.is_authenticated:
+            return Response(status=400)
+
+        # Check quotas
+        has_seer_scanner_quota: bool = quotas.backend.has_available_reserved_budget(
+            org_id=organization.id, data_category=DataCategory.SEER_SCANNER
+        )
+        has_autofix_quota: bool = quotas.backend.has_available_reserved_budget(
+            org_id=organization.id, data_category=DataCategory.SEER_AUTOFIX
+        )
+
+        # Check consent
+        user_acknowledgement = get_seer_user_acknowledgement(
+            user_id=request.user.id, org_id=organization.id
+        )
+        org_acknowledgement = True
+        if not user_acknowledgement:  # If the user has acknowledged, the org must have too.
+            org_acknowledgement = get_seer_org_acknowledgement(org_id=organization.id)
+
+        return Response(
+            {
+                "setupAcknowledgement": {
+                    "orgHasAcknowledged": org_acknowledgement,
+                    "userHasAcknowledged": user_acknowledgement,
+                },
+                "billing": {
+                    "hasAutofixQuota": has_autofix_quota,
+                    "hasScannerQuota": has_seer_scanner_quota,
+                },
+            }
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -37,6 +37,7 @@ from sentry.api.endpoints.organization_projects_experiment import (
 from sentry.api.endpoints.organization_sampling_project_span_counts import (
     OrganizationSamplingProjectSpanCountsEndpoint,
 )
+from sentry.api.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheck
 from sentry.api.endpoints.organization_spans_aggregation import OrganizationSpansAggregationEndpoint
 from sentry.api.endpoints.organization_stats_summary import OrganizationStatsSummaryEndpoint
 from sentry.api.endpoints.organization_trace_item_attributes import (
@@ -2122,6 +2123,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/trace-explorer-ai/query/$",
         TraceExplorerAIQuery.as_view(),
         name="sentry-api-0-trace-explorer-ai-query",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/setup-check/$",
+        OrganizationSeerSetupCheck.as_view(),
+        name="sentry-api-0-organization-seer-setup-check",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/sentry-app-components/$",

--- a/tests/sentry/api/endpoints/test_organization_seer_setup_check.py
+++ b/tests/sentry/api/endpoints/test_organization_seer_setup_check.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import calendar
+from unittest.mock import patch
+
+import orjson
+from django.utils import timezone
+
+from sentry.models.promptsactivity import PromptsActivity
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+
+
+class OrganizationSeerSetupCheckTestBase(APITestCase, SnubaTestCase):
+    endpoint = "sentry-api-0-organization-seer-setup-check"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def get_response(self, organization_slug, **kwargs):
+        url = f"/api/0/organizations/{organization_slug}/seer/setup-check/"
+        return self.client.get(url, format="json", **kwargs)
+
+
+class OrganizationSeerSetupCheckSuccessTest(OrganizationSeerSetupCheckTestBase):
+    def test_successful_setup_default_state(self):
+        """
+        Test the default state with no acknowledgements and quotas available.
+        """
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "setupAcknowledgement": {
+                "orgHasAcknowledged": False,
+                "userHasAcknowledged": False,
+            },
+            "billing": {
+                "hasAutofixQuota": True,
+                "hasScannerQuota": True,
+            },
+        }
+
+    def test_current_user_acknowledged_setup(self):
+        """
+        Test when the current user has acknowledged the setup.
+        """
+        feature = "seer_autofix_setup_acknowledged"
+        PromptsActivity.objects.create(
+            user_id=self.user.id,
+            feature=feature,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps(
+                {"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}
+            ).decode("utf-8"),
+        )
+
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data["setupAcknowledgement"] == {
+            "orgHasAcknowledged": True,
+            "userHasAcknowledged": True,
+        }
+
+    def test_org_acknowledged_not_user(self):
+        """
+        Test when another user in the org has acknowledged, but not the requesting user.
+        """
+        other_user = self.create_user()
+        self.create_member(user=other_user, organization=self.organization, role="member")
+        feature = "seer_autofix_setup_acknowledged"
+        PromptsActivity.objects.create(
+            user_id=other_user.id,
+            feature=feature,
+            organization_id=self.organization.id,
+            project_id=0,
+            data=orjson.dumps(
+                {"dismissed_ts": calendar.timegm(timezone.now().utctimetuple())}
+            ).decode("utf-8"),
+        )
+
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data["setupAcknowledgement"] == {
+            "orgHasAcknowledged": True,
+            "userHasAcknowledged": False,
+        }
+
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_no_autofix_quota(self, mock_has_budget):
+        """
+        Test when the organization has no autofix quota available.
+        """
+
+        def side_effect(org_id, data_category):
+            from sentry.constants import DataCategory
+
+            if data_category == DataCategory.SEER_AUTOFIX:
+                return False
+            return True  # Scanner quota available
+
+        mock_has_budget.side_effect = side_effect
+
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data["billing"] == {
+            "hasAutofixQuota": False,
+            "hasScannerQuota": True,
+        }
+
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_no_scanner_quota(self, mock_has_budget):
+        """
+        Test when the organization has no scanner quota available.
+        """
+
+        def side_effect(org_id, data_category):
+            from sentry.constants import DataCategory
+
+            if data_category == DataCategory.SEER_SCANNER:
+                return False
+            return True  # Autofix quota available
+
+        mock_has_budget.side_effect = side_effect
+
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data["billing"] == {
+            "hasAutofixQuota": True,
+            "hasScannerQuota": False,
+        }
+
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_no_quotas_available(self, mock_has_budget):
+        """
+        Test when the organization has no quotas available for either service.
+        """
+        mock_has_budget.return_value = False
+
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 200
+        assert response.data["billing"] == {
+            "hasAutofixQuota": False,
+            "hasScannerQuota": False,
+        }


### PR DESCRIPTION
Adds an endpoint that gets Seer consent and quota information for an organization. The existing setup check endpoint is specific to a given issue, so we need this endpoint to enable frontend changes when we aren't within the Issues page.