### PR TITLE
fix(agents-insights): onboarding next.js instructions

### DIFF
--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -562,7 +562,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/nextjs',
+    basePackage: 'nextjs',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/react-router.tsx
+++ b/static/app/gettingStartedDocs/javascript/react-router.tsx
@@ -503,7 +503,7 @@ const docs: Docs = {
   performanceOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/react-router',
+    basePackage: 'react-router',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/javascript/remix.tsx
@@ -264,7 +264,7 @@ const docs: Docs = {
   featureFlagOnboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/remix',
+    basePackage: 'remix',
   }),
 };
 

--- a/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
+++ b/static/app/gettingStartedDocs/javascript/tanstackstart-react.tsx
@@ -455,7 +455,7 @@ const docs: Docs = {
   onboarding,
   profilingOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/tanstackstart-react',
+    basePackage: 'tanstackstart-react',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/awslambda.tsx
+++ b/static/app/gettingStartedDocs/node/awslambda.tsx
@@ -226,7 +226,7 @@ const docs: Docs<PlatformOptions> = {
     basePackage: '@sentry/aws-serverless',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/aws-serverless',
+    basePackage: 'aws-serverless',
   }),
   platformOptions,
 };

--- a/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-pages.tsx
@@ -174,7 +174,7 @@ const docs: Docs = {
   onboarding,
   crashReportOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/cloudflare',
+    basePackage: 'cloudflare',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
+++ b/static/app/gettingStartedDocs/node/cloudflare-workers.tsx
@@ -166,7 +166,7 @@ const docs: Docs = {
   onboarding,
   crashReportOnboarding,
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/cloudflare',
+    basePackage: 'cloudflare',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/node/gcpfunctions.tsx
@@ -131,7 +131,7 @@ const docs: Docs = {
     basePackage: '@sentry/google-cloud-serverless',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/google-cloud-serverless',
+    basePackage: 'google-cloud-serverless',
   }),
 };
 

--- a/static/app/gettingStartedDocs/node/nestjs.tsx
+++ b/static/app/gettingStartedDocs/node/nestjs.tsx
@@ -286,7 +286,7 @@ const docs: Docs = {
     basePackage: '@sentry/nestjs',
   }),
   agentMonitoringOnboarding: getNodeAgentMonitoringOnboarding({
-    basePackage: '@sentry/nestjs',
+    basePackage: 'nestjs',
   }),
 };
 

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -317,7 +317,7 @@ Sentry.profiler.stopProfiler();
           additionalInfo:
             profilingLifecycle === 'trace'
               ? tct(
-                  'If you need more fine grained control over which spans are profiled, you can do so by [link:enabling manual lifecycle profiling].',
+                  'If you eed more fine grained control over which spans are profiled, you can do so by [link:enabling manual lifecycle profiling].',
                   {
                     link: (
                       <ExternalLink
@@ -354,7 +354,7 @@ Sentry.profiler.stopProfiler();
 });
 
 export const getNodeAgentMonitoringOnboarding = ({
-  basePackage = '@sentry/node',
+  basePackage = 'node',
 }: {
   basePackage?: string;
 } = {}): OnboardingConfig => ({
@@ -394,7 +394,10 @@ export const getNodeAgentMonitoringOnboarding = ({
           language: 'javascript',
           code: [
             {
-              label: 'Javascript',
+              label:
+                params.platformKey === 'javascript-nextjs'
+                  ? 'config.server.ts'
+                  : 'JavaScript',
               value: 'javascript',
               language: 'javascript',
               code: `${getImport(basePackage === '@sentry/node' ? 'node' : (basePackage as any)).join('\n')}
@@ -403,6 +406,7 @@ Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
     // Add the Vercel AI SDK integration
+    ${basePackage === 'nextjs' && '// vercelAIIntegration should be included only to config.server'}
     Sentry.vercelAIIntegration({
       recordInputs: true,
       recordOutputs: true,
@@ -426,7 +430,7 @@ Sentry.init({
           ),
           code: [
             {
-              label: 'Javascript',
+              label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
               code: `import { generateText } from 'ai';

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -317,7 +317,7 @@ Sentry.profiler.stopProfiler();
           additionalInfo:
             profilingLifecycle === 'trace'
               ? tct(
-                  'If you eed more fine grained control over which spans are profiled, you can do so by [link:enabling manual lifecycle profiling].',
+                  'If you need more fine grained control over which spans are profiled, you can do so by [link:enabling manual lifecycle profiling].',
                   {
                     link: (
                       <ExternalLink


### PR DESCRIPTION
Also fixes `@sentry/nextjs/nextjs` and similar appearing in onboarding instructions 