### PR TITLE
fix(detectors): Fix redis key deletion in `should_create_group`

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -693,7 +693,7 @@ def should_create_group(
     )
 
     if over_threshold:
-        client.delete(grouphash)
+        client.delete(key)
         return True
     else:
         client.expire(key, noise_config.expiry_seconds)


### PR DESCRIPTION
`grouphash` isn't being used as the key, we should delete `key`