### PR TITLE
theme: remove some usage of ColorOrAlias

### DIFF
--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -27,7 +27,7 @@ import type {
   StatusPageServiceStatus,
 } from 'sentry/types/system';
 import {sanitizedMarked} from 'sentry/utils/marked/marked';
-import type {ColorOrAlias} from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 
 interface Props {
   incident: StatuspageIncident;
@@ -177,16 +177,30 @@ const UpdatesList = styled(List)`
   }
 `;
 
-type UpdateStatus = StatusPageIncidentUpdate['status'];
+function getIndicatorColor({
+  theme,
+  status,
+}: {
+  status: StatusPageIncidentUpdate['status'];
+  theme: Theme;
+}): string {
+  switch (status) {
+    case 'investigating':
+      return theme.red200;
+    case 'identified':
+      return theme.blue200;
+    case 'monitoring':
+      return theme.yellow200;
+    case 'resolved':
+      return theme.green200;
+    default: {
+      const _exhaustiveCheck: never = status;
+      return _exhaustiveCheck;
+    }
+  }
+}
 
-const indicatorColor: Record<UpdateStatus, ColorOrAlias> = {
-  investigating: 'red200',
-  identified: 'blue200',
-  monitoring: 'yellow200',
-  resolved: 'green200',
-};
-
-const UpdateHeading = styled('div')<{status: UpdateStatus}>`
+const UpdateHeading = styled('div')<{status: StatusPageIncidentUpdate['status']}>`
   margin-bottom: ${space(0.5)};
   display: flex;
   align-items: center;
@@ -201,7 +215,7 @@ const UpdateHeading = styled('div')<{status: UpdateStatus}>`
     width: 8px;
     margin-left: -15px;
     border-radius: 50%;
-    background: ${p => p.theme[indicatorColor[p.status]]};
+    background: ${p => getIndicatorColor({theme: p.theme, status: p.status})};
   }
 `;
 

--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -184,15 +184,13 @@ function getIndicatorColor({
   status: StatusPageIncidentUpdate['status'];
   theme: Theme;
 }): string {
-  const indicatorColor: Record<UpdateStatus, string> = {
-	  investigating: theme.red200,
-	  identified: theme.blue200,
-	  monitoring: theme.yellow200,
-	  resolved: theme.green200,
-	};
-	return indicatorColor[status];
-    }
-  }
+  const indicatorColor: Record<StatusPageIncidentUpdate['status'], string> = {
+    investigating: theme.red200,
+    identified: theme.blue200,
+    monitoring: theme.yellow200,
+    resolved: theme.green200,
+  };
+  return indicatorColor[status];
 }
 
 const UpdateHeading = styled('div')<{status: StatusPageIncidentUpdate['status']}>`

--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -184,18 +184,13 @@ function getIndicatorColor({
   status: StatusPageIncidentUpdate['status'];
   theme: Theme;
 }): string {
-  switch (status) {
-    case 'investigating':
-      return theme.red200;
-    case 'identified':
-      return theme.blue200;
-    case 'monitoring':
-      return theme.yellow200;
-    case 'resolved':
-      return theme.green200;
-    default: {
-      const _exhaustiveCheck: never = status;
-      return _exhaustiveCheck;
+  const indicatorColor: Record<UpdateStatus, string> = {
+	  investigating: theme.red200,
+	  identified: theme.blue200,
+	  monitoring: theme.yellow200,
+	  resolved: theme.green200,
+	};
+	return indicatorColor[status];
     }
   }
 }

--- a/static/app/components/serviceIncidentDetails.tsx
+++ b/static/app/components/serviceIncidentDetails.tsx
@@ -208,7 +208,7 @@ const UpdateHeading = styled('div')<{status: StatusPageIncidentUpdate['status']}
     width: 8px;
     margin-left: -15px;
     border-radius: 50%;
-    background: ${p => getIndicatorColor({theme: p.theme, status: p.status})};
+    background: ${getIndicatorColor};
   }
 `;
 

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -451,7 +451,6 @@ const generateThemeAliases = (colors: Colors) => ({
 });
 
 type Alert = 'muted' | 'info' | 'warning' | 'success' | 'error';
