### PR TITLE
ref(alerts): Pull code out into smaller functions

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -236,7 +236,7 @@ class SubscriptionProcessor:
         return aggregation_value
 
     def get_aggregation_value(
-        self, subscription_update: QuerySubscriptionUpdate, comparison_delta: int | None = None
+        self, subscription_update: QuerySubscriptionUpdate, comparison_delta: int | None
     ) -> float | None:
         if self.subscription.snuba_query.dataset == Dataset.Metrics.value:
             aggregation_value = self.get_crash_rate_alert_metrics_aggregation_value(
@@ -316,34 +316,34 @@ class SubscriptionProcessor:
         aggregation_value: float,
         fired_incident_triggers: list[IncidentTrigger],
         metrics_incremented: bool,
-    ) -> list[IncidentTrigger]:
+    ) -> tuple[list[IncidentTrigger], bool]:
         # OVER/UNDER value trigger
-        trigger_matches_status = self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
         alert_operator, resolve_operator = self.THRESHOLD_TYPE_OPERATORS[
             AlertRuleThresholdType(self.alert_rule.threshold_type)
         ]
+        trigger_matches_status = self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
         if (
             alert_operator(aggregation_value, trigger.alert_threshold)
             and not trigger_matches_status
         ):
             # If the value has breached our threshold (above/below)
             # And the trigger is not yet active
+            metrics.incr(
+                "incidents.alert_rules.threshold.alert",
+                tags={"detection_type": self.alert_rule.detection_type},
+            )
+            if (
+                features.has(
+                    "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                    self.subscription.project.organization,
+                )
+                and not metrics_incremented
+            ):
+                metrics.incr("dual_processing.alert_rules.fire")
+                metrics_incremented = True
             # triggering a threshold will create an incident and set the status to active
             incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
             if incident_trigger is not None:
-                metrics.incr(
-                    "incidents.alert_rules.threshold.alert",
-                    tags={"detection_type": self.alert_rule.detection_type},
-                )
-                if (
-                    features.has(
-                        "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                        self.subscription.project.organization,
-                    )
-                    and not metrics_incremented
-                ):
-                    metrics.incr("dual_processing.alert_rules.fire")
-                    metrics_incremented = True
                 fired_incident_triggers.append(incident_trigger)
         else:
             self.trigger_alert_counts[trigger.id] = 0
@@ -353,24 +353,25 @@ class SubscriptionProcessor:
             and self.active_incident
             and trigger_matches_status
         ):
+            metrics.incr(
+                "incidents.alert_rules.threshold.resolve",
+                tags={"detection_type": self.alert_rule.detection_type},
+            )
+            if features.has(
+                "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                self.subscription.project.organization,
+            ):
+                metrics.incr("dual_processing.alert_rules.resolve")
             incident_trigger = self.trigger_resolve_threshold(trigger, aggregation_value)
+
             if incident_trigger is not None:
-                metrics.incr(
-                    "incidents.alert_rules.threshold.resolve",
-                    tags={"detection_type": self.alert_rule.detection_type},
-                )
-                if features.has(
-                    "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                    self.subscription.project.organization,
-                ):
-                    metrics.incr("dual_processing.alert_rules.resolve")
                 fired_incident_triggers.append(incident_trigger)
         else:
             self.trigger_resolve_counts[trigger.id] = 0
 
-        return fired_incident_triggers
+        return fired_incident_triggers, metrics_incremented
 
-    def get_comparison_delta(self, detector: Detector | None) -> float:
+    def get_comparison_delta(self, detector: Detector | None) -> int | None:
         comparison_delta = None
 
         if detector:
@@ -397,31 +398,30 @@ class SubscriptionProcessor:
     def process_results_workflow_engine(
         self, subscription_update: QuerySubscriptionUpdate, aggregation_value: float
     ) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]]:
