### PR TITLE
ref(simple-table): Simplify header sort prop API

### DIFF
--- a/static/app/components/tables/simpleTable/index.stories.tsx
+++ b/static/app/components/tables/simpleTable/index.stories.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
@@ -6,6 +6,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
+import type {Sort} from 'sentry/utils/discover/fields';
 
 interface Data {
   action: string;
@@ -14,29 +15,48 @@ interface Data {
   name: string;
 }
 
+const headers = [
+  {
+    key: 'name',
+    label: 'Name',
+  },
+  {
+    key: 'monitors',
+    label: 'Monitors',
+  },
+  {
+    key: 'action',
+    label: 'Action',
+  },
+  {
+    key: 'lastTriggered',
+    label: 'Last Triggered',
+  },
+];
+
+const data: Data[] = [
+  {
+    name: 'Row A',
+    monitors: [1],
+    action: 'Email',
+    lastTriggered: moment().subtract(1, 'day').toDate(),
+  },
+  {
+    name: 'Row B',
+    monitors: [3, 5, 7],
+    action: 'Slack',
+    lastTriggered: moment().subtract(2, 'days').toDate(),
+  },
+  {
+    name: 'Row C',
+    monitors: [2, 4, 6, 8],
+    action: 'PagerDuty',
+    lastTriggered: moment().subtract(3, 'days').toDate(),
+  },
+];
+
 export default Storybook.story('SimpleTable', story => {
   story('Default', () => {
-    const data: Data[] = [
-      {
-        name: 'Row A',
-        monitors: [1],
-        action: 'Email',
-        lastTriggered: moment().subtract(1, 'day').toDate(),
-      },
-      {
-        name: 'Row B',
-        monitors: [3, 5, 7],
-        action: 'Slack',
-        lastTriggered: moment().subtract(2, 'days').toDate(),
-      },
-      {
-        name: 'Row C',
-        monitors: [2, 4, 6, 8],
-        action: 'PagerDuty',
-        lastTriggered: moment().subtract(3, 'days').toDate(),
-      },
-    ];
-
     return (
       <Fragment>
         <p>
@@ -71,12 +91,10 @@ export default Storybook.story('SimpleTable', story => {
         </p>
         <SimpleTableWithColumns>
           <SimpleTable.Header>
-            <SimpleTable.HeaderCell sortKey="name">Name</SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell sortKey="monitors">Monitors</SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell sortKey="action">Action</SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell sortKey="lastTriggered">
-              Last Triggered
-            </SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell>Name</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell>Monitors</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell>Action</SimpleTable.HeaderCell>
+            <SimpleTable.HeaderCell>Last Triggered</SimpleTable.HeaderCell>
           </SimpleTable.Header>
           {data.map(row => (
             <SimpleTable.Row key={row.name}>
@@ -105,12 +123,11 @@ export default Storybook.story('SimpleTable', story => {
 
         <SimpleTableWithColumns>
           <SimpleTable.Header>
-            <SimpleTable.HeaderCell sortKey="name">Name</SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell sortKey="monitors">Monitors</SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell sortKey="action">Action</SimpleTable.HeaderCell>
-            <SimpleTable.HeaderCell sortKey="lastTriggered">
-              Last Triggered
-            </SimpleTable.HeaderCell>
+            {headers.map(header => (
+              <SimpleTable.HeaderCell key={header.key}>
+                {header.label}
+              </SimpleTable.HeaderCell>
+            ))}
           </SimpleTable.Header>
           <SimpleTable.Empty>No data</SimpleTable.Empty>
         </SimpleTableWithColumns>
@@ -119,36 +136,14 @@ export default Storybook.story('SimpleTable', story => {
   });
 
   story('Custom widths and hidden columns', () => {
-    const data: Data[] = [
-      {
-        name: 'Row A',
-        monitors: [1],
-        action: 'Email',
-        lastTriggered: moment().subtract(1, 'day').toDate(),
-      },
-      {
-        name: 'Row B',
-        monitors: [3, 5, 7],
-        action: 'Slack',
-        lastTriggered: moment().subtract(2, 'days').toDate(),
-      },
-      {
-        name: 'Row C',
-        monitors: [2, 4, 6, 8],
-        action: 'PagerDuty',
-        lastTriggered: moment().subtract(3, 'days').toDate(),
-      },
-    ];
-
     const tableContent = (
       <Fragment>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell sortKey="name">Name</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell sortKey="monitors">Monitors</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell sortKey="action">Action</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell sortKey="lastTriggered">
-            Last Triggered
-          </SimpleTable.HeaderCell>
+          {headers.map(header => (
+            <SimpleTable.HeaderCell key={header.key}>
+              {header.label}
+            </SimpleTable.HeaderCell>
+          ))}
         </SimpleTable.Header>
         {data.map(row => (
           <SimpleTable.Row key={row.name}>
@@ -176,6 +171,69 @@ export default Storybook.story('SimpleTable', story => {
           for creating responsive tables.
         </p>
         <SimpleTableWithHiddenColumns>{tableContent}</SimpleTableWithHiddenColumns>
+      </Fragment>
+    );
+  });
+
+  story('Sortable headers', () => {
+    const [sort, setSort] = useState<Sort | undefined>(undefined);
+
+    const handleSort = (field: string) => {
+      if (sort) {
+        setSort(
+          sort.field === field
+            ? {field, kind: sort.kind === 'asc' ? 'desc' : 'asc'}
+            : {field, kind: 'asc'}
+        );
+      } else {
+        setSort({field, kind: 'asc'});
+      }
+    };
+
+    const sortField = sort?.field;
+    const sortDirection = sort?.kind;
+
+    return (
+      <Fragment>
+        <p>
+          Header cells can be made sortable by providing{' '}
+          <Storybook.JSXProperty name="sort" value="'asc' | 'desc'" /> and{' '}
+          <Storybook.JSXProperty name="handleSortClick" value="() => void" /> props. The{' '}
+          <code>sort</code> prop controls the visual indicator (arrow direction), while{' '}
+          <code>handleSortClick</code> is called when the header is clicked.
+        </p>
+
+        <p>
+          Click on the column headers below to sort the data. The current sort is:{' '}
+          <strong>{sortField || 'none'}</strong>{' '}
+          {sortField && <strong>({sortDirection})</strong>}
+        </p>
+
+        <SimpleTableWithColumns>
+          <SimpleTable.Header>
+            {headers.map(header => (
+              <SimpleTable.HeaderCell
+                key={header.key}
+                sort={sortField === header.key ? sortDirection : undefined}
+                handleSortClick={() => handleSort(header.key)}
+              >
+                {header.label}
+              </SimpleTable.HeaderCell>
+            ))}
+          </SimpleTable.Header>
+          {data.map(row => (
+            <SimpleTable.Row key={row.name}>
+              <SimpleTable.RowCell>{row.name}</SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                {t('%s monitors', row.monitors.length)}
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>{row.action}</SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                <TimeAgoCell date={row.lastTriggered} />
+              </SimpleTable.RowCell>
+            </SimpleTable.Row>
+          ))}
+        </SimpleTableWithColumns>
       </Fragment>
     );
   });

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -7,7 +7,6 @@ import {Flex} from 'sentry/components/core/layout/flex';
 import Panel from 'sentry/components/panels/panel';
 import {IconArrow} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
-import type {Sort} from 'sentry/utils/discover/fields';
 
 interface TableProps {
   children: React.ReactNode;
@@ -33,35 +32,34 @@ function Header({children}: {children: React.ReactNode}) {
 function HeaderCell({
   children,
   className,
-  sortKey,
   sort,
   handleSortClick,
 }: {
   children?: React.ReactNode;
   className?: string;
   handleSortClick?: () => void;
-  sort?: Sort;
-  sortKey?: string;
+  sort?: 'asc' | 'desc';
 }) {
-  const isSortedByField = sort?.field === sortKey;
+  const isSorted = sort !== undefined;
+  const canSort = handleSortClick !== undefined;
 
   return (
     <ColumnHeaderCell
       className={className}
-      isSorted={isSortedByField}
+      isSorted={isSorted}
       onClick={handleSortClick}
       role="columnheader"
-      as={sortKey ? 'button' : 'div'}
+      as={canSort ? 'button' : 'div'}
     >
       {children && <HeaderDivider />}
-      {sortKey && <InteractionStateLayer />}
+      {canSort && <InteractionStateLayer />}
       <HeadingText>{children}</HeadingText>
-      {sortKey && (
+      {isSorted && (
         <SortIndicator
           aria-hidden
           size="xs"
-          direction={sort?.kind === 'asc' ? 'up' : 'down'}
-          isSorted={isSortedByField}
+          direction={sort === 'asc' ? 'up' : 'down'}
+          isSorted={isSorted}
         />
       )}
     </ColumnHeaderCell>

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -57,9 +57,8 @@ function HeaderCell({
   return (
     <SimpleTable.HeaderCell
       className={className}
-      sort={sort}
-      sortKey={sortKey}
-      handleSortClick={handleSort}
+      sort={sort && sortKey === sort?.field ? sort.kind : undefined}
+      handleSortClick={sortKey ? handleSort : undefined}
     >
       {children}
     </SimpleTable.HeaderCell>

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -57,9 +57,8 @@ function HeaderCell({
   return (
     <SimpleTable.HeaderCell
       className={name}
-      sort={sort}
-      sortKey={sortKey}
-      handleSortClick={handleSort}
+      sort={sort && sortKey === sort?.field ? sort.kind : undefined}
+      handleSortClick={sortKey ? handleSort : undefined}
     >
       {children}
     </SimpleTable.HeaderCell>


### PR DESCRIPTION
Now for sortable headers, just pass `sort: 'asc' | 'desc'` to display the indicator and `handleSortClick` for the sort logic.

![CleanShot 2025-06-26 at 10 50 20](https://github.com/user-attachments/assets/44f4fa3c-bf95-4722-bda3-8b48293b75e7)
