### PR TITLE
feat(seer): Shows welcome screen in settings pages for seer

### DIFF
--- a/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
+++ b/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
@@ -6,7 +6,7 @@ import {
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export interface OrganizationSeerSetupResponse {
+interface OrganizationSeerSetupResponse {
   billing: {
     hasAutofixQuota: boolean;
     hasScannerQuota: boolean;

--- a/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
+++ b/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
@@ -1,0 +1,56 @@
+import {
+  type ApiQueryKey,
+  useApiQuery,
+  type UseApiQueryOptions,
+} from 'sentry/utils/queryClient';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export interface OrganizationSeerSetupResponse {
+  billing: {
+    hasAutofixQuota: boolean;
+    hasScannerQuota: boolean;
+  };
+  setupAcknowledgement: {
+    orgHasAcknowledged: boolean;
+    userHasAcknowledged: boolean;
+  };
+}
+
+function makeOrganizationSeerSetupQueryKey(orgSlug: string): ApiQueryKey {
+  return [`/organizations/${orgSlug}/seer/setup-check/`];
+}
+
+export function useOrganizationSeerSetup(
+  options: Omit<
+    UseApiQueryOptions<OrganizationSeerSetupResponse, RequestError>,
+    'staleTime'
+  > = {}
+) {
+  const orgSlug = useOrganization().slug;
+
+  const queryData = useApiQuery<OrganizationSeerSetupResponse>(
+    makeOrganizationSeerSetupQueryKey(orgSlug),
+    {
+      staleTime: 0,
+      retry: false,
+      ...options,
+    }
+  );
+
+  return {
+    ...queryData,
+    billing: {
+      hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),
+      hasScannerQuota: Boolean(queryData.data?.billing?.hasScannerQuota),
+    },
+    setupAcknowledgement: {
+      orgHasAcknowledged: Boolean(
+        queryData.data?.setupAcknowledgement?.orgHasAcknowledged
+      ),
+      userHasAcknowledged: Boolean(
+        queryData.data?.setupAcknowledgement?.userHasAcknowledged
+      ),
+    },
+  };
+}

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -42,6 +42,22 @@ describe('ProjectSeer', function () {
       features: ['autofix-seer-preferences', 'trigger-autofix-on-issue-summary'],
     });
 
+    // Mock the seer setup check endpoint
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/setup-check/`,
+      method: 'GET',
+      body: {
+        setupAcknowledgement: {
+          orgHasAcknowledged: true,
+          userHasAcknowledged: true,
+        },
+        billing: {
+          hasAutofixQuota: true,
+          hasScannerQuota: true,
+        },
+      },
+    });
+
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
       query: {status: 'active'},

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -7,10 +7,13 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {Alert} from 'sentry/components/core/alert';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject, JsonFormObject} from 'sentry/components/forms/types';
+import HookOrDefault from 'sentry/components/hookOrDefault';
 import Link from 'sentry/components/links/link';
+import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -25,6 +28,11 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
 import {AutofixRepositories} from './autofixRepositories';
+
+const AiSetupDataConsent = HookOrDefault({
+  hookName: 'component:ai-setup-data-consent',
+  defaultComponent: () => <div data-test-id="ai-setup-data-consent" />,
+});
 
 interface ProjectSeerProps {
   project: Project;
@@ -232,6 +240,41 @@ function ProjectSeerGeneralForm({project}: ProjectSeerProps) {
 
 function ProjectSeer({project}: ProjectSeerProps) {
   const organization = useOrganization();
+  const {setupAcknowledgement, billing, isLoading} = useOrganizationSeerSetup();
+
+  const needsSetup =
+    !setupAcknowledgement.userHasAcknowledged ||
+    !setupAcknowledgement.orgHasAcknowledged ||
+    (!billing.hasAutofixQuota && organization.features.includes('seer-billing'));
+
+  if (isLoading) {
+    return (
+      <Fragment>
+        <SentryDocumentTitle
+          title={t('Project Seer Settings')}
+          projectSlug={project.slug}
+        />
+        <Placeholder height="60px" />
+        <br />
+        <Placeholder height="200px" />
+        <br />
+        <Placeholder height="200px" />
+      </Fragment>
+    );
+  }
+
+  if (needsSetup) {
+    return (
+      <Fragment>
+        <SentryDocumentTitle
+          title={t('Project Seer Settings')}
+          projectSlug={project.slug}
+        />
+        <AiSetupDataConsent />
+      </Fragment>
+    );
+  }
+
   return (
     <Fragment>
       <SentryDocumentTitle

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -9,6 +9,7 @@ import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
 import {useAutofixSetup} from 'sentry/components/events/autofix/useAutofixSetup';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconRefresh, IconSeer} from 'sentry/icons';
@@ -28,23 +29,36 @@ import {getPotentialProductTrial} from 'getsentry/utils/billing';
 import {openOnDemandBudgetEditModal} from 'getsentry/views/onDemandBudgets/editOnDemandButton';
 
 type AiSetupDataConsentProps = {
-  groupId: string;
+  groupId?: string;
 };
 
 function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
   const queryClient = useQueryClient();
-  const {data: autofixSetupData, hasAutofixQuota, refetch} = useAutofixSetup({groupId});
   const navigate = useNavigate();
   const subscription = useSubscription();
+
+  // Use group-specific setup if groupId is provided, otherwise use organization setup
+  const groupSetup = useAutofixSetup({groupId: groupId!}, {enabled: Boolean(groupId)});
+  const orgSetup = useOrganizationSeerSetup({enabled: !groupId});
+
+  // Determine which data to use based on whether groupId is provided
+  const isGroupMode = Boolean(groupId);
+  const setupData = isGroupMode ? groupSetup.data : null;
+  const hasAutofixQuota = isGroupMode
+    ? groupSetup.hasAutofixQuota
+    : orgSetup.billing.hasAutofixQuota;
+  const orgHasAcknowledged = isGroupMode
+    ? setupData?.setupAcknowledgement.orgHasAcknowledged
+    : orgSetup.setupAcknowledgement.orgHasAcknowledged;
+  const refetch = isGroupMode ? groupSetup.refetch : orgSetup.refetch;
 
   const trial = getPotentialProductTrial(
     subscription?.productTrials ?? null,
     DataCategory.SEER_AUTOFIX
   );
 
-  const orgHasAcknowledged = autofixSetupData?.setupAcknowledgement.orgHasAcknowledged;
   const shouldShowBilling =
     organization.features.includes('seer-billing') && !hasAutofixQuota;
   const canStartTrial = Boolean(trial && !trial.isStarted);
@@ -60,7 +74,8 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const userHasBillingAccess = organization.access.includes('org:billing');
 
   const warnAboutGithubIntegration =
-    !autofixSetupData?.integration.ok &&
+    isGroupMode &&
+    !setupData?.integration.ok &&
     shouldShowBilling &&
     !isTouchCustomer &&
     !hasSeerButNeedsPayg;
@@ -74,12 +89,18 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
       });
     },
     onSuccess: () => {
-      // Make sure this query key doesn't go out of date with the one on the Sentry side!
-      queryClient.invalidateQueries({
-        queryKey: [
-          `/organizations/${organization.slug}/issues/${groupId}/autofix/setup/`,
-        ],
-      });
+      // Invalidate the appropriate query based on mode
+      if (isGroupMode && groupId) {
+        queryClient.invalidateQueries({
+          queryKey: [
+            `/organizations/${organization.slug}/issues/${groupId}/autofix/setup/`,
+          ],
+        });
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: [`/organizations/${organization.slug}/seer/setup-check/`],
+        });
+      }
     },
   });
 

--- a/static/gsApp/views/seerAutomation/index.spec.tsx
+++ b/static/gsApp/views/seerAutomation/index.spec.tsx
@@ -8,6 +8,24 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import SeerAutomationRoot from './index';
 
 describe('SeerAutomation', function () {
+  beforeEach(() => {
+    // Mock the seer setup check endpoint for all tests
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/seer/setup-check/',
+      method: 'GET',
+      body: {
+        setupAcknowledgement: {
+          orgHasAcknowledged: true,
+          userHasAcknowledged: true,
+        },
+        billing: {
+          hasAutofixQuota: true,
+          hasScannerQuota: true,
+        },
+      },
+    });
+  });
+
   afterEach(() => {
     MockApiClient.clearMockResponses();
     jest.resetAllMocks();

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -2,9 +2,11 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
+import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import Link from 'sentry/components/links/link';
 import {NoAccess} from 'sentry/components/noAccess';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
+import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -14,15 +16,52 @@ import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/noti
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 
+import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
+
 import {SeerAutomationDefault} from './seerAutomationDefault';
 import {SeerAutomationProjectList} from './seerAutomationProjectList';
 
 function SeerAutomationRoot() {
   const organization = useOrganization();
+  const {isLoading, billing, setupAcknowledgement} = useOrganizationSeerSetup();
+
   if (!organization.features.includes('trigger-autofix-on-issue-summary')) {
     return <NoAccess />;
   }
 
+  // Show loading placeholders while checking setup
+  if (isLoading) {
+    return (
+      <Fragment>
+        <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
+        <Placeholder height="60px" />
+        <br />
+        <Placeholder height="200px" />
+        <br />
+        <Placeholder height="200px" />
+      </Fragment>
+    );
+  }
+
+  // Check if setup is needed
+  const needsUserAcknowledgement = !setupAcknowledgement.userHasAcknowledged;
+  const needsOrgAcknowledgement = !setupAcknowledgement.orgHasAcknowledged;
+  const needsBilling =
+    !billing.hasAutofixQuota && organization.features.includes('seer-billing');
+
+  const needsSetup = needsUserAcknowledgement || needsOrgAcknowledgement || needsBilling;
+
+  // Show setup screen if needed
+  if (needsSetup) {
+    return (
+      <Fragment>
+        <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
+        <AiSetupDataConsent />
+      </Fragment>
+    );
+  }
+
+  // Show the regular settings page
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />


### PR DESCRIPTION
Shows the same billing/consent screen from the Seer Issue Details flyout in the settings pages as well.

<img width="1410" alt="Screenshot 2025-06-26 at 10 07 01 AM" src="https://github.com/user-attachments/assets/b05b5575-d876-41a6-a387-9b0a1c5efa83" />
