### PR TITLE
feat(nextjs-insights): allow custom transactions in client table

### DIFF
--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -69,6 +69,7 @@ export function ClientTable() {
   existingQuery.addOp(')');
   existingQuery.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
   existingQuery.addFilterValue('is_transaction', 'true');
+  existingQuery.addFilterValues('!sentry.origin', ['auto.db.*', 'auto'], false);
 
   const tableDataRequest = useTableData({
     query: existingQuery.formatString(),
@@ -146,7 +147,11 @@ export function ClientTable() {
               dataRow={dataRow}
               targetView="frontend"
               projectId={dataRow['project.id'].toString()}
-              query={`transaction.op:${dataRow['span.op']}`}
+              query={
+                ['navigation', 'pageload'].includes(dataRow['span.op'])
+                  ? `transaction.op:${dataRow['span.op']}`
+                  : undefined
+              }
             />
           );
         }

--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -8,10 +8,13 @@ import {
   type GridColumnOrder,
 } from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useOrganization from 'sentry/utils/useOrganization';
 import {HeadSortCell} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
+import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
+import {EAP_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/frontend/settings';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {PlatformInsightsTable} from 'sentry/views/insights/pages/platform/shared/table';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
@@ -58,8 +61,17 @@ export function ClientTable() {
   const hasWebVitalsFlag = organization.features.includes('insights-initial-modules');
   const webVitalsUrl = useModuleURL(ModuleName.VITAL, false, 'frontend');
 
+  const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload', 'navigation', 'default'];
+
+  const existingQuery = new MutableSearch('');
+  existingQuery.addOp('(');
+  existingQuery.addFilterValue('span.op', `[${spanOps.join(',')}]`);
+  existingQuery.addOp(')');
+  existingQuery.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
+  existingQuery.addFilterValue('is_transaction', 'true');
+
   const tableDataRequest = useTableData({
-    query: `span.op:[pageload, navigation]`,
+    query: existingQuery.formatString(),
     fields: [
       'transaction',
       'project.id',

--- a/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/clientTable.tsx
@@ -64,9 +64,7 @@ export function ClientTable() {
   const spanOps = [...EAP_OVERVIEW_PAGE_ALLOWED_OPS, 'pageload', 'navigation', 'default'];
 
   const existingQuery = new MutableSearch('');
-  existingQuery.addOp('(');
   existingQuery.addFilterValue('span.op', `[${spanOps.join(',')}]`);
-  existingQuery.addOp(')');
   existingQuery.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
   existingQuery.addFilterValue('is_transaction', 'true');
   existingQuery.addFilterValues('!sentry.origin', ['auto.db.*', 'auto'], false);


### PR DESCRIPTION
- use existing filtering from frontend page to allow custom transactions in nextjs insights
- display custom transactions using their `default` span.op

Before: 
![Screenshot 2025-07-04 at 12 49 37](https://github.com/user-attachments/assets/f51fd9c1-6823-4332-a9f1-d1f769931e6f)

After: 
![Screenshot 2025-07-04 at 12 50 05](https://github.com/user-attachments/assets/ece39202-1721-4340-be05-7fe5b598eae1)
