### PR TITLE
fix(releases): Fix `get_latest_release` query to not be expensive for orgs with 100ks of releases

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -435,45 +435,57 @@ def _run_latest_release_query(
     if not project_ids:
         return []
 
-    env_join = ""
-    env_where = ""
+    extra_join_conditions = ""
     extra_conditions = ""
     if environments:
-        env_join = "INNER JOIN sentry_releaseprojectenvironment srpe on srpe.release_id = sr.id"
-        env_where = "AND srpe.environment_id in %s AND srpe.project_id in %s"
-        adopted_table_alias = "srpe"
+        extra_join_conditions = "AND jt.environment_id IN %s"
+        join_table = "sentry_releaseprojectenvironment"
     else:
-        adopted_table_alias = "srp"
+        join_table = "sentry_release_project"
 
     if adopted:
-        extra_conditions += f" AND {adopted_table_alias}.adopted IS NOT NULL AND {adopted_table_alias}.unadopted IS NULL "
+        extra_conditions += " AND jt.adopted IS NOT NULL AND jt.unadopted IS NULL "
 
     rank_order_by, query_type_conditions = _get_release_query_type_sql(query_type, True)
     extra_conditions += query_type_conditions
 
+    # XXX: This query can be very inefficient for projects with a large (100k+)
+    # number of releases. To work around this, we only check 1000 releases
+    # ordered by highest release id, which is generally correlated with
+    # most recent releases for a project. This isn't guaranteed to be correct,
+    # since `date_released` could end up out of order, or we might be using semver.
+    # However, this should be close enough the majority of the time. If a project has
+    # > 400 newer releases that were more recently associated with the "true" most recent
+    # release then likely something is off.
+    # We might be able to remove this kind of hackery once we add retention to the release
+    # and related tables.
     query = f"""
         SELECT DISTINCT version
         FROM (
             SELECT sr.version, rank() OVER (
-                PARTITION BY srp.project_id
+                PARTITION BY jt.project_id
                 ORDER BY {rank_order_by}
             ) AS rank
             FROM "sentry_release" sr
-            INNER JOIN "sentry_release_project" srp ON sr.id = srp.release_id
-            {env_join}
+            INNER JOIN (
+                SELECT release_id, project_id, adopted, unadopted
+                FROM {join_table} jt
+                WHERE jt.project_id IN %s
+                {extra_join_conditions}
+                ORDER BY release_id desc
+                LIMIT 1000
+            ) jt on sr.id = jt.release_id
             WHERE sr.organization_id = %s
             AND sr.status = {ReleaseStatus.OPEN}
-            AND srp.project_id IN %s
             {extra_conditions}
-            {env_where}
         ) sr
         WHERE rank = 1
     """
     cursor = connections[router.db_for_read(Release, replica=True)].cursor()
-    query_args: list[int | tuple[int, ...]] = [organization_id, tuple(project_ids)]
+    query_args: list[int | tuple[int, ...]] = [tuple(project_ids)]
     if environments:
         query_args.append(tuple(e.id for e in environments))
-        query_args.append(tuple(project_ids))
+    query_args.append(organization_id)
     cursor.execute(query, query_args)
     return [row[0] for row in cursor.fetchall()]
 


### PR DESCRIPTION
This fixes a common problem we have with complex queries to releases - when an org/project has 100k+ releases, we end up having multiple second long queries here, since we can't index appropriately.

The way we typically handle this is by estimating the latest release for these orgs. An example is https://github.com/getsentry/sentry/blob/92b02f850cd7066fa7625f69a680eb3704d6cf6d/src/sentry/api/serializers/models/project.py#L840-L848

We're doing something similar here. Instead of joining directly to the table that links the release to a project, instead we join to a subquery where we select the 1000 most recent release ids associated with projects, using `release_id` ordering as a proxy for how new the release is. We have compound indexes on these fields, so this works well.

I've also simplified the query. Previously, when an environment was passed, we'd join to an additional table. We don't really need to do that - it's fine to either join to ReleaseProject or ReleaseProjectEnvironment, since we can filter to project successfully on either.

<!-- Describe your PR here. -->