### PR TITLE
theme: remove >3xl values from spacing

### DIFF
--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -549,12 +549,6 @@ const space = {
   xl: '16px',
   '2xl': '24px',
   '3xl': '32px',
-  '4xl': '48px',
-  '5xl': '64px',
-  '6xl': '80px',
-  '7xl': '96px',
-  '8xl': '112px',
-  '9xl': '128px',
 } as const;
 
 const radius = {


### PR DESCRIPTION
Temporarily removing this to have min compliance with the current space API that goes up to 30px.

Having >3xl values means that the autocomplete experience becomes quite polluted, but there may also be a split here where the space sizes would actually be renamed to 'sizing', which folks could use to size different element. In that case, it would make sense to have a separate sizing scale that folks can use, and keep the space scale mostly for padding and simple layout