### PR TITLE
theme: remove aliases export

### DIFF
--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {IconAdd, IconFire, IconProfiling, IconSubtract} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import type {Aliases, Color} from 'sentry/utils/theme';
+import type {ColorOrAlias} from 'sentry/utils/theme';
 
 export const DividerContainer = styled('div')`
   position: relative;
@@ -50,7 +50,7 @@ export const DividerLineGhostContainer = styled('div')`
 `;
 
 const BadgeBorder = styled('div')<{
-  color: Color | keyof Aliases;
+  color: ColorOrAlias;
   fillBackground?: boolean;
 }>`
   position: absolute;

--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -1,12 +1,12 @@
 import {useTheme} from '@emotion/react';
 
-import type {Aliases, Color, IconSize} from 'sentry/utils/theme';
+import type {ColorOrAlias, IconSize} from 'sentry/utils/theme';
 
 import {useIconDefaults} from './useIconDefaults';
 
 export interface SVGIconProps extends React.SVGAttributes<SVGSVGElement> {
   className?: string;
-  color?: Color | keyof Aliases | 'currentColor';
+  color?: ColorOrAlias | 'currentColor';
   /**
    * DO NOT USE THIS! Please use the `size` prop
    *

--- a/static/app/utils/theme/index.tsx
+++ b/static/app/utils/theme/index.tsx
@@ -1,5 +1,4 @@
 export type {
-  Aliases,
   Color,
   ColorOrAlias,
   FormSize,

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1322,7 +1322,7 @@ export const darkTheme: typeof lightTheme = {
 export type ColorMapping = typeof lightColors;
 export type Color = keyof typeof lightColors;
 export type IconSize = Size;
-export type Aliases = typeof lightAliases;
+type Aliases = typeof lightAliases;
 export type ColorOrAlias = keyof Aliases | Color;
 export type Theme = typeof lightTheme;
 


### PR DESCRIPTION
Remove Aliases export from theme as it is basically an escape hatch type into the entire theme color set. We will encourage folks to use tokens once the UI2 release is done, and we have token docs