### PR TITLE
fix(agent-insights): Prevent double counting tokens and cost

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -23,7 +23,6 @@ import {
   AI_HANDOFF_OPS,
   AI_MODEL_ID_ATTRIBUTE,
   AI_MODEL_NAME_FALLBACK_ATTRIBUTE,
-  AI_RUN_DESCRIPTIONS,
   AI_RUN_OPS,
   AI_TOOL_CALL_DESCRIPTIONS,
   AI_TOOL_CALL_OPS,
@@ -360,10 +359,7 @@ function getNodeInfo(
   const truncatedOp = op.startsWith('gen_ai.') ? op.slice(7) : op;
   nodeInfo.title = truncatedOp;
 
-  if (
-    AI_RUN_OPS.includes(op) ||
-    AI_RUN_DESCRIPTIONS.includes(node.value.description ?? '')
-  ) {
+  if (AI_RUN_OPS.includes(op)) {
     const agentName = getNodeAttribute(AI_AGENT_NAME_ATTRIBUTE) || '';
     const model =
       getNodeAttribute(AI_MODEL_ID_ATTRIBUTE) ||

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -26,6 +26,7 @@ import {
   AI_COST_ATTRIBUTE_SUM,
   AI_GENERATION_OPS,
   AI_TOKEN_USAGE_ATTRIBUTE_SUM,
+  getAgentRunsFilter,
   getAITracesFilter,
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
@@ -97,7 +98,8 @@ export function TracesTable() {
 
   const spansRequest = useEAPSpans(
     {
-      search: `trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
+      // Exclude agent runs as they include aggregated data which would lead to double counting e.g. token usage
+      search: `${getAgentRunsFilter({negated: true})} trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,
       fields: [
         'trace',
         ...GENERATION_COUNTS,

--- a/static/app/views/insights/agentMonitoring/utils/query.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/query.tsx
@@ -13,7 +13,6 @@ export const AI_RUN_OPS = [
   'ai.pipeline.stream_text',
   'ai.pipeline.stream_object',
 ];
-export const AI_RUN_DESCRIPTIONS = ['ai.generateText', 'generateText'];
 
 // AI Generations - equivalent to OTEL Inference span
 // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md#inference
@@ -40,11 +39,7 @@ export const AI_TOOL_CALL_OPS = ['gen_ai.execute_tool'];
 export const AI_TOOL_CALL_DESCRIPTIONS = ['ai.toolCall'];
 
 const AI_OPS = [...AI_RUN_OPS, ...AI_GENERATION_OPS, ...AI_TOOL_CALL_OPS];
-const AI_DESCRIPTIONS = [
-  ...AI_RUN_DESCRIPTIONS,
-  ...AI_GENERATION_DESCRIPTIONS,
-  ...AI_TOOL_CALL_DESCRIPTIONS,
-];
+const AI_DESCRIPTIONS = [...AI_GENERATION_DESCRIPTIONS, ...AI_TOOL_CALL_DESCRIPTIONS];
 
 export const AI_MODEL_ID_ATTRIBUTE = 'gen_ai.request.model' as EAPSpanProperty;
 export const AI_MODEL_NAME_FALLBACK_ATTRIBUTE =
@@ -128,8 +123,8 @@ function joinValues(values: string[]) {
   return values.map(value => `"${value}"`).join(',');
 }
 
-export const getAgentRunsFilter = () => {
-  return `(span.op:[${joinValues(AI_RUN_OPS)}] or span.description:[${joinValues(AI_RUN_DESCRIPTIONS)}])`;
+export const getAgentRunsFilter = ({negated = false}: {negated?: boolean} = {}) => {
+  return `${negated ? '!' : ''}span.op:[${joinValues(AI_RUN_OPS)}]`;
 };
 
 export const getAIGenerationsFilter = () => {


### PR DESCRIPTION
Exclude agent spans from the token & cost query to prevent double counting. (agent spans include aggregated information)

- closes [TET-783: Costs / tokens are counted double atm](https://linear.app/getsentry/issue/TET-783/costs-tokens-are-counted-double-atm)
- part of [TET-693: Remove legacy attribute support from queries](https://linear.app/getsentry/issue/TET-693/remove-legacy-attribute-support-from-queries)