### PR TITLE
fix(billing): fix conflicting pending reserved budget changes

### DIFF
--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -273,6 +273,7 @@ class PendingChanges extends Component<Props> {
       seenBudgets.add(pendingBudgetInfo?.apiName ?? '');
 
       if (pendingBudgetInfo?.isFixed) {
+        // if it's a fixed budget, we don't care about the existing budget state
         results.push(
           tct('[productName] product access will be [accessState]', {
             productName: toTitleCase(pendingBudgetInfo?.productName),


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1011/subscription-page-showing-conflicting-messages-about-pending-seer