### PR TITLE
fix(getting-started): Deno docs minor fixes

### DIFF
--- a/static/app/gettingStartedDocs/deno/deno.tsx
+++ b/static/app/gettingStartedDocs/deno/deno.tsx
@@ -16,12 +16,6 @@ const getInstallConfig = () => [
   {
     code: [
       {
-        label: 'Deno registry',
-        value: 'deno',
-        language: 'javascript',
-        code: `import * as Sentry from "https://deno.land/x/sentry/index.mjs";"`,
-      },
-      {
         label: 'npm registry',
         value: 'npm',
         language: 'javascript',
@@ -44,7 +38,7 @@ Sentry.init({
 });
 `;
 
-const getVerifySnippet = () => `;
+const getVerifySnippet = () => `
 setTimeout(() => {
   throw new Error();
 });


### PR DESCRIPTION
1. I noticed that the default option to import the SDK is from `deno.land` but there's a deprecation notice on the repo here: https://github.com/getsentry/sentry-deno.
2. Besides that, I noticed a rogue semicolon in the "Verify" section
