### PR TITLE
fix(insights): Fix open in explore not propagating page filters for some charts in insights

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
@@ -13,6 +13,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {
@@ -201,8 +202,9 @@ const BodyCell = memo(function BodyCell({
   dataRow: TableData;
 }) {
   const organization = useOrganization();
-
+  const {selection} = usePageFilters();
   const exploreUrl = getExploreUrl({
+    selection,
     organization,
     mode: Mode.SAMPLES,
     visualize: [

--- a/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
@@ -12,6 +12,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {
@@ -188,8 +189,9 @@ const BodyCell = memo(function BodyCell({
   dataRow: TableData;
 }) {
   const organization = useOrganization();
-
+  const {selection} = usePageFilters();
   const exploreUrl = getExploreUrl({
+    selection,
     organization,
     mode: Mode.SAMPLES,
     visualize: [

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -41,6 +41,7 @@ export function ChartActionDropdown({
   const {selection} = usePageFilters();
 
   const exploreUrl = getExploreUrl({
+    selection,
     organization,
     visualize: [
       {

--- a/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
+++ b/static/app/views/insights/http/components/charts/responseCodeCountChart.tsx
@@ -81,6 +81,7 @@ export function ResponseCodeCountChart({
 
   const exploreUrl = getExploreUrl({
     organization,
+    selection,
     visualize: [
       {
         chartType: ChartType.LINE,

--- a/static/app/views/insights/queues/charts/throughputChart.tsx
+++ b/static/app/views/insights/queues/charts/throughputChart.tsx
@@ -75,6 +75,7 @@ export function ThroughputChart({id, error, destination, pageFilters, referrer}:
   const colors = theme.chart.getColorPalette(2);
 
   const exploreUrl = getExploreUrl({
+    selection,
     organization,
     visualize: [
       {

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -271,6 +271,7 @@ function WidgetInteractiveTitle({
         typeof eventView.yAxis === 'string' ? [eventView.yAxis] : (eventView.yAxis ?? []);
       navigate(
         getExploreUrl({
+          selection: eventView.getPageFilters(),
           organization,
           visualize: yAxis?.map(y => ({
             chartType: ChartType.LINE,


### PR DESCRIPTION
Updates areas where `getExploreUrl` calls were missing `selection`.