### PR TITLE
ref(uptime): Default writing snuba results to true

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3031,7 +3031,7 @@ register(
 register(
     "uptime.snuba_uptime_results.enabled",
     type=Bool,
-    default=False,
+    default=True,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -652,6 +652,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
                 extra={**result},
             )
 
+    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_missed_check_updated_interval(self):
         result = self.create_uptime_result(self.subscription.subscription_id)
 
@@ -803,6 +804,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         with pytest.raises(Group.DoesNotExist):
             Group.objects.get(grouphash__hash=hashed_fingerprint)
 
+    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_missed(self):
         features = [
             "organizations:uptime",
@@ -1182,6 +1184,7 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
         assert group_1 == [result_1, result_2]
         assert group_2 == [result_3]
 
+    @override_options({"uptime.snuba_uptime_results.enabled": False})
     def test_provider_stats(self):
         features = [
             "organizations:uptime",


### PR DESCRIPTION
If uptime is enabled we should default to writing the results into
snuba, since this is the only way to visualize uptime results