### PR TITLE
core: allow numberinput trailing button to shrink

### DIFF
--- a/static/app/components/core/input/numberInput.stories.tsx
+++ b/static/app/components/core/input/numberInput.stories.tsx
@@ -19,7 +19,12 @@ export default Storybook.story('NumberInput', (story, APIReference) => {
           <Storybook.JSXProperty name="max" value="number" /> validation, and comes with
           full accessibility features through React Aria.
         </p>
+        <label>Default size</label>
         <NumberInput />
+        <br />
+        <label>Extra small size</label>
+        <br />
+        <NumberInput size="xs" />
       </Fragment>
     );
   });

--- a/static/app/components/core/input/numberInput.tsx
+++ b/static/app/components/core/input/numberInput.tsx
@@ -11,6 +11,7 @@ import {Button} from 'sentry/components/core/button';
 import type {InputStylesProps} from 'sentry/components/core/input';
 import {InputGroup} from 'sentry/components/core/input/inputGroup';
 import {IconChevron} from 'sentry/icons/iconChevron';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface NumberInputProps
@@ -83,7 +84,7 @@ export function NumberInput({
             size="zero"
             borderless
             {...incrementProps}
-            aria-label={incrementProps['aria-label'] ?? 'Increment'}
+            aria-label={incrementProps['aria-label'] ?? t('Increment')}
             icon={<StyledIconChevron direction="up" />}
           />
           <StepButton
@@ -91,7 +92,7 @@ export function NumberInput({
             size="zero"
             borderless
             {...decrementProps}
-            aria-label={decrementProps['aria-label'] ?? 'Decrement'}
+            aria-label={decrementProps['aria-label'] ?? t('Decrement')}
             icon={<StyledIconChevron direction="down" />}
           />
         </StepWrap>

--- a/static/app/components/core/input/numberInput.tsx
+++ b/static/app/components/core/input/numberInput.tsx
@@ -78,12 +78,22 @@ export function NumberInput({
       />
       <InputGroup.TrailingItems>
         <StepWrap size={size}>
-          <StepButton ref={incrementButtonRef} size="zero" borderless {...incrementProps}>
-            <StyledIconChevron direction="up" />
-          </StepButton>
-          <StepButton ref={decrementButtonRef} size="zero" borderless {...decrementProps}>
-            <StyledIconChevron direction="down" />
-          </StepButton>
+          <StepButton
+            ref={incrementButtonRef}
+            size="zero"
+            borderless
+            {...incrementProps}
+            aria-label={incrementProps['aria-label'] ?? 'Increment'}
+            icon={<StyledIconChevron direction="up" />}
+          />
+          <StepButton
+            ref={decrementButtonRef}
+            size="zero"
+            borderless
+            {...decrementProps}
+            aria-label={decrementProps['aria-label'] ?? 'Decrement'}
+            icon={<StyledIconChevron direction="down" />}
+          />
         </StepWrap>
       </InputGroup.TrailingItems>
     </InputGroup>
@@ -102,6 +112,7 @@ const StepButton = styled(Button)`
   display: flex;
   height: 50%;
   padding: 0 ${space(0.25)};
+  min-height: 0;
   color: ${p => p.theme.subText};
 `;
 


### PR DESCRIPTION
Override button min height and allow it to shrink

![CleanShot 2025-06-30 at 10 56 54@2x](https://github.com/user-attachments/assets/a4856e0c-9b67-4fff-be04-9225bc1f0450)
![CleanShot 2025-06-30 at 10 56 50@2x](https://github.com/user-attachments/assets/54cd32c8-d98d-4d93-9474-be09d152f647)
