### PR TITLE
theme: make formsize internal

### DIFF
--- a/static/app/components/core/checkbox/index.tsx
+++ b/static/app/components/core/checkbox/index.tsx
@@ -14,7 +14,7 @@ type CheckboxConfig = {
   icon: string;
 };
 
-const checkboxSizeMap: Record<FormSize, CheckboxConfig> = {
+const checkboxSizeMap: Record<NonNullable<CheckboxProps['size']>, CheckboxConfig> = {
   xs: {box: '12px', borderRadius: '2px', icon: '10px'},
   sm: {box: '16px', borderRadius: '4px', icon: '12px'},
   md: {box: '22px', borderRadius: '6px', icon: '18px'},
@@ -83,7 +83,7 @@ export function Checkbox({
 }
 
 const CheckboxWrapper = styled('div')<{
-  size: FormSize;
+  size: NonNullable<CheckboxProps['size']>;
 }>`
   position: relative;
   cursor: pointer;
@@ -144,7 +144,7 @@ const NativeHiddenCheckbox = withChonk(
 );
 
 const FakeCheckbox = styled('div')<{
-  size: FormSize;
+  size: NonNullable<CheckboxProps['size']>;
 }>`
   position: relative;
   display: flex;

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -65,7 +65,7 @@ type CompositeSelectChild =
   | null
   | undefined;
 
-interface CompositeSelectProps extends ControlProps {
+export interface CompositeSelectProps extends ControlProps {
   /**
    * The "regions" inside this composite selector. Each region functions as a separated,
    * self-contained selectable list (each renders as a `ul` with its own list state)

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -606,12 +606,12 @@ const StyledBadge = styled(Badge)`
   top: auto;
 `;
 
-const headerVerticalPadding: Record<FormSize, string> = {
+const headerVerticalPadding: Record<NonNullable<ControlProps['size']>, string> = {
   xs: space(0.25),
   sm: space(0.5),
   md: space(0.75),
 };
-const MenuHeader = styled('div')<{size: FormSize}>`
+const MenuHeader = styled('div')<{size: NonNullable<ControlProps['size']>}>`
   position: relative;
   display: flex;
   align-items: center;

--- a/static/app/components/core/compactSelect/gridList/index.tsx
+++ b/static/app/components/core/compactSelect/gridList/index.tsx
@@ -15,9 +15,8 @@ import {
 } from 'sentry/components/core/compactSelect/styles';
 import type {SelectKey, SelectSection} from 'sentry/components/core/compactSelect/types';
 import {t} from 'sentry/locale';
-import type {FormSize} from 'sentry/utils/theme';
 
-import {GridListOption} from './option';
+import {GridListOption, type GridListOptionProps} from './option';
 import {GridListSection} from './section';
 
 interface GridListProps
@@ -56,7 +55,7 @@ interface GridListProps
     section: SelectSection<SelectKey>,
     type: 'select' | 'unselect'
   ) => void;
-  size?: FormSize;
+  size?: GridListOptionProps['size'];
   /**
    * Message to be displayed when some options are hidden due to `sizeLimit`.
    */

--- a/static/app/components/core/compactSelect/gridList/option.tsx
+++ b/static/app/components/core/compactSelect/gridList/option.tsx
@@ -14,7 +14,7 @@ import {IconCheckmark} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
 
-interface GridListOptionProps extends AriaGridListItemOptions {
+export interface GridListOptionProps extends AriaGridListItemOptions {
   listState: ListState<any>;
   node: Node<any>;
   size: FormSize;

--- a/static/app/components/core/compactSelect/gridList/section.tsx
+++ b/static/app/components/core/compactSelect/gridList/section.tsx
@@ -13,14 +13,13 @@ import {
 } from 'sentry/components/core/compactSelect/styles';
 import type {SelectKey, SelectSection} from 'sentry/components/core/compactSelect/types';
 import {SectionToggle} from 'sentry/components/core/compactSelect/utils';
-import type {FormSize} from 'sentry/utils/theme';
 
-import {GridListOption} from './option';
+import {GridListOption, type GridListOptionProps} from './option';
 
 interface GridListSectionProps {
   listState: ListState<any>;
   node: Node<any>;
-  size: FormSize;
+  size: GridListOptionProps['size'];
   onToggle?: (section: SelectSection<SelectKey>, type: 'select' | 'unselect') => void;
 }
 

--- a/static/app/components/core/compactSelect/listBox/option.tsx
+++ b/static/app/components/core/compactSelect/listBox/option.tsx
@@ -7,15 +7,18 @@ import type {Node} from '@react-types/shared';
 
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {CheckWrap} from 'sentry/components/core/compactSelect/styles';
-import {InnerWrap, MenuListItem} from 'sentry/components/core/menuListItem';
+import {
+  InnerWrap,
+  MenuListItem,
+  type MenuListItemProps,
+} from 'sentry/components/core/menuListItem';
 import {IconCheckmark} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import type {FormSize} from 'sentry/utils/theme';
 
 export interface ListBoxOptionProps extends AriaOptionProps {
   item: Node<any>;
   listState: ListState<any>;
-  size: FormSize;
+  size: MenuListItemProps['size'];
   showDetails?: boolean;
 }
 

--- a/static/app/components/core/compactSelect/listBox/option.tsx
+++ b/static/app/components/core/compactSelect/listBox/option.tsx
@@ -12,7 +12,7 @@ import {IconCheckmark} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
 
-interface ListBoxOptionProps extends AriaOptionProps {
+export interface ListBoxOptionProps extends AriaOptionProps {
   item: Node<any>;
   listState: ListState<any>;
   size: FormSize;

--- a/static/app/components/core/compactSelect/listBox/section.tsx
+++ b/static/app/components/core/compactSelect/listBox/section.tsx
@@ -14,16 +14,15 @@ import {
 } from 'sentry/components/core/compactSelect/styles';
 import type {SelectKey, SelectSection} from 'sentry/components/core/compactSelect/types';
 import {SectionToggle} from 'sentry/components/core/compactSelect/utils';
-import type {FormSize} from 'sentry/utils/theme';
 
-import {ListBoxOption} from './option';
+import {ListBoxOption, type ListBoxOptionProps} from './option';
 
 interface ListBoxSectionProps extends AriaListBoxSectionProps {
   hiddenOptions: Set<SelectKey>;
   item: Node<any>;
   listState: ListState<any>;
   showSectionHeaders: boolean;
-  size: FormSize;
+  size: ListBoxOptionProps['size'];
   onToggle?: (section: SelectSection<SelectKey>, type: 'select' | 'unselect') => void;
   showDetails?: boolean;
 }

--- a/static/app/components/core/input/inputGroup.chonk.tsx
+++ b/static/app/components/core/input/inputGroup.chonk.tsx
@@ -28,7 +28,7 @@ const chonkItemsPadding = {
   md: 8,
   sm: 6,
   xs: 4,
-} satisfies Record<FormSize, number>;
+} satisfies Record<NonNullable<InputStyleProps['size']>, number>;
 
 const chonkInputStyles = ({
   leadingWidth,
@@ -62,7 +62,7 @@ export const ChonkStyledTextArea = chonkStyled(TextArea)<InputStyleProps>`
 `;
 
 export const ChonkStyledLeadingItemsWrap = chonkStyled(InputItemsWrap)<{
-  size: FormSize;
+  size: NonNullable<InputStyleProps['size']>;
   disablePointerEvents?: boolean;
 }>`
     left: ${p => p.theme.formPadding[p.size].paddingLeft + 1}px;
@@ -70,7 +70,7 @@ export const ChonkStyledLeadingItemsWrap = chonkStyled(InputItemsWrap)<{
   `;
 
 export const ChonkStyledTrailingItemsWrap = chonkStyled(InputItemsWrap)<{
-  size: FormSize;
+  size: NonNullable<InputStyleProps['size']>;
   disablePointerEvents?: boolean;
 }>`
     right: ${p => p.theme.formPadding[p.size].paddingRight + 1}px;

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -22,7 +22,6 @@ import {
 } from 'sentry/components/core/input/inputGroup.chonk';
 import type {TextAreaProps} from 'sentry/components/core/textarea';
 import {TextArea as _TextArea} from 'sentry/components/core/textarea';
-import type {FormSize} from 'sentry/utils/theme';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 
 interface InputContext {
@@ -247,7 +246,7 @@ const StyledTextArea = withChonk(
 
 const InputLeadingItemsWrap = withChonk(
   styled(InputItemsWrap)<{
-    size: FormSize;
+    size: NonNullable<InputStyleProps['size']>;
     disablePointerEvents?: boolean;
   }>`
     left: ${p => p.theme.formPadding[p.size].paddingLeft + 1}px;
@@ -258,7 +257,7 @@ const InputLeadingItemsWrap = withChonk(
 
 const InputTrailingItemsWrap = withChonk(
   styled(InputItemsWrap)<{
-    size: FormSize;
+    size: NonNullable<InputStyleProps['size']>;
     disablePointerEvents?: boolean;
   }>`
     right: ${p => p.theme.formPadding[p.size].paddingRight * 0.75 + 1}px;

--- a/static/app/components/core/input/numberInput.tsx
+++ b/static/app/components/core/input/numberInput.tsx
@@ -12,7 +12,6 @@ import type {InputStylesProps} from 'sentry/components/core/input';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {space} from 'sentry/styles/space';
-import type {FormSize} from 'sentry/utils/theme';
 
 interface NumberInputProps
   extends InputStylesProps,
@@ -91,7 +90,7 @@ export function NumberInput({
   );
 }
 
-const StepWrap = styled('div')<{size?: FormSize}>`
+const StepWrap = styled('div')<{size?: NonNullable<NumberInputProps['size']>}>`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/static/app/components/core/select/index.tsx
+++ b/static/app/components/core/select/index.tsx
@@ -179,7 +179,7 @@ const getStylesConfig = ({
 }: {
   isInsideModal: boolean | undefined;
   maxMenuWidth: string | number | undefined;
-  size: FormSize | undefined;
+  size: ControlProps['size'];
   theme: Theme;
 }) => {
   // TODO(epurkhiser): The loading indicator should probably also be our loading

--- a/static/app/components/core/select/option.tsx
+++ b/static/app/components/core/select/option.tsx
@@ -2,12 +2,11 @@ import {Fragment} from 'react';
 import {ClassNames, css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {MenuListItem} from 'sentry/components/core/menuListItem';
+import {MenuListItem, type MenuListItemProps} from 'sentry/components/core/menuListItem';
 import {ChonkCheckWrap} from 'sentry/components/core/select/index.chonk';
 import type {components as selectComponents} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {IconAdd, IconCheckmark} from 'sentry/icons';
 import {defined} from 'sentry/utils';
-import type {FormSize} from 'sentry/utils/theme';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 
 type Props = React.ComponentProps<typeof selectComponents.Option>;
@@ -89,7 +88,11 @@ export function SelectOption(props: Props) {
 }
 
 const CheckWrap = withChonk(
-  styled('div')<{isMultiple: boolean; isSelected: boolean; size: FormSize}>`
+  styled('div')<{
+    isMultiple: boolean;
+    isSelected: boolean;
+    size: MenuListItemProps['size'];
+  }>`
     display: flex;
     justify-content: center;
     align-items: center;

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -7,7 +7,6 @@ import {Item, Section} from '@react-stately/collections';
 
 import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import DropdownButton from 'sentry/components/dropdownButton';
-import type {FormSize} from 'sentry/utils/theme';
 import type {UseOverlayProps} from 'sentry/utils/useOverlay';
 import useOverlay from 'sentry/utils/useOverlay';
 
@@ -96,7 +95,7 @@ export interface DropdownMenuProps
   /**
    * Affects the size of the trigger button and menu items.
    */
-  size?: FormSize;
+  size?: DropdownMenuListProps['size'];
   /**
    * Optionally replace the trigger button with a different component. Note
    * that the replacement must have the `props` and `ref` (supplied in

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -985,6 +985,11 @@ const iconDirectionToAngle: Record<IconDirection, number> = {
   left: 270,
 } as const;
 
+/**
+ * Unless you are implementing a new component in the `sentry/components/core`
+ * directory, use `ComponentProps['size']` instead.
+ * @internal
+ */
 export type FormSize = 'xs' | 'sm' | 'md';
 
 export type FormTheme = {

--- a/static/app/views/insights/crons/components/overviewTimeline/sortSelector.tsx
+++ b/static/app/views/insights/crons/components/overviewTimeline/sortSelector.tsx
@@ -1,8 +1,10 @@
-import {CompositeSelect} from 'sentry/components/core/compactSelect/composite';
+import {
+  CompositeSelect,
+  type CompositeSelectProps,
+} from 'sentry/components/core/compactSelect/composite';
 import type {SelectOption} from 'sentry/components/core/compactSelect/types';
 import {IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {FormSize} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
@@ -42,7 +44,7 @@ interface Props {
   onChangeOrder?: (order: SelectOption<MonitorSortOrder>) => void;
   onChangeSort?: (sort: SelectOption<MonitorSortOption>) => void;
   order?: MonitorSortOrder;
-  size?: FormSize;
+  size?: CompositeSelectProps['size'];
   sort?: MonitorSortOption;
 }
 


### PR DESCRIPTION
FormSize should be used inside core if anywhere, the rest of the APIs should infer size from the components that they are extending.

```
> rg 'FormSize' -l
static/app/utils/theme/theme.tsx
static/app/utils/theme/index.tsx
static/app/components/core/menuListItem/index.chonk.tsx
static/app/components/core/menuListItem/index.tsx
static/app/components/core/input/numberInput.tsx
static/app/components/core/input/index.tsx
static/app/components/core/input/inputGroup.tsx
static/app/components/core/select/option.tsx
static/app/components/core/select/index.chonk.tsx
static/app/components/core/select/index.tsx
static/app/components/core/input/inputGroup.chonk.tsx
static/app/components/core/segmentedControl/index.chonk.tsx
static/app/components/core/checkbox/index.tsx
static/app/components/core/segmentedControl/index.tsx
static/app/components/core/compactSelect/gridList/option.tsx
static/app/components/core/compactSelect/control.tsx
static/app/components/core/compactSelect/list.tsx
static/app/components/core/compactSelect/listBox/index.tsx
static/app/components/core/compactSelect/listBox/option.tsx
```