### PR TITLE
feat(feedback): Hide the URL section for mobile projects

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -1,8 +1,6 @@
 import {Fragment, useEffect, useRef} from 'react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {getOrderedContextItems} from 'sentry/components/events/contexts';
@@ -13,13 +11,13 @@ import FeedbackActivitySection from 'sentry/components/feedback/feedbackItem/fee
 import FeedbackItemHeader from 'sentry/components/feedback/feedbackItem/feedbackItemHeader';
 import FeedbackItemSection from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import FeedbackReplay from 'sentry/components/feedback/feedbackItem/feedbackReplay';
+import FeedbackUrl from 'sentry/components/feedback/feedbackItem/feedbackUrl';
 import MessageSection from 'sentry/components/feedback/feedbackItem/messageSection';
 import TraceDataSection from 'sentry/components/feedback/feedbackItem/traceDataSection';
 import {KeyValueData} from 'sentry/components/keyValueData';
 import PanelItem from 'sentry/components/panels/panelItem';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import TextCopyInput from 'sentry/components/textCopyInput';
-import {IconChat, IconFire, IconLink, IconTag} from 'sentry/icons';
+import {IconChat, IconFire, IconTag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
@@ -35,11 +33,7 @@ interface Props {
 
 export default function FeedbackItem({feedbackItem, eventData}: Props) {
   const organization = useOrganization();
-  const url =
-    eventData?.contexts?.feedback?.url ??
-    eventData?.tags?.find(tag => tag.key === 'url')?.value;
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
-  const theme = useTheme();
 
   const overflowRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -51,11 +45,6 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
     }, 100);
   }, [feedbackItem.id, overflowRef]);
 
