### PR TITLE
chore(launchpad): allow artifact downloads even if not processed

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_download.py
@@ -58,14 +58,6 @@ class ProjectPreprodArtifactDownloadEndpoint(ProjectEndpoint):
         if preprod_artifact.file_id is None:
             return Response({"error": "Preprod artifact file not available"}, status=404)
 
-        if preprod_artifact.state != PreprodArtifact.ArtifactState.PROCESSED:
-            return Response(
-                {
-                    "error": f"Preprod artifact is not ready for download (state: {preprod_artifact.get_state_display()})"
-                },
-                status=400,
-            )
-
         try:
             file_obj = File.objects.get(id=preprod_artifact.file_id)
         except File.DoesNotExist:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
@@ -52,24 +52,6 @@ class ProjectPreprodArtifactDownloadEndpointTest(TestCase):
         assert "not found" in response.json()["error"]
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
-    def test_download_preprod_artifact_not_processed(self):
-        # Create an artifact that's not processed yet
-        unprocessed_artifact = PreprodArtifact.objects.create(
-            project=self.project,
-            file_id=self.file.id,
-            state=PreprodArtifact.ArtifactState.UPLOADING,
-        )
-
-        url = f"/api/0/internal/{self.organization.slug}/{self.project.slug}/files/preprodartifacts/{unprocessed_artifact.id}/"
-
-        headers = self._get_authenticated_request_headers(url)
-
-        response = self.client.get(url, **headers)
-
-        assert response.status_code == 400
-        assert "not ready for download" in response.json()["error"]
-
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_download_preprod_artifact_no_file(self):
         # Create an artifact without a file
         no_file_artifact = PreprodArtifact.objects.create(


### PR DESCRIPTION
This endpoint will be used by launchpad to download the builds, so of course the build wont be processed when that call is made