### PR TITLE
chore(ui): Fix tsgo frame type errors

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -94,9 +94,9 @@ export function TransactionProfilesContent(props: TransactionProfilesContentProp
       return () => true;
     }
     if (frameFilter === 'application') {
-      return frame => frame.is_application;
+      return (frame: Frame) => frame.is_application;
     }
-    return frame => !frame.is_application;
+    return (frame: Frame) => !frame.is_application;
   }, [frameFilter]);
 
   const [visualization, setVisualization] = useLocalStorageState<

--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -228,9 +228,9 @@ export function LandingAggregateFlamegraph({
       return () => true;
     }
     if (frameFilter === 'application') {
-      return frame => frame.is_application;
+      return (frame: Frame) => frame.is_application;
     }
-    return frame => !frame.is_application;
+    return (frame: Frame) => !frame.is_application;
   }, [frameFilter]);
 
   const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);


### PR DESCRIPTION
Just adds types where tsgo couldn't yet figure out the types to silence the error.

if you want to run tsgo - try `npx @typescript/native-preview`