### PR TITLE
fix(taskworker): Check registry before creating task namespace in tests

### DIFF
--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -13,7 +13,10 @@ registry = TaskRegistry()
 class TestTaskworkerRollout(TestCase):
     def setUp(self):
         super().setUp()
-        self.namespace = registry.create_namespace(name="test_namespace")
+        if not registry.contains("test_namespace"):
+            self.namespace = registry.create_namespace(name="test_namespace")
+        else:
+            self.namespace = registry.get("test_namespace")
         self.config = TaskworkerConfig(
             namespace=self.namespace,
             retry=None,


### PR DESCRIPTION
This test is currently broken. This PR is responsible for fixing the set up for `TestTaskworkerRollout` by ensuring to not re-create the task namespace if it already exists.