### PR TITLE
feat(ACI): Restrict metric issue detector creation by flag

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -15,7 +15,7 @@ from sentry.snuba.models import (
     SnubaQueryEventType,
 )
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION
@@ -270,6 +270,7 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
 
 
 @region_silo_test
+@apply_feature_flag_on_cls("organizations:incidents")
 class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
     method = "POST"
 
@@ -339,7 +340,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             )
             assert response.data == {"type": ["Detector type not compatible with detectors"]}
 
-    @with_feature("organizations:incidents")
     def test_missing_project_id(self):
         data = {**self.valid_data}
         del data["projectId"]
@@ -350,7 +350,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"projectId": ["This field is required."]}
 
-    @with_feature("organizations:incidents")
     def test_project_id_not_found(self):
         data = {**self.valid_data}
         data["projectId"] = 123456
@@ -361,7 +360,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"projectId": ["Project not found"]}
 
-    @with_feature("organizations:incidents")
     def test_wrong_org_project_id(self):
         data = {**self.valid_data}
         data["projectId"] = self.create_project(organization=self.create_organization()).id
@@ -373,16 +371,16 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         assert response.data == {"projectId": ["Project not found"]}
 
     def test_without_feature_flag(self):
-        response = self.get_error_response(
-            self.organization.slug,
-            **self.valid_data,
-            status_code=404,
-        )
+        with self.feature({"organizations:incidents": False}):
+            response = self.get_error_response(
+                self.organization.slug,
+                **self.valid_data,
+                status_code=404,
+            )
         assert response.data == {
             "detail": ErrorDetail(string="The requested resource does not exist", code="error")
         }
 
-    @with_feature("organizations:incidents")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_valid_creation(self, mock_audit):
         with self.tasks():
@@ -438,7 +436,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
             data=detector.get_audit_log_data(),
         )
 
-    @with_feature("organizations:incidents")
     def test_missing_required_field(self):
         response = self.get_error_response(
             self.organization.slug,
@@ -446,7 +443,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"type": ["This field is required."]}
 
-    @with_feature("organizations:incidents")
     def test_missing_name(self):
         data = {**self.valid_data}
         del data["name"]
@@ -457,7 +453,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"name": ["This field is required."]}
 
-    @with_feature("organizations:incidents")
     def test_empty_query_string(self):
         data = {**self.valid_data}
         data["dataSource"]["query"] = ""
@@ -475,7 +470,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
 
         assert query_sub.snuba_query.query == ""
 
-    @with_feature("organizations:incidents")
     def test_valid_creation_with_owner(self):
         # Test data with owner field
         data_with_owner = {
@@ -501,7 +495,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         # Verify serialized response includes owner
         assert response.data["owner"] == self.user.get_actor_identifier()
 
-    @with_feature("organizations:incidents")
     def test_valid_creation_with_team_owner(self):
         # Create a team for testing
         team = self.create_team(organization=self.organization)
@@ -530,7 +523,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         # Verify serialized response includes team owner
         assert response.data["owner"] == f"team:{team.id}"
 
-    @with_feature("organizations:incidents")
     def test_invalid_owner(self):
         # Test with invalid owner format
         data_with_invalid_owner = {
@@ -545,7 +537,6 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert "owner" in response.data
 
-    @with_feature("organizations:incidents")
     def test_owner_not_in_organization(self):
         # Create a user in another organization
         other_org = self.create_organization()


### PR DESCRIPTION
Restrict metric issue detector creation by the `incidents` flag to maintain the same feature gating we have on metric alerts today.