### PR TITLE
feat(insights): adds empty state onboarding to mobile vitals

### DIFF
--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -323,10 +323,17 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
   },
   'mobile-vitals': {
     heading: t('Mobile Vitals'),
-    description: t('Explore mobile app metrics.'),
+    description: t(
+      'Key metrics for for mobile development that help you ensure a great mobile user experience.'
+    ),
     valuePropDescription: '',
-    valuePropPoints: [],
+    valuePropPoints: [
+      t('Recommendations for key mobile metrics based on industry standards.'),
+      t('Track the performance of your application on real user devices.'),
+      t('Understand the full lifecycle of an app, from startup to user interactions.'),
+    ],
     imageSrc: screenLoadsPreviewImg,
+    supportedSdks: ['android', 'flutter', 'apple-ios', 'react-native'],
   },
   cache: {
     heading: t('Bringing you one less hard problem in computer science'),

--- a/static/app/views/insights/common/components/modulesOnboarding.tsx
+++ b/static/app/views/insights/common/components/modulesOnboarding.tsx
@@ -326,9 +326,9 @@ const EMPTY_STATE_CONTENT: Record<TitleableModuleNames, EmptyStateContent> = {
     description: t(
       'Key metrics for for mobile development that help you ensure a great mobile user experience.'
     ),
-    valuePropDescription: '',
+    valuePropDescription: t('With Mobile Vitals:'),
     valuePropPoints: [
-      t('Recommendations for key mobile metrics based on industry standards.'),
+      t('Get recommendations for key mobile metrics based on industry standards.'),
       t('Track the performance of your application on real user devices.'),
       t('Understand the full lifecycle of an app, from startup to user interactions.'),
     ],

--- a/static/app/views/insights/common/queries/useHasFirstSpan.tsx
+++ b/static/app/views/insights/common/queries/useHasFirstSpan.tsx
@@ -7,7 +7,6 @@ import {ModuleName} from 'sentry/views/insights/types';
 const excludedModuleNames = [
   ModuleName.OTHER,
   ModuleName.MOBILE_UI,
-  ModuleName.MOBILE_VITALS,
   ModuleName.SESSIONS,
   ModuleName.AGENTS,
 ] as const;
@@ -29,6 +28,7 @@ const modulePropertyMap: Record<
   [ModuleName.RESOURCE]: 'hasInsightsAssets',
   [ModuleName.AI]: 'hasInsightsLlmMonitoring',
   [ModuleName.SCREEN_RENDERING]: 'hasInsightsScreenLoad', // Screen rendering and screen loads share similar spans
+  [ModuleName.MOBILE_VITALS]: 'hasInsightsScreenLoad',
 };
 
 /**

--- a/static/app/views/insights/mobile/screens/settings.ts
+++ b/static/app/views/insights/mobile/screens/settings.ts
@@ -14,6 +14,7 @@ export const MODULE_FEATURE = t('insights-addon-modules');
 export const DATA_TYPE = t('Mobile Vitals');
 export const DATA_TYPE_PLURAL = t('Mobile Vitals');
 
-export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';
+export const MODULE_DOC_LINK =
+  'https://docs.sentry.io/product/insights/mobile/mobile-vitals/';
 
 export const DEFAULT_SORT: Sort = {field: 'count()', kind: 'desc'};

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.spec.tsx
@@ -5,6 +5,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
@@ -19,7 +20,14 @@ describe('Screens Landing Page', function () {
   const organization = OrganizationFixture({
     features: [MODULE_FEATURE],
   });
-  const project = ProjectFixture({platform: 'react-native'});
+
+  const project = ProjectFixture({
+    hasInsightsScreenLoad: true,
+    firstTransactionEvent: true,
+    platform: 'react-native',
+  });
+
+  ProjectsStore.loadInitialData([project]);
 
   jest.mocked(useLocation).mockReturnValue({
     action: 'PUSH',

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -17,6 +17,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {
@@ -280,41 +281,43 @@ function ScreensLandingPage() {
                   </PageFilterBar>
                 </Container>
                 <PageAlert />
-                <ErrorBoundary mini>
-                  <Container>
-                    <Flex data-test-id="mobile-vitals-top-metrics">
-                      {vitalItems.map(item => {
-                        const metricValue: MetricValue = {
-                          type: metaFields?.[item.field],
-                          value: metricsData?.[item.field],
-                          unit: metaUnits?.[item.field],
-                        };
+                <ModulesOnboarding moduleName={moduleName}>
+                  <ErrorBoundary mini>
+                    <Container>
+                      <Flex data-test-id="mobile-vitals-top-metrics">
+                        {vitalItems.map(item => {
+                          const metricValue: MetricValue = {
+                            type: metaFields?.[item.field],
+                            value: metricsData?.[item.field],
+                            unit: metaUnits?.[item.field],
+                          };
 
-                        const status =
-                          (metricValue && item.getStatus(metricValue, item.field)) ??
-                          STATUS_UNKNOWN;
+                          const status =
+                            (metricValue && item.getStatus(metricValue, item.field)) ??
+                            STATUS_UNKNOWN;
 
-                        return (
-                          <VitalCard
-                            onClick={() => {
-                              setState({
-                                vital: item,
-                                status,
-                              });
-                            }}
-                            key={item.field}
-                            title={item.title}
-                            description={item.description}
-                            statusLabel={status.description}
-                            status={status.score}
-                            formattedValue={status.formattedValue}
-                          />
-                        );
-                      })}
-                    </Flex>
-                    <ScreensOverview />
-                  </Container>
-                </ErrorBoundary>
+                          return (
+                            <VitalCard
+                              onClick={() => {
+                                setState({
+                                  vital: item,
+                                  status,
+                                });
+                              }}
+                              key={item.field}
+                              title={item.title}
+                              description={item.description}
+                              statusLabel={status.description}
+                              status={status.score}
+                              formattedValue={status.formattedValue}
+                            />
+                          );
+                        })}
+                      </Flex>
+                      <ScreensOverview />
+                    </Container>
+                  </ErrorBoundary>
+                </ModulesOnboarding>
               </Layout.Main>
             </Layout.Body>
           </ModuleBodyUpsellHook>


### PR DESCRIPTION
Adds an onboarding page to mobile vitals when the project does not have a first screen load detected
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/af914441-84a0-48f8-b235-da6827c559e3" />
