### PR TITLE
ref(span-buffer): Set scope level to warning

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -65,6 +65,10 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
+        # TODO: remove once span buffer is live in all regions
+        scope = sentry_sdk.get_isolation_scope()
+        scope.level = "warning"
+
         self.rebalancing_count += 1
         sentry_sdk.set_tag("sentry_spans_rebalancing_count", str(self.rebalancing_count))
         sentry_sdk.set_tag("sentry_spans_buffer_component", "consumer")

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -141,6 +141,10 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
         healthy_since,
         produce_to_pipe: Callable[[KafkaPayload], None] | None,
     ) -> None:
+        # TODO: remove once span buffer is live in all regions
+        scope = sentry_sdk.get_isolation_scope()
+        scope.level = "warning"
+
         shard_tag = ",".join(map(str, shards))
         sentry_sdk.set_tag("sentry_spans_buffer_component", "flusher")
         sentry_sdk.set_tag("sentry_spans_buffer_shards", shard_tag)


### PR DESCRIPTION
Set all errors to level warning in Sentry so that we do not trigger any
alerts.

I don't think this is going to work reliably (and that we should just
change the alerts), but we can try it out.
