### PR TITLE
feat(trace-eap-waterfall): Fixing linking to node in tree error

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -149,7 +149,6 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
                 hideIfNoData={hideTraceWaterfallIfEmpty}
                 traceWaterfallScrollHandlers={traceWaterfallScroll}
                 traceWaterfallModels={traceWaterfallModels}
-                isVisible={currentTab === TraceLayoutTabKeys.WATERFALL}
               />
             </TabsWaterfallWrapper>
             {currentTab === TraceLayoutTabKeys.TAGS ||

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -1489,6 +1489,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
       }
       if (isSpanNode(n) || isEAPSpanNode(n)) {
         const spanId = 'span_id' in n.value ? n.value.span_id : n.value.event_id;
+
         if (spanId === eventId) {
           return true;
         }

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -31,7 +31,6 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import type {DispatchingReducerMiddleware} from 'sentry/utils/useDispatchingReducer';
-import {useIsMountedRef} from 'sentry/utils/useIsMountedRef';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
@@ -84,7 +83,7 @@ import TraceTypeWarnings from './traceTypeWarnings';
 import {TraceWaterfallState} from './traceWaterfallState';
 import {useTraceOnLoad} from './useTraceOnLoad';
 import {useTraceQueryParamStateSync} from './useTraceQueryParamStateSync';
-import {getScrollToPath, useTraceScrollToPath} from './useTraceScrollToPath';
+import {useTraceScrollToPath} from './useTraceScrollToPath';
 import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
 
 const TRACE_TAB: TraceReducerState['tabs']['tabs'][0] = {
@@ -106,7 +105,6 @@ export interface TraceWaterfallProps {
   tree: TraceTree;
   // If set to true, the entire waterfall will not render if it is empty.
   hideIfNoData?: boolean;
-  isVisible?: boolean;
   replayTraces?: ReplayTrace[];
 }
 
@@ -448,7 +446,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
 
     const eventId = scrollQueueRef.current?.eventId;
     const [type, path] = scrollQueueRef.current?.path?.[0]?.split('-') ?? [];
-    scrollQueueRef.current = null;
 
     let node =
       (path === 'root' && props.tree.root.children[0]) ||
@@ -528,19 +525,6 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     hasExceededPerformanceUsageLimit,
     source,
   ]);
-
-  // We re-init the view to sync back with URL params
-  // as they might have changed while the waterfall was hidden
-  const isMountedRef = useIsMountedRef();
-  useLayoutEffect(() => {
-    if (props.isVisible && isMountedRef.current) {
-      scrollQueueRef.current = getScrollToPath();
-      onTraceLoad();
-    }
-
-    // Only run if isVisible changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.isVisible]);
 
   // Setup the middleware for the trace reducer
   useLayoutEffect(() => {


### PR DESCRIPTION
Fixes: https://sentry.sentry.io/issues/6011914412/?project=11276&query=is%3Aunresolved&referrer=issue-stream&stream_index=1

The onTraceLoad function is only made to run once when the waterfall has completed loading, NOT on mount 