### PR TITLE
feat(ourlogs): Add auto-refresh to logs

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -104,15 +104,29 @@ export function SearchQueryBuilderProvider({
     disabled,
   });
 
+  const stableFieldDefinitionGetter = useMemo(
+    () => fieldDefinitionGetter,
+    [fieldDefinitionGetter]
+  );
+
+  const stableFilterKeys = useMemo(() => filterKeys, [filterKeys]);
+
+  const stableGetSuggestedFilterKey = useCallback(
+    (key: string) => {
+      return getSuggestedFilterKey ? getSuggestedFilterKey(key) : key;
+    },
+    [getSuggestedFilterKey]
+  );
+
   const parseQuery = useCallback(
     (query: string) =>
-      parseQueryBuilderValue(query, fieldDefinitionGetter, {
+      parseQueryBuilderValue(query, stableFieldDefinitionGetter, {
         getFilterTokenWarning,
         disallowFreeText,
         disallowLogicalOperators,
         disallowUnsupportedFilters,
         disallowWildcard,
-        filterKeys,
+        filterKeys: stableFilterKeys,
         invalidMessages,
         filterKeyAliases,
       }),
@@ -121,8 +135,8 @@ export function SearchQueryBuilderProvider({
       disallowLogicalOperators,
       disallowUnsupportedFilters,
       disallowWildcard,
-      fieldDefinitionGetter,
-      filterKeys,
+      stableFieldDefinitionGetter,
+      stableFilterKeys,
       getFilterTokenWarning,
       invalidMessages,
       filterKeyAliases,
@@ -150,10 +164,10 @@ export function SearchQueryBuilderProvider({
       parsedQuery,
       filterKeySections: filterKeySections ?? [],
       filterKeyMenuWidth,
-      filterKeys,
-      getSuggestedFilterKey: getSuggestedFilterKey ?? ((key: string) => key),
+      filterKeys: stableFilterKeys,
+      getSuggestedFilterKey: stableGetSuggestedFilterKey,
       getTagValues,
-      getFieldDefinition: fieldDefinitionGetter,
+      getFieldDefinition: stableFieldDefinitionGetter,
       dispatch,
       wrapperRef,
       actionBarRef,
@@ -177,10 +191,10 @@ export function SearchQueryBuilderProvider({
     parsedQuery,
     filterKeySections,
     filterKeyMenuWidth,
-    filterKeys,
-    getSuggestedFilterKey,
+    stableFilterKeys,
+    stableGetSuggestedFilterKey,
     getTagValues,
-    fieldDefinitionGetter,
+    stableFieldDefinitionGetter,
     dispatch,
     handleSearch,
     placeholder,

--- a/static/app/utils/timeSeries/markDelayedData.tsx
+++ b/static/app/utils/timeSeries/markDelayedData.tsx
@@ -2,7 +2,6 @@
  * Given a timeseries and a delay in seconds, goes through the timeseries data, and marks each point as either delayed (data bucket ended before the delay threshold) or not
  */
 
-import {defined} from 'sentry/utils';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
 export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeries {
@@ -22,10 +21,6 @@ export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeri
     values: timeSeries.values.map(datum => {
       const bucketEndTimestamp = new Date(datum.timestamp).getTime() + bucketSize;
       const delayed = bucketEndTimestamp >= ingestionDelayTimestamp;
-
-      if (defined(datum.incomplete)) {
-        return datum;
-      }
 
       if (!delayed) {
         return datum;

--- a/static/app/utils/timeSeries/markDelayedData.tsx
+++ b/static/app/utils/timeSeries/markDelayedData.tsx
@@ -2,6 +2,7 @@
  * Given a timeseries and a delay in seconds, goes through the timeseries data, and marks each point as either delayed (data bucket ended before the delay threshold) or not
  */
 
+import {defined} from 'sentry/utils';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
 export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeries {
@@ -21,6 +22,10 @@ export function markDelayedData(timeSeries: TimeSeries, delay: number): TimeSeri
     values: timeSeries.values.map(datum => {
       const bucketEndTimestamp = new Date(datum.timestamp).getTime() + bucketSize;
       const delayed = bucketEndTimestamp >= ingestionDelayTimestamp;
+
+      if (defined(datum.incomplete)) {
+        return datum;
+      }
 
       if (!delayed) {
         return datum;

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -240,15 +240,7 @@ function setLogsPageParams(location: Location, pageParams: LogPageParamsUpdate) 
   updateNullableLocation(target, LOGS_AGGREGATE_PARAM_KEY, pageParams.aggregateParam);
   if (!pageParams.isTableFrozen) {
     updateLocationWithLogSortBys(target, pageParams.sortBys);
-    if (
-      pageParams.sortBys ||
-      pageParams.search ||
-      pageParams.aggregateFn ||
-      pageParams.aggregateParam ||
-      pageParams.groupBy
-    ) {
-      updateLocationWithAggregateSortBys(target, pageParams.aggregateSortBys);
-    }
+    updateLocationWithAggregateSortBys(target, pageParams.aggregateSortBys);
     if (pageParams.sortBys || pageParams.aggregateSortBys || pageParams.search) {
       // make sure to clear the cursor every time the query is updated
       delete target.query[LOGS_CURSOR_KEY];

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -13,7 +13,10 @@ export const LogAttributesHumanLabel: Partial<Record<OurLogFieldKey, string>> = 
   [OurLogKnownFieldKey.TRACE_ID]: t('Trace'),
 };
 
-export const LOG_INGEST_DELAY = 10_000;
+export const MAX_LOG_INGEST_DELAY = 40_000;
+export const MAX_LOG_INGEST_QUERY_DELAY = 15_000;
+export const QUERY_PAGE_LIMIT = 5000; // If this does not equal the limit with auto-refresh, the query keys will diverge and they will have separate caches. We may want to make this change in the future.
+export const QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH = 5000;
 
 /**
  * These are required fields are always added to the query when fetching the log table.
@@ -66,6 +69,6 @@ export const LOGS_INSTRUCTIONS_URL =
 
 export const LOGS_FILTER_KEY_SECTIONS: FilterKeySection[] = [LOGS_FILTERS];
 
-export const VIRTUAL_STREAMED_INTERVAL_MS = 333;
+export const VIRTUAL_STREAMED_INTERVAL_MS = 250;
 
 export const LOGS_GRID_SCROLL_MIN_ITEM_THRESHOLD = 100; // Items from bottom of table to trigger table fetch.

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -14,7 +14,6 @@ export const LogAttributesHumanLabel: Partial<Record<OurLogFieldKey, string>> = 
 };
 
 export const MAX_LOG_INGEST_DELAY = 40_000;
-export const MAX_LOG_INGEST_QUERY_DELAY = 15_000;
 export const QUERY_PAGE_LIMIT = 5000; // If this does not equal the limit with auto-refresh, the query keys will diverge and they will have separate caches. We may want to make this change in the future.
 export const QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH = 5000;
 

--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -1,9 +1,12 @@
-import {useEffect, useRef} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import isEqual from 'lodash/isEqual';
 
 import {Switch} from 'sentry/components/core/switch';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import {t} from 'sentry/locale';
-import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {defined} from 'sentry/utils';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import usePrevious from 'sentry/utils/usePrevious';
 import {useLogsPageData} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {
   useLogsAutoRefresh,
@@ -12,105 +15,243 @@ import {
   useSetLogsAutoRefresh,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {AutoRefreshLabel} from 'sentry/views/explore/logs/styles';
-import {checkSortIsTimeBased} from 'sentry/views/explore/logs/utils';
+import {
+  checkSortIsTimeBasedDescending,
+  parseLinkHeaderFromLogsPage,
+} from 'sentry/views/explore/logs/utils';
 
-const MAX_AUTO_REFRESH_TIME_MS = 1000 * 60 * 5; // 5 minutes
-const MAX_PAGES_PER_REFRESH = 10;
-let _callCounts = 0;
+const ABSOLUTE_MAX_AUTO_REFRESH_TIME_MS = 1000 * 60 * 10; // 10 minutes absolute max
+const CONSECUTIVE_PAGES_WITH_MORE_DATA = 3; // Number of consecutive requests with more data before disabling
+
+type DisableReason = 'sort' | 'timeout' | 'rateLimit' | 'error';
+
+const SWITCH_DISABLE_REASONS: DisableReason[] = ['sort'];
 
 export function AutorefreshToggle() {
+  const {selection} = usePageFilters();
+  const previousProjects = usePrevious(selection.projects);
   const checked = useLogsAutoRefresh();
   const setChecked = useSetLogsAutoRefresh();
   const sortBys = useLogsSortBys();
   const refreshInterval = useLogsRefreshInterval();
   const {infiniteLogsQueryResult} = useLogsPageData();
-  const {fetchPreviousPage} = infiniteLogsQueryResult;
+  const {fetchPreviousPage, isError} = infiniteLogsQueryResult;
 
-  const refreshCallback = useRef(() => {}); // Since the interval fetches data, it's an infinite dependency loop.
+  const sortBysString = JSON.stringify(sortBys);
+  const previousSortBysString = usePrevious(sortBysString);
 
-  const isTimeBasedSort = checkSortIsTimeBased(sortBys);
-  const enabled = isTimeBasedSort && checked;
+  const [disableReason, setDisableReason] = useState<DisableReason | undefined>(
+    undefined
+  );
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const intervalStartTime = useRef(Date.now());
-  const pauseRef = useRef(false);
+  const isPausedRef = useRef(false);
+  const isRefreshRunningRef = useRef(false);
+  const consecutivePagesWithMoreDataRef = useRef(0);
+
+  const statsPeriod = usePageFilters().selection.datetime.period;
+  const isDescendingTimeBasedSort = checkSortIsTimeBasedDescending(sortBys);
+  const enabled = isDescendingTimeBasedSort && checked && defined(statsPeriod);
+
+  // Disable auto-refresh if the project changes
+  useEffect(() => {
+    if (!isEqual(selection.projects, previousProjects)) {
+      setChecked(false);
+    }
+  }, [selection.projects, previousProjects, setChecked]);
+
+  // Reset disableReason when sort bys change
+  useEffect(() => {
+    if (previousSortBysString && sortBysString !== previousSortBysString) {
+      setDisableReason(isDescendingTimeBasedSort ? undefined : 'sort');
+    }
+  }, [sortBysString, previousSortBysString, isDescendingTimeBasedSort]);
 
   useEffect(() => {
-    refreshCallback.current = async () => {
-      const timeSinceIntervalStarted = Date.now() - intervalStartTime.current;
-      if (timeSinceIntervalStarted > MAX_AUTO_REFRESH_TIME_MS) {
-        setChecked(false);
-        return;
-      }
+    if (isError && enabled) {
+      setDisableReason('error');
+      setChecked(false);
+    }
+  }, [isError, enabled, setChecked]);
 
-      if (document.visibilityState === 'hidden') {
-        pauseRef.current = true;
-      } else {
-        pauseRef.current = false;
-      }
+  const shouldPauseForVisibility = useCallback((): boolean => {
+    if (document.visibilityState === 'hidden') {
+      isPausedRef.current = true;
+      return true;
+    }
+    isPausedRef.current = false;
+    return false;
+  }, []);
 
-      let page = 0;
-      while (page < MAX_PAGES_PER_REFRESH) {
-        if (pauseRef.current) {
-          return;
-        }
-        const previousPage = await fetchPreviousPage();
-        _callCounts++;
-        if (!previousPage) {
-          return;
-        }
-        const parsed = parseLinkHeader(
-          previousPage.data?.pages?.[0]?.[2]?.getResponseHeader('Link') ?? null
-        );
-        // "Next" on the previous page is correct since the previous pages have reverse sort orders.
-        if (parsed.next?.results) {
-          page++;
-        } else {
-          return;
-        }
-      }
-    };
-    return () => {
-      pauseRef.current = true;
-    };
-  }, [fetchPreviousPage, setChecked]);
+  const shouldDisableForTimeout = useCallback((): boolean => {
+    const timeSinceStart = Date.now() - intervalStartTime.current;
 
+    // Check if we've exceeded the absolute max timeout
+    return timeSinceStart > ABSOLUTE_MAX_AUTO_REFRESH_TIME_MS;
+  }, []);
+
+  // Our querying is currently at 5000 max logs per page, and our default refresh interval is 5 seconds.
+  // This means each page if at it's max logs, we're getting 1000 logs per second.
+  // We check if this is happening 3 times in a row, and if so, we disable auto-refresh since our rate limit is 1k/s and we're exceeding it.
+  const shouldDisableForRateLimit = useCallback((pageResult: any): boolean => {
+    const parsed = parseLinkHeaderFromLogsPage(pageResult);
+
+    if (parsed.next?.results) {
+      consecutivePagesWithMoreDataRef.current++;
+
+      if (consecutivePagesWithMoreDataRef.current >= CONSECUTIVE_PAGES_WITH_MORE_DATA) {
+        consecutivePagesWithMoreDataRef.current = 0;
+        return true;
+      }
+    } else {
+      consecutivePagesWithMoreDataRef.current = 0;
+    }
+
+    return false;
+  }, []);
+
+  const fetchPageWithRateLimitCheck = useCallback(async (): Promise<void> => {
+    if (shouldPauseForVisibility()) {
+      return;
+    }
+
+    let previousPage: any;
+    try {
+      previousPage = await fetchPreviousPage();
+    } catch (error) {
+      // Handle network errors or other exceptions
+      setDisableReason('error');
+      setChecked(false);
+      return;
+    }
+
+    if (!previousPage) {
+      // This can happen if the fetchPreviousPage call is stale (it returns promise.resolve())
+      return;
+    }
+
+    // Check if the response indicates an error
+    if (previousPage.status === 'error' || previousPage.isError) {
+      setDisableReason('error');
+      setChecked(false);
+      return;
+    }
+
+    // Check rate limit using the pageResult we just fetched
+    if (shouldDisableForRateLimit(previousPage)) {
+      setDisableReason('rateLimit');
+      setChecked(false);
+      return;
+    }
+  }, [
+    shouldPauseForVisibility,
+    fetchPreviousPage,
+    shouldDisableForRateLimit,
+    setChecked,
+  ]);
+
+  // Set up the refresh interval
   useEffect(() => {
     if (enabled) {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-      pauseRef.current = false;
 
-      refreshCallback.current();
-      intervalRef.current = setInterval(refreshCallback.current, refreshInterval);
+      isPausedRef.current = false;
+      isRefreshRunningRef.current = false;
       intervalStartTime.current = Date.now();
+      consecutivePagesWithMoreDataRef.current = 0;
+
+      const executeRefresh = async () => {
+        if (isRefreshRunningRef.current) {
+          return;
+        }
+
+        isRefreshRunningRef.current = true;
+
+        try {
+          if (shouldDisableForTimeout()) {
+            setDisableReason('timeout');
+            setChecked(false);
+            return;
+          }
+
+          await fetchPageWithRateLimitCheck();
+        } finally {
+          isRefreshRunningRef.current = false;
+        }
+      };
+
+      executeRefresh();
+      intervalRef.current = setInterval(executeRefresh, refreshInterval);
     } else {
+      // Clean up interval when disabled
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
+
+      // Reset running state and counters
+      isRefreshRunningRef.current = false;
+      consecutivePagesWithMoreDataRef.current = 0;
     }
+
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
+      isRefreshRunningRef.current = false;
+      consecutivePagesWithMoreDataRef.current = 0;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, refreshInterval]);
 
+  const getTooltipMessage = (): string => {
+    switch (disableReason) {
+      case 'rateLimit':
+        return t(
+          'Auto-refresh was disabled due to high data volume. Try adding a filter to reduce the number of logs.'
+        );
+      case 'timeout':
+        return t(
+          'Auto-refresh was disabled due to reaching the absolute max auto-refresh time of 10 minutes. Re-enable to continue.'
+        );
+      case 'error':
+        return t(
+          'Auto-refresh was disabled due to an error fetching logs. If the issue persists, please contact support.'
+        );
+      case 'sort':
+      default:
+        return t(
+          'Auto-refresh is only supported when sorting by time in descending order and using a relative time period.'
+        );
+    }
+  };
+
   return (
-    <AutoRefreshLabel>
-      <Tooltip
-        title={t('Auto-refresh is only supported when sorting by time.')}
-        disabled={isTimeBasedSort}
-        skipWrapper
-      >
-        <Switch
-          disabled={!isTimeBasedSort}
-          checked={checked}
-          onChange={() => setChecked(!checked)}
-        />
-      </Tooltip>
-      {t('Auto-refresh')}
-    </AutoRefreshLabel>
+    <Fragment>
+      <AutoRefreshLabel>
+        <Tooltip
+          title={getTooltipMessage()}
+          disabled={disableReason === undefined}
+          skipWrapper
+        >
+          <Switch
+            disabled={disableReason && SWITCH_DISABLE_REASONS.includes(disableReason)}
+            checked={checked}
+            onChange={() => {
+              if (!checked) {
+                // When enabling auto-refresh, reset the disable reason
+                setDisableReason(undefined);
+              }
+              setChecked(!checked);
+            }}
+          />
+        </Tooltip>
+        {t('Auto-refresh')}
+      </AutoRefreshLabel>
+    </Fragment>
   );
 }

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -12,7 +12,7 @@ import type {InfiniteData} from 'sentry/utils/queryClient';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import * as logsPageParams from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import type {
   EventsLogsResult,
@@ -24,8 +24,6 @@ import {
   useInfiniteLogsQuery,
 } from 'sentry/views/explore/logs/useLogsQuery';
 import {OrganizationContext} from 'sentry/views/organizationContext';
-
-const {LogsPageParamsProvider} = logsPageParams;
 
 jest.mock('sentry/utils/useLocation');
 const mockedUsedLocation = jest.mocked(useLocation);

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -12,7 +12,7 @@ import type {InfiniteData} from 'sentry/utils/queryClient';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import * as logsPageParams from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import type {
   EventsLogsResult,
@@ -24,6 +24,8 @@ import {
   useInfiniteLogsQuery,
 } from 'sentry/views/explore/logs/useLogsQuery';
 import {OrganizationContext} from 'sentry/views/organizationContext';
+
+const {LogsPageParamsProvider} = logsPageParams;
 
 jest.mock('sentry/utils/useLocation');
 const mockedUsedLocation = jest.mocked(useLocation);
@@ -409,3 +411,222 @@ function createAscendingMocks(organization: Organization) {
     nextPageMock,
   };
 }
+
+// Virtual Streaming Tests
+describe('Virtual Streaming Integration (Auto Refresh enabled)', () => {
+  const organization = OrganizationFixture();
+  const queryClient = makeTestQueryClient();
+
+  function createWrapper({autoRefresh = true}: {autoRefresh?: boolean}) {
+    return function ({children}: {children?: React.ReactNode}) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <LogsPageParamsProvider
+            analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+            _testContext={{
+              autoRefresh,
+              refreshInterval: autoRefresh ? 1 : 0,
+            }}
+          >
+            <OrganizationContext.Provider value={organization}>
+              {children}
+            </OrganizationContext.Provider>
+          </LogsPageParamsProvider>
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    MockApiClient.clearMockResponses();
+    queryClient.clear();
+    mockedUsedLocation.mockReturnValue(LocationFixture());
+
+    mockUsePageFilters.mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: PageFiltersFixture(),
+    });
+  });
+
+  it('should integrate with virtual streaming when auto refresh is enabled', async () => {
+    const initialResponse = createMockLogsData([
+      {id: '4', timestamp_precise: '2000000000000000000', timestamp: '2000000000000'}, // far future
+      {id: '3', timestamp_precise: '3000000000', timestamp: '3000'}, // newest
+      {id: '2', timestamp_precise: '2000000000', timestamp: '2000'},
+      {id: '1', timestamp_precise: '1000000000', timestamp: '1000'}, // oldest
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: initialResponse,
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHook(() => useInfiniteLogsQuery(), {
+      wrapper: createWrapper({autoRefresh: true}),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    // With auto refresh enabled, virtual streaming should be active
+    // All data should be visible initially since all the mocked timestamps are well behind `now()`
+    expect(result.current.data).toHaveLength(3);
+  });
+
+  it('should not apply virtual streaming when auto refresh is disabled', async () => {
+    const initialResponse = createMockLogsData([
+      {id: '4', timestamp_precise: '2000000000000000000', timestamp: '2000000000000'}, // far future
+      {id: '3', timestamp_precise: '3000000000', timestamp: '3000'}, // newest
+      {id: '2', timestamp_precise: '2000000000', timestamp: '2000'},
+      {id: '1', timestamp_precise: '1000000000', timestamp: '1000'}, // oldest
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: initialResponse,
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHook(() => useInfiniteLogsQuery(), {
+      wrapper: createWrapper({autoRefresh: false}),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    // Without auto refresh, all data should always be visible
+    expect(result.current.data).toHaveLength(4);
+  });
+
+  it('should handle multiple pages with virtual streaming', async () => {
+    const eventsEndpoint = `/organizations/${organization.slug}/events/`;
+
+    // Initial page - newer timestamps (descending order)
+    const initialResponse = createMockLogsData([
+      {id: '6', timestamp_precise: '6000000000', timestamp: '6000'},
+      {id: '5', timestamp_precise: '5000000000', timestamp: '5000'},
+      {id: '4', timestamp_precise: '4000000000', timestamp: '4000'},
+    ]);
+
+    const initialMock = MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      body: initialResponse,
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.startsWith('tags[sentry.timestamp_precise,number]:<=');
+        },
+      ],
+      headers: linkHeaders,
+    });
+
+    // Next page - older timestamps
+    const previousPageResponse = createMockLogsData([
+      {id: '3', timestamp_precise: '3000000000', timestamp: '3000'},
+      {id: '2', timestamp_precise: '2000000000', timestamp: '2000'},
+      {id: '1', timestamp_precise: '1000000000', timestamp: '1000'},
+    ]);
+
+    const previousPageMock = MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.startsWith(
+            'tags[sentry.timestamp_precise,number]:>=6000000000 !sentry.item_id:6'
+          );
+        },
+      ],
+      body: previousPageResponse,
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHook(() => useInfiniteLogsQuery(), {
+      wrapper: createWrapper({autoRefresh: true}),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.data).toHaveLength(3);
+    expect(initialMock).toHaveBeenCalled();
+
+    // Fetch next page
+    await result.current.fetchPreviousPage();
+
+    await waitFor(() => {
+      expect(previousPageMock).toHaveBeenCalled();
+    });
+
+    // Should now have 6 total rows (virtual streaming will filter based on its internal state)
+    expect(result.current.data.length).toBeGreaterThan(0);
+    expect(result.current.data.length).toBeLessThanOrEqual(6);
+  });
+
+  it('should remove duplicate rows based on unique row ID', async () => {
+    const eventsEndpoint = `/organizations/${organization.slug}/events/`;
+
+    // Create pages with overlapping data (same ID)
+    const initialResponse = createMockLogsData([
+      {id: '2', timestamp_precise: '2000000000', timestamp: '2000'},
+      {id: '1', timestamp_precise: '1000000000', timestamp: '1000'},
+    ]);
+
+    const nextPageResponse = createMockLogsData([
+      {id: '3', timestamp_precise: '3000000000', timestamp: '3000'},
+      {id: '2', timestamp_precise: '2000000000', timestamp: '2000'}, // Duplicate
+    ]);
+
+    MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      body: initialResponse,
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.length === 0;
+        },
+      ],
+      headers: linkHeaders,
+    });
+
+    MockApiClient.addMockResponse({
+      url: eventsEndpoint,
+      body: nextPageResponse,
+      match: [
+        (_, options) => {
+          const query = options?.query || {};
+          return query.query.includes('tags[sentry.timestamp_precise,number]:<=1000');
+        },
+      ],
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHook(() => useInfiniteLogsQuery(), {
+      wrapper: createWrapper({autoRefresh: false}), // Disable auto refresh to avoid virtual streaming filtering
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.data).toHaveLength(2);
+
+    await result.current.fetchNextPage();
+
+    await waitFor(() => {
+      // Should have 3 unique rows, not 4 (duplicate ID '2' should be filtered out)
+      expect(result.current.data).toHaveLength(3);
+    });
+
+    const ids = result.current.data.map(row => row[OurLogKnownFieldKey.ID]);
+    expect(ids).toEqual(['2', '1', '3']);
+  });
+});

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 
 import {type ApiResult} from 'sentry/api';
 import {encodeSort, type EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -29,7 +29,6 @@ import {
   useLogsIsFrozen,
   useLogsLimitToTraceId,
   useLogsProjectIds,
-  useLogsRefreshInterval,
   useLogsSearch,
   useLogsSortBys,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
@@ -39,20 +38,23 @@ import {
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   AlwaysPresentLogFields,
-  LOG_INGEST_DELAY,
-  VIRTUAL_STREAMED_INTERVAL_MS,
+  MAX_LOG_INGEST_DELAY,
+  QUERY_PAGE_LIMIT,
+  QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH,
 } from 'sentry/views/explore/logs/constants';
 import {
   type EventsLogsResult,
   type LogsAggregatesResult,
   OurLogKnownFieldKey,
 } from 'sentry/views/explore/logs/types';
+import {
+  isRowVisibleInVirtualStream,
+  useVirtualStreaming,
+} from 'sentry/views/explore/logs/useVirtualStreaming';
 import {getTimeBasedSortBy} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getEventView} from 'sentry/views/insights/common/queries/useDiscover';
 import {getStaleTimeForEventView} from 'sentry/views/insights/common/queries/useSpansQuery';
-
-const UNIQUE_ROW_ID = OurLogKnownFieldKey.ID;
 
 export function useExploreLogsTableRow(props: {
   logId: string | number;
@@ -232,8 +234,17 @@ function useLogsQueryKey({limit, referrer}: {referrer: string; limit?: number}) 
   };
 }
 
-export function useLogsQueryKeyWithInfinite({referrer}: {referrer: string}) {
-  const {queryKey, other} = useLogsQueryKey({limit: 1000, referrer});
+export function useLogsQueryKeyWithInfinite({
+  referrer,
+  autoRefresh,
+}: {
+  autoRefresh: boolean;
+  referrer: string;
+}) {
+  const {queryKey, other} = useLogsQueryKey({
+    limit: autoRefresh ? QUERY_PAGE_LIMIT_WITH_AUTO_REFRESH : QUERY_PAGE_LIMIT,
+    referrer,
+  });
   return {
     queryKey: [...queryKey, 'infinite'] as QueryKey,
     other,
@@ -280,7 +291,11 @@ export function useLogsQuery({
  * Pages are represented by a window of time using the precise timestamp of either it's most recent or oldest row, depending on sort direction and which page we're fetching.
  * We will overlap pages on the nanosecond boundary (using => and <=) because events can happen on the same timestamp.
  */
-function getPageParam(pageDirection: 'previous' | 'next', sortBys: Sort[]) {
+function getPageParam(
+  pageDirection: 'previous' | 'next',
+  sortBys: Sort[],
+  autoRefresh: boolean
+) {
   const isGetPreviousPage = pageDirection === 'previous';
   return (
     [pageData]: ApiResult<EventsLogsResult>,
@@ -303,11 +318,11 @@ function getPageParam(pageDirection: 'previous' | 'next', sortBys: Sort[]) {
     const firstTimestamp = BigInt(firstRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]);
     const lastTimestamp = BigInt(lastRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]);
 
-    const timestampPrecise = isGetPreviousPage ? firstTimestamp : lastTimestamp;
     const logId = isGetPreviousPage
       ? firstRow[OurLogKnownFieldKey.ID]
       : lastRow[OurLogKnownFieldKey.ID];
     const isDescending = sortBy.kind === 'desc';
+    const timestampPrecise = isGetPreviousPage ? firstTimestamp : lastTimestamp;
     let querySortDirection: Sort | undefined = undefined;
     const reverseSortDirection = isDescending ? 'asc' : 'desc';
 
@@ -329,14 +344,50 @@ function getPageParam(pageDirection: 'previous' | 'next', sortBys: Sort[]) {
       querySortDirection,
       sortByDirection: sortBy.kind,
       indexFromInitialPage,
+      autoRefresh,
     };
 
     return pageParamResult;
   };
 }
 
-function getLogIngestDelay() {
-  return `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:<=${(Date.now() - LOG_INGEST_DELAY) * 1_000_000}`;
+/**
+ * Creates an initial page param for autoRefresh mode that enforces the MAX_LOG_INGEST_DELAY condition.
+ * This ensures the first page query filters for logs older than Date.now() - MAX_LOG_INGEST_DELAY
+ * which means the next logs page fetched will have results instead of having to wait for the MAX_LOG_INGEST_DELAY to pass.
+ */
+function getInitialPageParam(autoRefresh: boolean, sortBys: Sort[]): LogPageParam {
+  if (!autoRefresh) {
+    return null;
+  }
+
+  const sortBy = getTimeBasedSortBy(sortBys);
+  if (!sortBy) {
+    // Only sort by timestamp precise is supported for infinite queries.
+    return null;
+  }
+
+  const pageParamResult: LogPageParam = {
+    // Use an empty logId since we don't have a specific log to exclude yet
+    logId: '',
+    timestampPrecise: getMaxIngestDelayTimestamp(),
+    sortByDirection: sortBy.kind,
+    indexFromInitialPage: 0,
+    // No need to override query sort direction for initial page
+    querySortDirection: undefined,
+    autoRefresh,
+  };
+
+  return pageParamResult;
+}
+
+function getMaxIngestDelayTimestamp() {
+  return BigInt(Date.now() - MAX_LOG_INGEST_DELAY) * 1_000_000n;
+}
+
+function getIngestDelayFilter() {
+  const maxIngestDelayTimestamp = getMaxIngestDelayTimestamp();
+  return ` ${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:<=${maxIngestDelayTimestamp}`;
 }
 
 function getParamBasedQuery(
@@ -348,11 +399,20 @@ function getParamBasedQuery(
   }
   const comparison =
     (pageParam.querySortDirection ?? pageParam.sortByDirection === 'asc') ? '>=' : '<=';
-  const filter = `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:${comparison}${pageParam.timestampPrecise} !${OurLogKnownFieldKey.ID}:${pageParam.logId} ${getLogIngestDelay()}`;
+
+  const filter = `${OurLogKnownFieldKey.TIMESTAMP_PRECISE}:${comparison}${pageParam.timestampPrecise}`;
+
+  const ingestDelayFilter = pageParam.autoRefresh ? getIngestDelayFilter() : '';
+  // Only add the logId exclusion filter if we have a valid logId from the previous page.
+  const logIdFilter = pageParam.logId
+    ? ` !${OurLogKnownFieldKey.ID}:${pageParam.logId}`
+    : '';
 
   return {
     ...query,
-    query: [filter, query?.query].filter(Boolean).join(' AND '),
+    query: [filter + logIdFilter + ingestDelayFilter, query?.query]
+      .filter(Boolean)
+      .join(' AND '),
     sort: pageParam.querySortDirection
       ? encodeSort(pageParam.querySortDirection)
       : query?.sort,
@@ -360,6 +420,8 @@ function getParamBasedQuery(
 }
 
 interface PageParam {
+  // Whether the page param is for auto refresh mode.
+  autoRefresh: boolean;
   // The index of the page from the initial page. Useful for debugging and testing.
   indexFromInitialPage: number;
   // The id of the log row matching timestampPrecise. We use this to exclude the row from the query to avoid duplicates right on the nanosecond boundary.
@@ -383,23 +445,30 @@ export function useInfiniteLogsQuery({
   referrer?: string;
 } = {}) {
   const _referrer = referrer ?? 'api.explore.logs-table';
+  const autoRefresh = useLogsAutoRefresh();
   const {queryKey: queryKeyWithInfinite, other} = useLogsQueryKeyWithInfinite({
     referrer: _referrer,
+    autoRefresh,
   });
   const queryClient = useQueryClient();
   const sortBys = useLogsSortBys();
-  const autoRefresh = useLogsAutoRefresh();
 
   const getPreviousPageParam = useCallback(
     (data: ApiResult<EventsLogsResult>, _: unknown, pageParam: LogPageParam) =>
-      getPageParam('previous', sortBys)(data, _, pageParam),
-    [sortBys]
+      getPageParam('previous', sortBys, autoRefresh)(data, _, pageParam),
+    [sortBys, autoRefresh]
   );
   const getNextPageParam = useCallback(
     (data: ApiResult<EventsLogsResult>, _: unknown, pageParam: LogPageParam) =>
-      getPageParam('next', sortBys)(data, _, pageParam),
-    [sortBys]
+      getPageParam('next', sortBys, autoRefresh)(data, _, pageParam),
+    [sortBys, autoRefresh]
   );
+
+  const initialPageParam = useMemo(
+    () => getInitialPageParam(autoRefresh, sortBys),
+    [autoRefresh, sortBys]
+  );
+
   const queryResult = useInfiniteQuery<
     ApiResult<EventsLogsResult>,
     Error,
@@ -440,10 +509,10 @@ export function useInfiniteLogsQuery({
     },
     getPreviousPageParam,
     getNextPageParam,
-    initialPageParam: null,
+    initialPageParam,
     enabled: !disabled,
     staleTime: getStaleTimeForEventView(other.eventView),
-    maxPages: 10,
+    maxPages: 15,
   });
 
   const {
@@ -489,30 +558,27 @@ export function useInfiniteLogsQuery({
     );
   }, [queryClient, queryKeyWithInfinite, sortBys]);
 
-  const numberOfPages = data?.pages.length ?? 0;
-
-  const {virtualStreamedTimestamp} = useVirtualStreaming(numberOfPages);
+  const {virtualStreamedTimestamp} = useVirtualStreaming(data);
 
   const _data = useMemo(() => {
     const usedRowIds = new Set();
-    return (
+    const filteredData =
       data?.pages.flatMap(([pageData]) =>
         pageData.data.filter(row => {
-          if (usedRowIds.has(row[UNIQUE_ROW_ID])) {
+          if (usedRowIds.has(row[OurLogKnownFieldKey.ID])) {
             return false;
           }
-          if (virtualStreamedTimestamp) {
-            const rowTimestamp =
-              BigInt(row[OurLogKnownFieldKey.TIMESTAMP_PRECISE]) / 1_000_000n;
-            if (rowTimestamp > virtualStreamedTimestamp) {
-              return false;
-            }
+
+          if (!isRowVisibleInVirtualStream(row, virtualStreamedTimestamp)) {
+            return false;
           }
-          usedRowIds.add(row[UNIQUE_ROW_ID]);
+
+          usedRowIds.add(row[OurLogKnownFieldKey.ID]);
           return true;
         })
-      ) ?? []
-    );
+      ) ?? [];
+
+    return filteredData;
   }, [data, virtualStreamedTimestamp]);
 
   const _meta = useMemo<EventsMetaType>(() => {
@@ -530,7 +596,6 @@ export function useInfiniteLogsQuery({
   }, [data]);
 
   const _fetchPreviousPage = useCallback(() => {
-    // When auto-refresh is enabled it's possible that the previous page is empty, but we'll try to fetch it anyway.
     if (autoRefresh || hasPreviousPage) {
       return !isFetchingPreviousPage && !isError && fetchPreviousPage();
     }
@@ -553,7 +618,7 @@ export function useInfiniteLogsQuery({
   return {
     error,
     isError,
-    isFetching, // If the network is active
+    isFetching,
     isPending,
     data: _data,
     meta: _meta,
@@ -566,60 +631,6 @@ export function useInfiniteLogsQuery({
     isFetchingPreviousPage,
     lastPageLength: data?.pages?.[data.pages.length - 1]?.[0]?.data?.length ?? 0,
   };
-}
-
-function useVirtualStreaming(numberOfPages: number) {
-  const autoRefresh = useLogsAutoRefresh();
-  const refreshInterval = useLogsRefreshInterval();
-  const rafOn = useRef(false);
-  const [virtualStreamedQueryTimestamp, setVirtualStreamedQueryTimestamp] = useState(
-    Date.now()
-  );
-
-  useEffect(() => {
-    let rafId = 0;
-    rafOn.current = autoRefresh;
-    if (autoRefresh) {
-      const callback = () => {
-        if (!rafOn.current) {
-          return;
-        }
-        const targetVirtualTime = Date.now() - LOG_INGEST_DELAY;
-        setVirtualStreamedQueryTimestamp(prev => {
-          if (prev + VIRTUAL_STREAMED_INTERVAL_MS > targetVirtualTime) {
-            return prev;
-          }
-          return prev + VIRTUAL_STREAMED_INTERVAL_MS;
-        });
-        rafId = requestAnimationFrame(callback);
-      };
-
-      rafId = requestAnimationFrame(callback);
-    }
-
-    return () => {
-      rafOn.current = false;
-      if (rafId) {
-        window.cancelAnimationFrame(rafId);
-      }
-    };
-  }, [autoRefresh]);
-
-  const virtualStreamedTimestamp = useMemo(() => {
-    if (!autoRefresh || numberOfPages < 2) {
-      return undefined;
-    }
-    return virtualStreamedQueryTimestamp - refreshInterval - 1000; // We subtract the refresh interval when it comes to the UI updated virtual time
-  }, [autoRefresh, numberOfPages, refreshInterval, virtualStreamedQueryTimestamp]);
-
-  if (!autoRefresh || numberOfPages < 2) {
-    return {
-      virtualStreamedQueryTimestamp: undefined,
-      virtualStreamedTimestamp: undefined,
-    };
-  }
-
-  return {virtualStreamedQueryTimestamp, virtualStreamedTimestamp};
 }
 
 export type UseLogsQueryResult = ReturnType<typeof useLogsQuery>;

--- a/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
@@ -1,0 +1,371 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {LogFixture} from 'sentry-fixture/log';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {ApiResult} from 'sentry/api';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
+import type {InfiniteData} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {LogsPageParamsProvider} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import type {EventsLogsResult} from 'sentry/views/explore/logs/types';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {
+  isRowVisibleInVirtualStream,
+  updateVirtualStreamingTimestamp,
+  useVirtualStreaming,
+} from 'sentry/views/explore/logs/useVirtualStreaming';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+
+jest.mock('sentry/utils/useLocation');
+const mockUseLocation = jest.mocked(useLocation);
+
+describe('useVirtualStreaming', () => {
+  let requestAnimationFrameSpy: jest.SpyInstance<number, [FrameRequestCallback]>;
+  let cancelAnimationFrameSpy: jest.SpyInstance<void, [number]>;
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      {
+        projects: [parseInt(project.id, 10)],
+        environments: [],
+        datetime: {
+          period: '14d',
+          start: null,
+          end: null,
+          utc: null,
+        },
+      },
+      new Set()
+    );
+
+    requestAnimationFrameSpy = jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((_callback: FrameRequestCallback): number => {
+        return 1;
+      });
+    cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
+  const createWrapper = () => {
+    return function ({children}: {children: React.ReactNode}) {
+      return (
+        <OrganizationContext.Provider value={organization}>
+          <LogsPageParamsProvider
+            analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+          >
+            {children}
+          </LogsPageParamsProvider>
+        </OrganizationContext.Provider>
+      );
+    };
+  };
+
+  it('should initialize virtual timestamp to middle timestamp from first page', async () => {
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          live: 'true',
+        },
+      })
+    );
+
+    // Use timestamps relative to now for more realistic test data
+    const now = Date.now();
+    const mockData: InfiniteData<ApiResult<EventsLogsResult>> = {
+      pages: [
+        [
+          {
+            data: [
+              LogFixture({
+                [OurLogKnownFieldKey.ID]: '1',
+                // 50 seconds ago in nanoseconds
+                [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: String(
+                  BigInt(now - 50000) * 1_000_000n
+                ),
+              }),
+              LogFixture({
+                [OurLogKnownFieldKey.ID]: '2',
+                // 45 seconds ago in nanoseconds
+                [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: String(
+                  BigInt(now - 45000) * 1_000_000n
+                ),
+              }),
+              LogFixture({
+                [OurLogKnownFieldKey.ID]: '3',
+                // 42 seconds ago in nanoseconds
+                [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: String(
+                  BigInt(now - 42000) * 1_000_000n
+                ),
+              }),
+            ],
+            meta: {
+              fields: {},
+              units: {},
+            },
+          },
+          '',
+          {} as any,
+        ],
+      ],
+      pageParams: [null],
+    };
+
+    const {result} = renderHook(() => useVirtualStreaming(mockData), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.virtualStreamedTimestamp).toBeDefined();
+    });
+
+    // With MAX_LOG_INGEST_DELAY of 40 seconds and default refresh interval of 5 seconds,
+    // the target timestamp would be now - 40000 - 5000 = now - 45000
+    // Since all our timestamps are older than that, it should select the first one (50 seconds ago)
+    expect(result.current.virtualStreamedTimestamp).toBe(now - 50000);
+  });
+
+  it('should not initialize when auto refresh is disabled', () => {
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {},
+      })
+    );
+
+    const mockData: InfiniteData<ApiResult<EventsLogsResult>> = {
+      pages: [
+        [
+          {
+            data: [
+              LogFixture({
+                [OurLogKnownFieldKey.ID]: '1',
+                [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1000000000000000000',
+              }),
+            ],
+            meta: {
+              fields: {},
+              units: {},
+            },
+          },
+          '',
+          {} as any,
+        ],
+      ],
+      pageParams: [null],
+    };
+
+    const {result} = renderHook(() => useVirtualStreaming(mockData), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.virtualStreamedTimestamp).toBeUndefined();
+  });
+
+  it('should start RAF when auto refresh is enabled', async () => {
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          live: 'true',
+        },
+      })
+    );
+
+    const mockData: InfiniteData<ApiResult<EventsLogsResult>> = {
+      pages: [
+        [
+          {
+            data: [
+              LogFixture({
+                [OurLogKnownFieldKey.ID]: '1',
+                [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1000000000000000000',
+              }),
+            ],
+            meta: {
+              fields: {},
+              units: {},
+            },
+          },
+          '',
+          {} as any,
+        ],
+      ],
+      pageParams: [null],
+    };
+
+    renderHook(() => useVirtualStreaming(mockData), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(requestAnimationFrameSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('should stop RAF when auto refresh is disabled', async () => {
+    // Start with autoRefresh enabled
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          live: 'true',
+        },
+      })
+    );
+
+    const mockData: InfiniteData<ApiResult<EventsLogsResult>> = {
+      pages: [
+        [
+          {
+            data: [
+              LogFixture({
+                [OurLogKnownFieldKey.ID]: '1',
+                [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1000000000000000000',
+              }),
+            ],
+            meta: {
+              fields: {},
+              units: {},
+            },
+          },
+          '',
+          {} as any,
+        ],
+      ],
+      pageParams: [null],
+    };
+
+    const {rerender} = renderHook(() => useVirtualStreaming(mockData), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(requestAnimationFrameSpy).toHaveBeenCalled();
+    });
+
+    // Change to disabled by updating location
+    mockUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {},
+      })
+    );
+    rerender();
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+  });
+});
+
+describe('isRowVisibleInVirtualStream', () => {
+  it('should return true when virtual timestamp is undefined', () => {
+    const row = LogFixture({
+      [OurLogKnownFieldKey.ID]: '1',
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '2000000000000000000',
+    });
+
+    const result = isRowVisibleInVirtualStream(row, undefined);
+    expect(result).toBe(true);
+  });
+
+  it('should return true for rows with timestamp <= virtual timestamp', () => {
+    const row = LogFixture({
+      [OurLogKnownFieldKey.ID]: '1',
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '2000000000000000000', // 2 seconds in nanoseconds
+    });
+
+    // 2000000000000000000 nanoseconds / 1000000 = 2000000000000 milliseconds
+    // 2500000 milliseconds is much less than 2000000000000 milliseconds, so the row should be visible
+    const result = isRowVisibleInVirtualStream(row, 2000000000001); // Just slightly more than 2 seconds
+    expect(result).toBe(true);
+  });
+
+  it('should return false for rows with timestamp > virtual timestamp', () => {
+    const row = LogFixture({
+      [OurLogKnownFieldKey.ID]: '1',
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '3000000000000000000', // 3 seconds in nanoseconds
+    });
+
+    // 3000000000000000000 nanoseconds / 1000000 = 3000000000000 milliseconds
+    const result = isRowVisibleInVirtualStream(row, 2000000000000); // 2 seconds in milliseconds
+    expect(result).toBe(false);
+  });
+});
+
+describe('updateVirtualStreamingTimestamp', () => {
+  it('should catch up proportionally when significantly behind', () => {
+    const currentTimestamp = 1000;
+    const mostRecentPageDataTimestamp = 5000; // 4 seconds behind
+    const targetVirtualTime = 6000;
+
+    const result = updateVirtualStreamingTimestamp({
+      currentTimestamp,
+      mostRecentPageDataTimestamp,
+      targetVirtualTime,
+    });
+
+    // timeBehind = 4000ms, which is > 2 * VIRTUAL_STREAMED_INTERVAL_MS (2 * 250 = 500)
+    // Should use proportional catch-up
+    // proportionalCatchUp = min(4000 * 0.1, 250 * 3) = min(400, 750) = 400
+    // newTimestamp = 1000 + 400 = 1400
+    expect(result).toBe(1400);
+  });
+
+  it('should use normal progression when not significantly behind', () => {
+    const currentTimestamp = 1000;
+    const mostRecentPageDataTimestamp = 1500; // Only 0.5 seconds behind
+    const targetVirtualTime = 6000;
+
+    const result = updateVirtualStreamingTimestamp({
+      currentTimestamp,
+      mostRecentPageDataTimestamp,
+      targetVirtualTime,
+    });
+
+    // timeBehind = 500ms, which is exactly 2 * VIRTUAL_STREAMED_INTERVAL_MS (2 * 250 = 500)
+    // Since timeBehind (500) is NOT > 500, it uses normal progression
+    // newTimestamp = 1000 + 250 = 1250
+    expect(result).toBe(1250);
+  });
+
+  it('should not exceed target virtual time', () => {
+    const currentTimestamp = 5500;
+    const mostRecentPageDataTimestamp = 6000;
+    const targetVirtualTime = 5800; // Lower than what would normally be calculated
+
+    const result = updateVirtualStreamingTimestamp({
+      currentTimestamp,
+      mostRecentPageDataTimestamp,
+      targetVirtualTime,
+    });
+
+    // timeBehind = 500ms, which equals 2 * VIRTUAL_STREAMED_INTERVAL_MS
+    // Since timeBehind (500) is NOT > 500, it uses normal progression
+    // newTimestamp = 5500 + 250 = 5750, which is less than targetVirtualTime
+    expect(result).toBe(5750);
+  });
+
+  it('should not change timestamp when ahead of target virtual time', () => {
+    const currentTimestamp = 7000;
+    const mostRecentPageDataTimestamp = 6000;
+    const targetVirtualTime = 6000;
+
+    const result = updateVirtualStreamingTimestamp({
+      currentTimestamp,
+      mostRecentPageDataTimestamp,
+      targetVirtualTime,
+    });
+
+    // Should not change when ahead of target
+    expect(result).toBe(7000);
+  });
+});

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -177,10 +177,6 @@ export function useVirtualStreaming(
 
 /**
  * Checks if a log row should be visible in the virtual stream based on the current virtual timestamp.
- *
- * @param row - The log row to check
- * @param virtualStreamedTimestamp - The current virtual streaming timestamp (in milliseconds)
- * @returns true if the row should be visible, false if it should be filtered out
  */
 export function isRowVisibleInVirtualStream(
   row: OurLogsResponseItem,

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -1,0 +1,239 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+
+import type {ApiResult} from 'sentry/api';
+import type {InfiniteData} from 'sentry/utils/queryClient';
+import {
+  useLogsAutoRefresh,
+  useLogsRefreshInterval,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {
+  MAX_LOG_INGEST_DELAY,
+  VIRTUAL_STREAMED_INTERVAL_MS,
+} from 'sentry/views/explore/logs/constants';
+import type {
+  EventsLogsResult,
+  OurLogsResponseItem,
+} from 'sentry/views/explore/logs/types';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+/**
+ * Virtual Streaming
+ *
+ * Creates a streaming effect where logs appear to stream in real-time even though
+ * we're fetching them in chunks via polling. Works by keeping a "virtual timestamp" that moves
+ * forward over time, hiding rows that are "in the future" relative to this virtual time.
+ *
+ *    What we actually have (all the data):
+ *    ┌─────────────────────────────────────────────────────────────┐
+ *    │ [log1] [log2] [log3] [log4] [log5] [log6] [log7] [log8] ... │
+ *    │   10s    15s    20s    25s    30s    35s    40s    45s      │
+ *    └─────────────────────────────────────────────────────────────┘
+ *
+ *    What the user sees (virtual stream head at 22s):
+ *                            ↓
+ *    ┌─────────────────────────────────────────────────────────────┐
+ *    │ [log1] [log2] [log3] [••••] [••••] [••••] [••••] [••••] ... │
+ *    │   10s    15s    20s   HIDDEN HIDDEN HIDDEN HIDDEN           │
+ *    └─────────────────────────────────────────────────────────────┘
+ *                            ↑
+ *                      stream head moves right →
+ *
+ *    A bit later (stream head at 32s):
+ *                                     ↓
+ *    ┌─────────────────────────────────────────────────────────────┐
+ *    │ [log1] [log2] [log3] [log4] [log5] [••••] [••••] [••••] ... │
+ *    │   10s    15s    20s    25s    30s  HIDDEN HIDDEN HIDDEN     │
+ *    └─────────────────────────────────────────────────────────────┘
+ *
+ */
+export function useVirtualStreaming(
+  data: InfiniteData<ApiResult<EventsLogsResult>> | undefined
+) {
+  const autoRefresh = useLogsAutoRefresh();
+  const refreshInterval = useLogsRefreshInterval();
+  const rafOn = useRef(false);
+  const [virtualTimestamp, setVirtualTimestamp] = useState<number | undefined>(undefined);
+
+  // If we've received data, initialize the virtual timestamp to be refreshEvery seconds before the max ingest delay timestamp
+  const initializeVirtualTimestamp = useCallback(() => {
+    if (!data?.pages?.length || virtualTimestamp !== undefined) {
+      return;
+    }
+
+    const firstPageWithData = data.pages.find(page => page?.[0]?.data?.length > 0);
+    const pageData = firstPageWithData?.[0]?.data;
+
+    if (!pageData || pageData.length === 0) {
+      return;
+    }
+
+    // Calculate the target timestamp: refreshEvery seconds before the max ingest delay
+    const targetTimestamp = Date.now() - MAX_LOG_INGEST_DELAY - refreshInterval;
+
+    // Find the first row with timestamp less than targetTimestamp
+    let selectedRow = pageData[0];
+    for (const row of pageData) {
+      const rowTimestamp = Number(
+        BigInt(row[OurLogKnownFieldKey.TIMESTAMP_PRECISE]) / 1_000_000n
+      );
+      if (rowTimestamp <= targetTimestamp) {
+        selectedRow = row;
+        break;
+      }
+    }
+
+    const initialTimestamp = selectedRow
+      ? Number(BigInt(selectedRow[OurLogKnownFieldKey.TIMESTAMP_PRECISE]) / 1_000_000n)
+      : Number(
+          BigInt(pageData[0]?.[OurLogKnownFieldKey.TIMESTAMP_PRECISE] ?? 0n) / 1_000_000n
+        );
+
+    setVirtualTimestamp(initialTimestamp);
+  }, [data, virtualTimestamp, refreshInterval]);
+
+  // Initialize when auto refresh is enabled and we have data
+  useEffect(() => {
+    if (autoRefresh && virtualTimestamp === undefined) {
+      initializeVirtualTimestamp();
+    }
+  }, [autoRefresh, initializeVirtualTimestamp, virtualTimestamp]);
+
+  // Reset when auto refresh is disabled
+  useEffect(() => {
+    if (!autoRefresh) {
+      setVirtualTimestamp(undefined);
+    }
+  }, [autoRefresh]);
+
+  // Get the newest timestamp from the latest page to calculate how far behind we are
+  const getMostRecentPageDataTimestamp = useCallback(() => {
+    if (!data?.pages?.length) {
+      return 0;
+    }
+
+    const latestPage = data.pages[data.pages.length - 1];
+    const latestPageData = latestPage?.[0]?.data;
+
+    // Since data is always sorted by timestamp descending, the first row (index 0) is the latest timestamp.
+    return Number(
+      BigInt(latestPageData?.[0]?.[OurLogKnownFieldKey.TIMESTAMP_PRECISE] ?? 0n) /
+        1_000_000n
+    );
+  }, [data]);
+
+  // We setup a RAF loop to update the virtual timestamp smoothly to emulate real-time streaming.
+  useEffect(() => {
+    let rafId = 0;
+    rafOn.current = autoRefresh;
+
+    if (autoRefresh) {
+      const callback = () => {
+        if (!rafOn.current) {
+          return;
+        }
+
+        const targetVirtualTime = Date.now() - MAX_LOG_INGEST_DELAY - refreshInterval;
+        const mostRecentPageDataTimestamp = getMostRecentPageDataTimestamp();
+
+        setVirtualTimestamp(prev => {
+          if (prev === undefined) {
+            // We don't want the deps to include the virtual timestamp (to check if it's undefined), so we return the previous value if it's undefined.
+            return prev;
+          }
+
+          return updateVirtualStreamingTimestamp({
+            currentTimestamp: prev ?? 0,
+            mostRecentPageDataTimestamp,
+            targetVirtualTime,
+          });
+        });
+
+        rafId = requestAnimationFrame(callback);
+      };
+
+      rafId = requestAnimationFrame(callback);
+    }
+
+    return () => {
+      rafOn.current = false;
+      if (rafId) {
+        window.cancelAnimationFrame(rafId);
+      }
+    };
+  }, [autoRefresh, getMostRecentPageDataTimestamp, refreshInterval]);
+
+  const virtualStreamedTimestamp = useMemo(() => {
+    if (!autoRefresh || !virtualTimestamp) {
+      return undefined;
+    }
+
+    return virtualTimestamp;
+  }, [autoRefresh, virtualTimestamp]);
+
+  return {
+    virtualStreamedTimestamp,
+  };
+}
+
+/**
+ * Checks if a log row should be visible in the virtual stream based on the current virtual timestamp.
+ *
+ * @param row - The log row to check
+ * @param virtualStreamedTimestamp - The current virtual streaming timestamp (in milliseconds)
+ * @returns true if the row should be visible, false if it should be filtered out
+ */
+export function isRowVisibleInVirtualStream(
+  row: OurLogsResponseItem,
+  virtualStreamedTimestamp: number | undefined
+): boolean {
+  if (!virtualStreamedTimestamp) {
+    return true;
+  }
+
+  const rowTimestamp = BigInt(row[OurLogKnownFieldKey.TIMESTAMP_PRECISE]) / 1_000_000n;
+
+  // Show rows that are older than or equal to the virtual timestamp
+  return rowTimestamp <= virtualStreamedTimestamp;
+}
+
+/**
+ * Updates the virtual timestamp for streaming based on current state and target time.
+ * This function is extracted to be testable and mockable.
+ */
+export function updateVirtualStreamingTimestamp({
+  currentTimestamp,
+  mostRecentPageDataTimestamp,
+  targetVirtualTime,
+}: {
+  currentTimestamp: number;
+  mostRecentPageDataTimestamp: number;
+  targetVirtualTime: number;
+}): number {
+  if (currentTimestamp > targetVirtualTime) {
+    // If we're ahead of the target virtual time (eg. virtual time was just initialized), don't change the current virtual time.
+    return currentTimestamp;
+  }
+
+  // Calculate how far behind we are based on latest data
+  const timeBehind = mostRecentPageDataTimestamp - currentTimestamp;
+
+  // Catch up proportionally, but cap at 3 intervals per update
+  const maxCatchUp = VIRTUAL_STREAMED_INTERVAL_MS * 3;
+  const proportionalCatchUp = Math.min(
+    timeBehind * 0.1, // Catch up at 10% of the gap per update
+    maxCatchUp
+  );
+
+  let newTimestamp = currentTimestamp;
+
+  // If we're significantly behind, use proportional catch-up
+  if (timeBehind > VIRTUAL_STREAMED_INTERVAL_MS * 2) {
+    newTimestamp = currentTimestamp + proportionalCatchUp;
+  } else {
+    // Normal progression
+    newTimestamp = currentTimestamp + VIRTUAL_STREAMED_INTERVAL_MS;
+  }
+
+  // Don't exceed the target virtual time
+  return Math.min(newTimestamp, targetVirtualTime);
+}

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/react';
 
 import type {ApiResult} from 'sentry/api';
 import {t} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -15,13 +14,10 @@ import {
   fieldAlignment,
   type Sort,
 } from 'sentry/utils/discover/fields';
-import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import type {InfiniteData, InfiniteQueryObserverResult} from 'sentry/utils/queryClient';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
-import {getIntervalOptionsForPageFilter} from 'sentry/views/explore/hooks/useChartInterval';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   LogAttributesHumanLabel,
@@ -256,87 +252,4 @@ export function parseLinkHeaderFromLogsPage(
 ) {
   const linkHeader = page.data?.pages?.[0]?.[2]?.getResponseHeader('Link');
   return parseLinkHeader(linkHeader ?? null);
-}
-
-/**
- * Creates empty timeseries data for streaming when the original timeseries is empty.
- * Uses proper intervals that match the page filter datetime so that streaming table data
- * gets merged into the correct buckets.
- */
-export function createEmptyTimeseriesResults(
-  datetime: PageFilters['datetime'],
-  yAxis = 'count(message)',
-  bucketCount = 16
-): Record<string, TimeSeries[]> {
-  // Get the smallest interval possible (most bars) from page filter
-  const intervalOptions = getIntervalOptionsForPageFilter(datetime);
-  const intervalString = intervalOptions[0]?.value || '1m';
-
-  // Convert interval string to milliseconds
-  const intervalHours = parsePeriodToHours(intervalString);
-  const intervalMs = intervalHours * 60 * 60 * 1000;
-
-  // Create timestamps starting from current time and going back
-  const now = Date.now();
-  const values: Array<{timestamp: number; value: number}> = [];
-  const sampleCount: Array<{timestamp: number; value: number}> = [];
-  const samplingRate: Array<{timestamp: number; value: number}> = [];
-
-  for (let i = bucketCount - 1; i >= 0; i--) {
-    const timestamp = now - i * intervalMs;
-    // Round timestamp down to interval boundary
-    const roundedTimestamp = Math.floor(timestamp / intervalMs) * intervalMs;
-
-    values.push({
-      timestamp: roundedTimestamp,
-      value: 0, // Start with 0, streaming will add actual counts
-    });
-
-    // sampleCount uses timestamps in seconds
-    sampleCount.push({
-      timestamp: Math.floor(roundedTimestamp / 1000),
-      value: 0,
-    });
-
-    samplingRate.push({
-      timestamp: Math.floor(roundedTimestamp / 1000),
-      value: 1,
-    });
-  }
-
-  const timeSeries: TimeSeries = {
-    yAxis,
-    values,
-    meta: {
-      valueType: 'string',
-      valueUnit: null,
-      interval: intervalMs,
-    },
-    confidence: 'high',
-    sampleCount,
-    samplingRate,
-    dataScanned: 'full',
-  };
-
-  return {
-    [yAxis]: [timeSeries],
-  };
-}
-
-export function getLogRowTimestampMillis(row: OurLogsResponseItem): number {
-  return Number(row[OurLogKnownFieldKey.TIMESTAMP_PRECISE]) / 1_000_000;
-}
-
-export function getLogRowTimeSeriesBucket(
-  record: OurLogsResponseItem,
-  periodStartMillis: number,
-  intervalMillis: number // calculated from the distance between buckets in the events-stats response
-): {bucketIndex: number; bucketMillis: number} {
-  const rowTimestamp = getLogRowTimestampMillis(record);
-  const relativeRowTimestamp = rowTimestamp - periodStartMillis;
-  const bucketIndex = Math.floor(relativeRowTimestamp / intervalMillis);
-  return {
-    bucketIndex,
-    bucketMillis: periodStartMillis + bucketIndex * intervalMillis,
-  };
 }


### PR DESCRIPTION
### Summary
This adds an auto-refresh toggle behind the 'ourlogs-live-refresh' flag.

Auto-refresh can be enabled with filters so long as the sort is by time and descending. It works on 5 second polling, with a virtual time using RAF to emulate streaming. Filters are applied so data is queried in a ~30s second window behind our ingest delay.

Auto-refresh will automatically disable itself under the following conditions:
- You've hit a rate limit consistently over 3 polls (>1k logs/s)
- You've hit an api error for any reason
- You've hit the absolute timeout cap (10 minutes), you can re-enable it if you're actively using it
- You change sort / filter etc.

A subsequent PR will contain changes for the graph updates.

#### Other
- Added some memos and callbacks for performance reasons since the virtual timestamp updates fairly quickly
- Modified delayed data to follow already set delay in graphs (will be needed in the next PR)