### PR TITLE
fix(taskworker) Extend deadline on digests

### DIFF
--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -57,7 +57,7 @@ def monitor_release_adoption(**kwargs) -> None:
             on=(Exception,),
             delay=5,
         ),
-        processing_deadline_duration=150,
+        processing_deadline_duration=160,
     ),
 )
 def process_projects_with_sessions(org_id, project_ids) -> None:

--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -48,7 +48,7 @@ def schedule_digests() -> None:
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=digests_tasks,
-        processing_deadline_duration=300,
+        processing_deadline_duration=10 * 60,
     ),
 )
 def deliver_digest(


### PR DESCRIPTION
We're still seeing more deadlines being hit than I would like.