### PR TITLE
fix(laravel-insights): reset sort order when switching tables to prevent faulty query

### DIFF
--- a/static/app/views/insights/pages/platform/laravel/index.tsx
+++ b/static/app/views/insights/pages/platform/laravel/index.tsx
@@ -69,6 +69,9 @@ export function LaravelOverviewPage() {
           pathsCursor: undefined,
           commandsCursor: undefined,
           jobsCursor: undefined,
+          // Reset sort parameters when view changes
+          field: undefined,
+          order: undefined,
           view,
         },
       },


### PR DESCRIPTION
- Set sort field (column name) & order (asc vs desc) to undefined when switching between tables
- Current behaviour leads to broken query on switch when the column that is sorted by does not exist in the new view

Before: 
![Screenshot 2025-07-03 at 14 49 21](https://github.com/user-attachments/assets/0ebd420b-9960-403a-a938-6342f57e36d2)

After:
![Screenshot 2025-07-03 at 14 49 28](https://github.com/user-attachments/assets/f0522ff5-ee65-4e3b-9030-3a73274f589a)
