### PR TITLE
ref(flags): loosen length restrictions on generic webhook secret

### DIFF
--- a/src/sentry/flags/endpoints/secrets.py
+++ b/src/sentry/flags/endpoints/secrets.py
@@ -54,6 +54,10 @@ class FlagWebhookSigningSecretValidator(serializers.Serializer):
                 )
             return serializers.CharField(min_length=32, max_length=64).run_validation(value)
 
+        if self.initial_data.get("provider") == "generic":
+            # Flagsmith uses the generic webhook and secrets of 10-60 characters.
+            return serializers.CharField(min_length=10, max_length=64).run_validation(value)
+
         return serializers.CharField(min_length=32, max_length=32).run_validation(value)
 
 

--- a/src/sentry/flags/endpoints/secrets.py
+++ b/src/sentry/flags/endpoints/secrets.py
@@ -55,7 +55,6 @@ class FlagWebhookSigningSecretValidator(serializers.Serializer):
             return serializers.CharField(min_length=32, max_length=64).run_validation(value)
 
         if self.initial_data.get("provider") == "generic":
-            # Flagsmith uses the generic webhook and secrets of 10-60 characters.
             return serializers.CharField(min_length=10, max_length=64).run_validation(value)
 
         return serializers.CharField(min_length=32, max_length=32).run_validation(value)

--- a/tests/sentry/flags/endpoints/test_secrets.py
+++ b/tests/sentry/flags/endpoints/test_secrets.py
@@ -110,7 +110,7 @@ class OrganizationFlagsWebHookSigningSecretsEndpointTestCase(APITestCase):
 
     def test_post_invalid_secret(self):
         with self.feature(self.features):
-            for provider in ["launchdarkly", "generic", "unleash"]:
+            for provider in ["launchdarkly", "unleash"]:
                 response = self.client.post(
                     self.url, data={"secret": "a" * 31, "provider": provider}
                 )
@@ -126,6 +126,19 @@ class OrganizationFlagsWebHookSigningSecretsEndpointTestCase(APITestCase):
                 assert response.json()["secret"] == [
                     "Ensure this field has no more than 32 characters."
                 ], provider
+
+            # Generic
+            response = self.client.post(self.url, data={"secret": "a" * 9, "provider": "generic"})
+            assert response.status_code == 400, response.content
+            assert response.json()["secret"] == [
+                "Ensure this field has at least 10 characters."
+            ], "generic"
+
+            response = self.client.post(self.url, data={"secret": "a" * 65, "provider": "generic"})
+            assert response.status_code == 400, response.content
+            assert response.json()["secret"] == [
+                "Ensure this field has no more than 64 characters."
+            ], "generic"
 
             # Statsig
             response = self.client.post(self.url, data={"secret": "a" * 32, "provider": "statsig"})


### PR DESCRIPTION
See https://github.com/getsentry/sentry-docs/pull/14126/files. Providers may choose to develop their own webhooks with variable length secrets.