### PR TITLE
fix(profiling): emit profiling.profile.payload.size in vroomrs processing as well

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1319,14 +1319,10 @@ def _process_vroomrs_chunk_profile(profile: Profile) -> bool:
             # dict directly to the PyO3 module to avoid json serialization/deserialization
             with sentry_sdk.start_span(op="json.dumps"):
                 json_profile = json.dumps(profile)
-                metric_tags = (
-                    {
-                        "type": "chunk" if "profiler_id" in profile else "profile",
-                        "platform": profile["platform"],
-                    },
-                )
                 metrics.distribution(
-                    "profiling.profile.payload.size", len(json_profile), tags=metric_tags
+                    "profiling.profile.payload.size",
+                    len(json_profile),
+                    tags={"type": "chunk", "platform": profile["platform"]},
                 )
             with sentry_sdk.start_span(op="json.unmarshal"):
                 chunk = vroomrs.profile_chunk_from_json_str(json_profile, profile["platform"])

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1319,6 +1319,15 @@ def _process_vroomrs_chunk_profile(profile: Profile) -> bool:
             # dict directly to the PyO3 module to avoid json serialization/deserialization
             with sentry_sdk.start_span(op="json.dumps"):
                 json_profile = json.dumps(profile)
+                metric_tags = (
+                    {
+                        "type": "chunk" if "profiler_id" in profile else "profile",
+                        "platform": profile["platform"],
+                    },
+                )
+                metrics.distribution(
+                    "profiling.profile.payload.size", len(json_profile), tags=metric_tags
+                )
             with sentry_sdk.start_span(op="json.unmarshal"):
                 chunk = vroomrs.profile_chunk_from_json_str(json_profile, profile["platform"])
             chunk.normalize()


### PR DESCRIPTION
When we insert a profile through the `vroom` service we already emit this metric.

As we're transitioning to processing the profiles with the `vroomrs` library, we should emit that metric in there as well or we'll lose it once we're fully transitioned. 