### PR TITLE
fix(agent-monitoring): Rename enabled event property

### DIFF
--- a/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
@@ -18,7 +18,7 @@ export type AgentMonitoringEventParameters = {
   'agent-monitoring.trace.span-select': Record<string, unknown>;
   'agent-monitoring.trace.view-full-trace-click': Record<string, unknown>;
   'agent-monitoring.ui-toggle': {
-    enabled: boolean;
+    isEnabled: boolean;
   };
   'agent-monitoring.view-ai-trace-click': Record<string, unknown>;
 };

--- a/static/app/views/insights/agentMonitoring/components/aiModuleToggleButton.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiModuleToggleButton.tsx
@@ -19,7 +19,7 @@ export function AiModuleToggleButton() {
 
     trackAnalytics('agent-monitoring.ui-toggle', {
       organization,
-      enabled: isEnabled,
+      isEnabled,
     });
     togglePreferedModule();
   };


### PR DESCRIPTION
The enabled property was sent (checked in network tab) but never appeared in the UI of the analytics provider.
-> Rename the property from `enabled` to `isEnabled` as it is done for other events.