### PR TITLE
tooltip: improve shadow tooltips

### DIFF
--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -24,6 +24,7 @@ function ChonkOverlayArrow({
   size = 16,
   background,
   border,
+  ...props
 }: OverlayArrowProps) {
   const theme = useTheme();
 
@@ -33,7 +34,7 @@ function ChonkOverlayArrow({
   const heightRatio = 0.3;
 
   return (
-    <ChonkWrap size={size} ref={ref} placement={placement}>
+    <ChonkWrap size={size} ref={ref} placement={placement} {...props}>
       <svg
         width={size * sizeRatio}
         height={size * sizeRatio}
@@ -76,13 +77,12 @@ const ChonkWrap = chonkStyled('div')<{
   transform-origin: center;
 
   ${p =>
-    p.placement?.startsWith('top') &&
-    `top: 100%; left: 50%; transform: translateX(-50%) rotate(0deg);`}
-  ${p => p.placement?.startsWith('bottom') && `bottom: 100%; left: 50%; transform: translateX(-50%) rotate(180deg);`}
-  ${p => p.placement?.startsWith('left') && `left: 100%; top: 50%; transform: translateY(-50%) rotate(-90deg);`}
+    p.placement?.startsWith('top') && `top: 100%; left: 50%; transform: rotate(0deg);`}
+  ${p => p.placement?.startsWith('bottom') && `bottom: 100%; left: 50%; transform: rotate(180deg);`}
+  ${p => p.placement?.startsWith('left') && `left: 100%; top: 50%; transform: rotate(-90deg);`}
   ${p =>
     p.placement?.startsWith('right') &&
-    `right: 100%; top: 50%; transform: translateY(-50%) rotate(90deg);`}
+    `right: 100%; top: 50%; transform: rotate(90deg);`}
 
   > svg {
     width: ${p => p.size}px;

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
@@ -99,6 +99,9 @@ function FlamegraphOptionsMenu({
           icon={<IconChevron direction="right" />}
           aria-label={t('View Next 30 Minutes')}
           title={t('View Next 30 Minutes')}
+          tooltipProps={{
+            forceVisible: true,
+          }}
         />
       ) : null}
     </Fragment>


### PR DESCRIPTION
We forgot to spread props on the tooltip implementation, leaving out a crucial detail where the classname applies left offset to position the arrow closer to the hovered element implementation.

**Before:**
![CleanShot 2025-07-02 at 16 04 59@2x](https://github.com/user-attachments/assets/c070c14f-65f0-42ed-a214-e64befcf8673)

**After:**
![CleanShot 2025-07-02 at 16 04 09@2x](https://github.com/user-attachments/assets/471445d6-e8f2-437e-8109-c42abe52ffb5)

**After all placement**
![CleanShot 2025-07-02 at 16 04 21@2x](https://github.com/user-attachments/assets/559b1bc8-681d-4a17-b4d4-e9868a8d46c9)

