### PR TITLE
feat(agent-insights): Drawer and trace analytics

### DIFF
--- a/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
@@ -4,6 +4,9 @@ export type AgentMonitoringEventParameters = {
     direction: 'asc' | 'desc';
     table: string;
   };
+  'agent-monitoring.drawer.open': Record<string, unknown>;
+  'agent-monitoring.drawer.span-select': Record<string, unknown>;
+  'agent-monitoring.drawer.view-full-trace-click': Record<string, unknown>;
   'agent-monitoring.page-view': {
     isOnboarding: boolean;
   };
@@ -11,6 +14,10 @@ export type AgentMonitoringEventParameters = {
     newTable: string;
     previousTable: string;
   };
+  'agent-monitoring.trace.rendered': Record<string, unknown>;
+  'agent-monitoring.trace.span-select': Record<string, unknown>;
+  'agent-monitoring.trace.view-full-trace-click': Record<string, unknown>;
+  'agent-monitoring.view-ai-trace-click': Record<string, unknown>;
 };
 
 export const agentMonitoringEventMap: Record<
@@ -20,4 +27,13 @@ export const agentMonitoringEventMap: Record<
   'agent-monitoring.page-view': 'Agent Monitoring: Page View',
   'agent-monitoring.table-switch': 'Agent Monitoring: Table Switch',
   'agent-monitoring.column-sort': 'Agent Monitoring: Column Sort',
+  'agent-monitoring.drawer.open': 'Agent Monitoring: Drawer Open',
+  'agent-monitoring.drawer.span-select': 'Agent Monitoring: Span Select',
+  'agent-monitoring.drawer.view-full-trace-click':
+    'Agent Monitoring: View Full Trace Click',
+  'agent-monitoring.view-ai-trace-click': 'Agent Monitoring: View AI Trace Clicked',
+  'agent-monitoring.trace.rendered': 'Agent Monitoring: Trace Rendered',
+  'agent-monitoring.trace.span-select': 'Agent Monitoring: Trace Span Select',
+  'agent-monitoring.trace.view-full-trace-click':
+    'Agent Monitoring: Trace View Full Trace Click',
 };

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -45,6 +45,7 @@ import type {Event, EventTransaction} from 'sentry/types/event';
 import type {KeyValueListData} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import getDuration from 'sentry/utils/duration/getDuration';
 import type {Color, ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -499,6 +500,11 @@ function Highlights({
             hideNodeActions ? null : (
               <OpenInAIFocusButton
                 size="xs"
+                onClick={() => {
+                  trackAnalytics('agent-monitoring.view-ai-trace-click', {
+                    organization,
+                  });
+                }}
                 to={{
                   ...location,
                   query: {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -6,6 +6,7 @@ import EmptyMessage from 'sentry/components/emptyMessage';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -36,6 +37,12 @@ function TraceAiSpans({
     return lastSpan?.replace('span-', '') ?? null;
   });
 
+  useEffect(() => {
+    trackAnalytics('agent-monitoring.trace.rendered', {
+      organization,
+    });
+  }, [organization]);
+
   const selectedNode = useMemo(() => {
     return (
       nodes.find(node => getNodeId(node) === selectedNodeKey) ||
@@ -51,6 +58,10 @@ function TraceAiSpans({
       }
       setSelectedNodeKey(eventId);
 
+      trackAnalytics('agent-monitoring.trace.span-select', {
+        organization,
+      });
+
       // Update the node path url param to keep the trace waterfal in sync
       const nodeIdentifier: TraceTree.NodePath = `span-${eventId}`;
       navigate(
@@ -64,8 +75,14 @@ function TraceAiSpans({
         {replace: true}
       );
     },
-    [location, navigate]
+    [location, navigate, organization]
   );
+
+  const handleViewFullTraceClick = useCallback(() => {
+    trackAnalytics('agent-monitoring.trace.view-full-trace-click', {
+      organization,
+    });
+  }, [organization]);
 
   if (isLoading) {
     return <LoadingIndicator />;
@@ -85,6 +102,7 @@ function TraceAiSpans({
       <HeaderCell align={'right'}>
         <LinkButton
           size="xs"
+          onClick={handleViewFullTraceClick}
           to={{
             ...location,
             query: {


### PR DESCRIPTION
Add analytics for drawer and trace (navigations, opening drawer, selecting spans)

- part of [TET-602: Analytics](https://linear.app/getsentry/issue/TET-602/analytics)