### PR TITLE
fix(agent-monitoring): Trace generations count

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -99,6 +99,7 @@ export function TracesTable() {
       fields: [
         'trace',
         ...GENERATION_COUNTS,
+        'count_if(span.op,gen_ai.execute_tool)',
         AI_TOKEN_USAGE_ATTRIBUTE_SUM,
         AI_COST_ATTRIBUTE_SUM,
       ],


### PR DESCRIPTION
The generation count was not checking for all generation span ops.