### PR TITLE
feat(ai): Add models.dev as a second source of model costs

### DIFF
--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any
 
-import sentry_sdk
-
 from sentry.http import safe_urlopen
 from sentry.relay.config.ai_model_costs import (
     AI_MODEL_COSTS_CACHE_KEY,
@@ -55,7 +53,9 @@ def fetch_ai_model_costs() -> None:
         openrouter_models = _fetch_openrouter_models()
         models_dict.update(openrouter_models)
     except Exception as e:
-        sentry_sdk.capture_message(str(e), level="warning")
+        logger.warning(
+            "Failed to fetch AI model costs from OpenRouter API", extra={"error": str(e)}
+        )
         # re-raise to fail the task
         raise
 
@@ -68,7 +68,9 @@ def fetch_ai_model_costs() -> None:
                 models_dict[model_id] = model_cost
 
     except Exception as e:
-        sentry_sdk.capture_message(str(e), level="warning")
+        logger.warning(
+            "Failed to fetch AI model costs from models.dev API", extra={"error": str(e)}
+        )
         # re-raise to fail the task
         raise
 

--- a/tests/sentry/tasks/test_ai_agent_monitoring.py
+++ b/tests/sentry/tasks/test_ai_agent_monitoring.py
@@ -2,7 +2,11 @@ import pytest
 import responses
 
 from sentry.relay.config.ai_model_costs import AI_MODEL_COSTS_CACHE_KEY, AIModelCosts
-from sentry.tasks.ai_agent_monitoring import OPENROUTER_MODELS_API_URL, fetch_ai_model_costs
+from sentry.tasks.ai_agent_monitoring import (
+    MODELS_DEV_API_URL,
+    OPENROUTER_MODELS_API_URL,
+    fetch_ai_model_costs,
+)
 from sentry.testutils.cases import TestCase
 from sentry.utils.cache import cache
 
@@ -105,6 +109,39 @@ MOCK_OPENROUTER_API_RESPONSE = {
     ]
 }
 
+MOCK_MODELS_DEV_API_RESPONSE = {
+    "openai": {
+        "models": {
+            "gpt-4.1-mini": {
+                "cost": {
+                    "input": 0.4,
+                    "output": 1.6,
+                    "cache_read": 0.1,
+                }
+            },
+            "gpt-4": {  # This should be skipped since it exists in OpenRouter
+                "cost": {
+                    "input": 0.1,  # Different from OpenRouter price
+                    "output": 0.2,
+                    "cache_read": 0.05,
+                }
+            },
+        }
+    },
+    "google": {
+        "models": {
+            "gemini-2.5-pro": {
+                "cost": {
+                    "input": 1.25,
+                    "output": 10,
+                    "cache_read": 0.31,
+                }
+            },
+        }
+    },
+    "invalid_provider": "this should be ignored",
+}
+
 
 class FetchAIModelCostsTest(TestCase):
     def setUp(self):
@@ -120,10 +157,70 @@ class FetchAIModelCostsTest(TestCase):
             status=200,
         )
 
+    def _mock_models_dev_api_response(self, mock_response: dict):
+        responses.add(
+            responses.GET,
+            MODELS_DEV_API_URL,
+            json=mock_response,
+            status=200,
+        )
+
     @responses.activate
-    def test_fetch_ai_model_costs_success(self):
-        """Test successful fetching and caching of AI model costs"""
+    def test_fetch_ai_model_costs_success_both_apis(self):
+        """Test successful fetching and caching from both APIs"""
         self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
+        self._mock_models_dev_api_response(MOCK_MODELS_DEV_API_RESPONSE)
+
+        fetch_ai_model_costs()
+
+        # Verify the data was cached correctly
+        cached_data = _get_ai_model_costs_from_cache()
+        assert cached_data is not None
+        assert cached_data.get("version") == 2
+        assert cached_data.get("costs") is None
+        assert cached_data.get("models") is not None
+
+        models = cached_data.get("models")
+        assert models is not None
+        # Should have OpenRouter models + unique models.dev models
+        assert (
+            len(models) == 4
+        )  # gpt-4, gpt-5 from OpenRouter + gpt-4.1-mini, gemini-2.5-pro from models.dev
+
+        # Check OpenRouter models
+        gpt4_model = models["gpt-4"]
+        assert gpt4_model.get("inputPerToken") == 0.0000003  # OpenRouter price, not models.dev
+        assert gpt4_model.get("outputPerToken") == 0.00000165
+        assert gpt4_model.get("outputReasoningPerToken") == 0.0
+        assert gpt4_model.get("inputCachedPerToken") == 0.0
+
+        gpt5_model = models["gpt-5"]
+        assert gpt5_model.get("inputPerToken") == 0.00000055
+        assert gpt5_model.get("outputPerToken") == 0.0000022
+        assert gpt5_model.get("outputReasoningPerToken") == 0.00000055
+        assert gpt5_model.get("inputCachedPerToken") == 0.00000055
+
+        # Check models.dev models
+        gpt41_mini_model = models["gpt-4.1-mini"]
+        assert gpt41_mini_model.get("inputPerToken") == 0.4
+        assert gpt41_mini_model.get("outputPerToken") == 1.6
+        assert (
+            gpt41_mini_model.get("outputReasoningPerToken") == 0.0
+        )  # models.dev doesn't provide this
+        assert gpt41_mini_model.get("inputCachedPerToken") == 0.1
+
+        gemini_model = models["gemini-2.5-pro"]
+        assert gemini_model.get("inputPerToken") == 1.25
+        assert gemini_model.get("outputPerToken") == 10
+        assert gemini_model.get("outputReasoningPerToken") == 0.0
+        assert gemini_model.get("inputCachedPerToken") == 0.31
+
+    @responses.activate
+    def test_fetch_ai_model_costs_success_openrouter_only(self):
+        """Test successful fetching when only OpenRouter succeeds"""
+        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
+        # Also mock models.dev to return empty response to avoid real network call
+        self._mock_models_dev_api_response({})
 
         fetch_ai_model_costs()
 
