### PR TITLE
chore(detectors): Add tags to noise reduction metric

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -199,7 +199,10 @@ def save_issue_from_occurrence(
         cluster_key = settings.SENTRY_ISSUE_PLATFORM_RATE_LIMITER_OPTIONS.get("cluster", "default")
         client = redis.redis_clusters.get(cluster_key)
         if not should_create_group(occurrence.type, client, primary_hash, project):
-            metrics.incr("issues.issue.dropped.noise_reduction")
+            metrics.incr(
+                "issues.issue.dropped.noise_reduction",
+                tags={"group_type": occurrence.type.slug},
+            )
             return None
 
         with metrics.timer("issues.save_issue_from_occurrence.check_write_limits"):

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -418,7 +418,9 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
             occurrence = self.build_occurrence(type=TestGroupType.type_id)
             with mock.patch("sentry.issues.ingest.metrics") as metrics:
                 assert save_issue_from_occurrence(occurrence, event, None) is None
-                metrics.incr.assert_called_once_with("issues.issue.dropped.noise_reduction")
+                metrics.incr.assert_called_once_with(
+                    "issues.issue.dropped.noise_reduction", tags={"group_type": "test"}
+                )
 
             new_event = self.store_event(data={}, project_id=self.project.id)
             new_occurrence = self.build_occurrence(type=TestGroupType.type_id)


### PR DESCRIPTION
this metric is really only useful if we know what the group type is