### PR TITLE
fix(ui): Silence additional AbortErrors

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -153,7 +153,10 @@ export function initializeSdk(config: Config) {
        *
        * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
        */
-      'AbortError: Fetch is aborted',
+      /AbortError: Fetch is aborted/i,
+      /AbortError: The operation was aborted/i,
+      /AbortError: signal is aborted without reason/i,
+      /AbortError: The user aborted a request/i,
       /**
        * React internal error thrown when something outside react modifies the DOM
        * This is usually because of a browser extension or chrome translate page


### PR DESCRIPTION
Prevent more abort errors from being reported. Nobody is actioning on these issues.

Made them regexes because some have additional text like `Error: AbortError: ...`