### PR TITLE
fix(taskworker) Add metric to see how long we wait

### DIFF
--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -162,7 +162,6 @@ def child_process(
 
         while True:
             if max_task_count and processed_task_count >= max_task_count:
-
                 metrics.incr(
                     "taskworker.worker.max_task_count_reached",
                     tags={"count": processed_task_count, "processing_pool": processing_pool_name},
@@ -176,9 +175,17 @@ def child_process(
                 logger.info("taskworker.worker.shutdown_event")
                 break
 
+            child_tasks_get_start = time.monotonic()
             try:
+                # If the queue is empty, this could block for a second.
+                # We could be losing a bunch of throughput here.
                 inflight = child_tasks.get(timeout=1.0)
             except queue.Empty:
+                metrics.distribution(
+                    "taskworker.worker.child_task_queue_empty.wait_duration",
+                    time.monotonic() - child_tasks_get_start,
+                    tags={"processing_pool": processing_pool_name},
+                )
                 metrics.incr(
                     "taskworker.worker.child_task_queue_empty",
                     tags={"processing_pool": processing_pool_name},

--- a/src/sentry/taskworker/workerchild.py
+++ b/src/sentry/taskworker/workerchild.py
@@ -178,7 +178,6 @@ def child_process(
             child_tasks_get_start = time.monotonic()
             try:
                 # If the queue is empty, this could block for a second.
-                # We could be losing a bunch of throughput here.
                 inflight = child_tasks.get(timeout=1.0)
             except queue.Empty:
                 metrics.distribution(


### PR DESCRIPTION
I'm interested in understanding how much time we're losing to waiting on empty multiprocessing queues. This metric will help understand this, so we can tune workers more.
