### PR TITLE
ref: Move `<Accordion>` into components/containers/ where it can be found and re-used by others

### DIFF
--- a/static/app/components/container/accordion.spec.tsx
+++ b/static/app/components/container/accordion.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import Accordion from './accordion';
+import Accordion from 'sentry/components/container/accordion';
 
 const items = [
   {header: <p>header</p>, content: <p>first content</p>},

--- a/static/app/components/container/accordion.tsx
+++ b/static/app/components/container/accordion.tsx
@@ -30,7 +30,7 @@ export default function Accordion({
 
         return (
           <AccordionItem key={index}>
-            <ItemContainer>
+            <AccordionHeader>
               <Button
                 icon={<IconChevron size="xs" direction={isExpanded ? 'up' : 'down'} />}
                 aria-label={collapsible && isExpanded ? t('Collapse') : t('Expand')}
@@ -44,8 +44,8 @@ export default function Accordion({
               >
                 {item.header}
               </LineItemWrapper>
-            </ItemContainer>
-            <ContentContainer>{isExpanded && item.content}</ContentContainer>
+            </AccordionHeader>
+            <AccordionContent>{isExpanded && item.content}</AccordionContent>
           </AccordionItem>
         );
       })}
@@ -63,7 +63,7 @@ const AccordionContainer = styled('ul')`
   list-style-type: none;
 `;
 
-const ItemContainer = styled('div')`
+const AccordionHeader = styled('div')`
   display: flex;
   align-items: center;
   border-top: 1px solid ${p => p.theme.border};
@@ -72,7 +72,7 @@ const ItemContainer = styled('div')`
   column-gap: ${space(1.5)};
 `;
 
-const ContentContainer = styled('div')`
+const AccordionContent = styled('div')`
   padding: 0 ${space(0.25)};
 `;
 

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -2,12 +2,12 @@ import type {ReactNode} from 'react';
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
+import Accordion from 'sentry/components/container/accordion';
 import {LinkButton, type LinkButtonProps} from 'sentry/components/core/button/linkButton';
 import {Flex} from 'sentry/components/core/layout';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import Placeholder from 'sentry/components/placeholder';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import Accordion from 'sentry/components/replays/accordion';
 import TextOverflow from 'sentry/components/textOverflow';
 import {IconCursorArrow, IconSearch} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import emptyStateImg from 'sentry-images/spot/replays-empty-state.svg';
 
+import Accordion from 'sentry/components/container/accordion';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -10,7 +11,6 @@ import {Tooltip} from 'sentry/components/core/tooltip';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import Accordion from 'sentry/components/replays/accordion';
 import ReplayUnsupportedAlert from 'sentry/components/replays/alerts/replayUnsupportedAlert';
 import {replayPlatforms} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';


### PR DESCRIPTION
This isn't a replay specific component, there are no imports or props specific to replay. Having it in the replay folder might (incorrectly) suggest to someone that they shouldn't consider using it even if it fits their use-case.

More re-use will make this component more generic, and reduce effort and bytes across the app.

There may be other accordion-like components through, my goal would be that all of them should be co-located together and the differences ironed out so that instead of a bunch of different implementations with quirks, we have some uniformity across different surfaces.