### PR TITLE
ref(tags): add concurrent_limit to ratelimit

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -35,8 +35,8 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
 
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1),
+            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
             RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
         }
     }

--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -37,7 +37,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
             RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1, concurrent_limit=10),
         }
     }
 

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -35,8 +35,8 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
 
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=10, window=1),
-            RateLimitCategory.USER: RateLimit(limit=10, window=1),
+            RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
+            RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
             RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
         }
     }

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -37,7 +37,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
             RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1, concurrent_limit=10),
         }
     }
 


### PR DESCRIPTION
We've seen some load increases on the errors cluster that I think might have been partially driven by specific users (those users being proxy users of internal integrations) hitting endpoints that run expensive/long queries on clickhouse

We have some rate-limiting in snuba but that is on the project and organization level for the most part. When debugging on sentry it looked like default `concurrent_limit` is 25

```deprecated rate limit specification {'GET': {<RateLimitCategory.IP: 'ip'>: RateLimit(limit=10, window=1, concurrent_limit=25), <RateLimitCategory.USER: 'user'>: RateLimit(limit=10, window=1, concurrent_limit=25), <RateLimitCategory.ORGANIZATION: 'org'>: RateLimit(limit=40, window=1, concurrent_limit=25)}}```
(from SENTRY-3PFR)

For these endpoints we will want lower than 25 per user since the snuba concurrent ratelimiting is lower than 25 for this referrer

Adding this to `org` as well since integration tokens that are tied to orgs get org wide limits