### PR TITLE
feat(taskworker) Capture errors when retries are consumed

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -110,6 +110,7 @@ def child_process(
 
     from sentry import usage_accountant
     from sentry.taskworker.registry import taskregistry
+    from sentry.taskworker.retry import NoRetriesRemainingError
     from sentry.taskworker.state import clear_current_task, current_task, set_current_task
     from sentry.taskworker.task import Task
     from sentry.utils import metrics
@@ -258,18 +259,35 @@ def child_process(
                 )
                 next_state = TASK_ACTIVATION_STATUS_FAILURE
             except Exception as err:
-                if task_func.should_retry(inflight.activation.retry_state, err):
-                    logger.info(
-                        "taskworker.task.retry",
-                        extra={
-                            "namespace": inflight.activation.namespace,
-                            "taskname": inflight.activation.taskname,
-                            "processing_pool": processing_pool_name,
-                        },
-                    )
-                    next_state = TASK_ACTIVATION_STATUS_RETRY
+                retry = task_func.retry
+                captured_error = False
+                if retry:
+                    if retry.should_retry(inflight.activation.retry_state, err):
+                        logger.info(
+                            "taskworker.task.retry",
+                            extra={
+                                "namespace": inflight.activation.namespace,
+                                "taskname": inflight.activation.taskname,
+                                "processing_pool": processing_pool_name,
+                            },
+                        )
+                        next_state = TASK_ACTIVATION_STATUS_RETRY
+                    elif retry.max_attempts_reached(inflight.activation.retry_state):
+                        with sentry_sdk.isolation_scope() as scope:
+                            retry_error = NoRetriesRemainingError(
+                                f"{inflight.activation.taskname} has consumed all of its retries"
+                            )
+                            retry_error.__cause__ = err
+                            scope.fingerprint = [
+                                "taskworker.no_retries_remaining",
+                                inflight.activation.namespace,
+                                inflight.activation.taskname,
+                            ]
+                            scope.set_transaction_name(inflight.activation.taskname)
+                            sentry_sdk.capture_exception(retry_error)
+                            captured_error = True
 
-                if next_state != TASK_ACTIVATION_STATUS_RETRY:
+                if not captured_error and next_state != TASK_ACTIVATION_STATUS_RETRY:
                     sentry_sdk.capture_exception(err)
 
             clear_current_task()

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -283,7 +283,6 @@ def child_process(
                                 inflight.activation.namespace,
                                 inflight.activation.taskname,
                             ]
-                            scope.set_level("error")
                             scope.set_transaction_name(inflight.activation.taskname)
                             sentry_sdk.capture_exception(retry_error)
                             captured_error = True

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -269,6 +269,7 @@ def child_process(
                                 "namespace": inflight.activation.namespace,
                                 "taskname": inflight.activation.taskname,
                                 "processing_pool": processing_pool_name,
+                                "error": str(err),
                             },
                         )
                         next_state = TASK_ACTIVATION_STATUS_RETRY

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -283,6 +283,7 @@ def child_process(
                                 inflight.activation.namespace,
                                 inflight.activation.taskname,
                             ]
+                            scope.set_level("error")
                             scope.set_transaction_name(inflight.activation.taskname)
                             sentry_sdk.capture_exception(retry_error)
                             captured_error = True

--- a/tests/sentry/taskworker/test_retry.py
+++ b/tests/sentry/taskworker/test_retry.py
@@ -106,6 +106,16 @@ def test_should_retry_error_allow_list() -> None:
     assert not retry.should_retry(state, value_err)
 
 
+def test_max_attempts_reached() -> None:
+    retry = Retry(times=5)
+    state = retry.initial_state()
+
+    assert not retry.max_attempts_reached(state)
+
+    state.attempts = 4
+    assert retry.max_attempts_reached(state)
+
+
 def test_should_retry_allow_list_ignore_parent() -> None:
     retry = Retry(times=3, on=(Exception,), ignore=(RuntimeError,))
     state = retry.initial_state()


### PR DESCRIPTION
When a task consumes all of its retries we can capture an exception grouped by task name, so that it is easier for application teams to be alerted on failures from their tasks.

### Example error

![Screenshot 2025-06-26 at 3 51 11 PM](https://github.com/user-attachments/assets/eaeaeee2-cc7f-475a-8887-bf3e1a560685)
