### PR TITLE
fix(ui): make UnmaskAlert use core/alert

### DIFF
--- a/static/app/components/replays/unmaskAlert.tsx
+++ b/static/app/components/replays/unmaskAlert.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import useUserViewedReplays from 'sentry/components/replays/useUserViewedReplays';
-import {IconClose, IconInfo} from 'sentry/icons';
+import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
@@ -20,25 +21,27 @@ function UnmaskAlert() {
 
   return (
     <UnmaskAlertContainer data-test-id="unmask-alert">
-      <Alert>
-        <StyledIconInfo size="xs" />
-        <div>
-          {tct(
-            'Unmask non-sensitive text (****) and media (img, svg, video). [link:Learn more].',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/privacy/#privacy-configuration" />
-              ),
-            }
-          )}
-        </div>
-        <DismissButton
-          priority="link"
-          size="sm"
-          icon={<IconClose />}
-          aria-label={t('Close Alert')}
-          onClick={dismiss}
-        />
+      <Alert
+        showIcon
+        type="info"
+        trailingItems={
+          <Button
+            aria-label={t('Close Alert')}
+            icon={<IconClose />}
+            onClick={dismiss}
+            size="zero"
+            borderless
+          />
+        }
+      >
+        {tct(
+          'Unmask non-sensitive text (****) and media (img, svg, video). [link:Learn more].',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/privacy/#privacy-configuration" />
+            ),
+          }
+        )}
       </Alert>
     </UnmaskAlertContainer>
   );
@@ -49,45 +52,4 @@ export default UnmaskAlert;
 const UnmaskAlertContainer = styled('div')`
   position: absolute;
   bottom: ${space(1)};
-  left: 0;
-  width: 100%;
-  text-align: center;
-  font-size: ${p => p.theme.fontSize.md};
-  pointer-events: none;
-`;
-
-const Alert = styled('div')`
-  display: inline-flex;
-  align-items: flex-start;
-  justify-items: center;
-  padding: ${space(1)} ${space(2)};
-  margin: 0 ${space(1)};
-  color: ${p => p.theme.white};
-  background-color: ${p => p.theme.blue400};
-  border-radius: ${p => p.theme.borderRadius};
-  gap: 0 ${space(1)};
-  line-height: 1em;
-  a {
-    color: ${p => p.theme.white};
-    pointer-events: all;
-    text-decoration: underline;
-  }
-  a:hover {
-    color: ${p => p.theme.white};
-    opacity: 0.5;
-  }
-`;
-
-const StyledIconInfo = styled(IconInfo)`
-  margin-top: 1px;
-  min-width: 12px; /* Prevnt the icon from scaling down whenever text wraps */
-`;
-
-const DismissButton = styled(Button)`
-  color: ${p => p.theme.white};
-  pointer-events: all;
-  &:hover {
-    color: ${p => p.theme.white};
-    opacity: 0.5;
-  }
 `;


### PR DESCRIPTION
the custom stylings don’t work well in UI2, so the suggestion was to just use the build-in Alert, which allows us to get rid of all the custom styling.

before:

| oldUI | UI2 |
|--------|--------|
| ![Screenshot 2025-06-26 at 11 44 23](https://github.com/user-attachments/assets/2b01c7a0-a85f-406b-86b3-3c3b38128f32) | ![Screenshot 2025-06-26 at 11 44 36](https://github.com/user-attachments/assets/06c7676f-f4c3-46f4-9ad5-cc0353ec7471) |
| ![Screenshot 2025-06-26 at 11 44 28](https://github.com/user-attachments/assets/99a7daff-ae35-44db-9bc8-914cfc22cf8e)| ![Screenshot 2025-06-26 at 11 44 31](https://github.com/user-attachments/assets/39413725-eab3-4a7f-8ec8-5fea880e5731) | 

after:

| oldUI | UI2 |
|--------|--------|
| ![Screenshot 2025-06-26 at 11 43 43](https://github.com/user-attachments/assets/02bea0e7-23b7-43d2-98f8-a9053bdaecec)| ![Screenshot 2025-06-26 at 11 43 49](https://github.com/user-attachments/assets/eedf1e76-ea05-4cef-b55c-a499dc0aebe3) |
| ![Screenshot 2025-06-26 at 11 43 35](https://github.com/user-attachments/assets/82d16c75-806a-4969-95c7-f4153b8ed87e) | ![Screenshot 2025-06-26 at 11 43 55](https://github.com/user-attachments/assets/daf0f20a-84a3-4128-a5c7-0e468393c8d2) | 


