### PR TITLE
feat(ui2): combine UI2 opt-in with stacked nav

### DIFF
--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -121,7 +121,6 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                     onClick={() => {
                       mutateUserOptions({
                         prefersChonkUI: false,
-                        prefersStackedNavigation: false,
                       });
                       trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
                         organization,

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -127,7 +127,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                       });
                     }}
                   >
-                    {t('Switch back to old UI')}
+                    {t('Switch back to old Sentry')}
                   </SidebarMenuItem>
                 ) : (
                   <SidebarMenuItem
@@ -141,7 +141,7 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                       });
                     }}
                   >
-                    {t('Try the new UI')} <FeatureBadge type="beta" />
+                    {t('Try the new Sentry')} <FeatureBadge type="beta" />
                   </SidebarMenuItem>
                 )
               ) : null}

--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -98,43 +98,51 @@ function SidebarHelp({orientation, collapsed, hidePanel, organization}: Props) {
                   {t('Give Feedback')}
                 </SidebarMenuItem>
               ) : null}
-              {organization?.features?.includes('navigation-sidebar-v2') && (
-                <SidebarMenuItem
-                  onClick={() => {
-                    mutateUserOptions({prefersStackedNavigation: true});
-                    trackAnalytics(
-                      'navigation.help_menu_opt_in_stacked_navigation_clicked',
-                      {
-                        organization,
-                      }
-                    );
-                  }}
-                >
-                  {t('Try New Navigation')} <FeatureBadge type="new" />
-                </SidebarMenuItem>
-              )}
-              {organization?.features?.includes('chonk-ui') ? (
+              {organization?.features?.includes('navigation-sidebar-v2') &&
+                !organization?.features?.includes('chonk-ui') && (
+                  <SidebarMenuItem
+                    onClick={() => {
+                      mutateUserOptions({prefersStackedNavigation: true});
+                      trackAnalytics(
+                        'navigation.help_menu_opt_in_stacked_navigation_clicked',
+                        {
+                          organization,
+                        }
+                      );
+                    }}
+                  >
+                    {t('Try New Navigation')} <FeatureBadge type="new" />
+                  </SidebarMenuItem>
+                )}
+              {organization?.features?.includes('navigation-sidebar-v2') &&
+              organization?.features?.includes('chonk-ui') ? (
                 user.options.prefersChonkUI ? (
                   <SidebarMenuItem
                     onClick={() => {
-                      mutateUserOptions({prefersChonkUI: false});
+                      mutateUserOptions({
+                        prefersChonkUI: false,
+                        prefersStackedNavigation: false,
+                      });
                       trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
                         organization,
                       });
                     }}
                   >
-                    {t('Switch Back To Our Old Look')}
+                    {t('Switch back to old UI')}
                   </SidebarMenuItem>
                 ) : (
                   <SidebarMenuItem
                     onClick={() => {
-                      mutateUserOptions({prefersChonkUI: true});
+                      mutateUserOptions({
+                        prefersChonkUI: true,
+                        prefersStackedNavigation: true,
+                      });
                       trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {
                         organization,
                       });
                     }}
                   >
-                    {t('Try Our New Look')} <FeatureBadge type="beta" />
+                    {t('Try the new UI')} <FeatureBadge type="beta" />
                   </SidebarMenuItem>
                 )
               ) : null}

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -486,7 +486,7 @@ describe('Nav', function () {
           const helpMenu = screen.getByRole('button', {name: 'Help'});
           await userEvent.click(helpMenu);
 
-          expect(screen.getByText('Try the new UI')).toBeInTheDocument();
+          expect(screen.getByText('Try the new Sentry')).toBeInTheDocument();
 
           // Once for banner, once for dot indicator
           expect(dismissRequest).toHaveBeenCalledTimes(2);
@@ -505,7 +505,7 @@ describe('Nav', function () {
           const helpMenu = screen.getByRole('button', {name: 'Help'});
           await userEvent.click(helpMenu);
 
-          expect(screen.getByText('Switch back to old UI')).toBeInTheDocument();
+          expect(screen.getByText('Switch back to old Sentry')).toBeInTheDocument();
         });
       });
 
