### PR TITLE
ref: Remove quick start user option

### DIFF
--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -6,7 +6,6 @@ from django.contrib.auth import logout
 from django.db import router, transaction
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
-from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -37,17 +36,6 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 TIMEZONE_CHOICES = get_timezone_choices()
-
-
-def validate_quick_start_display(value: dict[str, int] | None) -> None:
-    if value is not None:
-        for display_value in value.values():
-            if not isinstance(display_value, int):
-                raise ValidationError("The value should be an integer.")
-            if display_value <= 0:
-                raise ValidationError("The value cannot be less than or equal to 0.")
-            if display_value > 2:
-                raise ValidationError("The value cannot exceed 2.")
 
 
 class UserOptionsSerializer(serializers.Serializer[UserOption]):
@@ -83,13 +71,6 @@ class UserOptionsSerializer(serializers.Serializer[UserOption]):
     prefersStackedNavigation = serializers.BooleanField(required=False)
     prefersChonkUI = serializers.BooleanField(required=False)
     prefersAgentsInsightsModule = serializers.BooleanField(required=False)
-
-    quickStartDisplay = serializers.JSONField(
-        required=False,
-        allow_null=True,
-        validators=[validate_quick_start_display],
-        help_text="Tracks whether the quick start guide was already automatically shown to the user during their second visit.",
-    )
 
 
 class BaseUserSerializer(CamelSnakeModelSerializer[User]):
@@ -262,32 +243,15 @@ class UserDetailsEndpoint(UserEndpoint):
             "prefersNextjsInsightsOverview": "prefers_nextjs_insights_overview",
             "prefersChonkUI": "prefers_chonk_ui",
             "prefersAgentsInsightsModule": "prefers_agents_insights_module",
-            "quickStartDisplay": "quick_start_display",
         }
 
         options_result = serializer_options.validated_data
 
         for key in key_map:
             if key in options_result:
-                if key == "quickStartDisplay":
-                    current_value = UserOption.objects.get_value(
-                        user=user, key=key_map.get(key, key)
-                    )
-
-                    if current_value is None:
-                        current_value = {}
-
-                    new_value = options_result.get(key)
-
-                    current_value.update(new_value)
-
-                    UserOption.objects.set_value(
-                        user=user, key=key_map.get(key, key), value=current_value
-                    )
-                else:
-                    UserOption.objects.set_value(
-                        user=user, key=key_map.get(key, key), value=options_result.get(key)
-                    )
+                UserOption.objects.set_value(
+                    user=user, key=key_map.get(key, key), value=options_result.get(key)
+                )
 
         with transaction.atomic(using=router.db_for_write(User)):
             user = serializer.save()

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -68,7 +68,6 @@ class _UserOptions(TypedDict):
     prefersNextjsInsightsOverview: bool
     prefersStackedNavigation: bool | None
     prefersChonkUI: bool
-    quickStartDisplay: dict[str, int]
     prefersAgentsInsightsModule: bool
 
 
@@ -208,7 +207,6 @@ class UserSerializer(Serializer):
                 ),
                 "prefersStackedNavigation": options.get("prefers_stacked_navigation"),
                 "prefersChonkUI": options.get("prefers_chonk_ui", False),
-                "quickStartDisplay": options.get("quick_start_display") or {},
                 "prefersAgentsInsightsModule": options.get("prefers_agents_insights_module", True),
             }
 

--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -173,8 +173,6 @@ class UserOption(Model):
         - Whether the user prefers the new Agents insights module experience (boolean)
      - prefers_chonk_ui
         - Whether the user prefers the new Chonk UI experience (boolean)
-     - quick_start_display
-        - Tracks whether the quick start guide was already automatically shown to the user during their second visit
      - language
         - which language to display the app in
      - mail:email

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -144,12 +144,6 @@ class UserDetailsUpdateTest(UserDetailsTest):
         assert UserOption.objects.get_value(user=self.user, key="prefers_stacked_navigation")
         assert UserOption.objects.get_value(user=self.user, key="prefers_chonk_ui")
         assert UserOption.objects.get_value(user=self.user, key="prefers_nextjs_insights_overview")
-        assert (
-            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(
-                str(self.organization.id)
-            )
-            == 1
-        )
 
         assert not UserOption.objects.get_value(user=self.user, key="extra")
         assert UserOption.objects.get_value(user=self.user, key="prefers_agents_insights_module")

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -48,7 +48,6 @@ class UserDetailsGetTest(UserDetailsTest):
         assert not resp.data["options"]["prefersIssueDetailsStreamlinedUI"]
         assert not resp.data["options"]["prefersStackedNavigation"]
         assert not resp.data["options"]["prefersChonkUI"]
-        assert not resp.data["options"]["quickStartDisplay"]
 
     def test_superuser_simple(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -122,7 +121,6 @@ class UserDetailsUpdateTest(UserDetailsTest):
                 "prefersNextjsInsightsOverview": True,
                 "prefersStackedNavigation": True,
                 "prefersChonkUI": True,
-                "quickStartDisplay": {self.organization.id: 1},
                 "prefersAgentsInsightsModule": True,
             },
         )
@@ -242,64 +240,6 @@ class UserDetailsUpdateTest(UserDetailsTest):
             "me",
         )
         assert resp.data["options"]["prefersNextjsInsightsOverview"] is True
-
-    def test_saving_quick_start_display_option(self):
-        org1_id = str(self.organization.id)
-        org2_id = str(self.create_organization().id)
-
-        # 1 = Shown once (on the second visit)
-        self.get_success_response(
-            "me",
-            options={"quickStartDisplay": {org1_id: 1, org2_id: 2}},
-        )
-        assert (
-            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org1_id)
-            == 1
-        )
-
-        # 2 = Hidden automatically after the second visit
-        self.get_success_response("me", options={"quickStartDisplay": {org1_id: 2}})
-        assert (
-            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org1_id)
-            == 2
-        )
-
-        # Validate that existing other orgs entries are not affected
-        assert (
-            UserOption.objects.get_value(user=self.user, key="quick_start_display").get(org2_id)
-            == 2
-        )
-
-        # Invalid values
-        self.get_error_response(
-            "me",
-            options={"quickStartDisplay": {org1_id: None}},
-            status_code=400,
-        )
-
-        self.get_error_response(
-            "me",
-            options={"quickStartDisplay": {org1_id: -1}},
-            status_code=400,
-        )
-
-        self.get_error_response(
-            "me",
-            options={"quickStartDisplay": {org1_id: 0}},
-            status_code=400,
-        )
-
-        self.get_error_response(
-            "me",
-            options={"quickStartDisplay": {org1_id: 3}},
-            status_code=400,
-        )
-
-        self.get_error_response(
-            "me",
-            options={"quickStartDisplay": {org1_id: "invalid"}},
-            status_code=400,
-        )
 
     def test_saving_agents_insights_module_option(self):
         self.get_success_response(


### PR DESCRIPTION


Frontend PR priscila/feat/quick-start/remove-second-open

closes https://linear.app/getsentry/issue/TET-227/remove-quick-start-default-open-on-second-visit