### PR TITLE
feat(detectors): Update query injection detectors 

### DIFF
--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-body.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-body.json
@@ -142,6 +142,9 @@
       "status": "ok",
       "description": "SELECT * FROM users WHERE username = 'hello'",
       "origin": "auto.db.otel.mysql2",
+      "sentry_tags": {
+        "description": "SELECT * FROM users WHERE username = %s"
+      },
       "data": {
         "db.system": "mysql",
         "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",

--- a/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
+++ b/fixtures/events/performance_problems/sql-injection/sql-injection-event-query.json
@@ -145,6 +145,9 @@
       "status": "ok",
       "description": "SELECT * FROM users WHERE username = 'hello' ORDER BY username ASC",
       "origin": "auto.db.otel.mysql2",
+      "sentry_tags": {
+        "description": "SELECT * FROM users WHERE username = %s ORDER BY username ASC"
+      },
       "data": {
         "db.system": "mysql",
         "db.connection_string": "jdbc:mysql://localhost:3306/injection_test",

--- a/src/sentry/performance_issues/detectors/query_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/query_injection_detector.py
@@ -66,7 +66,7 @@ class QueryInjectionDetector(PerformanceDetector):
 
             input_dict = {input_key: input_value}
             if json.dumps(input_dict) in description:
-                description = description.replace(json.dumps(input_value), "?")
+                description = description.replace(json.dumps(input_value), "[UNTRUSTED_INPUT]")
                 unsafe_inputs.append((input_key, original_input_value))
 
         if len(unsafe_inputs) == 0:

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -124,20 +124,21 @@ class SQLInjectionDetector(PerformanceDetector):
 
         for key, value in self.request_parameters:
             regex_key = rf'(?<![\w.$])"?{re.escape(key)}"?(?![\w.$"])'
-            regex_value = rf'(?<![\w.$])"?{re.escape(value)}"?(?![\w.$"])'
+            regex_value = rf"(?<![\w.$])(['\"]?){re.escape(value)}\1(?![\w.$'\"])"
             where_index = description.upper().find("WHERE")
             if re.search(regex_key, description[where_index:]) and re.search(
                 regex_value, description[where_index:]
             ):
                 description = description[:where_index] + re.sub(
-                    regex_value, "?", description[where_index:]
+                    regex_value, "[UNTRUSTED_INPUT]", description[where_index:]
                 )
                 vulnerable_parameters.append((key, value))
 
         if len(vulnerable_parameters) == 0:
             return
 
-        fingerprint = self._fingerprint(description)
+        parameterized_description = span.get("sentry_tags", {}).get("description")
+        fingerprint = self._fingerprint(parameterized_description)
 
         self.stored_problems[fingerprint] = PerformanceProblem(
             type=DBQueryInjectionVulnerabilityGroupType,

--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -137,8 +137,7 @@ class SQLInjectionDetector(PerformanceDetector):
         if len(vulnerable_parameters) == 0:
             return
 
-        parameterized_description = span.get("sentry_tags", {}).get("description")
-        fingerprint = self._fingerprint(parameterized_description)
+        fingerprint = self._fingerprint(description)
 
         self.stored_problems[fingerprint] = PerformanceProblem(
             type=DBQueryInjectionVulnerabilityGroupType,

--- a/tests/sentry/performance_issues/test_query_injection_detector.py
+++ b/tests/sentry/performance_issues/test_query_injection_detector.py
@@ -33,11 +33,11 @@ class QueryInjectionDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
         assert problem.type == DBQueryInjectionVulnerabilityGroupType
-        assert problem.fingerprint == "1-1020-658d7b7076aa52b858b95771ea65d658a2196653"
+        assert problem.fingerprint == "1-1020-cc646b5cb412d3878c638d3168fd6202ba2c28e0"
         assert problem.op == "db"
         assert (
             problem.desc
-            == '{"find":"?","filter":{"username":?},"limit":"?","singleBatch":"?","batchSize":"?"}'
+            == '{"find":"?","filter":{"username":[UNTRUSTED_INPUT]},"limit":"?","singleBatch":"?","batchSize":"?"}'
         )
         assert problem.evidence_data is not None
         assert problem.evidence_data["vulnerable_parameters"] == [("username", {"$ne": None})]

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -33,7 +33,7 @@ class SQLInjectionDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
         assert problem.type == DBQueryInjectionVulnerabilityGroupType
-        assert problem.fingerprint == "1-1020-53ed51b6ab22e4acdefa33bfc73c39ac33be7e41"
+        assert problem.fingerprint == "1-1020-29c2b54639697556914d1bbb843f0bbb8cdd3397"
         assert problem.op == "db"
         assert (
             problem.desc
@@ -50,7 +50,7 @@ class SQLInjectionDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
         assert problem.type == DBQueryInjectionVulnerabilityGroupType
-        assert problem.fingerprint == "1-1020-55d5da306c0665487d2cf852301b6a8811a514bd"
+        assert problem.fingerprint == "1-1020-197d2a9a95568a75551e4448423a7fe658ac21d2"
         assert problem.op == "db"
         assert problem.desc == "SELECT * FROM users WHERE username = [UNTRUSTED_INPUT]"
         assert problem.evidence_data is not None

--- a/tests/sentry/performance_issues/test_sql_injection_detector.py
+++ b/tests/sentry/performance_issues/test_sql_injection_detector.py
@@ -33,9 +33,12 @@ class SQLInjectionDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
         assert problem.type == DBQueryInjectionVulnerabilityGroupType
-        assert problem.fingerprint == "1-1020-d9460b7b6c17b64a51f0390b53390cb1b4c39662"
+        assert problem.fingerprint == "1-1020-53ed51b6ab22e4acdefa33bfc73c39ac33be7e41"
         assert problem.op == "db"
-        assert problem.desc == "SELECT * FROM users WHERE username = '?' ORDER BY username ASC"
+        assert (
+            problem.desc
+            == "SELECT * FROM users WHERE username = [UNTRUSTED_INPUT] ORDER BY username ASC"
+        )
         assert problem.evidence_data is not None
         assert problem.evidence_data["vulnerable_parameters"] == [("username", "hello")]
         assert problem.evidence_data["request_url"] == "http://localhost:3001/vulnerable-login"
@@ -47,9 +50,9 @@ class SQLInjectionDetectorTest(TestCase):
         assert len(problems) == 1
         problem = problems[0]
         assert problem.type == DBQueryInjectionVulnerabilityGroupType
-        assert problem.fingerprint == "1-1020-841b1fd77bae6e89b3570a2ab0bf43d3c8cfbac6"
+        assert problem.fingerprint == "1-1020-55d5da306c0665487d2cf852301b6a8811a514bd"
         assert problem.op == "db"
-        assert problem.desc == "SELECT * FROM users WHERE username = '?'"
+        assert problem.desc == "SELECT * FROM users WHERE username = [UNTRUSTED_INPUT]"
         assert problem.evidence_data is not None
         assert problem.evidence_data["vulnerable_parameters"] == [("username", "hello")]
         assert problem.evidence_data["request_url"] == "http://localhost:3001/vulnerable-login"


### PR DESCRIPTION
this pr makes a few updates to the query injection detectors:
1) if the matched value is a string, it replaces the whole string instead of just the contents (replaced "hello" instead of just hello in the description)
2) Replaces the ? in the description with [UNTRUSTED_INPUT] to make it more clear that the query has a problem. the previous version could look too much like a properly parameterized query. 