### PR TITLE
ref(dashboards): Add fallback for Issues dataset custom field renderer

### DIFF
--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -19,7 +19,6 @@ import {
 import type {TableDataRow, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
 import {isFieldSortable} from 'sentry/utils/discover/eventView';
-import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {
   fieldAlignment,
@@ -199,9 +198,11 @@ export const renderGridBodyCell = ({
           return dataRow[column.key];
         }
 
-        cell = (
-          getIssueFieldRenderer(columnKey) ?? getFieldRenderer(columnKey, tableData.meta)
-        )(dataRow, {organization, location, theme});
+        cell = getIssueFieldRenderer(columnKey, tableData.meta)(dataRow, {
+          organization,
+          location,
+          theme,
+        });
         break;
       case WidgetType.DISCOVER:
       case WidgetType.TRANSACTIONS:

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -11,7 +11,13 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
 
 describe('getIssueFieldRenderer', function () {
-  let location: any, context: any, project: any, organization: any, data: any, user: any;
+  let location: any,
+    context: any,
+    project: any,
+    organization: any,
+    theme: any,
+    data: any,
+    user: any;
 
   beforeEach(function () {
     context = initializeOrg({
@@ -94,12 +100,13 @@ describe('getIssueFieldRenderer', function () {
         },
       });
       GroupStore.add([group]);
-      const renderer = getIssueFieldRenderer('assignee');
+      const renderer = getIssueFieldRenderer('assignee', {});
 
       render(
-        renderer!(data, {
+        renderer(data, {
           location,
           organization,
+          theme,
         }) as React.ReactElement
       );
       await userEvent.hover(screen.getByText('TU'));
@@ -107,12 +114,13 @@ describe('getIssueFieldRenderer', function () {
     });
 
     it('can render counts', async function () {
-      const renderer = getIssueFieldRenderer('events');
+      const renderer = getIssueFieldRenderer('events', {});
 
       render(
-        renderer!(data, {
+        renderer(data, {
           location,
           organization,
+          theme,
         }) as React.ReactElement
       );
       expect(screen.getByText('3k')).toBeInTheDocument();
@@ -125,22 +133,23 @@ describe('getIssueFieldRenderer', function () {
   });
 
   it('can render links', function () {
-    const renderer = getIssueFieldRenderer('links');
+    const renderer = getIssueFieldRenderer('links', {});
 
     render(
-      renderer!(data, {
+      renderer(data, {
         location,
         organization,
+        theme,
       }) as React.ReactElement
     );
     expect(screen.getByText('ANNO-123')).toBeInTheDocument();
   });
 
   it('can render multiple links', function () {
-    const renderer = getIssueFieldRenderer('links');
+    const renderer = getIssueFieldRenderer('links', {});
 
     render(
-      renderer!(
+      renderer(
         {
           data,
           ...{
@@ -153,6 +162,7 @@ describe('getIssueFieldRenderer', function () {
         {
           location,
           organization,
+          theme,
         }
       ) as React.ReactElement
     );

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -13,8 +13,10 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {IssueAssignee} from 'sentry/utils/dashboards/issueAssignee';
-import type {EventData} from 'sentry/utils/discover/eventView';
+import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import EventView from 'sentry/utils/discover/eventView';
+import type {FieldFormatterRenderFunctionPartial} from 'sentry/utils/discover/fieldRenderers';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {Container, FieldShortId, OverflowLink} from 'sentry/utils/discover/styles';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
@@ -28,11 +30,6 @@ type RenderFunctionBaggage = {
   organization: Organization;
   eventView?: EventView;
 };
-
-type FieldFormatterRenderFunctionPartial = (
-  data: EventData,
-  baggage: RenderFunctionBaggage
-) => React.ReactNode;
 
 type SpecialFieldRenderFunc = (
   data: EventData,
@@ -305,14 +302,13 @@ const LinksContainer = styled('span')`
  * @returns {Function}
  */
 export function getIssueFieldRenderer(
-  field: string
-): FieldFormatterRenderFunctionPartial | null {
+  field: string,
+  meta: MetaType
+): FieldFormatterRenderFunctionPartial {
   if (SPECIAL_FIELDS.hasOwnProperty(field)) {
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     return SPECIAL_FIELDS[field].renderFunc;
   }
 
-  // Return null if there is no field renderer for this field
-  // Should check the discover field renderer for this field
-  return null;
+  return getFieldRenderer(field, meta, false);
 }

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -106,7 +106,7 @@ type FieldFormatterRenderFunction = (
   baggage?: RenderFunctionBaggage
 ) => React.ReactNode;
 
-type FieldFormatterRenderFunctionPartial = (
+export type FieldFormatterRenderFunctionPartial = (
   data: EventData,
   baggage: RenderFunctionBaggage
 ) => React.ReactNode;

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -133,7 +133,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     meta: MetaType,
     widget?: Widget,
     organization?: Organization
-  ) => ReturnType<typeof getFieldRenderer> | null;
+  ) => ReturnType<typeof getFieldRenderer>;
   /**
    * Generate field header used for mapping column
    * names to more desirable values in tables.

--- a/static/app/views/dashboards/datasetConfig/errors.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errors.spec.tsx
@@ -41,7 +41,7 @@ describe('ErrorsConfig', function () {
     it('links trace ids to performance', async function () {
       const customFieldRenderer = ErrorsConfig.getCustomFieldRenderer!('trace', {});
       render(
-        customFieldRenderer!(
+        customFieldRenderer(
           {trace: 'abcd'},
           {
             organization,
@@ -73,7 +73,7 @@ describe('ErrorsConfig', function () {
       const project = ProjectFixture();
       const customFieldRenderer = ErrorsConfig.getCustomFieldRenderer!('id', {});
       render(
-        customFieldRenderer!(
+        customFieldRenderer(
           {id: 'defg', 'project.name': project.slug},
           {
             organization,


### PR DESCRIPTION
The issues dataset is the _only_ one that that has a field renderer getter that sometimes returns `null`. Instead, I'm setting it to return `getFieldRenderer`, like all the other datasets do.

This results in the same exact behaviour because the simple table component and the modal cell renderer are falling back to `getFieldRenderer` anyway, but this is nice and consistent, since we can rely on the configuration to always return a config.
