### PR TITLE
feat: Add visual feedback for loader script & describe defaults

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -105,7 +105,10 @@ export interface OnboardingConfig<
       onPlatformOptionsChange?: (
         platformOptions: SelectedPlatformOptions<PlatformOptions>
       ) => void;
-      onProductSelectionChange?: (products: ProductSolution[]) => void;
+      onProductSelectionChange?: (params: {
+        previousProducts: ProductSolution[];
+        products: ProductSolution[];
+      }) => void;
       onProductSelectionLoad?: (products: ProductSolution[]) => void;
     },
     DocsParams<PlatformOptions>

--- a/static/app/components/onboarding/productSelection.spec.tsx
+++ b/static/app/components/onboarding/productSelection.spec.tsx
@@ -248,7 +248,10 @@ describe('Onboarding Product Selection', function () {
     );
 
     await userEvent.click(screen.getByRole('presentation', {name: 'Profiling'}));
-    expect(handleChange).toHaveBeenCalledWith(['performance-monitoring', 'profiling']);
+    expect(handleChange).toHaveBeenCalledWith({
+      previousProducts: ['performance-monitoring'],
+      products: ['performance-monitoring', 'profiling'],
+    });
   });
 
   it('does not overwrite URL products if others are present', function () {

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -298,7 +298,10 @@ export type ProductSelectionProps = {
   /**
    * Fired when the product selection changes
    */
-  onChange?: (products: ProductSolution[]) => void;
+  onChange?: (params: {
+    previousProducts: ProductSolution[];
+    products: ProductSolution[];
+  }) => void;
   /**
    * Triggered when the component is loaded
    */
@@ -365,7 +368,10 @@ export function ProductSelection({
 
       const selectedProducts = Array.from(newProduct);
 
-      onChange?.(selectedProducts);
+      onChange?.({
+        previousProducts: urlProducts as ProductSolution[],
+        products: selectedProducts,
+      });
       setParams({product: selectedProducts});
     },
     [products, setParams, urlProducts, onChange]

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -472,9 +472,7 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: (
-        <Fragment>{t('Add this script tag to the top of the page:')}</Fragment>
-      ),
+      description: t('Add this script tag to the top of the page:'),
       configurations: [
         {
           language: 'html',

--- a/static/app/gettingStartedDocs/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/javascript.tsx
@@ -1,7 +1,9 @@
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 
 import {SdkProviderEnum as FeatureFlagProviderEnum} from 'sentry/components/events/featureFlags/utils';
 import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
 import {buildSdkConfig} from 'sentry/components/onboarding/gettingStartedDoc/buildSdkConfig';
 import crashReportCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/crashReportCallout';
 import widgetCallout from 'sentry/components/onboarding/gettingStartedDoc/feedback/widgetCallout';
@@ -470,7 +472,9 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   install: params => [
     {
       type: StepType.INSTALL,
-      description: t('Add this script tag to the top of the page:'),
+      description: (
+        <Fragment>{t('Add this script tag to the top of the page:')}</Fragment>
+      ),
       configurations: [
         {
           language: 'html',
@@ -488,6 +492,41 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
           ],
         },
       ],
+      additionalInfo: (
+        <Fragment>
+          <h5>{t('Default Configuration')}</h5>
+          <p>
+            {t(
+              'The Loader Script settings are automatically updated based on the product selection above. Toggling products will dynamically configure the SDK defaults.'
+            )}
+          </p>
+          <p>
+            {tct(
+              'For Tracing, the SDK is initialized with [code:tracesSampleRate: 1], meaning all traces will be captured.',
+              {
+                code: <code />,
+              }
+            )}
+          </p>
+          <p>
+            {tct(
+              'For Session Replay, the default rates are [code:replaysSessionSampleRate: 0.1] and [code:replaysOnErrorSampleRate: 1]. This captures 10% of regular sessions and 100% of sessions with an error.',
+              {
+                code: <code />,
+              }
+            )}
+          </p>
+          <p>
+            {tct('You can review or change these settings in [link:Project Settings].', {
+              link: (
+                <Link
+                  to={`/settings/${params.organization.slug}/projects/${params.projectSlug}/loader-script/`}
+                />
+              ),
+            })}
+          </p>
+        </Fragment>
+      ),
     },
   ],
   configure: params => [
@@ -574,11 +613,12 @@ const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
     };
   },
   onProductSelectionChange: params => {
-    return products => {
+    return ({previousProducts, products}) => {
       updateDynamicSdkLoaderOptions({
         orgSlug: params.organization.slug,
         projectSlug: params.projectSlug,
         products,
+        previousProducts,
         projectKey: params.projectKeyId,
         api: params.api,
       });
@@ -654,7 +694,7 @@ const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
     };
   },
   onProductSelectionChange: params => {
-    return products => {
+    return ({products}) => {
       updateDynamicSdkLoaderOptions({
         orgSlug: params.organization.slug,
         projectSlug: params.projectSlug,

--- a/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
@@ -22,7 +22,7 @@ const getInstallConfig = (params: Params) => [
     type: StepType.INSTALL,
     configurations: [
       {
-        description: t('Add this script tag to the top of the pageA:'),
+        description: t('Add this script tag to the top of the page:'),
         language: 'html',
         code: beautify.html(
           `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,
@@ -65,7 +65,7 @@ const feedbackOnboardingJsLoader: OnboardingConfig = {
       type: StepType.INSTALL,
       configurations: [
         {
-          description: t('Add this script tag to the top of the pageB:'),
+          description: t('Add this script tag to the top of the page:'),
           language: 'html',
           code: beautify.html(
             `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,

--- a/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/jsLoader.tsx
@@ -22,7 +22,7 @@ const getInstallConfig = (params: Params) => [
     type: StepType.INSTALL,
     configurations: [
       {
-        description: t('Add this script tag to the top of the page:'),
+        description: t('Add this script tag to the top of the pageA:'),
         language: 'html',
         code: beautify.html(
           `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,
@@ -65,7 +65,7 @@ const feedbackOnboardingJsLoader: OnboardingConfig = {
       type: StepType.INSTALL,
       configurations: [
         {
-          description: t('Add this script tag to the top of the page:'),
+          description: t('Add this script tag to the top of the pageB:'),
           language: 'html',
           code: beautify.html(
             `<script src="${params.dsn.cdn}" crossorigin="anonymous"></script>`,

--- a/static/app/gettingStartedDocs/javascript/jsLoader/updateDynamicSdkLoaderOptions.ts
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/updateDynamicSdkLoaderOptions.ts
@@ -1,3 +1,4 @@
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {Client} from 'sentry/api';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t} from 'sentry/locale';
@@ -5,46 +6,95 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project, ProjectKey} from 'sentry/types/project';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 
+const PRODUCT_MESSAGES = {
+  [ProductSolution.PERFORMANCE_MONITORING]: {
+    enabled: t('Enabled Tracing in the Loader Script Config'),
+    disabled: t('Disabled Tracing in the Loader Script Config'),
+    enableError: t('Failed to enable Tracing in the Loader Script Config'),
+    disableError: t('Failed to disable Tracing in the Loader Script Config'),
+  },
+  [ProductSolution.SESSION_REPLAY]: {
+    enabled: t('Enabled Session Replay in the Loader Script Config'),
+    disabled: t('Disabled Session Replay in the Loader Script Config'),
+    enableError: t('Failed to enable Session Replay in the Loader Script Config'),
+    disableError: t('Failed to disable Session Replay in the Loader Script Config'),
+  },
+  [ProductSolution.PROFILING]: {
+    enabled: t('Enabled Profiling in the Loader Script Config'),
+    disabled: t('Disabled Profiling in the Loader Script Config'),
+    enableError: t('Failed to enable Profiling in the Loader Script Config'),
+    disableError: t('Failed to disable Profiling in the Loader Script Config'),
+  },
+};
+
+function addProductMessage(
+  products: ProductSolution[],
+  previousProducts?: ProductSolution[],
+  isError = false
+) {
+  if (!previousProducts) {
+    return;
+  }
+
+  const previousSet = new Set(previousProducts);
+
+  const toggledProduct =
+    products.find(product => !previousSet.has(product)) ||
+    previousProducts.find(product => !new Set(products).has(product));
+
+  if (!toggledProduct) {
+    return;
+  }
+
+  const messages = PRODUCT_MESSAGES[toggledProduct as keyof typeof PRODUCT_MESSAGES];
+
+  if (!messages) {
+    return;
+  }
+
+  const isEnabled = products.includes(toggledProduct);
+
+  if (isError) {
+    addErrorMessage(isEnabled ? messages.enableError : messages.disableError);
+  } else {
+    addSuccessMessage(isEnabled ? messages.enabled : messages.disabled);
+  }
+}
+
 export async function updateDynamicSdkLoaderOptions({
   orgSlug,
   projectSlug,
   products,
   api,
   projectKey,
+  previousProducts,
 }: {
   api: Client;
   orgSlug: Organization['slug'];
+  products: ProductSolution[];
   projectKey: ProjectKey['id'];
   projectSlug: Project['slug'];
-  products?: ProductSolution[];
+  previousProducts?: ProductSolution[];
 }) {
-  const newDynamicSdkLoaderOptions: ProjectKey['dynamicSdkLoaderOptions'] = {
-    hasPerformance: false,
-    hasReplay: false,
-    hasDebug: false,
-  };
-
-  (products ?? []).forEach(product => {
-    // eslint-disable-next-line default-case
-    switch (product) {
-      case ProductSolution.PERFORMANCE_MONITORING:
-        newDynamicSdkLoaderOptions.hasPerformance = true;
-        break;
-      case ProductSolution.SESSION_REPLAY:
-        newDynamicSdkLoaderOptions.hasReplay = true;
-        break;
-    }
-  });
-
   try {
     await api.requestPromise(`/projects/${orgSlug}/${projectSlug}/keys/${projectKey}/`, {
       method: 'PUT',
       data: {
-        dynamicSdkLoaderOptions: newDynamicSdkLoaderOptions,
+        dynamicSdkLoaderOptions: {
+          hasPerformance: products.includes(ProductSolution.PERFORMANCE_MONITORING),
+          hasReplay: products.includes(ProductSolution.SESSION_REPLAY),
+          hasDebug: false,
+        },
       },
     });
+
+    addProductMessage(products, previousProducts);
   } catch (error) {
-    const message = t('Unable to dynamically update the SDK loader configuration');
-    handleXhrErrorResponse(message, error);
+    addProductMessage(products, previousProducts, true);
+
+    handleXhrErrorResponse(
+      'Unable to dynamically update the SDK loader configuration',
+      error
+    );
   }
 }


### PR DESCRIPTION
**Problem**
In the onboarding flow, when users select the Browser JavaScript SDK, we show the Loader Script by default.

When users toggle products like Tracing or Session Replay, we automatically update the Loader Script settings behind the scenes. But users don’t get any feedback, so they don’t know this is happening.

**Solution**
Display a toast notification when the Loader Script updates. Example messages:

“Enabled Session Replay in the Loader Configuration”

“Disabled Tracing in the Loader Configuration”

This makes it clear to users that their actions changed the Loader settings.

We also updated the Loader Script description to mention the default sample rates for Tracing and Session Replay.

**Before**


https://github.com/user-attachments/assets/7853e465-457e-45b0-843e-56803cfbf347




**After**

https://github.com/user-attachments/assets/d84a08af-06cd-4c6f-910a-daecfd1a5da5



closes https://linear.app/getsentry/issue/TET-734/expand-configure-sdk-optional-step-for-tracingreplay