### PR TITLE
fix(dev): mktemp: too few X's in template

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -121,7 +121,7 @@ if [ -n "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
 else
     # Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
     # the script will use the EXIT path
-    _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.$$.out || mktemp /tmp/sentry.envrc.XXXXXXXX.out)
+    _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.out.$$.XXXXXX)
     exec > >(tee "$_SENTRY_LOG_FILE")
     exec 2>&1
     debug "Development errors will be reported to Sentry.io. If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."


### PR DESCRIPTION
For maximum compatibility, busybox mktemp requires at least six X's and that they appear at the end.
Then there's no more need to try twice.
