### PR TITLE
chore(explore): No special handling for standalone spans in traces

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_traces.py
+++ b/tests/sentry/api/endpoints/test_organization_traces.py
@@ -251,22 +251,6 @@ class OrganizationTracesEndpointTestBase(BaseSpansTestCase, APITestCase):
         error_data["tags"] = [["transaction", "foo"]]
         self.store_event(error_data, project_id=project_1.id)
 
-        timestamps.append(now - timedelta(days=1, minutes=20, seconds=0))
-        self.store_indexed_span(
-            organization_id=project_1.organization.id,
-            project_id=project_1.id,
-            trace_id=trace_id_2,
-            transaction_id=None,  # mock an INP span
-            span_id=span_ids[12],
-            parent_span_id=span_ids[4],
-            timestamp=timestamps[-1],
-            transaction="",
-            duration=1_000,
-            exclusive_time=1_000,
-            op="ui.navigation.click",
-            is_eap=self.is_eap,
-        )
-
         return (
             project_1,
             project_2,


### PR DESCRIPTION
In preparation for getsentry/snuba#7257, we don't have to test with standalone spans anymore.