### PR TITLE
chore(launchpad): change size analysis upload logic to create/update size metrics table

### DIFF
--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -205,6 +205,10 @@ def assemble_preprod_artifact_size_analysis(
                     },
                 )
 
+                # Mark the artifact as processed
+                preprod_artifact.state = PreprodArtifact.ArtifactState.PROCESSED
+                preprod_artifact.save(update_fields=["state", "date_updated"])
+
                 logger.info(
                     "Created or updated preprod artifact size metrics with analysis file",
                     extra={

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -195,8 +195,8 @@ def assemble_preprod_artifact_size_analysis(
                     id=artifact_id,
                 )
 
-                # Get or create PreprodArtifactSizeMetrics record
-                size_metrics, created = PreprodArtifactSizeMetrics.objects.get_or_create(
+                # Upsert PreprodArtifactSizeMetrics record
+                size_metrics, created = PreprodArtifactSizeMetrics.objects.update_or_create(
                     preprod_artifact=preprod_artifact,
                     defaults={
                         "analysis_file_id": assemble_result.bundle.id,
@@ -204,12 +204,6 @@ def assemble_preprod_artifact_size_analysis(
                         "state": PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                     },
                 )
-
-                if not created:
-                    # Update existing record
-                    size_metrics.analysis_file_id = assemble_result.bundle.id
-                    size_metrics.state = PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
-                    size_metrics.save(update_fields=["analysis_file_id", "state", "date_updated"])
 
                 logger.info(
                     "Created or updated preprod artifact size metrics with analysis file",


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
