### PR TITLE
ref(ACI): Refactor subscription processor tests

### DIFF
--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor.py
@@ -241,26 +241,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         return self.create_rule_trigger_and_action(projects=[self.project, self.other_project])
 
     @cached_property
-    def comparison_rule_above(self):
-        rule = self.rule
-        rule.update(comparison_delta=60 * 60, resolve_threshold=None)
-        rule.snuba_query.update(time_window=60 * 60)
-        self.trigger.update(alert_threshold=150)
-        return rule
-
-    @cached_property
-    def comparison_rule_below(self):
-        rule = self.rule
-        rule.update(
-            comparison_delta=60,
-            threshold_type=AlertRuleThresholdType.BELOW.value,
-            resolve_threshold=None,
-        )
-        rule.snuba_query.update(time_window=60 * 60)
-        self.trigger.update(alert_threshold=50)
-        return rule
-
-    @cached_property
     def trigger(self):
         return self.rule.alertruletrigger_set.get()
 
@@ -405,8 +385,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_action_handler_called_with_actions(None, [])
 
     def test_alert_dedupe(self):
-        # Verify that an alert rule that only expects a single update to be over the
-        # alert threshold triggers correctly
+        """
+        Verify that an alert rule that only expects a single update to be over the
+        alert threshold triggers correctly
+        """
         rule = self.rule
         c_trigger = self.trigger
         create_alert_rule_trigger_action(
@@ -448,8 +430,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
     def test_alert_nullable(self):
-        # Verify that an alert rule that only expects a single update to be over the
-        # alert threshold triggers correctly
+        """
+        Verify that an alert rule that only expects a single update to be over the
+        alert threshold triggers correctly
+        """
         rule = self.rule
         self.trigger
         processor = self.send_update(rule, None)
@@ -457,8 +441,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         self.assert_no_active_incident(rule)
 
     def test_alert_multiple_threshold_periods(self):
-        # Verify that a rule that expects two consecutive updates to be over the
-        # alert threshold triggers correctly
+        """
+        Verify that a rule that expects two consecutive updates to be over the
+        alert threshold triggers correctly
+        """
         rule = self.rule
         trigger = self.trigger
         rule.update(threshold_period=2)
@@ -488,8 +474,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
     def test_no_new_incidents_within_ten_minutes(self):
-        # Verify that a new incident is not made for the same rule, trigger, and
-        # subscription if an incident was already made within the last 10 minutes.
+        """
+        Verify that a new incident is not made for the same rule, trigger, and
+        subscription if an incident was already made within the last 10 minutes.
+        """
         rule = self.rule
         trigger = self.trigger
         processor = self.send_update(
@@ -526,9 +514,11 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         )
 
     def test_incident_made_after_ten_minutes(self):
-        # Verify that a new incident will be made for the same rule, trigger, and
-        # subscription if the last incident made for those was made more tha 10 minutes
-        # ago
+        """
+        Verify that a new incident will be made for the same rule, trigger, and
+        subscription if the last incident made for those was made more tha 10 minutes
+        ago
+        """
         rule = self.rule
         trigger = self.trigger
         processor = self.send_update(
@@ -554,8 +544,10 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
 
 class ProcessUpdateResolveTest(ProcessUpdateTest):
     def test_no_active_incident_resolve(self):
-        # Test that we don't track stats for resolving if there are no active incidents
-        # related to the alert rule.
+        """
+        Test that we don't track stats for resolving if there are no active incidents
+        related to the alert rule.
+        """
         rule = self.rule
         trigger = self.trigger
         processor = self.send_update(rule, rule.resolve_threshold - 1)
@@ -565,8 +557,10 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         self.assert_action_handler_called_with_actions(None, [])
 
     def test_resolve_multiple_threshold_periods(self):
-        # Verify that a rule that expects two consecutive updates to be under the
-        # resolve threshold triggers correctly
+        """
+        Verify that a rule that expects two consecutive updates to be under the
+        resolve threshold triggers correctly
+        """
         rule = self.rule
         trigger = self.trigger
 
@@ -616,9 +610,11 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_resolve_multiple_threshold_periods_non_consecutive(self):
-        # Verify that a rule that expects two consecutive updates to be under the
-        # resolve threshold doesn't trigger if there's two updates that are below with
-        # an update that is above the threshold in the middle
+        """
+        Verify that a rule that expects two consecutive updates to be under the
+        resolve threshold doesn't trigger if there's two updates that are below with
+        an update that is above the threshold in the middle
+        """
         rule = self.rule
         trigger = self.trigger
 
@@ -661,8 +657,10 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         self.assert_action_handler_called_with_actions(incident, [])
 
     def test_auto_resolve(self):
-        # Verify that we resolve an alert rule automatically even if no resolve
-        # threshold is set
+        """
+        Verify that we resolve an alert rule automatically even if no resolve
+        threshold is set
+        """
         rule = self.rule
         rule.update(resolve_threshold=None)
         trigger = self.trigger
@@ -705,8 +703,10 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_auto_resolve_percent_boundary(self):
-        # Verify that we resolve an alert rule automatically even if no resolve
-        # threshold is set
+        """
+        Verify that we resolve an alert rule automatically even if no resolve
+        threshold is set
+        """
         rule = self.rule
         rule.update(resolve_threshold=None)
         trigger = self.trigger
@@ -750,8 +750,10 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_auto_resolve_boundary(self):
-        # Verify that we resolve an alert rule automatically if the value hits the
-        # original alert trigger value
+        """
+        Verify that we resolve an alert rule automatically if the value hits the
+        original alert trigger value
+        """
         rule = self.rule
         rule.update(resolve_threshold=None)
         trigger = self.trigger
@@ -794,7 +796,9 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_auto_resolve_reversed(self):
-        # Test auto resolving works correctly when threshold is reversed
+        """
+        Test auto resolving works correctly when threshold is reversed
+        """
         rule = self.rule
         rule.update(resolve_threshold=None, threshold_type=AlertRuleThresholdType.BELOW.value)
         trigger = self.trigger
@@ -837,7 +841,9 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_reversed_threshold_alert(self):
-        # Test that inverting thresholds correctly alerts
+        """
+        Test that inverting thresholds correctly alerts
+        """
         rule = self.rule
         trigger = self.trigger
         rule.update(threshold_type=AlertRuleThresholdType.BELOW.value)
@@ -868,7 +874,9 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_reversed_threshold_resolve(self):
-        # Test that inverting thresholds correctly resolves
+        """
+        Test that inverting thresholds correctly resolves
+        """
         rule = self.rule
         trigger = self.trigger
         rule.update(threshold_type=AlertRuleThresholdType.BELOW.value)
@@ -919,8 +927,10 @@ class ProcessUpdateResolveTest(ProcessUpdateTest):
         )
 
     def test_multiple_subscriptions_do_not_conflict(self):
-        # Verify that multiple subscriptions associated with a rule don't conflict with
-        # each other
+        """
+        Verify that multiple subscriptions associated with a rule don't conflict with
+        each other
+        """
         rule = self.rule
         rule.update(threshold_period=2)
         trigger = self.trigger
@@ -1181,9 +1191,11 @@ class ProcessUpdateMultipleTriggersTest(ProcessUpdateTest):
         )
 
     def test_alert_multiple_triggers_non_consecutive(self):
