### PR TITLE
fix(ui): remove unnecessary double border

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -70,7 +70,6 @@ function FocusTabs({isVideoReplay}: Props) {
 
 const TabContainer = styled('div')`
   padding-inline: ${space(1)};
-  border-bottom: solid 1px #e0dce5;
 
   & > * {
     margin-bottom: -1px;


### PR DESCRIPTION
this looked broken in both UI1 and UI2

| before | after |
|--------|--------|
| ![Screenshot 2025-06-27 at 15 59 40](https://github.com/user-attachments/assets/7ca0191c-9ffd-44c0-95d7-9b3e93b907ad) | ![Screenshot 2025-06-27 at 16 00 46](https://github.com/user-attachments/assets/7c229560-9eaa-49a5-bf1e-9d3dce68abf4) | 
| ![Screenshot 2025-06-27 at 15 59 55](https://github.com/user-attachments/assets/dd7781d7-8872-4b92-9854-f37a2d9a9062) | ![Screenshot 2025-06-27 at 16 00 28](https://github.com/user-attachments/assets/8835e0c1-aaec-4c7e-924c-c1786a92cf90) | 