### PR TITLE
fix(aci): Add taskworker.workflow_engine.rollout option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3279,6 +3279,11 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "taskworker.workflow_engine.rollout",
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "taskworker.alerts.rollout",
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,


### PR DESCRIPTION
It seems these were added for existing namespaces, and we needed to know to add it when we created a new one.