-        # Verify that a rule that expects two consecutive updates to be over the
-        # alert threshold doesn't trigger if there are two updates that are above with
-        # an update that is below the threshold in the middle
+        """
+        Verify that a rule that expects two consecutive updates to be over the
+        alert threshold doesn't trigger if there are two updates that are above with
+        an update that is below the threshold in the middle
+        """
         rule = self.rule
         rule.update(threshold_period=2)
         trigger = self.trigger
@@ -1411,8 +1423,10 @@ class ProcessUpdateMultipleTriggersTest(ProcessUpdateTest):
         )
 
     def test_multiple_triggers_at_same_time(self):
-        # Check that both triggers fire if an update comes through that exceeds both of
-        # their thresholds
+        """
+        Check that both triggers fire if an update comes through that exceeds both of
+        their thresholds
+        """
         rule = self.rule
         trigger = self.trigger
         other_trigger = create_alert_rule_trigger(
@@ -1488,8 +1502,10 @@ class ProcessUpdateMultipleTriggersTest(ProcessUpdateTest):
         )
 
     def test_multiple_triggers_with_identical_actions_at_same_time(self):
-        # Check that both triggers fire if an update comes through that exceeds both of
-        # their thresholds
+        """
+        Check that both triggers fire if an update comes through that exceeds both of
+        their thresholds
+        """
         rule = self.rule
         trigger = self.trigger
         other_trigger = create_alert_rule_trigger(
@@ -1551,7 +1567,9 @@ class ProcessUpdateMultipleTriggersTest(ProcessUpdateTest):
         )
 
     def test_auto_resolve_multiple_trigger(self):
