### PR TITLE
fix(ourlogs): Make body grow to full height if possible

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -329,6 +329,8 @@ export const BottomSectionBody = styled('div')`
 
 export const ToolbarAndBodyContainer = styled('div')<{sidebarOpen: boolean}>`
   height: 100%;
+  flex: 1 1 auto;
+
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
     display: grid;
     grid-template-columns: ${p => (p.sidebarOpen ? '325px minmax(100px, auto)' : 'auto')};


### PR DESCRIPTION
The body element needs flex grow to fill the screen, otherwise the sidebar looks weird.