### PR TITLE
feat(ourlogs): Increase max allowed results in logs to 9999

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -594,7 +594,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
 
         data_fn = data_fn_factory(dataset)
 
-        max_per_page = 1000 if dataset == ourlogs else None
+        max_per_page = 9999 if dataset == ourlogs else None
 
         with handle_query_errors():
             # Don't include cursor headers if the client won't be using them

--- a/src/sentry/api/endpoints/organization_trace_logs.py
+++ b/src/sentry/api/endpoints/organization_trace_logs.py
@@ -120,5 +120,5 @@ class OrganizationTraceLogsEndpoint(OrganizationEventsV2EndpointBase):
         return self.paginate(
             request=request,
             paginator=GenericOffsetPaginator(data_fn=data_fn),
-            max_per_page=1000,
+            max_per_page=9999,
         )


### PR DESCRIPTION
### Summary
This bumps the allowed returned results to Snuba's max (~10k), which helps us run autorefresh smoothly without making continous requests to catch up.

