### PR TITLE
feat(search-bar): Add search Ask Seer button

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeer.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+export const AskSeerPane = styled('div')`
+  grid-area: seer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 0;
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+  background-color: ${p => p.theme.purple100};
+  width: 100%;
+`;
+
+export const AskSeerListItem = styled('div')`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: ${space(1)} ${space(1.5)};
+  background: transparent;
+  border-radius: 0;
+  background-color: none;
+  box-shadow: none;
+  color: ${p => p.theme.purple400};
+  font-size: ${p => p.theme.fontSize.md};
+  font-weight: ${p => p.theme.fontWeight.bold};
+  text-align: left;
+  justify-content: flex-start;
+  gap: ${space(1)};
+  list-style: none;
+  margin: 0;
+
+  &:hover,
+  &:focus {
+    cursor: pointer;
+    background-color: ${p => p.theme.purple100};
+    color: ${p => p.theme.purple400};
+  }
+
+  &[aria-selected='true'] {
+    background: ${p => p.theme.purple100};
+    color: ${p => p.theme.purple400};
+  }
+`;
+
+export const AskSeerLabel = styled('span')`
+  ${p => p.theme.overflowEllipsis};
+  color: ${p => p.theme.purple400};
+  font-size: ${p => p.theme.fontSize.md};
+  font-weight: ${p => p.theme.fontWeight.bold};
+`;

--- a/static/app/components/searchQueryBuilder/askSeer.tsx
+++ b/static/app/components/searchQueryBuilder/askSeer.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
 