-        # Test auto resolving works correctly when multiple triggers are present.
+        """
+        Test auto resolving works correctly when multiple triggers are present.
+        """
         rule = self.rule
         rule.update(resolve_threshold=None)
         trigger = self.trigger
@@ -1618,7 +1636,9 @@ class ProcessUpdateMultipleTriggersTest(ProcessUpdateTest):
         )
 
     def test_multiple_triggers_resolve_separately(self):
-        # Check that resolve triggers fire separately
+        """
+        Check that resolve triggers fire separately
+        """
         rule = self.rule
         trigger = self.trigger
         other_trigger = create_alert_rule_trigger(
@@ -1723,6 +1743,26 @@ class ProcessUpdateMultipleTriggersTest(ProcessUpdateTest):
 
 
 class ProcessUpdateComparisonAlertTest(ProcessUpdateTest):
+    @cached_property
+    def comparison_rule_above(self):
+        rule = self.rule
+        rule.update(comparison_delta=60 * 60, resolve_threshold=None)
+        rule.snuba_query.update(time_window=60 * 60)
+        self.trigger.update(alert_threshold=150)
+        return rule
+
+    @cached_property
+    def comparison_rule_below(self):
+        rule = self.rule
+        rule.update(
+            comparison_delta=60,
+            threshold_type=AlertRuleThresholdType.BELOW.value,
+            resolve_threshold=None,
+        )
+        rule.snuba_query.update(time_window=60 * 60)
+        self.trigger.update(alert_threshold=50)
+        return rule
+
     @patch("sentry.incidents.utils.process_update_helpers.metrics")
     def test_comparison_alert_above(self, helper_metrics):
         rule = self.comparison_rule_above

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -39,12 +39,12 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.subscription_processor.test_subscription_processor import (
     ProcessUpdateAnomalyDetectionTest,
-    ProcessUpdateTest,
+    ProcessUpdateComparisonAlertTest,
 )
 
 
 @freeze_time()
-class ProcessUpdateWorkflowEngineTest(ProcessUpdateTest):
+class ProcessUpdateWorkflowEngineTest(ProcessUpdateComparisonAlertTest):
     @with_feature("organizations:workflow-engine-metric-alert-dual-processing-logs")
     @with_feature("organizations:workflow-engine-metric-alert-processing")
     @patch("sentry.incidents.subscription_processor.metrics")
@@ -389,8 +389,11 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
         assert deserialized_body["organization_id"] == self.sub.project.organization.id
         assert deserialized_body["project_id"] == self.sub.project_id
         assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
-        assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["expected_seasonality"] == rule.seasonality.value
+        assert rule.sensitivity is not None
+        assert deserialized_body["config"]["sensitivity"] == rule.sensitivity
+        assert rule.seasonality is not None
+        assert deserialized_body["config"]["expected_seasonality"] == rule.seasonality
+        assert rule.threshold_type is not None
         assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
         assert deserialized_body["context"]["source_id"] == self.sub.id
         assert deserialized_body["context"]["cur_window"]["value"] == value

--- a/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
+++ b/tests/sentry/incidents/subscription_processor/test_subscription_processor_workflow_engine.py
@@ -14,6 +14,7 @@ from sentry.incidents.logic import (
     create_alert_rule_trigger_action,
 )
 from sentry.incidents.models.alert_rule import (
+    AlertRule,
     AlertRuleDetectionType,
     AlertRuleSeasonality,
     AlertRuleSensitivity,
@@ -361,6 +362,67 @@ class ProcessUpdateWorkflowEngineTest(ProcessUpdateTest):
 
 @freeze_time()
 class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetectionTest):
+    def get_seer_return_value(
+        self, anomaly_score: float, value: int, anomaly_type: AnomalyType, success: bool = True
+    ) -> DetectAnomaliesResponse:
+        seer_return_value: DetectAnomaliesResponse = {
+            "success": success,
+            "timeseries": [
+                {
+                    "anomaly": {
+                        "anomaly_score": anomaly_score,
+                        "anomaly_type": anomaly_type.value,
+                    },
+                    "timestamp": 1,
+                    "value": value,
+                }
+            ],
+        }
+        return seer_return_value
+
+    def assert_seer_results(
+        self, mock_seer_request: MagicMock, rule: AlertRule, value: int
+    ) -> None:
+        assert mock_seer_request.call_args.args[0] == "POST"
+        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
+        deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
+        assert deserialized_body["organization_id"] == self.sub.project.organization.id
+        assert deserialized_body["project_id"] == self.sub.project_id
+        assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
+        assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
+        assert deserialized_body["config"]["expected_seasonality"] == rule.seasonality.value
+        assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
+        assert deserialized_body["context"]["source_id"] == self.sub.id
+        assert deserialized_body["context"]["cur_window"]["value"] == value
+
+    def create_workflow_engine_models(self, rule: AlertRule) -> None:
+        data_condition_group = self.create_data_condition_group()
+        detector = self.create_detector(
+            name="hojicha",
+            type=MetricIssue.slug,
+            config={
+                "detection_type": AlertRuleDetectionType.DYNAMIC,
+                "sensitivity": AlertRuleSensitivity.HIGH,
+                "seasonality": AlertRuleSeasonality.AUTO,
+                "threshold_period": rule.threshold_period,
+            },
+            workflow_condition_group=data_condition_group,
+        )
+        data_source = self.create_data_source(source_id=str(self.sub.id))
+        data_source.detectors.set([detector])
+        self.create_workflow(organization=self.organization)
+        comparison = {
+            "sensitivity": AnomalyDetectionSensitivity.HIGH,
+            "seasonality": AnomalyDetectionSeasonality.AUTO,
+            "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
+        }
+        self.create_data_condition(
+            condition_group=data_condition_group,
+            type=Condition.ANOMALY_DETECTION,
+            comparison=comparison,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
     @with_feature("organizations:metric-issue-poc")
     @with_feature("projects:metric-issue-creation")
     @with_feature("organizations:anomaly-detection-alerts")
@@ -374,30 +436,18 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
     ):
         rule = self.dynamic_rule
         trigger = self.trigger
-
-        seer_return_value: DetectAnomaliesResponse = {
-            "success": True,
-            "timeseries": [
-                {
-                    "anomaly": {
-                        "anomaly_score": 0.9,
-                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
-                    },
-                    "timestamp": 1,
-                    "value": 10,
-                }
-            ],
-        }
-
+        seer_return_value = self.get_seer_return_value(
+            anomaly_score=0.9, value=10, anomaly_type=AnomalyType.HIGH_CONFIDENCE
+        )
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
         processor = self.send_update(rule, trigger.alert_threshold + 1)
 
-        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        self.assert_trigger_counts(processor, trigger, 0, 0)
         incident = self.assert_active_incident(rule)
         assert incident.date_started == (
             timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
         )
-        self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
+        self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
         latest_activity = self.latest_activity(incident)
         uuid = str(latest_activity.notification_uuid)
         self.assert_actions_fired_for_incident(
@@ -441,63 +491,15 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
             AlertRuleTriggerAction.TargetType.USER,
             str(self.user.id),
         )
-
-        data_condition_group = self.create_data_condition_group()
-        detector = self.create_detector(
-            name="hojicha",
-            type=MetricIssue.slug,
-            config={
-                "detection_type": AlertRuleDetectionType.DYNAMIC,
-                "sensitivity": AlertRuleSensitivity.HIGH,
-                "seasonality": AlertRuleSeasonality.AUTO,
-                "threshold_period": rule.threshold_period,
-            },
-            workflow_condition_group=data_condition_group,
+        self.create_workflow_engine_models(rule)
+        value = 5
+        seer_return_value = self.get_seer_return_value(
+            anomaly_score=0.7, value=value, anomaly_type=AnomalyType.LOW_CONFIDENCE
         )
-        data_source = self.create_data_source(source_id=str(self.sub.id))
-        data_source.detectors.set([detector])
-        self.create_workflow(organization=self.organization)
-        comparison = {
-            "sensitivity": AnomalyDetectionSensitivity.HIGH,
-            "seasonality": AnomalyDetectionSeasonality.AUTO,
-            "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
-        }
-        self.create_data_condition(
-            condition_group=data_condition_group,
-            type=Condition.ANOMALY_DETECTION,
-            comparison=comparison,
-            condition_result=DetectorPriorityLevel.HIGH,
-        )
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        processor = self.send_update(rule, value, timedelta(minutes=-3))
 
-        seer_return_value_1: DetectAnomaliesResponse = {
-            "success": True,
-            "timeseries": [
-                {
-                    "anomaly": {
-                        "anomaly_score": 0.7,
-                        "anomaly_type": AnomalyType.LOW_CONFIDENCE.value,
-                    },
-                    "timestamp": 1,
-                    "value": 5,
-                }
-            ],
-        }
-
-        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_1), status=200)
-        processor = self.send_update(rule, 5, timedelta(minutes=-3))
-
-        assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
-        deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
-        assert deserialized_body["organization_id"] == self.sub.project.organization.id
-        assert deserialized_body["project_id"] == self.sub.project_id
-        assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
-        assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["expected_seasonality"] == rule.seasonality.value
-        assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
-        assert deserialized_body["context"]["source_id"] == self.sub.id
-        assert deserialized_body["context"]["cur_window"]["value"] == 5
-
+        self.assert_seer_results(mock_seer_request, rule, value)
         self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, warning_trigger, 0, 0)
         self.assert_no_active_incident(rule)  # there is no warning for dynamic alerts
