### PR TITLE
feat(trace-eap-waterfall): Adding additional data section to contexts

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -20,7 +20,7 @@ import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTra
 import {extendWithLegacyAttributeKeys} from 'sentry/views/insights/agentMonitoring/utils/query';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
-import {SectionTitleWithQuestionTooltip} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
   findSpanAttributeValue,
   getTraceAttributesTreeActions,
@@ -171,7 +171,7 @@ export function Attributes({
     <FoldSection
       sectionKey={SectionKey.SPAN_ATTRIBUTES}
       title={
-        <SectionTitleWithQuestionTooltip
+        <TraceDrawerComponents.SectionTitleWithQuestionTooltip
           title={t('Attributes')}
           tooltipText={t(
             'These attributes are indexed and can be queried in the Trace Explorer.'

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
@@ -1,0 +1,39 @@
+import {t} from 'sentry/locale';
+import {EntryType, type EventTransaction} from 'sentry/types/event';
+import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
+import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
+import {SectionTitleWithQuestionTooltip} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span';
+import {
+  AdditionalData,
+  hasAdditionalData,
+} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/additionalData';
+import {Request} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/request';
+
+export function Contexts({event}: {event: EventTransaction | undefined}) {
+  const eventHasRequestEntry = event?.entries.some(
+    entry => entry.type === EntryType.REQUEST
+  );
+  const eventHasAdditionalData = event ? hasAdditionalData(event) : false;
+
+  if (!event || (!eventHasRequestEntry && !eventHasAdditionalData)) {
+    return null;
+  }
+
+  return (
+    <FoldSection
+      sectionKey={SectionKey.CONTEXTS}
+      title={
+        <SectionTitleWithQuestionTooltip
+          title={t('Contexts')}
+          tooltipText={t(
+            "This data is not indexed and can't be queried in the Trace Explorer. For querying, attach these as attributes to your spans."
+          )}
+        />
+      }
+      disableCollapsePersistence
+    >
+      {eventHasRequestEntry ? <Request event={event} /> : null}
+      {eventHasAdditionalData ? <AdditionalData event={event} /> : null}
+    </FoldSection>
+  );
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
@@ -2,7 +2,7 @@ import {t} from 'sentry/locale';
 import {EntryType, type EventTransaction} from 'sentry/types/event';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
-import {SectionTitleWithQuestionTooltip} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span';
+import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
   AdditionalData,
   hasAdditionalData,
@@ -23,7 +23,7 @@ export function Contexts({event}: {event: EventTransaction | undefined}) {
     <FoldSection
       sectionKey={SectionKey.CONTEXTS}
       title={
-        <SectionTitleWithQuestionTooltip
+        <TraceDrawerComponents.SectionTitleWithQuestionTooltip
           title={t('Contexts')}
           tooltipText={t(
             "This data is not indexed and can't be queried in the Trace Explorer. For querying, attach these as attributes to your spans."

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -16,7 +16,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {EntryType, type EventTransaction} from 'sentry/types/event';
+import {type EventTransaction} from 'sentry/types/event';
 import type {NewQuery, Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
@@ -45,10 +45,10 @@ import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/de
 import {AIInputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
 import {AIOutputSection} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import {Attributes} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes';
+import {Contexts} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {BreadCrumbs} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs';
 import ReplayPreview from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview';
-import {Request} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/request';
 import {getProfileMeta} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import {
@@ -408,10 +408,6 @@ function EAPSpanNodeDetails({
   const profileId =
     typeof profileMeta === 'string' ? profileMeta : profileMeta.profiler_id;
 
-  const eventHasRequestEntry = eventTransaction?.entries.some(
-    entry => entry.type === EntryType.REQUEST
-  );
-
   return (
     <TraceDrawerComponents.DetailContainer>
       <SpanNodeDetailHeader
@@ -468,22 +464,7 @@ function EAPSpanNodeDetails({
                       project={project}
                     />
 
-                    {isTransaction && eventHasRequestEntry ? (
-                      <FoldSection
-                        sectionKey={SectionKey.CONTEXTS}
-                        title={
-                          <SectionTitleWithQuestionTooltip
-                            title={t('Contexts')}
-                            tooltipText={t(
-                              "This data is not indexed and can't be queried in the Trace Explorer. For querying, attach these as attributes to your spans."
-                            )}
-                          />
-                        }
-                        disableCollapsePersistence
-                      >
-                        <Request event={eventTransaction} />
-                      </FoldSection>
-                    ) : null}
+                    {isTransaction ? <Contexts event={eventTransaction} /> : null}
 
                     <LogDetails />
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -13,7 +13,6 @@ import {
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {type EventTransaction} from 'sentry/types/event';
@@ -526,24 +525,3 @@ function EAPSpanNodeDetails({
     </TraceDrawerComponents.DetailContainer>
   );
 }
-
-export function SectionTitleWithQuestionTooltip({
-  title,
-  tooltipText,
-}: {
-  title: string;
-  tooltipText: string;
-}) {
-  return (
-    <Flex>
-      <div>{title}</div>
-      <QuestionTooltip title={tooltipText} size="sm" />
-    </Flex>
-  );
-}
-
-const Flex = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
-`;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1345,6 +1345,21 @@ const MultilineTextLabel = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
+function SectionTitleWithQuestionTooltip({
+  title,
+  tooltipText,
+}: {
+  title: string;
+  tooltipText: string;
+}) {
+  return (
+    <Flex style={{gap: space(0.5)}}>
+      <div>{title}</div>
+      <QuestionTooltip title={tooltipText} size="sm" />
+    </Flex>
+  );
+}
+
 export const TraceDrawerComponents = {
   DetailContainer,
   BodyContainer,
@@ -1359,6 +1374,7 @@ export const TraceDrawerComponents = {
   NodeActions,
   KeyValueAction,
   Table,
+  SectionTitleWithQuestionTooltip,
   IconTitleWrapper,
   IconBorder,
   TitleText,


### PR DESCRIPTION
<img width="1197" alt="Screenshot 2025-07-02 at 4 17 23 PM" src="https://github.com/user-attachments/assets/caf37270-dc72-4b3c-8bd8-58b369540f56" />
