### PR TITLE
feat(explore): Autocomplete equations with different types

### DIFF
--- a/static/app/components/arithmeticBuilder/context.tsx
+++ b/static/app/components/arithmeticBuilder/context.tsx
@@ -5,23 +5,23 @@ import type {
   ArithmeticBuilderAction,
   FocusOverride,
 } from 'sentry/components/arithmeticBuilder/action';
-import type {
-  AggregateFunction,
-  FunctionArgument,
-} from 'sentry/components/arithmeticBuilder/types';
+import type {FunctionArgument} from 'sentry/components/arithmeticBuilder/types';
+import type {FieldDefinition} from 'sentry/utils/fields';
 
 interface ArithmeticBuilderContextData {
-  aggregateFunctions: AggregateFunction[];
+  aggregations: string[];
   dispatch: Dispatch<ArithmeticBuilderAction>;
   focusOverride: FocusOverride | null;
   functionArguments: FunctionArgument[];
+  getFieldDefinition: (key: string) => FieldDefinition | null;
 }
 
 export const ArithmeticBuilderContext = createContext<ArithmeticBuilderContextData>({
   dispatch: () => {},
   focusOverride: null,
-  aggregateFunctions: [],
+  aggregations: [],
   functionArguments: [],
+  getFieldDefinition: () => null,
 });
 
 export function useArithmeticBuilder() {

--- a/static/app/components/arithmeticBuilder/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/index.spec.tsx
@@ -1,16 +1,29 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
+import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 
-const aggregateFunctions = [{name: 'avg'}, {name: 'sum'}, {name: 'count'}];
+const aggregations = ['avg', 'sum', 'count', 'count_unique'];
 
-const functionArguments = [{name: 'span.duration'}, {name: 'span.self_time'}];
+const functionArguments = [
+  {name: 'span.duration', kind: FieldKind.MEASUREMENT},
+  {name: 'span.self_time', kind: FieldKind.MEASUREMENT},
+  {name: 'span.op', kind: FieldKind.TAG},
+];
+
+const getSpanFieldDefinition = (key: string) => {
+  const argument = functionArguments.find(
+    functionArgument => functionArgument.name === key
+  );
+  return getFieldDefinition(key, 'span', argument?.kind);
+};
 
 function ArithmeticBuilderWrapper({expression}: {expression: string}) {
   return (
     <ArithmeticBuilder
-      aggregateFunctions={aggregateFunctions}
+      aggregations={aggregations}
       functionArguments={functionArguments}
+      getFieldDefinition={getSpanFieldDefinition}
       expression={expression}
     />
   );

--- a/static/app/components/arithmeticBuilder/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/index.spec.tsx
@@ -9,6 +9,7 @@ const functionArguments = [
   {name: 'span.duration', kind: FieldKind.MEASUREMENT},
   {name: 'span.self_time', kind: FieldKind.MEASUREMENT},
   {name: 'span.op', kind: FieldKind.TAG},
+  {name: 'span.description', kind: FieldKind.TAG},
 ];
 
 const getSpanFieldDefinition = (key: string) => {

--- a/static/app/components/arithmeticBuilder/index.tsx
+++ b/static/app/components/arithmeticBuilder/index.tsx
@@ -6,17 +6,17 @@ import {useArithmeticBuilderAction} from 'sentry/components/arithmeticBuilder/ac
 import {ArithmeticBuilderContext} from 'sentry/components/arithmeticBuilder/context';
 import type {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {TokenGrid} from 'sentry/components/arithmeticBuilder/token/grid';
-import type {
-  AggregateFunction,
-  FunctionArgument,
-} from 'sentry/components/arithmeticBuilder/types';
+import type {FunctionArgument} from 'sentry/components/arithmeticBuilder/types';
 import {Input} from 'sentry/components/core/input';
+import type {FieldDefinition} from 'sentry/utils/fields';
+import {FieldKind} from 'sentry/utils/fields';
 import PanelProvider from 'sentry/utils/panelProvider';
 
 interface ArithmeticBuilderProps {
-  aggregateFunctions: AggregateFunction[];
+  aggregations: string[];
   expression: string;
   functionArguments: FunctionArgument[];
+  getFieldDefinition: (key: string) => FieldDefinition | null;
   className?: string;
   disabled?: boolean;
   setExpression?: (expression: Expression) => void;
@@ -25,8 +25,9 @@ interface ArithmeticBuilderProps {
 export function ArithmeticBuilder({
   expression,
   setExpression,
-  aggregateFunctions,
+  aggregations,
   functionArguments,
+  getFieldDefinition,
   className,
   disabled,
 }: ArithmeticBuilderProps) {
@@ -39,10 +40,13 @@ export function ArithmeticBuilder({
     return {
       dispatch,
       focusOverride: state.focusOverride,
-      aggregateFunctions,
+      aggregations: aggregations.filter(aggregation => {
+        return getFieldDefinition(aggregation)?.kind === FieldKind.FUNCTION;
+      }),
       functionArguments,
+      getFieldDefinition,
     };
-  }, [state, dispatch, aggregateFunctions, functionArguments]);
+  }, [state, dispatch, aggregations, functionArguments, getFieldDefinition]);
 
   return (
     <PanelProvider>

--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -19,7 +19,6 @@ import {
   nextTokenKeyOfKind,
   tokenizeExpression,
 } from 'sentry/components/arithmeticBuilder/tokenizer';
-import type {AggregateFunction} from 'sentry/components/arithmeticBuilder/types';
 import type {
   SelectOptionWithKey,
   SelectSectionWithKey,
@@ -116,11 +115,23 @@ function InternalInput({
     updateSelectionIndex();
   }, [trimmedTokenValue, updateSelectionIndex]);
 
-  const {dispatch, aggregateFunctions} = useArithmeticBuilder();
+  const {dispatch, aggregations, getFieldDefinition} = useArithmeticBuilder();
+
+  const getFunctionDefault = useCallback(
+    (func: string): string => {
+      const definition = getFieldDefinition(func);
+      const parameterDefinitions = definition?.parameters ?? [];
+      const parameters = parameterDefinitions.map(
+        parameterDefinition => parameterDefinition.defaultValue
+      );
+      return `${func}(${parameters.join(',')})`;
+    },
+    [getFieldDefinition]
+  );
 
   const items: Array<SelectSectionWithKey<string>> = useSuggestionItems({
     nextAllowedTokenKinds,
-    allowedFunctions: aggregateFunctions,
+    allowedFunctions: aggregations,
     filterValue,
   });
 
@@ -165,11 +176,11 @@ function InternalInput({
           if (input.endsWith('(')) {
             const pos = input.lastIndexOf(' ');
             const maybeFunc = input.substring(pos + 1, input.length - 1);
-            if (aggregateFunctions.some(func => func.name === maybeFunc)) {
+            if (aggregations.includes(maybeFunc)) {
               dispatch({
                 type: 'REPLACE_TOKEN',
                 token,
-                text: `${input.substring(0, pos + 1)}${getInitialText(maybeFunc, true)}`,
+                text: `${input.substring(0, pos + 1)}${getFunctionDefault(maybeFunc)}`,
                 focusOverride: {
                   itemKey: nextTokenKeyOfKind(state, token, TokenKind.FUNCTION),
                 },
@@ -184,7 +195,15 @@ function InternalInput({
       setInputValue(evt.target.value);
       setSelectionIndex(evt.target.selectionStart ?? 0);
     },
-    [aggregateFunctions, dispatch, resetInputValue, setInputValue, state, token]
+    [
+      aggregations,
+      dispatch,
+      getFunctionDefault,
+      resetInputValue,
+      setInputValue,
+      state,
+      token,
+    ]
   );
 
   const onInputCommit = useCallback(() => {
@@ -275,12 +294,12 @@ function InternalInput({
       dispatch({
         type: 'REPLACE_TOKEN',
         token,
-        text: getInitialText(option.value, isFunction),
+        text: isFunction ? getFunctionDefault(option.value) : option.value,
         focusOverride: {itemKey},
       });
       resetInputValue();
     },
-    [dispatch, state, token, resetInputValue]
+    [dispatch, getFunctionDefault, state, token, resetInputValue]
   );
 
   const onPaste = useCallback((_evt: React.ClipboardEvent<HTMLInputElement>) => {
@@ -340,7 +359,7 @@ function useSuggestionItems({
   filterValue,
   nextAllowedTokenKinds,
 }: {
-  allowedFunctions: AggregateFunction[];
+  allowedFunctions: string[];
   filterValue: string;
   nextAllowedTokenKinds: TokenKind[];
 }): Array<SelectSectionWithKey<string>> {
@@ -463,7 +482,7 @@ function useFunctionItems({
   filterValue,
   nextAllowedTokenKinds,
 }: {
-  allowedFunctions: AggregateFunction[];
+  allowedFunctions: string[];
   filterValue: string;
   nextAllowedTokenKinds: TokenKind[];
 }): Array<SelectSectionWithKey<string>> {
@@ -473,7 +492,7 @@ function useFunctionItems({
     }
 
     const items = filterValue
-      ? allowedFunctions.filter(agg => agg.name.includes(filterValue))
+      ? allowedFunctions.filter(agg => agg.includes(filterValue))
       : allowedFunctions;
 
     return [
@@ -481,10 +500,10 @@ function useFunctionItems({
         key: 'functions',
         label: t('functions'),
         options: items.map(item => ({
-          key: `${TokenKind.FUNCTION}:${item.name}`,
-          label: item.label ?? item.name,
-          value: item.name,
-          textValue: item.name,
+          key: `${TokenKind.FUNCTION}:${item}`,
+          label: item,
+          value: item,
+          textValue: item,
           hideCheck: true,
         })),
       },
@@ -494,14 +513,6 @@ function useFunctionItems({
 
 function stopPropagation(evt: MouseEvent<HTMLElement>) {
   evt.stopPropagation();
-}
-
-function getInitialText(key: string, isFunction: boolean) {
-  if (!isFunction) {
-    return key;
-  }
-  // TODO: generate this
-  return `${key}(span.duration)`;
 }
 
 const Row = styled('div')`

--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -34,6 +34,7 @@ import {IconParenthesis} from 'sentry/icons/iconParenthesis';
 import {IconSubtract} from 'sentry/icons/iconSubtract';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import type {AggregateParameter} from 'sentry/utils/fields';
 
 interface ArithmeticTokenFreeTextProps {
   item: Node<Token>;
@@ -120,9 +121,9 @@ function InternalInput({
   const getFunctionDefault = useCallback(
     (func: string): string => {
       const definition = getFieldDefinition(func);
-      const parameterDefinitions = definition?.parameters ?? [];
-      const parameters = parameterDefinitions.map(
-        parameterDefinition => parameterDefinition.defaultValue
+      const parameterDefinitions: AggregateParameter[] = definition?.parameters ?? [];
+      const parameters: string[] = parameterDefinitions.map(
+        parameterDefinition => parameterDefinition.defaultValue ?? ''
       );
       return `${func}(${parameters.join(',')})`;
     },

--- a/static/app/components/arithmeticBuilder/types.tsx
+++ b/static/app/components/arithmeticBuilder/types.tsx
@@ -1,13 +1,9 @@
 import type {ReactNode} from 'react';
 
-export interface AggregateFunction {
-  name: string;
-  label?: ReactNode;
-  // TODO: add other attributes here like arguments
-}
+import type {FieldKind} from 'sentry/utils/fields';
 
 export interface FunctionArgument {
+  kind: FieldKind;
   name: string;
   label?: ReactNode;
-  // TODO: add other attributes here like argument type
 }

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -867,6 +867,19 @@ const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
       },
     ],
   },
+  [AggregationKey.COUNT_UNIQUE]: {
+    ...AGGREGATION_FIELDS[AggregationKey.COUNT_UNIQUE],
+    valueType: FieldValueType.INTEGER,
+    parameters: [
+      {
+        name: 'column',
+        kind: 'column',
+        columnTypes: [FieldValueType.STRING],
+        defaultValue: 'span.op',
+        required: true,
+      },
+    ],
+  },
   [AggregationKey.MIN]: {
     ...AGGREGATION_FIELDS[AggregationKey.MIN],
     parameters: [

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -208,7 +208,7 @@ describe('SchemaHintsList', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'UPDATE_QUERY',
-      query: 'count_unique(user):>0',
+      query: 'count_unique(span.op):>0',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.spec.tsx
@@ -225,7 +225,7 @@ describe('SchemaHintsList', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'UPDATE_QUERY',
-      query: 'count_unique(user):>0',
+      query: 'count_unique(span.op):>0',
       focusOverride: {
         itemKey: 'filter:0',
         part: 'value',

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -6,10 +6,7 @@ import styled from '@emotion/styled';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
 import type {Expression} from 'sentry/components/arithmeticBuilder/expression';
-import type {
-  AggregateFunction,
-  FunctionArgument,
-} from 'sentry/components/arithmeticBuilder/types';
+import type {FunctionArgument} from 'sentry/components/arithmeticBuilder/types';
 import {Button} from 'sentry/components/core/button';
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
@@ -29,7 +26,11 @@ import {
   parseFunction,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {
+  ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  FieldKind,
+  getFieldDefinition,
+} from 'sentry/utils/fields';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {
@@ -391,24 +392,40 @@ function AggregateSelector({
   );
 }
 
-function EquationSelector({numberTags, onChange, visualize}: VisualizeSelectorProps) {
+function EquationSelector({
+  numberTags,
+  stringTags,
+  onChange,
+  visualize,
+}: VisualizeSelectorProps) {
   const expression = stripEquationPrefix(visualize.yAxis);
 
-  const aggregateFunctions: AggregateFunction[] = useMemo(() => {
-    return ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.map(aggregate => ({
-      name: aggregate,
-      label: aggregate,
-    }));
-  }, []);
-
   const functionArguments: FunctionArgument[] = useMemo(() => {
-    return Object.entries(numberTags).map(([key, tag]) => {
-      return {
-        name: key,
-        label: tag.name,
-      };
-    });
-  }, [numberTags]);
+    return [
+      ...Object.entries(numberTags).map(([key, tag]) => {
+        return {
+          kind: FieldKind.MEASUREMENT,
+          name: key,
+          label: tag.name,
+        };
+      }),
+      ...Object.entries(stringTags).map(([key, tag]) => {
+        return {
+          kind: FieldKind.TAG,
+          name: key,
+          label: tag.name,
+        };
+      }),
+    ];
+  }, [numberTags, stringTags]);
+
+  const getSpanFieldDefinition = useCallback(
+    (key: string) => {
+      const tag = numberTags[key] ?? stringTags[key];
+      return getFieldDefinition(key, 'span', tag?.kind);
+    },
+    [numberTags, stringTags]
+  );
 
   const handleExpressionChange = useCallback(
     (newExpression: Expression) => {
@@ -419,8 +436,9 @@ function EquationSelector({numberTags, onChange, visualize}: VisualizeSelectorPr
 
   return (
     <ArithmeticBuilder
-      aggregateFunctions={aggregateFunctions}
+      aggregations={ALLOWED_EXPLORE_VISUALIZE_AGGREGATES}
       functionArguments={functionArguments}
+      getFieldDefinition={getSpanFieldDefinition}
       expression={expression}
       setExpression={handleExpressionChange}
     />


### PR DESCRIPTION
Previously, we only supported aggregates that took a single numeric column as an argument. This now validates the type of the argument and suggests the appropriate types.