### PR TITLE
fix(organizations): Improve autocomplete on org creation

### DIFF
--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -111,6 +111,7 @@ function OrganizationCreate() {
             id="organization-name"
             name="name"
             label={t('Organization Name')}
+            autoComplete="organization"
             placeholder={t('e.g. My Company')}
             inline={false}
             flexibleControlStateSize


### PR DESCRIPTION
This specifically ensures that when browser/1Password/etc autocomplete is used this field will be populated with the user's company name rather than their own name.

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-organization

Manually verified the before/after in 1Password.