### PR TITLE
feat(dashboards): Use starred endpoint for ordered dashboards

### DIFF
--- a/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
@@ -1,20 +1,30 @@
+import type {Organization} from 'sentry/types/organization';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
+function getQueryKey(organization: Organization): ApiQueryKey {
+  const DASHBOARDS_QUERY_KEY = [
+    `/organizations/${organization.slug}/dashboards/`,
+    {
+      query: {
+        filter: 'onlyFavorites',
+      },
+    },
+  ] as const;
+  const STARRED_DASHBOARDS_QUERY_KEY = [
+    `/organizations/${organization.slug}/dashboards/starred/`,
+    {},
+  ] as const;
+  return organization.features.includes('dashboards-starred-reordering')
+    ? STARRED_DASHBOARDS_QUERY_KEY
+    : DASHBOARDS_QUERY_KEY;
+}
+
 export function useGetStarredDashboards() {
   const organization = useOrganization();
-  return useApiQuery<DashboardListItem[]>(
-    [
-      `/organizations/${organization.slug}/dashboards/`,
-      {
-        query: {
-          filter: 'onlyFavorites',
-        },
-      },
-    ],
-    {
-      staleTime: Infinity,
-    }
-  );
+  return useApiQuery<DashboardListItem[]>(getQueryKey(organization), {
+    staleTime: Infinity,
+  });
 }


### PR DESCRIPTION
This endpoint returns starred dashboards in order of position. It uses the same serializer so the handling of the response does not need to change.

In the backend, behind the scenes, it also backfills in position data from the original sorting if there are no positions set yet (i.e. it'll order by title)