### PR TITLE
feat: Update rules for Flutter

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -89,6 +89,7 @@ family:native function:"?[[]Sentry*"                              -app -group
 # Dart/Flutter stacktraces that are not in-app
 family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
 family:javascript module:**/packages/flutter/** -app
+family:native stack.abs_path:**/packages/flutter/** -app
 # sentry-dart SDK frames are not in app
 stack.abs_path:package:sentry/** -app -group
 stack.abs_path:package:sentry_flutter/** -app -group


### PR DESCRIPTION
Forgot to add this in another PR. this automatically marks frames coming out of Flutter as not inApp