@@ -520,63 +522,16 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
             AlertRuleTriggerAction.TargetType.USER,
             str(self.user.id),
         )
+        self.create_workflow_engine_models(rule)
+        value = 10
 
-        data_condition_group = self.create_data_condition_group()
-        detector = self.create_detector(
-            name="hojicha",
-            type=MetricIssue.slug,
-            config={
-                "detection_type": AlertRuleDetectionType.DYNAMIC,
-                "sensitivity": AlertRuleSensitivity.HIGH,
-                "seasonality": AlertRuleSeasonality.AUTO,
-                "threshold_period": rule.threshold_period,
-            },
-            workflow_condition_group=data_condition_group,
+        seer_return_value = self.get_seer_return_value(
+            anomaly_score=0.9, value=value, anomaly_type=AnomalyType.HIGH_CONFIDENCE
         )
-        data_source = self.create_data_source(source_id=str(self.sub.id))
-        data_source.detectors.set([detector])
-        self.create_workflow(organization=self.organization)
-        comparison = {
-            "sensitivity": AnomalyDetectionSensitivity.HIGH,
-            "seasonality": AnomalyDetectionSeasonality.AUTO,
-            "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
-        }
-        self.create_data_condition(
-            condition_group=data_condition_group,
-            type=Condition.ANOMALY_DETECTION,
-            comparison=comparison,
-            condition_result=DetectorPriorityLevel.HIGH,
-        )
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        processor = self.send_update(rule, value, timedelta(minutes=-2))
 
-        seer_return_value_2: DetectAnomaliesResponse = {
-            "success": True,
-            "timeseries": [
-                {
-                    "anomaly": {
-                        "anomaly_score": 0.9,
-                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
-                    },
-                    "timestamp": 1,
-                    "value": 10,
-                }
-            ],
-        }
-
-        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_2), status=200)
-        processor = self.send_update(rule, 10, timedelta(minutes=-2))
-
-        assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
-        deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
-        assert deserialized_body["organization_id"] == self.sub.project.organization.id
-        assert deserialized_body["project_id"] == self.sub.project_id
-        assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
-        assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["expected_seasonality"] == rule.seasonality.value
-        assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
-        assert deserialized_body["context"]["source_id"] == self.sub.id
-        assert deserialized_body["context"]["cur_window"]["value"] == 10
-
+        self.assert_seer_results(mock_seer_request, rule, value)
         self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, warning_trigger, 0, 0)
         incident = self.assert_active_incident(rule)
