### PR TITLE
fix(feedback): Fix padding in crash report dialog

### DIFF
--- a/src/sentry/templates/sentry/error-page-embed.html
+++ b/src/sentry/templates/sentry/error-page-embed.html
@@ -30,7 +30,7 @@
   border: 1px solid #fff;
   padding: 40px;
   padding-top: constant(safe-area-inset-top);
-  padding-top: env(safe-area-inset-top);
+  padding-top: calc(40px + env(safe-area-inset-top));
   max-width: 700px;
   overflow: auto;
   border-radius: 3px;
@@ -208,7 +208,7 @@
   .sentry-error-embed {
     padding: 10px;
     padding-top: constant(safe-area-inset-top);
-    padding-top: env(safe-area-inset-top);
+    padding-top: calc(10px + env(safe-area-inset-top));
     max-width: none;
   }
   .sentry-error-embed h2 {
@@ -222,7 +222,7 @@
   .sentry-error-embed {
     padding: 10px;
     padding-top: constant(safe-area-inset-top);
-    padding-top: env(safe-area-inset-top);
+    padding-top: calc(10px + env(safe-area-inset-top));
     margin-top: 0;
     position: absolute;
     top: 0;

--- a/src/sentry/templates/sentry/error-page-embed.html
+++ b/src/sentry/templates/sentry/error-page-embed.html
@@ -29,7 +29,7 @@
   text-align: left;
   border: 1px solid #fff;
   padding: 40px;
-  padding-top: constant(safe-area-inset-top);
+  padding-top: calc(40px + constant(safe-area-inset-top));
   padding-top: calc(40px + env(safe-area-inset-top));
   max-width: 700px;
   overflow: auto;
@@ -207,7 +207,7 @@
 @media screen and (max-width: 660px) {
   .sentry-error-embed {
     padding: 10px;
-    padding-top: constant(safe-area-inset-top);
+    padding-top: calc(10px + constant(safe-area-inset-top));
     padding-top: calc(10px + env(safe-area-inset-top));
     max-width: none;
   }
@@ -221,7 +221,7 @@
 @media screen and (max-width: 480px) {
   .sentry-error-embed {
     padding: 10px;
-    padding-top: constant(safe-area-inset-top);
+    padding-top: calc(10px + constant(safe-area-inset-top));
     padding-top: calc(10px + env(safe-area-inset-top));
     margin-top: 0;
     position: absolute;

--- a/src/sentry/templates/sentry/error-page-embed.html
+++ b/src/sentry/templates/sentry/error-page-embed.html
@@ -29,6 +29,8 @@
   text-align: left;
   border: 1px solid #fff;
   padding: 40px;
+  padding-top: constant(safe-area-inset-top);
+  padding-top: env(safe-area-inset-top);
   max-width: 700px;
   overflow: auto;
   border-radius: 3px;
@@ -205,6 +207,8 @@
 @media screen and (max-width: 660px) {
   .sentry-error-embed {
     padding: 10px;
+    padding-top: constant(safe-area-inset-top);
+    padding-top: env(safe-area-inset-top);
     max-width: none;
   }
   .sentry-error-embed h2 {
@@ -217,6 +221,8 @@
 @media screen and (max-width: 480px) {
   .sentry-error-embed {
     padding: 10px;
+    padding-top: constant(safe-area-inset-top);
+    padding-top: env(safe-area-inset-top);
     margin-top: 0;
     position: absolute;
     top: 0;


### PR DESCRIPTION
This padding will only kick-in on devices that have a "safe-zone" because of a notch or something like that.

**The problem**

Devices with a notch or something cutting into the screen have also defined a "safe-zone" where content can render below the notch. By default this makes it so that all the app content is un-obstructed to the user.

It's possible however to override this safe-zone, and render you own stuff around that notch. You can do this on a web-app by setting the following meta tags:
```
<meta name="apple-mobile-web-app-capable" content="yes" />
<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
```
With these meta tags in place, if an end-user chooses to add your web-app to their device homescreen then it'll wrap that notch and be hard to read.
The fix is to add extra padding, based on the defined safe-zone. https://developer.mozilla.org/en-US/docs/Web/CSS/env

Some images to help illustrate things are below..
- Web is fine no matter what
- The app, with and without padding added
- The fixed crash report dialog, with it's own padding (this PR)

**The Fix**

The fix of course is to add some padding that overrides the default. As with all CSS, we're adding overrides for the browser that understand them. Browsers that don't understand `constant()` or `env()` or don't have `safe-area-inset-top` defined will ignore these overrides and use the original padding: 40px or 10px or whatever.

You can test directly on a device by visiting https://pokemon-market.sentry.dev/feedback and adding the site to your homescreen. See https://github.com/getsentry/pokemon-market/commit/a16d14a839b2a8b7ab0e4980fb0426fb933cc92a to see how i made the site app-capable.

| Website In Safari | App - No Padding | App - with padding | App Crash Report - with padding |
| --- | --- | --- | --- |
| ![website](https://github.com/user-attachments/assets/352be2bb-ff36-4b42-bb8e-6558de74f497) | ![app-no-padding](https://github.com/user-attachments/assets/4ff49412-3ecb-4946-b415-1ae340c5450b) | ![app-padding](https://github.com/user-attachments/assets/d6fa4eea-0d21-4ed0-a2f4-69c0d0279554) | ![crash-report](https://github.com/user-attachments/assets/66a1aa3c-8656-4a42-a02a-778ded5dac88)


Fixes #43715