### PR TITLE
:wrench: chore(integration slos): log out halt states for slos as `info` level

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -170,7 +170,7 @@ class EventLifecycle:
         if outcome == EventLifecycleOutcome.FAILURE:
             logger.warning(key, **log_params)
         elif outcome == EventLifecycleOutcome.HALTED:
-            logger.warning(key, **log_params)
+            logger.info(key, **log_params)
 
     @staticmethod
     def _report_flow_error(message) -> None:

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -75,7 +75,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         with metric_obj.capture(assume_success=False):
             pass
         self._check_metrics_call_args(mock_metrics, "halted")
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "integrations.slo.halted",
             extra={
                 "integration_domain": "messaging",
@@ -93,7 +93,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
             lifecycle.record_halt(ExampleException(""), extra={"even": "more"})
 
         self._check_metrics_call_args(mock_metrics, "halted")
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "integrations.slo.halted",
             extra={
                 "extra": "value",
@@ -114,7 +114,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
             lifecycle.record_halt("Integration went boom", extra={"even": "more"})
 
         self._check_metrics_call_args(mock_metrics, "halted")
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "integrations.slo.halted",
             extra={
                 "outcome_reason": "Integration went boom",
@@ -222,7 +222,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
 
         self._check_metrics_call_args(mock_metrics, "halted")
         mock_sentry_sdk.capture_exception.assert_called_once()
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.info.assert_called_once_with(
             "integrations.slo.halted",
             extra={
                 "extra": "value",


### PR DESCRIPTION
to make it more apparent when viewing logs, lets log out halts at `info` level and failures at `warning`