### PR TITLE
:wrench: chore: sample sentry app client error slo logs

### DIFF
--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -147,7 +147,8 @@ def send_and_save_webhook_request(
 
         elif 400 <= response.status_code < 500:
             lifecycle.record_halt(
-                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.GOT_CLIENT_ERROR}_{response.status_code}"
+                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.GOT_CLIENT_ERROR}_{response.status_code}",
+                sample_log_rate=0.05,
             )
             raise ClientError(response.status_code, url, response=response)
 


### PR DESCRIPTION
this log makes up a massive chunk of the costs associated to our SLO logging. lets sample it down to 5% so that we can save about 5k

contributes to ECO-692