### PR TITLE
fix(ACI): Don't dual process dynamic alerts

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -13,7 +13,6 @@ from django.utils import timezone
 from sentry_redis_tools.retrying_cluster import RetryingRedisCluster
 
 from sentry import features
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import ObjectStatus
 from sentry.incidents.logic import (
     CRITICAL_TRIGGER_LABEL,
@@ -51,9 +50,6 @@ from sentry.incidents.utils.types import (
 )
 from sentry.models.project import Project
 from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer_legacy
-from sentry.seer.anomaly_detection.get_historical_anomalies import (
-    get_anomaly_evaluation_from_workflow_engine,
-)
 from sentry.seer.anomaly_detection.utils import anomaly_has_confidence, has_anomaly
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription
@@ -374,28 +370,16 @@ class SubscriptionProcessor:
         aggregation_value = self.get_aggregation_value(subscription_update, comparison_delta)
 
         if aggregation_value is not None:
-            if has_metric_alert_processing:
-                if self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
-                    packet = QuerySubscriptionUpdate(
-                        entity=subscription_update.get("entity", ""),
-                        subscription_id=subscription_update["subscription_id"],
-                        values={
-                            "values": {
-                                "value": aggregation_value,
-                                "source_id": str(self.subscription.id),
-                                "subscription_id": subscription_update["subscription_id"],
-                                "timestamp": self.last_update,
-                            },
-                        },
-                        timestamp=self.last_update,
-                    )
-                else:
-                    packet = QuerySubscriptionUpdate(
-                        entity=subscription_update.get("entity", ""),
-                        subscription_id=subscription_update["subscription_id"],
-                        values={"value": aggregation_value},
-                        timestamp=self.last_update,
-                    )
+            if (
+                has_metric_alert_processing
+                and not self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
+            ):
+                packet = QuerySubscriptionUpdate(
+                    entity=subscription_update.get("entity", ""),
+                    subscription_id=subscription_update["subscription_id"],
+                    values={"value": aggregation_value},
+                    timestamp=self.last_update,
+                )
                 data_packet = DataPacket[QuerySubscriptionUpdate](
                     source_id=str(self.subscription.id), packet=packet
                 )
@@ -441,26 +425,7 @@ class SubscriptionProcessor:
             # Triggers is the threshold - NOT an instance of a trigger
             metrics_incremented = False
             for trigger in self.triggers:
-                # dual processing of anomaly detection alerts
-                if (
-                    has_anomaly_detection
-                    and has_metric_alert_processing
-                    and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
-                ):
-                    if not detector:
-                        raise ResourceDoesNotExist("Detector not found, cannot evaluate anomaly")
-
-                    is_anomalous = get_anomaly_evaluation_from_workflow_engine(detector, results)
-                    if is_anomalous is None:
-                        # we only care about True and False — None indicates no change
-                        continue
-
-                    assert isinstance(is_anomalous, bool)
-                    fired_incident_triggers = self.handle_trigger_anomalies(
-                        is_anomalous, trigger, aggregation_value, fired_incident_triggers
-                    )
-
-                elif potential_anomalies:
+                if potential_anomalies:
                     # NOTE: There should only be one anomaly in the list
                     for potential_anomaly in potential_anomalies:
                         # check to see if we have enough data for the dynamic alert rule now

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest import mock
+from unittest import mock, skip
 from unittest.mock import MagicMock, call, patch
 
 import orjson
@@ -430,6 +430,7 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @skip("not enabled yet")
     def test_seer_call_dual_processing__warning(self, mock_seer_request: MagicMock):
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -508,6 +509,7 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @skip("not enabled yet")
     def test_seer_call_dual_processing__critical(self, mock_seer_request: MagicMock):
         rule = self.dynamic_rule
         trigger = self.trigger
@@ -602,6 +604,7 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:anomaly-detection-rollout")
     @with_feature("organizations:workflow-engine-metric-alert-processing")
+    @skip("not enabled yet")
     def test_seer_call_dual_processing__resolution(self, mock_seer_request: MagicMock):
         rule = self.dynamic_rule
         trigger = self.trigger


### PR DESCRIPTION
Disables dual processing dynamic alerts until we can fix https://sentry.sentry.io/issues/6713407596/?environment=prod&project=1&query=%21level%3Ainfo%20%21level%3Awarning&referrer=issue-stream&stream_index=0 which is pausing deploys. 

Because I merged https://github.com/getsentry/sentry/pull/94574 after merging https://github.com/getsentry/sentry/pull/93851 I can't safely revert it.