### PR TITLE
fix(aci): Add body and headers to uptime detector queryObj serializer

### DIFF
--- a/src/sentry/uptime/endpoints/serializers.py
+++ b/src/sentry/uptime/endpoints/serializers.py
@@ -146,6 +146,8 @@ class UptimeSubscriptionSerializerResponse(TypedDict):
     traceSampling: bool
     hostProviderId: str
     hostProviderName: str
+    headers: Sequence[tuple[str, str]]
+    body: str | None
 
 
 @register(UptimeSubscription)
@@ -163,4 +165,6 @@ class UptimeSubscriptionSerializer(Serializer):
             "traceSampling": obj.trace_sampling,
             "hostProviderId": obj.host_provider_id,
             "hostProviderName": obj.host_provider_name,
+            "headers": obj.headers,
+            "body": obj.body,
         }


### PR DESCRIPTION
`headers` and `body` were missing from the serializer added in https://github.com/getsentry/sentry/pull/92150