### PR TITLE
ref(issues): Add rate limiting to GroupTagKeyValuesEndpoint

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -21,6 +21,7 @@ from sentry.apidocs.examples.tags_examples import TagsExamples
 from sentry.apidocs.parameters import GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.tagstore.types import TagValueSerializerResponse
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 @extend_schema(tags=["Events"])
@@ -30,6 +31,15 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
+    enforce_rate_limit = True
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(limit=10, window=1),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+        }
+    }
 
     @extend_schema(
         operation_id="List a Tag's Values for an Issue",

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -208,7 +208,6 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
             response = self.client.get(url)
             assert response.status_code == 429
 
-
         mock_record.assert_called_with(
             "eventuser_endpoint.request",
             project_id=project.id,

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -1,10 +1,12 @@
+import datetime
 from datetime import timedelta
 from unittest import mock
 
+from django.test import override_settings
 from django.utils import timezone
 
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 
 
 class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
@@ -181,3 +183,34 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
         assert response.data[1]["email"] == "bar@example.com"
         assert response.data[1]["value"] == "id:2"
+
+    @mock.patch("sentry.analytics.record")
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_ratelimit(self, mock_record) -> None:
+        key, value = "foo", "bar"
+
+        project = self.create_project()
+
+        event = self.store_event(
+            data={"tags": {key: value}, "timestamp": before_now(seconds=1).isoformat()},
+            project_id=project.id,
+        )
+        group = event.group
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group.id}/tags/{key}/values/"
+
+        with freeze_time(datetime.datetime.now()):
+            for i in range(10):
+                response = self.client.get(url)
+                assert response.status_code == 200
+            response = self.client.get(url)
+            assert response.status_code == 429
+
+
+        mock_record.assert_called_with(
+            "eventuser_endpoint.request",
+            project_id=project.id,
+            endpoint="sentry.api.endpoints.group_tagkey_values.get",
+        )


### PR DESCRIPTION
Used the same settings as ProjectGroupIndexEndpoint 
