### PR TITLE
feat: Remove quick start opening automatically on second visit

### DIFF
--- a/static/app/components/performanceOnboarding/sidebar.spec.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.spec.tsx
@@ -2,7 +2,6 @@ import type {UseQueryResult} from '@tanstack/react-query';
 import {BroadcastFixture} from 'sentry-fixture/broadcast';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
-import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -11,7 +10,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import SidebarContainer from 'sentry/components/sidebar';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import ConfigStore from 'sentry/stores/configStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
@@ -56,14 +54,6 @@ describe('Sidebar > Performance Onboarding Checklist', function () {
         datetime: {start: null, end: null, period: '24h', utc: null},
       },
       new Set()
-    );
-
-    const userMock = UserFixture();
-    ConfigStore.set(
-      'user',
-      UserFixture({
-        options: {...userMock.options, quickStartDisplay: {[organization.id]: 2}},
-      })
     );
 
     apiMocks.broadcasts = MockApiClient.addMockResponse({

--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -44,10 +44,7 @@ jest.mock('sentry/utils/demoMode');
 describe('Sidebar', function () {
   const organization = OrganizationFixture();
   const broadcast = BroadcastFixture();
-  const userMock = UserFixture();
-  const user = UserFixture({
-    options: {...userMock.options, quickStartDisplay: {[organization.id]: 2}},
-  });
+  const user = UserFixture();
   const apiMocks = {
     broadcasts: jest.fn(),
     broadcastsMarkAsSeen: jest.fn(),

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useContext, useEffect, useMemo} from 'react';
+import {useCallback, useContext, useEffect} from 'react';
 import type {Theme} from '@emotion/react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -18,11 +18,8 @@ import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
-import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
-import {useOnboardingSidebar} from 'sentry/views/onboarding/useOnboardingSidebar';
 
 import type {CommonSidebarProps} from './types';
 import {SidebarPanelKey} from './types';
@@ -36,10 +33,7 @@ export function OnboardingStatus({
   hidePanel,
   onShowPanel,
 }: OnboardingStatusProps) {
-  const user = useUser();
   const theme = useTheme();
-  const {mutate: mutateUserOptions} = useMutateUserOptions();
-  const {activateSidebar} = useOnboardingSidebar();
   const organization = useOrganization();
   const hasStreamlinedUI = useHasStreamlinedUI();
   const {shouldAccordionFloat} = useContext(ExpandedContext);
@@ -70,14 +64,6 @@ export function OnboardingStatus({
   const skipQuickStart =
     (!demoMode && !organization.features?.includes('onboarding')) ||
     (allTasksCompleted && !isActive);
-
-  const orgId = organization.id;
-
-  const quickStartDisplay = useMemo(() => {
-    return user?.options?.quickStartDisplay ?? {};
-  }, [user?.options?.quickStartDisplay]);
-
-  const quickStartDisplayStatus = quickStartDisplay[orgId] ?? 0;
 
   const handleShowPanel = useCallback(() => {
     if (!demoMode && isActive !== true) {
@@ -114,26 +100,6 @@ export function OnboardingStatus({
     setQuickStartCompleted,
     allTasksCompleted,
   ]);
-
-  useEffect(() => {
-    if (skipQuickStart || quickStartDisplayStatus > 1 || demoMode) {
-      return;
-    }
-
-    const newQuickStartDisplay = {...quickStartDisplay};
-    newQuickStartDisplay[orgId] = quickStartDisplayStatus + 1;
-
-    mutateUserOptions({['quickStartDisplay']: newQuickStartDisplay});
-
-    if (quickStartDisplayStatus === 1) {
-      activateSidebar({
-        userClicked: false,
-        source: 'onboarding_sidebar_user_second_visit',
-      });
-    }
-    // be careful when adding dependencies here as it can cause side-effects, e.g activateSidebar
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mutateUserOptions, orgId, skipQuickStart]);
 
   if (skipQuickStart) {
     return null;

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -21,12 +21,6 @@ export type AvatarUser = {
   };
 };
 
-// This object tracks the status of the quick start display for each organization.
-// The key is the organization ID, and the value represents the display status:
-// Null = Hidden on the first visit
-// 1 = Shown once (on the second visit)
-// 2 = Hidden automatically after the second visit
-type QuickStartDisplay = Record<string, number>;
 export interface User extends Omit<AvatarUser, 'options'> {
   canReset2fa: boolean;
   dateJoined: string;
@@ -56,7 +50,6 @@ export interface User extends Omit<AvatarUser, 'options'> {
     prefersIssueDetailsStreamlinedUI: boolean | null;
     prefersNextjsInsightsOverview: boolean;
     prefersStackedNavigation: boolean | null;
-    quickStartDisplay: QuickStartDisplay;
     stacktraceOrder: number;
     theme: 'system' | 'light' | 'dark';
     timezone: string;

--- a/static/app/utils/analytics/quickStartAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/quickStartAnalyticsEvents.tsx
@@ -7,8 +7,7 @@ export type QuickStartEventParameters = {
       | 'targeted_onboarding_welcome_skip'
       | 'targeted_onboarding_select_platform_skip'
       | 'targeted_onboarding_first_event_footer_skip'
-      | 'onboarding_sidebar'
-      | 'onboarding_sidebar_user_second_visit';
+      | 'onboarding_sidebar';
     user_clicked: boolean;
   };
   'quick_start.task_card_clicked': {

--- a/static/app/views/nav/primary/onboarding.spec.tsx
+++ b/static/app/views/nav/primary/onboarding.spec.tsx
@@ -3,13 +3,9 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import ConfigStore from 'sentry/stores/configStore';
 import {OnboardingTaskKey} from 'sentry/types/onboarding';
 import type {Organization} from 'sentry/types/organization';
 import {PrimaryNavigationOnboarding} from 'sentry/views/nav/primary/onboarding';
-import * as useOnboardingSidebar from 'sentry/views/onboarding/useOnboardingSidebar';
-
-const userMock = UserFixture();
 
 jest.mock('framer-motion', () => ({
   ...jest.requireActual('framer-motion'),
@@ -37,13 +33,6 @@ describe('Onboarding Status', function () {
   const organizationId = OrganizationFixture().id;
 
   beforeEach(function () {
-    ConfigStore.set(
-      'user',
-      UserFixture({
-        options: {...userMock.options, quickStartDisplay: {[organizationId]: 2}},
-      })
-    );
-
     MockApiClient.clearMockResponses();
 
     MockApiClient.addMockResponse({
@@ -108,83 +97,5 @@ describe('Onboarding Status', function () {
     await waitFor(() =>
       expect(screen.queryByTestId('pending-seen-indicator')).not.toBeInTheDocument()
     );
-  });
-
-  it("overlay is not automatically opened because the user option 'quickStartDisplay' is not set", async function () {
-    ConfigStore.set(
-      'user',
-      UserFixture({
-        options: {...userMock.options, quickStartDisplay: {}},
-      })
-    );
-
-    const organization = OrganizationFixture({
-      id: organizationId,
-      features: ['onboarding'],
-    });
-
-    const {mutateUserOptionsMock} = renderMockRequests(organization);
-
-    const mockActivateSidebar = jest.fn();
-
-    jest.spyOn(useOnboardingSidebar, 'useOnboardingSidebar').mockReturnValue({
-      activateSidebar: mockActivateSidebar,
-    });
-
-    render(<PrimaryNavigationOnboarding />, {
-      organization,
-    });
-
-    await waitFor(() =>
-      expect(mutateUserOptionsMock).toHaveBeenCalledWith(
-        '/users/me/',
-        expect.objectContaining({
-          data: {
-            options: {quickStartDisplay: {[organizationId]: 1}},
-          },
-        })
-      )
-    );
-
-    expect(mockActivateSidebar).not.toHaveBeenCalled();
-  });
-
-  it("overlay is automatically opened because the user option 'quickStartDisplay' is set to 1", async function () {
-    ConfigStore.set(
-      'user',
-      UserFixture({
-        options: {...userMock.options, quickStartDisplay: {[organizationId]: 1}},
-      })
-    );
-
-    const organization = OrganizationFixture({
-      id: organizationId,
-      features: ['onboarding'],
-    });
-
-    const {mutateUserOptionsMock} = renderMockRequests(organization);
-
-    const mockActivateSidebar = jest.fn();
-
-    jest.spyOn(useOnboardingSidebar, 'useOnboardingSidebar').mockReturnValue({
-      activateSidebar: mockActivateSidebar,
-    });
-
-    render(<PrimaryNavigationOnboarding />, {
-      organization,
-    });
-
-    await waitFor(() =>
-      expect(mutateUserOptionsMock).toHaveBeenCalledWith(
-        '/users/me/',
-        expect.objectContaining({
-          data: {
-            options: {quickStartDisplay: {[organizationId]: 2}},
-          },
-        })
-      )
-    );
-
-    expect(mockActivateSidebar).toHaveBeenCalled();
   });
 });

--- a/tests/js/fixtures/activityFeed.ts
+++ b/tests/js/fixtures/activityFeed.ts
@@ -38,7 +38,6 @@ export function ActivityFeedFixture(params: Partial<Activity> = {}): Activity {
         prefersAgentsInsightsModule: false,
         prefersStackedNavigation: false,
         prefersChonkUI: false,
-        quickStartDisplay: {},
       },
       flags: {newsletter_consent_prompt: false},
       avatar: {avatarUuid: null, avatarType: 'letter_avatar'},

--- a/tests/js/fixtures/commitAuthor.ts
+++ b/tests/js/fixtures/commitAuthor.ts
@@ -43,7 +43,6 @@ export function CommitAuthorFixture(params: Partial<User> = {}): User {
       prefersNextjsInsightsOverview: false,
       prefersAgentsInsightsModule: false,
       prefersChonkUI: false,
-      quickStartDisplay: {},
     },
     permissions: new Set(),
     canReset2fa: false,

--- a/tests/js/fixtures/user.ts
+++ b/tests/js/fixtures/user.ts
@@ -20,7 +20,6 @@ export function UserFixture(params: Partial<User> = {}): User {
       prefersNextjsInsightsOverview: false,
       prefersAgentsInsightsModule: false,
       prefersChonkUI: false,
-      quickStartDisplay: {},
     },
     ip_address: '127.0.0.1',
     hasPasswordAuth: true,

--- a/tests/js/fixtures/userDetails.ts
+++ b/tests/js/fixtures/userDetails.ts
@@ -36,7 +36,6 @@ export function UserDetailsFixture(params: Partial<User> = {}): User {
       prefersAgentsInsightsModule: false,
       prefersStackedNavigation: false,
       prefersChonkUI: false,
-      quickStartDisplay: {},
     },
     avatar: {avatarUuid: null, avatarType: 'letter_avatar'},
     lastLogin: '2018-01-25T19:57:46.973Z',


### PR DESCRIPTION
This PR removes the functionality that automatically opened the Quick Start sidebar on a user's second visit. 

backend PR will follow.

contributes to https://linear.app/getsentry/issue/TET-227/remove-quick-start-default-open-on-second-visit