### PR TITLE
fix(ui): Throw error if response is undefined in api client

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -533,6 +533,11 @@ export class Client {
     fetchRequest
       .then(
         async response => {
+          if (response === undefined) {
+            // For some reason, response is undefined? Throw to the error path.
+            throw new Error('Response is undefined');
+          }
+
           // The Response's body can only be resolved/used at most once.
           // So we clone the response so we can resolve the body content as text content.
           // Response objects need to be cloned before its body can be used.
@@ -649,7 +654,7 @@ export class Client {
         // eslint-disable-next-line no-console
         console.error(error);
 
-        if (error?.name !== 'AbortError') {
+        if (error?.name !== 'AbortError' && error?.message !== 'Response is undefined') {
           Sentry.captureException(error);
         }
       });


### PR DESCRIPTION
Ignore the error if caught. I'm not sure how this happens but its probably some sort of browser extension or browser error. fetch should always return an object Response

fixes JAVASCRIPT-31AQ - `Cannot destructure property 'status' of 'r' as it is undefined.`
