### PR TITLE
feat(explore): Add a way to disable extrapolation

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -572,6 +572,8 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                             auto_fields=True,
                             use_aggregate_conditions=use_aggregate_conditions,
                             fields_acl=FieldsACL(functions={"time_spent_percentage"}),
+                            disable_aggregate_extrapolation="disableAggregateExtrapolation"
+                            in request.GET,
                         ),
                         sampling_mode=snuba_params.sampling_mode,
                     )

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -224,6 +224,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                         config=SearchResolverConfig(
                             auto_fields=False,
                             use_aggregate_conditions=True,
+                            disable_aggregate_extrapolation="disableAggregateExtrapolation"
+                            in request.GET,
                         ),
                         sampling_mode=snuba_params.sampling_mode,
                         equations=self.get_equation_list(organization, request),
@@ -258,6 +260,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     config=SearchResolverConfig(
                         auto_fields=False,
                         use_aggregate_conditions=True,
+                        disable_aggregate_extrapolation="disableAggregateExtrapolation"
+                        in request.GET,
                     ),
                     sampling_mode=snuba_params.sampling_mode,
                     comparison_delta=comparison_delta,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -246,6 +246,8 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                     config=SearchResolverConfig(
                         auto_fields=False,
                         use_aggregate_conditions=True,
+                        disable_aggregate_extrapolation="disableAggregateExtrapolation"
+                        in request.GET,
                     ),
                     sampling_mode=snuba_params.sampling_mode,
                     equations=self.get_equation_list(organization, request, param_name="groupBy"),
@@ -278,6 +280,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsV2EndpointBase):
                 config=SearchResolverConfig(
                     auto_fields=False,
                     use_aggregate_conditions=True,
+                    disable_aggregate_extrapolation="disableAggregateExtrapolation" in request.GET,
                 ),
                 sampling_mode=snuba_params.sampling_mode,
                 comparison_delta=comparison_delta,

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5577,3 +5577,47 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
                 "timestamp": three_days_ago.isoformat(),
             },
         ]
+
+    def test_disable_extrapolation(self):
+        spans = []
+        spans.append(
+            self.create_span(
+                {
+                    "description": "foo",
+                    "sentry_tags": {"status": "success"},
+                    "measurements": {"client_sample_rate": {"value": 0.1}},
+                },
+                start_ts=self.ten_mins_ago,
+            )
+        )
+        spans.append(
+            self.create_span(
+                {
+                    "description": "bar",
+                    "sentry_tags": {"status": "success"},
+                },
+                start_ts=self.ten_mins_ago,
+            )
+        )
+        self.store_spans(spans, is_eap=self.is_eap)
+        response = self.do_request(
+            {
+                "field": ["description", "count()"],
+                "orderby": "-count()",
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "disableAggregateExtrapolation": 1,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        confidence = meta["accuracy"]["confidence"]
+        assert len(data) == 2
+        assert len(confidence) == 2
+        assert data[0]["count()"] == 1
+        assert "count()" not in confidence[0]
+        assert data[1]["count()"] == 1
+        assert "count()" not in confidence[1]

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_indexed.py
@@ -2378,3 +2378,42 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsStatsSpansMetri
         assert data[0][1][0]["count"] == 0.0
         assert data[1][1][0]["count"] == 0.0
         assert data[2][1][0]["count"] == 4.0
+
+    def test_disable_extrapolation(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        spans = []
+        for hour, count in enumerate(event_counts):
+            spans.extend(
+                [
+                    self.create_span(
+                        {
+                            "description": "foo",
+                            "sentry_tags": {"status": "success"},
+                            "measurements": {"client_sample_rate": {"value": 0.1}},
+                        },
+                        start_ts=self.day_ago + timedelta(hours=hour, minutes=minute),
+                    )
+                    for minute in range(count)
+                ],
+            )
+        self.store_spans(spans, is_eap=self.is_eap)
+
+        response = self._do_request(
+            data={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=6),
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "disableAggregateExtrapolation": 1,
+            },
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 6
+        assert response.data["meta"]["dataset"] == self.dataset
+
+        rows = data[0:6]
+        for test in zip(event_counts, rows):
+            assert test[1][1][0]["count"] == test[0]


### PR DESCRIPTION
- Extrapolation is on by default for users, but sometimes for debugging its useful to know what the non-extrapolated numbers are. This adds a url param that will disable extrapolation for this purpose