### PR TITLE
feat(agent-monitoring): Enable project selector persistence

### DIFF
--- a/static/app/views/insights/agentMonitoring/settings.ts
+++ b/static/app/views/insights/agentMonitoring/settings.ts
@@ -6,6 +6,6 @@ export const BASE_URL = '';
 export const DATA_TYPE = t('Agent');
 export const DATA_TYPE_PLURAL = t('Agents');
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/ai/';
+export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/agents/';
 
 export const MODULE_FEATURES = ['agents-insights'];

--- a/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
+++ b/static/app/views/insights/agentMonitoring/views/agentsOverviewPage.tsx
@@ -7,7 +7,6 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {
   EAPSpanSearchQueryBuilder,
   useEAPSpanSearchQueryBuilderProps,
@@ -47,6 +46,7 @@ import {Onboarding} from 'sentry/views/insights/agentMonitoring/views/onboarding
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
+import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsDurationChartWidget';
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
@@ -155,7 +155,7 @@ function AgentsMonitoringPage() {
               <ModuleLayout.Full>
                 <ToolRibbon>
                   <PageFilterBar condensed>
-                    <ProjectPageFilter resetParamsOnChange={['starred']} />
+                    <InsightsProjectSelector />
                     <EnvironmentPageFilter />
                     <DatePageFilter {...datePageFilterProps} />
                   </PageFilterBar>

--- a/static/app/views/insights/common/utils/moduleTitles.tsx
+++ b/static/app/views/insights/common/utils/moduleTitles.tsx
@@ -15,6 +15,7 @@ export const DOMAIN_VIEW_MODULE_TITLES: Record<
 > = {
   ai: {},
   backend: {},
+  agents: {},
   mobile: {
     [ModuleName.HTTP]: HTTP_MOBILE_MODULE_TITLE,
   },

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -69,7 +69,7 @@ export function PlatformLandingPageLayout({
             <ModuleLayout.Full>
               <ToolRibbon>
                 <PageFilterBar condensed>
-                  <InsightsProjectSelector resetParamsOnChange={['starred']} />
+                  <InsightsProjectSelector />
                   <EnvironmentPageFilter />
                   <DatePageFilter />
                 </PageFilterBar>

--- a/static/app/views/insights/pages/settings.ts
+++ b/static/app/views/insights/pages/settings.ts
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {MODULES as AGENTS_MODULES} from 'sentry/views/insights/pages/agents/settings';
 import {MODULES as AI_MODULES} from 'sentry/views/insights/pages/ai/settings';
 import {MODULES as BACKEND_MODULES} from 'sentry/views/insights/pages/backend/settings';
 import {MODULES as FRONTEND_MODULES} from 'sentry/views/insights/pages/frontend/settings';
@@ -14,5 +15,6 @@ export const DOMAIN_VIEW_MODULES: Record<DomainView, ModuleName[]> = {
   frontend: FRONTEND_MODULES,
   backend: BACKEND_MODULES,
   ai: AI_MODULES,
+  agents: AGENTS_MODULES,
   mobile: MOBILE_MODULES,
 };

--- a/static/app/views/insights/pages/types.ts
+++ b/static/app/views/insights/pages/types.ts
@@ -1,3 +1,4 @@
+import {AGENTS_LANDING_TITLE} from 'sentry/views/insights/pages/agents/settings';
 import {AI_LANDING_TITLE} from 'sentry/views/insights/pages/ai/settings';
 import {BACKEND_LANDING_TITLE} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_LANDING_TITLE} from 'sentry/views/insights/pages/frontend/settings';
@@ -9,4 +10,5 @@ export const DOMAIN_VIEW_TITLES: Record<DomainView, string> = {
   backend: BACKEND_LANDING_TITLE,
   frontend: FRONTEND_LANDING_TITLE,
   mobile: MOBILE_LANDING_TITLE,
+  agents: AGENTS_LANDING_TITLE,
 };

--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -1,4 +1,5 @@
 import {useLocation} from 'sentry/utils/useLocation';
+import {AGENTS_LANDING_SUB_PATH} from 'sentry/views/insights/pages/agents/settings';
 import {AI_LANDING_SUB_PATH} from 'sentry/views/insights/pages/ai/settings';
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
@@ -9,6 +10,7 @@ export type DomainView =
   | typeof FRONTEND_LANDING_SUB_PATH
   | typeof BACKEND_LANDING_SUB_PATH
   | typeof AI_LANDING_SUB_PATH
+  | typeof AGENTS_LANDING_SUB_PATH
   | typeof MOBILE_LANDING_SUB_PATH;
 
 const domainViews = [
@@ -16,6 +18,7 @@ const domainViews = [
   BACKEND_LANDING_SUB_PATH,
   AI_LANDING_SUB_PATH,
   MOBILE_LANDING_SUB_PATH,
+  AGENTS_LANDING_SUB_PATH,
 ];
 
 export type DomainViewFilters = {

--- a/static/app/views/insights/sessions/components/chartMap.tsx
+++ b/static/app/views/insights/sessions/components/chartMap.tsx
@@ -72,6 +72,7 @@ export const PAGE_CHART_OPTIONS: Record<
   ],
   backend: [],
   ai: [],
+  agents: [],
 };
 
 export const DEFAULT_LAYOUTS: Record<
@@ -98,4 +99,5 @@ export const DEFAULT_LAYOUTS: Record<
   ],
   backend: [],
   ai: [],
+  agents: [],
 };


### PR DESCRIPTION
Enable project selector persistence for agent monitoring

- closes [TET-705: Ensure consistent project selection behavior across overview pages](https://linear.app/getsentry/issue/TET-705/ensure-consistent-project-selection-behavior-across-overview-pages)