### PR TITLE
fix(simpleTable): Rename prop `name` to `className`

### DIFF
--- a/static/app/components/workflowEngine/simpleTable/index.spec.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.spec.tsx
@@ -7,19 +7,19 @@ describe('SimpleTable component', function () {
     render(
       <SimpleTable>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell name="a">A</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="b">B</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="c">C</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>A</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>B</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>C</SimpleTable.HeaderCell>
         </SimpleTable.Header>
         <SimpleTable.Row data-test-id="row-1">
-          <SimpleTable.RowCell name="a">0</SimpleTable.RowCell>
-          <SimpleTable.RowCell name="b">1</SimpleTable.RowCell>
-          <SimpleTable.RowCell name="c">2</SimpleTable.RowCell>
+          <SimpleTable.RowCell>0</SimpleTable.RowCell>
+          <SimpleTable.RowCell>1</SimpleTable.RowCell>
+          <SimpleTable.RowCell>2</SimpleTable.RowCell>
         </SimpleTable.Row>
         <SimpleTable.Row data-test-id="row-2">
-          <SimpleTable.RowCell name="a">3</SimpleTable.RowCell>
-          <SimpleTable.RowCell name="b">4</SimpleTable.RowCell>
-          <SimpleTable.RowCell name="c">5</SimpleTable.RowCell>
+          <SimpleTable.RowCell>3</SimpleTable.RowCell>
+          <SimpleTable.RowCell>4</SimpleTable.RowCell>
+          <SimpleTable.RowCell>5</SimpleTable.RowCell>
         </SimpleTable.Row>
       </SimpleTable>
     );

--- a/static/app/components/workflowEngine/simpleTable/index.stories.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.stories.tsx
@@ -71,27 +71,21 @@ export default Storybook.story('SimpleTable', story => {
         </p>
         <SimpleTableWithColumns>
           <SimpleTable.Header>
-            <SimpleTable.HeaderCell name="name" sortKey="name">
-              Name
-            </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell name="monitors" sortKey="monitors">
-              Monitors
-            </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell name="action" sortKey="action">
-              Action
-            </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell name="lastTriggered" sortKey="lastTriggered">
+            <SimpleTable.HeaderCell sortKey="name">Name</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell sortKey="monitors">Monitors</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell sortKey="action">Action</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell sortKey="lastTriggered">
               Last Triggered
             </SimpleTable.HeaderCell>
           </SimpleTable.Header>
           {data.map(row => (
             <SimpleTable.Row key={row.name}>
-              <SimpleTable.RowCell name="name">{row.name}</SimpleTable.RowCell>
-              <SimpleTable.RowCell name="monitors">
+              <SimpleTable.RowCell>{row.name}</SimpleTable.RowCell>
+              <SimpleTable.RowCell>
                 {t('%s monitors', row.monitors.length)}
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell name="action">{row.action}</SimpleTable.RowCell>
-              <SimpleTable.RowCell name="lastTriggered">
+              <SimpleTable.RowCell>{row.action}</SimpleTable.RowCell>
+              <SimpleTable.RowCell>
                 <TimeAgoCell date={row.lastTriggered} />
               </SimpleTable.RowCell>
             </SimpleTable.Row>
@@ -111,16 +105,10 @@ export default Storybook.story('SimpleTable', story => {
 
         <SimpleTableWithColumns>
           <SimpleTable.Header>
-            <SimpleTable.HeaderCell name="name" sortKey="name">
-              Name
-            </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell name="monitors" sortKey="monitors">
-              Monitors
-            </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell name="action" sortKey="action">
-              Action
-            </SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell name="lastTriggered" sortKey="lastTriggered">
+            <SimpleTable.HeaderCell sortKey="name">Name</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell sortKey="monitors">Monitors</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell sortKey="action">Action</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell sortKey="lastTriggered">
               Last Triggered
             </SimpleTable.HeaderCell>
           </SimpleTable.Header>
@@ -155,27 +143,19 @@ export default Storybook.story('SimpleTable', story => {
     const tableContent = (
       <Fragment>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell name="name" sortKey="name">
-            Name
-          </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="monitors" sortKey="monitors">
-            Monitors
-          </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="action" sortKey="action">
-            Action
-          </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="lastTriggered" sortKey="lastTriggered">
+          <SimpleTable.HeaderCell sortKey="name">Name</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell sortKey="monitors">Monitors</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell sortKey="action">Action</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell sortKey="lastTriggered">
             Last Triggered
           </SimpleTable.HeaderCell>
         </SimpleTable.Header>
         {data.map(row => (
           <SimpleTable.Row key={row.name}>
-            <SimpleTable.RowCell name="name">{row.name}</SimpleTable.RowCell>
-            <SimpleTable.RowCell name="monitors">
-              {row.monitors.length} monitors
-            </SimpleTable.RowCell>
-            <SimpleTable.RowCell name="action">{row.action}</SimpleTable.RowCell>
-            <SimpleTable.RowCell name="lastTriggered">
+            <SimpleTable.RowCell>{row.name}</SimpleTable.RowCell>
+            <SimpleTable.RowCell>{row.monitors.length} monitors</SimpleTable.RowCell>
+            <SimpleTable.RowCell>{row.action}</SimpleTable.RowCell>
+            <SimpleTable.RowCell>
               <TimeAgoCell date={row.lastTriggered} />
             </SimpleTable.RowCell>
           </SimpleTable.Row>

--- a/static/app/components/workflowEngine/simpleTable/index.tsx
+++ b/static/app/components/workflowEngine/simpleTable/index.tsx
@@ -32,13 +32,13 @@ function Header({children}: {children: React.ReactNode}) {
 
 function HeaderCell({
   children,
-  name,
+  className,
   sortKey,
   sort,
   handleSortClick,
 }: {
-  name: string;
   children?: React.ReactNode;
+  className?: string;
   handleSortClick?: () => void;
   sort?: Sort;
   sortKey?: string;
@@ -47,7 +47,7 @@ function HeaderCell({
 
   return (
     <ColumnHeaderCell
-      className={name}
+      className={className}
       isSorted={isSortedByField}
       onClick={handleSortClick}
       role="columnheader"
@@ -79,15 +79,15 @@ function Row({children, variant = 'default', ...props}: RowProps) {
 
 function RowCell({
   children,
-  name,
+  className,
   justify,
 }: {
   children: React.ReactNode;
-  name: string;
+  className?: string;
   justify?: CSSProperties['justifyContent'];
 }) {
   return (
-    <StyledRowCell className={name} role="cell" align="center" justify={justify}>
+    <StyledRowCell className={className} role="cell" align="center" justify={justify}>
       {children}
     </StyledRowCell>
   );

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -23,22 +23,22 @@ export default function AutomationHistoryList({history}: Props) {
   return (
     <SimpleTableWithColumns>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell className="dateSent">
           {tct('Time Sent ([timezone])', {timezone: moment.tz(timezone).zoneAbbr()})}
         </SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>Monitor</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell>Issue</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell className="monitor">Monitor</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell className="groupId">Issue</SimpleTable.HeaderCell>
       </SimpleTable.Header>
       {history.length === 0 && <SimpleTable.Empty>No history found</SimpleTable.Empty>}
       {history.map((row, index) => (
         <SimpleTable.Row key={index}>
-          <SimpleTable.RowCell>
+          <SimpleTable.RowCell className="dateSent">
             <DateTime date={row.dateSent} forcedTimezone={timezone} />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell>
+          <SimpleTable.RowCell className="monitor">
             <Link to={row.monitor.link}>{row.monitor.name}</Link>
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell>
+          <SimpleTable.RowCell className="groupId">
             <Link to={`/issues/${row.groupId}`}>{`#${row.groupId}`}</Link>
           </SimpleTable.RowCell>
         </SimpleTable.Row>

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -23,22 +23,22 @@ export default function AutomationHistoryList({history}: Props) {
   return (
     <SimpleTableWithColumns>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell name="dateSent">
+        <SimpleTable.HeaderCell>
           {tct('Time Sent ([timezone])', {timezone: moment.tz(timezone).zoneAbbr()})}
         </SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell name="monitor">Monitor</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell name="groupId">Issue</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>Monitor</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>Issue</SimpleTable.HeaderCell>
       </SimpleTable.Header>
       {history.length === 0 && <SimpleTable.Empty>No history found</SimpleTable.Empty>}
       {history.map((row, index) => (
         <SimpleTable.Row key={index}>
-          <SimpleTable.RowCell name="dateSent">
+          <SimpleTable.RowCell>
             <DateTime date={row.dateSent} forcedTimezone={timezone} />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell name="monitor">
+          <SimpleTable.RowCell>
             <Link to={row.monitor.link}>{row.monitor.name}</Link>
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell name="groupId">
+          <SimpleTable.RowCell>
             <Link to={`/issues/${row.groupId}`}>{`#${row.groupId}`}</Link>
           </SimpleTable.RowCell>
         </SimpleTable.Row>

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -29,12 +29,10 @@ function LoadingSkeletons() {
 
 function HeaderCell({
   children,
-  name,
   sortKey,
   sort,
 }: {
   children: React.ReactNode;
-  name: string;
   sort: Sort | undefined;
   divider?: boolean;
   sortKey?: string;
@@ -55,12 +53,7 @@ function HeaderCell({
   };
 
   return (
-    <SimpleTable.HeaderCell
-      name={name}
-      sort={sort}
-      sortKey={sortKey}
-      handleSortClick={handleSort}
-    >
+    <SimpleTable.HeaderCell sort={sort} sortKey={sortKey} handleSortClick={handleSort}>
       {children}
     </SimpleTable.HeaderCell>
   );
@@ -76,19 +69,15 @@ function AutomationListTable({
   return (
     <AutomationsSimpleTable>
       <SimpleTable.Header>
-        <HeaderCell name="name" sort={sort} sortKey="name">
+        <HeaderCell sort={sort} sortKey="name">
           {t('Name')}
         </HeaderCell>
-        <HeaderCell name="last-triggered" sort={sort}>
-          {t('Last Triggered')}
-        </HeaderCell>
-        <HeaderCell name="action" sort={sort} sortKey="actions">
+        <HeaderCell sort={sort}>{t('Last Triggered')}</HeaderCell>
+        <HeaderCell sort={sort} sortKey="actions">
           {t('Actions')}
         </HeaderCell>
-        <HeaderCell name="projects" sort={sort}>
-          {t('Projects')}
-        </HeaderCell>
-        <HeaderCell name="connected-monitors" sort={sort} sortKey="connectedDetectors">
+        <HeaderCell sort={sort}>{t('Projects')}</HeaderCell>
+        <HeaderCell sort={sort} sortKey="connectedDetectors">
           {t('Monitors')}
         </HeaderCell>
       </SimpleTable.Header>

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -29,10 +29,12 @@ function LoadingSkeletons() {
 
 function HeaderCell({
   children,
+  className,
   sortKey,
   sort,
 }: {
   children: React.ReactNode;
+  className: string;
   sort: Sort | undefined;
   divider?: boolean;
   sortKey?: string;
@@ -53,7 +55,12 @@ function HeaderCell({
   };
 
   return (
-    <SimpleTable.HeaderCell sort={sort} sortKey={sortKey} handleSortClick={handleSort}>
+    <SimpleTable.HeaderCell
+      className={className}
+      sort={sort}
+      sortKey={sortKey}
+      handleSortClick={handleSort}
+    >
       {children}
     </SimpleTable.HeaderCell>
   );
@@ -69,15 +76,23 @@ function AutomationListTable({
   return (
     <AutomationsSimpleTable>
       <SimpleTable.Header>
-        <HeaderCell sort={sort} sortKey="name">
+        <HeaderCell className="name" sort={sort} sortKey="name">
           {t('Name')}
         </HeaderCell>
-        <HeaderCell sort={sort}>{t('Last Triggered')}</HeaderCell>
-        <HeaderCell sort={sort} sortKey="actions">
+        <HeaderCell className="last-triggered" sort={sort}>
+          {t('Last Triggered')}
+        </HeaderCell>
+        <HeaderCell className="action" sort={sort} sortKey="actions">
           {t('Actions')}
         </HeaderCell>
-        <HeaderCell sort={sort}>{t('Projects')}</HeaderCell>
-        <HeaderCell sort={sort} sortKey="connectedDetectors">
+        <HeaderCell className="projects" sort={sort}>
+          {t('Projects')}
+        </HeaderCell>
+        <HeaderCell
+          className="connected-monitors"
+          sort={sort}
+          sortKey="connectedDetectors"
+        >
           {t('Monitors')}
         </HeaderCell>
       </SimpleTable.Header>

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -31,19 +31,19 @@ export function AutomationListRow({automation}: AutomationListRowProps) {
       variant={disabled ? 'faded' : 'default'}
       data-test-id="automation-list-row"
     >
-      <SimpleTable.RowCell name="name">
+      <SimpleTable.RowCell className="name">
         <AutomationTitleCell automation={automation} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="last-triggered">
+      <SimpleTable.RowCell className="last-triggered">
         <TimeAgoCell date={lastTriggered} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="action">
+      <SimpleTable.RowCell className="action">
         <ActionCell actions={actions} disabled={disabled} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="projects">
+      <SimpleTable.RowCell className="projects">
         <ProjectList projectSlugs={projectSlugs} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="connected-monitors">
+      <SimpleTable.RowCell className="connected-monitors">
         <AutomationListConnectedDetectors detectorIds={detectorIds} />
       </SimpleTable.RowCell>
     </AutomationSimpleTableRow>
@@ -53,19 +53,19 @@ export function AutomationListRow({automation}: AutomationListRowProps) {
 export function AutomationListRowSkeleton() {
   return (
     <AutomationSimpleTableRow>
-      <SimpleTable.RowCell name="name">
+      <SimpleTable.RowCell className="name">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="last-triggered">
+      <SimpleTable.RowCell className="last-triggered">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="action">
+      <SimpleTable.RowCell className="action">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="projects">
+      <SimpleTable.RowCell className="projects">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="connected-monitors">
+      <SimpleTable.RowCell className="connected-monitors">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
     </AutomationSimpleTableRow>

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -39,31 +39,35 @@ export default function ConnectedMonitorsList({
     <Container>
       <SimpleTableWithColumns>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell>{t('Type')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell>{t('Last Issue')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell>{t('Assignee')}</SimpleTable.HeaderCell>
-          {canEdit && <SimpleTable.HeaderCell />}
+          <SimpleTable.HeaderCell className="name">{t('Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell className="type">{t('Type')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell className="last-issue">
+            {t('Last Issue')}
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell className="owner">
+            {t('Assignee')}
+          </SimpleTable.HeaderCell>
+          {canEdit && <SimpleTable.HeaderCell className="connected" />}
         </SimpleTable.Header>
         {monitors.length === 0 && (
           <SimpleTable.Empty>{t('No monitors connected')}</SimpleTable.Empty>
         )}
         {monitors.map(monitor => (
           <SimpleTable.Row key={monitor.id}>
-            <SimpleTable.RowCell>
+            <SimpleTable.RowCell className="name">
               <DetectorLink detector={monitor} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell>
+            <SimpleTable.RowCell className="type">
               <DetectorTypeCell type={monitor.type} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell>
+            <SimpleTable.RowCell className="last-issue">
               <IssueCell group={undefined} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell>
+            <SimpleTable.RowCell className="owner">
               <DetectorAssigneeCell assignee={monitor.owner} />
             </SimpleTable.RowCell>
             {canEdit && (
-              <SimpleTable.RowCell justify="flex-end">
+              <SimpleTable.RowCell className="connected" justify="flex-end">
                 <Button onClick={() => toggleConnected(monitor.id)} size="sm">
                   {connectedIds?.has(monitor.id) ? t('Disconnect') : t('Connect')}
                 </Button>

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -39,33 +39,31 @@ export default function ConnectedMonitorsList({
     <Container>
       <SimpleTableWithColumns>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell name="name">{t('Name')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="type">{t('Type')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="last-issue">
-            {t('Last Issue')}
-          </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="owner">{t('Assignee')}</SimpleTable.HeaderCell>
-          {canEdit && <SimpleTable.HeaderCell name="connected" />}
+          <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Type')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Last Issue')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Assignee')}</SimpleTable.HeaderCell>
+          {canEdit && <SimpleTable.HeaderCell />}
         </SimpleTable.Header>
         {monitors.length === 0 && (
           <SimpleTable.Empty>{t('No monitors connected')}</SimpleTable.Empty>
         )}
         {monitors.map(monitor => (
           <SimpleTable.Row key={monitor.id}>
-            <SimpleTable.RowCell name="name">
+            <SimpleTable.RowCell>
               <DetectorLink detector={monitor} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell name="type">
+            <SimpleTable.RowCell>
               <DetectorTypeCell type={monitor.type} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell name="last-issue">
+            <SimpleTable.RowCell>
               <IssueCell group={undefined} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell name="owner">
+            <SimpleTable.RowCell>
               <DetectorAssigneeCell assignee={monitor.owner} />
             </SimpleTable.RowCell>
             {canEdit && (
-              <SimpleTable.RowCell name="connected" justify="flex-end">
+              <SimpleTable.RowCell justify="flex-end">
                 <Button onClick={() => toggleConnected(monitor.id)} size="sm">
                   {connectedIds?.has(monitor.id) ? t('Disconnect') : t('Connect')}
                 </Button>

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -29,17 +29,17 @@ function Skeletons({canEdit}: {canEdit: boolean}) {
     <Fragment>
       {Array.from({length: AUTOMATIONS_PER_PAGE}).map((_, index) => (
         <SimpleTable.Row key={index}>
-          <SimpleTable.RowCell name="name">
+          <SimpleTable.RowCell className="name">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell name="last-triggered">
+          <SimpleTable.RowCell className="last-triggered">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell name="action-filters">
+          <SimpleTable.RowCell className="action-filters">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
           {canEdit && (
-            <SimpleTable.RowCell name="connected">
+            <SimpleTable.RowCell className="connected">
               <Placeholder height="20px" />
             </SimpleTable.RowCell>
           )}
@@ -80,14 +80,14 @@ export function ConnectedAutomationsList({
     <Container>
       <SimpleTableWithColumns>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell name="name">{t('Name')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="last-triggered">
+          <SimpleTable.HeaderCell className="name">{t('Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell className="last-triggered">
             {t('Last Triggered')}
           </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell name="action-filters">
+          <SimpleTable.HeaderCell className="action-filters">
             {t('Actions')}
           </SimpleTable.HeaderCell>
-          {canEdit && <SimpleTable.HeaderCell name="connected" />}
+          {canEdit && <SimpleTable.HeaderCell className="connected" />}
         </SimpleTable.Header>
         {isLoading && <Skeletons canEdit={canEdit} />}
         {isError && <LoadingError />}
@@ -100,17 +100,17 @@ export function ConnectedAutomationsList({
               key={automation.id}
               variant={automation.disabled ? 'faded' : 'default'}
             >
-              <SimpleTable.RowCell name="name">
+              <SimpleTable.RowCell className="name">
                 <AutomationTitleCell automation={automation} />
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell name="last-triggered">
+              <SimpleTable.RowCell className="last-triggered">
                 <TimeAgoCell date={automation.lastTriggered} />
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell name="action-filters">
+              <SimpleTable.RowCell className="action-filters">
                 <ActionCell actions={getAutomationActions(automation)} />
               </SimpleTable.RowCell>
               {canEdit && (
-                <SimpleTable.RowCell name="connected" justify="flex-end">
+                <SimpleTable.RowCell className="connected" justify="flex-end">
                   <Button onClick={() => toggleConnected?.(automation.id)} size="sm">
                     {connectedAutomationIds?.has(automation.id)
                       ? t('Disconnect')

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -22,19 +22,19 @@ export function DetectorListRow({detector}: DetectorListRowProps) {
       variant={detector.disabled ? 'faded' : 'default'}
       data-test-id="detector-list-row"
     >
-      <SimpleTable.RowCell name="name">
+      <SimpleTable.RowCell className="name">
         <DetectorLink detector={detector} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="type">
+      <SimpleTable.RowCell className="type">
         <DetectorTypeCell type={detector.type} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="last-issue">
+      <SimpleTable.RowCell className="last-issue">
         <IssueCell group={issues.length > 0 ? issues[0] : undefined} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="assignee">
+      <SimpleTable.RowCell className="assignee">
         <DetectorAssigneeCell assignee={detector.owner} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="connected-automations">
+      <SimpleTable.RowCell className="connected-automations">
         <DetectorListConnectedAutomations automationIds={detector.workflowIds} />
       </SimpleTable.RowCell>
     </DetectorSimpleTableRow>
@@ -44,22 +44,22 @@ export function DetectorListRow({detector}: DetectorListRowProps) {
 export function DetectorListRowSkeleton() {
   return (
     <DetectorSimpleTableRow>
-      <SimpleTable.RowCell name="name">
+      <SimpleTable.RowCell className="name">
         <div style={{width: '100%'}}>
           <Placeholder height="20px" width="50%" style={{marginBottom: '4px'}} />
           <Placeholder height="16px" width="20%" />
         </div>
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="type">
+      <SimpleTable.RowCell className="type">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="last-issue">
+      <SimpleTable.RowCell className="last-issue">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="assignee">
+      <SimpleTable.RowCell className="assignee">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell name="connected-automations">
+      <SimpleTable.RowCell className="connected-automations">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
     </DetectorSimpleTableRow>

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -29,12 +29,10 @@ function LoadingSkeletons() {
 
 function HeaderCell({
   children,
-  name,
   sortKey,
   sort,
 }: {
   children: React.ReactNode;
-  name: string;
   sort: Sort | undefined;
   divider?: boolean;
   sortKey?: string;
@@ -55,12 +53,7 @@ function HeaderCell({
   };
 
   return (
-    <SimpleTable.HeaderCell
-      name={name}
-      sort={sort}
-      sortKey={sortKey}
-      handleSortClick={handleSort}
-    >
+    <SimpleTable.HeaderCell sort={sort} sortKey={sortKey} handleSortClick={handleSort}>
       {children}
     </SimpleTable.HeaderCell>
   );
@@ -77,24 +70,19 @@ function DetectorListTable({
     <Container>
       <DetectorListSimpleTable>
         <SimpleTable.Header>
-          <HeaderCell name="name" sortKey="name" sort={sort}>
+          <HeaderCell sortKey="name" sort={sort}>
             {t('Name')}
           </HeaderCell>
-          <HeaderCell name="type" divider sortKey="type" sort={sort}>
+          <HeaderCell divider sortKey="type" sort={sort}>
             {t('Type')}
           </HeaderCell>
-          <HeaderCell name="last-issue" divider sort={sort}>
+          <HeaderCell divider sort={sort}>
             {t('Last Issue')}
           </HeaderCell>
-          <HeaderCell name="assignee" divider sort={sort}>
+          <HeaderCell divider sort={sort}>
             {t('Assignee')}
           </HeaderCell>
-          <HeaderCell
-            name="connected-automations"
-            divider
-            sortKey="connectedWorkflows"
-            sort={sort}
-          >
+          <HeaderCell divider sortKey="connectedWorkflows" sort={sort}>
             {t('Automations')}
           </HeaderCell>
         </SimpleTable.Header>

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -29,10 +29,12 @@ function LoadingSkeletons() {
 
 function HeaderCell({
   children,
+  name,
   sortKey,
   sort,
 }: {
   children: React.ReactNode;
+  name: string;
   sort: Sort | undefined;
   divider?: boolean;
   sortKey?: string;
@@ -53,7 +55,12 @@ function HeaderCell({
   };
 
   return (
-    <SimpleTable.HeaderCell sort={sort} sortKey={sortKey} handleSortClick={handleSort}>
+    <SimpleTable.HeaderCell
+      className={name}
+      sort={sort}
+      sortKey={sortKey}
+      handleSortClick={handleSort}
+    >
       {children}
     </SimpleTable.HeaderCell>
   );
@@ -70,19 +77,24 @@ function DetectorListTable({
     <Container>
       <DetectorListSimpleTable>
         <SimpleTable.Header>
-          <HeaderCell sortKey="name" sort={sort}>
+          <HeaderCell name="name" sortKey="name" sort={sort}>
             {t('Name')}
           </HeaderCell>
-          <HeaderCell divider sortKey="type" sort={sort}>
+          <HeaderCell name="type" divider sortKey="type" sort={sort}>
             {t('Type')}
           </HeaderCell>
-          <HeaderCell divider sort={sort}>
+          <HeaderCell name="last-issue" divider sort={sort}>
             {t('Last Issue')}
           </HeaderCell>
-          <HeaderCell divider sort={sort}>
+          <HeaderCell name="assignee" divider sort={sort}>
             {t('Assignee')}
           </HeaderCell>
-          <HeaderCell divider sortKey="connectedWorkflows" sort={sort}>
+          <HeaderCell
+            name="connected-automations"
+            divider
+            sortKey="connectedWorkflows"
+            sort={sort}
+          >
             {t('Automations')}
           </HeaderCell>
         </SimpleTable.Header>


### PR DESCRIPTION
Before we were taking the `name` prop and passing it into the `className` prop on the component. We shouldn't ever be setting className to a string like this directly, instead emotion should generate the classNames for us.

There's a story and the extra classnames were visible in the html (before):

<img width="1079" alt="SCR-20250625-onus" src="https://github.com/user-attachments/assets/89a1498b-d9d4-48bb-816d-799eac3c6d42" />

