### PR TITLE
fix(insights): Chart action events not sent to amplitude

### DIFF
--- a/static/app/utils/analytics/insightAnalyticEvents.tsx
+++ b/static/app/utils/analytics/insightAnalyticEvents.tsx
@@ -42,13 +42,13 @@ export type InsightEventParameters = {
   'insight.vital.overview.toggle_tab': {tab: string};
   'insight.vital.select_browser_value': {browsers: string[]};
   'insight.vital.vital_sidebar_opened': {vital: string};
-  'insights.create_alert': {organization: string; referrer: string};
+  'insights.create_alert': {referrer: string};
   'insights.eap.toggle': {
     isEapEnabled: boolean;
     page: ModuleName | 'overview';
     view: DomainView | undefined;
   };
-  'insights.open_in_explore': {organization: string; referrer: string};
+  'insights.open_in_explore': {referrer: string};
   'insights.page_loads.overview': {domain: DomainView | undefined; platforms: string[]};
   'insights.session_health_tour.dismissed': Record<string, unknown>;
 };

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -106,7 +106,7 @@ export function BaseChartActionDropdown({
       to: exploreUrl,
       onAction: () => {
         trackAnalytics('insights.open_in_explore', {
-          organization: organization.slug,
+          organization,
           referrer,
         });
       },
@@ -123,7 +123,7 @@ export function BaseChartActionDropdown({
         onAction: () => {
           option.onAction?.();
           trackAnalytics('insights.create_alert', {
-            organization: organization.slug,
+            organization,
             referrer,
           });
         },


### PR DESCRIPTION
As the organization slug was passed instead of the whole org object, our analytics logic failed to extract the org id and skipped those two events.