### PR TITLE
fix(dashboards): Pass in sampling rate to span widget queries

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -17,6 +17,7 @@ import {
   type Widget,
   WidgetType,
 } from 'sentry/views/dashboards/types';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
 import type {
@@ -166,6 +167,9 @@ function WidgetQueries({
           organization={organization}
           selection={selection}
           widget={widget}
+          samplingMode={
+            widget.widgetType === WidgetType.SPANS ? SAMPLING_MODE.NORMAL : undefined
+          }
           cursor={cursor}
           limit={limit}
           dashboardFilters={dashboardFilters}


### PR DESCRIPTION
Slack thread for context: https://sentry.slack.com/archives/C072KUA8R1U/p1750974006347889

I've passed in the `NORMAL` sampling mode on span widgets so that table queries don't time out.