+export const ASK_SEER_ITEM_KEY = 'ask_seer';
+
 export const AskSeerPane = styled('div')`
   grid-area: seer;
   display: flex;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -938,6 +938,20 @@ describe('SearchQueryBuilder', function () {
       expect(screen.getByRole('row', {name: 'browser.name:foo'})).toBeInTheDocument();
     });
 
+    it('displays ask seer button when searching free text', async function () {
+      const mockOnSearch = jest.fn();
+      render(<SearchQueryBuilder {...defaultProps} onSearch={mockOnSearch} />, {
+        organization: {
+          features: ['gen-ai-features', 'gen-ai-explore-traces'],
+        },
+      });
+
+      await userEvent.click(getLastInput());
+      await userEvent.type(screen.getByRole('combobox'), 'some free text');
+
+      expect(screen.getByRole('option', {name: 'Ask Seer'})).toBeInTheDocument();
+    });
+
     it('can add parens by typing', async function () {
       const mockOnChange = jest.fn();
       render(<SearchQueryBuilder {...defaultProps} onChange={mockOnChange} />);

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -31,6 +31,7 @@ import {
   getFieldDefinition,
 } from 'sentry/utils/fields';
 import localStorageWrapper from 'sentry/utils/localStorage';
+import {TraceExploreAiQueryContext} from 'sentry/views/explore/contexts/traceExploreAiQueryContext';
 
 const FILTER_KEYS: TagCollection = {
   [FieldKey.AGE]: {key: FieldKey.AGE, name: 'Age', kind: FieldKind.FIELD},
@@ -940,11 +941,14 @@ describe('SearchQueryBuilder', function () {
 
     it('displays ask seer button when searching free text', async function () {
       const mockOnSearch = jest.fn();
-      render(<SearchQueryBuilder {...defaultProps} onSearch={mockOnSearch} />, {
-        organization: {
-          features: ['gen-ai-features', 'gen-ai-explore-traces'],
-        },
-      });
+      render(
+        <TraceExploreAiQueryContext.Provider value={{}}>
+          <SearchQueryBuilder {...defaultProps} onSearch={mockOnSearch} />
+        </TraceExploreAiQueryContext.Provider>,
+        {
+          organization: {features: ['gen-ai-features', 'gen-ai-explore-traces']},
+        }
+      );
 
       await userEvent.click(getLastInput());
       await userEvent.type(screen.getByRole('combobox'), 'some free text');

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -10,12 +10,13 @@ import {
 import {usePopper} from 'react-popper';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps} from '@react-aria/combobox';
-import type {AriaListBoxOptions} from '@react-aria/listbox';
+import {type AriaListBoxOptions, useOption} from '@react-aria/listbox';
 import {ariaHideOutside} from '@react-aria/overlays';
 import {mergeRefs} from '@react-aria/utils';
 import {type ComboBoxState, useComboBoxState} from '@react-stately/combobox';
 import type {CollectionChildren, Key, KeyboardEvent} from '@react-types/shared';
 
+import Feature from 'sentry/components/acl/feature';
 import {ListBox} from 'sentry/components/core/compactSelect/listBox';
 import type {
   SelectKey,
@@ -27,7 +28,13 @@ import {
 } from 'sentry/components/core/compactSelect/utils';
 import {Input} from 'sentry/components/core/input';
 import {useAutosizeInput} from 'sentry/components/core/input/useAutosizeInput';
+import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Overlay} from 'sentry/components/overlay';
+import {
+  AskSeerLabel,
+  AskSeerListItem,
+  AskSeerPane,
+} from 'sentry/components/searchQueryBuilder/askSeer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/tokens/useSearchTokenCombobox';
 import {
@@ -35,10 +42,15 @@ import {
   itemIsSection,
 } from 'sentry/components/searchQueryBuilder/tokens/utils';
 import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
+import {IconSeer} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
 import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
+import {useTraceExploreAiQueryContext} from 'sentry/views/explore/contexts/traceExploreAiQueryContext';
 
 type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<string>> = {
   children: CollectionChildren<T>;
@@ -169,20 +181,29 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
   filterValue,
   maxOptions,
   shouldFilterResults,
+  showAskSeerOption,
 }: {
   filterValue: string;
   items: T[];
+  showAskSeerOption: boolean;
   maxOptions?: number;
   shouldFilterResults?: boolean;
 }) {
   const hiddenOptions: Set<SelectKey> = useMemo(() => {
-    return getHiddenOptions(items, shouldFilterResults ? filterValue : '', maxOptions);
-  }, [items, shouldFilterResults, filterValue, maxOptions]);
+    const options = getHiddenOptions(
+      items,
+      shouldFilterResults ? filterValue : '',
+      maxOptions
+    );
+    return showAskSeerOption ? options.add('ask_seer') : options;
+  }, [items, shouldFilterResults, filterValue, maxOptions, showAskSeerOption]);
 
-  const disabledKeys = useMemo(
-    () => [...getDisabledOptions(items), ...hiddenOptions],
-    [hiddenOptions, items]
-  );
+  const disabledKeys = useMemo(() => {
+    const baseDisabledKeys = [...getDisabledOptions(items), ...hiddenOptions];
+    return showAskSeerOption
+      ? baseDisabledKeys.filter(key => key !== 'ask_seer')
+      : baseDisabledKeys;
+  }, [hiddenOptions, items, showAskSeerOption]);
 
   return {
     hiddenOptions,
@@ -238,6 +259,39 @@ function useUpdateOverlayPositionOnContentChange({
   }, [contentRef, isOpen, updateOverlayPosition]);
 }
 
+function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const {setDisplaySeerResults} = useSearchQueryBuilder();
+  const organization = useOrganization();
+
+  const {optionProps, labelProps, isFocused, isPressed} = useOption(
+    {
+      key: 'ask_seer',
+      'aria-label': 'Ask Seer',
+      shouldFocusOnHover: true,
+      shouldSelectOnPressUp: true,
+    },
+    state,
+    ref
+  );
+
+  const handleClick = () => {
+    trackAnalytics('trace.explorer.ai_query_interface', {
+      organization,
+      action: 'opened',
+    });
+    setDisplaySeerResults(true);
+  };
+
+  return (
+    <AskSeerListItem ref={ref} onClick={handleClick} {...optionProps}>
+      <InteractionStateLayer isHovered={isFocused} isPressed={isPressed} />
+      <IconSeer />
+      <AskSeerLabel {...labelProps}>{t('Ask Seer')}</AskSeerLabel>
+    </AskSeerListItem>
+  );
+}
+
 function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   customMenu,
   filterValue,
@@ -261,6 +315,13 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   customMenu?: CustomComboboxMenu<T>;
   portalTarget?: HTMLElement | null;
 }) {
+  const organization = useOrganization();
+  const traceExploreAiQueryContext = useTraceExploreAiQueryContext();
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+
+  const showAskSeerOption = !!(traceExploreAiQueryContext && areAiFeaturesAllowed);
+
   if (customMenu) {
     return customMenu({
       popoverRef,
@@ -288,6 +349,13 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
           overlayIsOpen={isOpen}
           size="sm"
         />
+        {showAskSeerOption ? (
+          <Feature features="organizations:gen-ai-explore-traces">
+            <AskSeerPane>
+              <AskSeerOption state={state} />
+            </AskSeerPane>
+          </Feature>
+        ) : null}
       </ListBoxOverlay>
     </StyledPositionWrapper>
   );
@@ -335,11 +403,20 @@ export function SearchQueryBuilderCombobox<
   const popoverRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLDivElement>(null);
 
+  const organization = useOrganization();
+  const traceExploreAiQueryContext = useTraceExploreAiQueryContext();
+
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+
+  const showAskSeerOption = Boolean(traceExploreAiQueryContext && areAiFeaturesAllowed);
+
   const {hiddenOptions, disabledKeys} = useHiddenItems({
     items,
     filterValue,
     maxOptions,
     shouldFilterResults,
+    showAskSeerOption,
   });
 
   const onSelectionChange = useCallback(

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -31,6 +31,7 @@ import {useAutosizeInput} from 'sentry/components/core/input/useAutosizeInput';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Overlay} from 'sentry/components/overlay';
 import {
+  ASK_SEER_ITEM_KEY,
   AskSeerLabel,
   AskSeerListItem,
   AskSeerPane,
@@ -195,13 +196,13 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
       shouldFilterResults ? filterValue : '',
       maxOptions
     );
-    return showAskSeerOption ? options.add('ask_seer') : options;
+    return showAskSeerOption ? options.add(ASK_SEER_ITEM_KEY) : options;
   }, [items, shouldFilterResults, filterValue, maxOptions, showAskSeerOption]);
 
   const disabledKeys = useMemo(() => {
     const baseDisabledKeys = [...getDisabledOptions(items), ...hiddenOptions];
     return showAskSeerOption
-      ? baseDisabledKeys.filter(key => key !== 'ask_seer')
+      ? baseDisabledKeys.filter(key => key !== ASK_SEER_ITEM_KEY)
       : baseDisabledKeys;
   }, [hiddenOptions, items, showAskSeerOption]);
 
@@ -266,7 +267,7 @@ function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
 
   const {optionProps, labelProps, isFocused, isPressed} = useOption(
     {
-      key: 'ask_seer',
+      key: ASK_SEER_ITEM_KEY,
       'aria-label': 'Ask Seer',
       shouldFocusOnHover: true,
       shouldSelectOnPressUp: true,

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -15,6 +15,11 @@ import type {
 } from 'sentry/components/core/compactSelect/types';
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Overlay} from 'sentry/components/overlay';
+import {
+  AskSeerLabel,
+  AskSeerListItem,
+  AskSeerPane,
+} from 'sentry/components/searchQueryBuilder/askSeer';
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
 import type {CustomComboboxMenuProps} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
@@ -141,7 +146,7 @@ function RecentSearchFilterOption<T>({
 }
 
 function AskSeerOption<T>({state}: {state: ComboBoxState<T>}) {
-  const ref = useRef<HTMLLIElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
   const {setDisplaySeerResults} = useSearchQueryBuilder();
   const organization = useOrganization();
 
@@ -631,52 +636,4 @@ const EmptyState = styled('div')`
   div {
     max-width: 280px;
   }
