### PR TITLE
feat(uptime): Use EAP to query in `organization_uptime_stats`

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -453,6 +453,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:uptime-detector-create-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable sending uptime results to EAP (Events Analytics Platform)
     manager.add("organizations:uptime-eap-results", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable querying uptime data from EAP uptime_results instead of uptime_checks
+    manager.add("organizations:uptime-eap-uptime-results-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam classification at User Feedback ingest time

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -17,7 +17,7 @@ MOCK_DATETIME = datetime.now(tz=timezone.utc) - timedelta(days=1)
 class OrganizationUptimeStatsBaseTest(APITestCase):
     __test__ = False
     endpoint = "sentry-api-0-organization-uptime-stats"
-    features = {}
+    features: dict[str, bool] = {}
 
     def setUp(self):
         super().setUp()
@@ -43,7 +43,13 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
         for scenario in scenarios:
             self.store_uptime_data(self.subscription_id, **scenario)
 
-    def store_uptime_data(self, subscription_id, check_status, **kwargs):
+    def store_uptime_data(
+        self,
+        subscription_id,
+        check_status,
+        incident_status=IncidentStatus.NO_INCIDENT,
+        scheduled_check_time=None,
+    ):
         """Store a single uptime data row. Must be implemented by subclasses."""
         raise NotImplementedError("Subclasses must implement store_uptime_data")
 
@@ -243,18 +249,18 @@ class OrganizationUptimeCheckIndexEndpointTest(
 ):
     __test__ = True
 
-    def store_uptime_data(self, subscription_id, check_status, **kwargs):
-        default_timestamp = datetime.now(timezone.utc) - timedelta(hours=12)
+    def store_uptime_datastore_uptime_data(
+        self,
+        subscription_id,
+        check_status,
+        incident_status=IncidentStatus.NO_INCIDENT,
+        scheduled_check_time=None,
+    ):
         self.store_snuba_uptime_check(
             subscription_id=subscription_id,
             check_status=check_status,
-            incident_status=kwargs.get("incident_status", IncidentStatus.NO_INCIDENT),
-            scheduled_check_time=kwargs.get("scheduled_check_time", default_timestamp),
-            **{
-                k: v
-                for k, v in kwargs.items()
-                if k not in ["incident_status", "scheduled_check_time"]
-            },
+            incident_status=incident_status,
+            scheduled_check_time=scheduled_check_time,
         )
 
 
@@ -322,7 +328,6 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
         self,
         subscription_id,
         check_status,
-        *,
         incident_status=IncidentStatus.NO_INCIDENT,
         scheduled_check_time=None,
     ):

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -249,7 +249,7 @@ class OrganizationUptimeCheckIndexEndpointTest(
 ):
     __test__ = True
 
-    def store_uptime_datastore_uptime_data(
+    def store_uptime_data(
         self,
         subscription_id,
         check_status,

--- a/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
+++ b/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
@@ -152,13 +152,13 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 check_status="success",
                 http_status_code=200,
                 region="us-east-1",
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
                 http_status_code=500,
                 region="us-west-2",
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
         ]
         self.store_uptime_results(results)
@@ -192,17 +192,17 @@ class OrganizationEventsUptimeResultsEndpointTest(
             self.create_uptime_result(
                 check_status="success",
                 http_status_code=200,
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
                 http_status_code=500,
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="success",
                 http_status_code=201,
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
         ]
         self.store_uptime_results(results)
@@ -234,7 +234,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 request_duration_us=125000,
                 dns_lookup_duration_us=25000,
                 tcp_connection_duration_us=15000,
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
@@ -242,7 +242,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 request_duration_us=30000000,
                 dns_lookup_duration_us=200000,
                 tcp_connection_duration_us=25000,
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
         ]
         self.store_uptime_results(results)
@@ -291,21 +291,21 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 http_status_code=200,
                 dns_lookup_duration_us=15000,
                 region="us-east-1",
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
                 http_status_code=504,
                 dns_lookup_duration_us=150000,
                 region="us-east-1",
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
                 http_status_code=500,
                 dns_lookup_duration_us=20000,
                 region="us-west-2",
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
         ]
         self.store_uptime_results(results)
@@ -346,7 +346,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 http_status_code=301,
                 request_url="http://example.com",
                 trace_id=trace_id,
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_id=check_id,
@@ -355,7 +355,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 http_status_code=200,
                 request_url="https://example.com",
                 trace_id=trace_id,
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_id=uuid4().hex,
@@ -363,7 +363,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 check_status="success",
                 http_status_code=200,
                 request_url="https://other.com",
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
         ]
         self.store_uptime_results(results)
@@ -397,25 +397,25 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 check_status="success",
                 region="us-east-1",
                 http_status_code=200,
-                timestamp=self.ten_mins_ago,
+                scheduled_check_time=self.ten_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
                 region="us-east-1",
                 http_status_code=500,
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="success",
                 region="us-west-2",
                 http_status_code=200,
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
             self.create_uptime_result(
                 check_status="failure",
                 region="us-west-2",
                 http_status_code=503,
-                timestamp=self.nine_mins_ago,
+                scheduled_check_time=self.nine_mins_ago,
             ),
         ]
         self.store_uptime_results(results)
@@ -449,17 +449,17 @@ class OrganizationEventsUptimeResultsEndpointTest(
             self.create_uptime_result(
                 check_status="success",
                 guid="check-1",
-                timestamp=base_time,
+                scheduled_check_time=base_time,
             ),
             self.create_uptime_result(
                 check_status="success",
                 guid="check-2",
-                timestamp=base_time + timedelta(microseconds=1),
+                scheduled_check_time=base_time + timedelta(microseconds=1),
             ),
             self.create_uptime_result(
                 check_status="success",
                 guid="check-3",
-                timestamp=base_time + timedelta(microseconds=2),
+                scheduled_check_time=base_time + timedelta(microseconds=2),
             ),
         ]
         self.store_uptime_results(results)


### PR DESCRIPTION
This introduces a feature flag that will allow us to query uptime stats via EAP

<!-- Describe your PR here. -->