### PR TITLE
feat(agent-monitoring): Display project name in onboarding

### DIFF
--- a/static/app/views/insights/agentMonitoring/views/onboarding.tsx
+++ b/static/app/views/insights/agentMonitoring/views/onboarding.tsx
@@ -25,6 +25,7 @@ import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingSt
 import {useLoadGettingStarted} from 'sentry/components/onboarding/gettingStartedDoc/utils/useLoadGettingStarted';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
+import {SetupTitle} from 'sentry/components/updatedEmptyState';
 import {agentMonitoringPlatforms} from 'sentry/data/platformCategories';
 import platforms, {otherPlatform} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
@@ -328,7 +329,7 @@ export function Onboarding() {
 
   return (
     <OnboardingPanel project={project}>
-      <BodyTitle>{t('Set up the Sentry SDK')}</BodyTitle>
+      <SetupTitle project={project} />
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <GuidedSteps>
         {steps


### PR DESCRIPTION
- closes [TET-743: Display project name in onboarding](https://linear.app/getsentry/issue/TET-743/display-project-name-in-onboarding)