### PR TITLE
fix(uptime): Fix uptime eap result queries to use correct subscriptio…

### DIFF
--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import uuid
 from collections import defaultdict
+from collections.abc import Callable
 
 from drf_spectacular.utils import extend_schema
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -63,10 +64,21 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 status=400,
             )
 
+        use_eap_results = features.has(
+            "organizations:uptime-eap-uptime-results-query", organization, actor=request.user
+        )
+
         try:
+            # XXX: We need to query these using hex, since we store them without dashes.
+            # We remove this once we remove the old uptime checks
+            if use_eap_results:
+                subscription_id_formatter = lambda sub_id: uuid.UUID(sub_id).hex
+            else:
+                subscription_id_formatter = lambda sub_id: str(uuid.UUID(sub_id))
+
             subscription_id_to_project_uptime_subscription_id, subscription_ids = (
                 self._authorize_and_map_project_uptime_subscription_ids(
-                    project_uptime_subscription_ids, projects
+                    project_uptime_subscription_ids, projects, subscription_id_formatter
                 )
             )
         except ValueError:
@@ -78,9 +90,7 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
         )
 
         try:
-            if features.has(
-                "organizations:uptime-eap-uptime-results-query", organization, actor=request.user
-            ):
+            if use_eap_results:
                 eap_response = self._make_eap_request(
                     organization,
                     projects,
@@ -125,7 +135,10 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
         return self.respond(response_with_extra_buckets)
 
     def _authorize_and_map_project_uptime_subscription_ids(
-        self, project_uptime_subscription_ids: list[str], projects: list[Project]
+        self,
+        project_uptime_subscription_ids: list[str],
+        projects: list[Project],
+        sub_id_formatter: Callable[[str], str],
     ) -> tuple[dict[str, int], list[str]]:
         """
         Authorize the project uptime subscription ids and return their corresponding subscription ids
@@ -146,14 +159,14 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
             raise ValueError("Invalid project uptime subscription ids provided")
 
         subscription_id_to_project_uptime_subscription_id = {
-            str(uuid.UUID(project_uptime_subscription[1])): project_uptime_subscription[0]
+            sub_id_formatter(project_uptime_subscription[1]): project_uptime_subscription[0]
             for project_uptime_subscription in project_uptime_subscriptions
             if project_uptime_subscription[0] is not None
             and project_uptime_subscription[1] is not None
         }
 
         validated_subscription_ids = [
-            str(uuid.UUID(project_uptime_subscription[1]))
+            sub_id_formatter(project_uptime_subscription[1])
             for project_uptime_subscription in project_uptime_subscriptions
             if project_uptime_subscription[1] is not None
         ]

--- a/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
+++ b/src/sentry/uptime/endpoints/project_uptime_alert_checks_index.py
@@ -125,6 +125,14 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
         start_timestamp.FromDatetime(start)
         end_timestamp = Timestamp()
         end_timestamp.FromDatetime(end)
+
+        if trace_item_type == TraceItemType.TRACE_ITEM_TYPE_UPTIME_CHECK:
+            subscription_id = str(
+                uuid.UUID(uptime_subscription.uptime_subscription.subscription_id)
+            )
+        else:
+            subscription_id = uuid.UUID(uptime_subscription.uptime_subscription.subscription_id).hex
+
         subscription_filter = TraceItemFilter(
             comparison_filter=ComparisonFilter(
                 key=AttributeKey(
@@ -132,9 +140,7 @@ class ProjectUptimeAlertCheckIndexEndpoint(ProjectUptimeAlertEndpoint):
                     type=AttributeKey.Type.TYPE_STRING,
                 ),
                 op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(
-                    val_str=str(uuid.UUID(uptime_subscription.uptime_subscription.subscription_id))
-                ),
+                value=AttributeValue(val_str=subscription_id),
             )
         )
 

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -330,8 +330,8 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
         scheduled_check_time=None,
     ):
         uptime_result = self.create_eap_uptime_result(
-            subscription_id=str(uuid.UUID(subscription_id)),
-            guid=str(uuid.UUID(subscription_id)),
+            subscription_id=uuid.UUID(subscription_id).hex,
+            guid=uuid.UUID(subscription_id).hex,
             request_url="https://santry.io",
             check_status=check_status,
             incident_status=incident_status,

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -251,9 +251,9 @@ class ProjectUptimeAlertCheckIndexEndpointWithEAPTests(
         http_status=None,
     ):
         create_params = {
-            "subscription_id": str(uuid.UUID(subscription_id)),
-            "guid": str(uuid.UUID(subscription_id)),
-            "check_id": str(uuid.uuid4()),
+            "subscription_id": uuid.UUID(subscription_id).hex,
+            "guid": uuid.UUID(subscription_id).hex,
+            "check_id": uuid.uuid4().hex,
             "check_status": check_status,
             "incident_status": incident_status,
             "scheduled_check_time": scheduled_check_time,


### PR DESCRIPTION
…n ids

The `subscription_ids` that we're storing in snuba are being stored without dashes, and so if we make a query with dashes we find no results. This is different to uptime checks, because in that case the data structure on the snuba side explicitly expects a UUID, and so it ends up stored with dashes.

This fixes the queries to use `.hex`, which produces a uuid with no dashes.

<!-- Describe your PR here. -->