### PR TITLE
chore(detectors): Add google API filtering for Consecutive HTTP detector 

### DIFF
--- a/src/sentry/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/performance_issues/detectors/consecutive_http_detector.py
@@ -160,12 +160,7 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         ):  # Just using all methods to see if anything interesting pops up
             return False
 
-        if any(
-            [
-                x in description
-                for x in ["_next/static/", "_next/data/", "aiplatform.googleapis.com"]
-            ]
-        ):
+        if any([x in description for x in ["_next/static/", "_next/data/", "googleapis.com"]]):
             return False
 
         return True

--- a/src/sentry/performance_issues/detectors/consecutive_http_detector.py
+++ b/src/sentry/performance_issues/detectors/consecutive_http_detector.py
@@ -160,7 +160,12 @@ class ConsecutiveHTTPSpanDetector(PerformanceDetector):
         ):  # Just using all methods to see if anything interesting pops up
             return False
 
-        if any([x in description for x in ["_next/static/", "_next/data/"]]):
+        if any(
+            [
+                x in description
+                for x in ["_next/static/", "_next/data/", "aiplatform.googleapis.com"]
+            ]
+        ):
             return False
 
         return True


### PR DESCRIPTION
this pr updates the eligible span method to look for `googleapis.com` in the description. one example of this would be their ai platform which has `aiplatform.googleapis.com` in the description. 