### PR TITLE
HACK: Force leaked connection teardown failure

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -18,6 +18,7 @@ from sentry.workflow_engine.endpoints.serializers import (
     WorkflowGroupHistory,
     fetch_workflow_groups_paginated,
     fetch_workflow_hourly_stats,
+    leak_lots_of_connections,
 )
 from sentry.workflow_engine.models import Action, DataConditionGroup, WorkflowFireHistory
 from sentry.workflow_engine.models.data_condition import Condition
@@ -25,6 +26,11 @@ from sentry.workflow_engine.registry import data_source_type_registry
 from sentry.workflow_engine.types import DetectorPriorityLevel
 
 pytestmark = [requires_snuba]
+
+
+class TestRuinTheFun(TestCase):
+    def test_leak_lots_of_connections(self):
+        leak_lots_of_connections()
 
 
 class TestDetectorSerializer(TestCase):


### PR DESCRIPTION
Demonstration test case that causes DI-1008 reliably.

The N threads stuff is unnecessary, really. One thread should be enough, but I wanted to test if rate of failure was related to # of open connections.