@@ -615,80 +570,29 @@ class ProcessUpdateAnomalyDetectionWorkflowEngineTest(ProcessUpdateAnomalyDetect
             AlertRuleTriggerAction.TargetType.USER,
             str(self.user.id),
         )
-
-        data_condition_group = self.create_data_condition_group()
-        detector = self.create_detector(
-            name="hojicha",
-            type=MetricIssue.slug,
-            config={
-                "detection_type": AlertRuleDetectionType.DYNAMIC,
-                "sensitivity": AlertRuleSensitivity.HIGH,
-                "seasonality": AlertRuleSeasonality.AUTO,
-                "threshold_period": rule.threshold_period,
-            },
-            workflow_condition_group=data_condition_group,
-        )
-        data_source = self.create_data_source(source_id=str(self.sub.id))
-        data_source.detectors.set([detector])
-        self.create_workflow(organization=self.organization)
-        comparison = {
-            "sensitivity": AnomalyDetectionSensitivity.HIGH,
-            "seasonality": AnomalyDetectionSeasonality.AUTO,
-            "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW,
-        }
-        self.create_data_condition(
-            condition_group=data_condition_group,
-            type=Condition.ANOMALY_DETECTION,
-            comparison=comparison,
-            condition_result=DetectorPriorityLevel.HIGH,
-        )
+        self.create_workflow_engine_models(rule)
 
         # trigger critical first
