### PR TITLE
fix(anomaly detection): turn processing back on for dynamic rules

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -402,7 +402,6 @@ class SubscriptionProcessor:
         if (
             has_anomaly_detection
             and self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC
-            and not has_metric_alert_processing
         ):
             with metrics.timer(
                 "incidents.subscription_processor.process_update.get_anomaly_data_from_seer_legacy"


### PR DESCRIPTION
Since we had to roll back dual processing for dynamic alerts, re-enable processing through subscription processor.