### PR TITLE
feat(explore): Serialize aggregate orderby

### DIFF
--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -72,7 +72,7 @@ class QuerySerializer(serializers.Serializer):
     orderby = serializers.CharField(
         required=False,
         allow_null=True,
-        help_text="How to order the query results. Must be something in the `field` list, excluding equations.",
+        help_text="How to order the query results. Must be something in the `field` list.",
     )
     groupby = ListField(child=serializers.CharField(), required=False, allow_null=True)
     query = serializers.CharField(
@@ -92,6 +92,11 @@ class QuerySerializer(serializers.Serializer):
         required=False,
         allow_null=True,
         help_text="The visualizations to be plotted on the chart.",
+    )
+    aggregateOrderby = serializers.CharField(
+        required=False,
+        allow_null=True,
+        help_text="How to order the query results. Must be something in the `aggregateField` list, excluding equations.",
     )
     mode = serializers.ChoiceField(
         choices=[
@@ -118,10 +123,14 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
         help_text="The dataset you would like to query. `spans` is the only supported value for now.",
     )
     start = serializers.DateTimeField(
-        required=False, allow_null=True, help_text="The saved start time for this saved query."
+        required=False,
+        allow_null=True,
+        help_text="The saved start time for this saved query.",
     )
     end = serializers.DateTimeField(
-        required=False, allow_null=True, help_text="The saved end time for this saved query."
+        required=False,
+        allow_null=True,
+        help_text="The saved end time for this saved query.",
     )
     range = serializers.CharField(
         required=False,
@@ -163,6 +172,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
             "visualize",
             "mode",
             "aggregateField",
+            "aggregateOrderby",
         ]
 
         for key in query_keys:

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -117,7 +117,10 @@ class ExploreSavedQueriesTest(APITestCase):
 
     def test_get_all_paginated(self):
         for i in range(0, 10):
-            query = {"range": "24h", "query": [{"fields": ["span.op"], "mode": "samples"}]}
+            query = {
+                "range": "24h",
+                "query": [{"fields": ["span.op"], "mode": "samples"}],
+            }
             model = ExploreSavedQuery.objects.create(
                 organization=self.org,
                 created_by_id=self.user.id,
@@ -276,7 +279,10 @@ class ExploreSavedQueriesTest(APITestCase):
             date_added=before_now(days=90),
             date_updated=before_now(minutes=10),
         )
-        with self.options({"system.event-retention-days": 60}), self.feature(self.features):
+        with (
+            self.options({"system.event-retention-days": 60}),
+            self.feature(self.features),
+        ):
             response = self.client.get(self.url, {"query": "name:My expired query"})
 
         assert response.status_code == 200, response.content
@@ -627,7 +633,12 @@ class ExploreSavedQueriesTest(APITestCase):
                     "name": "New query",
                     "projects": [-1],
                     "range": "24h",
-                    "query": [{"fields": ["span.op", "count(span.duration)"], "mode": "samples"}],
+                    "query": [
+                        {
+                            "fields": ["span.op", "count(span.duration)"],
+                            "mode": "samples",
+                        }
+                    ],
                 },
             )
         assert response.status_code == 201, response.content
@@ -729,7 +740,12 @@ class ExploreSavedQueriesTest(APITestCase):
                     "name": "without team query",
                     "projects": [],
                     "range": "24h",
-                    "query": [{"fields": ["span.op", "count(span.duration)"], "mode": "samples"}],
+                    "query": [
+                        {
+                            "fields": ["span.op", "count(span.duration)"],
+                            "mode": "samples",
+                        }
+                    ],
                 },
             )
 
@@ -746,7 +762,12 @@ class ExploreSavedQueriesTest(APITestCase):
                     "name": "with team query",
                     "projects": [],
                     "range": "24h",
-                    "query": [{"fields": ["span.op", "count(span.duration)"], "mode": "samples"}],
+                    "query": [
+                        {
+                            "fields": ["span.op", "count(span.duration)"],
+                            "mode": "samples",
+                        }
+                    ],
                 },
             )
 
@@ -866,7 +887,7 @@ class ExploreSavedQueriesTest(APITestCase):
             {"yAxes": ["count(span.duration)"]},
         ]
 
-    def test_save_aggregate_field(self):
+    def test_save_aggregate_field_and_orderby(self):
         with self.feature(self.features):
             response = self.client.post(
                 self.url,
@@ -890,6 +911,7 @@ class ExploreSavedQueriesTest(APITestCase):
                                     "chartType": 0,
                                 },
                             ],
+                            "aggregateOrderby": "-avg(span.duration)",
                         }
                     ],
                     "interval": "1m",
@@ -911,6 +933,7 @@ class ExploreSavedQueriesTest(APITestCase):
                 "chartType": 0,
             },
         ]
+        assert response.data["query"][0]["aggregateOrderby"] == "-avg(span.duration)"
 
     def test_save_invalid_ambiguous_aggregate_field(self):
         with self.feature(self.features):


### PR DESCRIPTION
We want to save a different order by for the aggregate view than the samples view.