### PR TITLE
fix(reports): Significantly increase the schedule_organizations deadline

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -63,7 +63,11 @@ logger = logging.getLogger(__name__)
     max_retries=5,
     acks_late=True,
     silo_mode=SiloMode.REGION,
-    taskworker_config=TaskworkerConfig(namespace=reports_tasks, retry=Retry(times=5)),
+    taskworker_config=TaskworkerConfig(
+        namespace=reports_tasks,
+        retry=Retry(times=5),
+        processing_deadline_duration=timedelta(minutes=10),
+    ),
 )
 @retry
 def schedule_organizations(


### PR DESCRIPTION
Weekly report scheduling has been timing out recently on taskbroker.
It seems to be due to the default 10s deadline being applied, where we probably want to wait much longer.
This explicitly picks a generous deadline to ensure we can complete our weekly work without timing out.