### PR TITLE
checkout: fix chevron color DE-168

### DIFF
--- a/static/gsApp/views/amCheckout/steps/stepHeader.tsx
+++ b/static/gsApp/views/amCheckout/steps/stepHeader.tsx
@@ -1,10 +1,9 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import kebabCase from 'lodash/kebabCase';
 
 import {Button} from 'sentry/components/core/button';
 import {Flex} from 'sentry/components/core/layout';
-import {IconCheckmark, IconChevron, IconEdit} from 'sentry/icons';
+import {IconCheckmark, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -42,14 +41,14 @@ function StepHeader({
   organization,
 }: Props) {
   const canEdit = !isActive && (isCompleted || canSkip);
-
   const toggleTier = getToggleTier(checkoutTier);
+  const onEditClick = canEdit ? () => onEdit(stepNumber) : undefined;
 
   return (
     <Header
       isActive={isActive}
       canEdit={canEdit}
-      onClick={canEdit ? () => onEdit(stepNumber) : undefined}
+      onClick={onEditClick}
       data-test-id={`header-${kebabCase(title)}`}
     >
       <Flex justify="space-between">
@@ -75,17 +74,15 @@ function StepHeader({
           )
         ) : (
           <EditStep>
-            {isCompleted && (
-              <Button size="sm" onClick={() => onEdit(stepNumber)} icon={<IconEdit />}>
-                {t('Edit')}
-              </Button>
-            )}
             {canEdit && (
               <Button
                 size="sm"
                 aria-label={t('Expand section')}
                 icon={<IconChevron direction="down" />}
-              />
+                onClick={onEditClick}
+              >
+                {t('Edit')}
+              </Button>
             )}
           </EditStep>
         )}
@@ -103,12 +100,7 @@ const Header = styled('div')<{canEdit?: boolean; isActive?: boolean}>`
   align-items: center;
   padding: ${space(3)} ${space(2)};
   cursor: ${p => (p.canEdit ? 'pointer' : undefined)};
-
-  ${p =>
-    p.isActive &&
-    css`
-      border-bottom: 1px solid ${p.theme.border};
-    `};
+  border-bottom: 1px solid ${p => (p.isActive ? p.theme.border : 'transparent')};
 `;
 
 const StepTitle = styled('div')`

--- a/static/gsApp/views/amCheckout/steps/stepHeader.tsx
+++ b/static/gsApp/views/amCheckout/steps/stepHeader.tsx
@@ -128,7 +128,7 @@ const EditStep = styled('div')`
 `;
 
 const StyledIconChevron = styled(IconChevron)`
-  color: ${p => p.theme.border};
+  color: ${p => p.theme.tokens.content.accent};
   justify-self: end;
 `;
 

--- a/static/gsApp/views/amCheckout/steps/stepHeader.tsx
+++ b/static/gsApp/views/amCheckout/steps/stepHeader.tsx
@@ -2,7 +2,9 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import kebabCase from 'lodash/kebabCase';
 
-import {IconCheckmark, IconChevron} from 'sentry/icons';
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
+import {IconCheckmark, IconChevron, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -47,10 +49,10 @@ function StepHeader({
     <Header
       isActive={isActive}
       canEdit={canEdit}
-      onClick={() => canEdit && onEdit(stepNumber)}
+      onClick={canEdit ? () => onEdit(stepNumber) : undefined}
       data-test-id={`header-${kebabCase(title)}`}
     >
-      <StepTitleWrapper>
+      <Flex justify="space-between">
         <StepTitle>
           {isCompleted ? (
             <IconCheckmark isCircled color="green300" />
@@ -60,7 +62,7 @@ function StepHeader({
           {title}
         </StepTitle>
         {trailingItems && <div>{trailingItems}</div>}
-      </StepTitleWrapper>
+      </Flex>
       <div>
         {isActive && toggleTier ? (
           typeof onToggleLegacy === 'function' && (
@@ -73,12 +75,16 @@ function StepHeader({
           )
         ) : (
           <EditStep>
-            {isCompleted && <a onClick={() => onEdit(stepNumber)}>{t('Edit')}</a>}
+            {isCompleted && (
+              <Button size="sm" onClick={() => onEdit(stepNumber)} icon={<IconEdit />}>
+                {t('Edit')}
+              </Button>
+            )}
             {canEdit && (
-              <StyledIconChevron
-                direction="down"
-                aria-label={t('Expand section')}
+              <Button
                 size="sm"
+                aria-label={t('Expand section')}
+                icon={<IconChevron direction="down" />}
               />
             )}
           </EditStep>
@@ -96,17 +102,12 @@ const Header = styled('div')<{canEdit?: boolean; isActive?: boolean}>`
   gap: ${space(1)};
   align-items: center;
   padding: ${space(3)} ${space(2)};
+  cursor: ${p => (p.canEdit ? 'pointer' : undefined)};
 
   ${p =>
     p.isActive &&
     css`
       border-bottom: 1px solid ${p.theme.border};
-    `};
-
-  ${p =>
-    p.canEdit &&
-    css`
-      cursor: pointer;
     `};
 `;
 
@@ -125,14 +126,4 @@ const EditStep = styled('div')`
   grid-auto-flow: column;
   gap: ${space(1)};
   align-items: center;
-`;
-
-const StyledIconChevron = styled(IconChevron)`
-  color: ${p => p.theme.tokens.content.accent};
-  justify-self: end;
-`;
-
-const StepTitleWrapper = styled('div')`
-  display: flex;
-  justify-content: space-between;
 `;


### PR DESCRIPTION
Use buttons for headers and fix chevron being nearly invisible

Fixes DE-168

Before:
![CleanShot 2025-06-26 at 16 04 33@2x](https://github.com/user-attachments/assets/fa894d32-a5ad-41df-be97-3b8d6dd1bfb9)
![CleanShot 2025-06-26 at 16 04 29@2x](https://github.com/user-attachments/assets/2b917a34-6e12-46bc-9398-65279c645d3d)

![CleanShot 2025-06-26 at 16 01 13@2x](https://github.com/user-attachments/assets/cd854c18-cab4-4336-b9d2-fe46f83759e5)
![CleanShot 2025-06-26 at 16 00 57@2x](https://github.com/user-attachments/assets/17f86e61-6f42-41e4-a368-4198b98fa253)
![CleanShot 2025-06-26 at 16 00 53@2x](https://github.com/user-attachments/assets/de67b32e-7b00-4ed1-8280-de9fa30a2617)
![CleanShot 2025-06-26 at 16 00 46@2x](https://github.com/user-attachments/assets/450b3f2e-db6c-4fc4-b60d-c60368cb4ab9)
