### PR TITLE
fix(billing): Display usage totals table rows based on category

### DIFF
--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -50,17 +50,16 @@ const DEFAULT_BILLED_DATA_CATEGORY_INFO = {
 } as Record<DataCategoryExact, BilledDataCategoryInfo>;
 Object.entries(DEFAULT_BILLED_DATA_CATEGORY_INFO).forEach(
   ([categoryExact, categoryInfo]) => {
-    if (!categoryInfo.isBilledCategory) {
-      DEFAULT_BILLED_DATA_CATEGORY_INFO[categoryExact as DataCategoryExact] = {
-        ...categoryInfo,
-        canAllocate: false,
-        canProductTrial: false,
-        maxAdminGift: 0,
-        freeEventsMultiple: 0,
-        feature: null,
-        reservedVolumeTooltip: null,
-      };
-    }
+    DEFAULT_BILLED_DATA_CATEGORY_INFO[categoryExact as DataCategoryExact] = {
+      ...categoryInfo,
+      canAllocate: false,
+      canProductTrial: false,
+      maxAdminGift: 0,
+      freeEventsMultiple: 0,
+      feature: null,
+      hasSpikeProtection: false,
+      reservedVolumeTooltip: null,
+    };
   }
 );
 
@@ -77,6 +76,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
     canProductTrial: false,
     maxAdminGift: 10_000_000,
     freeEventsMultiple: 1_000,
+    hasSpikeProtection: true,
     reservedVolumeTooltip: t(
       'Errors are sent every time an SDK catches a bug. You can send them manually too, if you want.'
     ),
@@ -88,6 +88,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
     maxAdminGift: 50_000_000,
     freeEventsMultiple: 1_000,
     feature: 'performance-view',
+    hasSpikeProtection: true,
     reservedVolumeTooltip: t(
       'Transactions are sent when your service receives a request and sends a response.'
     ),
@@ -99,6 +100,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'event-attachments',
+    hasSpikeProtection: true,
     reservedVolumeTooltip: t(
       'Attachments are files attached to errors, such as minidumps.'
     ),
@@ -121,6 +123,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
     maxAdminGift: 1_000_000_000,
     freeEventsMultiple: 100_000,
     feature: 'spans-usage-tracking',
+    hasSpikeProtection: true,
     reservedVolumeTooltip: t(
       'Tracing is enabled by spans. A span represents a single operation of work within a trace.'
     ),
@@ -147,7 +150,7 @@ export const BILLED_DATA_CATEGORY_INFO = {
     canProductTrial: false,
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
-    feature: 'uptime',
+    feature: 'uptime-billing',
   },
   [DataCategoryExact.PROFILE_DURATION]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PROFILE_DURATION],

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -1018,6 +1018,10 @@ export interface BilledDataCategoryInfo extends DataCategoryInfo {
    */
   freeEventsMultiple: number;
   /**
+   * Whether the category has spike protection support
+   */
+  hasSpikeProtection: boolean;
+  /**
    * The maximum number of free events that can be gifted
    */
   maxAdminGift: number;

--- a/static/gsApp/utils/dataCategory.spec.tsx
+++ b/static/gsApp/utils/dataCategory.spec.tsx
@@ -17,7 +17,6 @@ import {
   getPlanCategoryName,
   getReservedBudgetDisplayName,
   hasCategoryFeature,
-  isSeer,
   listDisplayNames,
   sortCategories,
   sortCategoriesWithKeys,
@@ -399,16 +398,5 @@ describe('listDisplayNames', function () {
     ).toBe(
       'errors, replays, attachments, cron monitors, accepted spans, uptime monitors, and stored spans'
     );
-  });
-});
-
-describe('isSeer', () => {
-  it.each([
-    [DataCategory.SEER_AUTOFIX, true],
-    [DataCategory.SEER_SCANNER, true],
-    [DataCategory.ERRORS, false],
-    [DataCategory.TRANSACTIONS, false],
-  ])('returns %s for category %s', (category, expected) => {
-    expect(isSeer(category)).toBe(expected);
   });
 });

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -286,7 +286,3 @@ export function getChunkCategoryFromDuration(category: DataCategory) {
   }
   return '';
 }
-
-export function isSeer(category: DataCategory): boolean {
-  return category === DataCategory.SEER_AUTOFIX || category === DataCategory.SEER_SCANNER;
-}

