### PR TITLE
feat(workflow_engine): Hook up activity updates to process_workflows

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -183,7 +183,7 @@ def evaluate_workflow_triggers(
             "group_id": event_data.group.id,
             "event_id": event_id,
             "event_data": asdict(event_data),
-            "event_environment_id": environment.id,
+            "event_environment_id": environment.id if environment else None,
             "triggered_workflows": [workflow.id for workflow in triggered_workflows],
         },
     )
@@ -401,9 +401,11 @@ def process_workflows(
 
     actions_to_trigger = evaluate_workflows_action_filters(triggered_workflows, event_data)
     actions = filter_recently_fired_workflow_actions(actions_to_trigger, event_data)
+
     if not actions:
         # If there aren't any actions on the associated workflows, there's nothing to trigger
         return triggered_workflows
+
     create_workflow_fire_histories(detector, actions, event_data)
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -335,7 +335,7 @@ def _get_associated_workflows(
 
 @log_context.root()
 def process_workflows(
-    event_data: WorkflowEventData, detector_id: DetectorId = None
+    event_data: WorkflowEventData, detector: Detector | None = None
 ) -> set[Workflow]:
     """
     This method will get the detector based on the event, and then gather the associated workflows.
@@ -345,13 +345,10 @@ def process_workflows(
     Finally, each of the triggered workflows will have their actions evaluated and executed.
     """
     try:
-        detector: Detector
-        if detector_id is not None:
-            detector = Detector.objects.get(id=detector_id)
-        elif isinstance(event_data.event, GroupEvent):
+        if detector is None and isinstance(event_data.event, GroupEvent):
             detector = get_detector_by_event(event_data)
         else:
-            raise ValueError("Unable to determine the detector_id for the event")
+            raise ValueError("Unable to determine the detector for the event")
 
         log_context.add_extras(detector_id=detector.id)
         organization = detector.project.organization

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from sentry import buffer, features
 from sentry.eventstore.models import GroupEvent
+from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.utils import json
 from sentry.workflow_engine.models import (
@@ -271,7 +272,7 @@ def evaluate_workflows_action_filters(
     return filtered_action_groups
 
 
-def get_environment_by_event(event_data: WorkflowEventData) -> Environment:
+def get_environment_by_event(event_data: WorkflowEventData) -> Environment | None:
     if isinstance(event_data.event, GroupEvent):
         try:
             environment = event_data.event.get_environment()
@@ -283,22 +284,27 @@ def get_environment_by_event(event_data: WorkflowEventData) -> Environment:
             raise Environment.DoesNotExist("Environment does not exist for the event")
 
         return environment
+    elif isinstance(event_data.event, Activity):
+        return None
 
-    raise TypeError(
-        "Expected event_data.event to be an instance of GroupEvent, got %s" % type(event_data.event)
-    )
+    raise TypeError(f"Cannot access the environment from, {type(event_data.event)}.")
 
 
 def _get_associated_workflows(
-    detector: Detector, environment: Environment, event_data: WorkflowEventData
+    detector: Detector, environment: Environment | None, event_data: WorkflowEventData
 ) -> set[Workflow]:
     """
     This is a wrapper method to get the workflows associated with a detector and environment.
     Used in process_workflows to wrap the query + logging into a single method
     """
+    environment_filter = (
+        (Q(environment_id=None) | Q(environment_id=environment.id))
+        if environment
+        else Q(environment_id=None)
+    )
     workflows = set(
         Workflow.objects.filter(
-            (Q(environment_id=None) | Q(environment_id=environment.id)),
+            environment_filter,
             detectorworkflow__detector_id=detector.id,
             enabled=True,
         )
@@ -324,7 +330,7 @@ def _get_associated_workflows(
                 "group_id": event_data.group.id,
                 "event_id": event_id,
                 "event_data": asdict(event_data),
-                "event_environment_id": environment.id,
+                "event_environment_id": environment.id if environment else None,
                 "workflows": [workflow.id for workflow in workflows],
                 "detector_type": detector.type,
             },
@@ -347,7 +353,8 @@ def process_workflows(
     try:
         if detector is None and isinstance(event_data.event, GroupEvent):
             detector = get_detector_by_event(event_data)
-        else:
+
+        if detector is None:
             raise ValueError("Unable to determine the detector for the event")
 
         log_context.add_extras(detector_id=detector.id)

--- a/src/sentry/workflow_engine/tasks.py
+++ b/src/sentry/workflow_engine/tasks.py
@@ -46,15 +46,11 @@ logger = log_context.get_logger(__name__)
 )
 def process_workflow_activity(activity_id: int, group_id: int, detector_id: int) -> None:
     """
-    Process a workflow task identified by the given Activity ID and Detector ID.
+    Process a workflow task identified by the given activity, group, and detector.
 
     The task will get the Activity from the database, create a WorkflowEventData object,
     and then process the data in `process_workflows`.
     """
-    # TODO - @saponifi3d - implement this in a follow-up PR. This update will require WorkflowEventData
-    # to allow for an activity in the `event` attribute. That refactor is a bit noisy
-    # and will be done in a subsequent pr.
-
     with transaction.atomic(router.db_for_write(Detector)):
         try:
             activity = Activity.objects.get(id=activity_id)

--- a/src/sentry/workflow_engine/tasks.py
+++ b/src/sentry/workflow_engine/tasks.py
@@ -65,6 +65,7 @@ def process_workflow_activity(activity_id: int, group_id: int, detector_id: int)
                     "detector_id": detector_id,
                 },
             )
+            return  # Exit execution that we cannot recover from
 
     event_data = WorkflowEventData(
         event=activity,

--- a/tests/sentry/workflow_engine/test_task_integration.py
+++ b/tests/sentry/workflow_engine/test_task_integration.py
@@ -44,7 +44,7 @@ class IssuePlatformIntegrationTests(TestCase):
         with mock.patch("sentry.workflow_engine.tasks.metrics.incr") as mock_incr:
             _process_message(message)
 
-            mock_incr.assert_called_with(
+            mock_incr.assert_any_call(
                 "workflow_engine.process_workflow.activity_update",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )
@@ -66,7 +66,7 @@ class IssuePlatformIntegrationTests(TestCase):
 
         with mock.patch("sentry.workflow_engine.tasks.metrics.incr") as mock_incr:
             update_status(self.group, message)
-            mock_incr.assert_called_with(
+            mock_incr.assert_any_call(
                 "workflow_engine.process_workflow.activity_update",
                 tags={"activity_type": ActivityType.SET_RESOLVED.value},
             )


### PR DESCRIPTION
## Description
Complete support for `Activity` updates from the issue platform. This will filter to known activities that we can handle (right now, it's just issue resolution).

- Needed to fix a few areas of logic to support the full end to end of `process_workflows` with an activity update.
- Added Tests to ensure we could create an activity, run the task and it will fetch any associated data an evaluate as exected.