### PR TITLE
test(performance): Remove deprecated router mocks

### DIFF
--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -8,15 +8,10 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import Table from 'sentry/views/performance/table';
 
 const FEATURES = ['performance-view'];
-
-jest.mock('sentry/utils/useLocation');
-
-const mockUseLocation = jest.mocked(useLocation);
 
 const initializeData = (settings = {}, features: string[] = []) => {
   const projects = [
@@ -37,7 +32,7 @@ function WrappedComponent({data, ...rest}: any) {
       <MEPSettingProvider>
         <Table
           organization={data.organization}
-          location={data.router.location}
+          location={LocationFixture({...data.initialRouterConfig.location})}
           setError={jest.fn()}
           summaryConditions=""
           {...data}
@@ -108,9 +103,6 @@ function mockEventView(data: ReturnType<typeof initializeData>) {
 describe('Performance > Table', function () {
   let eventsMock: jest.Mock;
   beforeEach(function () {
-    mockUseLocation.mockReturnValue(
-      LocationFixture({pathname: '/organizations/org-slug/insights/summary'})
-    );
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [],
@@ -201,7 +193,7 @@ describe('Performance > Table', function () {
 
       ProjectsStore.loadInitialData(data.projects);
 
-      render(
+      const {router} = render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
@@ -210,10 +202,10 @@ describe('Performance > Table', function () {
           projects={data.projects}
         />,
         {
-          router: data.router,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         }
       );
+      const initialLocation = router.location;
 
       const rows = await screen.findAllByTestId('grid-body-row');
       const transactionCells = within(rows[0]!).getAllByTestId('grid-body-cell');
@@ -243,16 +235,15 @@ describe('Performance > Table', function () {
       expect(transactionCellTrigger).toBeInTheDocument();
       await userEvent.click(transactionCellTrigger);
 
-      expect(data.router.push).toHaveBeenCalledTimes(0);
+      expect(router.location).toEqual(initialLocation);
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'Add to filter'}));
 
-      expect(data.router.push).toHaveBeenCalledTimes(1);
-      expect(data.router.push).toHaveBeenNthCalledWith(1, {
-        pathname: undefined,
-        query: expect.objectContaining({
+      expect(router.location).not.toEqual(initialLocation);
+      expect(router.location.query).toEqual(
+        expect.objectContaining({
           query: 'transaction:/apple/cart',
-        }),
-      });
+        })
+      );
     });
 
     it('hides cell actions when withStaticFilters is true', async function () {
@@ -268,10 +259,7 @@ describe('Performance > Table', function () {
           summaryConditions=""
           projects={data.projects}
           withStaticFilters
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
@@ -299,10 +287,7 @@ describe('Performance > Table', function () {
           setError={jest.fn()}
           summaryConditions=""
           projects={data.projects}
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       const indicatorContainer = await screen.findByTestId('unparameterized-indicator');
@@ -360,10 +345,7 @@ describe('Performance > Table', function () {
           summaryConditions=""
           projects={data.projects}
           isMEPEnabled
-        />,
-        {
-          deprecatedRouterMocks: true,
-        }
+        />
       );
 
       expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -31,11 +31,6 @@ function initializeData(settings: Parameters<typeof _initializeData>[0]) {
 describe('Performance > Transaction Spans > Span Summary', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
-      body: [],
-    });
-
-    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {data: [{'count()': 1}]},
     });
@@ -113,7 +108,6 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
         {
           organization: data.organization,
-          deprecatedRouterMocks: true,
         }
       );
 
@@ -127,7 +121,6 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
         {
           organization: data.organization,
-          deprecatedRouterMocks: true,
         }
       );
 
@@ -141,9 +134,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        router: data.router,
         organization: data.organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: data.initialRouterConfig,
       });
 
       expect(
@@ -221,9 +213,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        router: data.router,
         organization: data.organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: data.initialRouterConfig,
       });
 
       expect(await screen.findByText('Event ID')).toBeInTheDocument();
@@ -296,9 +287,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        router: data.router,
         organization: data.organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: data.initialRouterConfig,
       });
 
       expect(await screen.findByText('Span Summary')).toBeInTheDocument();
@@ -363,9 +353,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        router: data.router,
         organization: data.organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: data.initialRouterConfig,
       });
 
       expect(await screen.findByText('Self Time Breakdown')).toBeInTheDocument();
@@ -378,9 +367,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
       });
 
       render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-        router: data.router,
         organization: data.organization,
-        deprecatedRouterMocks: true,
+        initialRouterConfig: data.initialRouterConfig,
       });
 
       expect(await screen.findByText('Event ID')).toBeInTheDocument();
@@ -408,9 +396,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         const searchBarNode = await screen.findByPlaceholderText('Filter Transactions');
@@ -424,9 +411,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         const resetButton = await screen.findByRole('button', {
@@ -443,9 +429,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         const resetButton = await screen.findByRole('button', {
@@ -460,17 +445,19 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           query: {project: '1', transaction: 'transaction', min: '10', max: '100'},
         });
 
-        render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
-          organization: data.organization,
-          deprecatedRouterMocks: true,
-        });
+        const {router} = render(
+          <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
+          {
+            organization: data.organization,
+            initialRouterConfig: data.initialRouterConfig,
+          }
+        );
 
         const resetButton = await screen.findByRole('button', {
           name: /reset view/i,
         });
         await userEvent.click(resetButton);
-        expect(data.router.push).toHaveBeenCalledWith(
+        expect(router.location.query).toEqual(
           expect.not.objectContaining({min: expect.any(String), max: expect.any(String)})
         );
       });
