### PR TITLE
fix(txn-migration): Don't mark empty metrics data as mismatch

### DIFF
--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -19,9 +19,11 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.events.fields import is_function, parse_arguments
 from sentry.search.events.filter import to_list
 from sentry.search.events.types import EventsResponse, SnubaParams
 from sentry.snuba import metrics_enhanced_performance, spans_rpc
+from sentry.utils.snuba import is_measurement
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +72,19 @@ def compare_table_results(metrics_query_result: EventsResponse, eap_result: EAPR
             if is_equation(field):
                 continue
             translated_field, *rest = translate_columns([field])
-            if data is not None and eap_data_row[translated_field] is None:
+            arg: str | None = None
+            if match := is_function(field):
+                function = match.group("function")
+                args = parse_arguments(function, match.group("columns"))
+                if args:
+                    arg = args[0]
+
+            if data is None or (
+                arg and (arg == "transaction.duration" or is_measurement(arg)) and data == 0
+            ):
+                continue
+
+            if eap_data_row[translated_field] is None:
                 logger.info("Field %s not found in EAP response", field)
                 mismatches.append(field)
 

--- a/tests/sentry/discover/test_compare_tables.py
+++ b/tests/sentry/discover/test_compare_tables.py
@@ -362,3 +362,25 @@ class CompareTablesTestCase(BaseMetricsLayerTestCase, TestCase, BaseSpansTestCas
         assert comparison_result["passed"] is False
         # assert that both queries don't fail due to the environment filter
         assert comparison_result["reason"] != CompareTableResult.BOTH_FAILED
+
+    def test_compare_widget_query_with_no_metrics_data(self):
+        widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard_2,
+            title="Test No Metrics Data Widget",
+            order=1,
+            display_type=DashboardWidgetDisplayTypes.TABLE,
+            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
+        )
+
+        widget_query = DashboardWidgetQuery.objects.create(
+            widget=widget,
+            name="",
+            order=0,
+            conditions="",
+            aggregates=["p75(measurements.app_start_warm)"],
+            columns=["p75(measurements.app_start_warm)"],
+            fields=["p75(measurements.app_start_warm)"],
+        )
+
+        comparison_result = compare_tables_for_dashboard_widget_queries(widget_query)
+        assert comparison_result["passed"] is True


### PR DESCRIPTION
Metrics data returns 0 if no data, so the `None` check fails marking
the field as a mismatch. Adding some code so we skip those fields.