### PR TITLE
fix(aci): Report Snuba exceptions as warnings and retry

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -9,8 +9,6 @@ from typing import Any, TypeAlias
 
 import sentry_sdk
 from celery import Task
-from celery.exceptions import MaxRetriesExceededError
-from celery.exceptions import Retry as CeleryRetry
 from django.utils import timezone
 from pydantic import BaseModel, validator
 
@@ -761,7 +759,7 @@ def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
         ),
     ),
 )
-@retry(exclude=(MaxRetriesExceededError, CeleryRetry))
+@retry
 @log_context.root()
 def process_delayed_workflows(
     project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -9,6 +9,7 @@ from typing import Any, TypeAlias
 
 import sentry_sdk
 from celery import Task
+from celery.exceptions import MaxAttemptsExceededError
 from django.utils import timezone
 from pydantic import BaseModel, validator
 
@@ -759,7 +760,7 @@ def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
         ),
     ),
 )
-@retry
+@retry(exclude=(MaxAttemptsExceededError,))
 @log_context.root()
 def process_delayed_workflows(
     project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -9,7 +9,8 @@ from typing import Any, TypeAlias
 
 import sentry_sdk
 from celery import Task
-from celery.exceptions import MaxAttemptsExceededError
+from celery.exceptions import MaxRetriesExceededError
+from celery.exceptions import Retry as CeleryRetry
 from django.utils import timezone
 from pydantic import BaseModel, validator
 
@@ -760,7 +761,7 @@ def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
         ),
     ),
 )
-@retry(exclude=(MaxAttemptsExceededError,))
+@retry(exclude=(MaxRetriesExceededError, CeleryRetry))
 @log_context.root()
 def process_delayed_workflows(
     project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any


### PR DESCRIPTION
Snuba errors are expected and should not be treated as errors; when they occur, we'd like to retry.
We log them as warnings before retry so we still have record of them; if we used `@retry` for this, it'd report them as high priority and we'd like to avoid that in this context.