### PR TITLE
fix: replace deprecated check arg with condition

### DIFF
--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -81,7 +81,7 @@ class WebhookPayload(Model):
 
         constraints = [
             models.CheckConstraint(
-                check=Q(destination_type=DestinationType.SENTRY_REGION)
+                condition=Q(destination_type=DestinationType.SENTRY_REGION)
                 & Q(region_name__isnull=False),
                 name="webhookpayload_region_name_not_null",
             ),


### PR DESCRIPTION
it was emitting a warning when running tests