### PR TITLE
fix(taskworker): Use local task registry isolated to test

### DIFF
--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -11,7 +11,6 @@ from sentry.testutils.helpers.options import override_options
 class TestTaskworkerRollout(TestCase):
     def setUp(self):
         super().setUp()
-        # Create a fresh registry for each test to ensure isolation
         self.registry = TaskRegistry()
         self.namespace = self.registry.create_namespace(name="test_namespace")
         self.config = TaskworkerConfig(

--- a/tests/sentry/tasks/test_taskworker_rollout.py
+++ b/tests/sentry/tasks/test_taskworker_rollout.py
@@ -7,16 +7,13 @@ from sentry.taskworker.registry import TaskRegistry
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 
-registry = TaskRegistry()
-
 
 class TestTaskworkerRollout(TestCase):
     def setUp(self):
         super().setUp()
-        if not registry.contains("test_namespace"):
-            self.namespace = registry.create_namespace(name="test_namespace")
-        else:
-            self.namespace = registry.get("test_namespace")
+        # Create a fresh registry for each test to ensure isolation
+        self.registry = TaskRegistry()
+        self.namespace = self.registry.create_namespace(name="test_namespace")
         self.config = TaskworkerConfig(
             namespace=self.namespace,
             retry=None,


### PR DESCRIPTION
This PR is fixes the issue with this test irreversibly modifying global state of task registry by creating a fresh local registry per test. 