### PR TITLE
feat(ai): Options for custom model cost mappings

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1102,6 +1102,10 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Custom model costs mapping for AI Agent Monitoring. Used to map alternative model ids to existing model ids.
+# {"alternative_model_id": "gpt-4o", "existing_model_id": "openai/gpt-4o"}
+register("ai-agent-monitoring.custom-model-mapping", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # ## sentry.killswitches
 #
 # The following options are documented in sentry.killswitches in more detail

--- a/tests/sentry/tasks/test_ai_agent_monitoring.py
+++ b/tests/sentry/tasks/test_ai_agent_monitoring.py
@@ -8,6 +8,7 @@ from sentry.tasks.ai_agent_monitoring import (
     fetch_ai_model_costs,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.cache import cache
 
 
@@ -437,3 +438,51 @@ class FetchAIModelCostsTest(TestCase):
         """Test retrieving from empty cache"""
         cached_data = _get_ai_model_costs_from_cache()
         assert cached_data is None
+
+    @override_options(
+        {
+            "ai-agent-monitoring.custom-model-mapping": [
+                {
+                    "alternative_model_id": "gemini-pro-alternative",
+                    "existing_model_id": "gemini-2.5-pro",
+                },
+                {
+                    "alternative_model_id": "nonexistent-mapping",
+                    "existing_model_id": "model-that-does-not-exist",
+                },
+            ]
+        }
+    )
+    @responses.activate
+    def test_fetch_ai_model_costs_custom_model_mapping(self):
+        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
+        self._mock_models_dev_api_response(MOCK_MODELS_DEV_API_RESPONSE)
+
+        fetch_ai_model_costs()
+
+        # Verify the data was cached correctly
+        cached_data = _get_ai_model_costs_from_cache()
+        assert cached_data is not None
+        models = cached_data.get("models")
+        assert models is not None
+
+        # Original models should exist
+        assert "gemini-2.5-pro" in models
+
+        # Alternative model IDs should be mapped to existing models
+        assert "gemini-pro-alternative" in models
+
+        # Verify that the alternative models have the same pricing as the existing models
+        gemini_model = models["gemini-2.5-pro"]
+        gemini_alt_model = models["gemini-pro-alternative"]
+        assert gemini_model.get("inputPerToken") == gemini_alt_model.get("inputPerToken")
+        assert gemini_model.get("outputPerToken") == gemini_alt_model.get("outputPerToken")
+        assert gemini_model.get("outputReasoningPerToken") == gemini_alt_model.get(
+            "outputReasoningPerToken"
+        )
+        assert gemini_model.get("inputCachedPerToken") == gemini_alt_model.get(
+            "inputCachedPerToken"
+        )
+
+        # Non-existent mapping should not create a new model
+        assert "nonexistent-mapping" not in models


### PR DESCRIPTION
Since this is still a very young field, there is a lot of irregularities in model naming. This PR introduces an option to configure custom model mappings, where we can assign alternative names to existing models in our pricing map. Often the same models have different names, depending on where they are hosted.

For example:
![image](https://github.com/user-attachments/assets/3385b86c-1937-4b99-8365-1ba8779b2aca)

We need to have a way to add custom mappings, which can be easily changed and quickly deployed - that's why the options are used. 
