### PR TITLE
feat(explore): Allow separate sort bys in samples and aggregates

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/aggregateSortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/aggregateSortBys.tsx
@@ -1,0 +1,73 @@
+import type {Location} from 'history';
+
+import {defined} from 'sentry/utils';
+import type {Sort} from 'sentry/utils/discover/fields';
+import {decodeSorts} from 'sentry/utils/queryString';
+
+import type {Visualize} from './visualizes';
+
+export function defaultAggregateSortBys(yAxes: string[]): Sort[] {
+  if (yAxes[0]) {
+    return [
+      {
+        field: yAxes[0],
+        kind: 'desc' as const,
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function getAggregateSortBysFromLocation(
+  location: Location,
+  groupBys: string[],
+  visualizes: Visualize[]
+) {
+  const sortBys = decodeSorts(location.query.aggregateSort);
+
+  if (sortBys.length > 0 && validateSorts(sortBys, groupBys, visualizes)) {
+    return sortBys;
+  }
+
+  // we want to check the `sort` query param for backwards compatibility
+  // when the both modes shared a single query param for the sort
+  const sortBysFallback = decodeSorts(location.query.sort);
+
+  if (
+    sortBysFallback.length > 0 &&
+    validateSorts(sortBysFallback, groupBys, visualizes)
+  ) {
+    return sortBysFallback;
+  }
+
+  return defaultAggregateSortBys(visualizes.map(visualize => visualize.yAxis));
+}
+
+function validateSorts(
+  sortBys: Sort[],
+  groupBys: string[],
+  visualizes: Visualize[]
+): boolean {
+  return sortBys.every(
+    sortBy =>
+      groupBys.includes(sortBy.field) ||
+      visualizes.some(visualize => visualize.yAxis === sortBy.field)
+  );
+}
+
+export function updateLocationWithAggregateSortBys(
+  location: Location,
+  sortBys: Sort[] | null | undefined
+) {
+  if (defined(sortBys)) {
+    location.query.aggregateSort = sortBys.map(sortBy =>
+      sortBy.kind === 'desc' ? `-${sortBy.field}` : sortBy.field
+    );
+
+    // make sure to clear the cursor every time the query is updated
+    delete location.query.cursor;
+  } else if (sortBys === null) {
+    delete location.query.aggregateSort;
+  }
+}

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -78,7 +78,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           {
@@ -111,7 +112,8 @@ describe('PageParamsProvider', function () {
         ],
         mode: Mode.SAMPLES,
         query: '',
-        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateSortBys: [{field: 'count(span.duration)', kind: 'desc'}],
         aggregateFields: [{groupBy: ''}, new Visualize('count(span.duration)')],
       })
     );
@@ -128,7 +130,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'span.op', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('count(span.self_time)', {
@@ -150,7 +153,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'browser.name'},
           new Visualize('count(span.self_time)', {
@@ -173,7 +177,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           new Visualize('count(span.self_time)', {
             chartType: ChartType.AREA,
@@ -195,7 +200,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: ''},
           new Visualize('count(span.self_time)', {
@@ -217,7 +223,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('count(span.self_time)', {
@@ -238,7 +245,8 @@ describe('PageParamsProvider', function () {
           yAxes: ['count(span.self_time)'],
         },
       ],
-      sortBys: null,
+      sampleSortBys: null,
+      aggregateSortBys: null,
     });
 
     act(() => setMode(Mode.SAMPLES));
@@ -249,7 +257,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
-        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: ''},
           new Visualize('count(span.self_time)', {
@@ -263,7 +272,8 @@ describe('PageParamsProvider', function () {
   it('correctly updates mode from aggregates to sample with group bys', function () {
     renderTestComponent({
       mode: Mode.AGGREGATE,
-      sortBys: null,
+      sampleSortBys: null,
+      aggregateSortBys: null,
       fields: ['id', 'sdk.name', 'sdk.version', 'timestamp'],
       aggregateFields: [
         {groupBy: 'sdk.name'},
@@ -292,7 +302,8 @@ describe('PageParamsProvider', function () {
         ],
         mode: Mode.SAMPLES,
         query: '',
-        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
           {groupBy: 'sdk.version'},
@@ -317,7 +328,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: 'foo:bar',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('count(span.self_time)', {
@@ -339,7 +351,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
-        sortBys: [{field: 'id', kind: 'desc'}],
+        sampleSortBys: [{field: 'id', kind: 'desc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('count(span.self_time)', {
@@ -361,7 +374,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.SAMPLES,
         query: '',
-        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('count(span.self_time)', {
@@ -392,7 +406,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'max(span.duration)', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'max(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('min(span.self_time)', {
@@ -426,7 +441,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('min(span.self_time)', {
@@ -460,7 +476,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'sdk.name', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'sdk.name', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
           new Visualize('count(span.self_time)', {
@@ -491,7 +508,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'sdk.name'},
           new Visualize('count(span.self_time)', {
@@ -513,7 +531,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.duration)', kind: 'desc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.duration)', kind: 'desc'}],
         aggregateFields: [{groupBy: 'span.op'}, new Visualize('count(span.duration)')],
       })
     );
@@ -541,7 +560,8 @@ describe('PageParamsProvider', function () {
         fields: ['id', 'timestamp', 'span.self_time', 'span.duration'],
         mode: Mode.AGGREGATE,
         query: '',
-        sortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
+        sampleSortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'count(span.self_time)', kind: 'asc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
           new Visualize('count(span.self_time)', {

--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -32,6 +32,11 @@ import {
   updateLocationWithAggregateFields,
 } from './aggregateFields';
 import {
+  defaultAggregateSortBys,
+  getAggregateSortBysFromLocation,
+  updateLocationWithAggregateSortBys,
+} from './aggregateSortBys';
+import {
   defaultDataset,
   getDatasetFromLocation,
   updateLocationWithDataset,
@@ -54,22 +59,24 @@ import type {BaseVisualize, Visualize} from './visualizes';
 
 interface ReadablePageParamsOptions {
   aggregateFields: AggregateField[];
+  aggregateSortBys: Sort[];
   dataset: DiscoverDatasets | undefined;
   fields: string[];
   mode: Mode;
   query: string;
-  sortBys: Sort[];
+  sampleSortBys: Sort[];
   id?: string;
   title?: string;
 }
 
 class ReadablePageParams {
   aggregateFields: AggregateField[];
+  aggregateSortBys: Sort[];
   dataset: DiscoverDatasets | undefined;
   fields: string[];
   mode: Mode;
   query: string;
-  sortBys: Sort[];
+  sampleSortBys: Sort[];
   id?: string;
   title?: string;
   private _groupBys: string[];
@@ -77,11 +84,12 @@ class ReadablePageParams {
 
   constructor(options: ReadablePageParamsOptions) {
     this.aggregateFields = options.aggregateFields;
+    this.aggregateSortBys = options.aggregateSortBys;
     this.dataset = options.dataset;
     this.fields = options.fields;
     this.mode = options.mode;
     this.query = options.query;
-    this.sortBys = options.sortBys;
+    this.sampleSortBys = options.sampleSortBys;
     this.id = options.id;
     this.title = options.title;
 
@@ -89,6 +97,10 @@ class ReadablePageParams {
       .filter(isGroupBy)
       .map(groupBy => groupBy.groupBy);
     this._visualizes = this.aggregateFields.filter(isVisualize);
+  }
+
+  get sortBys(): Sort[] {
+    return this.mode === Mode.AGGREGATE ? this.aggregateSortBys : this.sampleSortBys;
   }
 
   get groupBys(): string[] {
@@ -102,12 +114,13 @@ class ReadablePageParams {
 
 interface WritablePageParams {
   aggregateFields?: Array<GroupBy | BaseVisualize> | null;
+  aggregateSortBys?: Sort[] | null;
   dataset?: DiscoverDatasets | null;
   fields?: string[] | null;
   id?: string | null;
   mode?: Mode | null;
   query?: string | null;
-  sortBys?: Sort[] | null;
+  sampleSortBys?: Sort[] | null;
   title?: string | null;
 }
 
@@ -119,19 +132,19 @@ function defaultPageParams(): ReadablePageParams {
   const query = defaultQuery();
   const title = defaultTitle();
   const id = defaultId();
-  const sortBys = defaultSortBys(
-    mode,
-    fields,
+  const sortBys = defaultSortBys(fields);
+  const aggregateSortBys = defaultAggregateSortBys(
     aggregateFields.filter(isVisualize).map(visualize => visualize.yAxis)
   );
 
   return new ReadablePageParams({
     aggregateFields,
+    aggregateSortBys,
     dataset,
     fields,
     mode,
     query,
-    sortBys,
+    sampleSortBys: sortBys,
     title,
     id,
   });
@@ -184,17 +197,23 @@ export function PageParamsProvider({children}: PageParamsProviderProps) {
     const query = getQueryFromLocation(location);
     const groupBys = aggregateFields.filter(isGroupBy).map(groupBy => groupBy.groupBy);
     const visualizes = aggregateFields.filter(isVisualize);
-    const sortBys = getSortBysFromLocation(location, mode, fields, groupBys, visualizes);
+    const sortBys = getSortBysFromLocation(location, fields);
+    const aggregateSortBys = getAggregateSortBysFromLocation(
+      location,
+      groupBys,
+      visualizes
+    );
     const title = getTitleFromLocation(location);
     const id = getIdFromLocation(location);
 
     return new ReadablePageParams({
       aggregateFields,
+      aggregateSortBys,
       dataset,
       fields,
       mode,
       query,
-      sortBys,
+      sampleSortBys: sortBys,
       title,
       id,
     });
@@ -274,7 +293,9 @@ export function useExploreQuery(): string {
 
 export function useExploreSortBys(): Sort[] {
   const pageParams = useExplorePageParams();
-  return pageParams.sortBys;
+  return pageParams.mode === Mode.AGGREGATE
+    ? pageParams.aggregateSortBys
+    : pageParams.sortBys;
 }
 
 export function useExploreTitle(): string | undefined {
@@ -309,11 +330,12 @@ export function newExploreTarget(
 ): Location {
   const target = {...location, query: {...location.query}};
   updateLocationWithAggregateFields(target, pageParams.aggregateFields);
+  updateLocationWithAggregateSortBys(target, pageParams.aggregateSortBys);
   updateLocationWithDataset(target, pageParams.dataset);
   updateLocationWithFields(target, pageParams.fields);
   updateLocationWithMode(target, pageParams.mode);
   updateLocationWithQuery(target, pageParams.query);
-  updateLocationWithSortBys(target, pageParams.sortBys);
+  updateLocationWithSortBys(target, pageParams.sampleSortBys);
   updateLocationWithTitle(target, pageParams.title);
   updateLocationWithId(target, pageParams.id);
   return target;
@@ -617,12 +639,17 @@ export function useSetExploreQuery() {
 }
 
 export function useSetExploreSortBys() {
+  const pageParams = useExplorePageParams();
   const setPageParams = useSetExplorePageParams();
   return useCallback(
     (sortBys: Sort[]) => {
-      setPageParams({sortBys});
+      setPageParams(
+        pageParams.mode === Mode.AGGREGATE
+          ? {aggregateSortBys: sortBys}
+          : {sampleSortBys: sortBys}
+      );
     },
-    [setPageParams]
+    [pageParams, setPageParams]
   );
 }
 

--- a/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/sortBys.tsx
@@ -5,75 +5,38 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 
-import {Mode} from './mode';
-import type {Visualize} from './visualizes';
-
-export function defaultSortBys(mode: Mode, fields: string[], yAxes: string[]): Sort[] {
-  if (mode === Mode.SAMPLES) {
-    if (fields.includes('timestamp')) {
-      return [
-        {
-          field: 'timestamp',
-          kind: 'desc' as const,
-        },
-      ];
-    }
-
-    if (fields.length) {
-      return [
-        {
-          field: fields[0]!,
-          kind: 'desc' as const,
-        },
-      ];
-    }
+export function defaultSortBys(fields: string[]): Sort[] {
+  if (fields.includes('timestamp')) {
+    return [
+      {
+        field: 'timestamp',
+        kind: 'desc' as const,
+      },
+    ];
   }
 
-  if (mode === Mode.AGGREGATE) {
-    if (yAxes[0]) {
-      return [
-        {
-          field: yAxes[0],
-          kind: 'desc' as const,
-        },
-      ];
-    }
+  if (fields.length) {
+    return [
+      {
+        field: fields[0]!,
+        kind: 'desc' as const,
+      },
+    ];
   }
 
   return [];
 }
 
-export function getSortBysFromLocation(
-  location: Location,
-  mode: Mode,
-  fields: string[],
-  groupBys: string[],
-  visualizes: Visualize[]
-): Sort[] {
+export function getSortBysFromLocation(location: Location, fields: string[]): Sort[] {
   const sortBys = decodeSorts(location.query.sort);
 
   if (sortBys.length > 0) {
-    if (mode === Mode.SAMPLES && sortBys.every(sortBy => fields.includes(sortBy.field))) {
-      return sortBys;
-    }
-
-    if (
-      mode === Mode.AGGREGATE &&
-      sortBys.every(
-        sortBy =>
-          groupBys.includes(sortBy.field) ||
-          visualizes.some(visualize => visualize.yAxis === sortBy.field)
-      )
-    ) {
+    if (sortBys.every(sortBy => fields.includes(sortBy.field))) {
       return sortBys;
     }
   }
 
-  return defaultSortBys(
-    mode,
-    fields,
-    visualizes.map(visualize => visualize.yAxis)
-  );
+  return defaultSortBys(fields);
 }
 
 export function updateLocationWithSortBys(

--- a/static/app/views/explore/multiQueryMode/locationUtils.tsx
+++ b/static/app/views/explore/multiQueryMode/locationUtils.tsx
@@ -10,6 +10,7 @@ import {decodeList, decodeSorts} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {defaultAggregateSortBys} from 'sentry/views/explore/contexts/pageParamsContext/aggregateSortBys';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {defaultSortBys} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {
@@ -46,8 +47,8 @@ function validateSortBys(
 ): Sort[] {
   const mode = getQueryMode(groupBys);
 
-  if (parsedSortBys.length > 0) {
-    if (mode === Mode.SAMPLES) {
+  if (mode === Mode.SAMPLES) {
+    if (parsedSortBys.length > 0) {
       if (parsedSortBys.every(sort => fields?.includes(sort.field))) {
         return parsedSortBys;
       }
@@ -59,16 +60,24 @@ function validateSortBys(
       ];
     }
 
-    if (
-      mode === Mode.AGGREGATE &&
-      parsedSortBys.every(
-        sort => groupBys?.includes(sort.field) || yAxes?.includes(sort.field)
-      )
-    ) {
-      return parsedSortBys;
-    }
+    return defaultSortBys(fields ?? []);
   }
-  return defaultSortBys(mode, fields ?? [], yAxes ?? []);
+
+  if (mode === Mode.AGGREGATE) {
+    if (parsedSortBys.length > 0) {
+      if (
+        parsedSortBys.every(
+          sort => groupBys?.includes(sort.field) || yAxes?.includes(sort.field)
+        )
+      ) {
+        return parsedSortBys;
+      }
+    }
+
+    return defaultAggregateSortBys(yAxes ?? []);
+  }
+
+  return [];
 }
 
 function parseQuery(raw: string): ReadableExploreQueryParts {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -3,6 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -19,6 +20,7 @@ import {
   useExploreMode,
   useExploreSortBys,
   useExploreVisualizes,
+  useSetExploreMode,
 } from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
@@ -393,7 +395,7 @@ describe('ExploreToolbar', function () {
     expect(groupBys).toEqual(['', '']);
   });
 
-  it('allows changing sort by', async function () {
+  it('allows changing sort by in samples mode', async function () {
     let sortBys: any;
     function Component() {
       sortBys = useExploreSortBys();
@@ -448,6 +450,124 @@ describe('ExploreToolbar', function () {
     expect(within(section).getByRole('button', {name: 'span.op'})).toBeInTheDocument();
     expect(within(section).getByRole('button', {name: 'Asc'})).toBeInTheDocument();
     expect(sortBys).toEqual([{field: 'span.op', kind: 'asc'}]);
+  });
+
+  it('allows changing sort by in aggregates mode', async function () {
+    let sortBys: any;
+    let setMode: any;
+    function Component() {
+      setMode = useSetExploreMode();
+      sortBys = useExploreSortBys();
+      return <ExploreToolbar />;
+    }
+    render(
+      <PageParamsProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+          <Component />
+        </TraceItemAttributeProvider>
+      </PageParamsProvider>
+    );
+
+    act(() => setMode(Mode.AGGREGATE));
+
+    const visualizeSection = screen.getByTestId('section-visualizes');
+
+    // try changing the aggregate
+    await userEvent.click(within(visualizeSection).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(visualizeSection).getByRole('option', {name: 'avg'}));
+
+    // try changing the field
+    await userEvent.click(
+      within(visualizeSection).getByRole('button', {name: 'span.duration'})
+    );
+    await userEvent.click(
+      within(visualizeSection).getByRole('option', {name: 'span.self_time'})
+    );
+
+    await userEvent.click(
+      within(visualizeSection).getByRole('button', {
+        name: 'Add Chart',
+      })
+    );
+
+    const section = screen.getByTestId('section-sort-by');
+
+    // this is the default
+    expect(
+      within(section).getByRole('button', {name: 'avg(span.self_time)'})
+    ).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Desc'})).toBeInTheDocument();
+    expect(sortBys).toEqual([{field: 'avg(span.self_time)', kind: 'desc'}]);
+
+    // check the default field options
+    const fields = ['avg(span.self_time)', 'count(spans)'];
+    await userEvent.click(
+      within(section).getByRole('button', {name: 'avg(span.self_time)'})
+    );
+    const fieldOptions = await within(section).findAllByRole('option');
+    expect(fieldOptions).toHaveLength(fields.length);
+    fieldOptions.forEach((option, i) => {
+      expect(option).toHaveTextContent(fields[i]!);
+    });
+
+    // try changing the field
+    await userEvent.click(
+      within(section).getByRole('option', {name: 'avg(span.self_time)'})
+    );
+    expect(
+      within(section).getByRole('button', {name: 'avg(span.self_time)'})
+    ).toBeInTheDocument();
+    expect(within(section).getByRole('button', {name: 'Desc'})).toBeInTheDocument();
+    expect(sortBys).toEqual([{field: 'avg(span.self_time)', kind: 'desc'}]);
+
+    // check the kind options
+    await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));
+    const kindOptions = await within(section).findAllByRole('option');
+    expect(kindOptions).toHaveLength(2);
+    expect(kindOptions[0]).toHaveTextContent('Desc');
+    expect(kindOptions[1]).toHaveTextContent('Asc');
+  });
+
+  it('allows for different sort bys on samples and aggregates mode', async function () {
+    let sortBys: any;
+    let setMode: any;
+    function Component() {
+      setMode = useSetExploreMode();
+      sortBys = useExploreSortBys();
+      return <ExploreToolbar />;
+    }
+
+    render(
+      <PageParamsProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+          <Component />
+        </TraceItemAttributeProvider>
+      </PageParamsProvider>
+    );
+
+    const section = screen.getByTestId('section-sort-by');
+
+    expect(sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'Asc'}));
+
+    expect(sortBys).toEqual([{field: 'timestamp', kind: 'asc'}]);
+
+    act(() => setMode(Mode.AGGREGATE));
+
+    expect(sortBys).toEqual([{field: 'count(span.duration)', kind: 'desc'}]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'Desc'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'Asc'}));
+
+    expect(sortBys).toEqual([{field: 'count(span.duration)', kind: 'asc'}]);
+
+    act(() => setMode(Mode.SAMPLES));
+    expect(sortBys).toEqual([{field: 'timestamp', kind: 'asc'}]);
+
+    act(() => setMode(Mode.AGGREGATE));
+    expect(sortBys).toEqual([{field: 'count(span.duration)', kind: 'asc'}]);
   });
 
   it('opens compare queries', async function () {
@@ -630,6 +750,7 @@ describe('ExploreToolbar', function () {
     function Component() {
       return <ExploreToolbar />;
     }
+
     render(
       <PageParamsProvider>
         <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
@@ -649,13 +770,13 @@ describe('ExploreToolbar', function () {
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
-          sort: ['count(span.duration)'],
+          aggregateSort: ['count(span.duration)'],
         }),
       })
     );
 
     // Simulate navigation from sort change
-    router.location.query.sort = ['count(span.duration)'];
+    router.location.query.aggregateSort = ['count(span.duration)'];
     router.push(router.location);
     render(
       <PageParamsProvider>

--- a/static/app/views/explore/toolbar/index.tsx
+++ b/static/app/views/explore/toolbar/index.tsx
@@ -1,13 +1,6 @@
 import styled from '@emotion/styled';
 
 import {defined} from 'sentry/utils';
-import {
-  useExploreFields,
-  useExploreGroupBys,
-  useExploreSortBys,
-  useExploreVisualizes,
-  useSetExploreSortBys,
-} from 'sentry/views/explore/contexts/pageParamsContext';
 import {ToolbarGroupBy} from 'sentry/views/explore/toolbar/toolbarGroupBy';
 import {ToolbarSaveAs} from 'sentry/views/explore/toolbar/toolbarSaveAs';
 import {ToolbarSortBy} from 'sentry/views/explore/toolbar/toolbarSortBy';
@@ -21,23 +14,11 @@ interface ExploreToolbarProps {
 }
 
 export function ExploreToolbar({extras, width}: ExploreToolbarProps) {
-  const fields = useExploreFields();
-  const groupBys = useExploreGroupBys();
-  const visualizes = useExploreVisualizes();
-  const sortBys = useExploreSortBys();
-  const setSortBys = useSetExploreSortBys();
-
   return (
     <Container width={width}>
       <ToolbarVisualize allowEquations={extras?.includes('equations') || false} />
       <ToolbarGroupBy autoSwitchToAggregates />
-      <ToolbarSortBy
-        fields={fields}
-        groupBys={groupBys}
-        visualizes={visualizes}
-        sorts={sortBys}
-        setSorts={setSortBys}
-      />
+      <ToolbarSortBy />
       <ToolbarSaveAs />
     </Container>
   );

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -6,30 +6,29 @@ import {CompactSelect} from 'sentry/components/core/compactSelect';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {useExploreMode} from 'sentry/views/explore/contexts/pageParamsContext';
+import {
+  useExploreFields,
+  useExploreGroupBys,
+  useExploreMode,
+  useExploreSortBys,
+  useExploreVisualizes,
+  useSetExploreSortBys,
+} from 'sentry/views/explore/contexts/pageParamsContext';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 
 import {ToolbarHeader, ToolbarLabel, ToolbarRow, ToolbarSection} from './styles';
 
-interface ToolbarSortByProps {
-  fields: string[];
-  groupBys: string[];
-  setSorts: (newSorts: Sort[]) => void;
-  sorts: Sort[];
-  visualizes: Visualize[];
-}
-
-export function ToolbarSortBy({
-  fields,
-  groupBys,
-  setSorts,
-  sorts,
-  visualizes,
-}: ToolbarSortByProps) {
+export function ToolbarSortBy() {
   const mode = useExploreMode();
+  const fields = useExploreFields();
+  const groupBys = useExploreGroupBys();
+  const visualizes = useExploreVisualizes();
+
+  const sorts = useExploreSortBys();
+  const setSorts = useSetExploreSortBys();
+
   const [tab] = useTab();
 
   // traces table is only sorted by timestamp so disable the sort by

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -340,7 +340,7 @@ export function viewSamplesTarget({
     mode: Mode.SAMPLES,
     fields: newFields,
     query: search.formatString(),
-    sortBys: [sortBy],
+    sampleSortBys: [sortBy],
   });
 }
 


### PR DESCRIPTION
The sort bys are not transferable from samples to aggregates mode. So make them 2 separate controls.
