### PR TITLE
feat(events): Put errors in the nodestore cache on save

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -121,6 +121,7 @@ class NodeData(MutableMapping[str, Any]):
         :param subkeys: Additional JSON payloads to attach to nodestore value,
             currently only {"unprocessed": {...}} is added for reprocessing.
             See documentation of nodestore.
+        :param force_cache_write: Force the cache to be written to.
         """
 
         # We never loaded any data for reading or writing, so there

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -114,7 +114,7 @@ class NodeData(MutableMapping[str, Any]):
             self.data["_ref"] = ref
             self.data["_ref_version"] = self.ref_version
 
-    def save(self, subkeys=None):
+    def save(self, subkeys=None, force_cache_write=False):
         """
         Write current data back to nodestore.
 
@@ -137,4 +137,4 @@ class NodeData(MutableMapping[str, Any]):
         subkeys = subkeys or {}
         subkeys[None] = to_write
 
-        nodestore.backend.set_subkeys(self.id, subkeys)
+        nodestore.backend.set_subkeys(self.id, subkeys, force_cache_write=force_cache_write)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1103,9 +1103,13 @@ def _nodestore_save_many(jobs: Sequence[Job], app_feature: str) -> None:
                 usage_type=UsageUnit.BYTES,
             )
         job["event"].data["nodestore_insert"] = inserted_time
-        # Error events are nearly all expected to be read shortly after ingestion by
-        # post-processing tasks, so it's worth writing to cache.
-        force_cache_write = event_type == "error"
+        force_cache_write = False
+        if features.has(
+            "organizations:error-event-save-force-cache-write", event.project.organization
+        ):
+            # Error events are nearly all expected to be read shortly after ingestion by
+            # post-processing tasks, so it's worth writing to cache.
+            force_cache_write = event_type == "error"
         job["event"].data.save(subkeys=subkeys, force_cache_write=force_cache_write)
 
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -507,6 +507,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-metric-alert-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Creation of Metric Alerts that use the `group_by` field in the workflow_engine
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable writing to the cache when saving error events in nodestore
+    manager.add("organizations:error-event-save-force-cache-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only
     manager.add("organizations:ingest-through-trusted-relays-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new workflow_engine UI (see: alerts create issues)

--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -249,7 +249,11 @@ class NodeStorage(local, Service):
 
     @sentry_sdk.tracing.trace
     def set_subkeys(
-        self, item_id: str, data: dict[str | None, Mapping[str, Any]], ttl: timedelta | None = None
+        self,
+        item_id: str,
+        data: dict[str | None, Mapping[str, Any]],
+        ttl: timedelta | None = None,
+        force_cache_write: bool = False,
     ) -> None:
         """
         Set value for `item_id` and its subkeys.
@@ -268,7 +272,7 @@ class NodeStorage(local, Service):
         bytes_data = self._encode(data)
         self.set_bytes(item_id, bytes_data, ttl=ttl)
         # set cache only after encoding and write to nodestore has succeeded
-        if options.get("nodestore.set-subkeys.enable-set-cache-item"):
+        if options.get("nodestore.set-subkeys.enable-set-cache-item") or force_cache_write:
             self._set_cache_item(item_id, cache_item)
 
     def cleanup(self, cutoff_timestamp: datetime) -> None:

--- a/tests/sentry/nodestore/test_common.py
+++ b/tests/sentry/nodestore/test_common.py
@@ -118,7 +118,7 @@ def test_set_subkeys(ns: NodeStorage) -> None:
 
 
 @override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
-def test_set_subkeys_force_cache_write(ns):
+def test_set_subkeys_force_cache_write(ns: NodeStorage) -> None:
     """
     Test that set_subkeys writes to cache when force_cache_write is True,
     even when the option is disabled.
@@ -128,6 +128,8 @@ def test_set_subkeys_force_cache_write(ns):
 
     # With force_cache_write=True, should write to cache even when option is disabled
     ns.set_subkeys(node_id1, {None: data}, force_cache_write=True)
+
+    assert ns.cache
 
     # Verify it's in the cache without a `get` call.
     assert ns.cache.get(node_id1) == data

--- a/tests/sentry/nodestore/test_common.py
+++ b/tests/sentry/nodestore/test_common.py
@@ -115,3 +115,25 @@ def test_set_subkeys(ns: NodeStorage) -> None:
     ns.delete("node_1")
     assert ns.get("node_1") is None
     assert ns.get("node_1", subkey="other") is None
+
+
+@override_options({"nodestore.set-subkeys.enable-set-cache-item": False})
+def test_set_subkeys_force_cache_write(ns):
+    """
+    Test that set_subkeys writes to cache when force_cache_write is True,
+    even when the option is disabled.
+    """
+    node_id1 = "test_force_cache_write"
+    data = {"foo": "bar"}
+
+    # With force_cache_write=True, should write to cache even when option is disabled
+    ns.set_subkeys(node_id1, {None: data}, force_cache_write=True)
+
+    # Verify it's in the cache without a `get` call.
+    assert ns.cache.get(node_id1) == data
+
+    node_id2 = "test_force_cache_write_2"
+    ns.set_subkeys(node_id2, {None: data}, force_cache_write=False)
+
+    # Verify it's not in the cache without a `get` call.
+    assert ns.cache.get(node_id2) is None


### PR DESCRIPTION
With workflow processing for error events happening on another task, we can avoid some significant load to bigtable and latency by writing to the cache as we save events.
