### PR TITLE
fit(replay): Fix tab border in Replay Details

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -33,7 +33,7 @@ type Props = {
   isVideoReplay: boolean;
 };
 
-function FocusTabs({isVideoReplay}: Props) {
+export default function FocusTabs({isVideoReplay}: Props) {
   const organization = useOrganization();
   const {getActiveTab, setActiveTab} = useActiveReplayTab({isVideoReplay});
   const activeTab = getActiveTab();
@@ -56,7 +56,7 @@ function FocusTabs({isVideoReplay}: Props) {
           });
         }}
       >
-        <TabList>
+        <TabList hideBorder>
           {tabs.map(([tab, label]) => (
             <TabList.Item key={tab} data-test-id={`replay-details-${tab}-btn`}>
               {label}
@@ -69,11 +69,6 @@ function FocusTabs({isVideoReplay}: Props) {
 }
 
 const TabContainer = styled('div')`
-  padding-inline: ${space(1)};
-
-  & > * {
-    margin-bottom: -1px;
-  }
+  ${p => (p.theme.isChonk ? '' : `padding-inline: ${space(1)};`)}
+  border-bottom: 1px solid ${p => p.theme.border};
 `;
-
-export default FocusTabs;


### PR DESCRIPTION
For a little while there was a double-border because the `<Tabs>` component removed the border in all cases, and buttons changed to overflow their container. The `hideBorder` prop is deprecated, but it is required as long at ui1 is available.

Here's what this PR does:
| UI1 | UI2 | 
| --- | --- |
| <img width="626" alt="Screenshot 2025-06-27 at 8 08 12 AM" src="https://github.com/user-attachments/assets/c3fdab68-fa9f-465d-a5f7-ee5f4c02f9e0" />
 | <img width="626" alt="Screenshot 2025-06-27 at 8 08 01 AM" src="https://github.com/user-attachments/assets/fc8cd6d5-48d1-47f4-af53-c00cc9843baa" />

---

For context here's what `<Tabs>` look like with/without `hideBorder` (UI1 has a border):
| UI1 | UI2 |
| --- | --- |
| <img width="858" alt="Screenshot 2025-06-27 at 8 16 54 AM" src="https://github.com/user-attachments/assets/c8558bf2-27eb-4415-9318-f8f793b09f09" /> | <img width="858" alt="Screenshot 2025-06-27 at 8 17 12 AM" src="https://github.com/user-attachments/assets/efe1f7d0-dcaa-4f58-97d5-68e194c9572f" />

Notice how in UI1 there is a border, and ui 2 never has one
also notice how in ui1 the bottom border does not extend all the way to the left under the :hover'd background :(. to account for this we need to hide the tabs border, and create our own.
