### PR TITLE
feat(replay): Detect graphql network requests and surface the operationName

### DIFF
--- a/static/app/utils/replays/hydrateSpans.tsx
+++ b/static/app/utils/replays/hydrateSpans.tsx
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 import isValidDate from 'sentry/utils/date/isValidDate';
 import {
   getGraphQLDescription,
-  isFrameGraphQLRequest,
+  isFrameMaybeGraphQLRequest,
 } from 'sentry/utils/replays/resourceFrame';
 import type {RawSpanFrame, SpanFrame} from 'sentry/utils/replays/types';
 import {isSpanFrame} from 'sentry/utils/replays/types';
@@ -32,7 +32,7 @@ export default function hydrateSpans(
           timestampMs: start.getTime(),
         };
 
-        if (isFrameGraphQLRequest(spanFrame)) {
+        if (isFrameMaybeGraphQLRequest(spanFrame)) {
           spanFrame.description =
             getGraphQLDescription(spanFrame) ?? spanFrame.description;
         }

--- a/static/app/utils/replays/resourceFrame.spec.tsx
+++ b/static/app/utils/replays/resourceFrame.spec.tsx
@@ -1,0 +1,202 @@
+import {
+  ReplayRequestFrameFixture,
+  ReplayResourceFrameFixture,
+} from 'sentry-fixture/replay/replaySpanFrameData';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import hydrateSpans from 'sentry/utils/replays/hydrateSpans';
+import {isFrameGraphQLRequest} from 'sentry/utils/replays/resourceFrame';
+
+describe('isFrameGraphQLRequest', () => {
+  it('should return false for resource requests', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayResourceFrameFixture({
+        op: 'resource.css',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+  });
+
+  it('should return false when the request body is missing', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        data: {},
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+  });
+
+  it('should return false when content-type is undefined', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        data: {
+          request: {
+            headers: {},
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+  });
+
+  it('should return false when content-type is not application/json', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/img',
+            },
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+  });
+
+  it('should return true when content-type is application/graphql-response+json', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/graphql-response+json',
+            },
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should return false when the request is missing a `query`', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/app',
+            },
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+  });
+
+  it('should return true when a GET request has a `query` parameter', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'https://example.com?query=123',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should return true when a POST request has a `query` in the body', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'https://example.com',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({query: '123'}),
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should not care if the a body is invalid when the url has ?query', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'https://example.com?query=123',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: 'not json',
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should skip invalid urls and only check bodies', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'foo-bar-baz',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({query: '123'}),
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should not throw when the url and body are invalid values', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'foo-bar-baz',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: 'not json',
+          },
+        },
+      }),
+    ]);
+    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+  });
+});

--- a/static/app/utils/replays/resourceFrame.spec.tsx
+++ b/static/app/utils/replays/resourceFrame.spec.tsx
@@ -5,7 +5,7 @@ import {
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import hydrateSpans from 'sentry/utils/replays/hydrateSpans';
-import {isFrameGraphQLRequest} from 'sentry/utils/replays/resourceFrame';
+import {isFrameMaybeGraphQLRequest} from 'sentry/utils/replays/resourceFrame';
 
 describe('isFrameGraphQLRequest', () => {
   it('should return false for resource requests', () => {
@@ -16,7 +16,7 @@ describe('isFrameGraphQLRequest', () => {
         endTimestamp: new Date(30000),
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should return false when the request body is missing', () => {
@@ -28,7 +28,7 @@ describe('isFrameGraphQLRequest', () => {
         data: {},
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should return false when content-type is undefined', () => {
@@ -44,7 +44,7 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should return false when content-type is not application/json', () => {
@@ -62,7 +62,7 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should return true when content-type is application/graphql-response+json', () => {
@@ -80,7 +80,7 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
   });
 
   it('should return false when the request is missing a `query`', () => {
@@ -98,7 +98,7 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should return true when a GET request has a `query` parameter', () => {
@@ -117,7 +117,46 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should return true when a GET request has only known query parameters', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description:
+          'https://example.com?query=123&operationName=123&variables=123&extensions=123',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        },
+      }),
+    ]);
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should return false when a GET request has query and also random query parameters', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'https://example.com?query=123&random=123',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        },
+      }),
+    ]);
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should return true when a POST request has a `query` in the body', () => {
@@ -137,7 +176,55 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should return true when a POST request has a `query` in the body and only known fields', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'https://example.com',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              query: '123',
+              operationName: '123',
+              variables: '123',
+              extensions: '123',
+            }),
+          },
+        },
+      }),
+    ]);
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
+  });
+
+  it('should return false when a POST request has a `query` in the body along with random fields', () => {
+    const frames = hydrateSpans(ReplayRecordFixture(), [
+      ReplayRequestFrameFixture({
+        op: 'resource.fetch',
+        startTimestamp: new Date(10000),
+        endTimestamp: new Date(30000),
+        description: 'https://example.com',
+        data: {
+          request: {
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              query: '123',
+              random: '123',
+            }),
+          },
+        },
+      }),
+    ]);
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 
   it('should not care if the a body is invalid when the url has ?query', () => {
@@ -157,7 +244,7 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
   });
 
   it('should skip invalid urls and only check bodies', () => {
@@ -177,7 +264,7 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeTruthy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeTruthy();
   });
 
   it('should not throw when the url and body are invalid values', () => {
@@ -197,6 +284,6 @@ describe('isFrameGraphQLRequest', () => {
         },
       }),
     ]);
