### PR TITLE
ref(aci): fix updateCondition reducer actions

### DIFF
--- a/static/app/views/automations/components/actionFilters/ageComparison.tsx
+++ b/static/app/views/automations/components/actionFilters/ageComparison.tsx
@@ -50,9 +50,7 @@ function ComparisonField() {
       value={condition.comparison.comparison_type}
       options={AGE_COMPARISON_CHOICES}
       onChange={(option: SelectValue<AgeComparison>) => {
-        onUpdate({
-          comparison_type: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, comparison_type: option.value}});
       }}
     />
   );
@@ -67,9 +65,7 @@ function ValueField() {
       min={0}
       step={1}
       onChange={(value: number) => {
-        onUpdate({
-          value,
-        });
+        onUpdate({comparison: {...condition.comparison, value}});
       }}
       placeholder={'10'}
     />
@@ -84,9 +80,7 @@ function TimeField() {
       value={condition.comparison.time}
       options={TIME_CHOICES}
       onChange={(option: SelectValue<TimeUnit>) => {
-        onUpdate({
-          time: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, time: option.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -59,7 +59,13 @@ function TargetTypeField() {
       value={condition.comparison.targetType}
       options={TARGET_TYPE_CHOICES}
       onChange={(option: SelectValue<string>) =>
-        onUpdate({targetType: option.value, targetIdentifier: ''})
+        onUpdate({
+          comparison: {
+            ...condition.comparison,
+            targetType: option.value,
+            targetIdentifier: '',
+          },
+        })
       }
     />
   );
@@ -75,7 +81,9 @@ function IdentifierField() {
         <TeamSelector
           name={`${condition_id}.data.targetIdentifier`}
           value={condition.comparison.targetIdentifier}
-          onChange={(value: SelectValue<string>) => onUpdate({targetIdentifier: value})}
+          onChange={(value: SelectValue<string>) =>
+            onUpdate({comparison: {...condition.comparison, targetIdentifier: value}})
+          }
           useId
           styles={selectControlStyles}
         />
@@ -90,7 +98,11 @@ function IdentifierField() {
           organization={organization}
           key={`${condition_id}.data.targetIdentifier`}
           value={condition.comparison.targetIdentifier}
-          onChange={(value: any) => onUpdate({targetIdentifier: value.actor.id})}
+          onChange={(value: any) =>
+            onUpdate({
+              comparison: {...condition.comparison, targetIdentifier: value.actor.id},
+            })
+          }
           styles={selectControlStyles}
         />
       </SelectWrapper>

--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -32,9 +32,7 @@ function ValueField() {
       min={1}
       step={1}
       onChange={(value: number) => {
-        onUpdate({
-          value,
-        });
+        onUpdate({comparison: {...condition.comparison, value}});
       }}
       placeholder="100"
     />
@@ -49,9 +47,7 @@ function IntervalField() {
       value={condition.comparison.interval}
       options={INTERVAL_CHOICES}
       onChange={(option: SelectValue<string>) => {
-        onUpdate({
-          interval: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, interval: option.value}});
       }}
     />
   );
@@ -66,7 +62,7 @@ function ComparisonIntervalField() {
       options={COMPARISON_INTERVAL_CHOICES}
       onChange={(option: SelectValue<string>) => {
         onUpdate({
-          comparison_interval: option.value,
+          comparison: {...condition.comparison, comparison_interval: option.value},
         });
       }}
     />

--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -39,9 +39,7 @@ function AttributeField() {
         label: attribute,
       }))}
       onChange={(value: Attributes) => {
-        onUpdate({
-          attribute: value,
-        });
+        onUpdate({comparison: {...condition.comparison, attribute: value}});
       }}
     />
   );
@@ -55,9 +53,7 @@ function MatchField() {
       value={condition.comparison.match}
       options={MATCH_CHOICES}
       onChange={(value: MatchType) => {
-        onUpdate({
-          match: value,
-        });
+        onUpdate({comparison: {...condition.comparison, match: value}});
       }}
     />
   );
@@ -71,9 +67,7 @@ function ValueField() {
       placeholder={t('value')}
       value={condition.comparison.value}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        onUpdate({
-          value: e.target.value,
-        });
+        onUpdate({comparison: {...condition.comparison, value: e.target.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/eventFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventFrequency.tsx
@@ -81,7 +81,7 @@ export function EventFrequencyNode() {
 }
 
 function ComparisonTypeField() {
-  const {condition, condition_id, onUpdateType} = useDataConditionNodeContext();
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
 
   if (condition.type === DataConditionType.EVENT_FREQUENCY_COUNT) {
     return <CountBranch />;
@@ -105,7 +105,7 @@ function ComparisonTypeField() {
         },
       ]}
       onChange={(option: SelectValue<DataConditionType>) => {
-        onUpdateType(option.value);
+        onUpdate({type: option.value});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
+++ b/static/app/views/automations/components/actionFilters/eventUniqueUserFrequency.tsx
@@ -93,7 +93,7 @@ export function EventUniqueUserFrequencyNode() {
 }
 
 function ComparisonTypeField() {
-  const {condition, condition_id, onUpdateType} = useDataConditionNodeContext();
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
 
   if (condition.type === DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT) {
     return <CountBranch />;
@@ -117,7 +117,7 @@ function ComparisonTypeField() {
         },
       ]}
       onChange={(option: SelectValue<DataConditionType>) => {
-        onUpdateType(option.value);
+        onUpdate({type: option.value});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/issueOccurrences.tsx
+++ b/static/app/views/automations/components/actionFilters/issueOccurrences.tsx
@@ -24,9 +24,7 @@ function ValueField() {
       min={1}
       step={1}
       onChange={(value: number) => {
-        onUpdate({
-          value,
-        });
+        onUpdate({comparison: {...condition.comparison, value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/issuePriority.tsx
+++ b/static/app/views/automations/components/actionFilters/issuePriority.tsx
@@ -11,8 +11,8 @@ import {useDataConditionNodeContext} from 'sentry/views/automations/components/d
 export function IssuePriorityDetails({condition}: {condition: DataCondition}) {
   return tct('Current issue priority is [level]', {
     level:
-      PRIORITY_CHOICES.find(choice => choice.value === condition.comparison.level)
-        ?.label || condition.comparison.level,
+      PRIORITY_CHOICES.find(choice => choice.value === condition.comparison)?.label ||
+      condition.comparison,
   });
 }
 
@@ -22,12 +22,10 @@ export function IssuePriorityNode() {
     level: (
       <AutomationBuilderSelect
         name={`${condition_id}.comparison`}
-        value={condition.comparison.match}
+        value={condition.comparison}
         options={PRIORITY_CHOICES}
         onChange={(option: SelectValue<Priority>) => {
-          onUpdate({
-            match: option.value,
-          });
+          onUpdate({comparison: option.value});
         }}
       />
     ),

--- a/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
+++ b/static/app/views/automations/components/actionFilters/latestAdoptedRelease.tsx
@@ -49,9 +49,7 @@ function ReleaseAgeTypeField() {
       value={condition.comparison.release_age_type}
       options={MODEL_AGE_CHOICES}
       onChange={(option: SelectValue<ModelAge>) => {
-        onUpdate({
-          match: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, release_age_type: option.value}});
       }}
     />
   );
@@ -65,9 +63,7 @@ function AgeComparisonField() {
       value={condition.comparison.age_comparison}
       options={AGE_COMPARISON_CHOICES}
       onChange={(option: SelectValue<AgeComparison>) => {
-        onUpdate({
-          match: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, age_comparison: option.value}});
       }}
     />
   );
@@ -89,9 +85,7 @@ function EnvironmentField() {
       options={environmentOptions}
       placeholder={t('environment')}
       onChange={(option: SelectValue<string>) => {
-        onUpdate({
-          environment: option,
-        });
+        onUpdate({comparison: {...condition.comparison, environment: option.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/level.tsx
+++ b/static/app/views/automations/components/actionFilters/level.tsx
@@ -36,9 +36,7 @@ function MatchField() {
       value={condition.comparison.match}
       options={LEVEL_MATCH_CHOICES}
       onChange={(option: SelectValue<MatchType>) => {
-        onUpdate({
-          match: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, match: option.value}});
       }}
     />
   );
@@ -52,9 +50,7 @@ function LevelField() {
       value={condition.comparison.level}
       options={LEVEL_CHOICES}
       onChange={(option: SelectValue<Level>) => {
-        onUpdate({
-          level: option.value,
-        });
+        onUpdate({comparison: {...condition.comparison, level: option.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -84,7 +84,7 @@ export function PercentSessionsNode() {
 }
 
 function ComparisonTypeField() {
-  const {condition, condition_id, onUpdateType} = useDataConditionNodeContext();
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
 
   if (condition.type === DataConditionType.PERCENT_SESSIONS_COUNT) {
     return <CountBranch />;
@@ -108,7 +108,7 @@ function ComparisonTypeField() {
         },
       ]}
       onChange={(option: SelectValue<DataConditionType>) => {
-        onUpdateType(option.value);
+        onUpdate({type: option.value});
       }}
     />
   );

--- a/static/app/views/automations/components/actionFilters/subfiltersList.tsx
+++ b/static/app/views/automations/components/actionFilters/subfiltersList.tsx
@@ -48,14 +48,14 @@ export function SubfiltersList() {
         match: MatchType.EQUAL,
       },
     ];
-    onUpdate({filters: newSubfilters});
+    onUpdate({comparison: {...condition.comparison, filters: newSubfilters}});
   }
 
   function removeSubfilter(id: string) {
     const newSubfilters = subfilters.filter(
       (subfilter: Record<string, any>) => subfilter.id !== id
     );
-    onUpdate({filters: newSubfilters});
+    onUpdate({comparison: {...condition.comparison, filters: newSubfilters}});
   }
 
   function updateSubfilter(id: string, comparison: Record<string, any>) {
@@ -68,7 +68,7 @@ export function SubfiltersList() {
       }
       return subfilter;
     });
-    onUpdate({filters: newSubfilters});
+    onUpdate({comparison: {...condition.comparison, filters: newSubfilters}});
   }
 
   return (

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -35,9 +35,7 @@ function KeyField() {
       placeholder={t('tag')}
       value={condition.comparison.key}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        onUpdate({
-          key: e.target.value,
-        });
+        onUpdate({comparison: {...condition.comparison, key: e.target.value}});
       }}
     />
   );
@@ -51,9 +49,7 @@ function MatchField() {
       value={condition.comparison.match}
       options={MATCH_CHOICES}
       onChange={(value: SelectValue<MatchType>) => {
-        onUpdate({
-          match: value,
-        });
+        onUpdate({comparison: {...condition.comparison, match: value}});
       }}
     />
   );
@@ -67,9 +63,7 @@ function ValueField() {
       placeholder={t('value')}
       value={condition.comparison.value}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        onUpdate({
-          value: e.target.value,
-        });
+        onUpdate({comparison: {...condition.comparison, value: e.target.value}});
       }}
     />
   );

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -169,11 +169,8 @@ function ActionFilterBlock({
             conditions={actionFilter?.conditions || []}
             onAddRow={type => actions.addIfCondition(actionFilter.id, type)}
             onDeleteRow={id => actions.removeIfCondition(actionFilter.id, id)}
-            updateCondition={(id, comparison) =>
-              actions.updateIfCondition(actionFilter.id, id, comparison)
-            }
-            updateConditionType={(id, type) =>
-              actions.updateIfConditionType(actionFilter.id, id, type)
+            updateCondition={(id, params) =>
+              actions.updateIfCondition(actionFilter.id, id, params)
             }
             conflictingConditionIds={conflictingConditions}
           />

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -27,8 +27,7 @@ interface DataConditionNodeListProps {
   onAddRow: (type: DataConditionType) => void;
   onDeleteRow: (id: string) => void;
   placeholder: string;
-  updateCondition: (id: string, condition: Record<string, any>) => void;
-  updateConditionType?: (id: string, type: DataConditionType) => void;
+  updateCondition: (id: string, params: {comparison?: any; type?: any}) => void;
 }
 
 interface Option {
@@ -44,7 +43,6 @@ export default function DataConditionNodeList({
   onAddRow,
   onDeleteRow,
   updateCondition,
-  updateConditionType,
   conflictingConditionIds,
 }: DataConditionNodeListProps) {
   const {data: dataConditionHandlers = []} = useDataConditionsQuery(handlerGroup);
@@ -121,9 +119,7 @@ export default function DataConditionNodeList({
             value={{
               condition,
               condition_id: `${group}.conditions.${condition.id}`,
-              onUpdate: newCondition => updateCondition(condition.id, newCondition),
-              onUpdateType: type =>
-                updateConditionType && updateConditionType(condition.id, type),
+              onUpdate: params => updateCondition(condition.id, params),
             }}
           >
             <Node />

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -69,8 +69,7 @@ import {
 interface DataConditionNodeProps {
   condition: DataCondition;
   condition_id: string;
-  onUpdate: (comparison: Record<string, any>) => void;
-  onUpdateType: (type: DataConditionType) => void;
+  onUpdate: (params: {comparison?: any; type?: DataConditionType}) => void;
 }
 
 export const DataConditionNodeContext = createContext<DataConditionNodeProps | null>(
@@ -90,7 +89,7 @@ export function useDataConditionNodeContext(): DataConditionNodeProps {
 type DataConditionNode = {
   label: string;
   dataCondition?: React.ComponentType<any>;
-  defaultComparison?: Record<string, any>;
+  defaultComparison?: any;
   details?: React.ComponentType<any>;
 };
 
@@ -155,12 +154,12 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
     },
   ],
   [
-    DataConditionType.ISSUE_PRIORITY_EQUALS,
+    DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
     {
       label: t('Issue priority'),
       dataCondition: IssuePriorityNode,
       details: IssuePriorityDetails,
-      defaultComparison: {match: Priority.HIGH},
+      defaultComparison: Priority.HIGH,
     },
   ],
   [


### PR DESCRIPTION
fixing the `updateWhenCondition` and `updateIfCondition` reducer actions to take a `params` object that can be used to update either the condition `type` or `comparison`, instead of having separate actions for updating the 2

since `comparison` doesn't have to be an object, i also fixed the update actions to replace `comparison` with the provided value instead of spreading and inserting only the new field