### PR TITLE
feat(aci): handle special case for issue priority deescalating data condition

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -30,6 +30,7 @@ export enum DataConditionType {
   TAGGED_EVENT = 'tagged_event',
   ISSUE_PRIORITY_EQUALS = 'issue_priority_equals',
   ISSUE_PRIORITY_GREATER_OR_EQUAL = 'issue_priority_greater_or_equal',
+  ISSUE_PRIORITY_DEESCALATING = 'issue_priority_deescalating',
 
   // frequency
   EVENT_FREQUENCY_COUNT = 'event_frequency_count',

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -2,6 +2,7 @@ import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
+import {Checkbox} from 'sentry/components/core/checkbox';
 import {Select} from 'sentry/components/core/select';
 import {t} from 'sentry/locale';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
@@ -66,8 +67,11 @@ export default function DataConditionNodeList({
     ];
 
     dataConditionHandlers.forEach(handler => {
-      if (percentageTypes.includes(handler.type)) {
-        return; // Skip percentage types so that frequency conditions are not duplicated
+      if (
+        percentageTypes.includes(handler.type) || // Skip percentage types so that frequency conditions are not duplicated
+        handler.type === DataConditionType.ISSUE_PRIORITY_DEESCALATING // Skip issue priority deescalating condition since it is handled separately
+      ) {
+        return;
       }
 
       const conditionType = frequencyTypeMapping[handler.type] || handler.type;
@@ -107,25 +111,68 @@ export default function DataConditionNodeList({
     ];
   }, [dataConditionHandlers, handlerGroup]);
 
+  const issuePriorityDeescalatingConditionId: string | undefined = useMemo(() => {
+    return conditions.find(
+      condition => condition.type === DataConditionType.ISSUE_PRIORITY_DEESCALATING
+    )?.id;
+  }, [conditions]);
+
+  const onIssuePriorityDeescalatingChange = () => {
+    if (issuePriorityDeescalatingConditionId) {
+      onDeleteRow(issuePriorityDeescalatingConditionId);
+    } else {
+      onAddRow(DataConditionType.ISSUE_PRIORITY_DEESCALATING);
+    }
+  };
+
+  const onDeleteRowHandler = (condition: DataCondition) => {
+    onDeleteRow(condition.id);
+
+    // Count remaining ISSUE_PRIORITY_GREATER_OR_EQUAL conditions (excluding the one being deleted)
+    const remainingPriorityConditions = conditions.filter(
+      c =>
+        c.type === DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL &&
+        c.id !== condition.id
+    ).length;
+
+    // If no more ISSUE_PRIORITY_GREATER_OR_EQUAL conditions exist, remove the ISSUE_PRIORITY_DEESCALATING condition
+    if (remainingPriorityConditions === 0 && issuePriorityDeescalatingConditionId) {
+      onDeleteRow(issuePriorityDeescalatingConditionId);
+    }
+  };
+
   return (
     <Fragment>
-      {conditions.map(condition => (
-        <AutomationBuilderRow
-          key={`${group}.conditions.${condition.id}`}
-          onDelete={() => onDeleteRow(condition.id)}
-          isConflicting={conflictingConditionIds.includes(condition.id)}
-        >
-          <DataConditionNodeContext.Provider
-            value={{
-              condition,
-              condition_id: `${group}.conditions.${condition.id}`,
-              onUpdate: params => updateCondition(condition.id, params),
-            }}
-          >
-            <Node />
-          </DataConditionNodeContext.Provider>
-        </AutomationBuilderRow>
-      ))}
+      {conditions.map(
+        condition =>
+          // ISSUE_PRIORITY_DEESCALATING condition is a special case attached to the ISSUE_PRIORITY_GREATER_OR_EQUAL condition
+          condition.type !== DataConditionType.ISSUE_PRIORITY_DEESCALATING && (
+            <AutomationBuilderRow
+              key={`${group}.conditions.${condition.id}`}
+              onDelete={() => onDeleteRowHandler(condition)}
+              isConflicting={conflictingConditionIds.includes(condition.id)}
+            >
+              <DataConditionNodeContext.Provider
+                value={{
+                  condition,
+                  condition_id: `${group}.conditions.${condition.id}`,
+                  onUpdate: params => updateCondition(condition.id, params),
+                }}
+              >
+                <Node />
+                {condition.type === DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL && (
+                  <Fragment>
+                    <Checkbox
+                      checked={!!issuePriorityDeescalatingConditionId}
+                      onChange={() => onIssuePriorityDeescalatingChange()}
+                    />
+                    {t('Notify on deescalation')}
+                  </Fragment>
+                )}
+              </DataConditionNodeContext.Provider>
+            </AutomationBuilderRow>
+          )
+      )}
       {/* Always show alert for conflicting action filters, but only show alert for triggers when the trigger conditions conflict with each other */}
       {((handlerGroup === DataConditionHandlerGroupType.ACTION_FILTER &&
         conflictingConditionIds.length > 0) ||


### PR DESCRIPTION
"notify on deescalation" is actually it's own data condition (`type = ISSUE_PRIORITY_DEESCALATING`) in a data condition group, but we want to display it in the same row as issue priority (`type = ISSUE_PRIORITY_GREATER_OR_EQUAL`) conditions in the UI

as a result we need a lot of special handling for this case, since the checkbox is adding/removing a data condition and we want to delete both the issue priority and deescalating conditions when the row is deleted

<img width="551" alt="Screenshot 2025-06-30 at 4 13 17 PM" src="https://github.com/user-attachments/assets/f2ba121f-cf4f-4ca7-80f3-178629b3ccf9" />
