### PR TITLE
chore(performance): Remove suspect spans from transaction summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -19,7 +19,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {defined, generateQueryWithTag} from 'sentry/utils';
+import {generateQueryWithTag} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import {
@@ -75,7 +75,6 @@ import {PerformanceAtScaleContextProvider} from './performanceAtScaleContext';
 import RelatedIssues from './relatedIssues';
 import SidebarCharts from './sidebarCharts';
 import StatusBreakdown from './statusBreakdown';
-import SuspectSpans from './suspectSpans';
 import {TagExplorer} from './tagExplorer';
 import UserStats from './userStats';
 
@@ -226,10 +225,6 @@ function OTelSummaryContentInner({
 
   transactionsListEventView.fields = fields;
 
-  const hasNewSpansUIFlag =
-    organization.features.includes('performance-spans-new-ui') &&
-    organization.features.includes('insights-initial-modules');
-
   const projectIds = useMemo(() => eventView.project.slice(), [eventView.project]);
 
   function renderSearchBar() {
@@ -270,22 +265,6 @@ function OTelSummaryContentInner({
             showViewSampledEventsButton
           />
         </PerformanceAtScaleContextProvider>
-
-        {!hasNewSpansUIFlag && (
-          <SuspectSpans
-            location={location}
-            organization={organization}
-            eventView={eventView}
-            totals={
-              defined(totalValues?.['count()'])
-                ? {'count()': totalValues['count()']}
-                : null
-            }
-            projectId={projectId}
-            transactionName={transactionName}
-          />
-        )}
-
         <TagExplorer
           eventView={eventView}
           organization={organization}
@@ -295,7 +274,6 @@ function OTelSummaryContentInner({
           currentFilter={spanOperationBreakdownFilter}
           domainViewFilters={domainViewFilters}
         />
-
         <SuspectFunctionsTable
           eventView={eventView}
           analyticsPageSource="performance_transaction"
@@ -561,10 +539,6 @@ function SummaryContent({
     handleOpenAllEventsClick: handleAllEventsViewClick,
   };
 
-  const hasNewSpansUIFlag =
-    organization.features.includes('performance-spans-new-ui') &&
-    organization.features.includes('insights-initial-modules');
-
   const projectIds = useMemo(() => eventView.project.slice(), [eventView.project]);
 
   function renderSearchBar() {
@@ -640,22 +614,6 @@ function SummaryContent({
             supportsInvestigationRule
           />
         </PerformanceAtScaleContextProvider>
-
-        {!hasNewSpansUIFlag && (
-          <SuspectSpans
-            location={location}
-            organization={organization}
-            eventView={eventView}
-            totals={
-              defined(totalValues?.['count()'])
-                ? {'count()': totalValues['count()']}
-                : null
-            }
-            projectId={projectId}
-            transactionName={transactionName}
-          />
-        )}
-
         <TagExplorer
           eventView={eventView}
           organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -1044,30 +1044,6 @@ describe('Performance > TransactionSummary', function () {
       expect(issueGet).toHaveBeenCalled();
     });
 
-    it('renders the suspect spans table if the feature is enabled', async function () {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/events-spans-performance/',
-        body: [],
-      });
-
-      const {organization, router} = initializeData();
-
-      render(
-        <TestComponent
-          organization={organization}
-          router={router}
-          location={router.location}
-        />,
-        {
-          router,
-          organization,
-          deprecatedRouterMocks: true,
-        }
-      );
-
-      expect(await screen.findByText('Suspect Spans')).toBeInTheDocument();
-    });
-
     it('adds search condition on transaction status when clicking on status breakdown', async function () {
       const {organization, router} = initializeData();
 


### PR DESCRIPTION
The spans tab has been removed so time to remove this as well.