### PR TITLE
feat(explore): Persist toolbar collapsed state

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -31,9 +31,12 @@ import {
   type AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
 } from 'sentry/utils/fields';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {chonkStyled} from 'sentry/utils/theme/theme.chonk';
 import {withChonk} from 'sentry/utils/theme/withChonk';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -100,6 +103,27 @@ export function SpansTabOnboarding({
   );
 }
 
+function useControlSectionExpanded() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const controlSectionExpanded = decodeScalar(location.query.toolbar);
+  const setControlSectionExpanded = useCallback(
+    (expanded: boolean) => {
+      const newControlSectionExpanded = expanded ? undefined : 'collapsed';
+      navigate({
+        ...location,
+        query: {
+          ...location.query,
+          toolbar: newControlSectionExpanded,
+        },
+      });
+    },
+    [location, navigate]
+  );
+
+  return [controlSectionExpanded !== 'collapsed', setControlSectionExpanded] as const;
+}
+
 interface SpanTabProps {
   datePageFilterProps: PickableDays;
 }
@@ -108,7 +132,7 @@ export function SpansTabContent({datePageFilterProps}: SpanTabProps) {
   useVisitExplore();
 
   const organization = useOrganization();
-  const [controlSectionExpanded, setControlSectionExpanded] = useState(true);
+  const [controlSectionExpanded, setControlSectionExpanded] = useControlSectionExpanded();
 
   return (
     <Fragment>


### PR DESCRIPTION
This persists the collapsed state of the toolbar when navigating through browser history.

Closes EXP-369