### PR TITLE
Use external_type for grouping strategy names

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -75,7 +75,7 @@ def strategy(
         in the event, only exception will be used for hash
     """
 
-    name = interface.path
+    name = interface.external_type
 
     if not ids:
         raise TypeError("no ids given")

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -79,6 +79,7 @@ class Interface:
     def external_type(cls):
         """The external name of the interface.  This is mostly the same as
         path with some small differences (message, debugmeta).
+        Also used as the display name for grouping strategy hints.
         """
         return cls.path
 

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-26T00:33:37.643566+00:00'
+created: '2025-06-27T19:26:06.169641+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (logentry takes precedence)
+    app (message takes precedence)
       threads
         stacktrace
           frame
@@ -32,7 +32,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (logentry takes precedence)
+    system (message takes precedence)
       threads
         stacktrace
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-04-29T22:29:14.124783+00:00'
+created: '2025-06-27T19:26:06.340999+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (logentry takes precedence)
+    app (message takes precedence)
       threads
         stacktrace
           frame (marked in-app by stack trace rule (family:native package:**/Containers/Bundle/Application/** +app))
@@ -68,7 +68,7 @@ system:
   hash: null
   contributing component: null
   component:
-    system (logentry takes precedence)
+    system (message takes precedence)
       threads
         stacktrace
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-02-19T15:24:59.578125+00:00'
+created: '2025-06-27T19:26:10.991077+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   contributing component: null
   component:
-    app (logentry takes precedence)
+    app (message takes precedence)
       threads (ignored because contains 63 threads)
 --------------------------------------------------------------------------
 default:
@@ -22,5 +22,5 @@ system:
   hash: null
   contributing component: null
   component:
-    system (logentry takes precedence)
+    system (message takes precedence)
       threads (ignored because contains 63 threads)


### PR DESCRIPTION
<!-- Describe your PR here. -->
[Ticket](https://linear.app/getsentry/issue/ID-246/grouping-info-name-things-in-more-recognizable-ways)

Modify `strategy` to prefer `interface.external_type` over `interface.path` for strategy names, allowing interfaces to customize their display names in grouping hints without affecting their core path identifier.

Only two Interfaces have an `external_type`: `logentry` and `debug_meta`.
Since `debug_meta` is not part of hints, this will change just one interface hint:
`logentry` will be referred to as `message`