### PR TITLE
feat(upsampling) - issues-stats API error upsampling support

### DIFF
--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -8,6 +8,8 @@ from sentry import options
 from sentry.models.organization import Organization
 from sentry.search.events.types import SnubaParams
 
+UPSAMPLED_ERROR_AGGREGATION = "upsampled_count"
+
 
 def is_errors_query_for_error_upsampled_projects(
     snuba_params: SnubaParams,
@@ -19,15 +21,13 @@ def is_errors_query_for_error_upsampled_projects(
     Determine if this query should use error upsampling transformations.
     Only applies when ALL projects are allowlisted and we're querying error events.
     """
-    if not _are_all_projects_error_upsampled(snuba_params.project_ids, organization):
+    if not are_all_projects_error_upsampled(snuba_params.project_ids):
         return False
 
     return _should_apply_sample_weight_transform(dataset, request)
 
 
-def _are_all_projects_error_upsampled(
-    project_ids: Sequence[int], organization: Organization
-) -> bool:
+def are_all_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
     """
     Check if ALL projects in the query are allowlisted for error upsampling.
     Only returns True if all projects pass the allowlist condition.

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
 from sentry import features, tagstore
+from sentry.api.helpers.error_upsampling import are_all_projects_error_upsampled
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
@@ -1066,6 +1067,11 @@ class GroupSerializerSnuba(GroupSerializerBase):
             ["max", "timestamp", "last_seen"],
             ["uniq", "tags[sentry:user]", "count"],
         ]
+        # Check if all projects are allowlisted for error upsampling
+        is_upsampled = are_all_projects_error_upsampled(project_ids)
+        if is_upsampled:
+            aggregations[0] = ["upsampled_count", "", "times_seen"]
+
         filters = {"project_id": project_ids, "group_id": group_ids}
         if environment_ids:
             filters["environment"] = environment_ids

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -247,6 +247,7 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         conditions=None,
         environment_ids=None,
         user=None,
+        aggregation_override: str | None = None,
         **kwargs,
     ):
         try:

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -384,7 +384,7 @@ class SnubaTSDB(BaseTSDB):
                 get_upsampled_count_snql_with_alias(aggregated_as)
             ]
         else:
