### PR TITLE
ref: Update customer/project details to have staleTime: Infinity in queries

### DIFF
--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -108,19 +108,19 @@ export default function CustomerDetails() {
     refetch: refetchSubscription,
     isError: isErrorSubscription,
     isPending: isPendingSubscription,
-  } = useApiQuery<Subscription>(SUBSCRIPTION_QUERY_KEY, {staleTime: 0});
+  } = useApiQuery<Subscription>(SUBSCRIPTION_QUERY_KEY, {staleTime: Infinity});
   const {
     data: organization,
     refetch: refetchOrganization,
     isError: isErrorOrganization,
     isPending: isPendingOrganization,
-  } = useApiQuery<Organization>(ORGANIZATION_QUERY_KEY, {staleTime: 0});
+  } = useApiQuery<Organization>(ORGANIZATION_QUERY_KEY, {staleTime: Infinity});
   const {
     data: billingConfig,
     refetch: refetchBillingConfig,
     isError: isErrorBillingConfig,
     isPending: isPendingBillingConfig,
-  } = useApiQuery<BillingConfig>(BILLING_CONFIG_QUERY_KEY, {staleTime: 0});
+  } = useApiQuery<BillingConfig>(BILLING_CONFIG_QUERY_KEY, {staleTime: Infinity});
 
   useEffect(() => {
     if (location.query.dataType) {

--- a/static/gsAdmin/views/projectDetails.tsx
+++ b/static/gsAdmin/views/projectDetails.tsx
@@ -34,7 +34,7 @@ function ProjectDetails() {
   }>();
   const {data, isPending, isError} = useApiQuery<Project>(
     [`/projects/${orgId}/${projectId}/`],
-    {staleTime: 0}
+    {staleTime: Infinity}
   );
   const api = useApi();
   const location = useLocation();


### PR DESCRIPTION
Before converting everything to functional components and adding react-query, data was only fetched on page load. During the conversion, we used `staleTime: 0`, which is too short and causes unnecessary refetches. This PR updates the code to restore the behavior from before the conversion.