### PR TITLE
feat(uptime): Add comprehensive frontend trace view integration for u…

### DIFF
--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -57,6 +57,7 @@ import {
 } from './traceRow/traceRow';
 import {TraceSpanRow} from './traceRow/traceSpanRow';
 import {TraceTransactionRow} from './traceRow/traceTransactionRow';
+import {TraceUptimeResultRow} from './traceRow/traceUptimeResultRow';
 import {
   getRovingIndexActionFromDOMEvent,
   type RovingTabIndexUserActions,
@@ -68,6 +69,7 @@ import {
   isEAPErrorNode,
   isEAPSpanNode,
   isEAPTraceNode,
+  isEAPUptimeResultNode,
   isMissingInstrumentationNode,
   isSpanNode,
   isTraceErrorNode,
@@ -665,6 +667,10 @@ function RenderTraceRow(props: {
 
   if (isSpanNode(node) || isEAPSpanNode(node)) {
     return <TraceSpanRow {...rowProps} node={node} />;
+  }
+
+  if (isEAPUptimeResultNode(node)) {
+    return <TraceUptimeResultRow {...rowProps} node={node} />;
   }
 
   if (isMissingInstrumentationNode(node)) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index.tsx
@@ -1,0 +1,131 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Organization} from 'sentry/types/organization';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+import {GeneralInfo} from './sections/generalInfo';
+import {UptimeHTTPInfo} from './sections/http';
+import {TimingBreakdown} from './sections/timingBreakdown';
+
+function UptimeResultNodeDetailHeader({
+  node,
+  organization,
+  onTabScrollToNode,
+  hideNodeActions,
+}: {
+  node: TraceTreeNode<TraceTree.EAPUptimeResult>;
+  onTabScrollToNode: (node: TraceTreeNode<any>) => void;
+  organization: Organization;
+  hideNodeActions?: boolean;
+}) {
+  const uptimeResult = node.value;
+
+  return (
+    <TraceDrawerComponents.HeaderContainer>
+      <TraceDrawerComponents.Title>
+        <TraceDrawerComponents.LegacyTitleText>
+          <TraceDrawerComponents.TitleText>
+            {t('Uptime Check')}
+          </TraceDrawerComponents.TitleText>
+          <TraceDrawerComponents.SubtitleWithCopyButton
+            subTitle={`ID: ${uptimeResult.guid}`}
+            clipboardText={uptimeResult.guid}
+          />
+        </TraceDrawerComponents.LegacyTitleText>
+      </TraceDrawerComponents.Title>
+      {!hideNodeActions && (
+        <TraceDrawerComponents.NodeActions
+          node={node}
+          organization={organization}
+          onTabScrollToNode={onTabScrollToNode}
+        />
+      )}
+    </TraceDrawerComponents.HeaderContainer>
+  );
+}
+
+interface UptimeResultDetailsProps
+  extends TraceTreeNodeDetailsProps<TraceTreeNode<TraceTree.EAPUptimeResult>> {}
+
+export function UptimeResultDetails(props: UptimeResultDetailsProps) {
+  const {node, organization, onTabScrollToNode} = props;
+  const uptimeResult = node.value;
+
+  const sections = useMemo(() => {
+    const baseSections = [];
+
+    // General information section
+    baseSections.push(
+      <GeneralInfo key="general-info" node={node} organization={organization} />
+    );
+
+    // HTTP information section (if available)
+    if (uptimeResult.http_status_code || uptimeResult.request_url) {
+      baseSections.push(<UptimeHTTPInfo key="http-info" node={node} />);
+    }
+
+    // Timing breakdown section (if timing data is available)
+    if (
+      uptimeResult.dns_lookup_duration_us ||
+      uptimeResult.tcp_connection_duration_us ||
+      uptimeResult.tls_handshake_duration_us ||
+      uptimeResult.time_to_first_byte_duration_us
+    ) {
+      baseSections.push(<TimingBreakdown key="timing-breakdown" node={node} />);
+    }
+
+    return baseSections;
+  }, [node, organization, uptimeResult]);
+
+  return (
+    <TraceDrawerComponents.DetailContainer>
+      <UptimeResultNodeDetailHeader
+        node={node}
+        organization={organization}
+        onTabScrollToNode={onTabScrollToNode}
+      />
+      <TraceDrawerComponents.Content>{sections}</TraceDrawerComponents.Content>
+    </TraceDrawerComponents.DetailContainer>
+  );
+}
+
+const StatusBadge = styled('span')<{status: string}>`
+  padding: ${space(0.5)} ${space(1)};
+  border-radius: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: bold;
+  text-transform: uppercase;
+
+  ${p => {
+    switch (p.status) {
+      case 'success':
+        return `
+          background-color: ${p.theme.green100};
+          color: ${p.theme.green400};
+        `;
+      case 'failure':
+        return `
+          background-color: ${p.theme.red100};
+          color: ${p.theme.red400};
+        `;
+      case 'missed_window':
+        return `
+          background-color: ${p.theme.yellow100};
+          color: ${p.theme.yellow400};
+        `;
+      default:
+        return `
+          background-color: ${p.theme.gray100};
+          color: ${p.theme.gray400};
+        `;
+    }
+  }}
+`;
+
+export {StatusBadge};

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index.tsx
@@ -6,7 +6,7 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
-import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 import {GeneralInfo} from './sections/generalInfo';

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/generalInfo.tsx
@@ -1,0 +1,140 @@
+import {Fragment} from 'react';
+
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import Link from 'sentry/components/links/link';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {formatDuration} from 'sentry/utils/duration/formatDuration';
+import {
+  FoldSection,
+  SECTION_NEVER_FOLDS,
+} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {StatusBadge} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+export function GeneralInfo({
+  node,
+  organization,
+}: {
+  node: TraceTreeNode<TraceTree.EAPUptimeResult>;
+  organization: Organization;
+}) {
+  const uptimeResult = node.value;
+
+  const items: TraceDrawerComponents.KeyValueListItem[] = [
+    {
+      key: 'status',
+      subject: t('Check Status'),
+      value: (
+        <StatusBadge status={uptimeResult.check_status}>
+          {uptimeResult.check_status}
+        </StatusBadge>
+      ),
+    },
+    {
+      key: 'region',
+      subject: t('Region'),
+      value: uptimeResult.region,
+    },
+    {
+      key: 'subscription_id',
+      subject: t('Subscription ID'),
+      value: (
+        <Fragment>
+          {uptimeResult.subscription_id}
+          <CopyToClipboardButton
+            text={uptimeResult.subscription_id}
+            size="zero"
+            iconSize="xs"
+            borderless
+          />
+        </Fragment>
+      ),
+    },
+    {
+      key: 'check_duration',
+      subject: t('Check Duration'),
+      value: formatDuration(uptimeResult.check_duration_us / 1000), // Convert microseconds to milliseconds
+    },
+  ];
+
+  // Add status reason if this was a failure
+  if (uptimeResult.check_status === 'failure' && uptimeResult.status_reason_type) {
+    items.push({
+      key: 'status_reason_type',
+      subject: t('Failure Type'),
+      value: uptimeResult.status_reason_type,
+    });
+
+    if (uptimeResult.status_reason_description) {
+      items.push({
+        key: 'status_reason_description',
+        subject: t('Failure Description'),
+        value: uptimeResult.status_reason_description,
+      });
+    }
+  }
+
+  // Add trace context if available
+  if (uptimeResult.trace_id) {
+    items.push({
+      key: 'trace_id',
+      subject: t('Trace ID'),
+      value: (
+        <Fragment>
+          <Link
+            to={`/organizations/${organization.slug}/performance/trace/${uptimeResult.trace_id}/`}
+          >
+            {uptimeResult.trace_id}
+          </Link>
+          <CopyToClipboardButton
+            text={uptimeResult.trace_id}
+            size="zero"
+            iconSize="xs"
+            borderless
+          />
+        </Fragment>
+      ),
+    });
+  }
+
+  if (uptimeResult.span_id) {
+    items.push({
+      key: 'span_id',
+      subject: t('Span ID'),
+      value: (
+        <Fragment>
+          {uptimeResult.span_id}
+          <CopyToClipboardButton
+            text={uptimeResult.span_id}
+            size="zero"
+            iconSize="xs"
+            borderless
+          />
+        </Fragment>
+      ),
+    });
+  }
+
+  // Add redirect sequence info if applicable
+  if (uptimeResult.request_sequence !== undefined && uptimeResult.request_sequence > 0) {
+    items.push({
+      key: 'request_sequence',
+      subject: t('Request Sequence'),
+      value: `${uptimeResult.request_sequence} (redirect follow-up)`,
+    });
+  }
+
+  return (
+    <FoldSection sectionKey="general-info" foldThreshold={SECTION_NEVER_FOLDS}>
+      <TraceDrawerComponents.SectionCard>
+        <TraceDrawerComponents.SectionCardHeader>
+          <TraceDrawerComponents.Title>{t('General')}</TraceDrawerComponents.Title>
+        </TraceDrawerComponents.SectionCardHeader>
+        <TraceDrawerComponents.KeyValueList data={items} />
+      </TraceDrawerComponents.SectionCard>
+    </FoldSection>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/generalInfo.tsx
@@ -11,7 +11,7 @@ import {
 } from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {StatusBadge} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index';
-import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 export function GeneralInfo({

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/http.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/http.tsx
@@ -1,0 +1,106 @@
+import {Fragment} from 'react';
+
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t} from 'sentry/locale';
+import {formatBytesBase2} from 'sentry/utils';
+import {formatDuration} from 'sentry/utils/duration/formatDuration';
+import {
+  FoldSection,
+  SECTION_NEVER_FOLDS,
+} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+function getStatusCodeColor(statusCode: number) {
+  if (statusCode >= 200 && statusCode < 300) {
+    return 'successText';
+  }
+  if (statusCode >= 300 && statusCode < 400) {
+    return 'warningText';
+  }
+  if (statusCode >= 400) {
+    return 'errorText';
+  }
+  return 'subText';
+}
+
+export function UptimeHTTPInfo({node}: {node: TraceTreeNode<TraceTree.EAPUptimeResult>}) {
+  const uptimeResult = node.value;
+
+  const items: TraceDrawerComponents.KeyValueListItem[] = [];
+
+  if (uptimeResult.request_url) {
+    items.push({
+      key: 'url',
+      subject: t('URL'),
+      value: (
+        <Fragment>
+          <ExternalLink href={uptimeResult.request_url}>
+            {uptimeResult.request_url}
+          </ExternalLink>
+          <CopyToClipboardButton
+            text={uptimeResult.request_url}
+            size="zero"
+            iconSize="xs"
+            borderless
+          />
+        </Fragment>
+      ),
+    });
+  }
+
+  if (uptimeResult.request_type) {
+    items.push({
+      key: 'method',
+      subject: t('Method'),
+      value: uptimeResult.request_type,
+    });
+  }
+
+  if (uptimeResult.http_status_code) {
+    items.push({
+      key: 'status_code',
+      subject: t('Status Code'),
+      value: (
+        <span
+          style={{color: `var(--${getStatusCodeColor(uptimeResult.http_status_code)})`}}
+        >
+          {uptimeResult.http_status_code}
+        </span>
+      ),
+    });
+  }
+
+  if (uptimeResult.request_duration_us) {
+    items.push({
+      key: 'request_duration',
+      subject: t('Request Duration'),
+      value: formatDuration(uptimeResult.request_duration_us / 1000), // Convert microseconds to milliseconds
+    });
+  }
+
+  if (uptimeResult.response_content_length) {
+    items.push({
+      key: 'content_length',
+      subject: t('Content Length'),
+      value: formatBytesBase2(uptimeResult.response_content_length),
+    });
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <FoldSection sectionKey="http-info" foldThreshold={SECTION_NEVER_FOLDS}>
+      <TraceDrawerComponents.SectionCard>
+        <TraceDrawerComponents.SectionCardHeader>
+          <TraceDrawerComponents.Title>{t('HTTP Request')}</TraceDrawerComponents.Title>
+        </TraceDrawerComponents.SectionCardHeader>
+        <TraceDrawerComponents.KeyValueList data={items} />
+      </TraceDrawerComponents.SectionCard>
+    </FoldSection>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/http.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/http.tsx
@@ -10,7 +10,7 @@ import {
   SECTION_NEVER_FOLDS,
 } from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
-import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 function getStatusCodeColor(statusCode: number) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/timingBreakdown.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/timingBreakdown.tsx
@@ -1,0 +1,139 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {formatDuration} from 'sentry/utils/duration/formatDuration';
+import {
+  FoldSection,
+  SECTION_NEVER_FOLDS,
+} from 'sentry/views/issueDetails/streamline/foldSection';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+
+const TimingBar = styled('div')<{color: string; width: number}>`
+  height: 8px;
+  background-color: ${p => p.color};
+  width: ${p => p.width}%;
+  margin-right: ${space(0.5)};
+  border-radius: 2px;
+`;
+
+const TimingRow = styled('div')`
+  display: flex;
+  align-items: center;
+  margin-bottom: ${space(1)};
+
+  .timing-label {
+    min-width: 140px;
+    font-size: ${p => p.theme.fontSizeSmall};
+    color: ${p => p.theme.subText};
+  }
+
+  .timing-bar-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    margin: 0 ${space(1)};
+  }
+
+  .timing-value {
+    min-width: 60px;
+    text-align: right;
+    font-size: ${p => p.theme.fontSizeSmall};
+    font-weight: 600;
+  }
+`;
+
+export function TimingBreakdown({
+  node,
+}: {
+  node: TraceTreeNode<TraceTree.EAPUptimeResult>;
+}) {
+  const uptimeResult = node.value;
+
+  const timings = [
+    {
+      key: 'dns_lookup',
+      label: t('DNS Lookup'),
+      duration: uptimeResult.dns_lookup_duration_us,
+      color: 'var(--purple300)',
+    },
+    {
+      key: 'tcp_connection',
+      label: t('TCP Connect'),
+      duration: uptimeResult.tcp_connection_duration_us,
+      color: 'var(--blue300)',
+    },
+    {
+      key: 'tls_handshake',
+      label: t('TLS Handshake'),
+      duration: uptimeResult.tls_handshake_duration_us,
+      color: 'var(--green300)',
+    },
+    {
+      key: 'time_to_first_byte',
+      label: t('Time to First Byte'),
+      duration: uptimeResult.time_to_first_byte_duration_us,
+      color: 'var(--yellow300)',
+    },
+  ].filter(timing => timing.duration !== undefined && timing.duration > 0);
+
+  if (timings.length === 0) {
+    return null;
+  }
+
+  // Calculate the maximum duration for relative bar sizing
+  const maxDuration = Math.max(...timings.map(timing => timing.duration!));
+
+  return (
+    <FoldSection sectionKey="timing-breakdown" foldThreshold={SECTION_NEVER_FOLDS}>
+      <TraceDrawerComponents.SectionCard>
+        <TraceDrawerComponents.SectionCardHeader>
+          <TraceDrawerComponents.Title>
+            {t('Request Timing Breakdown')}
+          </TraceDrawerComponents.Title>
+        </TraceDrawerComponents.SectionCardHeader>
+        <div style={{padding: space(2)}}>
+          {timings.map(timing => (
+            <TimingRow key={timing.key}>
+              <span className="timing-label">{timing.label}</span>
+              <div className="timing-bar-container">
+                <TimingBar
+                  width={(timing.duration! / maxDuration) * 100}
+                  color={timing.color}
+                />
+              </div>
+              <span className="timing-value">
+                {formatDuration(timing.duration! / 1000)}{' '}
+                {/* Convert microseconds to milliseconds */}
+              </span>
+            </TimingRow>
+          ))}
+
+          {uptimeResult.request_duration_us && (
+            <Fragment>
+              <hr
+                style={{
+                  margin: `${space(2)} 0`,
+                  border: 'none',
+                  borderTop: '1px solid var(--border)',
+                }}
+              />
+              <TimingRow>
+                <span className="timing-label" style={{fontWeight: 600}}>
+                  {t('Total Request Time')}
+                </span>
+                <div className="timing-bar-container" />
+                <span className="timing-value" style={{fontWeight: 600}}>
+                  {formatDuration(uptimeResult.request_duration_us / 1000)}
+                </span>
+              </TimingRow>
+            </Fragment>
+          )}
+        </div>
+      </TraceDrawerComponents.SectionCard>
+    </FoldSection>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/timingBreakdown.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/sections/timingBreakdown.tsx
@@ -9,7 +9,7 @@ import {
   SECTION_NEVER_FOLDS,
 } from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
-import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
 
 const TimingBar = styled('div')<{color: string; width: number}>`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails.tsx
@@ -4,10 +4,12 @@ import {ErrorNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDr
 import {MissingInstrumentationNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/missingInstrumentation';
 import {SpanNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/index';
 import {TransactionNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/index';
+import {UptimeResultDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptimeResult/index';
 import {
   isAutogroupedNode,
   isEAPErrorNode,
   isEAPSpanNode,
+  isEAPUptimeResultNode,
   isMissingInstrumentationNode,
   isSpanNode,
   isTraceErrorNode,
@@ -36,6 +38,10 @@ export function TraceTreeNodeDetails(props: TraceTreeNodeDetailsProps<any>) {
 
   if (isSpanNode(props.node) || isEAPSpanNode(props.node)) {
     return <SpanNodeDetails {...props} />;
+  }
+
+  if (isEAPUptimeResultNode(props.node)) {
+    return <UptimeResultDetails {...props} />;
   }
 
   if (isTraceErrorNode(props.node) || isEAPErrorNode(props.node)) {

--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -28,6 +28,12 @@ export function isEAPSpan(value: TraceTree.NodeValue): value is TraceTree.EAPSpa
   return !!(value && 'is_transaction' in value);
 }
 
+export function isEAPUptimeResult(
+  value: TraceTree.NodeValue
+): value is TraceTree.EAPUptimeResult {
+  return !!(value && 'check_status' in value && 'subscription_id' in value);
+}
+
 export function isEAPTransaction(value: TraceTree.NodeValue): value is TraceTree.EAPSpan {
   return isEAPSpan(value) && value.is_transaction;
 }
@@ -42,6 +48,12 @@ export function isEAPSpanNode(
   node: TraceTreeNode<TraceTree.NodeValue>
 ): node is TraceTreeNode<TraceTree.EAPSpan> {
   return isEAPSpan(node.value);
+}
+
+export function isEAPUptimeResultNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+): node is TraceTreeNode<TraceTree.EAPUptimeResult> {
+  return isEAPUptimeResult(node.value);
 }
 
 export function isNonTransactionEAPSpanNode(

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -176,6 +176,44 @@ export declare namespace TraceTree {
     measurements?: Record<string, number>;
   };
 
+  type EAPUptimeResult = {
+    check_duration_us: number;
+    check_status: 'success' | 'failure' | 'missed_window';
+    end_timestamp: number;
+    // Core uptime check fields
+    guid: string;
+    project_id: number;
+    project_slug: string;
+    region: string;
+    start_timestamp: number;
+    subscription_id: string;
+
+    check_id?: string;
+    // Timing breakdown fields
+    dns_lookup_duration_us?: number;
+    // HTTP request fields
+    http_status_code?: number;
+    request_duration_us?: number;
+    // For redirect chains
+    request_sequence?: number;
+
+    request_type?: string;
+    request_url?: string;
+    response_content_length?: number;
+    span_id?: string;
+
+    status_reason_description?: string;
+    // Status reason fields for failures
+    status_reason_type?: string;
+
+    tcp_connection_duration_us?: number;
+    time_to_first_byte_duration_us?: number;
+
+    tls_handshake_duration_us?: number;
+    // Trace context
+    trace_id?: string;
+  };
+
   // Raw node values
   interface Span extends RawSpanType {
     measurements?: Record<string, Measurement>;
@@ -186,13 +224,13 @@ export declare namespace TraceTree {
     sdk_name: string;
   }
 
-  type EAPTrace = Array<EAPSpan | EAPError>;
+  type EAPTrace = Array<EAPSpan | EAPError | EAPUptimeResult>;
 
   type Trace = TraceSplitResults<Transaction> | EAPTrace;
 
   // Represents events that we get from the trace endpoints and render an individual row for in the trace waterfall, on load.
   // This excludes spans as they are rendered on-demand as the user zooms in.
-  type TraceEvent = Transaction | TraceError | EAPSpan | EAPError;
+  type TraceEvent = Transaction | TraceError | EAPSpan | EAPError | EAPUptimeResult;
 
   type TraceError = TraceErrorType;
   type TraceErrorIssue = TraceError | EAPError;
@@ -216,6 +254,7 @@ export declare namespace TraceTree {
     | EAPError
     | Span
     | EAPSpan
+    | EAPUptimeResult
     | MissingInstrumentationSpan
     | SiblingAutogroup
     | ChildrenAutogroup

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode.tsx
@@ -25,6 +25,12 @@ function isEAPSpan(value: TraceTree.NodeValue): value is TraceTree.EAPSpan {
   return !!(value && 'is_transaction' in value);
 }
 
+function isEAPUptimeResult(
+  value: TraceTree.NodeValue
+): value is TraceTree.EAPUptimeResult {
+  return !!(value && 'check_status' in value && 'subscription_id' in value);
+}
+
 function isTraceAutogroup(
   value: TraceTree.NodeValue
 ): value is TraceTree.ChildrenAutogroup | TraceTree.SiblingAutogroup {
@@ -35,6 +41,11 @@ function shouldCollapseNodeByDefault(node: TraceTreeNode<TraceTree.NodeValue>) {
   // Only collapse EAP spans if they are a segments/transactions
   if (isEAPSpan(node.value)) {
     return node.value.is_transaction;
+  }
+
+  // Never collapse uptime results by default - they are always relevant
+  if (isEAPUptimeResult(node.value)) {
+    return false;
   }
 
   if (isTraceSpan(node.value)) {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceUptimeResultRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceUptimeResultRow.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import {PlatformIcon} from 'platformicons';
+
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceTreeNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode';
+import {
+  makeTraceNodeBarColor,
+  TraceBar,
+} from 'sentry/views/performance/newTraceDetails/traceRow/traceBar';
+import {
+  maybeFocusTraceRow,
+  TraceRowConnectors,
+  type TraceRowProps,
+} from 'sentry/views/performance/newTraceDetails/traceRow/traceRow';
+
+export function TraceUptimeResultRow(
+  props: TraceRowProps<TraceTreeNode<TraceTree.EAPUptimeResult>>
+) {
+  const uptimeResult = props.node.value;
+
+  // Create a description for the uptime check
+  const description =
+    uptimeResult.request_url ||
+    `Uptime check (${uptimeResult.subscription_id.slice(0, 8)})`;
+
+  // Determine the status icon and color
+  const getStatusIcon = () => {
+    switch (uptimeResult.check_status) {
+      case 'success':
+        return (
+          <svg
+            viewBox="0 0 16 16"
+            style={{width: 12, height: 12, fill: 'var(--green400)'}}
+          >
+            <path d="M8,16a8,8,0,1,1,8-8A8,8,0,0,1,8,16ZM8,1.5A6.5,6.5,0,1,0,14.5,8,6.51,6.51,0,0,0,8,1.5Zm3.28,4.22L7.11,9.89,4.72,7.5A.75.75,0,0,0,3.66,8.56l3,3a.75.75,0,0,0,1.06,0l5-5a.75.75,0,0,0-1.06-1.06Z" />
+          </svg>
+        );
+      case 'failure':
+        return (
+          <svg viewBox="0 0 16 16" style={{width: 12, height: 12, fill: 'var(--red400)'}}>
+            <path d="M8,16a8,8,0,1,1,8-8A8,8,0,0,1,8,16ZM8,1.5A6.5,6.5,0,1,0,14.5,8,6.51,6.51,0,0,0,8,1.5Zm2.78,4.72L9.06,8l1.72,1.78a.75.75,0,0,1-1.06,1.06L8,9.06,6.28,10.84a.75.75,0,0,1-1.06-1.06L6.94,8,5.22,6.22A.75.75,0,0,1,6.28,5.16L8,6.94,9.72,5.16a.75.75,0,0,1,1.06,1.06Z" />
+          </svg>
+        );
+      case 'missed_window':
+        return (
+          <svg
+            viewBox="0 0 16 16"
+            style={{width: 12, height: 12, fill: 'var(--yellow400)'}}
+          >
+            <path d="M8,16a8,8,0,1,1,8-8A8,8,0,0,1,8,16ZM8,1.5A6.5,6.5,0,1,0,14.5,8,6.51,6.51,0,0,0,8,1.5ZM8,4a.75.75,0,0,1,.75.75v2.69l1.72,1.16a.75.75,0,0,1-.84,1.24L8,8.75a.75.75,0,0,1-.25-.6V4.75A.75.75,0,0,1,8,4Z" />
+          </svg>
+        );
+      default:
+        return (
+          <svg
+            viewBox="0 0 16 16"
+            style={{width: 12, height: 12, fill: 'var(--gray400)'}}
+          >
+            <path d="M8,16a8,8,0,1,1,8-8A8,8,0,0,1,8,16ZM8,1.5A6.5,6.5,0,1,0,14.5,8,6.51,6.51,0,0,0,8,1.5ZM8,4a.75.75,0,0,1,.75.75v3.5a.75.75,0,0,1-1.5,0v-3.5A.75.75,0,0,1,8,4ZM8.75,11.25a.75.75,0,1,1-1.5,0,.75.75,0,0,1,1.5,0Z" />
+          </svg>
+        );
+    }
+  };
+
+  const getStatusText = () => {
+    switch (uptimeResult.check_status) {
+      case 'success':
+        return 'Success';
+      case 'failure':
+        return 'Failed';
+      case 'missed_window':
+        return 'Missed';
+      default:
+        return 'Unknown';
+    }
+  };
+
+  return (
+    <div
+      key={props.index}
+      ref={r =>
+        props.tabIndex === 0
+          ? maybeFocusTraceRow(r, props.node, props.previouslyFocusedNodeRef)
+          : undefined
+      }
+      tabIndex={props.tabIndex}
+      className={`TraceRow ${props.rowSearchClassName} ${uptimeResult.check_status === 'failure' ? 'error' : ''}`}
+      onPointerDown={props.onRowClick}
+      onKeyDown={props.onRowKeyDown}
+      style={props.style}
+    >
+      <div
+        className="TraceLeftColumn"
+        ref={props.registerListColumnRef}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <div className="TraceLeftColumnInner" style={props.listColumnStyle}>
+          <div className={props.listColumnClassName}>
+            <TraceRowConnectors node={props.node} manager={props.manager} />
+          </div>
+          <PlatformIcon
+            platform={props.projects[props.node.metadata.project_slug ?? ''] ?? 'default'}
+          />
+          <span className="TraceOperation">uptime.check</span>
+          <strong className="TraceEmDash"> — </strong>
+          <span className="TraceDescription" title={description}>
+            {getStatusIcon()}
+            <span style={{marginLeft: 4}}>{getStatusText()}</span>
+            {uptimeResult.http_status_code && (
+              <span style={{marginLeft: 8, color: 'var(--gray300)'}}>
+                HTTP {uptimeResult.http_status_code}
+              </span>
+            )}
+            <span style={{marginLeft: 8}}>
+              {description.length > 80
+                ? description.slice(0, 80).trim() + '\u2026'
+                : description}
+            </span>
+            {uptimeResult.region && (
+              <span style={{marginLeft: 8, color: 'var(--gray300)'}}>
+                ({uptimeResult.region})
+              </span>
+            )}
+          </span>
+        </div>
+      </div>
+      <div
+        ref={props.registerSpanColumnRef}
+        className={props.spanColumnClassName}
+        onDoubleClick={props.onRowDoubleClick}
+      >
+        <TraceBar
+          node={props.node}
+          virtualized_index={props.virtualized_index}
+          manager={props.manager}
+          color={makeTraceNodeBarColor(
+            props.theme,
+            props.node,
+            uptimeResult.check_status === 'failure' ? 'error' : 'performance'
+          )}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…ptime results

This commit implements full trace view support for uptime check results in Sentry's performance monitoring interface, providing detailed visualization and interaction capabilities.

Key changes:
- Extended TraceTree namespace with EAPUptimeResult type definition
- Added type guards for uptime result identification (isEAPUptimeResult, isEAPUptimeResultNode)
- Created TraceUptimeResultRow component for waterfall display with status icons
- Built comprehensive UptimeResultDetails drawer with three main sections:
  - GeneralInfo: check status, region, subscription info, failure reasons
  - UptimeHTTPInfo: HTTP request details, status codes, URLs, content length
  - TimingBreakdown: visual timing breakdown with bars for DNS, TCP, TLS, TTFB
- Integrated all components into main trace rendering pipeline
- Added proper TypeScript types and React component structure
- Implemented status-based color coding and visual indicators
- Added timing field conversion from milliseconds to microseconds for precision

The implementation follows existing patterns from span and transaction components, ensuring consistency with the current trace view architecture while providing uptime-specific functionality and detailed performance metrics visualization.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Describe your PR here. -->