### PR TITLE
fix: Do not render 'unminify code' button if context available

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -157,13 +157,13 @@ function DeprecatedLine({
   // This means they have a "good stack trace" with readable source lines
   // In this case, we want to hide the 'unminify code' button since the
   // user already has sufficient debugging information
-  const shouldShowSourceMapDebuggerButton = hasContextSource(data)
-    ? false
-    : !hideSourceMapDebugger &&
-      data.inApp &&
-      frameHasValidFileEndingForSourceMapDebugger &&
-      frameSourceResolutionResults &&
-      !frameSourceResolutionResults.frameIsResolved;
+  const shouldShowSourceMapDebuggerButton =
+    !hasContextSource(data) &&
+    !hideSourceMapDebugger &&
+    data.inApp &&
+    frameHasValidFileEndingForSourceMapDebugger &&
+    frameSourceResolutionResults &&
+    !frameSourceResolutionResults.frameIsResolved;
 
   const sourceMapDebuggerAmplitudeData = {
     organization: organization ?? null,
@@ -288,7 +288,7 @@ function DeprecatedLine({
                       modalProps => (
                         <SourceMapsDebuggerModal
                           analyticsParams={sourceMapDebuggerAmplitudeData}
-                          sourceResolutionResults={frameSourceResolutionResults!}
+                          sourceResolutionResults={frameSourceResolutionResults}
                           organization={organization}
                           projectId={event.projectID}
                           {...modalProps}

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -153,12 +153,17 @@ function DeprecatedLine({
         (data.absPath ?? '').endsWith(ending) || (data.filename ?? '').endsWith(ending)
     );
 
-  const shouldShowSourceMapDebuggerButton =
-    !hideSourceMapDebugger &&
-    data.inApp &&
-    frameHasValidFileEndingForSourceMapDebugger &&
-    frameSourceResolutionResults &&
-    (!frameSourceResolutionResults.frameIsResolved || !hasContextSource(data));
+  // If context is available (non-empty), users can already see the source code
+  // This means they have a "good stack trace" with readable source lines
+  // In this case, we want to hide the 'unminify code' button since the
+  // user already has sufficient debugging information
+  const shouldShowSourceMapDebuggerButton = hasContextSource(data)
+    ? false
+    : !hideSourceMapDebugger &&
+      data.inApp &&
+      frameHasValidFileEndingForSourceMapDebugger &&
+      frameSourceResolutionResults &&
+      !frameSourceResolutionResults.frameIsResolved;
 
   const sourceMapDebuggerAmplitudeData = {
     organization: organization ?? null,
@@ -283,7 +288,7 @@ function DeprecatedLine({
                       modalProps => (
                         <SourceMapsDebuggerModal
                           analyticsParams={sourceMapDebuggerAmplitudeData}
-                          sourceResolutionResults={frameSourceResolutionResults}
+                          sourceResolutionResults={frameSourceResolutionResults!}
                           organization={organization}
                           projectId={event.projectID}
                           {...modalProps}


### PR DESCRIPTION
When a stack trace frame already has source code context (readable source lines), the 'Unminify Code' button is now hidden. This reduces UI clutter since users already have sufficient debugging information and don't need additional source map setup guidance.

**Changes:**

- Updated logic to check if context source is available before showing the source map debugger button
- Added explanatory comments for the conditional logic

This improves the user experience by only showing the unminify button when it's actually needed - when source code is minified/unreadable and source maps could help.

**Before**
![image](https://github.com/user-attachments/assets/f8be10a2-0e4a-47f8-9f6e-fc152d42175a)


**After**
![image](https://github.com/user-attachments/assets/d57f6662-bce5-4aa5-bb9c-7f758bd8185a)


closes https://linear.app/getsentry/issue/TET-436/unminified-frames-still-display-the-unminify-code-button-in-the-rows