### PR TITLE
fix(insights): Updates transaction summary tabs to show old web vitals for am1 customers

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -46,6 +46,7 @@ import {profilesRouteWithQuery} from 'sentry/views/performance/transactionSummar
 import {replaysRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionReplays/utils';
 import {spansRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/utils';
 import {tagsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionTags/utils';
+import {vitalsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionVitals/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getSelectedProjectPlatforms} from 'sentry/views/performance/utils';
 
@@ -107,6 +108,9 @@ function TransactionHeader({
           return replaysRouteWithQuery(routeQuery);
         case Tab.PROFILING: {
           return profilesRouteWithQuery(routeQuery);
+        }
+        case Tab.WEB_VITALS: {
+          return vitalsRouteWithQuery(routeQuery);
         }
         case Tab.TRANSACTION_SUMMARY:
         default:

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -266,7 +266,11 @@ function PageLayout(props: Props) {
 
   let hasWebVitals: TransactionHeaderProps['hasWebVitals'] =
     tab === Tab.WEB_VITALS ? 'yes' : 'maybe';
-  if (isInDomainView) {
+
+  // TODO: /performance routes have been deprecated and all orgs should now evaluate isInDomainView as true
+  // We do not show the old web vitals tab for any orgs, with the exception of AM1 orgs as they do not have access to the new web vitals module
+  // Delete this check once all orgs have been migrated off AM1
+  if (isInDomainView && organization.features.includes('insights-modules-use-eap')) {
     hasWebVitals = 'no';
   }
 


### PR DESCRIPTION
AM1 customers do not have access to the new Web Vitals module. We've also removed access to the old web vitals tab by deprecating the `/performance` routes. Updates the new insights transaction summary tabs to display the old web vitals tab so that AM1 customers can have access again.