### PR TITLE
feat(seer): Access more granular data

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -277,9 +277,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
 
         STATS_PERIODS = [None, "", "24h", "14d", "auto"]
         if features.has("organizations:detailed-data-for-seer", organization, actor=request.user):
-            import pdb
-
-            pdb.set_trace()
             STATS_PERIODS.append("1h")
 
         if stats_period not in STATS_PERIODS:

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -272,15 +272,15 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         except InvalidParams as e:
             raise ParseError(detail=str(e))
 
-        import pdb
-
-        pdb.set_trace()
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", [])
 
         STATS_PERIODS = [None, "", "24h", "14d", "auto"]
         if features.has("organizations:detailed-data-for-seer", organization, actor=request.user):
-            STATS_PERIODS += "1hr"
+            import pdb
+
+            pdb.set_trace()
+            STATS_PERIODS.append("1h")
 
         if stats_period not in STATS_PERIODS:
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -274,7 +274,12 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
 
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", [])
-        if stats_period not in (None, "", "24h", "14d", "auto"):
+
+        STATS_PERIODS = [None, "", "24h", "14d", "auto"]
+        if features.has("organizations:detailed-data-for-seer", organization, actor=request.user):
+            STATS_PERIODS += "1hr"
+
+        if stats_period not in STATS_PERIODS:
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
         stats_period, stats_period_start, stats_period_end = calculate_stats_period(
             stats_period, start, end

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -272,6 +272,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
         except InvalidParams as e:
             raise ParseError(detail=str(e))
 
+        import pdb
+
+        pdb.set_trace()
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", [])
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4085,8 +4085,9 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_response()
         assert response.status_code == 500
 
-    def test_seer_resolution(self):
-        response = self.get_response(gruopStatsPeriod="1h")
+    def test_seer_resolution(self, mock_query: MagicMock):
+        self.login_as(user=self.user)
+        response = self.get_response(groupStatsPeriod="1h")
         assert response.status_code == 400
 
         with self.feature({"organizations:detailed-data-for-seer": True}):

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4085,6 +4085,13 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_response()
         assert response.status_code == 500
 
+    def test_seer_resolution(self):
+        response = self.get_response(gruopStatsPeriod="1h")
+        assert response.status_code == 400
+
+        with self.feature({"organizations:detailed-data-for-seer": True}):
+            self.get_success_response(groupStatsPeriod="1h")
+
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"


### PR DESCRIPTION
# Description
Adds the `1h` interval to the supported stats period in the API for access into data for a seer experiment.