### PR TITLE
ref(replay): Centralize ReplayTable cell rendering into replayTableColumns

### DIFF
--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -17,11 +17,9 @@ import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
 import {IconNext, IconPrevious} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useMarkReplayViewed from 'sentry/utils/replays/hooks/useMarkReplayViewed';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
@@ -56,12 +54,10 @@ export default function ReplayPreviewPlayer({
   showNextAndPrevious?: boolean;
 }) {
   const routes = useRoutes();
-  const location = useLocation();
   const organization = useOrganization();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const {replay, currentTime, isFetching, isFinished, isPlaying, isVideoReplay} =
     useReplayContext();
-  const eventView = EventView.fromLocation(location);
 
   const fullscreenRef = useRef<HTMLDivElement | null>(null);
   const {toggle: toggleFullscreen} = useFullscreen({
@@ -98,9 +94,7 @@ export default function ReplayPreviewPlayer({
       )}
       <HeaderWrapper>
         <StyledReplayCell
-          eventView={eventView}
           key="session"
-          referrer="issue-details-replay-header"
           replay={replayRecord as ReplayListRecord}
           rowIndex={0}
         />

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -54,7 +54,7 @@ interface RenderProps {
   showDropdownFilters: boolean;
 }
 
-export interface ReplayTableColumn {
+interface ReplayTableColumn {
   Component: (props: RenderProps) => ReactNode;
   name: string;
   sortKey: undefined | ReplayRecordNestedFieldName;

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -1,11 +1,61 @@
 import type {ReactNode} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import invariant from 'invariant';
 
+import {useAnalyticsArea} from 'sentry/components/analyticsArea';
+import {ProjectAvatar} from 'sentry/components/core/avatar/projectAvatar';
+import {UserAvatar} from 'sentry/components/core/avatar/userAvatar';
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout/flex';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import Duration from 'sentry/components/duration/duration';
 import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
+import {useSelectedReplayIndex} from 'sentry/components/replays/queryParams/selectedReplayIndex';
+import ReplayPlatformIcon from 'sentry/components/replays/replayPlatformIcon';
+import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
+import NumericDropdownFilter from 'sentry/components/replays/table/filters/numericDropdownFilter';
+import OSBrowserDropdownFilter from 'sentry/components/replays/table/filters/osBrowserDropdownFilter';
+import ScoreBar from 'sentry/components/scoreBar';
+import TimeSince from 'sentry/components/timeSince';
+import {IconCalendar} from 'sentry/icons/iconCalendar';
+import {IconCursorArrow} from 'sentry/icons/iconCursorArrow';
+import {IconDelete} from 'sentry/icons/iconDelete';
+import {IconFire} from 'sentry/icons/iconFire';
+import {IconNot} from 'sentry/icons/iconNot';
+import {IconPlay} from 'sentry/icons/iconPlay';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import EventView from 'sentry/utils/discover/eventView';
+import {spanOperationRelativeBreakdownRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {getShortEventId} from 'sentry/utils/events';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {MIN_DEAD_RAGE_CLICK_SDK} from 'sentry/utils/replays/sdkVersions';
-import type {ReplayRecordNestedFieldName} from 'sentry/views/replays/types';
+import {useLocation} from 'sentry/utils/useLocation';
+import useMedia from 'sentry/utils/useMedia';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
+import {useRoutes} from 'sentry/utils/useRoutes';
+import type {ReplayListRecordWithTx} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData';
+import {makeReplaysPathname} from 'sentry/views/replays/pathnames';
+import type {
+  ReplayListRecord,
+  ReplayRecordNestedFieldName,
+} from 'sentry/views/replays/types';
 
-interface ReplayTableColumn {
+type ListRecord = ReplayListRecord | ReplayListRecordWithTx;
+
+interface RenderProps {
+  columnIndex: number;
+  replay: ListRecord;
+  rowIndex: number;
+  showDropdownFilters: boolean;
+}
+
+export interface ReplayTableColumn {
+  Component: (props: RenderProps) => ReactNode;
   name: string;
   sortKey: undefined | ReplayRecordNestedFieldName;
   tooltip?: ReactNode;
@@ -17,11 +67,61 @@ export const ReplayActivityColumn: ReplayTableColumn = {
     'Activity represents how much user activity happened in a replay. It is determined by the number of errors encountered, duration, and UI events.'
   ),
   sortKey: 'activity',
+  Component: ({replay, showDropdownFilters}) => {
+    const theme = useTheme();
+
+    if (replay.is_archived) {
+      return null;
+    }
+    const colors = theme.chart.getColorPalette(0);
+    const scoreBarPalette = new Array(10).fill([colors[0]]);
+    return (
+      <DropdownContainer key="activity">
+        <ScoreBar
+          size={20}
+          score={replay?.activity ?? 1}
+          palette={scoreBarPalette}
+          radius={0}
+        />
+        {showDropdownFilters ? (
+          <NumericDropdownFilter type="activity" val={replay?.activity ?? 0} />
+        ) : null}
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayBrowserColumn: ReplayTableColumn = {
   name: t('Browser'),
   sortKey: 'browser.name',
+  Component: ({replay, showDropdownFilters}) => {
+    const theme = useTheme();
+    const isLargeBreakpoint = useMedia(`(min-width: ${theme.breakpoints.lg})`);
+
+    if (replay.is_archived) {
+      return null;
+    }
+    const {name, version} = replay.browser;
+    if (name === null && version === null) {
+      return <IconNot size="xs" color="gray300" />;
+    }
+
+    return (
+      <DropdownContainer key="browser">
+        <Tooltip title={`${name} ${version}`}>
+          <ReplayPlatformIcon
+            name={name ?? ''}
+            version={version && isLargeBreakpoint ? version : undefined}
+            showVersion={false}
+            showTooltip={false}
+          />
+          {showDropdownFilters ? (
+            <OSBrowserDropdownFilter type="browser" name={name} version={version} />
+          ) : null}
+        </Tooltip>
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayCountDeadClicksColumn: ReplayTableColumn = {
@@ -34,6 +134,31 @@ export const ReplayCountDeadClicksColumn: ReplayTableColumn = {
     }
   ),
   sortKey: 'count_dead_clicks',
+  Component: ({replay, showDropdownFilters}) => {
+    if (replay.is_archived) {
+      return null;
+    }
+    return (
+      <DropdownContainer key="countDeadClicks">
+        <TabularNumber>
+          {replay.count_dead_clicks ? (
+            <Flex gap={space(0.5)}>
+              <IconCursorArrow size="sm" color="yellow300" />
+              {replay.count_dead_clicks}
+            </Flex>
+          ) : (
+            0
+          )}
+        </TabularNumber>
+        {showDropdownFilters ? (
+          <NumericDropdownFilter
+            type="count_dead_clicks"
+            val={replay.count_dead_clicks ?? 0}
+          />
+        ) : null}
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayCountErrorsColumn: ReplayTableColumn = {
@@ -53,6 +178,28 @@ export const ReplayCountErrorsColumn: ReplayTableColumn = {
     }
   ),
   sortKey: 'count_errors',
+  Component: ({replay, showDropdownFilters}) => {
+    if (replay.is_archived) {
+      return null;
+    }
+    return (
+      <DropdownContainer key="countErrors">
+        <TabularNumber>
+          {replay.count_errors ? (
+            <Flex gap={space(0.5)}>
+              <IconFire color="red300" />
+              {replay.count_errors}
+            </Flex>
+          ) : (
+            0
+          )}
+        </TabularNumber>
+        {showDropdownFilters ? (
+          <NumericDropdownFilter type="count_errors" val={replay.count_errors ?? 0} />
+        ) : null}
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayCountRageClicksColumn: ReplayTableColumn = {
@@ -65,29 +212,326 @@ export const ReplayCountRageClicksColumn: ReplayTableColumn = {
     }
   ),
   sortKey: 'count_rage_clicks',
+  Component: ({replay, showDropdownFilters}) => {
+    if (replay.is_archived) {
+      return null;
+    }
+    return (
+      <DropdownContainer key="countRageClicks">
+        <TabularNumber>
+          {replay.count_rage_clicks ? (
+            <Flex gap={space(0.5)}>
+              <IconCursorArrow size="sm" color="red300" />
+              {replay.count_rage_clicks}
+            </Flex>
+          ) : (
+            0
+          )}
+        </TabularNumber>
+        {showDropdownFilters ? (
+          <NumericDropdownFilter
+            type="count_rage_clicks"
+            val={replay.count_rage_clicks ?? 0}
+          />
+        ) : null}
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayDurationColumn: ReplayTableColumn = {
   name: t('Duration'),
   sortKey: 'duration',
+  Component: ({replay, showDropdownFilters}) => {
+    if (replay.is_archived) {
+      return null;
+    }
+    invariant(
+      replay.duration,
+      'For TypeScript: replay.duration is implied because replay.is_archived is false'
+    );
+    return (
+      <DropdownContainer key="duration">
+        <Duration duration={[replay.duration.asMilliseconds(), 'ms']} precision="sec" />
+        {showDropdownFilters ? (
+          <NumericDropdownFilter
+            type="duration"
+            val={replay.duration.asSeconds() ?? 0}
+            formatter={(val: number) => `${val}s`}
+          />
+        ) : null}
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayOSColumn: ReplayTableColumn = {
   name: t('OS'),
   sortKey: 'os.name',
+  Component: ({replay, showDropdownFilters}) => {
+    const theme = useTheme();
+    const isLargeBreakpoint = useMedia(`(min-width: ${theme.breakpoints.lg})`);
+
+    if (replay.is_archived) {
+      return null;
+    }
+    const {name, version} = replay.os;
+    return (
+      <DropdownContainer key="os">
+        <Tooltip title={`${name ?? ''} ${version ?? ''}`}>
+          <ReplayPlatformIcon
+            name={name ?? ''}
+            version={version && isLargeBreakpoint ? version : undefined}
+            showVersion={false}
+            showTooltip={false}
+          />
+          {showDropdownFilters ? (
+            <OSBrowserDropdownFilter type="os" name={name} version={version} />
+          ) : null}
+        </Tooltip>
+      </DropdownContainer>
+    );
+  },
 };
 
 export const ReplayPlayPauseColumn: ReplayTableColumn = {
   name: '',
   sortKey: undefined,
+  Component: ({replay, rowIndex}) => {
+    const {index: selectedReplayIndex, select: setSelectedReplayIndex} =
+      useSelectedReplayIndex();
+
+    if (replay.is_archived) {
+      return null;
+    }
+    if (rowIndex === selectedReplayIndex) {
+      return (
+        <PlayPauseButtonContainer>
+          <ReplayPlayPauseButton
+            key="playPause-play"
+            borderless
+            priority="default"
+            size="sm"
+          />
+        </PlayPauseButtonContainer>
+      );
+    }
+    return (
+      <PlayPauseButtonContainer>
+        <Button
+          key="playPause-select"
+          aria-label={t('Play')}
+          borderless
+          data-test-id="replay-table-play-button"
+          icon={<IconPlay />}
+          onClick={() => setSelectedReplayIndex(rowIndex)}
+          priority="default"
+          size="sm"
+          title={t('Play')}
+        />
+      </PlayPauseButtonContainer>
+    );
+  },
 };
 
 export const ReplaySessionColumn: ReplayTableColumn = {
   name: t('Replay'),
   sortKey: 'started_at',
+  Component: ({replay}) => {
+    const routes = useRoutes();
+    const location = useLocation();
+    const organization = useOrganization();
+    const analyticsArea = useAnalyticsArea();
+    const project = useProjectFromId({project_id: replay.project_id ?? undefined});
+
+    // TODO(ryan953): This is a janky way to detect the current page.
+    const isIssuesReplayList = location.pathname.includes('issues');
+    const isSelectorWidget = analyticsArea.endsWith('example-replays-list');
+
+    if (replay.is_archived) {
+      return (
+        <Flex gap={space(1)} align="center" justify="center">
+          <div style={{paddingInline: space(0.5)}}>
+            <IconDelete color="gray500" size="md" />
+          </div>
+
+          <Flex direction="column" gap={space(0.5)}>
+            <Flex gap={space(0.5)} align="center">
+              {t('Deleted Replay')}
+            </Flex>
+            <Flex gap={space(0.5)} align="center">
+              {project ? <ProjectAvatar size={12} project={project} /> : null}
+              <SmallFont>{getShortEventId(replay.id)}</SmallFont>
+            </Flex>
+          </Flex>
+        </Flex>
+      );
+    }
+
+    invariant(
+      replay.started_at,
+      'For TypeScript: replay.started_at is implied because replay.is_archived is false'
+    );
+
+    const referrer = getRouteStringFromRoutes(routes);
+    const eventView = EventView.fromLocation(location);
+    const replayDetailsPathname = makeReplaysPathname({
+      path: `/${replay.id}/`,
+      organization,
+    });
+
+    const detailsTab = () => ({
+      pathname: replayDetailsPathname,
+      query: {
+        referrer,
+        ...eventView.generateQueryStringObject(),
+        f_b_type: isSelectorWidget ? 'rageOrDead' : undefined,
+      },
+    });
+    const trackNavigationEvent = () =>
+      trackAnalytics('replay.list-navigate-to-details', {
+        project_id: project?.id,
+        platform: project?.platform,
+        organization,
+        referrer,
+        referrer_table: isSelectorWidget ? 'selector-widget' : 'main',
+      });
+
+    return (
+      <Flex key="session" align="center" gap={space(1)}>
+        <UserAvatar user={getUserBadgeUser(replay)} size={24} />
+        <SubText>
+          <Flex gap={space(0.5)}>
+            <DisplayNameLink
+              to={
+                isIssuesReplayList
+                  ? // if on the issues replay list, don't redirect to the details tab. this causes URL flickering
+                    {
+                      pathname: location.pathname,
+                      query: location.query,
+                    }
+                  : detailsTab()
+              }
+              onClick={trackNavigationEvent}
+              data-has-viewed={replay.has_viewed}
+            >
+              {replay.user.display_name || t('Anonymous User')}
+            </DisplayNameLink>
+          </Flex>
+          <Flex gap={space(0.5)}>
+            {/* Avatar is used instead of ProjectBadge because using ProjectBadge increases spacing, which doesn't look as good */}
+            {project ? <ProjectAvatar size={12} project={project} /> : null}
+            {project ? project.slug : null}
+            <Link to={detailsTab()} onClick={trackNavigationEvent}>
+              {getShortEventId(replay.id)}
+            </Link>
+            <Flex gap={space(0.5)}>
+              <IconCalendar color="gray300" size="xs" />
+              <TimeSince date={replay.started_at} />
+            </Flex>
+          </Flex>
+        </SubText>
+      </Flex>
+    );
+  },
 };
 
 export const ReplaySlowestTransactionColumn: ReplayTableColumn = {
   name: t('Slowest Transaction'),
   sortKey: undefined,
+  Component: ({replay}) => {
+    const location = useLocation();
+    const organization = useOrganization();
+    const theme = useTheme();
+
+    if (replay.is_archived) {
+      return null;
+    }
+    const hasTxEvent = 'txEvent' in replay;
+    const txDuration = hasTxEvent ? replay.txEvent?.['transaction.duration'] : undefined;
+    if (!hasTxEvent) {
+      return null;
+    }
+    return (
+      <SpanOperationBreakdown key="slowestTransaction">
+        {txDuration ? <div>{txDuration}ms</div> : null}
+        {spanOperationRelativeBreakdownRenderer(
+          replay.txEvent,
+          {organization, location, theme},
+          {enableOnClick: false}
+        )}
+      </SpanOperationBreakdown>
+    );
+  },
 };
+
+function getUserBadgeUser(replay: ListRecord) {
+  return replay.is_archived
+    ? {
+        username: '',
+        email: '',
+        id: '',
+        ip_address: '',
+        name: '',
+      }
+    : {
+        username: replay.user?.display_name || '',
+        email: replay.user?.email || '',
+        id: replay.user?.id || '',
+        ip_address: replay.user?.ip || '',
+        name: replay.user?.username || '',
+      };
+}
+
+const DropdownContainer = styled(Flex)`
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const SmallFont = styled('div')`
+  font-size: ${p => p.theme.fontSize.sm};
+`;
+
+const TabularNumber = styled('div')`
+  font-variant-numeric: tabular-nums;
+`;
+
+const SubText = styled('div')`
+  font-size: 0.875em;
+  line-height: normal;
+  color: ${p => p.theme.subText};
+  ${p => p.theme.overflowEllipsis};
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.25)};
+`;
+
+const DisplayNameLink = styled(Link)`
+  font-size: ${p => p.theme.fontSize.lg};
+  line-height: normal;
+  ${p => p.theme.overflowEllipsis};
+
+  font-weight: ${p => p.theme.fontWeight.bold};
+  &[data-has-viewed='true'] {
+    font-weight: ${p => p.theme.fontWeight.normal};
+  }
+`;
+
+const PlayPauseButtonContainer = styled(Flex)`
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+
+  margin-inline: -${space(1)};
+`;
+
+const SpanOperationBreakdown = styled('div')`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+  color: ${p => p.theme.gray500};
+  font-size: ${p => p.theme.fontSize.md};
+  text-align: right;
+`;

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -1,6 +1,5 @@
 import type {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import type {Output} from 'sentry/views/replays/detail/network/details/getOutputType';
-import type {ReferrerTableType} from 'sentry/views/replays/replayTable/tableCell';
 
 export type ReplayEventParameters = {
   'replay.canvas-detected-banner-clicked': {
@@ -77,7 +76,7 @@ export type ReplayEventParameters = {
     platform: string | undefined;
     project_id: string | undefined;
     referrer: string;
-    referrer_table?: ReferrerTableType;
+    referrer_table?: 'main' | 'selector-widget';
   };
   'replay.list-paginated': {
     direction: 'next' | 'prev';

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -1,14 +1,13 @@
 import {Fragment, useMemo} from 'react';
 import type {Location} from 'history';
 
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
-import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import {StatusContainer} from 'sentry/views/profiling/landing/styles';
 import {ReplayCell} from 'sentry/views/replays/replayTable/tableCell';
 
@@ -70,9 +69,6 @@ export default function ExampleReplaysList({
     perPage: 3,
   });
 
-  const routes = useRoutes();
-  const referrer = getRouteStringFromRoutes(routes);
-
   return (
     <Fragment>
       {fetchError || (!isFetching && !replays?.length) ? (
@@ -84,19 +80,11 @@ export default function ExampleReplaysList({
           <LoadingIndicator />
         </StatusContainer>
       ) : (
-        replays?.map(r => {
-          return (
-            <ReplayCell
-              eventView={eventView}
-              isWidget
-              key={r.id}
-              referrer={referrer}
-              referrerTable="selector-widget"
-              replay={r}
-              rowIndex={0}
-            />
-          );
-        })
+        <AnalyticsArea name="example-replays-list">
+          {replays?.map(r => {
+            return <ReplayCell key={r.id} replay={r} rowIndex={0} />;
+          })}
+        </AnalyticsArea>
       )}
     </Fragment>
   );

--- a/static/app/views/replays/replayTable/index.tsx
+++ b/static/app/views/replays/replayTable/index.tsx
@@ -6,13 +6,9 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {PanelTable} from 'sentry/components/panels/panelTable';
 import {useSelectedReplayIndex} from 'sentry/components/replays/queryParams/selectedReplayIndex';
 import {t} from 'sentry/locale';
-import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
-import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {ERROR_MAP} from 'sentry/utils/requestError/requestError';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useRoutes} from 'sentry/utils/useRoutes';
 import type {ReplayListRecordWithTx} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData';
 import HeaderCell from 'sentry/views/replays/replayTable/headerCell';
 import {
@@ -73,9 +69,6 @@ function ReplayTable({
   onClickRow,
   referrerLocation,
 }: Props) {
-  const routes = useRoutes();
-  const location = useLocation();
-
   const {index: selectedReplayIndex} = useSelectedReplayIndex();
 
   const tableHeaders = visibleColumns
@@ -98,9 +91,6 @@ function ReplayTable({
       </StyledPanelTable>
     );
   }
-
-  const referrer = getRouteStringFromRoutes(routes);
-  const eventView = EventView.fromLocation(location);
 
   return (
     <StyledPanelTable
@@ -198,16 +188,7 @@ function ReplayTable({
                     );
 
                   case ReplayColumn.REPLAY:
-                    return (
-                      <ReplayCell
-                        key="session"
-                        replay={replay}
-                        rowIndex={index}
-                        eventView={eventView}
-                        referrer={referrer}
-                        referrerTable="main"
-                      />
-                    );
+                    return <ReplayCell key="session" replay={replay} rowIndex={index} />;
 
                   case ReplayColumn.PLAY_PAUSE:
                     return <PlayPauseCell key="play" replay={replay} rowIndex={index} />;


### PR DESCRIPTION
The places where these cells get rendered are:
- Replay List (`/explore/replays/`)
- Issue -> Replays (`/issues/<issue_id>/replays/`)
- Transaction Summary -> Replays (`/insights/frontend/summary/replays/?transaction=<transaction_name>`)

I checked each, and things look good.
- Sorting only on the Replay List page
- Dropdowns appear only on the Replay List page
- Padding is reasonable everywhere (including deleted replays on the list page)

| Desc | Img |
| --- | --- |
| Replay List | <img width="1252" alt="SCR-20250627-jrda" src="https://github.com/user-attachments/assets/1bd73f07-ace5-43ac-9289-d7244838f994" />
| Replay List (deleted item | <img width="1267" alt="SCR-20250627-jsmo" src="https://github.com/user-attachments/assets/cb238677-5eac-4ebe-b191-9ced4b708394" />
| Issues -> Replays | <img width="934" alt="SCR-20250627-jrgk" src="https://github.com/user-attachments/assets/c6ad93c5-987d-40bc-aa7a-d42437da173e" />
| Transaction -> Replays | <img width="1282" alt="SCR-20250627-jqyh" src="https://github.com/user-attachments/assets/e72187c8-a06b-4e78-be88-277739d18a16" />

