### PR TITLE
fix(agent-insights): Only indent if parent

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -111,7 +111,9 @@ export function AISpanList({
           }
         }
 
-        const shouldIndent = aiRunNode && aiRunNode !== node;
+        // Only indent if the node is a child of the last ai run node
+        const shouldIndent =
+          aiRunNode && !!TraceTree.ParentNode(node, n => n === aiRunNode);
 
         const uniqueKey = getNodeId(node);
         return (

--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -111,12 +111,14 @@ export function AISpanList({
           }
         }
 
+        const shouldIndent = aiRunNode && aiRunNode !== node;
+
         const uniqueKey = getNodeId(node);
         return (
           <Fragment key={uniqueKey}>
             {transactionName && <TransactionItem>{transactionName}</TransactionItem>}
             <TraceListItem
-              indent={aiRunNode === node ? 0 : 1}
+              indent={shouldIndent ? 1 : 0}
               traceBounds={getTimeBounds(currentAiRunNode)}
               key={uniqueKey}
               node={node}


### PR DESCRIPTION
Only indent a list item if the last encountered ai run node is a parent.