### PR TITLE
ref(issues): Fix stack trace root validation to support Windows paths with spaces

### DIFF
--- a/src/sentry/issues/auto_source_code_config/frame_info.py
+++ b/src/sentry/issues/auto_source_code_config/frame_info.py
@@ -35,7 +35,7 @@ class FrameInfo:
         if (
             not frame_file_path
             or frame_file_path[0] in ["[", "<"]
-            or frame_file_path.find(" ") != NOT_FOUND
+            or frame_file_path.find("http") != NOT_FOUND
             or self.normalized_path.find("/") == NOT_FOUND
         ):
             raise UnsupportedFrameInfo("This path is not supported.")

--- a/src/sentry/issues/auto_source_code_config/frame_info.py
+++ b/src/sentry/issues/auto_source_code_config/frame_info.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -13,6 +14,10 @@ from .errors import (
 from .utils.platform import PlatformConfig
 
 NOT_FOUND = -1
+
+# Regex patterns for unsupported frame paths
+UNSUPPORTED_FRAME_PATH_PATTERN = re.compile(r"^[\[<]|https?://", re.IGNORECASE)
+UNSUPPORTED_NORMALIZED_PATH_PATTERN = re.compile(r"^[^/]*$")
 
 
 class FrameInfo:
@@ -31,12 +36,10 @@ class FrameInfo:
         # the straight path prefix and drive letter
         self.normalized_path, removed_prefix = remove_prefixes(frame_file_path)
 
-        # Using regexes would be better but this is easier to understand
         if (
             not frame_file_path
-            or frame_file_path[0] in ["[", "<"]
-            or frame_file_path.find("http") != NOT_FOUND
-            or self.normalized_path.find("/") == NOT_FOUND
+            or UNSUPPORTED_FRAME_PATH_PATTERN.search(frame_file_path)
+            or UNSUPPORTED_NORMALIZED_PATH_PATTERN.search(self.normalized_path)
         ):
             raise UnsupportedFrameInfo("This path is not supported.")
 

--- a/tests/sentry/issues/auto_source_code_config/test_frame_info.py
+++ b/tests/sentry/issues/auto_source_code_config/test_frame_info.py
@@ -11,18 +11,34 @@ from sentry.issues.auto_source_code_config.errors import (
 from sentry.issues.auto_source_code_config.frame_info import FrameInfo
 
 UNSUPPORTED_FRAME_FILENAMES = [
+    # HTTP/HTTPS URLs
+    "https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+    "http://example.com/script.js",
+    "HTTP://EXAMPLE.COM/SCRIPT.JS",
     "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+    "webpack:///https://cdn.example.com/bundle.js",
+    # Special frame types
     "<anonymous>",
     "<frozen importlib._bootstrap>",
     "[native code]",
     "O$t",
     "async https://s1.sentry-cdn.com/_static/dist/sentry/entrypoints/app.js",
+    # Top level files
     "README",  # top level file
-    # XXX: Top level files will need to be supported
     "/gtm.js",  # Rejected because it's a top level file and not because it has a backslash
     "ssl.py",
     "initialization.dart",
     "backburner.js",
+]
+
+# Files with "http" substring that should be ACCEPTED
+LEGITIMATE_HTTP_FILENAMES = [
+    "src/httpclient/request.py",
+    "/usr/local/httpd/config.py",
+    "lib/http_utils.js",
+    "services/httpserver/main.go",
+    "lib/https_client.rb",
+    "network/http2/stream.go",
 ]
 
 NO_EXTENSION_FRAME_FILENAMES = [
@@ -39,6 +55,12 @@ class TestFrameInfo:
     def test_raises_unsupported(self, filepath: str) -> None:
         with pytest.raises(UnsupportedFrameInfo):
             FrameInfo({"filename": filepath})
+
+    @pytest.mark.parametrize("filepath", LEGITIMATE_HTTP_FILENAMES)
+    def test_legitimate_http_filenames_accepted(self, filepath: str) -> None:
+        # These files contain "http" but should NOT be rejected
+        frame_info = FrameInfo({"filename": filepath})
+        assert frame_info.raw_path == filepath
 
     def test_raises_no_extension(self) -> None:
         for filepath in NO_EXTENSION_FRAME_FILENAMES:


### PR DESCRIPTION
<!-- Describe your PR here. -->
[Ticket](https://linear.app/getsentry/issue/ID-86/stack-trace-root-should-be-able-to-handle-whitespace)

- Instead of blanket rejecting all paths with spaces (which broke legitimate Windows paths like C:\Program Files\), specifically reject HTTP URLs (which is the actual concern), allowing legitimate file paths with spaces to work properly.

- Use regex patterns rather than string methods.
