### PR TITLE
fix(nav): Prevent saved searches request when new nav is active

### DIFF
--- a/static/app/views/issueList/newViewEmptyState.tsx
+++ b/static/app/views/issueList/newViewEmptyState.tsx
@@ -70,9 +70,15 @@ function Query({label, query}: SearchSuggestion) {
 
 export function NewViewEmptyState() {
   const organization = useOrganization();
-  const {data: savedSearches = [], isPending} = useFetchSavedSearchesForOrg({
-    orgSlug: organization.slug,
-  });
+  const {data: savedSearches = [], isPending} = useFetchSavedSearchesForOrg(
+    {
+      orgSlug: organization.slug,
+    },
+    {
+      // Force this to be enabled even with the new navigation
+      enabled: true,
+    }
+  );
 
   const personalSavedSearches = savedSearches.filter(
     search => search.visibility === SavedSearchVisibility.OWNER

--- a/static/app/views/issueList/queries/useFetchSavedSearchesForOrg.tsx
+++ b/static/app/views/issueList/queries/useFetchSavedSearchesForOrg.tsx
@@ -1,6 +1,7 @@
 import type {SavedSearch} from 'sentry/types/group';
 import type {UseApiQueryOptions} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
 type FetchSavedSearchesForOrgParameters = {
   orgSlug: string;
@@ -17,10 +18,13 @@ export const useFetchSavedSearchesForOrg = (
   {orgSlug}: FetchSavedSearchesForOrgParameters,
   options: Partial<UseApiQueryOptions<FetchSavedSearchesForOrgResponse>> = {}
 ) => {
+  const prefersStackedNav = usePrefersStackedNav();
+
   return useApiQuery<FetchSavedSearchesForOrgResponse>(
     makeFetchSavedSearchesForOrgQueryKey({orgSlug}),
     {
       staleTime: 30000,
+      enabled: !prefersStackedNav,
       ...options,
     }
   );


### PR DESCRIPTION
It was already being disabled from overview.tsx, but there were other locations which used the hook and caused a request to fire, which caused some old default searches to apply their sort params