### PR TITLE
ref(span-buffer): Add way to shard buffered-segments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Sentry is a developer-first error tracking and performance monitoring platform. 
 - **Task Queue**: Celery 5.5+
 - **Databases**: PostgreSQL (primary), Redis, ClickHouse (via Snuba)
 - **Message Queue**: Kafka, RabbitMQ
+- **Stream Processing**: Arroyo (Kafka consumer/producer framework)
 - **Cloud Services**: Google Cloud Platform (Bigtable, Pub/Sub, Storage, KMS)
 
 ### Frontend
@@ -320,6 +321,7 @@ def send_email(user_id: int, subject: str, body: str) -> None:
 - Mock external services
 - Test database isolation with transactions
 - Use factories for test data
+- For Kafka/Arroyo components: Use `LocalProducer` with `MemoryMessageStorage` instead of mocks
 
 ### JavaScript Tests
 
@@ -402,6 +404,35 @@ analytics.record(
     organization_id=org.id,
     feature="new-dashboard",
 )
+```
+
+### Arroyo Stream Processing
+
+```python
+# Using Arroyo for Kafka producers with dependency injection for testing
+from arroyo.backends.abstract import Producer
+from arroyo.backends.kafka import KafkaProducer, KafkaPayload
+from arroyo.backends.local.backend import LocalBroker
+from arroyo.backends.local.storages.memory import MemoryMessageStorage
+
+# Production producer
+def create_kafka_producer(config):
+    return KafkaProducer(build_kafka_configuration(default_config=config))
+
+# Test producer using Arroyo's LocalProducer
+def create_test_producer_factory():
+    storage = MemoryMessageStorage()
+    broker = LocalBroker(storage)
+    return lambda config: broker.get_producer(), storage
+
+# Dependency injection pattern for testable Kafka producers
+class MultiProducer:
+    def __init__(self, topic: Topic, producer_factory: Callable[[Mapping[str, object]], Producer[KafkaPayload]] | None = None):
+        self.producer_factory = producer_factory or self._default_producer_factory
+        # ... setup code
+
+    def _default_producer_factory(self, config) -> KafkaProducer:
+        return KafkaProducer(build_kafka_configuration(default_config=config))
 ```
 
 ## Architecture Rules

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -22,7 +22,7 @@ from sentry.conf.api_pagination_allowlist_do_not_modify import (
 )
 from sentry.conf.types.bgtask import BgTaskConfig
 from sentry.conf.types.celery import SplitQueueSize, SplitQueueTaskRoute
-from sentry.conf.types.kafka_definition import ConsumerDefinition
+from sentry.conf.types.kafka_definition import ConsumerDefinition, MultiProducerConfigs
 from sentry.conf.types.logging_config import LoggingConfig
 from sentry.conf.types.region_config import RegionConfig
 from sentry.conf.types.role_dict import RoleDict
@@ -3438,14 +3438,12 @@ KAFKA_CONSUMER_FORCE_DISABLE_MULTIPROCESSING = False
 # Producer configs are taken from KAFKA_CLUSTERS.
 # Example:
 # KAFKA_MULTI_PRODUCER_CONFIGS = {
-#     "buffered-segments": {
-#         "producers": [
-#             {"cluster": "default", "topic": "buffered-segments-1"},
-#             {"cluster": "secondary", "topic": "buffered-segments-2"}
-#         ]
-#     }
+#     "buffered-segments": [
+#         {"cluster": "default", "topic": "buffered-segments-1"},
+#         {"cluster": "secondary", "topic": "buffered-segments-2"}
+#     ]
 # }
-KAFKA_MULTI_PRODUCER_CONFIGS: dict[str, dict[str, Any]] = {}
+KAFKA_MULTI_PRODUCER_CONFIGS: MultiProducerConfigs = {}
 
 
 # For Jira, only approved apps can use the access_email_addresses scope

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3433,6 +3433,21 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
 KAFKA_CONSUMER_FORCE_DISABLE_MULTIPROCESSING = False
 
 
+# Configuration for multi-producer setups to enable load balancing across multiple
+# Kafka clusters/brokers. Each topic can have multiple producers configured.
+# Producer configs are taken from KAFKA_CLUSTERS.
+# Example:
+# KAFKA_MULTI_PRODUCER_CONFIGS = {
+#     "buffered-segments": {
+#         "producers": [
+#             {"cluster": "default", "topic": "buffered-segments-1"},
+#             {"cluster": "secondary", "topic": "buffered-segments-2"}
+#         ]
+#     }
+# }
+KAFKA_MULTI_PRODUCER_CONFIGS: dict[str, dict[str, Any]] = {}
+
+
 # For Jira, only approved apps can use the access_email_addresses scope
 # This scope allows Sentry to use the email endpoint (https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-user-email-get)
 # We use the email with Jira 2-way sync in order to match the user

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3732,11 +3732,11 @@ SHOW_LOGIN_BANNER = False
 # the broker config from KAFKA_CLUSTERS. This is used for slicing only.
 # Example:
 # SLICED_KAFKA_TOPICS = {
-#   ("KAFKA_SNUBA_GENERIC_METRICS", 0): {
+#   ("snuba-generic-metrics", 0): {
 #       "topic": "generic_metrics_0",
 #       "cluster": "cluster_1",
 #   },
-#   ("KAFKA_SNUBA_GENERIC_METRICS", 1): {
+#   ("snuba-generic-metrics", 1): {
 #       "topic": "generic_metrics_1",
 #       "cluster": "cluster_2",
 # }

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -22,7 +22,7 @@ from sentry.conf.api_pagination_allowlist_do_not_modify import (
 )
 from sentry.conf.types.bgtask import BgTaskConfig
 from sentry.conf.types.celery import SplitQueueSize, SplitQueueTaskRoute
-from sentry.conf.types.kafka_definition import ConsumerDefinition, MultiProducerConfigs
+from sentry.conf.types.kafka_definition import ConsumerDefinition
 from sentry.conf.types.logging_config import LoggingConfig
 from sentry.conf.types.region_config import RegionConfig
 from sentry.conf.types.role_dict import RoleDict
@@ -3431,19 +3431,6 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
 # If True, sentry.utils.arroyo.run_task_with_multiprocessing will actually be
 # single-threaded under the hood for performance
 KAFKA_CONSUMER_FORCE_DISABLE_MULTIPROCESSING = False
-
-
-# Configuration for multi-producer setups to enable load balancing across multiple
-# Kafka clusters/brokers. Each topic can have multiple producers configured.
-# Producer configs are taken from KAFKA_CLUSTERS.
-# Example:
-# KAFKA_MULTI_PRODUCER_CONFIGS = {
-#     "buffered-segments": [
-#         {"cluster": "default", "topic": "buffered-segments-1"},
-#         {"cluster": "secondary", "topic": "buffered-segments-2"}
-#     ]
-# }
-KAFKA_MULTI_PRODUCER_CONFIGS: MultiProducerConfigs = {}
 
 
 # For Jira, only approved apps can use the access_email_addresses scope

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -144,16 +144,6 @@ def validate_consumer_definition(consumer_definition: ConsumerDefinition) -> Non
         )
 
 
-class ProducerConfig(TypedDict):
-    """Configuration for a single producer within a multi-producer setup."""
-
-    cluster: str
-    topic: str
-
-
-MultiProducerConfigs = dict[str, list[ProducerConfig]]
-
-
 def get_topic_codec(topic: Topic) -> Codec:
     """
     Like sentry_kafka_schemas.get_codec, but only accepts a Topic enum

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -144,6 +144,16 @@ def validate_consumer_definition(consumer_definition: ConsumerDefinition) -> Non
         )
 
 
+class ProducerConfig(TypedDict):
+    """Configuration for a single producer within a multi-producer setup."""
+
+    cluster: str
+    topic: str
+
+
+MultiProducerConfigs = dict[str, list[ProducerConfig]]
+
+
 def get_topic_codec(topic: Topic) -> Codec:
     """
     Like sentry_kafka_schemas.get_codec, but only accepts a Topic enum

--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -473,6 +473,7 @@ def get_stream_processor(
     enforce_schema: bool = False,
     group_instance_id: str | None = None,
     max_dlq_buffer_length: int | None = None,
+    kafka_slice_id: int | None = None,
 ) -> StreamProcessor:
     from sentry.utils import kafka_config
 
@@ -494,7 +495,7 @@ def get_stream_processor(
     strategy_factory_cls = import_string(consumer_definition["strategy_factory"])
     consumer_topic = consumer_definition["topic"]
 
-    topic_defn = get_topic_definition(consumer_topic)
+    topic_defn = get_topic_definition(consumer_topic, kafka_slice_id=kafka_slice_id)
     real_topic = topic_defn["real_topic_name"]
     cluster_from_config = topic_defn["cluster"]
 

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -86,7 +86,7 @@ class MultiProducer:
             self.producers.append(producer)
             self.topics.append(topic)
 
-    def produce(self, payload: KafkaPayload, key: str | None = None):
+    def produce(self, payload: KafkaPayload):
         """Produce message with load balancing."""
         if len(self.producers) == 1:
             # Single producer - no load balancing needed

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -34,19 +34,17 @@ class MultiProducerManager:
     Configure multiple producers in settings.py:
 
     KAFKA_MULTI_PRODUCER_CONFIGS = {
-        "buffered-segments": {
-            "producers": [
-                {"cluster": "default", "topic": "buffered-segments-1"},
-                {"cluster": "secondary", "topic": "buffered-segments-2"}
-            ]
-        }
+        "buffered-segments": [
+            {"cluster": "default", "topic": "buffered-segments-1"},
+            {"cluster": "secondary", "topic": "buffered-segments-2"}
+        ]
     }
     """
 
     def __init__(self, topic: Topic):
         self.topic = topic
-        self.producers = []
-        self.topics = []
+        self.producers: list[KafkaProducer] = []
+        self.topics: list[ArroyoTopic] = []
         self.current_index = 0
         self._setup_producers()
 
@@ -57,7 +55,7 @@ class MultiProducerManager:
 
         if multi_config:
             # Multiple producers configured
-            for config in multi_config["producers"]:
+            for config in multi_config:
                 cluster_name = config["cluster"]
                 topic_name = config.get(
                     "topic", get_topic_definition(self.topic)["real_topic_name"]

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -86,6 +86,10 @@ class MultiProducer:
             self.producers.append(producer)
             self.topics.append(topic)
 
+        # Validate that we have at least one producer
+        if not self.producers:
+            raise ValueError(f"No producers configured for topic {self.topic.value}")
+
     def produce(self, payload: KafkaPayload):
         """Produce message with load balancing."""
         if len(self.producers) == 1:

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -97,7 +97,14 @@ def get_kafka_admin_cluster_options(
     )
 
 
-def get_topic_definition(topic: Topic) -> TopicDefinition:
+def get_topic_definition(topic: Topic, kafka_slice_id: int | None = None) -> TopicDefinition:
+    if kafka_slice_id is not None:
+        defn = settings.SLICED_KAFKA_TOPICS[topic.value, kafka_slice_id]
+        return {
+            "cluster": defn["cluster"],
+            "real_topic_name": defn["topic"],
+        }
+
     return {
         "cluster": settings.KAFKA_TOPIC_TO_CLUSTER[topic.value],
         "real_topic_name": settings.KAFKA_TOPIC_OVERRIDES.get(topic.value, topic.value),

--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -99,7 +99,13 @@ def get_kafka_admin_cluster_options(
 
 def get_topic_definition(topic: Topic, kafka_slice_id: int | None = None) -> TopicDefinition:
     if kafka_slice_id is not None:
-        defn = settings.SLICED_KAFKA_TOPICS[topic.value, kafka_slice_id]
+        sliced_topics = settings.SLICED_KAFKA_TOPICS
+        key = (topic.value, kafka_slice_id)
+        if key not in sliced_topics:
+            raise KeyError(
+                f"No configuration found for topic '{topic.value}' with slice ID {kafka_slice_id}"
+            )
+        defn = sliced_topics[key]
         return {
             "cluster": defn["cluster"],
             "real_topic_name": defn["topic"],

--- a/tests/sentry/conf/test_kafka_definition.py
+++ b/tests/sentry/conf/test_kafka_definition.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from sentry.conf.types.kafka_definition import (
     ConsumerDefinition,
     Topic,
+    get_topic_codec,
     validate_consumer_definition,
 )
 from sentry.consumers import KAFKA_CONSUMERS
@@ -49,3 +50,14 @@ class ConsumersDefinitionTest(TestCase):
     def test_kafka_consumer_definition_validity(self):
         for definition in KAFKA_CONSUMERS.values():
             validate_consumer_definition(definition)
+
+
+def test_get_topic_codec():
+    """Test that get_topic_codec works with Topic enum values."""
+    # Test with a known topic
+    codec = get_topic_codec(Topic.BUFFERED_SEGMENTS)
+    assert codec is not None
+
+    # Should be equivalent to calling sentry_kafka_schemas.get_codec directly
+    expected_codec = sentry_kafka_schemas.get_codec(Topic.BUFFERED_SEGMENTS.value)
+    assert codec == expected_codec

--- a/tests/sentry/consumers/test_get_topic_definition.py
+++ b/tests/sentry/consumers/test_get_topic_definition.py
@@ -1,0 +1,44 @@
+from django.test import override_settings
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.utils.kafka_config import get_topic_definition
+
+
+def test_get_topic_definition_without_slice_id():
+    with override_settings(
+        KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
+        KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},
+    ):
+        topic_def = get_topic_definition(Topic.EVENTS)
+        assert topic_def["cluster"] == "default"
+        assert topic_def["real_topic_name"] == "custom-events-topic"
+
+
+def test_get_topic_definition_no_override():
+    with override_settings(
+        KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
+        KAFKA_TOPIC_OVERRIDES={},
+    ):
+        topic_def = get_topic_definition(Topic.EVENTS)
+        assert topic_def["cluster"] == "default"
+        assert topic_def["real_topic_name"] == "events"
+
+
+def test_get_topic_definition_with_slice_id():
+    with override_settings(
+        KAFKA_TOPIC_TO_CLUSTER={"events": "default"},
+        KAFKA_TOPIC_OVERRIDES={"events": "custom-events-topic"},
+        SLICED_KAFKA_TOPICS={
+            ("events", 0): {"cluster": "slice-0", "topic": "events-slice-0"},
+            ("events", 1): {"cluster": "slice-1", "topic": "events-slice-1"},
+        },
+    ):
+        # Test slice 0
+        topic_def = get_topic_definition(Topic.EVENTS, kafka_slice_id=0)
+        assert topic_def["cluster"] == "slice-0"
+        assert topic_def["real_topic_name"] == "events-slice-0"
+
+        # Test slice 1
+        topic_def = get_topic_definition(Topic.EVENTS, kafka_slice_id=1)
+        assert topic_def["cluster"] == "slice-1"
+        assert topic_def["real_topic_name"] == "events-slice-1"

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -1,5 +1,6 @@
 import time
 from time import sleep
+from typing import Any
 
 import orjson
 from arroyo.processing.strategies.noop import Noop
@@ -95,7 +96,7 @@ def create_memory_producer_factory():
     from arroyo.backends.local.storages.memory import MemoryMessageStorage
 
     # Create shared storage so we can inspect messages across producers
-    storage = MemoryMessageStorage()
+    storage = MemoryMessageStorage[Any]()
     broker = LocalBroker(storage)
 
     def producer_factory(producer_config):

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -3,9 +3,11 @@ from time import sleep
 
 import orjson
 from arroyo.processing.strategies.noop import Noop
+from django.test import override_settings
 
+from sentry.conf.types.kafka_definition import Topic
 from sentry.spans.buffer import Span, SpansBuffer
-from sentry.spans.consumers.process.flusher import SpanFlusher
+from sentry.spans.consumers.process.flusher import MultiProducer, SpanFlusher
 from sentry.testutils.helpers.options import override_options
 from tests.sentry.spans.test_buffer import DEFAULT_OPTIONS
 
@@ -85,3 +87,70 @@ def test_backpressure(monkeypatch):
     assert messages
 
     assert any(x.value for x in flusher.process_backpressure_since.values())
+
+
+def create_memory_producer_factory():
+    """Create a factory that returns in-memory LocalProducers from Arroyo."""
+    from arroyo.backends.local.backend import LocalBroker
+    from arroyo.backends.local.storages.memory import MemoryMessageStorage
+
+    # Create shared storage so we can inspect messages across producers
+    storage = MemoryMessageStorage()
+    broker = LocalBroker(storage)
+
+    def producer_factory(producer_config):
+        return broker.get_producer()
+
+    # Return both factory and storage for inspection
+    return broker, producer_factory, storage
+
+
+@override_settings(
+    SLICED_KAFKA_TOPICS={
+        ("buffered-segments", 0): {"cluster": "default", "topic": "buffered-segments-1"},
+        ("buffered-segments", 1): {"cluster": "default", "topic": "buffered-segments-2"},
+    }
+)
+def test_multi_producer_sliced_integration_with_arroyo_local_producer():
+    from arroyo import Topic as ArroyoTopic
+    from arroyo.backends.kafka import KafkaPayload
+
+    broker, producer_factory, storage = create_memory_producer_factory()
+    broker.create_topic(ArroyoTopic("buffered-segments-1"), partitions=1)
+    broker.create_topic(ArroyoTopic("buffered-segments-2"), partitions=1)
+
+    manager = MultiProducer(Topic.BUFFERED_SEGMENTS, producer_factory=producer_factory)
+
+    assert len(manager.producers) == 2
+    assert len(manager.topics) == 2
+
+    topic_names = [topic.name for topic in manager.topics]
+    assert "buffered-segments-1" in topic_names
+    assert "buffered-segments-2" in topic_names
+
+    payload1 = KafkaPayload(None, b"test-message-1", [])
+    payload2 = KafkaPayload(None, b"test-message-2", [])
+    payload3 = KafkaPayload(None, b"test-message-3", [])
+
+    manager.produce(payload1)
+    manager.produce(payload2)
+    manager.produce(payload3)
+
+    from arroyo import Partition
+
+    topic1_partition = Partition(ArroyoTopic("buffered-segments-1"), 0)
+    topic2_partition = Partition(ArroyoTopic("buffered-segments-2"), 0)
+
+    message1 = broker.consume(topic1_partition, 0)
+    message2 = broker.consume(topic2_partition, 0)
+    message3 = broker.consume(topic1_partition, 1)
+
+    assert message1 is not None
+    assert message2 is not None
+    assert message3 is not None
+
+    assert message1.payload.value == b"test-message-1"
+    assert message2.payload.value == b"test-message-2"
+    assert message3.payload.value == b"test-message-3"
+
+    manager.close()


### PR DESCRIPTION
Allow configuration of many producers so that the load can be spread
over many topics.

The code isn't fully generic for now, but the configuration can be
reused for other slicing efforts.

There is slices support in the metrics indexer but it seems way too
complicated for what I am trying to do.

ref STREAM-285