### PR TITLE
fix(spans): Trim segments based on compressed byte size

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -20,7 +20,7 @@ local num_spans = ARGV[1]
 local parent_span_id = ARGV[2]
 local has_root_span = ARGV[3] == "true"
 local set_timeout = tonumber(ARGV[4])
-local max_spans = tonumber(ARGV[5])
+local max_segment_bytes = tonumber(ARGV[5])
 local NUM_ARGS = 5
 
 local set_span_id = parent_span_id
@@ -28,7 +28,7 @@ local redirect_depth = 0
 
 local main_redirect_key = string.format("span-buf:sr:{%s}", project_and_trace)
 
-for i = 0, max_spans do
+for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
     local new_set_span = redis.call("hget", main_redirect_key, set_span_id)
     redirect_depth = i
     if not new_set_span or new_set_span == set_span_id then
@@ -71,11 +71,11 @@ redis.call("hset", main_redirect_key, unpack(hset_args))
 redis.call("expire", main_redirect_key, set_timeout)
 
 if #sunionstore_args > 0 then
-    local span_count = redis.call("zunionstore", set_key, #sunionstore_args + 1, set_key, unpack(sunionstore_args))
+    redis.call("zunionstore", set_key, #sunionstore_args + 1, set_key, unpack(sunionstore_args))
     redis.call("unlink", unpack(sunionstore_args))
 
-    if span_count > max_spans then
-        redis.call("zpopmin", set_key, span_count - max_spans)
+    while (redis.call("memory", "usage", set_key) or 0) > max_segment_bytes do
+        redis.call("zpopmin", set_key)
     end
 end
 

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -75,7 +75,7 @@ if #sunionstore_args > 0 then
     redis.call("unlink", unpack(sunionstore_args))
 
     if span_count > max_spans then
-        redis.call("zpopmin", set_key, 0, span_count - max_spans)
+        redis.call("zpopmin", set_key, span_count - max_spans)
     end
 end
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -189,7 +189,7 @@ class SpansBuffer:
         redis_ttl = options.get("spans.buffer.redis-ttl")
         timeout = options.get("spans.buffer.timeout")
         root_timeout = options.get("spans.buffer.root-timeout")
-        max_segment_spans = options.get("spans.buffer.max-segment-spans")
+        max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
 
         result_meta = []
         is_root_span_count = 0
@@ -224,7 +224,7 @@ class SpansBuffer:
                         parent_span_id,
                         "true" if any(span.is_segment_span for span in subsegment) else "false",
                         redis_ttl,
-                        max_segment_spans,
+                        max_segment_bytes,
                         *[span.span_id for span in subsegment],
                     )
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -612,7 +612,7 @@ def test_compression_functionality(compression_level):
 def test_max_segment_spans_limit(buffer: SpansBuffer):
     batch1 = [
         Span(
-            payload=_payload("e" * 16),
+            payload=_payload("c" * 16),
             trace_id="a" * 32,
             span_id="c" * 16,
             parent_span_id="b" * 16,
@@ -620,7 +620,7 @@ def test_max_segment_spans_limit(buffer: SpansBuffer):
             end_timestamp_precise=1700000002.0,
         ),
         Span(
-            payload=_payload("d" * 16),
+            payload=_payload("b" * 16),
             trace_id="a" * 32,
             span_id="b" * 16,
             parent_span_id="a" * 16,
@@ -630,6 +630,22 @@ def test_max_segment_spans_limit(buffer: SpansBuffer):
     ]
     batch2 = [
         Span(
+            payload=_payload("d" * 16),
+            trace_id="a" * 32,
+            span_id="d" * 16,
+            parent_span_id="a" * 16,
+            project_id=1,
+            end_timestamp_precise=1700000001.0,
+        ),
+        Span(
+            payload=_payload("e" * 16),
+            trace_id="a" * 32,
+            span_id="e" * 16,
+            parent_span_id="a" * 16,
+            project_id=1,
+            end_timestamp_precise=1700000004.0,
+        ),
+        Span(
             payload=_payload("a" * 16),
             trace_id="a" * 32,
             span_id="a" * 16,
@@ -638,32 +654,19 @@ def test_max_segment_spans_limit(buffer: SpansBuffer):
             is_segment_span=True,
             end_timestamp_precise=1700000005.0,
         ),
-        Span(
-            payload=_payload("b" * 16),
-            trace_id="a" * 32,
-            span_id="b" * 16,
-            parent_span_id="a" * 16,
-            project_id=1,
-            end_timestamp_precise=1700000001.0,
-        ),
-        Span(
-            payload=_payload("c" * 16),
-            trace_id="a" * 32,
-            span_id="c" * 16,
-            parent_span_id="a" * 16,
-            project_id=1,
-            end_timestamp_precise=1700000004.0,
-        ),
     ]
 
-    with override_options({"spans.buffer.max-segment-spans": 3}):
+    # TODO: Fix this with compression enabled
+    with override_options(
+        {"spans.buffer.max-segment-spans": 3, "spans.buffer.compression.level": -1}
+    ):
         buffer.process_spans(batch1, now=0)
         buffer.process_spans(batch2, now=0)
         rv = buffer.flush_segments(now=11)
 
     segment = rv[_segment_id(1, "a" * 32, "a" * 16)]
     retained_span_ids = {span.payload["span_id"] for span in segment.spans}
-    assert retained_span_ids == {"a" * 16, "c" * 16, "e" * 16}
+    assert retained_span_ids == {"a" * 16, "b" * 16, "e" * 16}
 
     buffer.done_flush_segments(rv)
     assert_clean(buffer.client)

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -607,3 +607,65 @@ def test_compression_functionality(compression_level):
 
         buffer.done_flush_segments(segments)
         assert_clean(buffer.client)
+
+
+def test_max_segment_spans_limit(buffer: SpansBuffer):
+    spans = [
+        Span(
+            payload=_payload("a" * 16),
+            trace_id="a" * 32,
+            span_id="a" * 16,
+            parent_span_id=None,
+            project_id=1,
+            is_segment_span=True,
+            end_timestamp_precise=1700000005.0,  # keep
+        ),
+        Span(
+            payload=_payload("b" * 16),
+            trace_id="a" * 32,
+            span_id="b" * 16,
+            parent_span_id="a" * 16,
+            project_id=1,
+            end_timestamp_precise=1700000001.0,  # remove (lowest)
+        ),
+        Span(
+            payload=_payload("c" * 16),
+            trace_id="a" * 32,
+            span_id="c" * 16,
+            parent_span_id="a" * 16,
+            project_id=1,
+            end_timestamp_precise=1700000004.0,  # keep
+        ),
+        Span(
+            payload=_payload("d" * 16),
+            trace_id="a" * 32,
+            span_id="d" * 16,
+            parent_span_id="a" * 16,
+            project_id=1,
+            end_timestamp_precise=1700000002.0,  # remove (second)
+        ),
+        Span(
+            payload=_payload("e" * 16),
+            trace_id="a" * 32,
+            span_id="e" * 16,
+            parent_span_id="a" * 16,
+            project_id=1,
+            end_timestamp_precise=1700000003.0,  # keep
+        ),
+    ]
+
+    with override_options(
+        {
+            "spans.buffer.max-segment-spans": 3,
+            "spans.buffer.compression.level": -1,  # Disable compression so zpopmin works on individual spans
+        }
+    ):
+        buffer.process_spans(spans, now=0)
+        rv = buffer.flush_segments(now=11)
+
+    segment = rv[_segment_id(1, "a" * 32, "a" * 16)]
+    retained_span_ids = {span.payload["span_id"] for span in segment.spans}
+    assert retained_span_ids == {"a" * 16, "c" * 16, "e" * 16}
+
+    buffer.done_flush_segments(rv)
+    assert_clean(buffer.client)


### PR DESCRIPTION
The call for ZPOPMIN introduced in #92393 is wrong. This did not trigger frequently, because compression was introduced and the script wrongly limits the number of batches instead of number of spans.

To fix this, we would have to keep track of the span count separately. Since the span count always was a proxy for the size of segments, we can use `MEMORY USAGE` to directly measure the size. The compression ratios are between 25% and 50% in practice, so we apply the `max-segment-bytes` limit directly on the compressed payloads and then check again during decompression.

Fixes Sentry Error: https://sentry.sentry.io/issues/6659512425/events/50f90304ec52458c8a8364cf8fa00420/
