### PR TITLE
feat: Initial regenerate modal sans confirmation modal

### DIFF
--- a/static/app/views/codecov/tokens/repoTokenTable/tableBody.tsx
+++ b/static/app/views/codecov/tokens/repoTokenTable/tableBody.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 
+import Confirm from 'sentry/components/confirm';
 import {Button} from 'sentry/components/core/button';
+import {t, tct} from 'sentry/locale';
 import {
   type Column,
   type Row,
@@ -18,14 +20,24 @@ export function renderTableBody({column, row}: TableBodyProps) {
   if (key === 'regenerateToken') {
     return (
       <AlignmentContainer alignment={alignment}>
-        <StyledButton
-          size="sm"
-          priority="default"
-          onClick={() => {}}
-          aria-label="regenerate token"
+        <Confirm
+          onConfirm={() => {}}
+          header={<h5>{t('Generate new token')}</h5>}
+          cancelText={t('Return')}
+          confirmText={t('Generate new token')}
+          isDangerous
+          message={tct(
+            `Are you sure you want to generate a new token for [repoName]? [break][break] If you create a new token, make sure to update the repository secret in GitHub. [break] [break]`,
+            {
+              repoName: <strong>{row.name}</strong>,
+              break: <br />,
+            }
+          )}
         >
-          Regenerate token
-        </StyledButton>
+          <StyledButton priority="default" size="sm" aria-label="regenerate token">
+            {t('Regenerate token')}
+          </StyledButton>
+        </Confirm>
       </AlignmentContainer>
     );
   }

--- a/static/app/views/codecov/tokens/tokens.spec.tsx
+++ b/static/app/views/codecov/tokens/tokens.spec.tsx
@@ -1,4 +1,10 @@
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import CodecovQueryParamsProvider from 'sentry/components/codecov/container/codecovParamsProvider';
 import TokensPage from 'sentry/views/codecov/tokens/tokens';
@@ -78,6 +84,65 @@ describe('TokensPage', () => {
       await waitFor(() => {
         expect(screen.getByRole('table')).toBeInTheDocument();
       });
+    });
+
+    it('renders repository tokens and related data', async () => {
+      render(
+        <CodecovQueryParamsProvider>
+          <TokensPage />
+        </CodecovQueryParamsProvider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/codecov/tokens/',
+              query: {
+                integratedOrg: 'some-org-name',
+              },
+            },
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('table')).toBeInTheDocument();
+      });
+      expect(screen.getByText('test2')).toBeInTheDocument();
+      expect(screen.getByText('test2Token')).toBeInTheDocument();
+      expect(screen.getByText('Mar 19, 2024 6:33:30 PM CET')).toBeInTheDocument();
+      expect(await screen.findAllByText('Regenerate token')).toHaveLength(2);
+    });
+
+    it('renders a confirm modal when the regenerate token button is clicked', async () => {
+      render(
+        <CodecovQueryParamsProvider>
+          <TokensPage />
+        </CodecovQueryParamsProvider>,
+        {
+          initialRouterConfig: {
+            location: {
+              pathname: '/codecov/tokens/',
+              query: {
+                integratedOrg: 'some-org-name',
+              },
+            },
+          },
+        }
+      );
+      renderGlobalModal();
+
+      await waitFor(() => {
+        expect(screen.getByRole('table')).toBeInTheDocument();
+      });
+
+      const regenerateTokenButtons = await screen.findAllByText('Regenerate token');
+      expect(regenerateTokenButtons).toHaveLength(2);
+      await userEvent.click(regenerateTokenButtons[0]!);
+
+      expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Generate new token'}));
+
+      // TODO: Add the action stuff when this is linked up
     });
   });
 });

--- a/static/app/views/codecov/tokens/tokens.tsx
+++ b/static/app/views/codecov/tokens/tokens.tsx
@@ -26,12 +26,12 @@ export default function TokensPage() {
     data: [
       {
         name: 'test',
-        token: 'test',
+        token: 'testToken',
         createdAt: 'Mar 20, 2024 6:33:30 PM CET',
       },
       {
         name: 'test2',
-        token: 'test2',
+        token: 'test2Token',
         createdAt: 'Mar 19, 2024 6:33:30 PM CET',
       },
     ],


### PR DESCRIPTION
This PR aims to create the initial popup modal using the Sentry "confirm" component that shows up when you click "regenerate token" on one of the table rows.

**Note:** This isn't currently hooked up to anything, we still gotta figure out the permissioning stuff before exposing the API for token regeneration since we don't want anyone to be able to regenerate a token for a random Repo or something.

This will be followed up with a separate PR for creating the "confirmed" regenerated token with the clipboard stuff.

[Figma](https://www.figma.com/design/mSyCX0wCk7e2yItQfiMhaa/GH-1247_MergePlan?node-id=973-18362&t=etjeteiDSrSlwyZV-0)

Closes https://linear.app/getsentry/issue/CCMRG-161/token-gen-page-create-generate-token-modal



https://github.com/user-attachments/assets/4b49c498-c3b1-404e-abd3-14014478a151





<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
