### PR TITLE
fix(insights): fix breadcrumbs not containing module landing page and remove module tabs on summary pages

### DIFF
--- a/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourceSummaryPage.tsx
@@ -21,6 +21,7 @@ import {ModulePageProviders} from 'sentry/views/insights/common/components/modul
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
@@ -40,6 +41,8 @@ const {
 } = SpanMetricsField;
 
 function ResourceSummary() {
+  const moduleTitle = useModuleTitle(ModuleName.RESOURCE);
+  const moduleURL = useModuleURL(ModuleName.RESOURCE);
   const webVitalsModuleURL = useModuleURL('vital');
   const {groupId} = useParams();
   const filters = useResourceModuleFilters();
@@ -103,10 +106,15 @@ function ResourceSummary() {
         headerTitle={spanMetrics[SpanMetricsField.SPAN_DESCRIPTION]}
         breadcrumbs={[
           {
+            label: moduleTitle,
+            to: moduleURL,
+          },
+          {
             label: tct('[dataType] Summary', {dataType: DATA_TYPE}),
           },
         ]}
         module={ModuleName.RESOURCE}
+        hideDefaultTabs
       />
 
       <ModuleBodyUpsellHook moduleName={ModuleName.RESOURCE}>

--- a/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
+++ b/static/app/views/insights/browser/webVitals/views/pageOverview.tsx
@@ -29,6 +29,7 @@ import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modul
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import PerformanceScoreBreakdownChartWidget from 'sentry/views/insights/common/components/widgets/performanceScoreBreakdownChartWidget';
+import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
 import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useWebVitalsDrawer} from 'sentry/views/insights/common/utils/useWebVitalsDrawer';
 import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
@@ -41,6 +42,7 @@ import {
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 function PageOverview() {
+  const moduleTitle = useModuleTitle(ModuleName.VITAL);
   const moduleURL = useModuleURL('vital');
   const organization = useOrganization();
   const location = useLocation();
@@ -144,8 +146,13 @@ function PageOverview() {
             </LinkButton>
           )
         }
-        breadcrumbs={transaction ? [{label: 'Page Summary'}] : []}
+        breadcrumbs={
+          transaction
+            ? [{label: moduleTitle, to: moduleURL}, {label: t('Page Summary')}]
+            : []
+        }
         module={ModuleName.VITAL}
+        hideDefaultTabs
       />
       <ModuleBodyUpsellHook moduleName={ModuleName.VITAL}>
         <Layout.Body>

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -25,6 +25,8 @@ import {
   useSpanMetrics,
   useSpansIndexed,
 } from 'sentry/views/insights/common/queries/useDiscover';
+import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
+import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import {
@@ -54,6 +56,8 @@ type Query = {
 type Props = RouteComponentProps<{groupId: string}, Record<string, unknown>, any, Query>;
 
 export function DatabaseSpanSummaryPage({params}: Props) {
+  const moduleTitle = useModuleTitle(ModuleName.DB);
+  const moduleURL = useModuleURL(ModuleName.DB);
   const location = useLocation<Query>();
 
   const {groupId} = params;
@@ -167,10 +171,15 @@ export function DatabaseSpanSummaryPage({params}: Props) {
         headerTitle={t('Query Summary')}
         breadcrumbs={[
           {
+            label: moduleTitle,
+            to: moduleURL,
+          },
+          {
             label: t('Query Summary'),
           },
         ]}
         module={ModuleName.DB}
+        hideDefaultTabs
       />
 
       <ModuleBodyUpsellHook moduleName={ModuleName.DB}>

--- a/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
+++ b/static/app/views/insights/http/views/httpDomainSummaryPage.tsx
@@ -22,6 +22,8 @@ import HttpDomainSummaryDurationChartWidget from 'sentry/views/insights/common/c
 import HttpDomainSummaryResponseCodesChartWidget from 'sentry/views/insights/common/components/widgets/httpDomainSummaryResponseCodesChartWidget';
 import HttpDomainSummaryThroughputChartWidget from 'sentry/views/insights/common/components/widgets/httpDomainSummaryThroughputChartWidget';
 import {useSpanMetrics} from 'sentry/views/insights/common/queries/useDiscover';
+import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
+import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
@@ -50,6 +52,8 @@ import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/insights/types';
 
 export function HTTPDomainSummaryPage() {
+  const moduleTitle = useModuleTitle(ModuleName.HTTP);
+  const moduleURL = useModuleURL(ModuleName.HTTP);
   const {projects} = useProjects();
   const {view} = useDomainViewFilters();
   const filters = useHttpDomainSummaryChartFilter();
@@ -130,11 +134,13 @@ export function HTTPDomainSummaryPage() {
       </Fragment>
     ),
     breadcrumbs: [
+      {label: moduleTitle, to: moduleURL},
       {
         label: t('Domain Summary'),
       },
     ],
     module: ModuleName.HTTP,
+    hideDefaultTabs: true,
   };
 
   return (

--- a/static/app/views/insights/queues/views/destinationSummaryPage.tsx
+++ b/static/app/views/insights/queues/views/destinationSummaryPage.tsx
@@ -18,6 +18,8 @@ import {ReadoutRibbon, ToolRibbon} from 'sentry/views/insights/common/components
 import QueuesSummaryLatencyChartWidget from 'sentry/views/insights/common/components/widgets/queuesSummaryLatencyChartWidget';
 import QueuesSummaryThroughputChartWidget from 'sentry/views/insights/common/components/widgets/queuesSummaryThroughputChartWidget';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
+import {useModuleTitle} from 'sentry/views/insights/common/utils/useModuleTitle';
+import {useModuleURL} from 'sentry/views/insights/common/utils/useModuleURL';
 import {useSamplesDrawer} from 'sentry/views/insights/common/utils/useSamplesDrawer';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {MessageSpanSamplesPanel} from 'sentry/views/insights/queues/components/messageSpanSamplesPanel';
@@ -29,6 +31,8 @@ import {ModuleName} from 'sentry/views/insights/types';
 import {LegacyOnboarding} from 'sentry/views/performance/onboarding';
 
 function DestinationSummaryPage() {
+  const moduleTitle = useModuleTitle(ModuleName.QUEUE);
+  const moduleURL = useModuleURL(ModuleName.QUEUE);
   const organization = useOrganization();
   const onboardingProject = useOnboardingProject();
 
@@ -53,10 +57,15 @@ function DestinationSummaryPage() {
         headerTitle={destination}
         breadcrumbs={[
           {
+            label: moduleTitle,
+            to: moduleURL,
+          },
+          {
             label: DESTINATION_TITLE,
           },
         ]}
         module={ModuleName.QUEUE}
+        hideDefaultTabs
       />
       <ModuleBodyUpsellHook moduleName={ModuleName.QUEUE}>
         <Layout.Body>


### PR DESCRIPTION
When viewing a page/asset/db/etc summary page:
- Add the module landing page to the header breadcrumbs (ie Assets)
- Removed the module tabs from the header (Users shouldn't be given the option to switch to a different module from within a specific summary page)

This fixes inconsistent rendering of breadcrumbs and tabs across insights modules.
<img width="345" alt="image" src="https://github.com/user-attachments/assets/b8331c88-530a-4629-95b5-38e656b4b259" />