@@ -520,7 +520,7 @@ describe('Nav', function () {
           const helpMenu = screen.getByRole('button', {name: 'Help'});
           await userEvent.click(helpMenu);
 
-          expect(screen.queryByText('Try the new UI')).not.toBeInTheDocument();
+          expect(screen.queryByText('Try the new Sentry')).not.toBeInTheDocument();
         });
       });
     });

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -486,7 +486,7 @@ describe('Nav', function () {
           const helpMenu = screen.getByRole('button', {name: 'Help'});
           await userEvent.click(helpMenu);
 
-          expect(screen.getByText('Try our new look')).toBeInTheDocument();
+          expect(screen.getByText('Try the new UI')).toBeInTheDocument();
 
           // Once for banner, once for dot indicator
           expect(dismissRequest).toHaveBeenCalledTimes(2);
@@ -505,7 +505,7 @@ describe('Nav', function () {
           const helpMenu = screen.getByRole('button', {name: 'Help'});
           await userEvent.click(helpMenu);
 
-          expect(screen.getByText('Switch back to our old look')).toBeInTheDocument();
+          expect(screen.getByText('Switch back to old UI')).toBeInTheDocument();
         });
       });
 
@@ -520,7 +520,7 @@ describe('Nav', function () {
           const helpMenu = screen.getByRole('button', {name: 'Help'});
           await userEvent.click(helpMenu);
 
-          expect(screen.queryByText('Try our new look')).not.toBeInTheDocument();
+          expect(screen.queryByText('Try the new UI')).not.toBeInTheDocument();
         });
       });
     });

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -150,10 +150,10 @@ export function PrimaryNavigationHelp() {
                       key: 'new-chonk-ui',
                       label: (
                         <Fragment>
-                          {t('Try the new UI')} <FeatureBadge type="beta" />
+                          {t('Try the new Sentry')} <FeatureBadge type="beta" />
                         </Fragment>
                       ),
-                      textValue: t('Try the new UI'),
+                      textValue: t('Try the new Sentry'),
                       onAction() {
                         mutateUserOptions({prefersChonkUI: true});
                         trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {

--- a/static/app/views/nav/primary/help.tsx
+++ b/static/app/views/nav/primary/help.tsx
@@ -131,26 +131,16 @@ export function PrimaryNavigationHelp() {
                   startTour();
                 },
               },
-              {
-                key: 'new-ui',
-                label: t('Switch to old navigation'),
-                onAction() {
-                  mutateUserOptions({prefersStackedNavigation: false});
-                  trackAnalytics(
-                    'navigation.help_menu_opt_out_stacked_navigation_clicked',
-                    {
-                      organization,
-                    }
-                  );
-                },
-              },
               organization?.features?.includes('chonk-ui')
                 ? user.options.prefersChonkUI
                   ? {
                       key: 'new-chonk-ui',
-                      label: t('Switch back to our old look'),
+                      label: t('Switch back to old UI'),
                       onAction() {
-                        mutateUserOptions({prefersChonkUI: false});
+                        mutateUserOptions({
+                          prefersChonkUI: false,
+                          prefersStackedNavigation: false,
+                        });
                         trackAnalytics('navigation.help_menu_opt_out_chonk_ui_clicked', {
                           organization,
                         });
@@ -160,10 +150,10 @@ export function PrimaryNavigationHelp() {
                       key: 'new-chonk-ui',
                       label: (
                         <Fragment>
-                          {t('Try our new look')} <FeatureBadge type="beta" />
+                          {t('Try the new UI')} <FeatureBadge type="beta" />
                         </Fragment>
                       ),
-                      textValue: 'Try our new look',
+                      textValue: t('Try the new UI'),
                       onAction() {
                         mutateUserOptions({prefersChonkUI: true});
                         trackAnalytics('navigation.help_menu_opt_in_chonk_ui_clicked', {


### PR DESCRIPTION
Adjusting our opt-in experience for UI2 as a follow-up to #94710.

One uncontroversial change here:
- Update the copy from "Try our new look" to "Try the new UI" / "Switch back to old UI"

Slightly more controversial change, but one that would reduce some indirection from a user perspective:
- Combine the `prefersChonkUI` and `prefersStackedNavigation` user preferences under a single item when an org has both flags (cc @malwilley @JonasBa)

|  | before | after |
|--|--------|--------|
| **opt-in** | <img width="265" alt="optin-before" src="https://github.com/user-attachments/assets/9bd2b3c8-272b-4b9f-9a51-5e0c2347fb1a" /> | <img width="290" alt="optin-after" src="https://github.com/user-attachments/assets/464c9562-22e5-4a70-aafd-c8fd01acfc8c" /> |
| **opt-out** | <img width="309" alt="optout-before" src="https://github.com/user-attachments/assets/4d84d6d4-060a-446f-b29a-3a0218304e75" /> | <img width="331" alt="optout-after" src="https://github.com/user-attachments/assets/27c7e891-5c5e-4494-8e69-90c063395ef8" /> |