### PR TITLE
chore(insights): removes unused discover function from type

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -621,8 +621,6 @@ type MetricsResponseRaw = {
 } & {
   [Property in MetricsStringFields as `${Property}`]: string;
 } & {
-  [Property in MetricsNumberFields as `count_web_vitals(${Property}, any)`]: string[];
-} & {
   ['project.id']: number;
 };
 export type MetricsResponse = Flatten<MetricsResponseRaw>;


### PR DESCRIPTION
Removes `count_web_vitals` function from response type since we don't actually use it in insights.