### PR TITLE
feat(agents-insights): Existing LLM user alert

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiModuleToggleButton.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiModuleToggleButton.tsx
@@ -4,27 +4,15 @@ import styled from '@emotion/styled';
 import DropdownButton from 'sentry/components/dropdownButton';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconLab} from 'sentry/icons';
-import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
   hasAgentInsightsFeature,
-  usePreferedAiModule,
+  useTogglePreferedAiModule,
 } from 'sentry/views/insights/agentMonitoring/utils/features';
 
 export function AiModuleToggleButton() {
-  const {mutate: mutateUserOptions} = useMutateUserOptions();
-  const preferedAiModule = usePreferedAiModule();
+  const [preferedAiModule, togglePreferedModule] = useTogglePreferedAiModule();
   const organization = useOrganization();
-
-  const togglePreferedModule = () => {
-    const prefersAgentsInsightsModule = preferedAiModule === 'agents-insights';
-    const newPrefersAgentsInsightsModule = !prefersAgentsInsightsModule;
-    mutateUserOptions({
-      ['prefersAgentsInsightsModule']: newPrefersAgentsInsightsModule,
-    });
-
-    return newPrefersAgentsInsightsModule;
-  };
 
   const handleExperimentDropdownAction = (key: Key) => {
     if (key === 'ai-module') {

--- a/static/app/views/insights/agentMonitoring/components/legacyLlmMonitoringAlert.tsx
+++ b/static/app/views/insights/agentMonitoring/components/legacyLlmMonitoringAlert.tsx
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/core/alert';
+import {Button} from 'sentry/components/core/button';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import {useTogglePreferedAiModule} from 'sentry/views/insights/agentMonitoring/utils/features';
+
+const LOCAL_STORAGE_KEY = 'llm-monitoring-info-alert-dismissed';
+
+export function LegacyLLMMonitoringInfoAlert() {
+  const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
+  const [_, togglePreferedModule] = useTogglePreferedAiModule();
+
+  const handleSwitchUI = () => {
+    dismiss();
+    togglePreferedModule();
+  };
+
+  if (isDismissed) {
+    return null;
+  }
+
+  return (
+    <StyledAlert type="info">
+      <Message>
+        {t('Looking for old LLM Monitoring Experience?')}
+        <Button size="xs" priority="primary" onClick={handleSwitchUI}>
+          {t('Switch UI')}
+        </Button>
+      </Message>
+      <DismissButton
+        priority="link"
+        size="sm"
+        icon={<IconClose />}
+        onClick={dismiss}
+        aria-label={t('Close Alert')}
+      />
+    </StyledAlert>
+  );
+}
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(2)};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  & > span {
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+
+    line-height: 1.5em;
+  }
+`;
+
+const Message = styled('span')`
+  display: flex;
+  flex-grow: 1;
+  gap: ${space(1)};
+  align-items: center;
+`;
+
+const DismissButton = styled(Button)`
+  pointer-events: all;
+  &:hover {
+    opacity: 0.5;
+  }
+`;

--- a/static/app/views/insights/agentMonitoring/utils/features.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/features.tsx
@@ -1,6 +1,7 @@
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import type {Organization} from 'sentry/types/organization';
+import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
@@ -19,6 +20,21 @@ export function usePreferedAiModule() {
   }
 
   return user.options.prefersAgentsInsightsModule ? 'agents-insights' : 'llm-monitoring';
+}
+
+export function useTogglePreferedAiModule(): [string, () => void] {
+  const preferedAiModule = usePreferedAiModule();
+  const {mutate: mutateUserOptions} = useMutateUserOptions();
+
+  const togglePreferedModule = () => {
+    const prefersAgentsInsightsModule = preferedAiModule === 'agents-insights';
+    const newPrefersAgentsInsightsModule = !prefersAgentsInsightsModule;
+    mutateUserOptions({
+      ['prefersAgentsInsightsModule']: newPrefersAgentsInsightsModule,
+    });
+  };
+
+  return [preferedAiModule, togglePreferedModule];
 }
 
 export function AIInsightsFeature(props: AgentInsightsFeatureProps) {

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -19,6 +19,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {limitMaxPickableDays} from 'sentry/views/explore/utils';
 import {AiModuleToggleButton} from 'sentry/views/insights/agentMonitoring/components/aiModuleToggleButton';
+import {LegacyLLMMonitoringInfoAlert} from 'sentry/views/insights/agentMonitoring/components/legacyLlmMonitoringAlert';
 import LLMGenerationsWidget from 'sentry/views/insights/agentMonitoring/components/llmGenerationsWidget';
 import {ModelsTable} from 'sentry/views/insights/agentMonitoring/components/modelsTable';
 import TokenUsageWidget from 'sentry/views/insights/agentMonitoring/components/tokenUsageWidget';
@@ -61,13 +62,29 @@ function useShowOnboarding() {
     pageFilters.selection.projects,
     projects
   );
+
   return !selectedProjects.some(p => p.hasInsightsAgentMonitoring);
+}
+
+function useShouldShowLegacyLLMAlert() {
+  const {projects} = useProjects();
+  const pageFilters = usePageFilters();
+  const selectedProjects = getSelectedProjectList(
+    pageFilters.selection.projects,
+    projects
+  );
+
+  const hasAgentMonitoring = selectedProjects.some(p => p.hasInsightsAgentMonitoring);
+  const hasLlmMonitoring = selectedProjects.some(p => p.hasInsightsLlmMonitoring);
+
+  return hasLlmMonitoring && !hasAgentMonitoring;
 }
 
 function AgentsMonitoringPage() {
   const location = useLocation();
   const organization = useOrganization();
   const showOnboarding = useShowOnboarding();
+  const hasInsightsLlmMonitoring = useShouldShowLegacyLLMAlert();
   const datePageFilterProps = limitMaxPickableDays(organization);
 
   const {eventView, handleSearch} = useTransactionNameQuery();
@@ -108,7 +125,9 @@ function AgentsMonitoringPage() {
                   )}
                 </ToolRibbon>
               </ModuleLayout.Full>
+
               <ModuleLayout.Full>
+                {hasInsightsLlmMonitoring && <LegacyLLMMonitoringInfoAlert />}
                 {showOnboarding ? (
                   <Onboarding />
                 ) : (


### PR DESCRIPTION
Closes [TET-691: Agents Beta banner for existing llm users](https://linear.app/getsentry/issue/TET-691/agents-beta-banner-for-existing-llm-users)

Shown only if the project selection has old LLM monitoring and does not have the new Agent Monitoring

<img width="1536" alt="image" src="https://github.com/user-attachments/assets/12be0864-c580-48b5-ae90-dcb7c6899f58" />
