### PR TITLE
ref(feedback): do not validate userreport email

### DIFF
--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -5,8 +5,7 @@ import random
 import uuid
 from datetime import datetime, timedelta
 
-from django.core.exceptions import PermissionDenied, ValidationError
-from django.core.validators import validate_email
+from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, router
 from django.utils import timezone
 
@@ -200,13 +199,11 @@ def validate_user_report(
     source: FeedbackCreationSource = FeedbackCreationSource.USER_REPORT_ENVELOPE,
 ) -> tuple[bool, str | None, str | None]:
     """
-    Validates required fields, field lengths, and garbage messages. Also checks email format and that event_id is a UUID.
+    Validates required fields, field lengths, and garbage messages. Also checks that event_id is a valid UUID. Does not raise errors.
 
     Reformatting: strips whitespace from comments and dashes from event_id.
 
     Returns a tuple of (should_filter, metrics_reason, display_reason). XXX: ensure metrics and outcome reasons have bounded cardinality.
-
-    At the moment we do not raise validation errors.
     """
     if "comments" not in report:
         return True, "missing_comments", "Missing comments"  # type: ignore[unreachable]
@@ -258,12 +255,6 @@ def validate_user_report(
     max_email_length = UserReport._meta.get_field("email").max_length
     if max_email_length and len(email) > max_email_length:
         return True, "too_large.email", "Email Too Large"
-
-    try:
-        if email:
-            validate_email(email)
-    except ValidationError:
-        return True, "invalid_email", "Invalid Email"
 
     try:
         # Validates UUID and strips dashes.

--- a/tests/sentry/ingest/test_userreport.py
+++ b/tests/sentry/ingest/test_userreport.py
@@ -136,22 +136,6 @@ def test_validator_should_not_filter_empty_message_without_option(set_sentry_opt
 
 
 @django_db_all
-def test_validator_should_filter_invalid_email():
-    should_filter, tag, reason = validate_user_report(
-        {
-            "name": "",
-            "email": "invalid-email",
-            "comments": "hello",
-            "event_id": "a49558bf9bd94e2da4c9c3dc1b5b95f7",
-        },
-        1,
-    )
-    assert should_filter is True
-    assert tag is not None
-    assert reason is not None
-
-
-@django_db_all
 def test_validator_should_not_filter_empty_email():
     should_filter, tag, reason = validate_user_report(
         {


### PR DESCRIPTION
Feedback v2, Relay, and issues does not validate the email format. We're deciding to leave validation up to SDK devs, it's not worth dropping the whole feedback