### PR TITLE
ref(flags): Remove beta label from ff settings navigation item

### DIFF
--- a/static/app/views/settings/organization/navigationConfiguration.tsx
+++ b/static/app/views/settings/organization/navigationConfiguration.tsx
@@ -138,14 +138,6 @@ export function getOrganizationNavigationConfiguration({
           path: `${organizationSettingsPathPrefix}/feature-flags/`,
           title: t('Feature Flags'),
           description: t('Set up feature flag integrations'),
-          badge: () => (
-            <FeatureBadge
-              type="beta"
-              tooltipProps={{
-                title: t('This feature is currently in open beta and may change'),
-              }}
-            />
-          ),
         },
         {
           path: `${organizationSettingsPathPrefix}/stats/`,

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -175,7 +175,6 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           path: `${organizationSettingsPathPrefix}/feature-flags/`,
           title: t('Feature Flags'),
           description: t('Set up feature flag integrations'),
-          badge: () => 'beta',
         },
       ],
     },


### PR DESCRIPTION
Remove this from settings sidebar
![Screenshot 2025-07-01 at 12 09 02 PM](https://github.com/user-attachments/assets/c2c034ba-ceb9-4d4e-a295-e61dbb43a00a)
