### PR TITLE
fix(hybrid-cloud): revoke all org auth tokens when org slug changes

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -324,6 +324,8 @@ def register_temporary_features(manager: FeatureManager):
     # Enable resolve in upcoming release
     # TODO(steve): Remove when we remove the feature from the UI
     manager.add("organizations:resolve-in-upcoming-release", OrganizationFeature, FeatureHandlerStrategy.OPTIONS, api_expose=True)
+    # Enable revocation of org auth keys when a user renames an org slug
+    manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable search query builder raw search replacement

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -229,7 +229,6 @@ class DatabaseBackedControlOrganizationProvisioningService(
                 reservation_type=OrganizationSlugReservationType.TEMPORARY_RENAME_ALIAS.value,
             ).save(unsafe_write=True)
 
-        with outbox_context(transaction.atomic(using=router.db_for_write(OrgAuthToken))):
             # Changing a slug invalidates all org tokens, so revoke them all.
             auth_tokens = OrgAuthToken.objects.filter(
                 organization_id=organization_id, date_deactivated__isnull=True


### PR DESCRIPTION
Org auth tokens embed org slugs, so if the slug changes, all tokens must be revoked.