### PR TITLE
feat(traces): Pass filter secondary aliases to search query builder

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -45,8 +45,10 @@ export function OurlogsDrawer({event, project, group}: LogIssueDrawerProps) {
   const hasInfiniteFeature = useOrganization().features.includes(
     'ourlogs-infinite-scroll'
   );
-  const {attributes: stringAttributes} = useTraceItemAttributes('string');
-  const {attributes: numberAttributes} = useTraceItemAttributes('number');
+  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemAttributes('string');
+  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemAttributes('number');
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery: logsSearch.formatString(),
@@ -55,6 +57,8 @@ export function OurlogsDrawer({event, project, group}: LogIssueDrawerProps) {
     numberAttributes,
     stringAttributes,
     itemType: TraceItemDataset.LOGS,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
   };
   const searchQueryBuilderProps = useSearchQueryBuilderProps(
     tracesItemSearchQueryBuilderProps

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -190,7 +190,7 @@ function IndexedSpanSearchQueryBuilder({
   return <SearchQueryBuilder {...searchQueryBuilderProps} />;
 }
 
-function EapSpanSearchQueryBuilderWrapper(props: SpanSearchQueryBuilderProps) {
+export function EapSpanSearchQueryBuilderWrapper(props: SpanSearchQueryBuilderProps) {
   const {tags: numberTags, secondaryAliases: numberSecondaryAliases} =
     useTraceItemTags('number');
   const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =

--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -190,21 +190,27 @@ function IndexedSpanSearchQueryBuilder({
   return <SearchQueryBuilder {...searchQueryBuilderProps} />;
 }
 
-export function EapSpanSearchQueryBuilderWrapper(props: SpanSearchQueryBuilderProps) {
-  const {tags: numberTags} = useTraceItemTags('number');
-  const {tags: stringTags} = useTraceItemTags('string');
+function EapSpanSearchQueryBuilderWrapper(props: SpanSearchQueryBuilderProps) {
+  const {tags: numberTags, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemTags('number');
+  const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemTags('string');
 
   return (
     <EAPSpanSearchQueryBuilder
       numberTags={numberTags}
       stringTags={stringTags}
+      numberSecondaryAliases={numberSecondaryAliases}
+      stringSecondaryAliases={stringSecondaryAliases}
       {...props}
     />
   );
 }
 
 export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderProps {
+  numberSecondaryAliases: TagCollection;
   numberTags: TagCollection;
+  stringSecondaryAliases: TagCollection;
   stringTags: TagCollection;
   autoFocus?: boolean;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
@@ -214,7 +220,13 @@ export interface EAPSpanSearchQueryBuilderProps extends SpanSearchQueryBuilderPr
 }
 
 export function useEAPSpanSearchQueryBuilderProps(props: EAPSpanSearchQueryBuilderProps) {
-  const {numberTags, stringTags, ...rest} = props;
+  const {
+    numberTags,
+    stringTags,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
+    ...rest
+  } = props;
 
   const numberAttributes = numberTags;
   const stringAttributes = useMemo(() => {
@@ -231,18 +243,28 @@ export function useEAPSpanSearchQueryBuilderProps(props: EAPSpanSearchQueryBuild
     itemType: TraceItemDataset.SPANS,
     numberAttributes,
     stringAttributes,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
     ...rest,
   });
 }
 
 export function EAPSpanSearchQueryBuilder(props: EAPSpanSearchQueryBuilderProps) {
-  const {numberTags, stringTags, ...rest} = props;
+  const {
+    numberTags,
+    stringTags,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
+    ...rest
+  } = props;
 
   return (
     <TraceItemSearchQueryBuilder
       itemType={TraceItemDataset.SPANS}
       numberAttributes={numberTags}
       stringAttributes={stringTags}
+      numberSecondaryAliases={numberSecondaryAliases}
+      stringSecondaryAliases={stringSecondaryAliases}
       {...rest}
     />
   );

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -335,6 +335,7 @@ export type Tag = {
    */
   maxSuggestedValues?: number;
   predefined?: boolean;
+  secondaryAliases?: string[];
   totalValues?: number;
   uniqueValues?: number;
   /**

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -780,8 +780,10 @@ function EAPSearchQueryBuilderWithContext({
   project,
   traceItemType,
 }: EAPSearchQueryBuilderWithContextProps) {
-  const {attributes: numberAttributes} = useTraceItemAttributes('number');
-  const {attributes: stringAttributes} = useTraceItemAttributes('string');
+  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemAttributes('number');
+  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemAttributes('string');
 
   const tracesItemSearchQueryBuilderProps = {
     initialQuery,
@@ -791,6 +793,8 @@ function EAPSearchQueryBuilderWithContext({
     stringAttributes,
     itemType: traceItemType,
     projects: [parseInt(project.id, 10)],
+    numberSecondaryAliases,
+    stringSecondaryAliases,
   };
 
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;

--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -117,8 +117,10 @@ function LogsSearchBar({
   const {
     selection: {projects},
   } = usePageFilters();
-  const {attributes: stringAttributes} = useTraceItemAttributes('string');
-  const {attributes: numberAttributes} = useTraceItemAttributes('number');
+  const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemAttributes('string');
+  const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemAttributes('number');
   return (
     <TraceItemSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
@@ -126,6 +128,8 @@ function LogsSearchBar({
       itemType={TraceItemDataset.LOGS}
       numberAttributes={numberAttributes}
       stringAttributes={stringAttributes}
+      numberSecondaryAliases={numberSecondaryAliases}
+      stringSecondaryAliases={stringSecondaryAliases}
       searchSource="dashboards"
       projects={projects}
       portalTarget={portalTarget}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.tsx
@@ -20,14 +20,18 @@ function SpansSearchBar({
   const {
     selection: {projects},
   } = usePageFilters();
-  const {tags: numberTags} = useTraceItemTags('number');
-  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemTags('number');
+  const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemTags('string');
   return (
     <EAPSpanSearchQueryBuilder
       initialQuery={widgetQuery.conditions}
       onSearch={onSearch}
       numberTags={numberTags}
       stringTags={stringTags}
+      numberSecondaryAliases={numberSecondaryAliases}
+      stringSecondaryAliases={stringSecondaryAliases}
       supportedAggregates={ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
       searchSource="dashboards"
       projects={projects}

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -21,7 +21,9 @@ describe('QueryFilterBuilder', () => {
       features: [],
     });
     jest.mocked(useCustomMeasurements).mockReturnValue({customMeasurements: {}});
-    jest.mocked(useTraceItemTags).mockReturnValue({tags: {}, isLoading: false});
+    jest
+      .mocked(useTraceItemTags)
+      .mockReturnValue({tags: {}, secondaryAliases: {}, isLoading: false});
 
     MockApiClient.addMockResponse({url: '/organizations/org-slug/recent-searches/'});
   });

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.spec.tsx
@@ -35,14 +35,16 @@ describe('Visualize', () => {
             key: 'span.duration',
             name: 'span.duration',
             kind: FieldKind.MEASUREMENT,
+            secondaryAliases: [],
           },
           'span.self_time': {
             key: 'span.self_time',
             name: 'span.self_time',
             kind: FieldKind.MEASUREMENT,
+            secondaryAliases: [],
           },
         };
-        return {tags, isLoading: false};
+        return {tags, isLoading: false, secondaryAliases: {}};
       }
 
       const tags: TagCollection = {
@@ -60,6 +62,7 @@ describe('Visualize', () => {
 
       return {
         tags,
+        secondaryAliases: {},
         isLoading: false,
       };
     });
@@ -1262,6 +1265,7 @@ describe('Visualize', () => {
                 kind: 'measurement',
               },
             } as TagCollection,
+            secondaryAliases: {},
             isLoading: false,
           };
         }
@@ -1274,6 +1278,7 @@ describe('Visualize', () => {
               kind: 'tag',
             },
           } as TagCollection,
+          secondaryAliases: {},
           isLoading: false,
         };
       });
@@ -1422,12 +1427,14 @@ describe('Visualize', () => {
             tags: {
               'tags[count,number]': {key: 'count', name: 'count', kind: 'measurement'},
             } as TagCollection,
+            secondaryAliases: {},
             isLoading: false,
           };
         }
 
         return {
           tags: {count: {key: 'count', name: 'count', kind: 'tag'}} as TagCollection,
+          secondaryAliases: {},
           isLoading: false,
         };
       });

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -32,7 +32,9 @@ describe('WidgetBuilderSlideout', () => {
 
     jest.mocked(useCustomMeasurements).mockReturnValue({customMeasurements: {}});
 
-    jest.mocked(useTraceItemTags).mockReturnValue({tags: {}, isLoading: false});
+    jest
+      .mocked(useTraceItemTags)
+      .mockReturnValue({tags: {}, secondaryAliases: {}, isLoading: false});
 
     jest.mocked(useParams).mockReturnValue({widgetIndex: undefined});
 

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -1,5 +1,8 @@
+import {useMemo} from 'react';
+
+import type {TagCollection} from 'sentry/types/group';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES, FieldKind} from 'sentry/utils/fields';
 import type {DetectorSearchBarProps} from 'sentry/views/detectors/datasetConfig/base';
 import {
   useTraceItemNumberAttributes,
@@ -22,10 +25,28 @@ export function TraceSearchBar({
     projectIds,
   });
 
+  const numberSecondaryAliases = useMemo(() => {
+    const secondaryAliases: TagCollection = Object.fromEntries(
+      Object.values(numberAttributes ?? {})
+        .flatMap(value => value.secondaryAliases ?? [])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.MEASUREMENT}])
+    );
+    return secondaryAliases;
+  }, [numberAttributes]);
+
   const {attributes: stringAttributes} = useTraceItemStringAttributes({
     traceItemType: traceDataset,
     projectIds,
   });
+
+  const stringSecondaryAliases = useMemo(() => {
+    const secondaryAliases: TagCollection = Object.fromEntries(
+      Object.values(stringAttributes ?? {})
+        .flatMap(value => value.secondaryAliases ?? [])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.MEASUREMENT}])
+    );
+    return secondaryAliases;
+  }, [stringAttributes]);
 
   return (
     <TraceItemSearchQueryBuilder
@@ -33,7 +54,9 @@ export function TraceSearchBar({
       initialQuery={initialQuery}
       onSearch={onSearch}
       numberAttributes={numberAttributes}
+      numberSecondaryAliases={numberSecondaryAliases}
       stringAttributes={stringAttributes}
+      stringSecondaryAliases={stringSecondaryAliases}
       supportedAggregates={isLogs ? [] : ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
       searchSource="detectors"
       projects={projectIds}

--- a/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
+++ b/static/app/views/detectors/datasetConfig/components/traceSearchBar.tsx
@@ -43,7 +43,7 @@ export function TraceSearchBar({
     const secondaryAliases: TagCollection = Object.fromEntries(
       Object.values(stringAttributes ?? {})
         .flatMap(value => value.secondaryAliases ?? [])
-        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.MEASUREMENT}])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.TAG}])
     );
     return secondaryAliases;
   }, [stringAttributes]);

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -16,7 +16,9 @@ import {SPANS_FILTER_KEY_SECTIONS} from 'sentry/views/insights/constants';
 type TraceItemSearchQueryBuilderProps = {
   itemType: TraceItemDataset;
   numberAttributes: TagCollection;
+  numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
+  stringSecondaryAliases: TagCollection;
   replaceRawSearchKeys?: string[];
 } & Omit<EAPSpanSearchQueryBuilderProps, 'numberTags' | 'stringTags'>;
 
@@ -52,7 +54,9 @@ function getTraceItemFieldDefinitionFunction(
 export function useSearchQueryBuilderProps({
   itemType,
   numberAttributes,
+  numberSecondaryAliases,
   stringAttributes,
+  stringSecondaryAliases,
   initialQuery,
   searchSource,
   getFilterTokenWarning,
@@ -98,6 +102,7 @@ export function useSearchQueryBuilderProps({
     showUnsubmittedIndicator: true,
     portalTarget,
     replaceRawSearchKeys,
+    filterKeyAliases: {...numberSecondaryAliases, ...stringSecondaryAliases},
   };
 }
 
@@ -108,7 +113,9 @@ export function useSearchQueryBuilderProps({
 export function TraceItemSearchQueryBuilder({
   autoFocus,
   initialQuery,
+  numberSecondaryAliases,
   numberAttributes,
+  stringSecondaryAliases,
   searchSource,
   stringAttributes,
   itemType,
@@ -125,6 +132,8 @@ export function TraceItemSearchQueryBuilder({
     itemType,
     numberAttributes,
     stringAttributes,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
     initialQuery,
     searchSource,
     getFilterTokenWarning,

--- a/static/app/views/explore/contexts/spanTagsContext.tsx
+++ b/static/app/views/explore/contexts/spanTagsContext.tsx
@@ -1,9 +1,10 @@
 import {useTraceItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 
 export function useTraceItemTags(type?: 'number' | 'string') {
-  const {attributes, isLoading} = useTraceItemAttributes(type);
+  const {attributes, isLoading, secondaryAliases} = useTraceItemAttributes(type);
   return {
     tags: attributes,
     isLoading,
+    secondaryAliases,
   };
 }

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -70,7 +70,7 @@ export function TraceItemAttributeProvider({
     const secondaryAliases: TagCollection = Object.fromEntries(
       Object.values(numberAttributes ?? {})
         .flatMap(value => value.secondaryAliases ?? [])
-        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.TAG}])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.MEASUREMENT}])
     );
 
     return {

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -13,7 +13,12 @@ import {
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
-type TypedTraceItemAttributes = {number: TagCollection; string: TagCollection};
+type TypedTraceItemAttributes = {
+  number: TagCollection;
+  numberSecondaryAliases: TagCollection;
+  string: TagCollection;
+  stringSecondaryAliases: TagCollection;
+};
 
 type TypedTraceItemAttributesStatus = {
   numberAttributesLoading: boolean;
@@ -62,7 +67,16 @@ export function TraceItemAttributeProvider({
       {key: measurement, name: measurement, kind: FieldKind.MEASUREMENT},
     ]);
 
-    return {...numberAttributes, ...Object.fromEntries(measurements)};
+    const secondaryAliases: TagCollection = Object.fromEntries(
+      Object.values(numberAttributes ?? {})
+        .flatMap(value => value.secondaryAliases ?? [])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.TAG}])
+    );
+
+    return {
+      attributes: {...numberAttributes, ...Object.fromEntries(measurements)},
+      secondaryAliases,
+    };
   }, [numberAttributes, traceItemType]);
 
   const allStringAttributes = useMemo(() => {
@@ -71,14 +85,25 @@ export function TraceItemAttributeProvider({
       {key: tag, name: tag, kind: FieldKind.TAG},
     ]);
 
-    return {...stringAttributes, ...Object.fromEntries(tags)};
+    const secondaryAliases: TagCollection = Object.fromEntries(
+      Object.values(stringAttributes ?? {})
+        .flatMap(value => value.secondaryAliases ?? [])
+        .map(alias => [alias, {key: alias, name: alias, kind: FieldKind.TAG}])
+    );
+
+    return {
+      attributes: {...stringAttributes, ...Object.fromEntries(tags)},
+      secondaryAliases,
+    };
   }, [traceItemType, stringAttributes]);
 
   return (
     <TraceItemAttributeContext
       value={{
-        number: allNumberAttributes,
-        string: allStringAttributes,
+        number: allNumberAttributes.attributes,
+        string: allStringAttributes.attributes,
+        numberSecondaryAliases: allNumberAttributes.secondaryAliases,
+        stringSecondaryAliases: allStringAttributes.secondaryAliases,
         numberAttributesLoading,
         stringAttributesLoading,
       }}
@@ -100,11 +125,13 @@ export function useTraceItemAttributes(type?: 'number' | 'string') {
   if (type === 'number') {
     return {
       attributes: typedAttributesResult.number,
+      secondaryAliases: typedAttributesResult.numberSecondaryAliases,
       isLoading: typedAttributesResult.numberAttributesLoading,
     };
   }
   return {
     attributes: typedAttributesResult.string,
+    secondaryAliases: typedAttributesResult.stringSecondaryAliases,
     isLoading: typedAttributesResult.stringAttributesLoading,
   };
 }

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -117,6 +117,7 @@ export function getTraceItemTagCollection(
       key: attribute.key,
       name: attribute.name,
       kind: type === 'number' ? FieldKind.MEASUREMENT : FieldKind.TAG,
+      secondaryAliases: attribute?.secondaryAliases ?? [],
     };
   }
 

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.spec.tsx
@@ -109,16 +109,19 @@ describe('useTraceItemAttributeKeys', () => {
         key: 'test.attribute1',
         name: 'Test Attribute 1',
         kind: FieldKind.TAG,
+        secondaryAliases: [],
       },
       'test.attribute2': {
         key: 'test.attribute2',
         name: 'Test Attribute 2',
         kind: FieldKind.TAG,
+        secondaryAliases: [],
       },
       'test.attribute3': {
         key: 'test.attribute3',
         name: 'Test Attribute 3',
         kind: FieldKind.TAG,
+        secondaryAliases: [],
       },
     };
 
@@ -171,16 +174,19 @@ describe('useTraceItemAttributeKeys', () => {
         key: 'measurement.duration',
         name: 'Duration',
         kind: FieldKind.MEASUREMENT,
+        secondaryAliases: [],
       },
       'measurement.size': {
         key: 'measurement.size',
         name: 'Size',
         kind: FieldKind.MEASUREMENT,
+        secondaryAliases: [],
       },
     };
 
     expect(result.current.attributes).toEqual(expectedAttributes);
   });
+
   it('test escape characters on the query', async () => {
     const attributesWithInvalidChars = [
       {
@@ -229,16 +235,81 @@ describe('useTraceItemAttributeKeys', () => {
         key: 'valid.attribute',
         name: 'Valid Attribute',
         kind: FieldKind.TAG,
+        secondaryAliases: [],
       },
       'valid-attribute-with-dash': {
         key: 'valid-attribute-with-dash',
         name: 'Valid Attribute With Dash',
         kind: FieldKind.TAG,
+        secondaryAliases: [],
       },
       'another_valid.attribute': {
         key: 'another_valid.attribute',
         name: 'Another Valid Attribute',
         kind: FieldKind.TAG,
+        secondaryAliases: [],
+      },
+    };
+
+    expect(result.current.attributes).toEqual(expectedAttributes);
+  });
+
+  it('should return secondary aliases for attributes', async () => {
+    const testAttributeKeys = [
+      {
+        key: 'test.attribute1',
+        name: 'Test Attribute 1',
+        kind: FieldKind.TAG,
+        secondaryAliases: ['test.attribute1.alias'],
+      },
+      {
+        key: 'test.attribute2',
+        name: 'Test Attribute 2',
+        kind: FieldKind.TAG,
+        secondaryAliases: ['test.attribute2.alias'],
+      },
+    ];
+
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/`,
+      body: testAttributeKeys,
+      match: [
+        (_url: string, options: {query?: Record<string, any>}) => {
+          const query = options?.query || {};
+          return (
+            query.itemType === TraceItemDataset.LOGS && query.attributeType === 'string'
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useTraceItemAttributeKeys({
+          traceItemType: TraceItemDataset.LOGS,
+          type: 'string',
+        }),
+      {
+        wrapper: createWrapper(organization),
+      }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockResponse).toHaveBeenCalled();
+
+    // Verify expected attributes (excluding sentry. prefixed ones)
+    const expectedAttributes = {
+      'test.attribute1': {
+        key: 'test.attribute1',
+        name: 'Test Attribute 1',
+        kind: FieldKind.TAG,
+        secondaryAliases: ['test.attribute1.alias'],
+      },
+      'test.attribute2': {
+        key: 'test.attribute2',
+        name: 'Test Attribute 2',
+        kind: FieldKind.TAG,
+        secondaryAliases: ['test.attribute2.alias'],
       },
     };
 

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -180,10 +180,16 @@ export function LogsTabContent({
     timeseriesIngestDelay
   );
 
-  const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
-    useTraceItemAttributes('string');
-  const {attributes: numberAttributes, isLoading: numberAttributesLoading} =
-    useTraceItemAttributes('number');
+  const {
+    attributes: stringAttributes,
+    isLoading: stringAttributesLoading,
+    secondaryAliases: stringSecondaryAliases,
+  } = useTraceItemAttributes('string');
+  const {
+    attributes: numberAttributes,
+    isLoading: numberAttributesLoading,
+    secondaryAliases: numberSecondaryAliases,
+  } = useTraceItemAttributes('number');
 
   const averageLogsPerSecond = calculateAverageLogsPerSecond(timeseriesResult);
 
@@ -218,6 +224,8 @@ export function LogsTabContent({
     numberAttributes,
     stringAttributes,
     itemType: TraceItemDataset.LOGS as TraceItemDataset.LOGS,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
   };
 
   const supportedAggregates = useMemo(() => {

--- a/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
+++ b/static/app/views/explore/multiQueryMode/queryConstructors/search.tsx
@@ -17,8 +17,10 @@ type Props = {index: number; query: ReadableExploreQueryParts};
 
 export function SearchBarSection({query, index}: Props) {
   const {selection} = usePageFilters();
-  const {tags: numberTags} = useTraceItemTags('number');
-  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemTags('number');
+  const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemTags('string');
 
   const updateQuerySearch = useUpdateQueryAtIndex(index);
 
@@ -36,6 +38,8 @@ export function SearchBarSection({query, index}: Props) {
         searchSource="explore"
         numberTags={numberTags}
         stringTags={stringTags}
+        numberSecondaryAliases={numberSecondaryAliases}
+        stringSecondaryAliases={stringSecondaryAliases}
       />
     </Section>
   );

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -190,11 +190,11 @@ describe('SpansTabContent', function () {
         .mockImplementation(type => {
           switch (type) {
             case 'number':
-              return {tags: mockNumberTags, isLoading: false};
+              return {tags: mockNumberTags, isLoading: false, secondaryAliases: {}};
             case 'string':
-              return {tags: mockStringTags, isLoading: false};
+              return {tags: mockStringTags, isLoading: false, secondaryAliases: {}};
             default:
-              return {tags: {}, isLoading: false};
+              return {tags: {}, isLoading: false, secondaryAliases: {}};
           }
         });
 

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -77,7 +77,6 @@ import {Onboarding} from 'sentry/views/performance/onboarding';
 
 // eslint-disable-next-line no-restricted-imports,boundaries/element-types
 import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
-import { useTraceExploreAiQuerySetup } from 'sentry/views/explore/hooks/useTraceExploreAiQuerySetup';
 
 interface SpansTabOnboardingProps {
   datePageFilterProps: PickableDays;
@@ -192,8 +191,6 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
   const organization = useOrganization();
   const areAiFeaturesAllowed =
     !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
-
-  useTraceExploreAiQuerySetup({enableAISearch: areAiFeaturesAllowed});
 
   const {
     tags: numberTags,

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -77,6 +77,7 @@ import {Onboarding} from 'sentry/views/performance/onboarding';
 
 // eslint-disable-next-line no-restricted-imports,boundaries/element-types
 import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
+import { useTraceExploreAiQuerySetup } from 'sentry/views/explore/hooks/useTraceExploreAiQuerySetup';
 
 interface SpansTabOnboardingProps {
   datePageFilterProps: PickableDays;
@@ -192,8 +193,18 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
   const areAiFeaturesAllowed =
     !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
 
-  const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
-  const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
+  useTraceExploreAiQuerySetup({enableAISearch: areAiFeaturesAllowed});
+
+  const {
+    tags: numberTags,
+    isLoading: numberTagsLoading,
+    secondaryAliases: numberSecondaryAliases,
+  } = useTraceItemTags('number');
+  const {
+    tags: stringTags,
+    isLoading: stringTagsLoading,
+    secondaryAliases: stringSecondaryAliases,
+  } = useTraceItemTags('string');
 
   const search = useMemo(() => new MutableSearch(query), [query]);
   const oldSearch = usePrevious(search);
@@ -233,8 +244,20 @@ function SpanTabSearchSection({datePageFilterProps}: SpanTabSearchSectionProps) 
       numberTags,
       stringTags,
       replaceRawSearchKeys: ['span.description'],
+      numberSecondaryAliases,
+      stringSecondaryAliases,
     }),
-    [fields, mode, query, setExplorePageParams, numberTags, stringTags, oldSearch]
+    [
+      query,
+      mode,
+      numberTags,
+      numberSecondaryAliases,
+      stringTags,
+      stringSecondaryAliases,
+      oldSearch,
+      fields,
+      setExplorePageParams,
+    ]
   );
 
   const eapSpanSearchQueryProviderProps = useEAPSpanSearchQueryBuilderProps(

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -120,8 +120,10 @@ function AgentsMonitoringPage() {
     [organization, activeTable, onActiveTableChange]
   );
 
-  const {tags: numberTags} = useTraceItemTags('number');
-  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemTags('number');
+  const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemTags('string');
 
   const eapSpanSearchQueryBuilderProps = useMemo(
     () => ({
@@ -132,9 +134,18 @@ function AgentsMonitoringPage() {
       searchSource: 'agent-monitoring',
       numberTags,
       stringTags,
+      numberSecondaryAliases,
+      stringSecondaryAliases,
       replaceRawSearchKeys: ['span.description'],
     }),
-    [searchQuery, numberTags, stringTags, setSearchQuery]
+    [
+      numberSecondaryAliases,
+      numberTags,
+      searchQuery,
+      setSearchQuery,
+      stringSecondaryAliases,
+      stringTags,
+    ]
   );
 
   const eapSpanSearchQueryProviderProps = useEAPSpanSearchQueryBuilderProps(

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -168,7 +168,14 @@ function McpOverviewPage() {
       stringSecondaryAliases,
       replaceRawSearchKeys: ['span.description'],
     }),
-    [numberSecondaryAliases, numberTags, searchQuery, stringSecondaryAliases, stringTags]
+    [
+      numberSecondaryAliases,
+      numberTags,
+      searchQuery,
+      setSearchQuery,
+      stringSecondaryAliases,
+      stringTags,
+    ]
   );
 
   const eapSpanSearchQueryProviderProps = useEAPSpanSearchQueryBuilderProps(

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -150,8 +150,10 @@ function McpOverviewPage() {
     [activeView, location, navigate, organization]
   );
 
-  const {tags: numberTags} = useTraceItemTags('number');
-  const {tags: stringTags} = useTraceItemTags('string');
+  const {tags: numberTags, secondaryAliases: numberSecondaryAliases} =
+    useTraceItemTags('number');
+  const {tags: stringTags, secondaryAliases: stringSecondaryAliases} =
+    useTraceItemTags('string');
 
   const eapSpanSearchQueryBuilderProps = useMemo(
     () => ({
@@ -162,9 +164,11 @@ function McpOverviewPage() {
       searchSource: 'mcp-monitoring',
       numberTags,
       stringTags,
+      numberSecondaryAliases,
+      stringSecondaryAliases,
       replaceRawSearchKeys: ['span.description'],
     }),
-    [searchQuery, numberTags, stringTags, setSearchQuery]
+    [numberSecondaryAliases, numberTags, searchQuery, stringSecondaryAliases, stringTags]
   );
 
   const eapSpanSearchQueryProviderProps = useEAPSpanSearchQueryBuilderProps(


### PR DESCRIPTION
This PR updates a couple of things to grab `secondaryAliases` from the API response grabbing filter values for the traces search bar so that certain filter keys no longer show invalid.

The way this is implemented also ensures that these secondary aliases are not included in the filter key drop down, so users will still be pushed to use the new filter keys when building new search queries.

Ticket EXP-363