### PR TITLE
test(aci): integration test cases for issue alert workflows

### DIFF
--- a/tests/sentry/workflow_engine/test_base.py
+++ b/tests/sentry/workflow_engine/test_base.py
@@ -155,13 +155,14 @@ class BaseWorkflowTest(TestCase, OccurrenceTestMixin):
         timestamp: datetime,
         fingerprint: str,
         environment=None,
+        level="error",
         tags: list[list[str]] | None = None,
     ) -> Event:
         data = {
             "timestamp": timestamp.isoformat(),
             "environment": environment,
             "fingerprint": [fingerprint],
-            "level": "error",
+            "level": level,
             "user": {"id": uuid4().hex},
             "exception": {
                 "values": [

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -1,14 +1,23 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
+import pytest
+from django.utils import timezone
+
+from sentry.eventstore.models import Event
+from sentry.eventstore.processing import event_processing_store
 from sentry.eventstream.types import EventStreamEventType
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+from sentry.issues.ignored import handle_ignored
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.models.group import Group
 from sentry.tasks.post_process import post_process_group
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import Feature, with_feature
+from sentry.utils.cache import cache_key_for_event
+from sentry.workflow_engine.models import Detector, DetectorWorkflow
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.processors import process_data_sources, process_detectors
 from sentry.workflow_engine.types import DetectorPriorityLevel
@@ -61,6 +70,8 @@ class BaseWorkflowIntegrationTest(BaseWorkflowTest):
         is_regression=False,
         is_new_group_environment=True,
         cache_key=None,
+        eventstream_type=EventStreamEventType.Generic.value,
+        include_occurrence=True,
     ):
         post_process_group(
             is_new=is_new,
@@ -68,9 +79,9 @@ class BaseWorkflowIntegrationTest(BaseWorkflowTest):
             is_new_group_environment=is_new_group_environment,
             cache_key=cache_key,
             group_id=group_id,
-            occurrence_id=self.occurrence.id,
+            occurrence_id=self.occurrence.id if include_occurrence else None,
             project_id=self.project.id,
-            eventstream_type=EventStreamEventType.Generic.value,
+            eventstream_type=eventstream_type,
         )
 
         return cache_key
@@ -179,3 +190,145 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
 
             # While this is the same test as the first one, it doesn't invoke the workflow engine because the feature flag is off.
             mock_process_workflow.assert_not_called()
+
+
+@mock.patch("sentry.workflow_engine.processors.workflow.Action.trigger")
+class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationTest):
+    def setUp(self):
+        (
+            self.workflow,
+            self.detector,
+            self.detector_workflow,
+            self.workflow_triggers,
+        ) = self.create_detector_and_workflow(
+            name_prefix="e2e-test",
+            detector_type="error",
+        )
+        self.workflow_triggers.conditions.all().delete()
+        self.action_group, self.action = self.create_workflow_action(workflow=self.workflow)
+
+    @pytest.fixture(autouse=True)
+    def with_feature_flags(self):
+        with Feature(
+            {
+                "organizations:workflow-engine-process-workflows": True,
+                "organizations:workflow-engine-trigger-actions": True,
+            }
+        ):
+            yield
+
+    def create_error_event(
+        self, project=None, detector=None, environment=None, fingerprint=None, level="error"
+    ) -> Event:
+        if project is None:
+            project = self.project
+        if detector is None:
+            detector = self.detector
+        if fingerprint is None:
+            fingerprint = str(detector.id)
+        event = self.create_event(
+            project_id=project.id,
+            timestamp=timezone.now(),
+            fingerprint=fingerprint,
+            environment=environment,
+            level=level,
+        )
+        event_processing_store.store({**event.data, "project": project.id})
+        return event
+
+    def get_cache_key(self, event: Event) -> str:
+        return cache_key_for_event({"project": event.project_id, "event_id": event.event_id})
+
+    def post_process_error(self, event: Event, **kwargs):
+        self.call_post_process_group(
+            event.group_id,
+            cache_key=self.get_cache_key(event),
+            eventstream_type=EventStreamEventType.Error.value,
+            include_occurrence=False,
+            **kwargs,
+        )
+
+    @with_feature("organizations:workflow-engine-issue-alert-dual-write")
+    def test_default_workflow(self, mock_trigger):
+        project = self.create_project(fire_project_created=True)
+        project.flags.has_high_priority_alerts = True
+        project.save()
+        detector = Detector.objects.get(project=project)
+        workflow = DetectorWorkflow.objects.get(detector=detector).workflow
+        workflow.update(config={"frequency": 0})
+
+        # fires for high priority issue
+        high_priority_event = self.create_error_event(project=project, detector=detector)
+        self.post_process_error(high_priority_event, is_new=True)
+        mock_trigger.assert_called_once()
+
+        # fires for existing high priority issue (has_reappeared or is_escalating)
+        mock_trigger.reset_mock()
+        high_priority_event_2 = self.create_error_event(project=project, detector=detector)
+        # ignore the issue to get has_reappeared
+        handle_ignored(
+            group_list=[high_priority_event_2.group],
+            status_details={"ignoreDuration": -1},
+            acting_user=self.user,
+        )
+        self.post_process_error(high_priority_event_2)
+        mock_trigger.assert_called_once()
+
+        # does not fire for low priority issue
+        mock_trigger.reset_mock()
+        low_priority_event = self.create_error_event(
+            project=project, detector=detector, fingerprint="asdf", level="warning"
+        )
+        self.post_process_error(low_priority_event, is_new=True)
+        assert not mock_trigger.called
+
+    def test_snoozed_workflow(self, mock_trigger):
+        event_1 = self.create_error_event()
+        self.post_process_error(event_1)
+        mock_trigger.assert_called_once()
+
+        self.workflow.update(enabled=False)
+        mock_trigger.reset_mock()
+        event_2 = self.create_error_event()
+        self.post_process_error(event_2)
+        assert not mock_trigger.called
+
+    def test_workflow_frequency(self, mock_trigger):
+        self.workflow.update(config={"frequency": 5})
+        now = timezone.now()
+
+        with freeze_time(now):
+            event_1 = self.create_error_event()
+            self.post_process_error(event_1)
+            mock_trigger.assert_called_once()
+
+            event_2 = self.create_error_event()
+            self.post_process_error(event_2)
+            assert mock_trigger.call_count == 1  # not called a second time
+
+        mock_trigger.reset_mock()
+
+        with freeze_time(now + timedelta(minutes=5, seconds=1)):
+            event_3 = self.create_error_event()
+            self.post_process_error(event_3)
+            mock_trigger.assert_called_once()  # called again after 5 minutes
+
+    def test_workflow_environment(self, mock_trigger):
+        env = self.create_environment(self.project, name="production")
+        self.workflow.update(environment=env)
+
+        event_with_env = self.create_error_event(environment="production")
+        event_without_env = self.create_error_event()
+
+        self.post_process_error(event_with_env)
+        mock_trigger.assert_called_once()
+
+        mock_trigger.reset_mock()
+        self.post_process_error(event_without_env)
+        assert not mock_trigger.called  # Should not trigger for events without the environment
+
+    def test_slow_condition_workflow_with_filter(self, mock_trigger):
+        pass
+
+    def test_slow_condition_subqueries(self, mock_trigger):
+        pass

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -266,6 +266,7 @@ class TestWorkflowEngineIntegrationFromErrorPostProcess(BaseWorkflowIntegrationT
         mock_trigger.reset_mock()
         high_priority_event_2 = self.create_error_event(project=project, detector=detector)
         # ignore the issue to get has_reappeared
+        assert high_priority_event_2.group
         handle_ignored(
             group_list=[high_priority_event_2.group],
             status_details={"ignoreDuration": -1},


### PR DESCRIPTION
Write out integration test cases beginning with calling `post_process_group` to test workflow engine.

This PR includes the test cases with only fast conditions. I've already tested these manually save for the existing high priority issue condition in the default workflow.
- Default workflow
- Snoozed workflow
- Workflow frequency
- Workflow environment

TODO: write tests for slow conditions