### PR TITLE
feat(simpleTable): Fix and iterate on the responsive columns strategy

### DIFF
--- a/static/app/components/tables/simpleTable/index.stories.tsx
+++ b/static/app/components/tables/simpleTable/index.stories.tsx
@@ -152,13 +152,7 @@ export default Storybook.story('SimpleTable', story => {
           <SimpleTableWithHiddenColumns>
             <SimpleTable.Header>
               {headers.map(header => (
-                <SimpleTable.HeaderCell
-                  key={header.key}
-                  data-max-width-sm-hide={header.key === 'action' ? 'true' : undefined}
-                  data-max-width-xs-hide={
-                    header.key === 'lastTriggered' ? 'true' : undefined
-                  }
-                >
+                <SimpleTable.HeaderCell key={header.key} data-column-name={header.key}>
                   {header.label}
                 </SimpleTable.HeaderCell>
               ))}
@@ -167,10 +161,10 @@ export default Storybook.story('SimpleTable', story => {
               <SimpleTable.Row key={row.name}>
                 <SimpleTable.RowCell>{row.name}</SimpleTable.RowCell>
                 <SimpleTable.RowCell>{row.monitors.length} monitors</SimpleTable.RowCell>
-                <SimpleTable.RowCell data-max-width-sm-hide>
+                <SimpleTable.RowCell data-column-name="action">
                   {row.action}
                 </SimpleTable.RowCell>
-                <SimpleTable.RowCell data-max-width-xs-hide>
+                <SimpleTable.RowCell data-column-name="lastTriggered">
                   <TimeAgoCell date={row.lastTriggered} />
                 </SimpleTable.RowCell>
               </SimpleTable.Row>
@@ -259,7 +253,7 @@ const SimpleTableWithHiddenColumns = styled(SimpleTable)`
   @container (max-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 2fr min-content auto;
 
-    [data-max-width-sm-hide='true'] {
+    [data-column-name='action'] {
       display: none;
     }
   }
@@ -267,7 +261,7 @@ const SimpleTableWithHiddenColumns = styled(SimpleTable)`
   @container (max-width: ${p => p.theme.breakpoints.xs}) {
     grid-template-columns: 2fr min-content;
 
-    [data-max-width-xs-hide='true'] {
+    [data-column-name='lastTriggered'] {
       display: none;
     }
   }

--- a/static/app/components/tables/simpleTable/index.stories.tsx
+++ b/static/app/components/tables/simpleTable/index.stories.tsx
@@ -136,41 +136,47 @@ export default Storybook.story('SimpleTable', story => {
   });
 
   story('Custom widths and hidden columns', () => {
-    const tableContent = (
-      <Fragment>
-        <SimpleTable.Header>
-          {headers.map(header => (
-            <SimpleTable.HeaderCell key={header.key}>
-              {header.label}
-            </SimpleTable.HeaderCell>
-          ))}
-        </SimpleTable.Header>
-        {data.map(row => (
-          <SimpleTable.Row key={row.name}>
-            <SimpleTable.RowCell>{row.name}</SimpleTable.RowCell>
-            <SimpleTable.RowCell>{row.monitors.length} monitors</SimpleTable.RowCell>
-            <SimpleTable.RowCell>{row.action}</SimpleTable.RowCell>
-            <SimpleTable.RowCell>
-              <TimeAgoCell date={row.lastTriggered} />
-            </SimpleTable.RowCell>
-          </SimpleTable.Row>
-        ))}
-      </Fragment>
-    );
-
     return (
       <Fragment>
         <p>
           Set custom widths for columns by styling SimpleTable with{' '}
           <code>grid-template-columns</code>.
         </p>
-
-        <SimpleTableWithCustomWidths>{tableContent}</SimpleTableWithCustomWidths>
         <p>
-          You can also hide columns by targeting the column's class name, which is useful
-          for creating responsive tables.
+          You can also hide columns by targeting the column in css, usually with a{' '}
+          <Storybook.JSXProperty name="data-*" value="string" />
+          attribute. This is useful for creating responsive tables.
         </p>
-        <SimpleTableWithHiddenColumns>{tableContent}</SimpleTableWithHiddenColumns>
+        <p>This table has 4 columns, but will hide some as it gets narrower.</p>
+        <SizingWindowContainer>
+          <SimpleTableWithHiddenColumns>
+            <SimpleTable.Header>
+              {headers.map(header => (
+                <SimpleTable.HeaderCell
+                  key={header.key}
+                  data-max-width-sm-hide={header.key === 'action' ? 'true' : undefined}
+                  data-max-width-xs-hide={
+                    header.key === 'lastTriggered' ? 'true' : undefined
+                  }
+                >
+                  {header.label}
+                </SimpleTable.HeaderCell>
+              ))}
+            </SimpleTable.Header>
+            {data.map(row => (
+              <SimpleTable.Row key={row.name}>
+                <SimpleTable.RowCell>{row.name}</SimpleTable.RowCell>
+                <SimpleTable.RowCell>{row.monitors.length} monitors</SimpleTable.RowCell>
+                <SimpleTable.RowCell data-max-width-sm-hide>
+                  {row.action}
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell data-max-width-xs-hide>
+                  <TimeAgoCell date={row.lastTriggered} />
+                </SimpleTable.RowCell>
+              </SimpleTable.Row>
+            ))}
+          </SimpleTableWithHiddenColumns>
+        </SizingWindowContainer>
       </Fragment>
     );
   });
@@ -243,14 +249,26 @@ const SimpleTableWithColumns = styled(SimpleTable)`
   grid-template-columns: 1fr 1fr 1fr 1fr;
 `;
 
-const SimpleTableWithCustomWidths = styled(SimpleTable)`
-  grid-template-columns: 2fr min-content auto 256px;
+const SizingWindowContainer = styled(Storybook.SizingWindow)`
+  container-type: inline-size;
 `;
 
-const SimpleTableWithHiddenColumns = styled(SimpleTableWithCustomWidths)`
-  grid-template-columns: 2fr min-content auto;
+const SimpleTableWithHiddenColumns = styled(SimpleTable)`
+  grid-template-columns: 2fr min-content auto 256px;
 
-  .lastTriggered {
-    display: none;
+  @container (max-width: ${p => p.theme.breakpoints.sm}) {
+    grid-template-columns: 2fr min-content auto;
+
+    [data-max-width-sm-hide='true'] {
+      display: none;
+    }
+  }
+
+  @container (max-width: ${p => p.theme.breakpoints.xs}) {
+    grid-template-columns: 2fr min-content;
+
+    [data-max-width-xs-hide='true'] {
+      display: none;
+    }
   }
 `;

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -31,13 +31,11 @@ function Header({children}: {children: React.ReactNode}) {
 
 function HeaderCell({
   children,
-  className,
   sort,
   handleSortClick,
   ...props
 }: HTMLAttributes<HTMLDivElement> & {
   children?: React.ReactNode;
-  className?: string;
   handleSortClick?: () => void;
   sort?: 'asc' | 'desc';
 }) {
@@ -47,7 +45,6 @@ function HeaderCell({
   return (
     <ColumnHeaderCell
       {...props}
-      className={className}
       isSorted={isSorted}
       onClick={handleSortClick}
       role="columnheader"

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -1,4 +1,4 @@
-import type {CSSProperties, HTMLAttributes} from 'react';
+import type {ComponentProps, CSSProperties, HTMLAttributes} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -34,7 +34,8 @@ function HeaderCell({
   className,
   sort,
   handleSortClick,
-}: {
+  ...props
+}: HTMLAttributes<HTMLDivElement> & {
   children?: React.ReactNode;
   className?: string;
   handleSortClick?: () => void;
@@ -45,6 +46,7 @@ function HeaderCell({
 
   return (
     <ColumnHeaderCell
+      {...props}
       className={className}
       isSorted={isSorted}
       onClick={handleSortClick}
@@ -79,13 +81,20 @@ function RowCell({
   children,
   className,
   justify,
-}: {
+  ...props
+}: ComponentProps<typeof Flex> & {
   children: React.ReactNode;
   className?: string;
   justify?: CSSProperties['justifyContent'];
 }) {
   return (
-    <StyledRowCell className={className} role="cell" align="center" justify={justify}>
+    <StyledRowCell
+      {...props}
+      className={className}
+      role="cell"
+      align="center"
+      justify={justify}
+    >
       {children}
     </StyledRowCell>
   );

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -24,22 +24,22 @@ export default function AutomationHistoryList({history}: Props) {
   return (
     <SimpleTableWithColumns>
       <SimpleTable.Header>
-        <SimpleTable.HeaderCell className="dateSent">
+        <SimpleTable.HeaderCell>
           {tct('Time Sent ([timezone])', {timezone: moment.tz(timezone).zoneAbbr()})}
         </SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell className="monitor">Monitor</SimpleTable.HeaderCell>
-        <SimpleTable.HeaderCell className="groupId">Issue</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>Monitor</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>Issue</SimpleTable.HeaderCell>
       </SimpleTable.Header>
       {history.length === 0 && <SimpleTable.Empty>No history found</SimpleTable.Empty>}
       {history.map((row, index) => (
         <SimpleTable.Row key={index}>
-          <SimpleTable.RowCell className="dateSent">
+          <SimpleTable.RowCell>
             <DateTime date={row.dateSent} forcedTimezone={timezone} />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell className="monitor">
+          <SimpleTable.RowCell>
             <Link to={row.monitor.link}>{row.monitor.name}</Link>
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell className="groupId">
+          <SimpleTable.RowCell>
             <Link to={`/issues/${row.groupId}`}>{`#${row.groupId}`}</Link>
           </SimpleTable.RowCell>
         </SimpleTable.Row>

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import LoadingError from 'sentry/components/loadingError';
@@ -30,16 +31,15 @@ function LoadingSkeletons() {
 
 function HeaderCell({
   children,
-  className,
   sortKey,
   sort,
+  ...props
 }: {
   children: React.ReactNode;
-  className: string;
   sort: Sort | undefined;
   divider?: boolean;
   sortKey?: string;
-}) {
+} & Omit<ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
   const location = useLocation();
   const navigate = useNavigate();
   const isSortedByField = sort?.field === sortKey;
@@ -57,7 +57,7 @@ function HeaderCell({
 
   return (
     <SimpleTable.HeaderCell
-      className={className}
+      {...props}
       sort={sort && sortKey === sort?.field ? sort.kind : undefined}
       handleSortClick={sortKey ? handleSort : undefined}
     >
@@ -76,20 +76,20 @@ function AutomationListTable({
   return (
     <AutomationsSimpleTable>
       <SimpleTable.Header>
-        <HeaderCell className="name" sort={sort} sortKey="name">
+        <HeaderCell sort={sort} sortKey="name">
           {t('Name')}
         </HeaderCell>
-        <HeaderCell className="last-triggered" sort={sort}>
+        <HeaderCell data-column-name="last-triggered" sort={sort}>
           {t('Last Triggered')}
         </HeaderCell>
-        <HeaderCell className="action" sort={sort} sortKey="actions">
+        <HeaderCell data-column-name="action" sort={sort} sortKey="actions">
           {t('Actions')}
         </HeaderCell>
-        <HeaderCell className="projects" sort={sort}>
+        <HeaderCell data-column-name="projects" sort={sort}>
           {t('Projects')}
         </HeaderCell>
         <HeaderCell
-          className="connected-monitors"
+          data-column-name="connected-monitors"
           sort={sort}
           sortKey="connectedDetectors"
         >
@@ -114,17 +114,17 @@ const AutomationsSimpleTable = styled(SimpleTable)`
 
   margin-bottom: ${space(2)};
 
-  .last-triggered,
-  .action,
-  .projects,
-  .connected-monitors {
+  [data-column-name='last-triggered'],
+  [data-column-name='action'],
+  [data-column-name='projects'],
+  [data-column-name='connected-monitors'] {
     display: none;
   }
 
   @media (min-width: ${p => p.theme.breakpoints.xs}) {
     grid-template-columns: 2.5fr 1fr;
 
-    .projects {
+    [data-column-name='projects'] {
       display: flex;
     }
   }
@@ -132,7 +132,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 2.5fr 1fr 1fr;
 
-    .action {
+    [data-column-name='action'] {
       display: flex;
     }
   }
@@ -140,7 +140,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   @media (min-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: 2.5fr 1fr 1fr 1fr;
 
-    .last-triggered {
+    [data-column-name='last-triggered'] {
       display: flex;
     }
   }
@@ -148,7 +148,7 @@ const AutomationsSimpleTable = styled(SimpleTable)`
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
     grid-template-columns: minmax(0, 3fr) 1fr 1fr 1fr 1fr;
 
-    .connected-monitors {
+    [data-column-name='connected-monitors'] {
       display: flex;
     }
   }

--- a/static/app/views/automations/components/automationListTable/row.tsx
+++ b/static/app/views/automations/components/automationListTable/row.tsx
@@ -31,19 +31,19 @@ export function AutomationListRow({automation}: AutomationListRowProps) {
       variant={disabled ? 'faded' : 'default'}
       data-test-id="automation-list-row"
     >
-      <SimpleTable.RowCell className="name">
+      <SimpleTable.RowCell>
         <AutomationTitleCell automation={automation} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="last-triggered">
+      <SimpleTable.RowCell data-column-name="last-triggered">
         <TimeAgoCell date={lastTriggered} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="action">
+      <SimpleTable.RowCell data-column-name="action">
         <ActionCell actions={actions} disabled={disabled} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="projects">
+      <SimpleTable.RowCell data-column-name="projects">
         <ProjectList projectSlugs={projectSlugs} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="connected-monitors">
+      <SimpleTable.RowCell data-column-name="connected-monitors">
         <AutomationListConnectedDetectors detectorIds={detectorIds} />
       </SimpleTable.RowCell>
     </AutomationSimpleTableRow>
@@ -53,19 +53,19 @@ export function AutomationListRow({automation}: AutomationListRowProps) {
 export function AutomationListRowSkeleton() {
   return (
     <AutomationSimpleTableRow>
-      <SimpleTable.RowCell className="name">
+      <SimpleTable.RowCell>
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="last-triggered">
+      <SimpleTable.RowCell data-column-name="last-triggered">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="action">
+      <SimpleTable.RowCell data-column-name="action">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="projects">
+      <SimpleTable.RowCell data-column-name="projects">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="connected-monitors">
+      <SimpleTable.RowCell data-column-name="connected-monitors">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
     </AutomationSimpleTableRow>

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -40,35 +40,37 @@ export default function ConnectedMonitorsList({
     <Container>
       <SimpleTableWithColumns>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell className="name">{t('Name')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell className="type">{t('Type')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell className="last-issue">
+          <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="type">
+            {t('Type')}
+          </SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="last-issue">
             {t('Last Issue')}
           </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell className="owner">
+          <SimpleTable.HeaderCell data-column-name="owner">
             {t('Assignee')}
           </SimpleTable.HeaderCell>
-          {canEdit && <SimpleTable.HeaderCell className="connected" />}
+          {canEdit && <SimpleTable.HeaderCell data-column-name="connected" />}
         </SimpleTable.Header>
         {monitors.length === 0 && (
           <SimpleTable.Empty>{t('No monitors connected')}</SimpleTable.Empty>
         )}
         {monitors.map(monitor => (
           <SimpleTable.Row key={monitor.id}>
-            <SimpleTable.RowCell className="name">
+            <SimpleTable.RowCell>
               <DetectorLink detector={monitor} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell className="type">
+            <SimpleTable.RowCell data-column-name="type">
               <DetectorTypeCell type={monitor.type} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell className="last-issue">
+            <SimpleTable.RowCell data-column-name="last-issue">
               <IssueCell group={undefined} />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell className="owner">
+            <SimpleTable.RowCell data-column-name="owner">
               <DetectorAssigneeCell assignee={monitor.owner} />
             </SimpleTable.RowCell>
             {canEdit && (
-              <SimpleTable.RowCell className="connected" justify="flex-end">
+              <SimpleTable.RowCell data-column-name="connected" justify="flex-end">
                 <Button onClick={() => toggleConnected(monitor.id)} size="sm">
                   {connectedIds?.has(monitor.id) ? t('Disconnect') : t('Connect')}
                 </Button>
@@ -94,14 +96,14 @@ const SimpleTableWithColumns = styled(SimpleTable)`
     The connected column can be added/removed depending on props, so in order to
     have a constant width we have an auto grid column and set the width here.
   */
-  .connected {
+  [data-column-name='connected'] {
     width: 140px;
   }
 
   @container (max-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: 1fr 100px auto auto;
 
-    .last-issue {
+    [data-column-name='last-issue'] {
       display: none;
     }
   }
@@ -109,7 +111,7 @@ const SimpleTableWithColumns = styled(SimpleTable)`
   @container (max-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 1fr 100px auto;
 
-    .owner {
+    [data-column-name='owner'] {
       display: none;
     }
   }
@@ -117,7 +119,7 @@ const SimpleTableWithColumns = styled(SimpleTable)`
   @container (max-width: ${p => p.theme.breakpoints.xs}) {
     grid-template-columns: 1fr 100px;
 
-    .type {
+    [data-column-name='type'] {
       display: none;
     }
   }

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -30,17 +30,17 @@ function Skeletons({canEdit}: {canEdit: boolean}) {
     <Fragment>
       {Array.from({length: AUTOMATIONS_PER_PAGE}).map((_, index) => (
         <SimpleTable.Row key={index}>
-          <SimpleTable.RowCell className="name">
+          <SimpleTable.RowCell>
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell className="last-triggered">
+          <SimpleTable.RowCell data-column-name="last-triggered">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
-          <SimpleTable.RowCell className="action-filters">
+          <SimpleTable.RowCell data-column-name="action-filters">
             <Placeholder height="20px" />
           </SimpleTable.RowCell>
           {canEdit && (
-            <SimpleTable.RowCell className="connected">
+            <SimpleTable.RowCell data-column-name="connected">
               <Placeholder height="20px" />
             </SimpleTable.RowCell>
           )}
@@ -81,14 +81,14 @@ export function ConnectedAutomationsList({
     <Container>
       <SimpleTableWithColumns>
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell className="name">{t('Name')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell className="last-triggered">
+          <SimpleTable.HeaderCell>{t('Name')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell data-column-name="last-triggered">
             {t('Last Triggered')}
           </SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell className="action-filters">
+          <SimpleTable.HeaderCell data-column-name="action-filters">
             {t('Actions')}
           </SimpleTable.HeaderCell>
-          {canEdit && <SimpleTable.HeaderCell className="connected" />}
+          {canEdit && <SimpleTable.HeaderCell data-column-name="connected" />}
         </SimpleTable.Header>
         {isLoading && <Skeletons canEdit={canEdit} />}
         {isError && <LoadingError />}
@@ -101,17 +101,17 @@ export function ConnectedAutomationsList({
               key={automation.id}
               variant={automation.disabled ? 'faded' : 'default'}
             >
-              <SimpleTable.RowCell className="name">
+              <SimpleTable.RowCell>
                 <AutomationTitleCell automation={automation} />
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell className="last-triggered">
+              <SimpleTable.RowCell data-column-name="last-triggered">
                 <TimeAgoCell date={automation.lastTriggered} />
               </SimpleTable.RowCell>
-              <SimpleTable.RowCell className="action-filters">
+              <SimpleTable.RowCell data-column-name="action-filters">
                 <ActionCell actions={getAutomationActions(automation)} />
               </SimpleTable.RowCell>
               {canEdit && (
-                <SimpleTable.RowCell className="connected" justify="flex-end">
+                <SimpleTable.RowCell data-column-name="connected" justify="flex-end">
                   <Button onClick={() => toggleConnected?.(automation.id)} size="sm">
                     {connectedAutomationIds?.has(automation.id)
                       ? t('Disconnect')
@@ -151,14 +151,14 @@ const SimpleTableWithColumns = styled(SimpleTable)`
     The connected column can be added/removed depending on props, so in order to
     have a constant width we have an auto grid column and set the width here.
     */
-  .connected {
+  [data-column-name='connected'] {
     width: 140px;
   }
 
   @container (max-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 1fr 180px auto;
 
-    .last-triggered {
+    [data-column-name='last-triggered'] {
       display: none;
     }
   }
@@ -166,7 +166,7 @@ const SimpleTableWithColumns = styled(SimpleTable)`
   @container (max-width: ${p => p.theme.breakpoints.xs}) {
     grid-template-columns: 1fr auto;
 
-    .action-filters {
+    [data-column-name='action-filters'] {
       display: none;
     }
   }

--- a/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
+++ b/static/app/views/detectors/components/detectorListTable/detectorListRow.tsx
@@ -22,19 +22,19 @@ export function DetectorListRow({detector}: DetectorListRowProps) {
       variant={detector.disabled ? 'faded' : 'default'}
       data-test-id="detector-list-row"
     >
-      <SimpleTable.RowCell className="name">
+      <SimpleTable.RowCell>
         <DetectorLink detector={detector} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="type">
+      <SimpleTable.RowCell data-column-name="type">
         <DetectorTypeCell type={detector.type} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="last-issue">
+      <SimpleTable.RowCell data-column-name="last-issue">
         <IssueCell group={issues.length > 0 ? issues[0] : undefined} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="assignee">
+      <SimpleTable.RowCell data-column-name="assignee">
         <DetectorAssigneeCell assignee={detector.owner} />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="connected-automations">
+      <SimpleTable.RowCell data-column-name="connected-automations">
         <DetectorListConnectedAutomations automationIds={detector.workflowIds} />
       </SimpleTable.RowCell>
     </DetectorSimpleTableRow>
@@ -44,22 +44,22 @@ export function DetectorListRow({detector}: DetectorListRowProps) {
 export function DetectorListRowSkeleton() {
   return (
     <DetectorSimpleTableRow>
-      <SimpleTable.RowCell className="name">
+      <SimpleTable.RowCell>
         <div style={{width: '100%'}}>
           <Placeholder height="20px" width="50%" style={{marginBottom: '4px'}} />
           <Placeholder height="16px" width="20%" />
         </div>
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="type">
+      <SimpleTable.RowCell data-column-name="type">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="last-issue">
+      <SimpleTable.RowCell data-column-name="last-issue">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="assignee">
+      <SimpleTable.RowCell data-column-name="assignee">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
-      <SimpleTable.RowCell className="connected-automations">
+      <SimpleTable.RowCell data-column-name="connected-automations">
         <Placeholder height="20px" />
       </SimpleTable.RowCell>
     </DetectorSimpleTableRow>

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,3 +1,4 @@
+import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import LoadingError from 'sentry/components/loadingError';
@@ -30,16 +31,15 @@ function LoadingSkeletons() {
 
 function HeaderCell({
   children,
-  name,
   sortKey,
   sort,
+  ...props
 }: {
   children: React.ReactNode;
-  name: string;
   sort: Sort | undefined;
   divider?: boolean;
   sortKey?: string;
-}) {
+} & Omit<ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
   const location = useLocation();
   const navigate = useNavigate();
   const isSortedByField = sort?.field === sortKey;
@@ -57,7 +57,7 @@ function HeaderCell({
 
   return (
     <SimpleTable.HeaderCell
-      className={name}
+      {...props}
       sort={sort && sortKey === sort?.field ? sort.kind : undefined}
       handleSortClick={sortKey ? handleSort : undefined}
     >
@@ -77,20 +77,20 @@ function DetectorListTable({
     <Container>
       <DetectorListSimpleTable>
         <SimpleTable.Header>
-          <HeaderCell name="name" sortKey="name" sort={sort}>
+          <HeaderCell sortKey="name" sort={sort}>
             {t('Name')}
           </HeaderCell>
-          <HeaderCell name="type" divider sortKey="type" sort={sort}>
+          <HeaderCell data-column-name="type" divider sortKey="type" sort={sort}>
             {t('Type')}
           </HeaderCell>
-          <HeaderCell name="last-issue" divider sort={sort}>
+          <HeaderCell data-column-name="last-issue" divider sort={sort}>
             {t('Last Issue')}
           </HeaderCell>
-          <HeaderCell name="assignee" divider sort={sort}>
+          <HeaderCell data-column-name="assignee" divider sort={sort}>
             {t('Assignee')}
           </HeaderCell>
           <HeaderCell
-            name="connected-automations"
+            data-column-name="connected-automations"
             divider
             sortKey="connectedWorkflows"
             sort={sort}
@@ -121,17 +121,17 @@ const DetectorListSimpleTable = styled(SimpleTable)`
 
   margin-bottom: ${space(2)};
 
-  .type,
-  .last-issue,
-  .assignee,
-  .connected-automations {
+  [data-column-name='type'],
+  [data-column-name='last-issue'],
+  [data-column-name='assignee'],
+  [data-column-name='connected-automations'] {
     display: none;
   }
 
   @container (min-width: ${p => p.theme.breakpoints.xs}) {
     grid-template-columns: 3fr 0.8fr;
 
-    .type {
+    [data-column-name='type'] {
       display: flex;
     }
   }
@@ -139,7 +139,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   @container (min-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
 
-    .last-issue {
+    [data-column-name='last-issue'] {
       display: flex;
     }
   }
@@ -147,7 +147,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   @container (min-width: ${p => p.theme.breakpoints.md}) {
     grid-template-columns: 3fr 0.8fr 1.5fr 0.8fr;
 
-    .assignee {
+    [data-column-name='assignee'] {
       display: flex;
     }
   }
@@ -155,7 +155,7 @@ const DetectorListSimpleTable = styled(SimpleTable)`
   @container (min-width: ${p => p.theme.breakpoints.lg}) {
     grid-template-columns: 4.5fr 0.8fr 1.5fr 0.8fr 2fr;
 
-    .connected-automations {
+    [data-column-name='connected-automations'] {
       display: flex;
     }
   }


### PR DESCRIPTION
Using un-minified `class` values is weird in our codebase, and these values specifically are hard to grep for in order to understand their purpose. A better example to set is using data-* attributes which will be easier to associate with the css that controls their visiblilty.