### PR TITLE
fix(taskworker) Downgrade RPC errors to warning

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -261,7 +261,7 @@ class TaskWorker:
             self._setstatus_backoff_seconds = min(self._setstatus_backoff_seconds + 1, 10)
             if e.code() == grpc.StatusCode.UNAVAILABLE:
                 self._processed_tasks.put(result)
-            logger.exception(
+            logger.warning(
                 "taskworker.send_update_task.failed",
                 extra={"task_id": result.task_id, "error": e},
             )


### PR DESCRIPTION
While RPC errors are a useful signal, they generally resolve automatically, as brokers restart or are rescheduled. If RPC errors are persistent, backlogs will form and we'll be alerted anyways, making the sentry errors more like noise.