### PR TITLE
gsapp: remove use of linkStyles

### DIFF
--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -1,8 +1,10 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
 import {Hovercard} from 'sentry/components/hovercard';
-import ExternalLink from 'sentry/components/links/externalLink';
+import {IconLightning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -99,18 +101,22 @@ class PowerFeatureHovercard extends Component<Props> {
 
           return (
             <LearnMoreTextBody data-test-id="power-hovercard">
-              <div>
-                {partial
-                  ? t('Better With %s Plan', planName)
-                  : t('Requires %s Plan', planName)}
-              </div>
-              <ExternalLink
-                href=""
-                onClick={this.handleClick}
-                data-test-id="power-learn-more"
-              >
-                {t('Learn More')}
-              </ExternalLink>
+              <Flex direction="column" gap={space(1)}>
+                <div>
+                  {partial
+                    ? t('Better With %s Plan', planName)
+                    : t('Requires %s Plan', planName)}
+                </div>
+                <Button
+                  priority="primary"
+                  onClick={this.handleClick}
+                  data-test-id="power-learn-more"
+                  size="xs"
+                  icon={<IconLightning size="xs" />}
+                >
+                  {t('Learn More')}
+                </Button>
+              </Flex>
             </LearnMoreTextBody>
           );
         }}

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -1,8 +1,8 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
-import {linkStyles} from 'sentry/components/core/link';
 import {Hovercard} from 'sentry/components/hovercard';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -104,9 +104,13 @@ class PowerFeatureHovercard extends Component<Props> {
                   ? t('Better With %s Plan', planName)
                   : t('Requires %s Plan', planName)}
               </div>
-              <LearnMoreLink onClick={this.handleClick} data-test-id="power-learn-more">
+              <ExternalLink
+                href=""
+                onClick={this.handleClick}
+                data-test-id="power-learn-more"
+              >
                 {t('Learn More')}
-              </LearnMoreLink>
+              </ExternalLink>
             </LearnMoreTextBody>
           );
         }}
@@ -127,21 +131,6 @@ class PowerFeatureHovercard extends Component<Props> {
     );
   }
 }
-
-const LearnMoreLink = styled('button')`
-  ${p => linkStyles({theme: p.theme})}
-  background: none;
-  border: none;
-  padding: 0;
-
-  color: ${p => p.theme.subText};
-  text-decoration: underline;
-
-  &:hover {
-    color: ${p => p.theme.subText};
-    text-decoration: none;
-  }
-`;
 
 const LearnMoreTextBody = styled('div')`
   padding: ${space(1)};


### PR DESCRIPTION
Fix the last remaining issue of linkStyle export which is blocking CI on https://github.com/getsentry/sentry/pull/94600

**Before**
![CleanShot 2025-06-30 at 13 40 29@2x](https://github.com/user-attachments/assets/cd8e66eb-e788-4e4e-a6bc-129c711cbedd)
**After**
![CleanShot 2025-06-30 at 13 43 22@2x](https://github.com/user-attachments/assets/e4304d37-f3d0-4c09-b198-57aa76cc5856)
