### PR TITLE
fix(search): ensure wildcard search splits work with single wildcard sets

### DIFF
--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -137,6 +137,36 @@ class DiscoverQueryBuilderTest(TestCase):
 
         self.assertCountEqual(query.where[0].conditions, expected.conditions)
 
+    def test_single_wildcard_set(self):
+        query = DiscoverQueryBuilder(Dataset.Discover, self.params, query='title:["*A", "D"]')
+
+        expected = Or(
+            [
+                Condition(
+                    Function("match", [Column("title"), "(?i)^.*A$"]),
+                    Op.EQ,
+                    1,
+                ),
+                Condition(Column("title"), Op.IN, ["D"]),
+            ]
+        )
+
+        self.assertCountEqual(query.where[0].conditions, expected.conditions)
+
+    def test_single_wildcard(self):
+        query = DiscoverQueryBuilder(Dataset.Discover, self.params, query='title:["*A"]')
+
+        expected = [
+            Condition(
+                Function("match", [Column("title"), "(?i)^.*A$"]),
+                Op.EQ,
+                1,
+            ),
+            *self.default_conditions,
+        ]
+
+        self.assertCountEqual(query.where, expected)
+
     def test_simple_orderby(self):
         query = DiscoverQueryBuilder(
             Dataset.Discover,


### PR DESCRIPTION
It's also the case that queries can look like 'foo:[A*]', meaning a single wildcard in a set.  Handle that case as well.

Fixes https://sentry.sentry.io/issues/6722968341/?project=1