### PR TITLE
fix(dashboards): correctly align column headers in widget table

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -178,7 +178,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
         type: column.type === 'never' ? null : column.type,
       }));
       const aliases = decodeColumnAliases(columns, fieldAliases, fieldHeaderMap);
-      const tableData = convertTableDataToTabularData(tableResults?.[0]);
+      const tableData = convertTableDataToTabularData(tableResults?.[i]);
 
       return (
         <TableWrapper key={`table:${result.title}`}>

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -169,14 +169,13 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
       const columns = decodeColumnOrder(
         fields.map(field => ({
           field,
-        }))
+        })),
+        tableResults[0]?.meta
       ).map(column => ({
         key: column.key,
         name: column.name,
         width: minTableColumnWidth ?? column.width,
-        type:
-          tableResults[0]?.meta?.[column.key] ??
-          (column.type === 'never' ? null : column.type),
+        type: column.type === 'never' ? null : column.type,
       }));
       const aliases = decodeColumnAliases(columns, fieldAliases, fieldHeaderMap);
       const tableData = convertTableDataToTabularData(tableResults?.[0]);

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -174,7 +174,9 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
         key: column.key,
         name: column.name,
         width: minTableColumnWidth ?? column.width,
-        type: column.type === 'never' ? null : column.type,
+        type:
+          tableResults[0]?.meta?.[column.key] ??
+          (column.type === 'never' ? null : column.type),
       }));
       const aliases = decodeColumnAliases(columns, fieldAliases, fieldHeaderMap);
       const tableData = convertTableDataToTabularData(tableResults?.[0]);

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -170,7 +170,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps> {
         fields.map(field => ({
           field,
         })),
-        tableResults[0]?.meta
+        tableResults[i]?.meta
       ).map(column => ({
         key: column.key,
         name: column.name,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -117,7 +117,7 @@ export function decodeColumnOrder(
     }
 
     // If provided meta with field type, prioritize that over guessing
-    if (meta?.fields[column.key]) {
+    if (meta?.fields?.[column.key]) {
       column.type = meta.fields[column.key];
     }
 

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -117,8 +117,8 @@ export function decodeColumnOrder(
     }
 
     // If provided meta with field type, prioritize that over guessing
-    if (meta?.[column.key]) {
-      column.type = meta[column.key];
+    if (meta?.fields[column.key]) {
+      column.type = meta.fields[column.key];
     }
 
     column.column = col;

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -17,7 +17,7 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
-import type {EventData} from 'sentry/utils/discover/eventView';
+import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import type EventView from 'sentry/utils/discover/eventView';
 import type {
   Aggregation,
@@ -77,7 +77,10 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<string> = {
   width: COL_WIDTH_UNDEFINED,
 };
 
-export function decodeColumnOrder(fields: readonly Field[]): Array<TableColumn<string>> {
+export function decodeColumnOrder(
+  fields: readonly Field[],
+  meta?: MetaType
+): Array<TableColumn<string>> {
   return fields.map((f: Field) => {
     const column: TableColumn<string> = {...TEMPLATE_TABLE_COLUMN};
 
@@ -112,6 +115,12 @@ export function decodeColumnOrder(fields: readonly Field[]): Array<TableColumn<s
         column.type = 'duration';
       }
     }
+
+    // If provided meta with field type, prioritize that over guessing
+    if (meta?.[column.key]) {
+      column.type = meta[column.key];
+    }
+
     column.column = col;
 
     return column;


### PR DESCRIPTION
### Changes
Prioritize getting column type data from the table results meta over decoded column. This is to fix some misalignment of certain fields

### Before
Notice the two tables in the bottom right:
<img width="1817" alt="Screenshot 2025-07-02 at 11 36 33 AM" src="https://github.com/user-attachments/assets/138f8a5c-9c5b-4975-90c6-dee164a2c294" />

### After

<img width="1822" alt="Screenshot 2025-07-02 at 11 36 50 AM" src="https://github.com/user-attachments/assets/3cc749b8-6a92-430d-9b44-d5f176c77b06" />
