### PR TITLE
fix(aci): Display skeleton with max of automation rows

### DIFF
--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -28,26 +28,24 @@ type Props = {
 function Skeletons({canEdit, numberOfRows}: {canEdit: boolean; numberOfRows: number}) {
   return (
     <Fragment>
-      {Array.from({length: Math.min(numberOfRows, AUTOMATIONS_PER_PAGE)}).map(
-        (_, index) => (
-          <SimpleTable.Row key={index}>
-            <SimpleTable.RowCell>
+      {Array.from({length: numberOfRows}).map((_, index) => (
+        <SimpleTable.Row key={index}>
+          <SimpleTable.RowCell>
+            <Placeholder height="20px" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell data-column-name="last-triggered">
+            <Placeholder height="20px" />
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell data-column-name="action-filters">
+            <Placeholder height="20px" />
+          </SimpleTable.RowCell>
+          {canEdit && (
+            <SimpleTable.RowCell data-column-name="connected">
               <Placeholder height="20px" />
             </SimpleTable.RowCell>
-            <SimpleTable.RowCell data-column-name="last-triggered">
-              <Placeholder height="20px" />
-            </SimpleTable.RowCell>
-            <SimpleTable.RowCell data-column-name="action-filters">
-              <Placeholder height="20px" />
-            </SimpleTable.RowCell>
-            {canEdit && (
-              <SimpleTable.RowCell data-column-name="connected">
-                <Placeholder height="20px" />
-              </SimpleTable.RowCell>
-            )}
-          </SimpleTable.Row>
-        )
-      )}
+          )}
+        </SimpleTable.Row>
+      ))}
     </Fragment>
   );
 }
@@ -92,7 +90,12 @@ export function ConnectedAutomationsList({
           </SimpleTable.HeaderCell>
           {canEdit && <SimpleTable.HeaderCell data-column-name="connected" />}
         </SimpleTable.Header>
-        {isLoading && <Skeletons canEdit={canEdit} numberOfRows={automationIds.length} />}
+        {isLoading && (
+          <Skeletons
+            canEdit={canEdit}
+            numberOfRows={Math.min(automationIds.length, AUTOMATIONS_PER_PAGE)}
+          />
+        )}
         {isError && <LoadingError />}
         {automationIds.length === 0 && (
           <SimpleTable.Empty>{t('No automations connected')}</SimpleTable.Empty>

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -25,27 +25,29 @@ type Props = {
   toggleConnected?: (id: string) => void;
 };
 
-function Skeletons({canEdit}: {canEdit: boolean}) {
+function Skeletons({canEdit, numberOfRows}: {canEdit: boolean; numberOfRows: number}) {
   return (
     <Fragment>
-      {Array.from({length: AUTOMATIONS_PER_PAGE}).map((_, index) => (
-        <SimpleTable.Row key={index}>
-          <SimpleTable.RowCell>
-            <Placeholder height="20px" />
-          </SimpleTable.RowCell>
-          <SimpleTable.RowCell data-column-name="last-triggered">
-            <Placeholder height="20px" />
-          </SimpleTable.RowCell>
-          <SimpleTable.RowCell data-column-name="action-filters">
-            <Placeholder height="20px" />
-          </SimpleTable.RowCell>
-          {canEdit && (
-            <SimpleTable.RowCell data-column-name="connected">
+      {Array.from({length: Math.min(numberOfRows, AUTOMATIONS_PER_PAGE)}).map(
+        (_, index) => (
+          <SimpleTable.Row key={index}>
+            <SimpleTable.RowCell>
               <Placeholder height="20px" />
             </SimpleTable.RowCell>
-          )}
-        </SimpleTable.Row>
-      ))}
+            <SimpleTable.RowCell data-column-name="last-triggered">
+              <Placeholder height="20px" />
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell data-column-name="action-filters">
+              <Placeholder height="20px" />
+            </SimpleTable.RowCell>
+            {canEdit && (
+              <SimpleTable.RowCell data-column-name="connected">
+                <Placeholder height="20px" />
+              </SimpleTable.RowCell>
+            )}
+          </SimpleTable.Row>
+        )
+      )}
     </Fragment>
   );
 }
@@ -90,7 +92,7 @@ export function ConnectedAutomationsList({
           </SimpleTable.HeaderCell>
           {canEdit && <SimpleTable.HeaderCell data-column-name="connected" />}
         </SimpleTable.Header>
-        {isLoading && <Skeletons canEdit={canEdit} />}
+        {isLoading && <Skeletons canEdit={canEdit} numberOfRows={automationIds.length} />}
         {isError && <LoadingError />}
         {automationIds.length === 0 && (
           <SimpleTable.Empty>{t('No automations connected')}</SimpleTable.Empty>


### PR DESCRIPTION
Instead of showing 10 rows, show 2 rows in the skeleton if there are only 2 automation ids