-    expect(isFrameGraphQLRequest(frames[0]!)).toBeFalsy();
+    expect(isFrameMaybeGraphQLRequest(frames[0]!)).toBeFalsy();
   });
 });

--- a/static/app/utils/replays/resourceFrame.tsx
+++ b/static/app/utils/replays/resourceFrame.tsx
@@ -1,3 +1,5 @@
+import invariant from 'invariant';
+
 import type {RequestFrame, ResourceFrame, SpanFrame} from 'sentry/utils/replays/types';
 
 export function isRequestFrame(frame: SpanFrame): frame is RequestFrame {
@@ -50,6 +52,103 @@ export function getResponseBodySize(frame: SpanFrame) {
     //   frame.data.decodedBodySize
     //   frame.data.encodedBodySize
     return frame.data.size;
+  }
+  return undefined;
+}
+
+// Looks at conventions described in https://graphql.org/learn/serving-over-http/
+// to infer if this is a GraphQL request, or GraphQL-like.
+// The SDK must be configured to capture the request body.
+export function isFrameGraphQLRequest(frame: SpanFrame): boolean {
+  if (!isRequestFrame(frame) || !frame.data?.request) {
+    return false;
+  }
+
+  const request = frame.data.request;
+  const contentType = request.headers?.['content-type'] ?? '';
+
+  // https://graphql.org/learn/serving-over-http/#headers
+  // `application/graphql-response+json` is a good indicator
+  if (contentType.includes('application/graphql-response+json')) {
+    return true;
+  }
+  // Legacy servers required `application/json`
+  if (!contentType.includes('application/json')) {
+    return false;
+  }
+
+  try {
+    const url = new URL(frame.description);
+    const hasUrlQuery = Boolean(url.searchParams.get('query'));
+    if (hasUrlQuery) {
+      return true;
+    }
+  } catch {
+    //
+  }
+
+  try {
+    const bodyJson =
+      typeof request.body === 'string' ? JSON.parse(request.body) : request.body;
+    const hasBodyQuery = 'query' in bodyJson;
+    if (hasBodyQuery) {
+      return true;
+    }
+  } catch {
+    //
+  }
+  return false;
+}
+
+export function getGraphQLDescription(frame: SpanFrame) {
+  if (!isRequestFrame(frame) || !isFrameGraphQLRequest(frame)) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(frame.description);
+    if (url.searchParams.has('operationName')) {
+      return `${frame.description} (${url.searchParams.get('operationName')})`;
+    }
+
+    const query = url.searchParams.get('query');
+    if (query) {
+      const operation = parseGraphQLQuery(query);
+      if (operation) {
+        return `${frame.description} (${operation.type} ${operation.name})`;
+      }
+    }
+  } catch {
+    //
+  }
+
+  try {
+    const request = frame.data.request;
+    invariant(request, 'For Typescript. isFrameGraphQLRequest() guards this already');
+    const bodyJson =
+      typeof request.body === 'string' ? JSON.parse(request.body) : request.body;
+
+    if (bodyJson.operationName) {
+      return `${frame.description} (${bodyJson.operationName})`;
+    }
+    const query = bodyJson.query;
+    if (query) {
+      const operation = parseGraphQLQuery(query);
+      if (operation) {
+        return `${frame.description} (${operation.type} ${operation.name})`;
+      }
+    }
+  } catch {
+    //
+  }
+  return undefined;
+}
+
+const queryRegExp = /(query|mutation|subscription)\s+([\w]+)/i;
+function parseGraphQLQuery(query: string): {name: string; type: string} | undefined {
+  const match = query.match(queryRegExp);
+  if (match) {
+    return {type: match[1]!, name: match[2]!};
   }
   return undefined;
 }


### PR DESCRIPTION
This starts to detect GraphQL network requests within the Replay Details Network tab.

I relied on a lot of the conventions here to try and detect if a request is using GraphQL or not. If it is, then we make a best-effort to extra the query or mutation or subscription name and show it on the screen. If we can't extract any of those, then we will continue to show the existing description (existing url) as before.

See:
- https://graphql.org/learn/serving-over-http/
- https://graphql.org/learn/queries/
- https://graphql.org/learn/mutations/
- https://graphql.org/learn/subscriptions/

**Next Steps**
No timeline on these, but things to think about:
- I didn't try to render any potential variables that get passed into the operation, that's an iteration we can followup with.
- Our `RequestFrame` type has `description:string` which is kind of limiting if we want to pre-compute graphql related data and save it somewhere. Creating a sub-type could be a good idea, then we could render more than a stringy 'description' at the end.


![SCR-20250701-mrsp](https://github.com/user-attachments/assets/6a42fded-878f-4d73-b22a-d9f23efd481b)

Fixes REPLAY-141
Fixes #94733 70139