### PR TITLE
ref(aci): clean up `updateIfAction` reducer action

### DIFF
--- a/static/app/views/automations/components/actions/email.tsx
+++ b/static/app/views/automations/components/actions/email.tsx
@@ -79,8 +79,17 @@ function TargetTypeField() {
       name={`${actionId}.config.target_type`}
       value={action.config.target_type}
       options={TARGET_TYPE_CHOICES}
-      onChange={(option: SelectValue<string>) => {
-        onUpdate({config: {target_type: option.value, target_identifier: undefined}});
+      onChange={(option: SelectValue<ActionTarget>) => {
+        onUpdate({
+          config: {
+            ...action.config,
+            target_type: option.value,
+            target_identifier: undefined,
+          },
+          ...(option.value === ActionTarget.ISSUE_OWNERS
+            ? {data: {fallthroughType: FallthroughChoiceType.ACTIVE_MEMBERS}}
+            : {}),
+        });
       }}
     />
   );
@@ -97,7 +106,10 @@ function IdentifierField() {
           name={`${actionId}.config.target_identifier`}
           value={action.config.target_identifier}
           onChange={(value: any) => {
-            onUpdate({config: {target_identifier: value.actor.id}, data: {}});
+            onUpdate({
+              config: {...action.config, target_identifier: value.actor.id},
+              data: {},
+            });
           }}
           useId
           styles={selectControlStyles}
@@ -113,7 +125,10 @@ function IdentifierField() {
           key={`${actionId}.config.target_identifier`}
           value={action.config.target_identifier}
           onChange={(value: any) =>
-            onUpdate({config: {target_identifier: value.actor.id}, data: {}})
+            onUpdate({
+              config: {...action.config, target_identifier: value.actor.id},
+              data: {},
+            })
           }
           styles={selectControlStyles}
         />

--- a/static/app/views/automations/components/actions/integrationField.tsx
+++ b/static/app/views/automations/components/actions/integrationField.tsx
@@ -19,7 +19,9 @@ export function IntegrationField() {
         const defaultService = integration?.services?.[0]?.id;
         onUpdate({
           integrationId: option.value,
-          ...(defaultService && {config: {target_identifier: defaultService}}),
+          ...(defaultService && {
+            config: {...action.config, target_identifier: defaultService},
+          }),
         });
       }}
     />

--- a/static/app/views/automations/components/actions/sentryApp.tsx
+++ b/static/app/views/automations/components/actions/sentryApp.tsx
@@ -49,7 +49,7 @@ function SentryAppActionSettingsButton() {
               sentryAppInstallationUuid={sentryApp.installationUuid}
               config={sentryApp.settings as SchemaFormConfig}
               appName={sentryApp.name}
-              onSubmitSuccess={(formData: Record<string, string>) =>
+              onSubmitSuccess={(formData: Record<string, any>) =>
                 onUpdate({data: {settings: formData.settings}})
               }
               resetValues={action.data}

--- a/static/app/views/automations/components/actions/sentryApp.tsx
+++ b/static/app/views/automations/components/actions/sentryApp.tsx
@@ -50,7 +50,7 @@ function SentryAppActionSettingsButton() {
               config={sentryApp.settings as SchemaFormConfig}
               appName={sentryApp.name}
               onSubmitSuccess={(formData: Record<string, string>) =>
-                onUpdate({data: formData})
+                onUpdate({data: {settings: formData.settings}})
               }
               resetValues={action.data}
             />

--- a/static/app/views/automations/components/actions/serviceField.tsx
+++ b/static/app/views/automations/components/actions/serviceField.tsx
@@ -21,7 +21,7 @@ export function ServiceField() {
       }))}
       onChange={(option: SelectValue<string>) => {
         onUpdate({
-          config: {target_identifier: option.value},
+          config: {...action.config, target_identifier: option.value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -92,10 +92,10 @@ function NotesField() {
     <AutomationBuilderInput
       name={`${actionId}.data.notes`}
       placeholder={t('example notes')}
-      value={action.data.tags}
+      value={action.data.notes}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
-          data: {tags: e.target.value},
+          data: {...action.data, notes: e.target.value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/tagsField.tsx
+++ b/static/app/views/automations/components/actions/tagsField.tsx
@@ -11,7 +11,7 @@ export function TagsField() {
       value={action.data.tags}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
-          data: {tags: e.target.value},
+          data: {...action.data, tags: e.target.value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/targetDisplayField.tsx
+++ b/static/app/views/automations/components/actions/targetDisplayField.tsx
@@ -11,7 +11,7 @@ export function TargetDisplayField({placeholder}: {placeholder?: string}) {
       value={action.config.target_display}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({
-          config: {target_display: e.target.value},
+          config: {...action.config, target_display: e.target.value},
         });
       }}
     />

--- a/static/app/views/automations/components/actions/webhook.tsx
+++ b/static/app/views/automations/components/actions/webhook.tsx
@@ -41,6 +41,7 @@ function ServicesField() {
       onChange={(option: SelectValue<string>) => {
         onUpdate({
           config: {
+            ...action.config,
             target_identifier: option.value,
           },
         });

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -1,9 +1,12 @@
 import {createContext, type Reducer, useCallback, useContext, useReducer} from 'react';
 import {uuid4} from '@sentry/core';
 
+import type {
+  Action,
+  ActionConfig,
+  ActionHandler,
+} from 'sentry/types/workflowEngine/actions';
 import {
-  type ActionConfig,
-  type ActionHandler,
   ActionTarget,
   ActionType,
   SentryAppIdentifier,
@@ -117,15 +120,8 @@ export function useAutomationBuilderReducer(initialState?: AutomationBuilderStat
       [dispatch]
     ),
     updateIfAction: useCallback(
-      (
-        groupId: string,
-        actionId: string,
-        params: {
-          config?: Record<string, any>;
-          data?: Record<string, any>;
-          integrationId?: string;
-        }
-      ) => dispatch({type: 'UPDATE_IF_ACTION', groupId, actionId, params}),
+      (groupId: string, actionId: string, params: Partial<Omit<Action, 'id' | 'type'>>) =>
+        dispatch({type: 'UPDATE_IF_ACTION', groupId, actionId, params}),
       [dispatch]
     ),
     updateIfLogicType: useCallback(
@@ -159,11 +155,7 @@ interface AutomationActions {
   updateIfAction: (
     groupId: string,
     actionId: string,
-    params: {
-      config?: Record<string, any>;
-      data?: Record<string, any>;
-      integrationId?: string;
-    }
+    params: Partial<Omit<Action, 'id' | 'type'>>
   ) => void;
   updateIfCondition: (
     groupId: string,
@@ -276,11 +268,7 @@ type RemoveIfActionAction = {
 type UpdateIfActionAction = {
   actionId: string;
   groupId: string;
-  params: {
-    config?: Record<string, any>;
-    data?: Record<string, any>;
-    integrationId?: string;
-  };
+  params: Partial<Omit<Action, 'id' | 'type'>>;
   type: 'UPDATE_IF_ACTION';
 };
 
@@ -558,7 +546,6 @@ function updateIfAction(
   action: UpdateIfActionAction
 ): AutomationBuilderState {
   const {groupId, actionId, params} = action;
-  const {integrationId, config, data} = params;
 
   return {
     ...state,
@@ -572,9 +559,7 @@ function updateIfAction(
           a.id === actionId
             ? {
                 ...a,
-                ...(integrationId && {integrationId}),
-                ...(config && {config: {...a.config, ...config}}),
-                ...(data && {data: {...a.data, ...data}}),
+                ...params,
               }
             : a
         ),


### PR DESCRIPTION
cleaning up the reducer action to take a partial `Action`

& fixed the action to replace `data` and/or `config` with the provided value instead of spreading and inserting only the new fields for clarity (this also allows us to remove the `fallthroughType` for user and team email notifications in the `email` action, which we couldn't do before with spreading)