### PR TITLE
chore(gitlab): Mark ApiHostError as halt

### DIFF
--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -22,6 +22,7 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
 from sentry.shared_integrations.response.sequence import SequenceApiResponse
+from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.integrations.gitlab")
 
@@ -67,6 +68,7 @@ def fetch_file_blames(
                 and rate_limit_info
                 and rate_limit_info.remaining < (MINIMUM_REQUESTS - len(files))
             ):
+                metrics.incr("integrations.gitlab.get_blame_for_files.rate_limit")
                 logger.warning(
                     "get_blame_for_files.rate_limit_too_low",
                     extra={

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -523,11 +523,11 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         with pytest.raises(ApiError):
             self.gitlab_client.get_blame_for_files(files=[self.file_1], extra={})
 
-    @mock.patch(
-        "sentry.integrations.gitlab.blame.logger.error",
-    )
     @responses.activate
-    def test_failure_approaching_rate_limit(self, mock_logger_error):
+    @mock.patch(
+        "sentry.integrations.gitlab.blame.logger.warning",
+    )
+    def test_failure_approaching_rate_limit(self, mock_logger_warning):
         """
         If there aren't enough requests left to stay above the minimum request
         limit, should raise a ApiRateLimitedError.
@@ -549,7 +549,7 @@ class GitLabBlameForFilesTest(GitLabClientTest):
             self.gitlab_client.get_blame_for_files(files=[self.file_1, self.file_2], extra={})
 
         assert excinfo.value.text == "Approaching GitLab API rate limit"
-        mock_logger_error.assert_called_with(
+        mock_logger_warning.assert_called_with(
             "get_blame_for_files.rate_limit_too_low",
             extra={
                 "provider": "gitlab",


### PR DESCRIPTION
We already mark `ApiRetryError` as halts, as seen in this[ sentry issue](https://sentry.sentry.io/issues/3919710734/?query=is%3Aunresolved%20integration_name%3Agitlab%20interaction_type%3Aget_blame_for_files&referrer=issue-stream&sort=date&stream_index=4) which aligns with the [error logs](https://console.cloud.google.com/logs/query;query=resource.labels.container_name%3D%22sentry%22%0AjsonPayload.event%20%3D%20%22integrations.slo.failure%22%20--%20if%20you%20are%20debugging%20a%20failure%20state%0A--%20jsonPayload.event%20%3D%20%22integrations.slo.halted%22%20--%20if%20you%20are%20debugging%20a%20halted%20state%0AjsonPayload.interaction_type%20%3D%20%22get_blame_for_files%22%20--%20interaction%20type%20defined%20for%20the%20slo%0AjsonPayload.integration_name%20%3D%20%22gitlab%22%20--%20what%20provider%3F;summaryFields=:false:32:beginning;cursorTimestamp=2025-06-27T12:53:33.452050886Z;duration=P1D?project=internal-sentry&inv=1&invt=Ab1Qtw), it looks like we're getting `ApiHostError` when we retry too much so mark it as a halt.