### PR TITLE
ref(api-client): Stop making Sentry issues for AbortErrors

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -648,7 +648,10 @@ export class Client {
       .catch(error => {
         // eslint-disable-next-line no-console
         console.error(error);
-        Sentry.captureException(error);
+
+        if (error?.name !== 'AbortError') {
+          Sentry.captureException(error);
+        }
       });
 
     const request = new Request(fetchRequest, aborter);


### PR DESCRIPTION
There are a lot of issues from [AbortError that we ignore](https://sentry.sentry.io/issues/?project=11276&query=error.type%3AAbortError&referrer=issue-list&statsPeriod=30d)