### PR TITLE
fix(flags): hide segmented control in drawer for unsupported/disabled orgs

### DIFF
--- a/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
@@ -74,7 +74,9 @@ export default function TagsDistributionDrawer({
           <EventStickyControls>
             {includeFeatureFlagsTab ? (
               <TagFlagPicker setTab={setTab} tab={DrawerTab.TAGS} />
-            ) : null}
+            ) : (
+              <div />
+            )}
 
             <ButtonBar gap={1}>
               <GroupDistributionsSearchInput

--- a/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
+++ b/static/app/views/issueDetails/groupDistributions/tagsDistributionDrawer.tsx
@@ -72,7 +72,9 @@ export default function TagsDistributionDrawer({
 
         {tagKey ? null : (
           <EventStickyControls>
-            <TagFlagPicker setTab={setTab} tab={DrawerTab.TAGS} />
+            {includeFeatureFlagsTab ? (
+              <TagFlagPicker setTab={setTab} tab={DrawerTab.TAGS} />
+            ) : null}
 
             <ButtonBar gap={1}>
               <GroupDistributionsSearchInput


### PR DESCRIPTION
After recent refactors segmented control shows even for unsupported platforms.
Before
<img width="753" alt="Screenshot 2025-06-26 at 8 43 20 AM" src="https://github.com/user-attachments/assets/d13441af-87ad-4d6e-9bb6-97e3fe7c9bb1" />
After
<img width="751" alt="Screenshot 2025-06-26 at 8 43 07 AM" src="https://github.com/user-attachments/assets/9733b6b0-1215-45cf-8558-8b7b93c66c67" />
