### PR TITLE
fix(trace-view-no-instrumentation): Fixing link to profiling doc

### DIFF
--- a/static/app/utils/profiling/platforms.tsx
+++ b/static/app/utils/profiling/platforms.tsx
@@ -144,9 +144,20 @@ export function getProfilingDocsForPlatform(platform: string | undefined): strin
   if (!docsPlatform) {
     return null;
   }
-  return docsPlatform === 'apple-ios'
-    ? 'https://docs.sentry.io/platforms/apple/guides/ios/profiling/'
-    : docsPlatform === 'apple-macos'
-      ? 'https://docs.sentry.io/platforms/apple/guides/macos/profiling/'
-      : `https://docs.sentry.io/platforms/${docsPlatform}/profiling/`;
+
+  if (docsPlatform === 'react-native') {
+    return `https://docs.sentry.io/platforms/react-native/profiling/`;
+  }
+
+  const [language, framework] = docsPlatform.split('-');
+
+  if (!language && !framework) {
+    return null;
+  }
+
+  if (!framework) {
+    return `https://docs.sentry.io/platforms/${language}/profiling/`;
+  }
+
+  return `https://docs.sentry.io/platforms/${language}/guides/${framework}/profiling/`;
 }


### PR DESCRIPTION
Taking platform javascript-nextjs as an example:
- old link that 404s: https://docs.sentry.io/platforms/javascript-nextjs/profiling/
- new link that works: https://docs.sentry.io/platforms/javascript/guides/nextjs/profiling/ 
<img width="724" alt="Screenshot 2025-07-01 at 7 56 06 PM" src="https://github.com/user-attachments/assets/028c8347-1100-4665-a3f7-14d6ca3fd9d7" />
