### PR TITLE
feat(agent-monitoring): open 2 charts in explore

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
@@ -211,6 +211,10 @@ const BodyCell = memo(function BodyCell({
         chartType: ChartType.BAR,
         yAxes: ['count(span.duration)'],
       },
+      {
+        chartType: ChartType.LINE,
+        yAxes: ['avg(span.duration)'],
+      },
     ],
     query: `${AI_MODEL_ID_ATTRIBUTE}:${dataRow.model}`,
   });

--- a/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
@@ -198,6 +198,10 @@ const BodyCell = memo(function BodyCell({
         chartType: ChartType.BAR,
         yAxes: ['count(span.duration)'],
       },
+      {
+        chartType: ChartType.LINE,
+        yAxes: ['avg(span.duration)'],
+      },
     ],
     query: `${AI_TOOL_NAME_ATTRIBUTE}:${dataRow.tool}`,
   });

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -223,9 +223,12 @@ const BodyCell = memo(function BodyCell({
     case 'traceId':
       return (
         <span>
-          <Button priority="link" onClick={() => openTraceViewDrawer(dataRow.traceId)}>
+          <TraceIdButton
+            priority="link"
+            onClick={() => openTraceViewDrawer(dataRow.traceId)}
+          >
             {dataRow.traceId.slice(0, 8)}
-          </Button>
+          </TraceIdButton>
         </span>
       );
     case 'transaction':
@@ -301,4 +304,8 @@ const HeadCell = styled('div')<{align: 'left' | 'right'}>`
   align-items: center;
   gap: ${space(0.5)};
   justify-content: ${p => (p.align === 'right' ? 'flex-end' : 'flex-start')};
+`;
+
+const TraceIdButton = styled(Button)`
+  font-weight: normal;
 `;


### PR DESCRIPTION
Closes [TET-791: Update trace explorer link for models and tools](https://linear.app/getsentry/issue/TET-791/update-trace-explorer-link-for-models-and-tools)

- also fixes inconsistent styling

<img width="910" alt="image" src="https://github.com/user-attachments/assets/c71aef47-fb6a-41b2-9983-4cc94af76e17" />
