### PR TITLE
:wrench: chore: add `event_type` to SnubaQuery Serializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/query_subscription.py
+++ b/src/sentry/incidents/endpoints/serializers/query_subscription.py
@@ -26,6 +26,7 @@ class SnubaQuerySerializer(Serializer):
             "aggregate": obj.aggregate,
             "timeWindow": obj.time_window,
             "environment": obj.environment.name if obj.environment else None,
+            "eventTypes": [event_type.name.lower() for event_type in obj.event_types],
         }
 
 


### PR DESCRIPTION
adding this information into the serializer will allow us to distinguish spans and logs datasets