### PR TITLE
feat(ACI): Single write to workflow engine models from alert rule payload

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -501,6 +501,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-ui-links", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine serializers to return data for old rule / incident endpoints
     manager.add("organizations:workflow-engine-rule-serializers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Take in alert rule data and only write to workflow engine models in old alert rule endpoints
+    manager.add("organizations:workflow-engine-rule-single-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable async processing of event workflows in a task rather than as part of post_process.
     manager.add("organizations:workflow-engine-post-process-async", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -75,6 +75,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.uptime.models import ProjectUptimeSubscription, UptimeStatus
 from sentry.uptime.types import UptimeMonitorMode
 from sentry.utils.cursors import Cursor, StringCursor
+from sentry.workflow_engine.endpoints.serializers import DetectorSerializer
 from sentry.workflow_engine.migration_helpers.alert_rule import single_write_workflow_engine_models
 from sentry.workflow_engine.models import Detector
 
@@ -132,7 +133,7 @@ def create_metric_alert(
                 serialize(
                     detector,
                     request.user,
-                    WorkflowEngineDetectorSerializer(),
+                    DetectorSerializer(),
                 ),
                 status=status.HTTP_201_CREATED,
             )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -264,6 +264,17 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             == list(audit_log_entry)[0].ip_address
         )
 
+    @with_feature("organizations:workflow-engine-rule-single-write")
+    @with_feature("organizations:incidents")
+    @with_feature("organizations:performance-view")
+    def test_single_write_workflow_engine(self):
+        resp = self.get_success_response(
+            self.organization.slug,
+            status_code=201,
+            **self.alert_rule_dict,
+        )
+        assert resp
+
     def test_workflow_engine_serializer(self):
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)


### PR DESCRIPTION
When we are ready to stop writes to the old models but aren't quite yet ready to deprecate the existing endpoints we can take in an alert rule payload and write to the workflow engine models instead. 

Lots of todos, also not sure if we want to use the detector serializer since it'll return a different response than the user is expecting but the intermediary one we made (`WorkflowEngineDetectorSerializer`) relies on the lookup tables, and since we're not writing to the old models we can't populate those.