### PR TITLE
ref(dashboards): add aliases prop to replace column alias field

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -62,7 +62,10 @@ import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegend
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import {BigNumberWidgetVisualization} from 'sentry/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
-import {convertTableDataToTabularData} from 'sentry/views/dashboards/widgets/tableWidget/utils';
+import {
+  convertTableDataToTabularData,
+  decodeColumnAliases,
+} from 'sentry/views/dashboards/widgets/tableWidget/utils';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {ConfidenceFooter} from 'sentry/views/explore/charts/confidenceFooter';
 
@@ -172,6 +175,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
         width: minTableColumnWidth ?? column.width,
         type: column.type === 'never' ? null : column.type,
       }));
+      const aliases = decodeColumnAliases(columns, fieldAliases);
       const tableData = convertTableDataToTabularData(tableResults?.[0]);
 
       return (
@@ -183,6 +187,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
               frameless
               scrollable
               fit="max-content"
+              aliases={aliases}
               getRenderer={(field, _dataRow, meta) => {
                 const customRenderer = datasetConfig.getCustomFieldRenderer?.(
                   field,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -164,6 +164,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
     return tableResults.map((result, i) => {
       const fields = widget.queries[i]?.fields?.map(stripDerivedMetricsPrefix) ?? [];
       const fieldAliases = widget.queries[i]?.fieldAliases ?? [];
+      const fieldHeaderMap = datasetConfig.getFieldHeaderMap?.() ?? {};
       const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);
       const columns = decodeColumnOrder(
         fields.map(field => ({
@@ -175,7 +176,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
         width: minTableColumnWidth ?? column.width,
         type: column.type === 'never' ? null : column.type,
       }));
-      const aliases = decodeColumnAliases(columns, fieldAliases);
+      const aliases = decodeColumnAliases(columns, fieldAliases, fieldHeaderMap);
       const tableData = convertTableDataToTabularData(tableResults?.[0]);
 
       return (

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -76,7 +76,6 @@ export type TabularData<TFields extends string = string> = {
 export type TabularColumn<TFields extends string = string> = {
   key: TFields;
   name: TFields;
-  alias?: string;
   type?: AttributeValueType;
   width?: number;
 };

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -17,6 +17,17 @@ import type {FieldRenderer} from 'sentry/views/dashboards/widgets/tableWidget/ta
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 
 describe('TableWidgetVisualization', function () {
+  const columns: Array<Partial<TabularColumn>> = [
+    {
+      key: 'count(span.duration)',
+      name: 'Count of Span Duration',
+    },
+    {
+      key: 'http.request_method',
+      name: 'HTTP Request Method',
+    },
+  ];
+
   it('Basic table renders correctly', async function () {
     render(<TableWidgetVisualization tableData={sampleHTTPRequestTableData} />);
 
@@ -27,17 +38,6 @@ describe('TableWidgetVisualization', function () {
   });
 
   it('Table applies custom order and column name if provided', function () {
-    const columns: Array<Partial<TabularColumn>> = [
-      {
-        key: 'count(span.duration)',
-        name: 'Count of Span Duration',
-      },
-      {
-        key: 'http.request_method',
-        name: 'HTTP Request Method',
-      },
-    ];
-
     render(
       <TableWidgetVisualization
         tableData={sampleHTTPRequestTableData}
@@ -117,5 +117,23 @@ describe('TableWidgetVisualization', function () {
 
     const $cells = await screen.findAllByRole('cell');
     expect($cells[0]).toHaveTextContent('relax, soon');
+  });
+
+  it('Uses aliases for column names if supplied', function () {
+    const aliases = {
+      'count(span.duration)': 'span duration count',
+      'http.request_method': 'request method http',
+    };
+    render(
+      <TableWidgetVisualization
+        tableData={sampleHTTPRequestTableData}
+        aliases={aliases}
+        columns={TabularColumnsFixture(columns)}
+      />
+    );
+
+    const $headers = screen.getAllByRole('columnheader');
+    expect($headers[0]).toHaveTextContent(aliases['count(span.duration)']);
+    expect($headers[1]).toHaveTextContent(aliases['http.request_method']);
   });
 });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -43,17 +43,21 @@ export default Storybook.story('TableWidgetVisualization', story => {
     const customColumns: TabularColumn[] = [
       {
         key: 'count(span.duration)',
-        name: 'Count of Span Duration',
+        name: 'count(span.duration)',
         type: 'number',
-        width: -1,
+        width: 200,
       },
       {
         key: 'http.request_method',
-        name: 'HTTP Request Method',
+        name: 'http.request_method',
         type: 'string',
         width: -1,
       },
     ];
+    const aliases = {
+      'count(span.duration)': 'Count of Span Duration',
+      'http.request_method': 'HTTP Request Method',
+    };
     return (
       <Fragment>
         <p>
@@ -74,19 +78,36 @@ ${JSON.stringify(tableWithEmptyData)}
           The prop is optional, as the table will fallback to extract the columns in order
           from the table data's <code>meta.fields</code>, displaying them as shown above.
         </p>
-        <p>
-          This prop is useful for reordering and giving custom display names to columns:
-        </p>
+        <p>This prop is used for reordering columns and setting column widths:</p>
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          columns={customColumns}
+        />
         <CodeSnippet language="json">
           {`
 ${JSON.stringify(customColumns)}
           `}
         </CodeSnippet>
-        <p>Resulting table:</p>
+        <p>
+          To pass custom names for a column header, provide the prop <code>aliases</code>{' '}
+          which maps column key to the alias. In some cases you may have both field
+          aliases set by user (ex. in dashboards) as well as a static mapping. The util
+          function <code>decodeColumnAliases</code> is provided to consolidate them, with
+          priority given to user field aliases.
+        </p>
+        <p>
+          Below is an example of setting aliases to make column headers more human
+          readable.
+        </p>
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
-          columns={customColumns}
+          aliases={aliases}
         />
+        <CodeSnippet language="json">
+          {`
+${JSON.stringify(aliases)}
+          `}
+        </CodeSnippet>
       </Fragment>
     );
   });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -41,6 +41,10 @@ interface TableWidgetVisualizationProps {
    */
   tableData: TabularData;
   /**
+   * A mapping between column key to a column alias to override header name.
+   */
+  aliases?: Record<string, string>;
+  /**
    * If supplied, will override the ordering of columns from `tableData`. Can also be used to
    * supply custom display names for columns, column widths and column data type
    */
@@ -94,6 +98,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     columns,
     scrollable,
     fit,
+    aliases,
   } = props;
 
   const theme = useTheme();
@@ -138,14 +143,14 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
       columnOrder={columnOrder}
       columnSortBy={[]}
       grid={{
-        renderHeadCell: (tableColumn, columnIndex) => {
+        renderHeadCell: (_tableColumn, columnIndex) => {
           const column = columnOrder[columnIndex]!;
-
           const align = fieldAlignment(column.name, column.type as ColumnValueType);
+          const name = aliases?.[column.key] || column.name;
 
           return (
             <CellWrapper align={align}>
-              <StyledTooltip title={tableColumn.name}>{tableColumn.name}</StyledTooltip>
+              <StyledTooltip title={name}>{name}</StyledTooltip>
             </CellWrapper>
           );
         },

--- a/static/app/views/dashboards/widgets/tableWidget/utils.spec.ts
+++ b/static/app/views/dashboards/widgets/tableWidget/utils.spec.ts
@@ -1,0 +1,34 @@
+import {TabularColumnsFixture} from 'sentry-fixture/tabularColumns';
+
+import {decodeColumnAliases} from 'sentry/views/dashboards/widgets/tableWidget/utils';
+
+describe('Table Widget Visualization Utils', function () {
+  describe('decodeColumnAliases', function () {
+    const columns = TabularColumnsFixture([
+      {
+        key: 'columnOne',
+        name: 'columnOne',
+      },
+      {
+        key: 'columnTwo',
+        name: 'columnTwo',
+      },
+    ]);
+    const fieldAliases = ['Column One', ''];
+    const fieldHeaderMap: Record<string, string> = {
+      columnOne: 'Custom column ONE',
+      columnTwo: 'Custom column TWO',
+    };
+
+    it('correctly combines both fieldAliases and fieldHeaderMap', function () {
+      const result = decodeColumnAliases(columns, fieldAliases, fieldHeaderMap);
+      expect(result.columnOne).toEqual(fieldAliases[0]);
+      expect(result.columnTwo).toEqual(fieldHeaderMap.columnTwo);
+    });
+
+    it('correctly defers to empty record if columns and fieldAlises do not match', function () {
+      const result = decodeColumnAliases([], fieldAliases);
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/static/app/views/dashboards/widgets/tableWidget/utils.ts
+++ b/static/app/views/dashboards/widgets/tableWidget/utils.ts
@@ -1,9 +1,15 @@
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type {
+  TabularColumn,
   TabularData,
   TabularValueUnit,
 } from 'sentry/views/dashboards/widgets/common/types';
 
+/**
+ * Converts the TableData type to TabularData type
+ * @param tableData
+ * @returns `TabularData`
+ */
 export function convertTableDataToTabularData(tableData?: TableData): TabularData {
   return {
     data: tableData?.data ?? [],
@@ -12,4 +18,30 @@ export function convertTableDataToTabularData(tableData?: TableData): TabularDat
       fields: tableData?.meta?.fields,
     },
   };
+}
+
+/**
+ * Takes columns and field aliases list, converting them to a record for `TableWidgetVisualization`.
+ * If field header map is supplied, it will combine them, giving priority to field aliases on
+ * duplicate keys
+ *
+ * @param columns a `TabularColumn[]`. Length and order must match `fieldAliases`
+ * @param fieldAliases a list of strings. Length and order must match `columns`
+ * @param fieldHeaderMap optional `Record<string, string>` to combine `fieldAliases` with
+ */
+export function decodeColumnAliases(
+  columns: TabularColumn[],
+  fieldAliases: string[],
+  fieldHeaderMap?: Record<string, string>
+): Record<string, string> {
+  if (columns.length !== fieldAliases.length) {
+    return fieldHeaderMap ?? {};
+  }
+  const fieldAliasesMap: Record<string, string> = {};
+  columns.forEach((column, index) => {
+    fieldAliasesMap[column.key] =
+      (fieldAliases[index] || fieldHeaderMap?.[column.key]) ?? '';
+  });
+
+  return fieldAliasesMap;
 }

--- a/static/app/views/dashboards/widgets/tableWidget/utils.ts
+++ b/static/app/views/dashboards/widgets/tableWidget/utils.ts
@@ -32,15 +32,15 @@ export function convertTableDataToTabularData(tableData?: TableData): TabularDat
 export function decodeColumnAliases(
   columns: TabularColumn[],
   fieldAliases: string[],
-  fieldHeaderMap: Record<string, string> = {}
+  fieldHeaderMap?: Record<string, string>
 ): Record<string, string> {
   if (columns.length !== fieldAliases.length) {
-    return fieldHeaderMap;
+    return fieldHeaderMap ?? {};
   }
   const fieldAliasesMap: Record<string, string> = {};
   columns.forEach((column, index) => {
     fieldAliasesMap[column.key] =
-      (fieldAliases[index] || fieldHeaderMap[column.key]) ?? '';
+      (fieldAliases[index] || fieldHeaderMap?.[column.key]) ?? '';
   });
 
   return fieldAliasesMap;

--- a/static/app/views/dashboards/widgets/tableWidget/utils.ts
+++ b/static/app/views/dashboards/widgets/tableWidget/utils.ts
@@ -32,15 +32,15 @@ export function convertTableDataToTabularData(tableData?: TableData): TabularDat
 export function decodeColumnAliases(
   columns: TabularColumn[],
   fieldAliases: string[],
-  fieldHeaderMap?: Record<string, string>
+  fieldHeaderMap: Record<string, string> = {}
 ): Record<string, string> {
   if (columns.length !== fieldAliases.length) {
-    return fieldHeaderMap ?? {};
+    return fieldHeaderMap;
   }
   const fieldAliasesMap: Record<string, string> = {};
   columns.forEach((column, index) => {
     fieldAliasesMap[column.key] =
-      (fieldAliases[index] || fieldHeaderMap?.[column.key]) ?? '';
+      (fieldAliases[index] || fieldHeaderMap[column.key]) ?? '';
   });
 
   return fieldAliasesMap;


### PR DESCRIPTION
### Changes

Replace the `alias` field in `TabularColumn` with `aliases` prop in the `TableWidgetVisualization` component. Part of simplifying the process of adding custom names to columns and removing redundant props.

### Before/After

No change in FE.
