### PR TITLE
feat(auth): Return the reason for check_permission() failures

### DIFF
--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -23,6 +23,7 @@ Required context variables:
       (function() {
         const referrer = '{{ referrer|escapejs }}';
         const state = '{{ state|escapejs }}'; // enum of: logged-out, missing-project, invalid-domain, logged-in
+            // The reason: {{ reason|escapejs }}
         const logging = '{{ logging|escapejs }}';
         const organizationSlug = '{{ organization_slug|escapejs }}';
         const projectIdOrSlug = '{{ project_id_or_slug|escapejs }}';

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -7,6 +7,7 @@ from sentry.api.utils import generate_region_url
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.absolute_url import generate_organization_url
+from sentry.organizations.services.organization import RpcOrganization
 from sentry.toolbar.utils.url import is_origin_allowed
 from sentry.web.frontend.base import ProjectView, region_silo_view
 
@@ -40,7 +41,12 @@ class IframeView(ProjectView):
         return self._respond_with_state("logged-out")
 
     def handle_permission_required(
-        self, request: HttpRequest, reason: str, *args, **kwargs
+        self,
+        request: HttpRequest,
+        organization: Organization | RpcOrganization | None,
+        reason: str,
+        *args,
+        **kwargs,
     ) -> HttpResponse:
         return self._respond_with_state("missing-project", reason)
 

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -7,7 +7,6 @@ from sentry.api.utils import generate_region_url
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.absolute_url import generate_organization_url
-from sentry.organizations.services.organization import RpcOrganization
 from sentry.toolbar.utils.url import is_origin_allowed
 from sentry.web.frontend.base import ProjectView, region_silo_view
 
@@ -43,7 +42,6 @@ class IframeView(ProjectView):
     def handle_permission_required(
         self,
         request: HttpRequest,
-        organization: Organization | RpcOrganization | None,
         reason: str,
         *args,
         **kwargs,

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -533,6 +533,7 @@ class AbstractOrganizationView(BaseView, abc.ABC):
         self,
         request: HttpRequest,
         organization: RpcOrganization | Organization | None,
+        reason: str = "",
         *args: Any,
         **kwargs: Any,
     ) -> tuple[bool, str]:

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -405,7 +405,6 @@ class BaseView(View, OrganizationMixin):
         if not has_permission:
             return self.handle_permission_required(
                 request,
-                self.active_organization.organization if self.active_organization else None,
                 reason,
                 *args,
                 **kwargs,
@@ -466,8 +465,8 @@ class BaseView(View, OrganizationMixin):
     def handle_permission_required(
         self,
         request: HttpRequest,
-        organization: Organization | RpcOrganization | None,
         reason: str,
+        organization: Organization | RpcOrganization | None,
         *args: Any,
         **kwargs: Any,
     ) -> HttpResponse:
@@ -595,8 +594,8 @@ class AbstractOrganizationView(BaseView, abc.ABC):
     def handle_permission_required(
         self,
         request: HttpRequest,
-        organization: Organization | RpcOrganization | None,
         reason: str,
+        organization: Organization | RpcOrganization | None,
         *args: Any,
         **kwargs: Any,
     ) -> HttpResponse:

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -544,7 +544,6 @@ class AbstractOrganizationView(BaseView, abc.ABC):
         self,
         request: HttpRequest,
         organization: RpcOrganization | Organization | None,
-        reason: str = "",
         *args: Any,
         **kwargs: Any,
     ) -> tuple[bool, str]:

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -404,7 +404,11 @@ class BaseView(View, OrganizationMixin):
         has_permission, reason = self.check_permission(request, *args, **kwargs)
         if not has_permission:
             return self.handle_permission_required(
-                request, self.active_organization, reason, *args, **kwargs
+                request,
+                self.active_organization.organization if self.active_organization else None,
+                reason,
+                *args,
+                **kwargs,
             )
 
         if "organization" in kwargs:

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -403,7 +403,9 @@ class BaseView(View, OrganizationMixin):
 
         has_permission, reason = self.check_permission(request, *args, **kwargs)
         if not has_permission:
-            return self.handle_permission_required(request, reason, *args, **kwargs)
+            return self.handle_permission_required(
+                request, self.active_organization, reason, *args, **kwargs
+            )
 
         if "organization" in kwargs:
             org = kwargs["organization"]
@@ -458,7 +460,12 @@ class BaseView(View, OrganizationMixin):
         return True, ""
 
     def handle_permission_required(
-        self, request: HttpRequest, *args: Any, **kwargs: Any
+        self,
+        request: HttpRequest,
+        organization: Organization | RpcOrganization | None,
+        reason: str,
+        *args: Any,
+        **kwargs: Any,
     ) -> HttpResponse:
         path = reverse("sentry-login")
         query_params = {
@@ -586,6 +593,7 @@ class AbstractOrganizationView(BaseView, abc.ABC):
         self,
         request: HttpRequest,
         organization: Organization | RpcOrganization | None,
+        reason: str,
         *args: Any,
         **kwargs: Any,
     ) -> HttpResponse:

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -898,7 +898,7 @@ urlpatterns += [
     ),
     # Dev toolbar
     re_path(
-        r"^toolbar/(?P<organization_slug>[\w_-]+)/(?P<project_id_or_slug>[\w_-]+)/",
+        r"^toolbar/(?P<project_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/",
         include(
             [
                 re_path(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -898,7 +898,7 @@ urlpatterns += [
     ),
     # Dev toolbar
     re_path(
-        r"^toolbar/(?P<project_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/",
+        r"^toolbar/(?P<organization_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/",
         include(
             [
                 re_path(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -898,17 +898,16 @@ urlpatterns += [
     ),
     # Dev toolbar
     re_path(
-        r"^toolbar/",
+        r"^toolbar/(?P<organization_slug>[\w_-]+)/(?P<project_id_or_slug>[\w_-]+)/",
         include(
             [
-                # Although the pattern looks project-scoped, these are OrganizationViews (auth and perms are org-scoped).
                 re_path(
-                    r"^(?P<organization_slug>[^/\.]+)/(?P<project_id_or_slug>[^/\.]+)/iframe/$",
+                    r"^iframe/$",
                     IframeView.as_view(),
                     name="sentry-toolbar-iframe",
                 ),
                 re_path(
-                    r"^(?P<organization_slug>[^/\.]+)/(?P<project_id_or_slug>[^/\.]+)/login-success/$",
+                    r"^login-success/$",
                     LoginSuccessView.as_view(),
                     name="sentry-toolbar-login-success",
                 ),


### PR DESCRIPTION
Right now it's really opaque when a missing-project error happens while logging into the toolbar. This will help reveal the specific case that's causing unexpected results.
Printing these reasons should not reveal anything dangerous because we're already dealing with a logged-in user at this point.