### PR TITLE
fix(simpleTable): Remove margin from `<SimpleTable>`

### DIFF
--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -93,6 +93,7 @@ function RowCell({
 
 const StyledPanel = styled(Panel)`
   display: grid;
+  margin: 0;
 `;
 
 const StyledPanelHeader = styled('div')`

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -6,6 +6,7 @@ import Link from 'sentry/components/links/link';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {useTimezone} from 'sentry/components/timezoneProvider';
 import {tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 
 interface AutomationHistoryData {
   dateSent: Date;
@@ -49,4 +50,6 @@ export default function AutomationHistoryList({history}: Props) {
 
 const SimpleTableWithColumns = styled(SimpleTable)`
   grid-template-columns: 1fr 2fr 2fr;
+
+  margin-bottom: ${space(2)};
 `;

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import LoadingError from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -110,6 +111,8 @@ function AutomationListTable({
 
 const AutomationsSimpleTable = styled(SimpleTable)`
   grid-template-columns: 1fr;
+
+  margin-bottom: ${space(2)};
 
   .last-triggered,
   .action,

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -5,6 +5,7 @@ import {Button} from 'sentry/components/core/button';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {DetectorLink} from 'sentry/views/detectors/components/detectorLink';
 import {DetectorAssigneeCell} from 'sentry/views/detectors/components/detectorListTable/detectorAssigneeCell';
@@ -86,6 +87,8 @@ const Container = styled('div')`
 
 const SimpleTableWithColumns = styled(SimpleTable)`
   grid-template-columns: 1fr 100px auto auto auto;
+
+  margin-bottom: ${space(2)};
 
   /*
     The connected column can be added/removed depending on props, so in order to

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -10,6 +10,7 @@ import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import AutomationTitleCell from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -143,6 +144,8 @@ const Container = styled('div')`
 
 const SimpleTableWithColumns = styled(SimpleTable)`
   grid-template-columns: 1fr 200px 180px auto;
+
+  margin-bottom: ${space(2)};
 
   /*
     The connected column can be added/removed depending on props, so in order to

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import LoadingError from 'sentry/components/loadingError';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -117,6 +118,8 @@ const Container = styled('div')`
 
 const DetectorListSimpleTable = styled(SimpleTable)`
   grid-template-columns: 1fr;
+
+  margin-bottom: ${space(2)};
 
   .type,
   .last-issue,


### PR DESCRIPTION
The previous margin-bottom was coming from https://github.com/getsentry/sentry/blob/master/static/app/components/panels/panel.tsx#L31 because SimpleTable is a `StyledPanel`