### PR TITLE
:sparkles: feat(integration slos): add sample rate param to slo logging

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -38,9 +39,11 @@ class EventLifecycleMetric(ABC):
         """Get extra data to log."""
         return {}
 
-    def capture(self, assume_success: bool = True) -> "EventLifecycle":
+    def capture(
+        self, assume_success: bool = True, sample_log_rate: float = 1.0
+    ) -> "EventLifecycle":
         """Open a context to measure the event."""
-        return EventLifecycle(self, assume_success)
+        return EventLifecycle(self, assume_success, sample_log_rate)
 
 
 class IntegrationEventLifecycleMetric(EventLifecycleMetric, ABC):
@@ -102,9 +105,15 @@ class EventLifecycle:
     that inserting `record_failure` calls is still a dev to-do item.
     """
 
-    def __init__(self, payload: EventLifecycleMetric, assume_success: bool = True) -> None:
+    def __init__(
+        self,
+        payload: EventLifecycleMetric,
+        assume_success: bool = True,
+        sample_log_rate: float = 1.0,
+    ) -> None:
         self.payload = payload
         self.assume_success = assume_success
+        self.sample_log_rate = sample_log_rate
         self._state: EventLifecycleOutcome | None = None
         self._extra = dict(self.payload.get_extras())
 
@@ -127,6 +136,7 @@ class EventLifecycle:
         outcome: EventLifecycleOutcome,
         outcome_reason: BaseException | str | None = None,
         create_issue: bool = False,
+        sample_log_rate: float | None = None,
     ) -> None:
         """Record a starting or halting event.
 
@@ -167,10 +177,20 @@ class EventLifecycle:
         elif isinstance(outcome_reason, str):
             extra["outcome_reason"] = outcome_reason
 
-        if outcome == EventLifecycleOutcome.FAILURE:
-            logger.warning(key, **log_params)
-        elif outcome == EventLifecycleOutcome.HALTED:
-            logger.info(key, **log_params)
+        if outcome == EventLifecycleOutcome.FAILURE or outcome == EventLifecycleOutcome.HALTED:
+            # Use provided sample_log_rate or fall back to instance default
+            effective_sample_log_rate = (
+                sample_log_rate if sample_log_rate is not None else self.sample_log_rate
+            )
+
+            should_log = (
+                effective_sample_log_rate >= 1.0 or random.random() < effective_sample_log_rate
+            )
+            if should_log:
+                if outcome == EventLifecycleOutcome.FAILURE:
+                    logger.warning(key, **log_params)
+                elif outcome == EventLifecycleOutcome.HALTED:
+                    logger.info(key, **log_params)
 
     @staticmethod
     def _report_flow_error(message) -> None:
@@ -181,13 +201,14 @@ class EventLifecycle:
         new_state: EventLifecycleOutcome,
         outcome_reason: BaseException | str | None = None,
         create_issue: bool = False,
+        sample_log_rate: float | None = None,
     ) -> None:
         if self._state is None:
             self._report_flow_error("The lifecycle has not yet been entered")
         if self._state != EventLifecycleOutcome.STARTED:
             self._report_flow_error("The lifecycle has already been exited")
         self._state = new_state
-        self.record_event(new_state, outcome_reason, create_issue)
+        self.record_event(new_state, outcome_reason, create_issue, sample_log_rate)
 
     def record_success(self) -> None:
         """Record that the event halted successfully.
@@ -204,6 +225,7 @@ class EventLifecycle:
         failure_reason: BaseException | str | None = None,
         extra: dict[str, Any] | None = None,
         create_issue: bool = True,
+        sample_log_rate: float | None = None,
     ) -> None:
         """Record that the event halted in failure. Additional data may be passed
         to be logged.
@@ -223,17 +245,26 @@ class EventLifecycle:
         example, if we receive an error status from a remote service and gracefully
         display an error response to the user, it would be necessary to manually call
         `record_failure` on the context object.
+
+        Args:
+            failure_reason: The reason for the failure (exception or string)
+            extra: Additional data to include in logs
+            create_issue: Whether to create a Sentry issue (default True)
+            sample_log_rate: Rate at which to sample logs (0.0-1.0). If None, uses instance default.
         """
 
         if extra:
             self._extra.update(extra)
-        self._terminate(EventLifecycleOutcome.FAILURE, failure_reason, create_issue)
+        self._terminate(
+            EventLifecycleOutcome.FAILURE, failure_reason, create_issue, sample_log_rate
+        )
 
     def record_halt(
         self,
         halt_reason: BaseException | str | None = None,
         extra: dict[str, Any] | None = None,
         create_issue: bool = False,
+        sample_log_rate: float | None = None,
     ) -> None:
         """Record that the event halted in an ambiguous state.
 
