### PR TITLE
feat(issue): convert external issue tracking to dropdown

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/types.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/types.tsx
@@ -46,7 +46,7 @@ export interface ExternalIssueAction {
  * Integrations, apps, or plugins that can create external issues.
  * Each integration can have one or more configurations.
  */
-interface ExternalIssueIntegration extends BaseIssueAction {
+export interface ExternalIssueIntegration extends BaseIssueAction {
   actions: ExternalIssueAction[];
 }
 

--- a/static/app/components/group/externalIssuesList/hooks/usePluginExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/usePluginExternalIssues.tsx
@@ -1,4 +1,5 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
 import {openPluginActionModal} from 'sentry/components/group/pluginActions';
 import {t} from 'sentry/locale';
 import plugins from 'sentry/plugins';
@@ -129,7 +130,7 @@ export function usePluginExternalIssues({
           name: action,
           href: action,
           onClick: () => {
-            // Do nothing
+            openNavigateToExternalLinkModal({linkText: action});
           },
         },
       ],

--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -30,7 +30,11 @@ function getActionLabelAndTextValue({
 }: {
   action: ExternalIssueAction;
   integrationDisplayName: string;
-}): {label: string | React.JSX.Element; textValue: string} {
+}): {
+  label: string | React.JSX.Element;
+  textValue: string;
+  details?: string | React.JSX.Element;
+} {
   // If there's no subtext or subtext matches name, just show name
   if (!action.nameSubText || action.nameSubText === action.name) {
     return {
@@ -49,12 +53,8 @@ function getActionLabelAndTextValue({
 
   // Otherwise show both name and subtext
   return {
-    label: (
-      <div>
-        <strong>{action.name}</strong>
-        <div>{action.nameSubText}</div>
-      </div>
-    ),
+    label: action.name,
+    details: action.nameSubText,
     textValue: `${action.name} ${action.nameSubText}`,
   };
 }
@@ -197,7 +197,6 @@ function ExternalIssueSubmenu(props: {integration: ExternalIssueIntegration}) {
         action,
         integrationDisplayName: integration.displayName,
       }),
-      label: <div onClick={() => action.onClick()}>{action.name}</div>,
     };
     return <MenuListItem key={action.id} {...itemProps} />;
   });

--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -189,6 +189,7 @@ function ExternalIssueMenu(props: ReturnType<typeof useGroupExternalIssues>) {
 }
 
 function ExternalIssueSubmenu(props: {integration: ExternalIssueIntegration}) {
+  const organization = useOrganization({allowNull: false});
   const {integration} = props;
   const {overlayState} = useContext(SelectContext);
   return integration.actions.map(action => {
@@ -203,6 +204,10 @@ function ExternalIssueSubmenu(props: {integration: ExternalIssueIntegration}) {
     const callbackProps: Record<string, () => void> = {
       onPointerDown: () => {
         overlayState?.close();
+        trackAnalytics('feedback.details-integration-issue-clicked', {
+          organization,
+          integration_key: integration.key,
+        });
         action.onClick();
       },
     };

--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -155,11 +155,11 @@ function ExternalIssueMenu(props: ReturnType<typeof useGroupExternalIssues>) {
             }
             if (integration.actions.length === 1) {
               const action = integration.actions[0]!;
-              action.onClick();
               trackAnalytics('feedback.details-integration-issue-clicked', {
                 organization,
                 integration_key: integration.key,
               });
+              action.onClick();
               return;
             }
           }}

--- a/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
+++ b/static/app/components/group/externalIssuesList/streamlinedExternalIssueList.tsx
@@ -81,7 +81,7 @@ export function StreamlinedExternalIssueList({
   }
 
   return (
-    <Fragment>
+    <Flex direction="row" wrap="wrap" gap={space(1)} flex={1}>
       {linkedIssues.length > 0 && (
         <IssueActionWrapper>
           {linkedIssues.map(linkedIssue => (
@@ -104,21 +104,21 @@ export function StreamlinedExternalIssueList({
                 }
                 isHoverable
               >
-                <LinkedIssue
+                <LinkButton
                   href={linkedIssue.url}
                   external
                   size="zero"
                   icon={linkedIssue.displayIcon}
                 >
                   <IssueActionName>{linkedIssue.displayName}</IssueActionName>
-                </LinkedIssue>
+                </LinkButton>
               </Tooltip>
             </ErrorBoundary>
           ))}
         </IssueActionWrapper>
       )}
       <ExternalIssueMenu linkedIssues={linkedIssues} integrations={integrations} />
-    </Fragment>
+    </Flex>
   );
 }
 
@@ -250,15 +250,6 @@ const IssueActionWrapper = styled('div')`
   flex-wrap: wrap;
   gap: ${space(1)};
   line-height: 1.2;
-`;
-
-const LinkedIssue = styled(LinkButton)`
-  display: flex;
-  align-items: center;
-  padding: ${space(0.5)} ${space(0.75)};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  font-weight: normal;
 `;
 
 const IssueActionName = styled('div')`

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
@@ -119,7 +119,7 @@ describe('GroupDetailsLayout', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Close sidebar'}));
     expect(await screen.findByTestId('children')).toBeInTheDocument();
     expect(
-      await screen.findByRole('button', {name: 'Add Linked Issue'})
+      screen.queryByRole('button', {name: 'Add Linked Issue'})
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
@@ -113,13 +113,13 @@ describe('GroupDetailsLayout', () => {
 
     expect(await screen.findByTestId('children')).toBeInTheDocument();
     expect(
-      await screen.findByText('Track this issue in Jira, GitHub, etc.')
+      await screen.findByRole('button', {name: 'Add Linked Issue'})
     ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', {name: 'Close sidebar'}));
     expect(await screen.findByTestId('children')).toBeInTheDocument();
     expect(
-      screen.queryByText('Track this issue in Jira, GitHub, etc.')
+      await screen.findByRole('button', {name: 'Add Linked Issue'})
     ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
@@ -160,15 +160,20 @@ describe('ExternalIssueSidebarList', () => {
 
     render(<ExternalIssueSidebarList event={event} group={group} project={project} />);
 
-    expect(await screen.findByRole('button', {name: 'GitHub'})).toBeInTheDocument();
-    await userEvent.click(await screen.findByRole('button', {name: 'GitHub'}));
+    expect(
+      await screen.findByRole('button', {name: 'Add Linked Issue'})
+    ).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', {name: 'Add Linked Issue'}));
+
+    expect(await screen.findByRole('option', {name: 'GitHub'})).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('option', {name: 'GitHub'}));
 
     // Both items are listed inside the dropdown
     expect(
-      await screen.findByRole('menuitemradio', {name: /GitHub sentry/})
+      await screen.findByRole('listitem', {name: /GitHub sentry/})
     ).toBeInTheDocument();
     expect(
-      await screen.findByRole('menuitemradio', {name: /GitHub codecov/})
+      await screen.findByRole('listitem', {name: /GitHub codecov/})
     ).toBeInTheDocument();
   });
 
@@ -185,7 +190,7 @@ describe('ExternalIssueSidebarList', () => {
     render(<ExternalIssueSidebarList event={event} group={group} project={project} />);
 
     expect(
-      await screen.findByText('Track this issue in Jira, GitHub, etc.')
+      await screen.findByText('No issue linking integration installed')
     ).toBeInTheDocument();
   });
 
@@ -217,17 +222,22 @@ describe('ExternalIssueSidebarList', () => {
 
     render(<ExternalIssueSidebarList event={event} group={group} project={project} />);
 
-    expect(await screen.findByRole('button', {name: 'Jira'})).toBeInTheDocument();
-    await userEvent.click(await screen.findByRole('button', {name: 'Jira'}));
+    expect(
+      await screen.findByRole('button', {name: 'Add Linked Issue'})
+    ).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', {name: 'Add Linked Issue'}));
+
+    expect(await screen.findByRole('option', {name: 'Jira'})).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('option', {name: 'Jira'}));
 
     // Item with different name and subtext should show both
-    const menuItem = await screen.findByRole('menuitemradio', {
+    const menuItem = await screen.findByRole('listitem', {
       name: /Jira Integration 1/,
     });
     expect(menuItem).toHaveTextContent('hello.com');
 
     // Item with name matching integration name should only show subtext
-    expect(screen.getByRole('menuitemradio', {name: 'example.com'})).toBeInTheDocument();
+    expect(screen.getByRole('listitem', {name: 'example.com'})).toBeInTheDocument();
   });
 
   it('should render links to group.pluginActions', async () => {
@@ -252,11 +262,12 @@ describe('ExternalIssueSidebarList', () => {
     );
 
     expect(
-      await screen.findByRole('button', {name: 'Create Redmine Issue'})
+      await screen.findByRole('button', {name: 'Add Linked Issue'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Create Redmine Issue'})).toHaveAttribute(
-      'href',
-      '/path/to/redmine'
-    );
+    await userEvent.click(await screen.findByRole('button', {name: 'Add Linked Issue'}));
+
+    expect(
+      await screen.findByRole('option', {name: 'Create Redmine Issue'})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
@@ -8,7 +8,13 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {SentryAppComponentFixture} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import SentryAppComponentsStore from 'sentry/stores/sentryAppComponentsStore';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
@@ -249,7 +255,6 @@ describe('ExternalIssueSidebarList', () => {
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [],
     });
-
     const groupWithPluginActions = GroupFixture({
       pluginActions: [['Create Redmine Issue', '/path/to/redmine']],
     });
@@ -260,6 +265,7 @@ describe('ExternalIssueSidebarList', () => {
         project={project}
       />
     );
+    renderGlobalModal();
 
     expect(
       await screen.findByRole('button', {name: 'Add Linked Issue'})
@@ -267,11 +273,14 @@ describe('ExternalIssueSidebarList', () => {
     await userEvent.click(await screen.findByRole('button', {name: 'Add Linked Issue'}));
 
     expect(
-      await screen.findByRole('link', {name: 'Create Redmine Issue'})
+      await screen.findByRole('option', {name: 'Create Redmine Issue'})
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Create Redmine Issue'})).toHaveAttribute(
-      'href',
-      '/path/to/redmine'
+    await userEvent.click(
+      await screen.findByRole('option', {name: 'Create Redmine Issue'})
     );
+
+    const button = await screen.findByRole('button', {name: 'Continue'});
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('href', '/path/to/redmine');
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/externalIssueSidebarList.spec.tsx
@@ -267,7 +267,11 @@ describe('ExternalIssueSidebarList', () => {
     await userEvent.click(await screen.findByRole('button', {name: 'Add Linked Issue'}));
 
     expect(
-      await screen.findByRole('option', {name: 'Create Redmine Issue'})
+      await screen.findByRole('link', {name: 'Create Redmine Issue'})
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Create Redmine Issue'})).toHaveAttribute(
+      'href',
+      '/path/to/redmine'
+    );
   });
 });


### PR DESCRIPTION
Updates the streamlined external issue tracking experience to use a dropdown rather than a row of buttons, per the [Issue Tracking v2 Mockups](https://www.figma.com/design/p2DOzd1RwAHQbq0v6KaYmF/Issue-Details?node-id=8061-42500&t=vu6zKtqxQbn9kqu3-11) in Figma.

This closes DE-14, which we hit in UI2 because of the dashed button border. @vuluongj20 put together a new design for this interaction as a solution.

## Pages
<details><summary><strong>Issue Details</strong></summary>

<img width="318" alt="issue-detail-0" src="https://github.com/user-attachments/assets/298fdaca-7a0e-4bba-985d-e7e989ce6c01" />

<br/>

<img width="290" alt="issue-detail-1" src="https://github.com/user-attachments/assets/e99bc17b-aac0-4649-a981-38f5d590c291" />

<img width="478" alt="issue-detail-2" src="https://github.com/user-attachments/assets/c1f88295-a72b-46e1-a47c-e8b46428c230" />

<img width="318" alt="issue-detail-3" src="https://github.com/user-attachments/assets/742ff728-6b5b-4fc6-806a-73ad98e539ba" />

<img width="283" alt="issue-detail-4" src="https://github.com/user-attachments/assets/96c8c01f-8d54-4c8d-8e61-e99d8a2a093a" />

</details>

<details><summary><strong>User Feedback</strong></summary>

<img width="715" alt="feedback-issue-0" src="https://github.com/user-attachments/assets/1c613928-ca9b-4ba9-8be5-18f0c6ac0a95" />

<img width="323" alt="feedback-issue-1" src="https://github.com/user-attachments/assets/6df68c90-01ef-40b6-9ddb-0dba53dac655" />

<img width="502" alt="feedback-issue-2" src="https://github.com/user-attachments/assets/f33e01d3-6ace-47cf-b840-c05acda7bf27" />

<img width="509" alt="feedback-issue-3" src="https://github.com/user-attachments/assets/346adb8c-f57b-449c-a38c-7e340e0cab6e" />

<img width="597" alt="feedback-issue-4" src="https://github.com/user-attachments/assets/7a22f53d-732a-4f75-8c21-facaa110a5ca" />

</details>