### PR TITLE
feat(insights): Redirect to last used domain view

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1701,6 +1701,7 @@ function buildRoutes() {
 
   const domainViewRoutes = (
     <Route path={`/${DOMAIN_VIEW_BASE_URL}/`} withOrgPath>
+      <IndexRoute component={make(() => import('sentry/views/insights/index'))} />
       {transactionSummaryRoutes}
       <Route path={`${FRONTEND_LANDING_SUB_PATH}/`}>
         <IndexRoute

--- a/static/app/views/insights/common/utils/domainRedirect.tsx
+++ b/static/app/views/insights/common/utils/domainRedirect.tsx
@@ -1,0 +1,30 @@
+import {useEffect} from 'react';
+
+import localStorage from 'sentry/utils/localStorage';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
+import {domainViews, useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+
+const STORAGE_KEY = 'insights-domain-redirect';
+
+export function useRegisterDomainViewUsage() {
+  const {view} = useDomainViewFilters();
+  useEffect(() => {
+    if (view) {
+      localStorage.setItem(STORAGE_KEY, view);
+    }
+  }, [view]);
+}
+
+function isDomainView(value: unknown): value is DomainView {
+  return domainViews.includes(value as DomainView);
+}
+
+export function getLastUsedDomainView(): DomainView {
+  const storedValue = localStorage.getItem(STORAGE_KEY);
+
+  if (isDomainView(storedValue)) {
+    return storedValue;
+  }
+
+  return 'frontend';
+}

--- a/static/app/views/insights/common/utils/domainRedirect.tsx
+++ b/static/app/views/insights/common/utils/domainRedirect.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 
 import localStorage from 'sentry/utils/localStorage';
+import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {domainViews, useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
@@ -26,5 +27,5 @@ export function getLastUsedDomainView(): DomainView {
     return storedValue;
   }
 
-  return 'frontend';
+  return FRONTEND_LANDING_SUB_PATH;
 }

--- a/static/app/views/insights/index.tsx
+++ b/static/app/views/insights/index.tsx
@@ -1,0 +1,12 @@
+import Redirect from 'sentry/components/redirect';
+import {getLastUsedDomainView} from 'sentry/views/insights/common/utils/domainRedirect';
+import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
+
+/**
+ * Redirect to the last used domain view
+ * domain view usage is tracked in localStorage via useRegisterDomainViewUsage
+ */
+export default function InsightsIndex() {
+  const lastUsedDomainView = getLastUsedDomainView();
+  return <Redirect to={`/${DOMAIN_VIEW_BASE_URL}/${lastUsedDomainView}/`} />;
+}

--- a/static/app/views/insights/index.tsx
+++ b/static/app/views/insights/index.tsx
@@ -1,4 +1,6 @@
 import Redirect from 'sentry/components/redirect';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import useOrganization from 'sentry/utils/useOrganization';
 import {getLastUsedDomainView} from 'sentry/views/insights/common/utils/domainRedirect';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 
@@ -8,5 +10,12 @@ import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
  */
 export default function InsightsIndex() {
   const lastUsedDomainView = getLastUsedDomainView();
-  return <Redirect to={`/${DOMAIN_VIEW_BASE_URL}/${lastUsedDomainView}/`} />;
+  const organization = useOrganization();
+  return (
+    <Redirect
+      to={normalizeUrl(
+        `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${lastUsedDomainView}/`
+      )}
+    />
+  );
 }

--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -13,7 +13,7 @@ export type DomainView =
   | typeof AGENTS_LANDING_SUB_PATH
   | typeof MOBILE_LANDING_SUB_PATH;
 
-const domainViews = [
+export const domainViews: DomainView[] = [
   FRONTEND_LANDING_SUB_PATH,
   BACKEND_LANDING_SUB_PATH,
   AI_LANDING_SUB_PATH,
@@ -35,7 +35,7 @@ export const useDomainViewFilters = () => {
   const view = pathSegments[indexOfInsights + 1] as DomainViewFilters['view'];
   const isInOverviewPage = pathSegments.length === indexOfInsights + 2; // TODO: remove this with `useInsightsEap`, only needed to seperately control eap on overview page
 
-  if (!domainViews.includes(view || '')) {
+  if (!domainViews.includes(view || ('' as DomainView))) {
     return {isInDomainView: false};
   }
 

--- a/static/app/views/insights/pages/useFilters.tsx
+++ b/static/app/views/insights/pages/useFilters.tsx
@@ -35,7 +35,7 @@ export const useDomainViewFilters = () => {
   const view = pathSegments[indexOfInsights + 1] as DomainViewFilters['view'];
   const isInOverviewPage = pathSegments.length === indexOfInsights + 2; // TODO: remove this with `useInsightsEap`, only needed to seperately control eap on overview page
 
-  if (!domainViews.includes(view || ('' as DomainView))) {
+  if (!view || !domainViews.includes(view)) {
     return {isInDomainView: false};
   }
 

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -113,7 +113,7 @@ export function PrimaryNavigationItems() {
             description={null}
           >
             <SidebarLink
-              to={`/${prefix}/insights/frontend/`}
+              to={`/${prefix}/insights/`}
               activeTo={`/${prefix}/insights`}
               analyticsKey="insights"
               group={PrimaryNavGroup.INSIGHTS}

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -18,6 +18,7 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import useInitSentryToolbar from 'sentry/utils/useInitSentryToolbar';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AppBodyContent} from 'sentry/views/app/appBodyContent';
+import {useRegisterDomainViewUsage} from 'sentry/views/insights/common/utils/domainRedirect';
 import Nav from 'sentry/views/nav';
 import {NavContextProvider} from 'sentry/views/nav/context';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
@@ -36,6 +37,7 @@ const OrganizationHeader = HookOrDefault({
 
 function OrganizationLayout({children}: Props) {
   useRouteAnalyticsHookSetup();
+  useRegisterDomainViewUsage();
 
   // XXX(epurkhiser): The OrganizationContainer is responsible for ensuring the
   // oganization is loaded before rendering children. Organization may not be


### PR DESCRIPTION
Redirect to the last used domain view when clicking on insights.

- closes [TET-744: Remember last visited insight (frontend/backend/mobile/agent)](https://linear.app/getsentry/issue/TET-744/remember-last-visited-insight-frontendbackendmobileagent)