### PR TITLE
feat(feedback): enable feedback category option for org stats page

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -352,6 +352,21 @@ export const DATA_CATEGORY_INFO = {
       showExternalStats: true,
     },
   },
+  [DataCategoryExact.USER_REPORT_V2]: {
+    name: DataCategoryExact.USER_REPORT_V2,
+    apiName: 'feedback',
+    plural: DataCategory.USER_REPORT_V2,
+    displayName: 'user feedback',
+    titleName: t('User Feedback'),
+    productName: t('User Feedback'),
+    uid: 14,
+    isBilledCategory: false,
+    docsUrl: 'https://docs.sentry.io/product/user-feedback/',
+    statsInfo: {
+      ...DEFAULT_STATS_INFO,
+      showExternalStats: true,
+    },
+  },
   [DataCategoryExact.TRANSACTION_PROCESSED]: {
     name: DataCategoryExact.TRANSACTION_PROCESSED,
     apiName: 'transactions',

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -93,6 +93,7 @@ export enum DataCategory {
   LOG_BYTE = 'logBytes',
   SEER_AUTOFIX = 'seerAutofix',
   SEER_SCANNER = 'seerScanner',
+  USER_REPORT_V2 = 'feedback',
 }
 
 /**
@@ -123,6 +124,7 @@ export enum DataCategoryExact {
   LOG_BYTE = 'logByte',
   SEER_AUTOFIX = 'seerAutofix',
   SEER_SCANNER = 'seerScanner',
+  USER_REPORT_V2 = 'user_report_v2',
 }
 
 export interface DataCategoryInfo {

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -124,7 +124,7 @@ export enum DataCategoryExact {
   LOG_BYTE = 'logByte',
   SEER_AUTOFIX = 'seerAutofix',
   SEER_SCANNER = 'seerScanner',
-  USER_REPORT_V2 = 'user_report_v2',
+  USER_REPORT_V2 = 'feedback',
 }
 
 export interface DataCategoryInfo {


### PR DESCRIPTION
Part of https://linear.app/getsentry/project/user-feedback-abuse-quotas-05cbd47d06cf/overview

Adds the option to see feedback usage in `/settings/stats`. We're already emitting accepted, invalid, and rate limited outcomes. Example from my test project:
![Screenshot 2025-06-30 at 1 32 16 PM](https://github.com/user-attachments/assets/73e97123-6872-4574-b819-068cd9323be1)

The category is named `user_report_v2` in Relay, but api name for the stats endpoint is feedback, product name User Feedback. Seems there's no backend changes needed for the query.