### PR TITLE
fix(ui): coloring of overflow menu in chonk

### DIFF
--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -15,7 +15,7 @@ import DropdownButton from 'sentry/components/dropdownButton';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {withChonk} from 'sentry/utils/theme/withChonk';
+import {isChonkTheme, withChonk} from 'sentry/utils/theme/withChonk';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {TabsContext} from './index';
@@ -344,4 +344,6 @@ const TabListOverflowWrap = styled('div')`
 const OverflowMenuTrigger = styled(DropdownButton)`
   padding-left: ${space(1)};
   padding-right: ${space(1)};
+  color: ${p =>
+    isChonkTheme(p.theme) ? p.theme.tokens.component.link.muted.default : undefined};
 `;


### PR DESCRIPTION
| before | after |
|--------|--------|
| ![Screenshot 2025-06-26 at 10 47 37](https://github.com/user-attachments/assets/37a8e687-9462-4afe-9375-d1b7bed7a80e) | ![Screenshot 2025-06-26 at 10 47 29](https://github.com/user-attachments/assets/2c7bc347-a94a-4a2c-9ab6-fc2d62df0782) | 
