### PR TITLE
feat(agent-insights): Collapes long inputs and outputs

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import * as Sentry from '@sentry/react';
 
-import {StructuredData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -29,7 +28,7 @@ function renderTextMessages(content: any) {
 }
 
 function renderToolMessage(content: any) {
-  return <StructuredData value={content} maxDefaultDepth={2} withAnnotatedText />;
+  return content;
 }
 
 function parseAIMessages(messages: string) {
@@ -172,9 +171,16 @@ export function AIInputSection({
               <TraceDrawerComponents.MultilineTextLabel>
                 {roleHeadings[message.role]}
               </TraceDrawerComponents.MultilineTextLabel>
-              <TraceDrawerComponents.MultilineText>
-                {message.content}
-              </TraceDrawerComponents.MultilineText>
+              {typeof message.content === 'string' ? (
+                <TraceDrawerComponents.MultilineText>
+                  {message.content}
+                </TraceDrawerComponents.MultilineText>
+              ) : (
+                <TraceDrawerComponents.MultilineJSON
+                  value={message.content}
+                  maxDefaultDepth={2}
+                />
+              )}
             </Fragment>
           ))}
         </Fragment>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1265,7 +1265,38 @@ const CardValueText = styled('span')`
   overflow-wrap: anywhere;
 `;
 
-const MultilineText = styled('div')`
+const MAX_TEXT_LENGTH = 300;
+const MAX_NEWLINES = 5;
+
+function MultilineText({children}: {children: string}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // find the position of the 7th occurrence of '\n'
+  const newLineMatches = Array.from(children.matchAll(/\n/g));
+  const seventhNewlinePosition = newLineMatches.at(MAX_NEWLINES - 1)?.index ?? Infinity;
+
+  const truncatePosition = Math.min(seventhNewlinePosition, MAX_TEXT_LENGTH);
+  const needsTruncation = truncatePosition < children.length;
+
+  return (
+    <MultilineTextWrapper>
+      {isExpanded || !needsTruncation ? (
+        children
+      ) : (
+        <Fragment>{children.slice(0, truncatePosition) + '...'}</Fragment>
+      )}
+      {needsTruncation ? (
+        <Flex style={{justifyContent: 'center', paddingTop: space(1)}}>
+          <Button size="xs" onClick={() => setIsExpanded(!isExpanded)}>
+            {isExpanded ? t('Show less') : t('Show all')}
+          </Button>
+        </Flex>
+      ) : null}
+    </MultilineTextWrapper>
+  );
+}
+
+const MultilineTextWrapper = styled('div')`
   white-space: pre-wrap;
   background-color: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
@@ -1276,30 +1307,33 @@ const MultilineText = styled('div')`
   }
 `;
 
+function tryParseJson(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return value;
+  }
+}
+
 function MultilineJSON({
   value,
   maxDefaultDepth = 2,
 }: {
-  value: string;
+  value: any;
   maxDefaultDepth?: number;
 }) {
-  try {
-    const json = JSON.parse(value);
-    return (
-      <TraceDrawerComponents.MultilineText>
-        <StructuredData
-          value={json}
-          maxDefaultDepth={maxDefaultDepth}
-          withAnnotatedText
-        />
-      </TraceDrawerComponents.MultilineText>
-    );
-  } catch (error) {
-    return (
-      <TraceDrawerComponents.MultilineText>{value}</TraceDrawerComponents.MultilineText>
-    );
-  }
+  const json = tryParseJson(value);
+  return (
+    <MultilineTextWrapperMonospace>
+      <StructuredData value={json} maxDefaultDepth={maxDefaultDepth} withAnnotatedText />
+    </MultilineTextWrapperMonospace>
+  );
 }
+
+const MultilineTextWrapperMonospace = styled(MultilineTextWrapper)`
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.codeFontSize};
+`;
 
 const MultilineTextLabel = styled('div')`
   font-weight: bold;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1271,11 +1271,10 @@ const MAX_NEWLINES = 5;
 function MultilineText({children}: {children: string}) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // find the position of the 7th occurrence of '\n'
   const newLineMatches = Array.from(children.matchAll(/\n/g));
-  const seventhNewlinePosition = newLineMatches.at(MAX_NEWLINES - 1)?.index ?? Infinity;
+  const maxNewlinePosition = newLineMatches.at(MAX_NEWLINES - 1)?.index ?? Infinity;
 
-  const truncatePosition = Math.min(seventhNewlinePosition, MAX_TEXT_LENGTH);
+  const truncatePosition = Math.min(maxNewlinePosition, MAX_TEXT_LENGTH);
   const needsTruncation = truncatePosition < children.length;
 
   return (


### PR DESCRIPTION
Collapse text after 5th newline or 300 characters, whatever is earlier.

https://github.com/user-attachments/assets/13802f15-2a38-4eeb-8d76-ac183b3f06e6


- closes [TET-727: Collapse long inputs and outputs](https://linear.app/getsentry/issue/TET-727/collapse-long-inputs-and-outputs)