### PR TITLE
fix(replay): Improve usability of the tooltip for Network Url column

### DIFF
--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -36,7 +36,7 @@ interface Props extends ReturnType<typeof useCrumbHandlers> {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const NetworkTableCell = ({
+export default function NetworkTableCell({
   columnIndex,
   currentHoverTime,
   currentTime,
@@ -50,7 +50,7 @@ const NetworkTableCell = ({
   startTimestampMs,
   style,
   ref,
-}: Props) => {
+}: Props) {
   // Rows include the sortable header, the dataIndex does not
   const dataIndex = rowIndex - 1;
 
@@ -117,9 +117,10 @@ const NetworkTableCell = ({
       <Cell {...columnProps}>
         <Tooltip
           title={frame.description}
+          delay={750}
           isHoverable
+          maxWidth={10_000}
           showOnlyOnOverflow
-          overlayStyle={{maxWidth: '500px !important'}}
         >
           <Text>{frame.description || EMPTY_CELL}</Text>
         </Tooltip>
@@ -162,6 +163,4 @@ const NetworkTableCell = ({
   ];
 
   return renderFns[columnIndex]!();
-};
-
-export default NetworkTableCell;
+}


### PR DESCRIPTION
I couldn't set a percentage, so i picked a really big number of pixels (10,000!) which means the tooltip will fill the screen, but not overflow.
The delay of `750` is kinda arbitrary, but it's much slower than the default of `50` which makes it easier to mouse around the table, and you'll still get the tooltip appear after pausing for a beat.

![SCR-20250630-jova](https://github.com/user-attachments/assets/11fbc1ff-d551-4739-8521-3d11219b5272)


Fixes REPLAY-457