### PR TITLE
quality(apidocs): remove warnings from build scripts

### DIFF
--- a/api-docs/package.json
+++ b/api-docs/package.json
@@ -2,6 +2,7 @@
   "name": "@sentry-internal/api-docs",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "description": "Sentry API docs",
   "main": "index.js",
   "scripts": {

--- a/api-docs/pnpm-workspace.yaml
+++ b/api-docs/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+ignoredBuiltDependencies:
+  - es5-ext


### PR DESCRIPTION
while working api docs, i've noticed two new warnings are occuring due to new node / pnpm stuff.

This PR addresses two:

1. we add a `api-docs/pnpm-workspace.yaml` that gets rid of this error:
```
│   Ignored build scripts: es5-ext.                                                          │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```
2. we add `"type":"module"` in the package json to remove 
```
(node:5599) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/jferge/code/sentry/api-docs/index.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/jferge/code/sentry/api-docs/package.json.
```