### PR TITLE
Mark Android stacktraces on Flutter inApp by default

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -87,7 +87,7 @@ family:native function:"__*[[]Sentry*"                            -app -group
 family:native function:"?[[]Sentry*"                              -app -group
 
 # Mark Dart Flutter Android stacktraces in-app by default, further not in-app rules are applied afterwards below
-family:native package:/data/app/** stack.abs_path:**.dart +app
+family:native stack.package:/data/app/** stack.abs_path:**.dart +app
 # Dart/Flutter stacktraces that are not in-app
 family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
 family:javascript module:**/packages/flutter/** -app

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -86,6 +86,8 @@ family:native function:"__*[[]Sentry*"                            -app -group
 # own grouping enhancers.
 family:native function:"?[[]Sentry*"                              -app -group
 
+# Mark Dart Flutter Android stacktraces in-app by default, further not in-app rules are applied afterwards below
+family:native package:/data/app/** stack.abs_path:**.dart +app
 # Dart/Flutter stacktraces that are not in-app
 family:javascript stack.abs_path:org-dartlang-sdk:///** -app -group
 family:javascript module:**/packages/flutter/** -app


### PR DESCRIPTION
Currently all Android Flutter frames are not inApp. We should mark inApp by default so we can then based on specific stackframes mark the correct frames as not inApp (see flutter rules below the one I added in this PR)