### PR TITLE
fix(issue-views): Remove layout animation to prevent floating query count

### DIFF
--- a/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
+++ b/static/app/views/nav/secondary/sections/issues/issueViews/issueViewQueryCount.tsx
@@ -71,7 +71,6 @@ export function IssueViewQueryCount({view, isActive}: IssueViewQueryCountProps) 
 
   return (
     <QueryCountBubble
-      layout="preserve-aspect"
       animate={{
         backgroundColor: isFetching
           ? [theme.surface400, theme.surface100, theme.surface400]


### PR DESCRIPTION
The layout transition is probably the cause of a rare bug where the query count badge repeatedly floats around the page. It's very subtle, so I'm going ahead and removing it to avoid this.