### PR TITLE
fix(issues): Don’t wrap markdown button

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -351,6 +351,7 @@ const MarkdownButton = styled('button')`
   text-decoration-color: ${p => Color(p.theme.gray300).alpha(0.5).string()};
   font-size: inherit;
   cursor: pointer;
+  text-wrap: nowrap;
 
   :hover {
     color: ${p => p.theme.subText};


### PR DESCRIPTION
**Before**
![image](https://github.com/user-attachments/assets/24edd540-9785-4813-b8b7-71b974dfd781)


**After**
![image](https://github.com/user-attachments/assets/2be8e052-01db-4929-bab8-995b9082a895)