-`;
-
-const AskSeerPane = styled('div')`
-  grid-area: seer;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0;
-  border-bottom: 1px solid ${p => p.theme.innerBorder};
-  background-color: ${p => p.theme.purple100};
-  width: 100%;
-`;
-
-const AskSeerListItem = styled('li')`
-  position: relative;
-  display: flex;
-  align-items: center;
-  width: 100%;
-  padding: ${space(1)} ${space(1.5)};
-  background: transparent;
-  border-radius: 0;
-  background-color: none;
-  box-shadow: none;
-  color: ${p => p.theme.purple400};
-  font-size: ${p => p.theme.fontSize.md};
-  font-weight: ${p => p.theme.fontWeight.bold};
-  text-align: left;
-  justify-content: flex-start;
-  gap: ${space(1)};
-  list-style: none;
-  margin: 0;
-
-  &:hover,
-  &:focus {
-    background-color: ${p => p.theme.purple100};
-    color: ${p => p.theme.purple400};
-  }
-
-  &[aria-selected='true'] {
-    background: ${p => p.theme.purple100};
-    color: ${p => p.theme.purple400};
-  }
-`;
-const AskSeerLabel = styled('span')`
-  ${p => p.theme.overflowEllipsis};
-  color: ${p => p.theme.purple400};
-  font-size: ${p => p.theme.fontSize.md};
-  font-weight: ${p => p.theme.fontWeight.bold};
 `;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -16,6 +16,7 @@ import type {
 import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
 import {Overlay} from 'sentry/components/overlay';
 import {
+  ASK_SEER_ITEM_KEY,
   AskSeerLabel,
   AskSeerListItem,
   AskSeerPane,
@@ -38,8 +39,6 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
 import {useTraceExploreAiQueryContext} from 'sentry/views/explore/contexts/traceExploreAiQueryContext';
-
-const ASK_SEER_ITEM_KEY = 'ask_seer';
 
 interface FilterKeyListBoxProps<T> extends CustomComboboxMenuProps<T> {
   recentFilters: Array<TokenResult<Token.FILTER>>;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -58,7 +58,8 @@ export type SearchKeyItem =
   | KeyItem
   | RawSearchItem
   | FilterValueItem
-  | RawSearchFilterValueItem;
+  | RawSearchFilterValueItem
+  | AskSeerItem;
 
 export type FilterKeyItem =
   | KeyItem

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {getEscapedKey} from 'sentry/components/core/compactSelect/utils';
+import {ASK_SEER_ITEM_KEY} from 'sentry/components/searchQueryBuilder/askSeer';
 import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {
@@ -201,8 +202,8 @@ export function createRecentQueryItem({
 
 export function createAskSeerItem(): AskSeerItem {
   return {
-    key: getEscapedKey('ask_seer'),
-    value: 'ask_seer',
+    key: getEscapedKey(ASK_SEER_ITEM_KEY),
+    value: ASK_SEER_ITEM_KEY,
     textValue: 'Ask Seer',
     type: 'ask-seer' as const,
     label: t('Ask Seer'),

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -7,6 +7,7 @@ import type {
   SearchKeyItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/types';
 import {
+  createAskSeerItem,
   createFilterValueItem,
   createItem,
   createRawSearchFilterValueItem,
@@ -18,6 +19,7 @@ import {defined} from 'sentry/utils';
 import {FieldKey} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useTraceExploreAiQueryContext} from 'sentry/views/explore/contexts/traceExploreAiQueryContext';
 
 type FilterKeySearchItem = {
   description: string;
@@ -136,9 +138,15 @@ export function useSortedFilterKeyItems({
     disallowFreeText,
     replaceRawSearchKeys,
   } = useSearchQueryBuilder();
-  const hasRawSearchReplacement = useOrganization().features.includes(
+  const organization = useOrganization();
+  const traceExploreAiQueryContext = useTraceExploreAiQueryContext();
+
+  const hasRawSearchReplacement = organization.features.includes(
     'search-query-builder-raw-search-replacement'
   );
+  const areAiFeaturesAllowed =
+    !organization?.hideAiFeatures && organization.features.includes('gen-ai-features');
+  const showAskSeerOption = !!(traceExploreAiQueryContext && areAiFeaturesAllowed);
 
   const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);
 
@@ -250,6 +258,7 @@ export function useSortedFilterKeyItems({
         ...(shouldIncludeRawSearch ? [rawSearchSection] : []),
         keyItemsSection,
         ...(!shouldShowAtTop && suggestedFiltersSection ? [suggestedFiltersSection] : []),
+        ...(showAskSeerOption ? [createAskSeerItem()] : []),
       ];
     }
 
@@ -266,5 +275,6 @@ export function useSortedFilterKeyItems({
     disallowFreeText,
     replaceRawSearchKeys,
     hasRawSearchReplacement,
+    showAskSeerOption,
   ]);
 }


### PR DESCRIPTION
This PR adds in an "Ask Seer" button when users start typing into the trace explorer search query builder.

Closes: AIML-516

Example:

![Screenshot 2025-07-02 at 13 43 03](https://github.com/user-attachments/assets/ab6025ad-3125-4b86-bc67-45ddec16737e)
