### PR TITLE
fix(explore): Chart always respect group bys

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.tsx
@@ -298,6 +298,11 @@ export function useExploreSortBys(): Sort[] {
     : pageParams.sortBys;
 }
 
+export function useExploreAggregateSortBys(): Sort[] {
+  const pageParams = useExplorePageParams();
+  return pageParams.aggregateSortBys;
+}
+
 export function useExploreTitle(): string | undefined {
   const pageParams = useExplorePageParams();
   return pageParams.title;

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -7,13 +7,11 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePrevious from 'sentry/utils/usePrevious';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {
+  useExploreAggregateSortBys,
   useExploreDataset,
   useExploreGroupBys,
-  useExploreMode,
-  useExploreSortBys,
   useExploreVisualizes,
 } from 'sentry/views/explore/contexts/pageParamsContext';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import type {Visualize} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {DEFAULT_VISUALIZATION} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
@@ -71,8 +69,7 @@ function useExploreTimeseriesImpl({
 }: UseExploreTimeseriesOptions): UseExploreTimeseriesResults {
   const dataset = useExploreDataset();
   const groupBys = useExploreGroupBys();
-  const mode = useExploreMode();
-  const sortBys = useExploreSortBys();
+  const sortBys = useExploreAggregateSortBys();
   const visualizes = useExploreVisualizes({validate: true});
   const [interval] = useChartInterval();
   const topEvents = useTopEvents();
@@ -82,12 +79,8 @@ function useExploreTimeseriesImpl({
   }, [visualizes]);
 
   const fields: string[] = useMemo(() => {
-    if (mode === Mode.SAMPLES) {
-      return [];
-    }
-
     return [...groupBys, ...validYAxes].filter(Boolean);
-  }, [mode, groupBys, validYAxes]);
+  }, [groupBys, validYAxes]);
 
   const orderby: string | string[] | undefined = useMemo(() => {
     if (!sortBys.length) {

--- a/static/app/views/explore/hooks/useTopEvents.tsx
+++ b/static/app/views/explore/hooks/useTopEvents.tsx
@@ -1,10 +1,6 @@
 import {useMemo} from 'react';
 
-import {
-  useExploreGroupBys,
-  useExploreMode,
-} from 'sentry/views/explore/contexts/pageParamsContext';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useExploreGroupBys} from 'sentry/views/explore/contexts/pageParamsContext';
 
 export const TOP_EVENTS_LIMIT = 5;
 
@@ -13,22 +9,14 @@ export const TOP_EVENTS_LIMIT = 5;
 // to get the series count without adding more complexity to this hook.
 export function useTopEvents(): number | undefined {
   const groupBys = useExploreGroupBys();
-  const mode = useExploreMode();
 
   const topEvents: number | undefined = useMemo(() => {
-    // We only support top events in aggregates mode for
-    // when there are no multiple y-axes chart and there is at least one group by.
-
-    if (mode === Mode.SAMPLES) {
-      return undefined;
-    }
-
     if (groupBys.every(groupBy => groupBy === '')) {
       return undefined;
     }
 
     return TOP_EVENTS_LIMIT;
-  }, [groupBys, mode]);
+  }, [groupBys]);
 
   return topEvents;
 }


### PR DESCRIPTION
We want the chart to always respect the group bys even in samples mode.