### PR TITLE
chore(explore): Render trace start timestamp

### DIFF
--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -260,7 +260,7 @@ function TraceRow({
         )}
       </StyledPanelItem>
       <StyledPanelItem align="right">
-        <SpanTimeRenderer timestamp={trace.end} tooltipShowSeconds />
+        <SpanTimeRenderer timestamp={trace.start} tooltipShowSeconds />
       </StyledPanelItem>
       {expanded && <SpanTable trace={trace} />}
     </Fragment>


### PR DESCRIPTION
The API is sorting it by the start timestamp so if we display the end timestamp, it can appear out of order.