### PR TITLE
fix(seer): Check gen ai toggle before running automation

### DIFF
--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -29,7 +29,7 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     if not project.get_option("sentry:seer_scanner_automation"):
         return None
     if group.organization.get_option("sentry:hide_ai_features"):
-        return
+        return None
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
         return None
 

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -28,6 +28,8 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
     project = group.project
     if not project.get_option("sentry:seer_scanner_automation"):
         return None
+    if group.organization.get_option("sentry:hide_ai_features"):
+        return
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
         return None
 

--- a/src/sentry/seer/autofix.py
+++ b/src/sentry/seer/autofix.py
@@ -853,6 +853,9 @@ def trigger_autofix(
     if not features.has("organizations:gen-ai-features", group.organization, actor=user):
         return _respond_with_error("AI Autofix is not enabled for this project.", 403)
 
+    if group.organization.get_option("sentry:hide_ai_features"):
+        return _respond_with_error("AI features are disabled for this organization.", 403)
+
     if not get_seer_org_acknowledgement(org_id=group.organization.id):
         return _respond_with_error(
             "Seer has not been enabled for this organization. Please open an issue at sentry.io/issues and set up Seer.",

--- a/src/sentry/seer/issue_summary.py
+++ b/src/sentry/seer/issue_summary.py
@@ -416,6 +416,9 @@ def get_issue_summary(
     if not features.has("organizations:gen-ai-features", group.organization, actor=user):
         return {"detail": "Feature flag not enabled"}, 400
 
+    if group.organization.get_option("sentry:hide_ai_features"):
+        return {"detail": "AI features are disabled for this organization."}, 403
+
     if not get_seer_org_acknowledgement(group.organization.id):
         return {"detail": "AI Autofix has not been acknowledged by the organization."}, 403
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1614,6 +1614,10 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
     ):
         return
 
+    gen_ai_allowed = not group.organization.get_option("sentry:hide_ai_features")
+    if not gen_ai_allowed:
+        return
+
     project = group.project
     if not project.get_option("sentry:seer_scanner_automation"):
         return

--- a/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
+++ b/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
@@ -1,0 +1,197 @@
+from unittest.mock import patch
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.integrations.utils.issue_summary_for_alerts import fetch_issue_summary
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+class FetchIssueSummaryTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        # Create an error group with the proper type
+        self.group = self.create_group(project=self.project, type=ErrorGroupType.type_id)
+
+    def test_fetch_issue_summary_returns_none_for_non_error_groups(self):
+        """Test that fetch_issue_summary returns None for non-error issue categories"""
+        # Create a performance group for this test
+        performance_group = self.create_group(
+            project=self.project, type=PerformanceNPlusOneGroupType.type_id
+        )
+
+        result = fetch_issue_summary(performance_group)
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_fetch_issue_summary_with_hide_ai_features_enabled(
+        self, mock_has_budget, mock_rate_limited, mock_seer_ack
+    ):
+        """Test that fetch_issue_summary returns None when hideAiFeatures is True"""
+        # Set up all the required conditions to pass except hideAiFeatures
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        self.organization.update_option("sentry:hide_ai_features", True)
+        mock_seer_ack.return_value = True
+        mock_rate_limited.return_value = False
+        mock_has_budget.return_value = True
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+        # Verify that budget check wasn't called since we returned early
+        mock_has_budget.assert_not_called()
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_fetch_issue_summary_with_hide_ai_features_disabled(
+        self, mock_has_budget, mock_rate_limited, mock_seer_ack, mock_get_issue_summary
+    ):
+        """Test that fetch_issue_summary proceeds normally when hideAiFeatures is False"""
+        # Set up all the required conditions to pass
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        self.organization.update_option("sentry:hide_ai_features", False)
+        mock_seer_ack.return_value = True
+        mock_rate_limited.return_value = False
+        mock_has_budget.return_value = True
+
+        # Mock successful summary response
+        mock_summary = {
+            "headline": "Test AI Summary",
+            "whatsWrong": "Something went wrong",
+            "possibleCause": "Test cause",
+        }
+        mock_get_issue_summary.return_value = (mock_summary, 200)
+
+        result = fetch_issue_summary(self.group)
+
+        assert result == mock_summary
+        mock_get_issue_summary.assert_called_once()
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    def test_fetch_issue_summary_without_seer_scanner_automation(self, mock_seer_ack):
+        """Test that fetch_issue_summary returns None when seer_scanner_automation is disabled"""
+        self.project.update_option("sentry:seer_scanner_automation", False)
+        mock_seer_ack.return_value = True
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    def test_fetch_issue_summary_without_org_acknowledgement(self, mock_seer_ack):
+        """Test that fetch_issue_summary returns None when org hasn't acknowledged Seer"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        mock_seer_ack.return_value = False
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    def test_fetch_issue_summary_without_gen_ai_features(self):
+        """Test that fetch_issue_summary returns None without gen-ai-features flag"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+
+        # No @with_feature decorator, so gen-ai-features is disabled
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    def test_fetch_issue_summary_without_trigger_autofix_feature(self):
+        """Test that fetch_issue_summary returns None without trigger-autofix-on-issue-summary flag"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+
+        # Only gen-ai-features enabled, not trigger-autofix-on-issue-summary
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
+    def test_fetch_issue_summary_rate_limited(self, mock_rate_limited, mock_seer_ack):
+        """Test that fetch_issue_summary returns None when rate limited"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        mock_seer_ack.return_value = True
+        mock_rate_limited.return_value = True
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_fetch_issue_summary_no_budget(self, mock_has_budget, mock_rate_limited, mock_seer_ack):
+        """Test that fetch_issue_summary returns None when no budget available"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        mock_seer_ack.return_value = True
+        mock_rate_limited.return_value = False
+        mock_has_budget.return_value = False
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_fetch_issue_summary_timeout_error(
+        self, mock_has_budget, mock_rate_limited, mock_seer_ack, mock_get_issue_summary
+    ):
+        """Test that fetch_issue_summary returns None when timeout occurs"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        mock_seer_ack.return_value = True
+        mock_rate_limited.return_value = False
+        mock_has_budget.return_value = True
+
+        # Mock timeout exception
+        import concurrent.futures
+
+        mock_get_issue_summary.side_effect = concurrent.futures.TimeoutError()
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None
+
+    @with_feature("organizations:gen-ai-features")
+    @with_feature("organizations:trigger-autofix-on-issue-summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_issue_summary")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.get_seer_org_acknowledgement")
+    @patch("sentry.integrations.utils.issue_summary_for_alerts.is_seer_scanner_rate_limited")
+    @patch("sentry.quotas.backend.has_available_reserved_budget")
+    def test_fetch_issue_summary_api_error(
+        self, mock_has_budget, mock_rate_limited, mock_seer_ack, mock_get_issue_summary
+    ):
+        """Test that fetch_issue_summary returns None when API returns error status"""
+        self.project.update_option("sentry:seer_scanner_automation", True)
+        mock_seer_ack.return_value = True
+        mock_rate_limited.return_value = False
+        mock_has_budget.return_value = True
+
+        # Mock error response
+        mock_get_issue_summary.return_value = (None, 500)
+
+        result = fetch_issue_summary(self.group)
+
+        assert result is None

--- a/tests/sentry/seer/test_issue_summary.py
+++ b/tests/sentry/seer/test_issue_summary.py
@@ -361,8 +361,8 @@ class IssueSummaryTest(APITestCase, SnubaTestCase):
         mock_blocking_acquire.assert_called_once()
         # Ensure generation was NOT called
         mock_generate_summary_core.assert_not_called()
-        # Ensure cache was checked twice (once initially, once after lock failure)
-        assert mock_cache_get.call_count == 2
+        # Ensure cache was checked three times (once initially, once after lock failure, and once for hideAiFeatures check)
+        assert mock_cache_get.call_count == 3
         mock_get_acknowledgement.assert_called_once_with(self.group.organization.id)
 
     @patch("sentry.seer.issue_summary.Project.objects.filter")


### PR DESCRIPTION
Guards automation, issue summary, autofix with a check on `hide_ai_features` (the gen ai toggle)