@@ -253,11 +284,17 @@ class EventLifecycle:
           (2) monitor it for sudden spikes in frequency; and
           (3) investigate whether more detailed error information is available
               (but probably later, as a backlog item).
+
+        Args:
+            halt_reason: The reason for the halt (exception or string)
+            extra: Additional data to include in logs
+            create_issue: Whether to create a Sentry issue (default False)
+            sample_log_rate: Rate at which to sample logs (0.0-1.0). If None, uses instance default.
         """
 
         if extra:
             self._extra.update(extra)
-        self._terminate(EventLifecycleOutcome.HALTED, halt_reason, create_issue)
+        self._terminate(EventLifecycleOutcome.HALTED, halt_reason, create_issue, sample_log_rate)
 
     def __enter__(self) -> Self:
         if self._state is not None:

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -256,7 +256,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             assert response.status_code == 201
             self.assert_correctly_linked(group, "APP-123", integration, org)
 
-        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch.object(ExampleIntegration, "get_issue")
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
@@ -422,7 +422,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                 "new": True,
             }
 
-            mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+            mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch.object(ExampleIntegration, "create_issue")
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -121,7 +121,7 @@ class JiraInstalledTest(APITestCase):
 
         mock_set_tag.assert_any_call("integration_id", integration.id)
         assert integration.status == ObjectStatus.ACTIVE
-        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @patch("sentry_sdk.set_tag")
     @responses.activate

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -123,7 +123,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
             # assert new ticket NOT created in DB
             assert ExternalIssue.objects.count() == external_issue_count
-            mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+            mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @mock.patch.object(MockJira, "create_issue")

--- a/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_assignee_outbound.py
@@ -54,7 +54,7 @@ class TestSyncAssigneeOutbound(TestCase):
         assert isinstance(user_arg, RpcUser)
         assert user_arg.id == self.user.id
 
-        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_failure")
     @mock.patch.object(ExampleIntegration, "sync_assignee_outbound")

--- a/tests/sentry/integrations/tasks/test_sync_status_outbound.py
+++ b/tests/sentry/integrations/tasks/test_sync_status_outbound.py
@@ -52,7 +52,7 @@ class TestSyncStatusOutbound(TestCase):
 
         sync_status_outbound(self.group.id, external_issue_id=external_issue.id)
         mock_sync_status.assert_called_once_with(external_issue, False, self.group.project_id)
-        mock_record_event.assert_any_call(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_any_call(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @mock.patch.object(ExampleIntegration, "sync_status_outbound")
@@ -69,7 +69,7 @@ class TestSyncStatusOutbound(TestCase):
         assert mock_record_event.call_count == 2
         start, success = mock_record_event.mock_calls
         assert start.args == (EventLifecycleOutcome.STARTED,)
-        assert success.args == (EventLifecycleOutcome.SUCCESS, None, False)
+        assert success.args == (EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch.object(ExampleIntegration, "sync_status_outbound")
     def test_missing_external_issue(self, mock_sync_status):

--- a/tests/sentry/integrations/utils/test_sync.py
+++ b/tests/sentry/integrations/utils/test_sync.py
@@ -76,7 +76,7 @@ class TestSyncAssigneeInbound(TestCase):
         )
 
         assert self.group.get_assignee() is None
-        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_assignment(self, mock_record_event):
@@ -99,7 +99,7 @@ class TestSyncAssigneeInbound(TestCase):
         assert updated_assignee is not None
         assert updated_assignee.id == self.test_user.id
         assert updated_assignee.email == "test@example.com"
-        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_assign_with_multiple_groups(self, mock_record_event):
@@ -149,7 +149,7 @@ class TestSyncAssigneeInbound(TestCase):
             assert assignee.id == self.test_user.id
             assert assignee.email == "test@example.com"
 
-        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False)
+        mock_record_event.assert_called_with(EventLifecycleOutcome.SUCCESS, None, False, None)
 
     @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
     def test_assign_with_no_user_found(self, mock_record_halt):


### PR DESCRIPTION
This PR adds the ability to control logging frequency for `record_failure()` and `record_halt()` calls to reduce log volume in high-traffic scenarios.

* Added sample_log_rate parameter to EventLifecycle constructor and capture methods (defaults to 1.0)
* Updated `record_failure()` and `record_halt()` to accept optional `sample_log_rate` parameter

**Metrics are still always recorded - only the actual logging output is sampled**

## Usage
```
# Log all failures/halts (current behavior)
with event.capture():
    ...

# Log only 10% of failures/halts
with event.capture(sample_log_rate=0.1):
    ...

# Per-call sampling
lifecycle.record_failure(exception, sample_log_rate=0.05)
lifecycle.record_halt(reason, sample_log_rate=0.2)
```