-            aggregations: list[SelectableExpression] = [
+            aggregations = [
                 Function(
                     function=aggregation,
                     parameters=[Column(model_aggregate)] if model_aggregate else [],

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -33,6 +33,7 @@ from sentry.utils import outcomes, snuba
 from sentry.utils.dates import to_datetime
 from sentry.utils.snuba import (
     get_snuba_translators,
+    get_upsampled_count_snql_with_alias,
     infer_project_ids_from_related_models,
     nest_groups,
     raw_snql_query,
@@ -378,13 +379,18 @@ class SnubaTSDB(BaseTSDB):
             model_aggregate = None
 
         aggregated_as = "aggregate"
-        aggregations: list[SelectableExpression] = [
-            Function(
-                aggregation,
-                [Column(model_aggregate)] if model_aggregate else [],
-                aggregated_as,
-            )
-        ]
+        if aggregation == "upsampled_count":
+            aggregations: list[SelectableExpression] = [
+                get_upsampled_count_snql_with_alias(aggregated_as)
+            ]
+        else:
+            aggregations: list[SelectableExpression] = [
+                Function(
+                    function=aggregation,
+                    parameters=[Column(model_aggregate)] if model_aggregate else [],
+                    alias=aggregated_as,
+                )
+            ]
 
         if group_on_time and manual_group_on_time:
             aggregations.append(manual_group_on_time_aggregation(rollup, "time"))
@@ -761,6 +767,7 @@ class SnubaTSDB(BaseTSDB):
         tenant_ids: dict[str, str | int] | None = None,
         referrer_suffix: str | None = None,
         group_on_time: bool = True,
+        aggregation_override: str | None = None,
     ) -> dict[TSDBKey, list[tuple[int, int]]]:
         result = self.get_data(
             model,
@@ -769,7 +776,7 @@ class SnubaTSDB(BaseTSDB):
             end,
             rollup,
             environment_ids,
-            aggregation=self.get_aggregate_function(model),
+            aggregation=aggregation_override or self.get_aggregate_function(model),
             group_on_time=True,
             conditions=conditions,
             use_cache=use_cache,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -23,9 +23,11 @@ import urllib3
 from dateutil.parser import parse as parse_datetime
 from django.conf import settings
 from django.core.cache import cache
-from snuba_sdk import DeleteQuery, MetricsQuery, Request
+from snuba_sdk import Column, DeleteQuery, Function, MetricsQuery, Request
 from snuba_sdk.legacy import json_to_snql
+from snuba_sdk.query import SelectableExpression
 
+from sentry.api.helpers.error_upsampling import UPSAMPLED_ERROR_AGGREGATION
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.grouprelease import GroupRelease
@@ -1665,8 +1667,24 @@ def aliased_query_params(
         selected_columns = [c for c in selected_columns if c]
 
     if aggregations:
+        new_aggs = []
         for aggregation in aggregations:
             derived_columns.append(aggregation[2])
+
+            if aggregation[0] == UPSAMPLED_ERROR_AGGREGATION:
+                # Special-case: upsampled_count aggregation - this aggregation type
+                # requires special handling to convert it into a selected column
+                # with the appropriate SNQL function structure
+                if selected_columns is None:
+                    selected_columns = []
+                selected_columns.append(
+                    get_upsampled_count_snql_with_alias(
+                        aggregation[2] if len(aggregation) > 2 else None
+                    )
+                )
+            else:
+                new_aggs.append(aggregation)
+        aggregations = new_aggs
 
     if conditions:
         if condition_resolver:
@@ -2059,3 +2077,23 @@ def process_value(value: None | str | int | float | list[str] | list[int] | list
         return value
 
     return value
+
+
+def get_upsampled_count_snql_with_alias(alias: str) -> list[SelectableExpression]:
+    return Function(
+        function="toInt64",
+        parameters=[
+            Function(
+                function="sum",
+                parameters=[
+                    Function(
+                        function="ifNull",
+                        parameters=[Column(name="sample_weight"), 1],
+                        alias=None,
+                    )
+                ],
+                alias=None,
+            )
+        ],
+        alias=alias,
+    )

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1679,7 +1679,9 @@ def aliased_query_params(
                     selected_columns = []
                 selected_columns.append(
                     get_upsampled_count_snql_with_alias(
-                        aggregation[2] if len(aggregation) > 2 else None
+                        aggregation[2]
+                        if len(aggregation) > 2 and aggregation[2] is not None
+                        else "upsampled_count"
                     )
                 )
             else:

--- a/tests/sentry/api/helpers/test_error_upsampling.py
+++ b/tests/sentry/api/helpers/test_error_upsampling.py
@@ -38,18 +38,18 @@ class ErrorUpsamplingTest(TestCase):
     def test_are_all_projects_error_upsampled(self, mock_options: Mock) -> None:
         # Test when all projects are allowlisted
         mock_options.get.return_value = self.project_ids
-        assert are_all_projects_error_upsampled(self.project_ids, self.organization) is True
+        assert are_all_projects_error_upsampled(self.project_ids) is True
 
         # Test when some projects are not allowlisted
         mock_options.get.return_value = self.project_ids[:-1]
-        assert are_all_projects_error_upsampled(self.project_ids, self.organization) is False
+        assert are_all_projects_error_upsampled(self.project_ids) is False
 
         # Test when no projects are allowlisted
         mock_options.get.return_value = []
-        assert are_all_projects_error_upsampled(self.project_ids, self.organization) is False
+        assert are_all_projects_error_upsampled(self.project_ids) is False
 
         # Test when no project IDs provided
-        assert are_all_projects_error_upsampled([], self.organization) is False
+        assert are_all_projects_error_upsampled([]) is False
 
     def test_transform_query_columns_for_error_upsampling(self) -> None:
         # Test count() transformation

--- a/tests/sentry/api/helpers/test_error_upsampling.py
+++ b/tests/sentry/api/helpers/test_error_upsampling.py
@@ -5,9 +5,9 @@ from django.test import RequestFactory
 from rest_framework.request import Request
 
 from sentry.api.helpers.error_upsampling import (
-    _are_all_projects_error_upsampled,
     _is_error_focused_query,
     _should_apply_sample_weight_transform,
+    are_all_projects_error_upsampled,
     transform_query_columns_for_error_upsampling,
 )
 from sentry.models.organization import Organization
@@ -38,18 +38,18 @@ class ErrorUpsamplingTest(TestCase):
     def test_are_all_projects_error_upsampled(self, mock_options: Mock) -> None:
         # Test when all projects are allowlisted
         mock_options.get.return_value = self.project_ids
-        assert _are_all_projects_error_upsampled(self.project_ids, self.organization) is True
+        assert are_all_projects_error_upsampled(self.project_ids, self.organization) is True
 
         # Test when some projects are not allowlisted
         mock_options.get.return_value = self.project_ids[:-1]
-        assert _are_all_projects_error_upsampled(self.project_ids, self.organization) is False
+        assert are_all_projects_error_upsampled(self.project_ids, self.organization) is False
 
         # Test when no projects are allowlisted
         mock_options.get.return_value = []
-        assert _are_all_projects_error_upsampled(self.project_ids, self.organization) is False
+        assert are_all_projects_error_upsampled(self.project_ids, self.organization) is False
 
         # Test when no project IDs provided
-        assert _are_all_projects_error_upsampled([], self.organization) is False
+        assert are_all_projects_error_upsampled([], self.organization) is False
 
     def test_transform_query_columns_for_error_upsampling(self) -> None:
         # Test count() transformation


### PR DESCRIPTION
issues-stats now will return upsampled error counts for projects in the allowlist. Required opening a special case for the non standard query in both SnubaTSDB and the snuba SDK `aliased_query`.
The chosen implementation avoids opening them up to be too flexible which might introduce vulnerabilites, while staying as clean as possible.

Review note - Notice issues-stats returns both a total count and the graph of counts over a period of time, hence the two queries needed. 
I had to improvise and get creative to open up paths to do what I needed here, I am not 100% sure about this solution. I think it strikes a good balance between safety and cleanliness, but feel free to suggest alternative approaches I may have missed.