### PR TITLE
feat(agent-monitoring): Improve small costs rendering

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -12,7 +12,7 @@ import {IconTool} from 'sentry/icons/iconTool';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import getDuration from 'sentry/utils/duration/getDuration';
-import {formatLLMCosts} from 'sentry/views/insights/agentMonitoring/utils/formatLLMCosts';
+import {LLMCosts} from 'sentry/views/insights/agentMonitoring/components/llmCosts';
 import {getNodeId} from 'sentry/views/insights/agentMonitoring/utils/getNodeId';
 import {getIsAiRunNode} from 'sentry/views/insights/agentMonitoring/utils/highlightedSpanAttributes';
 import {
@@ -399,7 +399,7 @@ function getNodeInfo(
     if (cost) {
       nodeInfo.subtitle = (
         <Fragment>
-          {nodeInfo.subtitle} ({formatLLMCosts(cost)})
+          {nodeInfo.subtitle} ({<LLMCosts cost={cost} />})
         </Fragment>
       );
     }

--- a/static/app/views/insights/agentMonitoring/components/llmCosts.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmCosts.tsx
@@ -1,0 +1,21 @@
+import {formatLLMCosts} from 'sentry/views/insights/agentMonitoring/utils/formatLLMCosts';
+
+interface LLMCostsProps {
+  cost: number | string;
+  className?: string;
+}
+
+export function LLMCosts({cost, className}: LLMCostsProps) {
+  return (
+    <span
+      className={className}
+      title={Number(cost).toLocaleString(undefined, {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 8,
+      })}
+    >
+      {formatLLMCosts(cost)}
+    </span>
+  );
+}

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -19,8 +19,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useTraces} from 'sentry/views/explore/hooks/useTraces';
 import {useTraceViewDrawer} from 'sentry/views/insights/agentMonitoring/components/drawer';
+import {LLMCosts} from 'sentry/views/insights/agentMonitoring/components/llmCosts';
 import {useColumnOrder} from 'sentry/views/insights/agentMonitoring/hooks/useColumnOrder';
-import {formatLLMCosts} from 'sentry/views/insights/agentMonitoring/utils/formatLLMCosts';
 import {
   AI_COST_ATTRIBUTE_SUM,
   AI_TOKEN_USAGE_ATTRIBUTE_SUM,
@@ -244,7 +244,11 @@ const BodyCell = memo(function BodyCell({
       if (dataRow.isSpanDataLoading) {
         return <NumberPlaceholder />;
       }
-      return <TextAlignRight>{formatLLMCosts(dataRow.totalCost)}</TextAlignRight>;
+      return (
+        <TextAlignRight>
+          <LLMCosts cost={dataRow.totalCost} />
+        </TextAlignRight>
+      );
     case 'timestamp':
       return (
         <TextAlignRight>

--- a/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
@@ -1,5 +1,8 @@
 import {formatAbbreviatedNumberWithDynamicPrecision} from 'sentry/utils/formatters';
 
 export function formatLLMCosts(cost: string | number) {
+  if (Number(cost) < 0.01) {
+    return `<$${(0.01).toLocaleString()}`;
+  }
   return `$${formatAbbreviatedNumberWithDynamicPrecision(cost)}`;
 }

--- a/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/highlightedSpanAttributes.tsx
@@ -6,9 +6,9 @@ import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {LLMCosts} from 'sentry/views/insights/agentMonitoring/components/llmCosts';
 import {ModelName} from 'sentry/views/insights/agentMonitoring/components/modelName';
 import {hasAgentInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
-import {formatLLMCosts} from 'sentry/views/insights/agentMonitoring/utils/formatLLMCosts';
 import {
   getIsAiRunSpan,
   getIsAiSpan,
@@ -110,7 +110,7 @@ export function getHighlightedSpanAttributes({
   if (totalCosts && Number(totalCosts) > 0) {
     highlightedAttributes.push({
       name: t('Cost'),
-      value: formatLLMCosts(totalCosts),
+      value: <LLMCosts cost={totalCosts} />,
     });
   }
 


### PR DESCRIPTION
Render sub-cent cost as `<$0.01` with a native tooltip to display the precise amount, as we do for abbreviated numbers.
![Screenshot 2025-07-01 at 08 23 09](https://github.com/user-attachments/assets/c0c8ae20-855f-4665-9f18-f8ddfee4ea70)

- closes [TET-740: Consider changing $0.0000704 to <$0.01 + tooltip with full value on hover](https://linear.app/getsentry/issue/TET-740/consider-changing-dollar00000704-to-dollar001-tooltip-with-full-value)