### PR TITLE
ref(replay): Extract components from `<BreadcrumbItem>`

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbCodeSnippet.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbCodeSnippet.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import beautify from 'js-beautify';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import Placeholder from 'sentry/components/placeholder';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
+import type {ReplayFrame} from 'sentry/utils/replays/types';
+import {isSpanFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
+
+interface Props {
+  frame: ReplayFrame;
+  isPending: boolean;
+  showSnippet: boolean;
+  extraction?: Extraction;
+}
+
+export function BreadcrumbCodeSnippet({
+  frame,
+  extraction,
+  showSnippet,
+  isPending,
+}: Props) {
+  if (showSnippet && isPending) {
+    return <Placeholder height="34px" />;
+  }
+
+  return (
+    (!isSpanFrame(frame) || !isWebVitalFrame(frame)) &&
+    !isPending &&
+    showSnippet &&
+    extraction?.html?.map(html => (
+      <CodeContainer key={html}>
+        <CodeSnippet language="html" hideCopyButton>
+          {beautify.html(html, {indent_size: 2})}
+        </CodeSnippet>
+      </CodeContainer>
+    ))
+  );
+}
+
+const CodeContainer = styled('div')`
+  max-height: 400px;
+  max-width: 100%;
+  overflow: auto;
+`;

--- a/static/app/components/replays/breadcrumbs/breadcrumbCodeSnippet.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbCodeSnippet.tsx
@@ -5,7 +5,7 @@ import {CodeSnippet} from 'sentry/components/codeSnippet';
 import Placeholder from 'sentry/components/placeholder';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
-import {isSpanFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
+import {isSpanFrame} from 'sentry/utils/replays/types';
 
 interface Props {
   frame: ReplayFrame;
@@ -20,22 +20,25 @@ export function BreadcrumbCodeSnippet({
   showSnippet,
   isPending,
 }: Props) {
-  if (showSnippet && isPending) {
+  if (!showSnippet) {
+    return null;
+  }
+
+  if (isPending) {
     return <Placeholder height="34px" />;
   }
 
-  return (
-    (!isSpanFrame(frame) || !isWebVitalFrame(frame)) &&
-    !isPending &&
-    showSnippet &&
-    extraction?.html?.map(html => (
-      <CodeContainer key={html}>
-        <CodeSnippet language="html" hideCopyButton>
-          {beautify.html(html, {indent_size: 2})}
-        </CodeSnippet>
-      </CodeContainer>
-    ))
-  );
+  if (isSpanFrame(frame)) {
+    return null;
+  }
+
+  return extraction?.html?.map(html => (
+    <CodeContainer key={html}>
+      <CodeSnippet language="html" hideCopyButton>
+        {beautify.html(html, {indent_size: 2})}
+      </CodeSnippet>
+    </CodeContainer>
+  ));
 }
 
 const CodeContainer = styled('div')`

--- a/static/app/components/replays/breadcrumbs/breadcrumbComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbComparisonButton.tsx
@@ -2,7 +2,7 @@ import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/
 import {t} from 'sentry/locale';
 import {getReplayDiffOffsetsFromFrame} from 'sentry/utils/replays/getDiffTimestamps';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
-import type {HydrationErrorFrame, ReplayFrame} from 'sentry/utils/replays/types';
+import type {ReplayFrame} from 'sentry/utils/replays/types';
 import {isBreadcrumbFrame, isHydrationErrorFrame} from 'sentry/utils/replays/types';
 
 interface Props {
@@ -15,16 +15,6 @@ export function BreadcrumbComparisonButton({frame, replay}: Props) {
     return null;
   }
 
-  return <CrumbHydrationButton replay={replay} frame={frame} />;
-}
-
-function CrumbHydrationButton({
-  replay,
-  frame,
-}: {
-  frame: HydrationErrorFrame;
-  replay: ReplayReader;
-}) {
   const {frameOrEvent, leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromFrame(
     replay,
     frame

--- a/static/app/components/replays/breadcrumbs/breadcrumbComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbComparisonButton.tsx
@@ -1,0 +1,47 @@
+import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
+import {t} from 'sentry/locale';
+import {getReplayDiffOffsetsFromFrame} from 'sentry/utils/replays/getDiffTimestamps';
+import type ReplayReader from 'sentry/utils/replays/replayReader';
+import type {HydrationErrorFrame, ReplayFrame} from 'sentry/utils/replays/types';
+import {isBreadcrumbFrame, isHydrationErrorFrame} from 'sentry/utils/replays/types';
+
+interface Props {
+  frame: ReplayFrame;
+  replay: ReplayReader | null;
+}
+
+export function BreadcrumbComparisonButton({frame, replay}: Props) {
+  if (!isBreadcrumbFrame(frame) || !isHydrationErrorFrame(frame) || !replay) {
+    return null;
+  }
+
+  return <CrumbHydrationButton replay={replay} frame={frame} />;
+}
+
+function CrumbHydrationButton({
+  replay,
+  frame,
+}: {
+  frame: HydrationErrorFrame;
+  replay: ReplayReader;
+}) {
+  const {frameOrEvent, leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromFrame(
+    replay,
+    frame
+  );
+
+  return (
+    <div>
+      <OpenReplayComparisonButton
+        frameOrEvent={frameOrEvent}
+        initialLeftOffsetMs={leftOffsetMs}
+        initialRightOffsetMs={rightOffsetMs}
+        replay={replay}
+        size="xs"
+        surface="replay-breadcrumbs"
+      >
+        {t('Open Hydration Diff')}
+      </OpenReplayComparisonButton>
+    </div>
+  );
+}

--- a/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
@@ -22,7 +22,7 @@ interface Props {
   expandPaths?: string[];
 }
 
-export function BreadcrumbItemDescription({
+export function BreadcrumbDescription({
   description,
   allowShowSnippet,
   showSnippet,

--- a/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
@@ -32,9 +32,8 @@ export function BreadcrumbDescription({
   onClickViewHtml,
 }: Props) {
   if (
-    typeof description !== 'string' &&
-    description !== undefined &&
-    isValidElement(description)
+    typeof description === 'string' ||
+    (description !== undefined && isValidElement(description))
   ) {
     return (
       <DescriptionWrapper>

--- a/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
@@ -8,7 +8,7 @@ import StructuredEventData from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ReplayFrame, WebVitalFrame} from 'sentry/utils/replays/types';
-import {isSpanFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
+import {isSpanFrame} from 'sentry/utils/replays/types';
 import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
 
 interface Props {
@@ -44,7 +44,7 @@ export function BreadcrumbDescription({
         {allowShowSnippet &&
           !showSnippet &&
           frame.data?.nodeId !== undefined &&
-          (!isSpanFrame(frame) || !isWebVitalFrame(frame)) && (
+          !isSpanFrame(frame) && (
             <ViewHtmlButton priority="link" onClick={onClickViewHtml} size="xs">
               {t('View HTML')}
             </ViewHtmlButton>

--- a/static/app/components/replays/breadcrumbs/breadcrumbIssueLink.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbIssueLink.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+
+import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
+import Link from 'sentry/components/links/link';
+import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
+import {space} from 'sentry/styles/space';
+import type {ErrorFrame, FeedbackFrame, ReplayFrame} from 'sentry/utils/replays/types';
+import {isErrorFrame, isFeedbackFrame} from 'sentry/utils/replays/types';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
+import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
+
+interface Props {
+  frame: ReplayFrame;
+}
+
+export function BreadcrumbIssueLink({frame}: Props) {
+  if (!isErrorFrame(frame) && !isFeedbackFrame(frame)) {
+    return null;
+  }
+
+  return <CrumbErrorIssue frame={frame} />;
+}
+
+function CrumbErrorIssue({frame}: {frame: FeedbackFrame | ErrorFrame}) {
+  const organization = useOrganization();
+  const project = useProjectFromSlug({organization, projectSlug: frame.data.projectSlug});
+  const {groupId} = useReplayGroupContext();
+
+  const projectAvatar = project ? <ProjectAvatar project={project} size={16} /> : null;
+
+  if (String(frame.data.groupId) === groupId) {
+    return (
+      <CrumbIssueWrapper>
+        {projectAvatar}
+        {frame.data.groupShortId}
+      </CrumbIssueWrapper>
+    );
+  }
+
+  return (
+    <CrumbIssueWrapper>
+      {projectAvatar}
+      <Link
+        to={
+          isFeedbackFrame(frame)
+            ? {
+                pathname: makeFeedbackPathname({
+                  path: '/',
+                  organization,
+                }),
+                query: {feedbackSlug: `${frame.data.projectSlug}:${frame.data.groupId}`},
+              }
+            : `/organizations/${organization.slug}/issues/${frame.data.groupId}/`
+        }
+      >
+        {frame.data.groupShortId}
+      </Link>
+    </CrumbIssueWrapper>
+  );
+}
+
+const CrumbIssueWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  font-size: ${p => p.theme.fontSize.sm};
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -126,6 +126,7 @@ function BreadcrumbItem({
           allowShowSnippet={allowShowSnippet}
           showSnippet={showSnippet}
           onClickViewHtml={handleViewHtml}
+          expandPaths={expandPaths}
           onInspectorExpanded={onInspectorExpanded}
         />
         <BreadcrumbComparisonButton frame={frame} replay={replay} />
@@ -162,7 +163,7 @@ const StyledTimelineItem = styled(Timeline.Item)`
   }
   cursor: pointer;
   /* vertical line connecting items */
-  &::before {
+  &:not(:last-child)::before {
     content: '';
     position: absolute;
     left: 16.5px;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,50 +1,26 @@
-import type {CSSProperties, ReactNode} from 'react';
+import type {CSSProperties} from 'react';
 import {useCallback, useEffect, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import beautify from 'js-beautify';
 
-import {CodeSnippet} from 'sentry/components/codeSnippet';
-import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
-import {Button} from 'sentry/components/core/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Link from 'sentry/components/links/link';
-import Placeholder from 'sentry/components/placeholder';
-import {BreadcrumbItemDescription} from 'sentry/components/replays/breadcrumbs/breadcrumbItemDescription';
-import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
+import {BreadcrumbCodeSnippet} from 'sentry/components/replays/breadcrumbs/breadcrumbCodeSnippet';
+import {BreadcrumbComparisonButton} from 'sentry/components/replays/breadcrumbs/breadcrumbComparisonButton';
+import {BreadcrumbDescription} from 'sentry/components/replays/breadcrumbs/breadcrumbDescription';
+import {BreadcrumbIssueLink} from 'sentry/components/replays/breadcrumbs/breadcrumbIssueLink';
+import {BreadcrumbWebVital} from 'sentry/components/replays/breadcrumbs/breadcrumbWebVital';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
-import StructuredEventData from 'sentry/components/structuredEventData';
 import {Timeline} from 'sentry/components/timeline';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
-import {getReplayDiffOffsetsFromFrame} from 'sentry/utils/replays/getDiffTimestamps';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
 import useExtractDomNodes from 'sentry/utils/replays/hooks/useExtractDomNodes';
-import type ReplayReader from 'sentry/utils/replays/replayReader';
-import type {
-  ErrorFrame,
-  FeedbackFrame,
-  HydrationErrorFrame,
-  ReplayFrame,
-  WebVitalFrame,
-} from 'sentry/utils/replays/types';
-import {
-  isBreadcrumbFrame,
-  isCLSFrame,
-  isErrorFrame,
-  isFeedbackFrame,
-  isHydrationErrorFrame,
-  isSpanFrame,
-  isWebVitalFrame,
-} from 'sentry/utils/replays/types';
+import type {ReplayFrame} from 'sentry/utils/replays/types';
+import {isErrorFrame} from 'sentry/utils/replays/types';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjectFromSlug from 'sentry/utils/useProjectFromSlug';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
-import {makeFeedbackPathname} from 'sentry/views/userFeedback/pathnames';
 
 type MouseCallback = (frame: ReplayFrame, nodeId?: number) => void;
 
@@ -119,57 +95,6 @@ function BreadcrumbItem({
     [onShowSnippet, organization, frame]
   );
 
-  const renderComparisonButton = useCallback(() => {
-    return isBreadcrumbFrame(frame) && isHydrationErrorFrame(frame) && replay ? (
-      <CrumbHydrationButton replay={replay} frame={frame} />
-    ) : null;
-  }, [frame, replay]);
-
-  const renderWebVital = useCallback(() => {
-    return isSpanFrame(frame) && isWebVitalFrame(frame) ? (
-      <WebVitalData
-        selectors={extraction?.selectors}
-        frame={frame}
-        expandPaths={expandPaths}
-        onInspectorExpanded={onInspectorExpanded}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      />
-    ) : null;
-  }, [
-    expandPaths,
-    extraction?.selectors,
-    frame,
-    onInspectorExpanded,
-    onMouseEnter,
-    onMouseLeave,
-  ]);
-
-  const renderCodeSnippet = useCallback(() => {
-    if (showSnippet && isPending) {
-      return <Placeholder height="34px" />;
-    }
-
-    return (
-      (!isSpanFrame(frame) || !isWebVitalFrame(frame)) &&
-      !isPending &&
-      showSnippet &&
-      extraction?.html?.map(html => (
-        <CodeContainer key={html}>
-          <CodeSnippet language="html" hideCopyButton>
-            {beautify.html(html, {indent_size: 2})}
-          </CodeSnippet>
-        </CodeContainer>
-      ))
-    );
-  }, [frame, isPending, extraction?.html, showSnippet]);
-
-  const renderIssueLink = useCallback(() => {
-    return isErrorFrame(frame) || isFeedbackFrame(frame) ? (
-      <CrumbErrorIssue frame={frame} />
-    ) : null;
-  }, [frame]);
-
   return (
     <StyledTimelineItem
       ref={ref}
@@ -195,7 +120,7 @@ function BreadcrumbItem({
       onMouseLeave={() => onMouseLeave(frame)}
     >
       <ErrorBoundary mini>
-        <BreadcrumbItemDescription
+        <BreadcrumbDescription
           description={description}
           frame={frame}
           allowShowSnippet={allowShowSnippet}
@@ -203,179 +128,26 @@ function BreadcrumbItem({
           onClickViewHtml={handleViewHtml}
           onInspectorExpanded={onInspectorExpanded}
         />
-        {renderComparisonButton()}
-        {renderWebVital()}
-        {renderCodeSnippet()}
-        {renderIssueLink()}
+        <BreadcrumbComparisonButton frame={frame} replay={replay} />
+        <BreadcrumbWebVital
+          frame={frame}
+          extraction={extraction || undefined}
+          expandPaths={expandPaths}
+          onInspectorExpanded={onInspectorExpanded}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        />
+        <BreadcrumbCodeSnippet
+          frame={frame}
+          extraction={extraction || undefined}
+          showSnippet={showSnippet}
+          isPending={isPending}
+        />
+        <BreadcrumbIssueLink frame={frame} />
       </ErrorBoundary>
     </StyledTimelineItem>
   );
 }
-
-function WebVitalData({
-  selectors,
-  frame,
-  expandPaths,
-  onInspectorExpanded,
-  onMouseEnter,
-  onMouseLeave,
-}: {
-  expandPaths: string[] | undefined;
-  frame: WebVitalFrame;
-  onInspectorExpanded: OnExpandCallback;
-  onMouseEnter: MouseCallback;
-  onMouseLeave: MouseCallback;
-  selectors: Map<number, string> | undefined;
-}) {
-  const webVitalData = {value: frame.data.value};
-  if (isCLSFrame(frame) && frame.data.attributions && selectors) {
-    const layoutShifts: Array<Record<string, ReactNode[]>> = [];
-    for (const attr of frame.data.attributions) {
-      const elements: ReactNode[] = [];
-      if ('nodeIds' in attr && Array.isArray(attr.nodeIds)) {
-        attr.nodeIds.forEach(nodeId => {
-          if (selectors.get(nodeId)) {
-            elements.push(
-              <span
-                key={nodeId}
-                onMouseEnter={() => onMouseEnter(frame, nodeId)}
-                onMouseLeave={() => onMouseLeave(frame, nodeId)}
-              >
-                <ValueObjectKey>{t('element')}</ValueObjectKey>
-                <span>{': '}</span>
-                <span>
-                  <SelectorButton>{selectors.get(nodeId)}</SelectorButton>
-                </span>
-              </span>
-            );
-          }
-        });
-      }
-      // if we can't find the elements associated with the layout shift, we still show the score with element: unknown
-      if (!elements.length) {
-        elements.push(
-          <span>
-            <ValueObjectKey>{t('element')}</ValueObjectKey>
-            <span>{': '}</span>
-            <ValueNull>{t('unknown')}</ValueNull>
-          </span>
-        );
-      }
-      layoutShifts.push({[`score ${attr.value}`]: elements});
-    }
-    if (layoutShifts.length) {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      webVitalData['Layout shifts'] = layoutShifts;
-    }
-  } else if (selectors) {
-    selectors.forEach((key, value) => {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      webVitalData[key] = (
-        <span
-          key={key}
-          onMouseEnter={() => onMouseEnter(frame, value)}
-          onMouseLeave={() => onMouseLeave(frame, value)}
-        >
-          <ValueObjectKey>{t('element')}</ValueObjectKey>
-          <span>{': '}</span>
-          <SelectorButton size="zero" borderless>
-            {key}
-          </SelectorButton>
-        </span>
-      );
-    });
-  }
-
-  return (
-    <Wrapper>
-      <StructuredEventData
-        initialExpandedPaths={expandPaths ?? []}
-        onToggleExpand={(expandedPaths, path) => {
-          onInspectorExpanded(
-            path,
-            Object.fromEntries(expandedPaths.map(item => [item, true]))
-          );
-        }}
-        data={webVitalData}
-        withAnnotatedText
-      />
-    </Wrapper>
-  );
-}
-
-function CrumbHydrationButton({
-  replay,
-  frame,
-}: {
-  frame: HydrationErrorFrame;
-  replay: ReplayReader;
-}) {
-  const {frameOrEvent, leftOffsetMs, rightOffsetMs} = getReplayDiffOffsetsFromFrame(
-    replay,
-    frame
-  );
-
-  return (
-    <div>
-      <OpenReplayComparisonButton
-        frameOrEvent={frameOrEvent}
-        initialLeftOffsetMs={leftOffsetMs}
-        initialRightOffsetMs={rightOffsetMs}
-        replay={replay}
-        size="xs"
-        surface="replay-breadcrumbs"
-      >
-        {t('Open Hydration Diff')}
-      </OpenReplayComparisonButton>
-    </div>
-  );
-}
-
-function CrumbErrorIssue({frame}: {frame: FeedbackFrame | ErrorFrame}) {
-  const organization = useOrganization();
-  const project = useProjectFromSlug({organization, projectSlug: frame.data.projectSlug});
-  const {groupId} = useReplayGroupContext();
-
-  const projectAvatar = project ? <ProjectAvatar project={project} size={16} /> : null;
-
-  if (String(frame.data.groupId) === groupId) {
-    return (
-      <CrumbIssueWrapper>
-        {projectAvatar}
-        {frame.data.groupShortId}
-      </CrumbIssueWrapper>
-    );
-  }
-
-  return (
-    <CrumbIssueWrapper>
-      {projectAvatar}
-      <Link
-        to={
-          isFeedbackFrame(frame)
-            ? {
-                pathname: makeFeedbackPathname({
-                  path: '/',
-                  organization,
-                }),
-                query: {feedbackSlug: `${frame.data.projectSlug}:${frame.data.groupId}`},
-              }
-            : `/organizations/${organization.slug}/issues/${frame.data.groupId}/`
-        }
-      >
-        {frame.data.groupShortId}
-      </Link>
-    </CrumbIssueWrapper>
-  );
-}
-
-const CrumbIssueWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
-  font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.subText};
-`;
 
 const StyledTimelineItem = styled(Timeline.Item)`
   width: 100%;
@@ -409,41 +181,6 @@ const ReplayTimestamp = styled('div')`
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSize.sm};
   align-self: flex-start;
-`;
-
-const CodeContainer = styled('div')`
-  max-height: 400px;
-  max-width: 100%;
-  overflow: auto;
-`;
-
-const ValueObjectKey = styled('span')`
-  color: var(--prism-keyword);
-`;
-
-const ValueNull = styled('span')`
-  font-weight: ${p => p.theme.fontWeight.bold};
-  color: var(--prism-property);
-`;
-
-const SelectorButton = styled(Button)`
-  background: none;
-  border: none;
-  padding: 0 2px;
-  border-radius: 2px;
-  font-weight: ${p => p.theme.fontWeight.normal};
-  box-shadow: none;
-  font-size: ${p => p.theme.fontSize.sm};
-  color: ${p => p.theme.subText};
-  margin: 0 ${space(0.5)};
-  height: auto;
-  min-height: auto;
-`;
-
-const Wrapper = styled('div')`
-  pre {
-    margin: 0;
-  }
 `;
 
 export default BreadcrumbItem;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItemDescription.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItemDescription.tsx
@@ -1,0 +1,96 @@
+import type {ReactNode} from 'react';
+import {isValidElement} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import StructuredEventData from 'sentry/components/structuredEventData';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {ReplayFrame, WebVitalFrame} from 'sentry/utils/replays/types';
+import {isSpanFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
+import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
+
+interface Props {
+  allowShowSnippet: boolean;
+  description: ReactNode;
+  frame: ReplayFrame | WebVitalFrame;
+  onClickViewHtml: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onInspectorExpanded: OnExpandCallback;
+  showSnippet: boolean;
+  className?: string;
+  expandPaths?: string[];
+}
+
+export function BreadcrumbItemDescription({
+  description,
+  allowShowSnippet,
+  showSnippet,
+  frame,
+  expandPaths,
+  onInspectorExpanded,
+  onClickViewHtml,
+}: Props) {
+  if (
+    typeof description !== 'string' &&
+    description !== undefined &&
+    isValidElement(description)
+  ) {
+    return (
+      <DescriptionWrapper>
+        <Description title={description} showOnlyOnOverflow isHoverable>
+          {description}
+        </Description>
+
+        {allowShowSnippet &&
+          !showSnippet &&
+          frame.data?.nodeId !== undefined &&
+          (!isSpanFrame(frame) || !isWebVitalFrame(frame)) && (
+            <ViewHtmlButton priority="link" onClick={onClickViewHtml} size="xs">
+              {t('View HTML')}
+            </ViewHtmlButton>
+          )}
+      </DescriptionWrapper>
+    );
+  }
+
+  return (
+    <Wrapper>
+      <StructuredEventData
+        initialExpandedPaths={expandPaths ?? []}
+        onToggleExpand={(expandedPaths, path) => {
+          onInspectorExpanded(
+            path,
+            Object.fromEntries(expandedPaths.map(item => [item, true]))
+          );
+        }}
+        data={description}
+        withAnnotatedText
+      />
+    </Wrapper>
+  );
+}
+
+const Description = styled(Tooltip)`
+  ${p => p.theme.overflowEllipsis};
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  line-height: ${p => p.theme.text.lineHeightBody};
+  color: ${p => p.theme.subText};
+`;
+
+const DescriptionWrapper = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  justify-content: space-between;
+`;
+
+const ViewHtmlButton = styled(Button)`
+  white-space: nowrap;
+`;
+
+const Wrapper = styled('div')`
+  pre {
+    margin: 0;
+  }
+`;

--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -6,8 +6,8 @@ import StructuredEventData from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
-import type {ReplayFrame, WebVitalFrame} from 'sentry/utils/replays/types';
-import {isCLSFrame, isSpanFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
+import type {ReplayFrame} from 'sentry/utils/replays/types';
+import {isCLSFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
 import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
 
 type MouseCallback = (frame: ReplayFrame, nodeId?: number) => void;
@@ -29,38 +29,13 @@ export function BreadcrumbWebVital({
   onMouseEnter,
   onMouseLeave,
 }: Props) {
-  if (!isSpanFrame(frame) || !isWebVitalFrame(frame)) {
+  if (!isWebVitalFrame(frame)) {
     return null;
   }
 
-  return (
-    <WebVitalData
-      selectors={extraction?.selectors}
-      frame={frame}
-      expandPaths={expandPaths}
-      onInspectorExpanded={onInspectorExpanded}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-    />
-  );
-}
-
-function WebVitalData({
-  selectors,
-  frame,
-  expandPaths,
-  onInspectorExpanded,
-  onMouseEnter,
-  onMouseLeave,
-}: {
-  expandPaths: string[] | undefined;
-  frame: WebVitalFrame;
-  onInspectorExpanded: OnExpandCallback;
-  onMouseEnter: MouseCallback;
-  onMouseLeave: MouseCallback;
-  selectors: Map<number, string> | undefined;
-}) {
   const webVitalData = {value: frame.data.value};
+  const selectors = extraction?.selectors;
+
   if (isCLSFrame(frame) && frame.data.attributions && selectors) {
     const layoutShifts: Array<Record<string, ReactNode[]>> = [];
     for (const attr of frame.data.attributions) {
@@ -120,19 +95,17 @@ function WebVitalData({
   }
 
   return (
-    <Wrapper>
-      <StructuredEventData
-        initialExpandedPaths={expandPaths ?? []}
-        onToggleExpand={(expandedPaths, path) => {
-          onInspectorExpanded(
-            path,
-            Object.fromEntries(expandedPaths.map(item => [item, true]))
-          );
-        }}
-        data={webVitalData}
-        withAnnotatedText
-      />
-    </Wrapper>
+    <StructuredEventData
+      initialExpandedPaths={expandPaths ?? []}
+      onToggleExpand={(expandedPaths, path) => {
+        onInspectorExpanded(
+          path,
+          Object.fromEntries(expandedPaths.map(item => [item, true]))
+        );
+      }}
+      data={webVitalData}
+      withAnnotatedText
+    />
   );
 }
 
@@ -157,10 +130,4 @@ const SelectorButton = styled(Button)`
   margin: 0 ${space(0.5)};
   height: auto;
   min-height: auto;
-`;
-
-const Wrapper = styled('div')`
-  pre {
-    margin: 0;
-  }
 `;

--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -1,0 +1,166 @@
+import type {ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/core/button';
+import StructuredEventData from 'sentry/components/structuredEventData';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Extraction} from 'sentry/utils/replays/extractDomNodes';
+import type {ReplayFrame, WebVitalFrame} from 'sentry/utils/replays/types';
+import {isCLSFrame, isSpanFrame, isWebVitalFrame} from 'sentry/utils/replays/types';
+import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
+
+type MouseCallback = (frame: ReplayFrame, nodeId?: number) => void;
+
+interface Props {
+  frame: ReplayFrame;
+  onInspectorExpanded: OnExpandCallback;
+  onMouseEnter: MouseCallback;
+  onMouseLeave: MouseCallback;
+  expandPaths?: string[];
+  extraction?: Extraction;
+}
+
+export function BreadcrumbWebVital({
+  frame,
+  extraction,
+  expandPaths,
+  onInspectorExpanded,
+  onMouseEnter,
+  onMouseLeave,
+}: Props) {
+  if (!isSpanFrame(frame) || !isWebVitalFrame(frame)) {
+    return null;
+  }
+
+  return (
+    <WebVitalData
+      selectors={extraction?.selectors}
+      frame={frame}
+      expandPaths={expandPaths}
+      onInspectorExpanded={onInspectorExpanded}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    />
+  );
+}
+
+function WebVitalData({
+  selectors,
+  frame,
+  expandPaths,
+  onInspectorExpanded,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  expandPaths: string[] | undefined;
+  frame: WebVitalFrame;
+  onInspectorExpanded: OnExpandCallback;
+  onMouseEnter: MouseCallback;
+  onMouseLeave: MouseCallback;
+  selectors: Map<number, string> | undefined;
+}) {
+  const webVitalData = {value: frame.data.value};
+  if (isCLSFrame(frame) && frame.data.attributions && selectors) {
+    const layoutShifts: Array<Record<string, ReactNode[]>> = [];
+    for (const attr of frame.data.attributions) {
+      const elements: ReactNode[] = [];
+      if ('nodeIds' in attr && Array.isArray(attr.nodeIds)) {
+        attr.nodeIds.forEach(nodeId => {
+          if (selectors.get(nodeId)) {
+            elements.push(
+              <span
+                key={nodeId}
+                onMouseEnter={() => onMouseEnter(frame, nodeId)}
+                onMouseLeave={() => onMouseLeave(frame, nodeId)}
+              >
+                <ValueObjectKey>{t('element')}</ValueObjectKey>
+                <span>{': '}</span>
+                <span>
+                  <SelectorButton>{selectors.get(nodeId)}</SelectorButton>
+                </span>
+              </span>
+            );
+          }
+        });
+      }
+      // if we can't find the elements associated with the layout shift, we still show the score with element: unknown
+      if (!elements.length) {
+        elements.push(
+          <span>
+            <ValueObjectKey>{t('element')}</ValueObjectKey>
+            <span>{': '}</span>
+            <ValueNull>{t('unknown')}</ValueNull>
+          </span>
+        );
+      }
+      layoutShifts.push({[`score ${attr.value}`]: elements});
+    }
+    if (layoutShifts.length) {
+      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      webVitalData['Layout shifts'] = layoutShifts;
+    }
+  } else if (selectors) {
+    selectors.forEach((key, value) => {
+      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      webVitalData[key] = (
+        <span
+          key={key}
+          onMouseEnter={() => onMouseEnter(frame, value)}
+          onMouseLeave={() => onMouseLeave(frame, value)}
+        >
+          <ValueObjectKey>{t('element')}</ValueObjectKey>
+          <span>{': '}</span>
+          <SelectorButton size="zero" borderless>
+            {key}
+          </SelectorButton>
+        </span>
+      );
+    });
+  }
+
+  return (
+    <Wrapper>
+      <StructuredEventData
+        initialExpandedPaths={expandPaths ?? []}
+        onToggleExpand={(expandedPaths, path) => {
+          onInspectorExpanded(
+            path,
+            Object.fromEntries(expandedPaths.map(item => [item, true]))
+          );
+        }}
+        data={webVitalData}
+        withAnnotatedText
+      />
+    </Wrapper>
+  );
+}
+
+const ValueObjectKey = styled('span')`
+  color: var(--prism-keyword);
+`;
+
+const ValueNull = styled('span')`
+  font-weight: ${p => p.theme.fontWeight.bold};
+  color: var(--prism-property);
+`;
+
+const SelectorButton = styled(Button)`
+  background: none;
+  border: none;
+  padding: 0 2px;
+  border-radius: 2px;
+  font-weight: ${p => p.theme.fontWeight.normal};
+  box-shadow: none;
+  font-size: ${p => p.theme.fontSize.sm};
+  color: ${p => p.theme.subText};
+  margin: 0 ${space(0.5)};
+  height: auto;
+  min-height: auto;
+`;
+
+const Wrapper = styled('div')`
+  pre {
+    margin: 0;
+  }
+`;

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -250,8 +250,8 @@ export function isConsoleFrame(frame: BreadcrumbFrame): frame is ConsoleFrame {
   return false;
 }
 
-export function isWebVitalFrame(frame: SpanFrame): frame is WebVitalFrame {
-  return frame.op === 'web-vital';
+export function isWebVitalFrame(frame: ReplayFrame): frame is WebVitalFrame {
+  return isSpanFrame(frame) && frame.op === 'web-vital';
 }
 
 export function isCLSFrame(frame: WebVitalFrame): frame is WebVitalFrame {

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -23,12 +23,14 @@ interface Props {
   startTimestampMs: number;
   style: CSSProperties;
   breadcrumbIndex?: number[][];
+  className?: string;
   expandPaths?: string[];
   ref?: React.Ref<HTMLDivElement>;
   updateDimensions?: () => void;
 }
 
 function BreadcrumbRow({
+  className,
   expandPaths,
   frame,
   index,
@@ -63,7 +65,7 @@ function BreadcrumbRow({
   return (
     <BreadcrumbItem
       ref={ref}
-      className={classNames({
+      className={classNames(className, {
         beforeCurrentTime: hasOccurred,
         afterCurrentTime: !hasOccurred,
         beforeHoverTime: currentHoverTime === undefined ? undefined : isBeforeHover,


### PR DESCRIPTION
## PR Description

This pull request refactors the `BreadcrumbItem` component in the Replays feature to improve its structure, readability, and maintainability. The original component was becoming too large and complex, handling multiple responsibilities within a single file. The goal is to decompose it into smaller, more focused components, each responsible for a specific aspect of the breadcrumb display.

<details>
<summary><b>Click to see more</b></summary>

### Key Technical Changes
The primary technical change is the extraction of several rendering functions within `BreadcrumbItem` into separate React components. Specifically:

*   `BreadcrumbCodeSnippet`: Handles the display of code snippets associated with breadcrumbs.
*   `BreadcrumbComparisonButton`: Renders a button to compare replay states related to hydration errors.
*   `BreadcrumbDescription`: Displays the description of the breadcrumb, including the 'View HTML' button.
*   `BreadcrumbIssueLink`: Creates a link to the associated issue, if the breadcrumb represents an error or feedback event.
*   `BreadcrumbWebVital`: Renders web vital data associated with the breadcrumb.

These new components are then used within `BreadcrumbItem` to render their respective parts of the breadcrumb. The `isSpanFrame` and `isWebVitalFrame` checks have been updated to ensure correct rendering of code snippets and the 'View HTML' button.

### Architecture Decisions
The architectural decision is to follow the Single Responsibility Principle by breaking down the monolithic `BreadcrumbItem` component into smaller, more manageable components. This promotes code reuse, improves testability, and makes it easier to understand and modify the breadcrumb rendering logic. Styled components are used to encapsulate the styling for each new component, maintaining a consistent look and feel.

### Dependencies and Interactions
The refactored components depend on the following:

*   `sentry/components/codeSnippet`, `sentry/components/placeholder`, `sentry/components/core/button`, `sentry/components/core/tooltip`, `sentry/components/structuredEventData`, `sentry/components/timeline`, and `sentry/components/links/link` for UI elements.
*   `sentry/utils/replays/extractDomNodes`, `sentry/utils/replays/getDiffTimestamps`, `sentry/utils/replays/getFrameDetails`, and `sentry/utils/replays/hooks/useExtractDomNodes` for data extraction and processing.
*   `sentry/utils/replays/types` for type definitions related to replay frames and events.
*   `sentry/utils/useOrganization` and `sentry/utils/useProjectFromSlug` for accessing organization and project information.
*   `sentry/views/replays/detail/timestampButton` and `sentry/views/replays/detail/useVirtualizedInspector` for replay-specific UI elements and functionality.

The components interact with the `ReplayContext` and `ReplayGroupContext` to access replay data and group information.

### Risk Considerations
The primary risk is that the refactoring might introduce regressions in the rendering of breadcrumbs. Thorough testing is required to ensure that all types of breadcrumbs are rendered correctly and that the new components handle all edge cases. The changes to the `isSpanFrame` and `isWebVitalFrame` checks need to be carefully reviewed to avoid unintended side effects. The removal of the `&:not(:last-child)::before` CSS selector might also have unintended visual consequences.

### Notable Implementation Details
The condition `(!isSpanFrame(frame) || !isWebVitalFrame(frame))` in `BreadcrumbCodeSnippet` and `BreadcrumbDescription` was identified as potentially incorrect and should be reviewed carefully. The `@ts-expect-error` comments in `BreadcrumbWebVital` indicate areas where type safety needs to be improved. The removal of the `render*` functions from `BreadcrumbItem` significantly reduces its complexity and improves readability.
</details>