### PR TITLE
fix(issues): Prevent copy to clipboard from wrapping

### DIFF
--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -351,6 +351,7 @@ const MarkdownButton = styled('button')`
   text-decoration-color: ${p => Color(p.theme.gray300).alpha(0.5).string()};
   font-size: inherit;
   cursor: pointer;
+  white-space: nowrap;
 
   :hover {
     color: ${p => p.theme.subText};


### PR DESCRIPTION
**Before**
<img width="961" alt="SCR-20250702-sbnw" src="https://github.com/user-attachments/assets/04522f74-92b6-4a6e-86d1-a75529085b81" />

**After**
<img width="960" alt="SCR-20250702-sbpa" src="https://github.com/user-attachments/assets/1a45142e-4458-421d-b893-9aa2a22f3f6c" />

