### PR TITLE
fix(billing): update conditions for orgStatsBanner to appear

### DIFF
--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -1661,7 +1661,7 @@ describe('GSBanner Overage Alerts', function () {
       organization,
       plan: 'am1_team',
       categories: {
-        errors: MetricHistoryFixture({sentUsageWarning: true}),
+        errors: MetricHistoryFixture({sentUsageWarning: true, usageExceeded: true}),
         transactions: MetricHistoryFixture({sentUsageWarning: false}),
         replays: MetricHistoryFixture({usageExceeded: false}),
         attachments: MetricHistoryFixture({sentUsageWarning: false}),

--- a/static/gsApp/hooks/orgStatsBanner.spec.tsx
+++ b/static/gsApp/hooks/orgStatsBanner.spec.tsx
@@ -30,6 +30,17 @@ describe('OrgStatsBanner', function () {
     expect(wrapper.container).toBeEmptyDOMElement();
   });
 
+  it('renders empty if business plan without usage exceeded', function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_business',
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+    wrapper = render(<OrgStatsBanner organization={organization} />);
+    expect(wrapper.container).toBeEmptyDOMElement();
+  });
+
   it('renders increase event limit CTA for billing user', function () {
     const organization = OrganizationFixture({
       access: ['org:billing'],

--- a/static/gsApp/hooks/orgStatsBanner.tsx
+++ b/static/gsApp/hooks/orgStatsBanner.tsx
@@ -72,16 +72,21 @@ function OrgStatsBanner({organization, subscription, referrer}: Props) {
           ),
         ];
       case 'send_to_checkout':
-      default:
         return [
           t('Upgrade to Business'),
           t(
             'Advanced integrations, deep insights, custom dashboards, and more. Upgrade to Sentry’s Business plan today.'
           ),
         ];
+      default:
+        return ['', ''];
     }
   };
   const [headerText, subText] = getTextContent();
+  if (!headerText && !subText) {
+    return null;
+  }
+
   return (
     <Panel>
       <SubscriptionBody withPadding>

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -941,6 +941,6 @@ describe('getBestActionToIncreaseEventLimits', function () {
       organization,
       plan: 'am3_business',
     });
-    expect(getBestActionToIncreaseEventLimits(organization, subscription)).toBeNull();
+    expect(getBestActionToIncreaseEventLimits(organization, subscription)).toBe('');
   });
 });

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment-timezone';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 
@@ -12,6 +13,7 @@ import {
   formatReservedWithUnits,
   formatUsageWithUnits,
   getActiveProductTrial,
+  getBestActionToIncreaseEventLimits,
   getOnDemandCategories,
   getProductTrial,
   getSlot,
@@ -23,6 +25,7 @@ import {
   isTeamPlanFamily,
   MILLISECONDS_IN_HOUR,
   trialPromptIsDismissed,
+  UsageAction,
 } from 'getsentry/utils/billing';
 
 describe('formatReservedWithUnits', function () {
@@ -899,5 +902,45 @@ describe('isEnterprise', function () {
     expect(isEnterprise('_enterprise')).toBe(false);
     expect(isEnterprise('am1_business')).toBe(false);
     expect(isEnterprise('am2_team')).toBe(false);
+  });
+});
+
+describe('getBestActionToIncreaseEventLimits', function () {
+  it('returns start trial for free plan', function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_f',
+    });
+    expect(getBestActionToIncreaseEventLimits(organization, subscription)).toBe(
+      UsageAction.START_TRIAL
+    );
+  });
+
+  it('returns add events for paid plan with usage exceeded', function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_team',
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: false}),
+        spans: MetricHistoryFixture({usageExceeded: true}),
+        replays: MetricHistoryFixture({usageExceeded: false}),
+        attachments: MetricHistoryFixture({usageExceeded: true}),
+        monitorSeats: MetricHistoryFixture({usageExceeded: false}),
+      },
+    });
+    expect(getBestActionToIncreaseEventLimits(organization, subscription)).toBe(
+      UsageAction.REQUEST_ADD_EVENTS
+    );
+  });
+
+  it('returns nothing for business plan without usage exceeded', function () {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_business',
+    });
+    expect(getBestActionToIncreaseEventLimits(organization, subscription)).toBeNull();
   });
 });

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -517,7 +517,7 @@ export function getBestActionToIncreaseEventLimits(
   if (!isBizPlanFamily(subscription.planDetails)) {
     return hasBillingPerms ? UsageAction.SEND_TO_CHECKOUT : UsageAction.REQUEST_UPGRADE;
   }
-  return null;
+  return '';
 }
 
 /**

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -507,11 +507,17 @@ export function getBestActionToIncreaseEventLimits(
     return UsageAction.START_TRIAL;
   }
   // paid plans should add events without changing plans
-  if (isPaidPlan && hasPerformance(subscription.planDetails)) {
+  const hasAnyUsageExceeded = Object.values(subscription.categories).some(
+    category => category.usageExceeded
+  );
+  if (isPaidPlan && hasPerformance(subscription.planDetails) && hasAnyUsageExceeded) {
     return hasBillingPerms ? UsageAction.ADD_EVENTS : UsageAction.REQUEST_ADD_EVENTS;
   }
-  // otherwise, we want them to upgrade to a different plan
-  return hasBillingPerms ? UsageAction.SEND_TO_CHECKOUT : UsageAction.REQUEST_UPGRADE;
+  // otherwise, we want them to upgrade to a different plan if they're not already on a Business plan
+  if (!isBizPlanFamily(subscription.planDetails)) {
+    return hasBillingPerms ? UsageAction.SEND_TO_CHECKOUT : UsageAction.REQUEST_UPGRADE;
+  }
+  return null;
 }
 
 /**

--- a/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
@@ -26,12 +26,15 @@ describe('Subscription > UsageAlert', function () {
     expect(screen.queryByTestId('usage-alert')).not.toBeInTheDocument();
   });
 
-  it('renders request add events CTA if am1 business and a member', function () {
+  it('renders request add events CTA if business, non-billing member, and usage exceeded', function () {
     const organization = OrganizationFixture({access: []});
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_business',
       canSelfServe: true,
+      categories: {
+        errors: MetricHistoryFixture({usageExceeded: true}),
+      },
     });
 
     SubscriptionStore.set(organization.slug, subscription);
@@ -39,7 +42,6 @@ describe('Subscription > UsageAlert', function () {
       organization,
     });
 
-    expect(screen.queryByTestId('usage-alert')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Request Additional Quota')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/RTC-1027/improve-copy-on-over-quota-banner-on-stats-page

- Increase your Reserved Quotas banner if a category is exceeded usage
- Upgrade to Business banner if subscription is not currently on a Business plan

