### PR TITLE
ref(demo-mode): cleaning up DemoModeGuard middleware

### DIFF
--- a/src/sentry/middleware/demo_mode_guard.py
+++ b/src/sentry/middleware/demo_mode_guard.py
@@ -7,7 +7,6 @@ from django.contrib.auth import logout
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 
-from sentry import options
 from sentry.demo_mode.utils import is_demo_mode_enabled, is_demo_org
 from sentry.organizations.services.organization import organization_service
 
@@ -31,23 +30,15 @@ class DemoModeGuardMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponseBase:
-        if not request.subdomain and request.path in ("", "/"):
-            if is_demo_mode_enabled() and options.get("demo-mode.disable-sandbox-redirect"):
-                logger.debug(
-                    "Maybe blocking redirect on subdomain: %s path: %s",
-                    request.subdomain,
-                    request.path,
-                )
-                # only in "sentry.io/"
-                session = getattr(request, "session", None)
-                if session and (activeorg := session.get("activeorg")):
-                    logger.debug("Maybe blocking org redirect for org: %s", activeorg)
-                    if is_demo_org(_get_org(activeorg)):
-                        logger.debug("Org %s is demo org, redirecting to welcome page", activeorg)
-
-                        if options.get("demo-mode.sandbox-redirect-logout"):
-                            logout(request)
-
-                        return HttpResponseRedirect("https://sentry.io/welcome")
+        if (
+            not request.subdomain
+            and request.path in ("", "/")
+            and is_demo_mode_enabled()
+            and (session := getattr(request, "session", None))
+            and (activeorg := session.get("activeorg"))
+            and is_demo_org(_get_org(activeorg))
+        ):
+            logout(request)
+            return HttpResponseRedirect("https://sentry.io/welcome")
 
         return self.get_response(request)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3114,18 +3114,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "demo-mode.disable-sandbox-redirect",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-register(
-    "demo-mode.sandbox-redirect-logout",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # option for sample size when fetching project tag keys
 register(
     "visibility.tag-key-sample-size",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3114,6 +3114,18 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "demo-mode.disable-sandbox-redirect",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
+    "demo-mode.sandbox-redirect-logout",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # option for sample size when fetching project tag keys
 register(
     "visibility.tag-key-sample-size",

--- a/tests/sentry/middleware/test_demo_mode_guard.py
+++ b/tests/sentry/middleware/test_demo_mode_guard.py
@@ -25,65 +25,8 @@ class DemoModeGuardMiddlewareTestCase(TestCase):
         rv.subdomain = None
         return rv
 
-    @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": True})
+    @override_options({"demo-mode.enabled": True})
     def test_middleware_okay(self):
-        demo_org = self.create_organization()
-        with override_options({"demo-mode.orgs": [demo_org.id]}):
-            self.request.session["activeorg"] = demo_org.slug
-            response = self.middleware(self.request)
-
-        # SHOULD redirect to welcome page
-        assert isinstance(response, HttpResponseRedirect)
-        assert response.url == "https://sentry.io/welcome"
-
-    @override_options({"demo-mode.enabled": False, "demo-mode.disable-sandbox-redirect": True})
-    def test_middleware_demo_mode_disabled(self):
-        demo_org = self.create_organization()
-        with override_options({"demo-mode.orgs": [demo_org.id]}):
-            self.request.session["activeorg"] = demo_org.slug
-            response = self.middleware(self.request)
-
-        # SHOULD NOT redirect to welcome page
-        assert getattr(response, "url", "") != "https://sentry.io/welcome"
-
-    @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": False})
-    def test_middleware_redirect_not_disabled(self):
-        demo_org = self.create_organization()
-        with override_options({"demo-mode.orgs": [demo_org.id]}):
-            self.request.session["activeorg"] = demo_org.slug
-            response = self.middleware(self.request)
-
-        # SHOULD NOT redirect to welcome page
-        assert getattr(response, "url", "") != "https://sentry.io/welcome"
-
-    @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": True})
-    def test_middleware_not_demo_org(self):
-        demo_org = self.create_organization()
-        self.request.session["activeorg"] = demo_org.slug
-        response = self.middleware(self.request)
-
-        # SHOULD NOT redirect to welcome page
-        assert getattr(response, "url", "") != "https://sentry.io/welcome"
-
-    @override_options({"demo-mode.enabled": True, "demo-mode.disable-sandbox-redirect": True})
-    def test_middleware_subdomain(self):
-        demo_org = self.create_organization()
-        with override_options({"demo-mode.orgs": [demo_org.id]}):
-            self.request.subdomain = "test"
-            self.request.session["activeorg"] = demo_org.slug
-            response = self.middleware(self.request)
-
-        # SHOULD NOT redirect to welcome page
-        assert getattr(response, "url", "") != "https://sentry.io/welcome"
-
-    @override_options(
-        {
-            "demo-mode.enabled": True,
-            "demo-mode.disable-sandbox-redirect": True,
-            "demo-mode.sandbox-redirect-logout": True,
-        }
-    )
-    def test_middleware_okay_logout(self):
         demo_org = self.create_organization()
         with override_options({"demo-mode.orgs": [demo_org.id]}):
             self.request.session["activeorg"] = demo_org.slug
@@ -95,3 +38,42 @@ class DemoModeGuardMiddlewareTestCase(TestCase):
         # SHOULD redirect to welcome page
         assert isinstance(response, HttpResponseRedirect)
         assert response.url == "https://sentry.io/welcome"
+
+    @override_options({"demo-mode.enabled": False})
+    def test_middleware_demo_mode_disabled(self):
+        demo_org = self.create_organization()
+        with override_options({"demo-mode.orgs": [demo_org.id]}):
+            self.request.session["activeorg"] = demo_org.slug
+            response = self.middleware(self.request)
+
+        # SHOULD NOT log out
+        assert not self.request.session.is_empty()
+
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"
+
+    @override_options({"demo-mode.enabled": True})
+    def test_middleware_not_demo_org(self):
+        demo_org = self.create_organization()
+        self.request.session["activeorg"] = demo_org.slug
+        response = self.middleware(self.request)
+
+        # SHOULD NOT log out
+        assert not self.request.session.is_empty()
+
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"
+
+    @override_options({"demo-mode.enabled": True})
+    def test_middleware_subdomain(self):
+        demo_org = self.create_organization()
+        with override_options({"demo-mode.orgs": [demo_org.id]}):
+            self.request.subdomain = "test"
+            self.request.session["activeorg"] = demo_org.slug
+            response = self.middleware(self.request)
+
+        # SHOULD NOT log out
+        assert not self.request.session.is_empty()
+
+        # SHOULD NOT redirect to welcome page
+        assert getattr(response, "url", "") != "https://sentry.io/welcome"


### PR DESCRIPTION
Removing options:
- demo-mode.disable-sandbox-redirect
- demo-mode.sandbox-redirect-logout


Closes https://linear.app/getsentry/issue/TET-737/sandbox-cleanup-redirect-code