### PR TITLE
fix(seer-ux): Remove confusing 'Try Seer' guard

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -59,7 +59,7 @@ export function useAutofixSetup(
     ...queryData,
     canStartAutofix: Boolean(
       queryData.data?.integration.ok &&
-        queryData.data?.setupAcknowledgement.userHasAcknowledged
+        queryData.data?.setupAcknowledgement.orgHasAcknowledged
     ),
     canCreatePullRequests: Boolean(queryData.data?.githubWriteIntegration?.ok),
     hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),

--- a/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
+++ b/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
@@ -48,9 +48,6 @@ export function useOrganizationSeerSetup(
       orgHasAcknowledged: Boolean(
         queryData.data?.setupAcknowledgement?.orgHasAcknowledged
       ),
-      userHasAcknowledged: Boolean(
-        queryData.data?.setupAcknowledgement?.userHasAcknowledged
-      ),
     },
   };
 }

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -13,7 +13,6 @@ interface AiConfigResult {
   hasResources: boolean;
   hasSummary: boolean;
   isAutofixSetupLoading: boolean;
-  needsGenAiAcknowledgement: boolean;
   orgNeedsGenAiAcknowledgement: boolean;
   refetchAutofixSetup: () => void;
 }
@@ -44,11 +43,6 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const hasAutofix = isAutofixEnabled && areAiFeaturesAllowed && !isSampleError;
   const hasGithubIntegration = !!autofixSetupData?.integration.ok;
 
-  const needsGenAiAcknowledgement =
-    !autofixSetupData?.setupAcknowledgement.userHasAcknowledged &&
-    (isSummaryEnabled || isAutofixEnabled) &&
-    areAiFeaturesAllowed;
-
   const orgNeedsGenAiAcknowledgement =
     !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
     (isSummaryEnabled || isAutofixEnabled) &&
@@ -57,7 +51,6 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   return {
     hasSummary,
     hasAutofix,
-    needsGenAiAcknowledgement,
     orgNeedsGenAiAcknowledgement,
     hasResources,
     isAutofixSetupLoading,

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -189,7 +189,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
   }
 
   const showWelcomeScreen =
-    aiConfig.needsGenAiAcknowledgement ||
+    aiConfig.orgNeedsGenAiAcknowledgement ||
     (!aiConfig.hasAutofixQuota && organization.features.includes('seer-billing'));
 
   return (
@@ -245,7 +245,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
               size="sm"
             />
           </Flex>
-          {!aiConfig.needsGenAiAcknowledgement && (
+          {!aiConfig.orgNeedsGenAiAcknowledgement && (
             <ButtonBarWrapper data-test-id="seer-button-bar">
               <ButtonBar gap={1}>
                 <Feature features={['organizations:autofix-seer-preferences']}>

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.tsx
@@ -87,13 +87,13 @@ export default function SeerSection({
   }
 
   const showCtaButton =
-    aiConfig.needsGenAiAcknowledgement ||
+    aiConfig.orgNeedsGenAiAcknowledgement ||
     aiConfig.hasAutofix ||
     (aiConfig.hasSummary && aiConfig.hasResources);
 
   const onlyHasResources =
     issueTypeDoesntHaveSeer ||
-    (!aiConfig.needsGenAiAcknowledgement &&
+    (!aiConfig.orgNeedsGenAiAcknowledgement &&
       !aiConfig.hasSummary &&
       !aiConfig.hasAutofix &&
       aiConfig.hasResources);

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -127,7 +127,7 @@ export function SeerSectionCtaButton({
   };
 
   const showCtaButton =
-    aiConfig.needsGenAiAcknowledgement ||
+    aiConfig.orgNeedsGenAiAcknowledgement ||
     aiConfig.hasAutofix ||
     (aiConfig.hasSummary && aiConfig.hasResources);
   const isButtonLoading =

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -243,7 +243,6 @@ function ProjectSeer({project}: ProjectSeerProps) {
   const {setupAcknowledgement, billing, isLoading} = useOrganizationSeerSetup();
 
   const needsSetup =
-    !setupAcknowledgement.userHasAcknowledged ||
     !setupAcknowledgement.orgHasAcknowledged ||
     (!billing.hasAutofixQuota && organization.features.includes('seer-billing'));
 

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -44,12 +44,11 @@ function SeerAutomationRoot() {
   }
 
   // Check if setup is needed
-  const needsUserAcknowledgement = !setupAcknowledgement.userHasAcknowledged;
   const needsOrgAcknowledgement = !setupAcknowledgement.orgHasAcknowledged;
   const needsBilling =
     !billing.hasAutofixQuota && organization.features.includes('seer-billing');
 
-  const needsSetup = needsUserAcknowledgement || needsOrgAcknowledgement || needsBilling;
+  const needsSetup = needsOrgAcknowledgement || needsBilling;
 
   // Show setup screen if needed
   if (needsSetup) {


### PR DESCRIPTION
Removes the confusing "Try Seer" user-level guard and only rely on the org-level guard. This includes in the drawer & in the settings page

Removes:
![CleanShot 2025-07-02 at 14 26 17@2x](https://github.com/user-attachments/assets/e0b774a0-975b-4e53-b3ee-be27c8d67e7d)