-        if not self.alert_rule.detection_type == AlertRuleDetectionType.DYNAMIC:
-            packet = QuerySubscriptionUpdate(
-                entity=subscription_update.get("entity", ""),
-                subscription_id=subscription_update["subscription_id"],
-                values={"value": aggregation_value},
-                timestamp=self.last_update,
+        packet = QuerySubscriptionUpdate(
+            entity=subscription_update.get("entity", ""),
+            subscription_id=subscription_update["subscription_id"],
+            values={"value": aggregation_value},
+            timestamp=self.last_update,
+        )
+        data_packet = DataPacket[QuerySubscriptionUpdate](
+            source_id=str(self.subscription.id), packet=packet
+        )
+        results = process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+        if features.has(
+            "organizations:workflow-engine-metric-alert-dual-processing-logs",
+            self.alert_rule.organization,
+        ):
+            logger.info(
+                "dual processing results for alert rule",
+                extra={
+                    "results": results,
+                    "num_results": len(results),
+                    "value": aggregation_value,
+                    "rule_id": self.alert_rule.id,
+                },
             )
-            data_packet = DataPacket[QuerySubscriptionUpdate](
-                source_id=str(self.subscription.id), packet=packet
-            )
-            results = process_data_packets([data_packet], DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
-            if features.has(
-                "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                self.alert_rule.organization,
-            ):
-                logger.info(
-                    "dual processing results for alert rule",
-                    extra={
-                        "results": results,
-                        "num_results": len(results),
-                        "value": aggregation_value,
-                        "rule_id": self.alert_rule.id,
-                    },
-                )
-            return results
+        return results
 
     def process_update(self, subscription_update: QuerySubscriptionUpdate) -> None:
         """
@@ -543,7 +543,7 @@ class SubscriptionProcessor:
                             is_anomalous, trigger, aggregation_value, fired_incident_triggers
                         )
                 else:
-                    fired_incident_triggers = self.handle_trigger_alerts(
+                    fired_incident_triggers, metrics_incremented = self.handle_trigger_alerts(
                         trigger, aggregation_value, fired_incident_triggers, metrics_incremented
                     )
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -264,11 +264,11 @@ class SubscriptionProcessor:
         trigger_matches_status = self.check_trigger_matches_status(trigger, TriggerStatus.ACTIVE)
 
         if has_anomaly and not trigger_matches_status:
-            incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
             metrics.incr(
                 "incidents.alert_rules.threshold.alert",
                 tags={"detection_type": self.alert_rule.detection_type},
             )
+            incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
             if features.has(
                 "organizations:workflow-engine-metric-alert-dual-processing-logs",
                 self.subscription.project.organization,

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -265,44 +265,44 @@ class SubscriptionProcessor:
 
         if has_anomaly and not trigger_matches_status:
             incident_trigger = self.trigger_alert_threshold(trigger, aggregation_value)
-            if incident_trigger is not None:
-                metrics.incr(
-                    "incidents.alert_rules.threshold.alert",
-                    tags={"detection_type": self.alert_rule.detection_type},
+            metrics.incr(
+                "incidents.alert_rules.threshold.alert",
+                tags={"detection_type": self.alert_rule.detection_type},
+            )
+            if features.has(
+                "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                self.subscription.project.organization,
+            ):
+                logger.info(
+                    "Firing dynamic rule",
+                    extra={
+                        "rule_id": self.alert_rule.id,
+                        "aggregation_value": aggregation_value,
+                    },
                 )
-                if features.has(
-                    "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                    self.subscription.project.organization,
-                ):
-                    logger.info(
-                        "Firing dynamic rule",
-                        extra={
-                            "rule_id": self.alert_rule.id,
-                            "aggregation_value": aggregation_value,
-                        },
-                    )
+            if incident_trigger is not None:
                 fired_incident_triggers.append(incident_trigger)
         else:
             self.trigger_alert_counts[trigger.id] = 0
 
         if not has_anomaly and self.active_incident and trigger_matches_status:
             incident_trigger = self.trigger_resolve_threshold(trigger, aggregation_value)
-            if incident_trigger is not None:
-                metrics.incr(
-                    "incidents.alert_rules.threshold.resolve",
-                    tags={"detection_type": self.alert_rule.detection_type},
+            metrics.incr(
+                "incidents.alert_rules.threshold.resolve",
+                tags={"detection_type": self.alert_rule.detection_type},
+            )
+            if features.has(
+                "organizations:workflow-engine-metric-alert-dual-processing-logs",
+                self.subscription.project.organization,
+            ):
+                logger.info(
+                    "Resolving dynamic rule",
+                    extra={
+                        "rule_id": self.alert_rule.id,
+                        "aggregation_value": aggregation_value,
+                    },
                 )
-                if features.has(
-                    "organizations:workflow-engine-metric-alert-dual-processing-logs",
-                    self.subscription.project.organization,
-                ):
-                    logger.info(
-                        "Resolving dynamic rule",
-                        extra={
-                            "rule_id": self.alert_rule.id,
-                            "aggregation_value": aggregation_value,
-                        },
-                    )
+            if incident_trigger is not None:
                 fired_incident_triggers.append(incident_trigger)
 
         else:


### PR DESCRIPTION
We're using a lot of flags and processing regular metric alerts, dynamic metric alerts, and workflow engine - the code in `process_update` was getting difficult to read. This PR pulls out some code into their own functions to make it more readable.