@@ -155,7 +252,7 @@ class FetchAIModelCostsTest(TestCase):
     @responses.activate
     def test_fetch_ai_model_costs_missing_pricing(self):
         """Test handling of models with missing pricing data"""
-        mock_response = {
+        mock_openrouter_response = {
             "data": [
                 {
                     "id": "openai/gpt-4",
@@ -178,12 +275,24 @@ class FetchAIModelCostsTest(TestCase):
             ]
         }
 
-        responses.add(
-            responses.GET,
-            OPENROUTER_MODELS_API_URL,
-            json=mock_response,
-            status=200,
-        )
+        mock_models_dev_response = {
+            "provider": {
+                "models": {
+                    "model-with-pricing": {
+                        "cost": {
+                            "input": 0.1,
+                            "output": 0.2,
+                        }
+                    },
+                    "model-no-cost": {
+                        # Missing cost field
+                    },
+                }
+            }
+        }
+
+        self._mock_openrouter_api_response(mock_openrouter_response)
+        self._mock_models_dev_api_response(mock_models_dev_response)
 
         fetch_ai_model_costs()
 
@@ -192,7 +301,7 @@ class FetchAIModelCostsTest(TestCase):
         assert cached_data is not None
         models = cached_data.get("models")
         assert models is not None
-        assert len(models) == 3
+        assert len(models) == 4  # 3 from OpenRouter + 1 valid from models.dev
 
         # Check valid model
         gpt4_model = models["gpt-4"]
@@ -213,28 +322,52 @@ class FetchAIModelCostsTest(TestCase):
         assert no_pricing_model.get("outputReasoningPerToken") == 0.0
         assert no_pricing_model.get("inputCachedPerToken") == 0.0
 
+        # Check models.dev model
+        models_dev_model = models["model-with-pricing"]
+        assert models_dev_model.get("inputPerToken") == 0.1
+        assert models_dev_model.get("outputPerToken") == 0.2
+        assert models_dev_model.get("outputReasoningPerToken") == 0.0
+        assert models_dev_model.get("inputCachedPerToken") == 0.0
+
     @responses.activate
-    def test_fetch_ai_model_costs_invalid_response_format(self):
-        """Test handling of invalid API response format"""
+    def test_fetch_ai_model_costs_openrouter_invalid_response(self):
+        """Test handling of invalid OpenRouter API response format"""
         # Invalid response - missing 'data' field
         mock_response = {"invalid": "response"}
 
-        responses.add(
-            responses.GET,
-            OPENROUTER_MODELS_API_URL,
-            json=mock_response,
-            status=200,
-        )
+        self._mock_openrouter_api_response(mock_response)
 
-        fetch_ai_model_costs()
+        with pytest.raises(ValueError, match="Invalid OpenRouter response format"):
+            fetch_ai_model_costs()
 
         # Verify nothing was cached
         cached_data = _get_ai_model_costs_from_cache()
         assert cached_data is None
 
     @responses.activate
-    def test_fetch_ai_model_costs_http_error(self):
-        """Test handling of HTTP errors"""
+    def test_fetch_ai_model_costs_models_dev_invalid_response(self):
+        """Test handling of invalid models.dev API response format"""
+        # Valid OpenRouter response
+        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
+
+        # Invalid models.dev response - not a dict
+        responses.add(
+            responses.GET,
+            MODELS_DEV_API_URL,
+            json=["not", "a", "dict"],
+            status=200,
+        )
+
+        with pytest.raises(ValueError, match="Invalid models.dev response format"):
+            fetch_ai_model_costs()
+
+        # Verify nothing was cached due to models.dev failure
+        cached_data = _get_ai_model_costs_from_cache()
+        assert cached_data is None
+
+    @responses.activate
+    def test_fetch_ai_model_costs_openrouter_http_error(self):
+        """Test handling of OpenRouter HTTP errors"""
         responses.add(
             responses.GET,
             OPENROUTER_MODELS_API_URL,
@@ -245,6 +378,26 @@ class FetchAIModelCostsTest(TestCase):
             fetch_ai_model_costs()
 
         # Verify nothing was cached
+        cached_data = _get_ai_model_costs_from_cache()
+        assert cached_data is None
+
+    @responses.activate
+    def test_fetch_ai_model_costs_models_dev_http_error(self):
+        """Test handling of models.dev HTTP errors"""
+        # Valid OpenRouter response
+        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
+
+        # models.dev API error
+        responses.add(
+            responses.GET,
+            MODELS_DEV_API_URL,
+            status=500,
+        )
+
+        with pytest.raises(Exception):
+            fetch_ai_model_costs()
+
+        # Verify nothing was cached due to models.dev failure
         cached_data = _get_ai_model_costs_from_cache()
         assert cached_data is None
 


### PR DESCRIPTION
Adds models.dev as a source for fetching AI costs.

It still first tries to fetch prices from OpenRouter API, and only if the model is not available there, it will be added to the cost list from models.dev.

If any of the fetching fails, the task should also fail, we will get the Sentry error, and examine what happened. We don't want to end up in the state where we can't fetch info about some models, because that would mean that we would silently stop supporting them. Prices are cached for 30 days, which gives us enough time to fix the reason of the fetching failure.

Closes [TET-730: Use models.dev also as a source for pricing](https://linear.app/getsentry/issue/TET-730/use-modelsdev-also-as-a-source-for-pricing)