-  const URL_NOT_FOUND = t('URL not found');
-  const displayUrl =
-    eventData?.contexts?.feedback || eventData?.tags ? (url ?? URL_NOT_FOUND) : '';
-  const urlIsLink = displayUrl.length && displayUrl !== URL_NOT_FOUND;
-
   return (
     <Fragment>
       <AnalyticsArea name="details">
@@ -65,28 +54,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
             <MessageSection eventData={eventData} feedbackItem={feedbackItem} />
           </FeedbackItemSection>
 
-          {!crashReportId || (crashReportId && url) ? (
-            <FeedbackItemSection
-              collapsible
-              icon={<IconLink size="xs" />}
-              sectionKey="url"
-              title={t('URL')}
-            >
-              <TextCopyInput
-                style={urlIsLink ? {color: theme.blue400} : undefined}
-                onClick={
-                  urlIsLink
-                    ? e => {
-                        e.preventDefault();
-                        openNavigateToExternalLinkModal({linkText: displayUrl});
-                      }
-                    : () => {}
-                }
-              >
-                {displayUrl}
-              </TextCopyInput>
-            </FeedbackItemSection>
-          ) : null}
+          <FeedbackUrl eventData={eventData} feedbackItem={feedbackItem} />
 
           {crashReportId && feedbackItem.project ? (
             <FeedbackItemSection

--- a/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
@@ -1,0 +1,60 @@
+import {useTheme} from '@emotion/react';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import FeedbackItemSection from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {frontend} from 'sentry/data/platformCategories';
+import {IconLink} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Event} from 'sentry/types/event';
+import type {FeedbackIssue} from 'sentry/utils/feedback/types';
+
+const URL_NOT_FOUND = t('URL not found');
+
+interface Props {
+  eventData: Event | undefined;
+  feedbackItem: FeedbackIssue;
+}
+
+export default function FeedbackUrl({eventData, feedbackItem}: Props) {
+  const theme = useTheme();
+
+  const isFrontend = frontend.includes(feedbackItem.project?.platform ?? 'other');
+  if (!isFrontend) {
+    return null;
+  }
+
+  const url =
+    eventData?.contexts?.feedback?.url ??
+    eventData?.tags?.find(tag => tag.key === 'url')?.value;
+  const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
+  const displayUrl =
+    eventData?.contexts?.feedback || eventData?.tags ? (url ?? URL_NOT_FOUND) : '';
+  const urlIsLink = displayUrl.length && displayUrl !== URL_NOT_FOUND;
+
+  if (crashReportId && !url) {
+    return null;
+  }
+  return (
+    <FeedbackItemSection
+      collapsible
+      icon={<IconLink size="xs" />}
+      sectionKey="url"
+      title={t('URL')}
+    >
+      <TextCopyInput
+        style={urlIsLink ? {color: theme.blue400} : undefined}
+        onClick={
+          urlIsLink
+            ? e => {
+                e.preventDefault();
+                openNavigateToExternalLinkModal({linkText: displayUrl});
+              }
+            : () => {}
+        }
+      >
+        {displayUrl}
+      </TextCopyInput>
+    </FeedbackItemSection>
+  );
+}

--- a/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
@@ -1,4 +1,5 @@
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
 import FeedbackItemSection from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
@@ -42,8 +43,8 @@ export default function FeedbackUrl({eventData, feedbackItem}: Props) {
       sectionKey="url"
       title={t('URL')}
     >
-      <TextCopyInput
-        style={urlIsLink ? {color: theme.blue400} : undefined}
+      <StyledTextCopyInput
+        style={urlIsLink ? {cursor: 'pointer', color: theme.blue400} : undefined}
         onClick={
           urlIsLink
             ? e => {
@@ -54,7 +55,13 @@ export default function FeedbackUrl({eventData, feedbackItem}: Props) {
         }
       >
         {displayUrl ?? ''}
-      </TextCopyInput>
+      </StyledTextCopyInput>
     </FeedbackItemSection>
   );
 }
+
+const StyledTextCopyInput = styled(TextCopyInput)`
+  & > input:hover {
+    text-decoration: underline;
+  }
+`;

--- a/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
@@ -24,17 +24,17 @@ export default function FeedbackUrl({eventData, feedbackItem}: Props) {
     return null;
   }
 
+  const mightHaveUrl = eventData?.contexts?.feedback || eventData?.tags;
   const url =
     eventData?.contexts?.feedback?.url ??
     eventData?.tags?.find(tag => tag.key === 'url')?.value;
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
-  const displayUrl =
-    eventData?.contexts?.feedback || eventData?.tags ? (url ?? URL_NOT_FOUND) : '';
-  const urlIsLink = displayUrl.length && displayUrl !== URL_NOT_FOUND;
-
   if (crashReportId && !url) {
     return null;
   }
+
+  const displayUrl = mightHaveUrl ? (url ?? URL_NOT_FOUND) : '';
+  const urlIsLink = displayUrl.length && displayUrl !== URL_NOT_FOUND;
   return (
     <FeedbackItemSection
       collapsible

--- a/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackUrl.tsx
@@ -24,7 +24,6 @@ export default function FeedbackUrl({eventData, feedbackItem}: Props) {
     return null;
   }
 
-  const mightHaveUrl = eventData?.contexts?.feedback || eventData?.tags;
   const url =
     eventData?.contexts?.feedback?.url ??
     eventData?.tags?.find(tag => tag.key === 'url')?.value;
@@ -33,8 +32,9 @@ export default function FeedbackUrl({eventData, feedbackItem}: Props) {
     return null;
   }
 
-  const displayUrl = mightHaveUrl ? (url ?? URL_NOT_FOUND) : '';
-  const urlIsLink = displayUrl.length && displayUrl !== URL_NOT_FOUND;
+  const urlIsExpected = eventData?.contexts?.feedback || eventData?.tags;
+  const displayUrl = urlIsExpected ? String(url ?? URL_NOT_FOUND) : undefined;
+  const urlIsLink = displayUrl && displayUrl !== URL_NOT_FOUND;
   return (
     <FeedbackItemSection
       collapsible
@@ -53,7 +53,7 @@ export default function FeedbackUrl({eventData, feedbackItem}: Props) {
             : () => {}
         }
       >
-        {displayUrl}
+        {displayUrl ?? ''}
       </TextCopyInput>
     </FeedbackItemSection>
   );


### PR DESCRIPTION
This hides the Url section when a project is not a 'frontend' project.

For example, a cocoa project vs. a javascript (web) one. The specific feedback the user submitted doesn't matter in this case.

| Desc | Img |
| --- | --- |
| Mobile | <img width="495" alt="SCR-20250630-psjt" src="https://github.com/user-attachments/assets/60240111-b4f2-4dec-89ee-c476fa8686dd" />
| Web | <img width="521" alt="SCR-20250630-psir" src="https://github.com/user-attachments/assets/acc18e57-7132-4eed-ac89-799baf486315" />




Fixes REPLAY-454