-
 type AlertColors = Record<
   Alert,
   {

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {css} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import round from 'lodash/round';
 
@@ -18,7 +18,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 
@@ -47,6 +46,7 @@ function TeamAlertsTriggered({
   period,
   utc,
 }: TeamAlertsTriggeredProps) {
+  const theme = useTheme();
   const datetime = {start, end, period, utc};
 
   const {
@@ -113,7 +113,7 @@ function TeamAlertsTriggered({
     }
 
     return (
-      <SubText color={diff <= 0 ? 'successText' : 'errorText'}>
+      <SubText color={diff <= 0 ? theme.successText : theme.errorText}>
         {formatPercentage(Math.abs(diff / weeklyAvg), 0)}
         <PaddedIconArrow direction={diff <= 0 ? 'down' : 'up'} size="xs" />
       </SubText>
@@ -249,8 +249,8 @@ const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
 `;
 
-const SubText = styled('div')<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
+const SubText = styled('div')<{color: string}>`
+  color: ${p => p.color};
 `;
 
 const ButtonsContainer = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -20,7 +20,6 @@ import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
@@ -162,7 +161,7 @@ function TeamMisery({
                         {t('change')}
                       </SubText>
                     ) : (
-                      <TrendText color={trend >= 0 ? 'successText' : 'errorText'}>
+                      <TrendText color={trend >= 0 ? theme.successText : theme.errorText}>
                         {`${trendValue}\u0025 `}
                         {trend >= 0 ? t('better') : t('worse')}
                       </TrendText>
@@ -326,6 +325,6 @@ const SubText = styled('div')`
   color: ${p => p.theme.subText};
 `;
 
-const TrendText = styled('div')<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
+const TrendText = styled('div')<{color: string}>`
+  color: ${p => p.color};
 `;

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {BarChart} from 'sentry/components/charts/barChart';
@@ -15,7 +16,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {
@@ -45,6 +45,7 @@ export function TeamUnresolvedIssues({
   utc,
   environment,
 }: TeamUnresolvedIssuesProps) {
+  const theme = useTheme();
   const {
     data: periodIssues = {},
     isPending,
@@ -184,10 +185,10 @@ export function TeamUnresolvedIssues({
                       <SubText
                         color={
                           totals.percentChange === 0
-                            ? 'subText'
+                            ? theme.subText
                             : totals.percentChange > 0
-                              ? 'errorText'
-                              : 'successText'
+                              ? theme.errorText
+                              : theme.successText
                         }
                       >
                         {formatPercentage(
@@ -245,6 +246,6 @@ const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
 `;
 
-const SubText = styled('div')<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
+const SubText = styled('div')<{color: string}>`
+  color: ${p => p.color};
 `;

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -1,5 +1,4 @@
-import type {Theme} from '@emotion/react';
-import {css} from '@emotion/react';
+import {css, type Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {OrganizationAvatar} from 'sentry/components/core/avatar/organizationAvatar';
@@ -17,7 +16,6 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
-import type {ColorOrAlias} from 'sentry/utils/theme';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -46,6 +44,7 @@ function SettingsIndex(props: SettingsIndexProps) {
   // organization
   const organization = useOrganization({allowNull: true});
   const user = useUser();
+  const theme = useTheme();
   const isSelfHosted = ConfigStore.get('isSelfHosted');
 
   const organizationSettingsUrl =
@@ -102,7 +101,7 @@ function SettingsIndex(props: SettingsIndexProps) {
           </HomeLinkIcon>
         ) : (
           <HomeLinkIcon to="/organizations/new/">
-            <HomeIconContainer color="green300">
+            <HomeIconContainer color={theme.green300}>
               <IconStack size="lg" />
             </HomeIconContainer>
             <HomeLinkLabel>{t('Create an Organization')}</HomeLinkLabel>
@@ -141,7 +140,7 @@ function SettingsIndex(props: SettingsIndexProps) {
     <GridPanel>
       <HomePanelHeader>
         <ExternalHomeLinkIcon href={LINKS.DOCUMENTATION}>
-          <HomeIconContainer color="pink300">
+          <HomeIconContainer color={theme.pink300}>
             <IconDocs size="lg" />
           </HomeIconContainer>
           <HomeLinkLabel>{t('Documentation')}</HomeLinkLabel>
@@ -175,7 +174,7 @@ function SettingsIndex(props: SettingsIndexProps) {
     <GridPanel>
       <HomePanelHeader>
         <SupportLink icon {...supportLinkProps}>
-          <HomeIconContainer color="activeText">
+          <HomeIconContainer color={theme.activeText}>
             <IconSupport size="lg" />
           </HomeIconContainer>
           <HomeLinkLabel>{t('Support')}</HomeLinkLabel>
@@ -300,8 +299,8 @@ const HomePanelBody = styled(PanelBody)`
   }
 `;
 
-const HomeIconContainer = styled('div')<{color?: ColorOrAlias}>`
-  background: ${p => p.theme[p.color || 'gray300']};
+const HomeIconContainer = styled('div')<{color?: string}>`
+  background: ${p => p.color || 'gray300'};
   color: ${p => p.theme.white};
   width: ${HOME_ICON_SIZE}px;
   height: ${HOME_ICON_SIZE}px;


### PR DESCRIPTION
`ColorOrAlias` is a bad type, because it is essentially an escape hatch into the entire theme.

Once chonk is released, these types should be removed, and guidelines added about how to use tokens and encourage people to use variants.