### PR TITLE
fix(flags): loosen length restrictions on frontend secret form

### DIFF
--- a/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
@@ -163,6 +163,7 @@ export default function NewProviderForm({
       <TextField
         name="secret"
         label={t('Secret')}
+        maxLength={100}
         minLength={1}
         required
         help={t(

--- a/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
@@ -163,8 +163,7 @@ export default function NewProviderForm({
       <TextField
         name="secret"
         label={t('Secret')}
-        maxLength={32}
-        minLength={32}
+        minLength={1}
         required
         help={t(
           'Paste the signing secret given by your provider when creating the webhook.'


### PR DESCRIPTION
[Statsig](https://docs.sentry.io/organization/integrations/feature-flag/statsig/#change-tracking) secrets are >32 chars. Future providers may have variable lengths too. We should defer to the backend for validation (backend currently enforces statsig length >=32, <=64).