### PR TITLE
feat(agents-insights): add link to manual instrumentation

### DIFF
--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -410,7 +410,7 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
           ),
           manual: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
+            <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/#manual-instrumentation" />
           ),
         }
       )}

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -401,13 +401,16 @@ export const agentMonitoringOnboarding: OnboardingConfig = {
   introduction: () => (
     <Alert type="info">
       {tct(
-        'Agent Monitoring is currently in beta with support for [vercelai:Vercel AI SDK] and [openai:OpenAI Agents SDK].',
+        'Agent Monitoring is currently in beta with support for [openai:OpenAI Agents SDK] and [vercelai:Vercel AI SDK]. If you are using something else, you can use [manual:manual instrumentation].',
         {
           vercelai: (
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-vercel-ai-sdk" />
           ),
           openai: (
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
+          ),
+          manual: (
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
           ),
         }
       )}

--- a/static/app/utils/gettingStartedDocs/node.tsx
+++ b/static/app/utils/gettingStartedDocs/node.tsx
@@ -361,13 +361,16 @@ export const getNodeAgentMonitoringOnboarding = ({
   introduction: () => (
     <Alert type="info">
       {tct(
-        'Agent Monitoring is currently in beta with support for [vercelai:Vercel AI SDK] and [openai:OpenAI Agents SDK].',
+        'Agent Monitoring is currently in beta with support for [vercelai:Vercel AI SDK] and [openai:OpenAI Agents SDK]. If you are using something else, you can use [manual:manual instrumentation].',
         {
           vercelai: (
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-vercel-ai-sdk" />
           ),
           openai: (
             <ExternalLink href="https://docs.sentry.io/product/insights/agents/getting-started/#quick-start-with-openai-agents" />
+          ),
+          manual: (
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/ai-agents-module/#manual-instrumentation" />
           ),
         }
       )}
@@ -415,22 +418,19 @@ export const getNodeAgentMonitoringOnboarding = ({
 Sentry.init({
   dsn: "${params.dsn.public}",
   integrations: [
-    // Add the Vercel AI SDK integration
-    ${basePackage === 'nextjs' && '// vercelAIIntegration should be included only to config.server'}
-    Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
-    }),
+    // Add the Vercel AI SDK integration ${basePackage === 'nextjs' ? 'to config.server.(js/ts)' : ''}
+    Sentry.vercelAIIntegration(),
   ],
   // Tracing must be enabled for agent monitoring to work
   tracesSampleRate: 1.0,
+  sendDefaultPii: true,
 });`,
             },
           ],
         },
         {
           description: tct(
-            'To correctly capture spans, pass the [code:experimental_telemetry] object with [code:isEnabled: true] to every [code:generateText], [code:generateObject], and [code:streamText] function call. For more details, see the [link:AI SDK Telemetry Metadata docs].',
+            'To correctly capture spans, pass the [code:experimental_telemetry] object to every [code:generateText], [code:generateObject], and [code:streamText] function call. For more details, see the [link:AI SDK Telemetry Metadata docs].',
             {
               code: <code />,
               link: (
@@ -451,6 +451,8 @@ const result = await generateText({
   prompt: "Tell me a joke",
   experimental_telemetry: {
     isEnabled: true,
+    recordInputs: true,
+    recordOutputs: true,
   },
 });`,
             },


### PR DESCRIPTION
Closes [TET-788: Update in-product nextjs/cloudflare instructions](https://linear.app/getsentry/issue/TET-788/update-in-product-nextjscloudflare-instructions)
Closes [TET-786: Add manual instrumentation link](https://linear.app/getsentry/issue/TET-786/add-manual-instrumentation-link)

<img width="584" alt="image" src="https://github.com/user-attachments/assets/96bd2073-b329-4222-98e7-ab337dfbb0f6" />
<img width="593" alt="image" src="https://github.com/user-attachments/assets/41ed4f4b-d6d6-4138-b745-83cd00725516" />
