### PR TITLE
fix(aci): Adjust retry criteria for nodestore.get in fetch_event

### DIFF
--- a/src/sentry/workflow_engine/tasks.py
+++ b/src/sentry/workflow_engine/tasks.py
@@ -1,3 +1,5 @@
+from google.api_core.exceptions import DeadlineExceeded, RetryError, ServiceUnavailable
+
 from sentry import nodestore
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.eventstream.base import GroupState
@@ -8,7 +10,6 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.post_process import should_retry_fetch
 from sentry.taskworker import config, namespaces, retry
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
@@ -82,12 +83,23 @@ def workflow_status_update_handler(
     )
 
 
+def _should_retry_nodestore_fetch(attempt: int, e: Exception) -> bool:
+    return not attempt > 3 and (
+        # ServiceUnavailable and DeadlineExceeded are generally retriable;
+        # we also include RetryError because the nodestore interface doesn't let
+        # us specify a timeout to BigTable and the default is 5s; see c5e2b40.
+        isinstance(e, (ServiceUnavailable, RetryError, DeadlineExceeded))
+    )
+
+
 def fetch_event(event_id: str, project_id: int) -> Event | None:
     """
     Fetch a single Event, with retries.
     """
     node_id = Event.generate_node_id(project_id, event_id)
-    fetch_retry_policy = ConditionalRetryPolicy(should_retry_fetch, exponential_delay(1.00))
+    fetch_retry_policy = ConditionalRetryPolicy(
+        _should_retry_nodestore_fetch, exponential_delay(1.00)
+    )
     data = fetch_retry_policy(lambda: nodestore.backend.get(node_id))
     if data is None:
         return None

--- a/tests/sentry/workflow_engine/test_tasks.py
+++ b/tests/sentry/workflow_engine/test_tasks.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from google.api_core.exceptions import RetryError
+
 from sentry.issues.status_change_consumer import update_status
 from sentry.issues.status_change_message import StatusChangeMessageData
 from sentry.models.activity import Activity
@@ -7,7 +9,28 @@ from sentry.models.group import GroupStatus
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
-from sentry.workflow_engine.tasks import workflow_status_update_handler
+from sentry.workflow_engine.tasks import fetch_event, workflow_status_update_handler
+
+
+class FetchEventTests(TestCase):
+    def test_fetch_event_retries_on_retry_error(self):
+        """Test that fetch_event retries when encountering RetryError."""
+        event_id = "test_event_id"
+        project_id = self.project.id
+
+        # Mock nodestore to fail with RetryError twice, then succeed
+        with mock.patch("sentry.workflow_engine.tasks.nodestore.backend.get") as mock_get:
+            mock_get.side_effect = [
+                RetryError("retry", None),
+                RetryError("retry", None),
+                {"data": "test"},
+            ]
+
+            result = fetch_event(event_id, project_id)
+
+            # Should have been called 3 times (2 failures + 1 success)
+            assert mock_get.call_count == 3
+            assert result is not None
 
 
 class IssuePlatformIntegrationTests(TestCase):


### PR DESCRIPTION
The default timeout of 5s for nodestore.get is a bit too low for us, and we can't really overwrite it, so this accounts for it in our retries.

Fixes ACI-400.