-        seer_return_value_2: DetectAnomaliesResponse = {
-            "success": True,
-            "timeseries": [
-                {
-                    "anomaly": {
-                        "anomaly_score": 0.9,
-                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE.value,
-                    },
-                    "timestamp": 1,
-                    "value": 10,
-                }
-            ],
-        }
-
-        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_2), status=200)
-        processor = self.send_update(rule, 10, timedelta(minutes=-2))
+        crit_value = 10
+        seer_return_value = self.get_seer_return_value(
+            anomaly_score=0.9, value=crit_value, anomaly_type=AnomalyType.HIGH_CONFIDENCE
+        )
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+        processor = self.send_update(rule, crit_value, timedelta(minutes=-2))
         incident = self.assert_active_incident(rule)
+
         # trigger a resolution
-        seer_return_value_3: DetectAnomaliesResponse = {
-            "success": True,
-            "timeseries": [
-                {
-                    "anomaly": {"anomaly_score": 0.5, "anomaly_type": AnomalyType.NONE.value},
-                    "timestamp": 1,
-                    "value": 1,
-                }
-            ],
-        }
+        resolve_value = 1
+        seer_return_value_resolve = self.get_seer_return_value(
+            anomaly_score=0.5, value=resolve_value, anomaly_type=AnomalyType.NONE
+        )
+        mock_seer_request.return_value = HTTPResponse(
+            orjson.dumps(seer_return_value_resolve), status=200
+        )
+        processor = self.send_update(rule, resolve_value, timedelta(minutes=-1))
 
-        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value_3), status=200)
-        processor = self.send_update(rule, 1, timedelta(minutes=-1))
-
-        assert mock_seer_request.call_args.args[0] == "POST"
-        assert mock_seer_request.call_args.args[1] == SEER_ANOMALY_DETECTION_ENDPOINT_URL
-        deserialized_body = json.loads(mock_seer_request.call_args.kwargs["body"])
-        assert deserialized_body["organization_id"] == self.sub.project.organization.id
-        assert deserialized_body["project_id"] == self.sub.project_id
-        assert deserialized_body["config"]["time_period"] == rule.snuba_query.time_window / 60
-        assert deserialized_body["config"]["sensitivity"] == rule.sensitivity.value
-        assert deserialized_body["config"]["expected_seasonality"] == rule.seasonality.value
-        assert deserialized_body["config"]["direction"] == translate_direction(rule.threshold_type)
-        assert deserialized_body["context"]["source_id"] == self.sub.id
-        assert deserialized_body["context"]["cur_window"]["value"] == 1
-
-        self.assert_trigger_counts(processor, self.trigger, 0, 0)
+        self.assert_seer_results(mock_seer_request, rule, resolve_value)
+        self.assert_trigger_counts(processor, trigger, 0, 0)
         self.assert_trigger_counts(processor, warning_trigger, 0, 0)
         self.assert_no_active_incident(rule)
         self.assert_trigger_exists_with_status(incident, warning_trigger, TriggerStatus.RESOLVED)


### PR DESCRIPTION
Make some reusable methods to clean up the workflow engine tests, move cached properties to the subclasses that use them, and standardize the way we write docstrings.