### PR TITLE
ref(traces): Remove `hiddenAttributes` prop from `AttributeTree`

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -75,7 +75,6 @@ interface AttributesTreeProps<RendererExtra extends RenderFunctionBaggage>
   config?: AttributesTreeRowConfig;
   getAdjustedAttributeKey?: (attribute: TraceItemResponseAttribute) => string;
   getCustomActions?: (content: AttributesTreeContent) => MenuItemProps[];
-  hiddenAttributes?: string[];
 }
 
 interface AttributesTreeColumnsProps<RendererExtra extends RenderFunctionBaggage>
@@ -212,7 +211,6 @@ function getAttributesTreeRows<RendererExtra extends RenderFunctionBaggage>({
 function AttributesTreeColumns<RendererExtra extends RenderFunctionBaggage>({
   attributes,
   columnCount,
-  hiddenAttributes = [],
   renderers = {},
   rendererExtra: renderExtra,
   config = {},
@@ -226,7 +224,7 @@ function AttributesTreeColumns<RendererExtra extends RenderFunctionBaggage>({
 
     // Convert attributes record to the format expected by addToAttributeTree
     const visibleAttributes = attributes
-      .map(key => getAttribute(key, hiddenAttributes, getAdjustedAttributeKey))
+      .map(key => getAttribute(key, getAdjustedAttributeKey))
       .filter(defined);
 
     // Create the AttributeTree data structure using all the given attributes
@@ -289,7 +287,6 @@ function AttributesTreeColumns<RendererExtra extends RenderFunctionBaggage>({
   }, [
     attributes,
     columnCount,
-    hiddenAttributes,
     renderers,
     renderExtra,
     config,
@@ -490,18 +487,12 @@ function AttributesTreeValue<RendererExtra extends RenderFunctionBaggage>({
 }
 
 /**
- * Filters out hidden attributes, replaces sentry. prefixed keys, and simplifies the value
+ * Replaces sentry. prefixed keys, and simplifies the value
  */
 function getAttribute(
   attribute: TraceItemResponseAttribute,
-  hiddenAttributes: string[],
   getAdjustedAttributeKey?: (attribute: TraceItemResponseAttribute) => string
 ): Attribute | undefined {
-  // Filter out hidden attributes
-  if (hiddenAttributes.includes(attribute.name)) {
-    return undefined;
-  }
-
   const attributeValue =
     attribute.type === 'bool' ? String(attribute.value) : attribute.value;
 

--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -60,6 +60,9 @@ export type AttributesFieldRendererProps<RendererExtra extends RenderFunctionBag
 };
 
 interface AttributesFieldRender<RendererExtra extends RenderFunctionBaggage> {
+  /**
+   * Extra data that gets passed to the renderer function for every attribute in the tree. If any of your field renderers rely on data that isn't related to the attributes (e.g., the current theme or location) or data that lives in another attribute (e.g., using the log level attribute to render the log text attribute) you should pass that data as here.
+   */
   rendererExtra: RendererExtra;
   renderers?: Record<
     string,
@@ -69,6 +72,9 @@ interface AttributesFieldRender<RendererExtra extends RenderFunctionBaggage> {
 
 interface AttributesTreeProps<RendererExtra extends RenderFunctionBaggage>
   extends AttributesFieldRender<RendererExtra> {
+  /**
+   * The attributes to show in the attribute tree. If you need to hide any attributes, filter them out before passing them here. If you need extra attribute information for rendering but you don't want to show those attributes, pass that information in the `rendererExtra` prop.
+   */
   attributes: TraceItemResponseAttribute[];
   // If provided, locks the number of columns to this number. If not provided, the number of columns will be dynamic based on width.
   columnCount?: number;

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -72,6 +72,7 @@ describe('logsTableRow', () => {
   const rowDetails = [
     ...Object.entries(rowData),
     ...Object.entries({
+      [OurLogKnownFieldKey.SPAN_ID]: 'faded0',
       [OurLogKnownFieldKey.CODE_FUNCTION_NAME]: 'derp',
       [OurLogKnownFieldKey.CODE_LINE_NUMBER]: '10',
       [OurLogKnownFieldKey.CODE_FILE_PATH]: 'herp/merp/derp.py',
@@ -129,6 +130,9 @@ describe('logsTableRow', () => {
     // Check that the log body and timestamp are rendered
     expect(screen.getByText('test log body')).toBeInTheDocument();
     expect(screen.getByText('2025-04-03T15:50:10+00:00')).toBeInTheDocument();
+
+    // Check that the span ID is not rendered
+    expect(screen.queryByText('span_id')).not.toBeInTheDocument();
 
     // Expand the row to show the attributes
     const logTableRow = await screen.findByTestId('log-table-row');

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -416,8 +416,9 @@ function LogRowDetails({
               </DetailsBody>
               <LogAttributeTreeWrapper>
                 <AttributesTree<RendererExtra>
-                  attributes={data.attributes}
-                  hiddenAttributes={HiddenLogDetailFields}
+                  attributes={data.attributes.filter(
+                    attribute => !HiddenLogDetailFields.includes(attribute.name)
+                  )}
                   getCustomActions={getActions}
                   getAdjustedAttributeKey={adjustAliases}
                   renderers={LogAttributesRendererMap}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -190,7 +190,6 @@ export function Attributes({
         {sortedAndFilteredAttributes.length > 0 ? (
           <AttributesTreeWrapper>
             <AttributesTree
-              hiddenAttributes={HIDDEN_ATTRIBUTES}
               columnCount={columnCount}
               attributes={sortedAndFilteredAttributes}
               renderers={customRenderers}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -101,16 +101,23 @@ export function Attributes({
       : undefined;
 
   const sortedAndFilteredAttributes = useMemo(() => {
-    const sorted = sortAttributes(attributes);
+    const sortedAttributes = sortAttributes(attributes);
+
+    const onlyVisibleAttributes = sortedAttributes.filter(
+      attribute => !HIDDEN_ATTRIBUTES.includes(attribute.name)
+    );
+
     if (!searchQuery.trim()) {
-      return sorted;
+      return onlyVisibleAttributes;
     }
 
-    return sorted.filter(
-      attribute =>
-        !HIDDEN_ATTRIBUTES.includes(attribute.name) &&
-        attribute.name.toLowerCase().trim().includes(searchQuery.toLowerCase().trim())
-    );
+    const normalizedSearchQuery = searchQuery.toLowerCase().trim();
+
+    const onlyMatchingAttributes = onlyVisibleAttributes.filter(attribute => {
+      return attribute.name.toLowerCase().trim().includes(normalizedSearchQuery);
+    });
+
+    return onlyMatchingAttributes;
   }, [attributes, searchQuery]);
 
   const customRenderers: Record<


### PR DESCRIPTION
Small refactor to simplify some upcoming changes. `AttributeTree` accepts an `attributes` prop, and a `hiddenAttributes` prop. Any attribute whose name is included in `hiddenAttributes` is visually filtered out. This seems strange:

1. It's strange that the tree component has to iterate all the attributes and then decide which ones to hide one-by-one. It's much more efficient to just _omit those attributes_ from the component, so it only iterates attributes that actually show up
2. The hidden attributes are redundant. The `AttributeTree` in the trace view, for example, both passes `HIDDEN_ATTRIBUTES` _and_ manually omits those fields from `attributes`, I'm not sure why
3. The logic that hides attributes is very deep inside `AttributeTree`, so it's not clear from looking at the component why some things are missing
4. In the near future, we'll need to omit attributes by some dynamic property (e.g., omit anything that starts with `"__sentry"` but not for Staff users), which cannot be expressed via `hiddenAttributes`

It seems easier and more consistent to remove the `hiddenAttributes` prop, and ensure that the parent component only passes whichever attributes should be omitted.

Am I missing something?

## Changes

- Add test case for hidden attributes
- Stop passing `hiddenAttributes`
- Remove unused hidden attributes prop
