### PR TITLE
:wrench: chore: make noa more resilient to soft timeout failures

### DIFF
--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
@@ -50,6 +50,8 @@ class DiscordMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
+        alert_rule_serialized_response = None
+        incident_serialized_response = None
         try:
             alert_rule_serialized_response = get_alert_rule_serializer(detector)
             incident_serialized_response = get_detailed_incident_serializer(open_period)

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/discord_metric_alert_handler.py
@@ -1,5 +1,7 @@
 import logging
 
+from celery.exceptions import SoftTimeLimitExceeded
+
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -48,15 +50,14 @@ class DiscordMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = get_alert_rule_serializer(detector)
-        incident_serialized_response = get_detailed_incident_serializer(open_period)
-
-        logger.info(
-            "notification_action.execute_via_metric_alert_handler.discord",
-            extra={
-                "action_id": alert_context.action_identifier_id,
-            },
-        )
+        try:
+            alert_rule_serialized_response = get_alert_rule_serializer(detector)
+            incident_serialized_response = get_detailed_incident_serializer(open_period)
+        except SoftTimeLimitExceeded:
+            logger.exception(
+                "notification_action.execute_via_metric_alert_handler.discord.soft_time_limit_exceeded",
+                extra={"action_id": alert_context.action_identifier_id},
+            )
 
         send_incident_alert_notification(
             notification_context=notification_context,

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
@@ -1,7 +1,5 @@
 import logging
 
-from celery.exceptions import SoftTimeLimitExceeded
-
 from sentry.incidents.action_handlers import email_users
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
@@ -55,16 +53,8 @@ class EmailMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = None
-        incident_serialized_response = None
-        try:
-            alert_rule_serialized_response = get_alert_rule_serializer(detector)
-            incident_serialized_response = get_detailed_incident_serializer(open_period)
-        except SoftTimeLimitExceeded:
-            logger.exception(
-                "notification_action.execute_via_metric_alert_handler.email.soft_time_limit_exceeded",
-                extra={"action_id": alert_context.action_identifier_id},
-            )
+        alert_rule_serialized_response = get_alert_rule_serializer(detector)
+        incident_serialized_response = get_detailed_incident_serializer(open_period)
 
         recipients = list(
             get_email_addresses(

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/email_metric_alert_handler.py
@@ -55,6 +55,8 @@ class EmailMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
+        alert_rule_serialized_response = None
+        incident_serialized_response = None
         try:
             alert_rule_serialized_response = get_alert_rule_serializer(detector)
             incident_serialized_response = get_detailed_incident_serializer(open_period)

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/msteams_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/msteams_metric_alert_handler.py
@@ -1,5 +1,7 @@
 import logging
 
+from celery.exceptions import SoftTimeLimitExceeded
+
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -46,15 +48,14 @@ class MSTeamsMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        alert_rule_serialized_response = get_alert_rule_serializer(detector)
-        incident_serialized_response = get_detailed_incident_serializer(open_period)
-
-        logger.info(
-            "notification_action.execute_via_metric_alert_handler.msteams",
-            extra={
-                "action_id": alert_context.action_identifier_id,
-            },
-        )
+        try:
+            alert_rule_serialized_response = get_alert_rule_serializer(detector)
+            incident_serialized_response = get_detailed_incident_serializer(open_period)
+        except SoftTimeLimitExceeded:
+            logger.exception(
+                "notification_action.execute_via_metric_alert_handler.msteams.soft_time_limit_exceeded",
+                extra={"action_id": alert_context.action_identifier_id},
+            )
 
         send_incident_alert_notification(
             notification_context=notification_context,

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/msteams_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/msteams_metric_alert_handler.py
@@ -48,6 +48,8 @@ class MSTeamsMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
+        alert_rule_serialized_response = None
+        incident_serialized_response = None
         try:
             alert_rule_serialized_response = get_alert_rule_serializer(detector)
             incident_serialized_response = get_detailed_incident_serializer(open_period)

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/sentry_app_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/sentry_app_metric_alert_handler.py
@@ -1,5 +1,7 @@
 import logging
 
+from celery.exceptions import SoftTimeLimitExceeded
+
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -39,14 +41,13 @@ class SentryAppMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        incident_serialized_response = get_incident_serializer(open_period)
-
-        logger.info(
-            "notification_action.execute_via_metric_alert_handler.sentry_app",
-            extra={
-                "action_id": alert_context.action_identifier_id,
-            },
-        )
+        try:
+            incident_serialized_response = get_incident_serializer(open_period)
+        except SoftTimeLimitExceeded:
+            logger.exception(
+                "notification_action.execute_via_metric_alert_handler.sentry_app.soft_time_limit_exceeded",
+                extra={"action_id": alert_context.action_identifier_id},
+            )
 
         send_incident_alert_notification(
             notification_context=notification_context,

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/sentry_app_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/sentry_app_metric_alert_handler.py
@@ -1,7 +1,5 @@
 import logging
 
-from celery.exceptions import SoftTimeLimitExceeded
-
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -41,14 +39,7 @@ class SentryAppMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
-        incident_serialized_response = None
-        try:
-            incident_serialized_response = get_incident_serializer(open_period)
-        except SoftTimeLimitExceeded:
-            logger.exception(
-                "notification_action.execute_via_metric_alert_handler.sentry_app.soft_time_limit_exceeded",
-                extra={"action_id": alert_context.action_identifier_id},
-            )
+        incident_serialized_response = get_incident_serializer(open_period)
 
         send_incident_alert_notification(
             notification_context=notification_context,

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/sentry_app_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/sentry_app_metric_alert_handler.py
@@ -41,6 +41,7 @@ class SentryAppMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
+        incident_serialized_response = None
         try:
             incident_serialized_response = get_incident_serializer(open_period)
         except SoftTimeLimitExceeded:

--- a/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
+++ b/src/sentry/notifications/notification_action/metric_alert_registry/handlers/slack_metric_alert_handler.py
@@ -47,6 +47,8 @@ class SlackMetricAlertHandler(BaseMetricAlertHandler):
         if not open_period:
             raise ValueError("Open period not found")
 
+        alert_rule_serialized_response = None
+        incident_serialized_response = None
         try:
             alert_rule_serialized_response = get_alert_rule_serializer(detector)
             incident_serialized_response = get_detailed_incident_serializer(open_period)

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_discord_metric_alert_handler.py
@@ -1,6 +1,8 @@
 import uuid
 from unittest import mock
 
+from celery.exceptions import SoftTimeLimitExceeded
+
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
@@ -131,3 +133,52 @@ class TestDiscordMetricAlertHandler(MetricAlertHandlerBase):
 
         assert organization == self.detector.project.organization
         assert isinstance(notification_uuid, str)
+
+    @mock.patch("sentry.integrations.discord.actions.metric_alert.send_incident_alert_notification")
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.handlers.discord_metric_alert_handler.logger"
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.handlers.discord_metric_alert_handler.get_alert_rule_serializer",
+        side_effect=SoftTimeLimitExceeded(),
+    )
+    @freeze_time("2021-01-01 00:00:00")
+    def test_send_alert_with_soft_time_limit_exceeded(
+        self, mock_get_alert_rule_serializer, mock_logger, mock_send_incident_alert_notification
+    ):
+        notification_context = NotificationContext.from_action_model(self.action)
+        assert self.group_event.occurrence is not None
+        alert_context = AlertContext.from_workflow_engine_models(
+            self.detector,
+            self.evidence_data,
+            self.group_event.group.status,
+            self.group_event.occurrence.priority,
+        )
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
+        open_period_context = OpenPeriodContext.from_group(self.group)
+        notification_uuid = str(uuid.uuid4())
+
+        self.handler.send_alert(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            trigger_status=TriggerStatus.ACTIVE,
+            project=self.detector.project,
+            organization=self.detector.project.organization,
+            notification_uuid=notification_uuid,
+        )
+
+        # Verify send_incident_alert_notification was still called with None values for serialized responses
+        mock_send_incident_alert_notification.assert_called_once_with(
+            organization=self.detector.project.organization,
+            alert_context=alert_context,
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            alert_rule_serialized_response=None,
+            incident_serialized_response=None,
+            notification_uuid=notification_uuid,
+        )

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_slack_metric_alert_handler.py
@@ -1,6 +1,8 @@
 import uuid
 from unittest import mock
 
+from celery.exceptions import SoftTimeLimitExceeded
+
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, AlertRuleThresholdType
 from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
 from sentry.incidents.typings.metric_detector import (
@@ -134,3 +136,51 @@ class TestSlackMetricAlertHandler(MetricAlertHandlerBase):
 
         assert organization == self.detector.project.organization
         assert isinstance(notification_uuid, str)
+
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.handlers.slack_metric_alert_handler.send_incident_alert_notification"
+    )
+    @mock.patch(
+        "sentry.notifications.notification_action.metric_alert_registry.handlers.slack_metric_alert_handler.get_alert_rule_serializer",
+        side_effect=SoftTimeLimitExceeded(),
+    )
+    @freeze_time("2021-01-01 00:00:00")
+    def test_send_alert_with_soft_time_limit_exceeded(
+        self, mock_get_alert_rule_serializer, mock_send_incident_alert_notification
+    ):
+        notification_context = NotificationContext.from_action_model(self.action)
+        assert self.group_event.occurrence is not None
+        alert_context = AlertContext.from_workflow_engine_models(
+            self.detector,
+            self.evidence_data,
+            self.group_event.group.status,
+            self.group_event.occurrence.priority,
+        )
+        metric_issue_context = MetricIssueContext.from_group_event(
+            self.group, self.evidence_data, self.group_event.occurrence.priority
+        )
+        open_period_context = OpenPeriodContext.from_group(self.group)
+        notification_uuid = str(uuid.uuid4())
+
+        self.handler.send_alert(
+            notification_context=notification_context,
+            alert_context=alert_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            trigger_status=TriggerStatus.ACTIVE,
+            project=self.detector.project,
+            organization=self.detector.project.organization,
+            notification_uuid=notification_uuid,
+        )
+
+        # Verify send_incident_alert_notification was still called with None values for serialized responses
+        mock_send_incident_alert_notification.assert_called_once_with(
+            organization=self.detector.project.organization,
+            alert_context=alert_context,
+            notification_context=notification_context,
+            metric_issue_context=metric_issue_context,
+            open_period_context=open_period_context,
+            alert_rule_serialized_response=None,
+            incident_serialized_response=None,
+            notification_uuid=notification_uuid,
+        )


### PR DESCRIPTION
we have seen the many queries we need to do in the serializers, we sometimes run into `SoftTimeLimitExceeded` (which we are fixing by adding indexes in a separate pr https://github.com/getsentry/sentry/pull/94490)

however - instead of falling over and passing out when there is a `SoftTimeLimitExceeded`, lets make NOA more resilient and send a notification regardless.

by not having the serializer information, in the worst case all you are doing is not creating a chart, which is a good enough trade-off to sending the actual notification