### PR TITLE
fix(ui): refactor replay fluidPanel layout from grid to flex

### DIFF
--- a/static/app/views/replays/detail/layout/fluidPanel.tsx
+++ b/static/app/views/replays/detail/layout/fluidPanel.tsx
@@ -2,31 +2,25 @@ import styled from '@emotion/styled';
 
 type Props = {
   children: React.ReactNode;
-  bodyRef?: React.RefObject<HTMLDivElement | null>;
-  bottom?: React.ReactNode;
-  className?: string;
   title?: React.ReactNode;
 };
 
-function FluidPanel({className, children, bottom, title, bodyRef}: Props) {
+export function FluidPanel({children, title}: Props) {
   return (
-    <FluidContainer className={className}>
+    <FluidContainer>
       {title}
-      <OverflowBody ref={bodyRef}>{children}</OverflowBody>
-      {bottom}
+      <OverflowBody>{children}</OverflowBody>
     </FluidContainer>
   );
 }
 
 const FluidContainer = styled('section')`
-  display: grid;
-  grid-template-rows: auto 1fr auto;
+  display: flex;
+  flex-direction: column;
   height: 100%;
 `;
 
 const OverflowBody = styled('div')`
-  height: 100%;
+  flex: 1 1 auto;
   overflow: auto;
 `;
-
-export default FluidPanel;

--- a/static/app/views/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/replays/detail/layout/replayLayout.tsx
@@ -10,7 +10,7 @@ import useReplayLayout, {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLa
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useFullscreen from 'sentry/utils/window/useFullscreen';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
-import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
+import {FluidPanel} from 'sentry/views/replays/detail/layout/fluidPanel';
 import FocusArea from 'sentry/views/replays/detail/layout/focusArea';
 import FocusTabs from 'sentry/views/replays/detail/layout/focusTabs';
 import SplitPanel from 'sentry/views/replays/detail/layout/splitPanel';

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
-import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
+import {FluidPanel} from 'sentry/views/replays/detail/layout/fluidPanel';
 import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
 import TagFilters from 'sentry/views/replays/detail/tagPanel/tagFilters';
 import useTagFilters from 'sentry/views/replays/detail/tagPanel/useTagFilters';


### PR DESCRIPTION
`FluidPanel` is basically just a vertical container, where we have two items underneath each other. The grid layout can, in certain situations, stop the child from shrinking. Since we have a one-dimensional layout only, `flex` does the job too and lets children shrink properly.

This issue was flagged as UI2, but it’s not UI2 related - it just shows up more often in UI2 because there’s more spacing between tabs. The before and after videos are both UI1:

before:

https://github.com/user-attachments/assets/bcc7f84b-6170-4c87-b823-2c700aa4318d

after:

https://github.com/user-attachments/assets/d3ea3f77-7c95-4c11-8c5a-37065b32c53f

I’ve also simplified the `FluidPanel` component by removing all unused props (there are only two usages) and switched towards a named export.