--- a/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotals.spec.tsx
@@ -181,7 +181,9 @@ describe('Subscription > UsageTotals', function () {
       screen.getByRole('row', {name: 'Total Dropped (estimated) 10 40%'})
     ).toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Over Quota 0 0%'})).toBeInTheDocument();
-    expect(screen.getByRole('row', {name: 'Spike Protection 0 0%'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('row', {name: 'Spike Protection 0 0%'})
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Other 0 0%'})).toBeInTheDocument();
   });
 
@@ -248,7 +250,9 @@ describe('Subscription > UsageTotals', function () {
       screen.getByRole('row', {name: 'Total Dropped (estimated) 5 25%'})
     ).toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Over Quota 0 0%'})).toBeInTheDocument();
-    expect(screen.getByRole('row', {name: 'Spike Protection 0 0%'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('row', {name: 'Spike Protection 0 0%'})
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('row', {name: 'Other 0 0%'})).toBeInTheDocument();
   });
 
@@ -1124,6 +1128,54 @@ describe('Subscription > CombinedUsageTotals', function () {
     expect(screen.getByRole('row', {name: 'Accepted 1 9%'})).toBeInTheDocument();
   });
 
+  it('shows table with dropped totals breakdown for reserved budgets', async function () {
+    const seerSubscription = SubscriptionWithSeerFixture({
+      organization,
+      plan: 'am3_business',
+    });
+    seerSubscription.planTier = 'am3';
+
+    render(
+      <CombinedUsageTotals
+        productGroup={seerSubscription.reservedBudgets![0]!}
+        subscription={seerSubscription}
+        organization={organization}
+        allTotalsByCategory={{
+          seerAutofix: totals,
+          seerScanner: totals,
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Expand usage totals'}));
+
+    const acceptedRows = screen.getAllByRole('row', {name: 'Accepted 0 0%'});
+    expect(acceptedRows).toHaveLength(2);
+
+    const totalDroppedRows = screen.getAllByRole('row', {name: 'Total Dropped 10 100%'});
+    expect(totalDroppedRows).toHaveLength(2);
+
+    const overQuotaRows = screen.getAllByRole('row', {name: 'Over Quota 7 70%'});
+    expect(overQuotaRows).toHaveLength(2);
+
+    const spikeProtectionRows = screen.queryAllByRole('row', {
+      name: 'Spike Protection 1 10%',
+    });
+    expect(spikeProtectionRows).toHaveLength(0); // not spike protected
+
+    const otherRows = screen.getAllByRole('row', {name: 'Other 2 20%'});
+    expect(otherRows).toHaveLength(2);
+
+    expect(screen.getByRole('columnheader', {name: 'Issue Fixes'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Issue Scans'})).toBeInTheDocument();
+
+    const seerAutofixTable = screen.getByTestId('category-table-seerAutofix');
+    const seerScannerTable = screen.getByTestId('category-table-seerScanner');
+
+    expect(within(seerAutofixTable).getAllByRole('row')).toHaveLength(5);
+    expect(within(seerScannerTable).getAllByRole('row')).toHaveLength(5);
+  });
+
   it('renders accepted spans in spend mode with reserved budgets and dynamic sampling', async function () {
     const dsSubscription = Am3DsEnterpriseSubscriptionFixture({
       organization,
@@ -1478,50 +1530,6 @@ describe('Subscription > CombinedUsageTotals', function () {
     expect(screen.getByText('On-Demand Issue Scans')).toBeInTheDocument();
 
     organization.features.pop();
-  });
-
-  it('shows accepted rows but hides dropped rows for SEER categories', async function () {
-    const seerSubscription = SubscriptionWithSeerFixture({
-      organization,
-      plan: 'am3_business',
-    });
-    seerSubscription.planTier = 'am3';
-
-    render(
-      <CombinedUsageTotals
-        productGroup={seerSubscription.reservedBudgets![0]!}
-        subscription={seerSubscription}
-        organization={organization}
-        allTotalsByCategory={{
-          seerAutofix: totals,
-          seerScanner: totals,
-        }}
-      />
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Expand usage totals'}));
-
-    const acceptedRows = screen.getAllByRole('row', {name: 'Accepted 0 0%'});
-    expect(acceptedRows).toHaveLength(2);
-
-    // Should NOT show dropped rows for SEER categories
-    expect(
-      screen.queryByRole('row', {name: 'Total Dropped 10 100%'})
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('row', {name: 'Over Quota 7 70%'})).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('row', {name: 'Spike Protection 1 10%'})
-    ).not.toBeInTheDocument();
-    expect(screen.queryByRole('row', {name: 'Other 2 20%'})).not.toBeInTheDocument();
-
-    expect(screen.getByRole('columnheader', {name: 'Issue Fixes'})).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', {name: 'Issue Scans'})).toBeInTheDocument();
-
-    const seerAutofixTable = screen.getByTestId('category-table-seerAutofix');
-    const seerScannerTable = screen.getByTestId('category-table-seerScanner');
-
-    expect(within(seerAutofixTable).getAllByRole('row')).toHaveLength(2);
-    expect(within(seerScannerTable).getAllByRole('row')).toHaveLength(2);
   });
 });
 

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -18,7 +18,6 @@ import {
   getCategoryInfoFromPlural,
   getPlanCategoryName,
   isContinuousProfiling,
-  isSeer,
 } from 'getsentry/utils/dataCategory';
 import {StripedTable} from 'getsentry/views/subscriptionPage/styles';
 import {displayPercentage} from 'getsentry/views/subscriptionPage/usageTotals';
@@ -145,6 +144,8 @@ type Props = {
 };
 
 function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Props) {
+  const categoryInfo = getCategoryInfoFromPlural(category);
+
   function OutcomeTable({children}: {children: React.ReactNode}) {
     const categoryName = isEventBreakdown
       ? toTitleCase(category, {allowInnerUpperCase: true})
@@ -167,10 +168,9 @@ function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Pr
               <TextOverflow>
                 {isEventBreakdown
                   ? tct('[singularName] Events', {
-                      singularName: toTitleCase(
-                        getCategoryInfoFromPlural(category)?.displayName ?? category,
-                        {allowInnerUpperCase: true}
-                      ),
+                      singularName: toTitleCase(categoryInfo?.displayName ?? category, {
+                        allowInnerUpperCase: true,
+                      }),
                     })
                   : categoryName}
               </TextOverflow>
@@ -191,6 +191,8 @@ function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Pr
     ? t('Total Dropped (estimated)')
     : t('Total Dropped');
 
+  const hasSpikeProtection = categoryInfo?.hasSpikeProtection ?? false;
+
   return (
     <UsageTableWrapper>
       <OutcomeTable>
@@ -200,21 +202,21 @@ function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Pr
           category={category}
           totals={totals}
         />
-        {!isSeer(category) && (
-          <OutcomeSection
-            isEventBreakdown={isEventBreakdown}
-            name={totalDropped}
-            quantity={totals.dropped}
+        <OutcomeSection
+          isEventBreakdown={isEventBreakdown}
+          name={totalDropped}
+          quantity={totals.dropped}
+          category={category}
+          totals={totals}
+        >
+          <OutcomeRow
+            indent
+            name={t('Over Quota')}
+            quantity={totals.droppedOverQuota}
             category={category}
             totals={totals}
-          >
-            <OutcomeRow
-              indent
-              name={t('Over Quota')}
-              quantity={totals.droppedOverQuota}
-              category={category}
-              totals={totals}
-            />
+          />
+          {hasSpikeProtection && (
             <OutcomeRow
               indent
               name={t('Spike Protection')}
@@ -222,18 +224,18 @@ function UsageTotalsTable({category, isEventBreakdown, totals, subscription}: Pr
               category={category}
               totals={totals}
             />
-            <OutcomeRow
-              indent
-              name={t('Other')}
-              quantity={totals.droppedOther}
-              category={category}
-              totals={totals}
-              tooltipTitle={t(
-                'The dropped other category is for all uncategorized dropped events. This is commonly due to user configured rate limits.'
-              )}
-            />
-          </OutcomeSection>
-        )}
+          )}
+          <OutcomeRow
+            indent
+            name={t('Other')}
+            quantity={totals.droppedOther}
+            category={category}
+            totals={totals}
+            tooltipTitle={t(
+              'The dropped other category is for all uncategorized dropped events. This is commonly due to user configured rate limits.'
+            )}
+          />
+        </OutcomeSection>
       </OutcomeTable>
     </UsageTableWrapper>
   );


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1012/support-seer-rate-limits-on-the-subscription-page

- Adds dropped breakdown to usage totals table for Seer categories
- Removes spike protection usage total table row for any categories that don't support spike protection