### PR TITLE
feat(uptime): Release the uptime group type

### DIFF
--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -288,6 +288,7 @@ class UptimeDomainCheckFailure(GroupType):
     type_id = 7001
     slug = GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE
     description = "Uptime Domain Monitor Failure"
+    released = True
     category = GroupCategory.UPTIME.value
     category_v2 = GroupCategory.OUTAGE.value
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds


### PR DESCRIPTION
This will allow us to remove the following feature flags

 - feature.organizations:issue-uptime-domain-failure-visible:
 - feature.organizations:issue-uptime-domain-failure-ingest:
 - feature.organizations:issue-uptime-domain-failure-post-process-group:

Depends on #94963 