@@ -481,17 +468,20 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           query: {project: '1', transaction: 'transaction'},
         });
 
-        render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
-          organization: data.organization,
-          deprecatedRouterMocks: true,
-        });
+        const {router} = render(
+          <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
+          {
+            organization: data.organization,
+            initialRouterConfig: data.initialRouterConfig,
+          }
+        );
+        const initialLocation = router.location;
 
         const searchBarNode = await screen.findByPlaceholderText('Filter Transactions');
         await userEvent.click(searchBarNode);
         await userEvent.paste('count():>3');
         expect(searchBarNode).toHaveTextContent('count():>3');
-        expect(data.router.push).not.toHaveBeenCalled();
+        expect(router.location).toEqual(initialLocation);
       });
 
       it('renders a display toggle that changes a chart view between timeseries and histogram by pushing it to the browser history', async function () {
@@ -509,11 +499,13 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           query: {project: '1', transaction: 'transaction'},
         });
 
-        render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
-          organization: data.organization,
-          deprecatedRouterMocks: true,
-        });
+        const {router} = render(
+          <SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />,
+          {
+            organization: data.organization,
+            initialRouterConfig: data.initialRouterConfig,
+          }
+        );
 
         expect(await screen.findByTestId('total-value')).toBeInTheDocument();
 
@@ -533,7 +525,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
           })
         );
 
-        expect(data.router.push).toHaveBeenCalledWith(
+        expect(router.location).toEqual(
           expect.objectContaining({
             query: {
               display: 'histogram',
@@ -560,9 +552,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         const displayToggle = await screen.findByTestId('display-toggle');
@@ -586,9 +577,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         expect(await screen.findByTestId('histogram-error-panel')).toBeInTheDocument();
@@ -610,9 +600,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         const nodes = await screen.findAllByText('Self Time Distribution');
@@ -630,9 +619,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         await waitFor(() => {
@@ -659,9 +647,8 @@ describe('Performance > Transaction Spans > Span Summary', function () {
         });
 
         render(<SpanDetails params={{spanSlug: 'op:aaaaaaaa'}} {...data} />, {
-          router: data.router,
           organization: data.organization,
-          deprecatedRouterMocks: true,
+          initialRouterConfig: data.initialRouterConfig,
         });
 
         await waitFor(() => {

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
@@ -1,3 +1,5 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
 import {
   initializeData as _initializeData,
   makeSuspectSpan,
@@ -26,7 +28,7 @@ describe('SuspectSpansTable', () => {
 
     render(
       <SuspectSpansTable
-        location={initialData.router.location}
+        location={LocationFixture({...initialData.initialRouterConfig.location})}
         organization={initialData.organization}
         transactionName="Test Transaction"
         isLoading={false}

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -42,17 +42,34 @@ export function initializeData(settings?: InitializeDataSettings) {
       ...query,
     },
   };
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/performance/`,
+      query: {...query} as Record<string, string>,
+    },
+    route: '/organizations/:orgId/performance/',
+  };
   if (settings?.selectedProject || settings?.project) {
     routerLocation.query.project = project || settings?.project;
+    initialRouterConfig.location.query.project = project || settings?.project;
   }
   const router = {
     location: routerLocation,
   };
   const initialData = initializeOrg({organization, projects, router});
   const location = initialData.router.location;
-  const eventView = EventView.fromLocation(location);
+  const eventView = EventView.fromLocation(initialRouterConfig.location as any);
 
-  return {...initialData, location, eventView};
+  return {
+    ...initialData,
+    /**
+     * @deprecated use initialRouterConfig instead. Avoid deprecatedRouterMocks.
+     */
+    router: initialData.router,
+    location,
+    eventView,
+    initialRouterConfig,
+  };
 }
 
 export const SAMPLE_SPANS = [


### PR DESCRIPTION
Remove use of deprecated router mocks. Remove a few useLocation mocks

part of https://github.com/getsentry/frontend-tsc/issues/78
