### PR TITLE
orgpicker: fix mobile

### DIFF
--- a/static/app/utils/useOnClickOutside.tsx
+++ b/static/app/utils/useOnClickOutside.tsx
@@ -1,41 +1,37 @@
-import {useEffect} from 'react';
+import {useLayoutEffect} from 'react';
 
 // hook from https://usehooks.com/useOnClickOutside/
 function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   ref: React.RefObject<T | null> | T | null,
   handler: (event: MouseEvent | TouchEvent) => void
 ) {
-  useEffect(
-    () => {
-      const listener = (event: MouseEvent | TouchEvent) => {
-        if (!ref) {
-          return;
-        }
-        let el: T | null;
-        if ('current' in ref) {
-          el = ref.current;
-        } else {
-          el = ref;
-        }
+  useLayoutEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref) {
+        return;
+      }
+      let el: T | null;
+      if ('current' in ref) {
+        el = ref.current;
+      } else {
+        el = ref;
+      }
 
-        // Do nothing if clicking ref's element or descendent elements
-        if (!el || el.contains(event.target as Node)) {
-          return;
-        }
+      // Do nothing if clicking ref's element or descendent elements
+      if (!el || el.contains(event.target as Node)) {
+        return;
+      }
 
-        handler(event);
-      };
+      handler(event);
+    };
 
-      document.addEventListener('mousedown', listener);
-      document.addEventListener('touchstart', listener);
-      return () => {
-        document.removeEventListener('mousedown', listener);
-        document.removeEventListener('touchstart', listener);
-      };
-    },
-    // Reload only if ref or handler changes
-    [ref, handler]
-  );
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
 }
 
 export default useOnClickOutside;

--- a/static/app/views/nav/mobileTopbar.tsx
+++ b/static/app/views/nav/mobileTopbar.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useLayoutEffect, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -46,11 +46,6 @@ function MobileTopbar() {
   const showSuperuserWarning =
     isActiveSuperuser() && !ConfigStore.get('isSelfHosted') && !isExcludedOrg;
 
-  const [navRef, setNavRef] = useState<HTMLDivElement | null>(null);
-  useOnClickOutside(navRef, () => {
-    setView('closed');
-  });
-
   return (
     <Topbar showSuperuserWarning={showSuperuserWarning}>
       <Left>
@@ -68,8 +63,8 @@ function MobileTopbar() {
       />
       {view === 'closed' ? null : (
         <NavigationOverlayPortal
-          ref={r => setNavRef(r)}
           label={view === 'primary' ? t('Primary Navigation') : t('Secondary Navigation')}
+          setView={setView}
         >
           {view === 'primary' ? <PrimaryNavigationItems /> : null}
           {view === 'secondary' ? (
@@ -104,12 +99,14 @@ function updateNavStyleAttributes(view: ActiveView) {
 function NavigationOverlayPortal({
   children,
   label,
-  ref,
+  setView,
 }: {
   children: React.ReactNode;
   label: string;
-  ref: React.RefCallback<HTMLDivElement | null>;
+  setView: (view: ActiveView) => void;
 }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useOnClickOutside(ref, () => setView('closed'));
   return createPortal(
     <NavigationOverlay ref={ref} aria-label={label}>
       {children}

--- a/static/app/views/nav/orgDropdown.tsx
+++ b/static/app/views/nav/orgDropdown.tsx
@@ -50,10 +50,12 @@ function createOrganizationMenuItem(): MenuItemProps {
 
 export function OrgDropdown({
   className,
+  onClick,
   hideOrgLinks,
 }: {
   className?: string;
   hideOrgLinks?: boolean;
+  onClick?: () => void;
 }) {
   const theme = useTheme();
 
@@ -102,9 +104,14 @@ export function OrgDropdown({
       trigger={props => (
         <OrgDropdownTrigger
           borderless={!theme.isChonk}
+          size={theme.isChonk ? 'xs' : undefined}
           width={isMobile ? 32 : 48}
           aria-label={t('Toggle organization menu')}
           {...props}
+          onClick={e => {
+            props.onClick?.(e);
+            onClick?.();
+          }}
         >
           <StyledOrganizationAvatar
             size={isMobile ? 24 : 36}
@@ -191,6 +198,7 @@ export function OrgDropdown({
 const OrgDropdownTrigger = styled(Button)<{width: number}>`
   height: ${p => p.width}px;
   width: ${p => p.width}px;
+  min-height: ${p => (p.theme.isChonk ? `${p.width}px` : undefined)};
   padding: 0; /* Without this the icon will be cutoff due to overflow */
 `;
 


### PR DESCRIPTION
Fix org picker on mobile by closing the nav menu.

This is not an ideal solution, however there are two issues, first one being that dropdown menus don't make it easy to pass a z index, second is that we use position: fixed for the toggled nav, which falls under position: sticky that is used for the topbar.

I have tried using useOnClickOutside, but it seems that dropdowntrigger calls stopPropagation or preventDefault as the handler never fires. Due to conditional rendering, there is a small quirk where we would have to store the ref in state to rerun the hook, but that didn't fix anything as I could verify that the outside click handler runs if we click the nav, but not if we toggle the menu... This leaves me with the "least bad" option to add a onclick handler to the org dropdown and just have it always close the mobile menu bar when clicked.

Fixes DE-176