### PR TITLE
fix(workflow_engine): Fix class level mutable state in `DetectorStateManager`

### DIFF
--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -79,12 +79,11 @@ class DetectorStateManager:
         detector: Detector,
         counter_names: list[DetectorCounter] | None = None,
     ):
-        self.counter_names = counter_names or []
         self.detector = detector
+        self.counter_names = counter_names or []
         self.dedupe_updates = {}
         self.counter_updates = {}
         self.state_updates = {}
-        self.counter_names = []
 
     def enqueue_dedupe_update(self, group_key: DetectorGroupKey, dedupe_value: int):
         self.dedupe_updates[group_key] = dedupe_value

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -68,10 +68,10 @@ class DetectorStateData:
 
 # TODO - we might want to extract this into another file to reduce noise in this file.
 class DetectorStateManager:
-    dedupe_updates: dict[DetectorGroupKey, int] = {}
-    counter_updates: dict[DetectorGroupKey, DetectorCounters] = {}
-    state_updates: dict[DetectorGroupKey, tuple[bool, DetectorPriorityLevel]] = {}
-    counter_names: list[DetectorCounter] = []
+    dedupe_updates: dict[DetectorGroupKey, int]
+    counter_updates: dict[DetectorGroupKey, DetectorCounters]
+    state_updates: dict[DetectorGroupKey, tuple[bool, DetectorPriorityLevel]]
+    counter_names: list[DetectorCounter]
     detector: Detector
 
     def __init__(
@@ -81,6 +81,10 @@ class DetectorStateManager:
     ):
         self.counter_names = counter_names or []
         self.detector = detector
+        self.dedupe_updates = {}
+        self.counter_updates = {}
+        self.state_updates = {}
+        self.counter_names = []
 
     def enqueue_dedupe_update(self, group_key: DetectorGroupKey, dedupe_value: int):
         self.dedupe_updates[group_key] = dedupe_value


### PR DESCRIPTION
`DetectorStateManager` declares a bunch of mutable values at the class level. This means that these are all shared between all instances of the class in a given process. This is likely causing all kinds of data leakage and crossover.
