### PR TITLE
chore(dashboards): Improve span dashboards to explore links

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -27,9 +27,18 @@ describe('getWidgetExploreUrl', () => {
     const url = getWidgetExploreUrl(widget, undefined, selection, organization);
 
     // Note: for table widgets the mode is set to samples and the fields are propagated
-    expect(url).toBe(
-      '/organizations/org-slug/traces/?groupBy=span.description&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
-    );
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.description'],
+        ['field', 'span.duration'],
+        ['groupBy', 'span.description'],
+        ['interval', '30m'],
+        ['mode', 'aggregate'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
+      ],
+    });
   });
 
   it('returns the correct samples mode url for table widgets without aggregation', () => {
@@ -50,9 +59,16 @@ describe('getWidgetExploreUrl', () => {
     const url = getWidgetExploreUrl(widget, undefined, selection, organization);
 
     // Note: for table widgets the mode is set to samples and the fields are propagated
-    expect(url).toBe(
-      '/organizations/org-slug/traces/?field=span.description&field=span.duration&interval=30m&mode=samples&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%5D%7D'
-    );
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.description'],
+        ['field', 'span.duration'],
+        ['interval', '30m'],
+        ['mode', 'samples'],
+        ['statsPeriod', '14d'],
+      ],
+    });
   });
 
   it('returns the correct url for timeseries widgets', () => {
@@ -74,9 +90,18 @@ describe('getWidgetExploreUrl', () => {
 
     // Note: for line widgets the mode is set to aggregate
     // The chart type is set to 1 for area charts
-    expect(url).toBe(
-      '/organizations/org-slug/traces/?groupBy=span.description&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
-    );
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.description'],
+        ['field', 'span.duration'],
+        ['groupBy', 'span.description'],
+        ['interval', '30m'],
+        ['mode', 'aggregate'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 2, yAxes: ['avg(span.duration)']})],
+      ],
+    });
   });
 
   it('returns the correct url for timeseries widgets without grouping', () => {
@@ -98,9 +123,17 @@ describe('getWidgetExploreUrl', () => {
 
     // Note: for line widgets the mode is set to aggregate
     // The chart type is set to 1 for area charts
-    expect(url).toBe(
-      '/organizations/org-slug/traces/?groupBy=&interval=30m&mode=aggregate&statsPeriod=14d&visualize=%7B%22chartType%22%3A2%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D'
-    );
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.duration'],
+        ['groupBy', ''],
+        ['interval', '30m'],
+        ['mode', 'aggregate'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 2, yAxes: ['avg(span.duration)']})],
+      ],
+    });
   });
 
   it('returns the correct URL for chart widgets where the sort is not in the yAxes', () => {
@@ -122,9 +155,20 @@ describe('getWidgetExploreUrl', () => {
     const url = getWidgetExploreUrl(widget, undefined, selection, organization);
 
     // The URL should have the sort and another visualize to plot the sort
-    expect(url).toBe(
-      '/organizations/org-slug/traces/?groupBy=span.description&interval=30m&mode=aggregate&sort=-count%28span.duration%29&statsPeriod=14d&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D&visualize=%7B%22chartType%22%3A1%2C%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D'
-    );
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.description'],
+        ['field', 'span.duration'],
+        ['groupBy', 'span.description'],
+        ['interval', '30m'],
+        ['mode', 'aggregate'],
+        ['sort', '-count(span.duration)'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
+        ['visualize', JSON.stringify({chartType: 1, yAxes: ['count(span.duration)']})],
+      ],
+    });
   });
 
   it('applies the dashboard filters to the query', () => {
@@ -152,9 +196,20 @@ describe('getWidgetExploreUrl', () => {
     );
 
     // Assert that the query contains the dashboard filters in its resulting URL
-    expect(url).toContain(
-      '&query=%28span.description%3Atest%29%20release%3A%5B%221.0.0%22%2C%222.0.0%22%5D%20'
-    );
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/traces/',
+      params: [
+        ['field', 'span.description'],
+        ['field', 'span.duration'],
+        ['groupBy', 'span.description'],
+        ['interval', '30m'],
+        ['mode', 'aggregate'],
+        ['query', '(span.description:test) release:\[\"1.0.0\",\"2.0.0\"\] '],
+        ['sort', '-avg(span.duration)'],
+        ['statsPeriod', '14d'],
+        ['visualize', JSON.stringify({chartType: 1, yAxes: ['avg(span.duration)']})],
+      ],
+    });
   });
 
   it('returns the correct url for multiple queries', () => {
@@ -205,3 +260,26 @@ describe('getWidgetExploreUrl', () => {
     expect(query2.query).toBe('is_transaction:false');
   });
 });
+
+function expectUrl(url: string) {
+  return {
+    toMatch({path, params}: {params: Array<[string, string]>; path: string}) {
+      expect(url).toMatch(new RegExp(`^${path}\?`));
+      const urlParams = new URLSearchParams(url.substring(path.length));
+      function compareFn(a: [string, string], b: [string, string]) {
+        if (a[0] < b[0]) {
+          return -1;
+        }
+
+        if (a[0] > b[0]) {
+          return 1;
+        }
+
+        return a[1].localeCompare(b[1]);
+      }
+      expect([...urlParams.entries()].sort(compareFn)).toEqual(
+        [...params].sort(compareFn)
+      );
+    },
+  };
+}

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -264,7 +264,7 @@ describe('getWidgetExploreUrl', () => {
 function expectUrl(url: string) {
   return {
     toMatch({path, params}: {params: Array<[string, string]>; path: string}) {
-      expect(url).toMatch(new RegExp(`^${path}\?`));
+      expect(url).toMatch(new RegExp(`^${path}\\?`));
       const urlParams = new URLSearchParams(url.substring(path.length));
       function compareFn(a: [string, string], b: [string, string]) {
         if (a[0] < b[0]) {

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -3,24 +3,20 @@ import trimStart from 'lodash/trimStart';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
-import toArray from 'sentry/utils/array/toArray';
 import {
   getAggregateAlias,
+  isAggregateField,
   isAggregateFieldOrEquation,
+  parseFunction,
 } from 'sentry/utils/discover/fields';
-import {
-  decodeBoolean,
-  decodeList,
-  decodeScalar,
-  decodeSorts,
-} from 'sentry/utils/queryString';
+import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {decodeBoolean, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {
   applyDashboardFilters,
   eventViewFromWidget,
-  getFieldsFromEquations,
   getWidgetInterval,
 } from 'sentry/views/dashboards/utils';
 import {
@@ -104,7 +100,8 @@ export function getWidgetExploreUrl(
   widget: Widget,
   dashboardFilters: DashboardFilters | undefined,
   selection: PageFilters,
-  organization: Organization
+  organization: Organization,
+  preferMode?: Mode
 ) {
   if (widget.queries.length > 1) {
     return _getWidgetExploreUrlForMultipleQueries(
@@ -115,7 +112,13 @@ export function getWidgetExploreUrl(
     );
   }
 
-  return _getWidgetExploreUrl(widget, dashboardFilters, selection, organization);
+  return _getWidgetExploreUrl(
+    widget,
+    dashboardFilters,
+    selection,
+    organization,
+    preferMode
+  );
 }
 
 function getChartType(displayType: DisplayType) {
@@ -140,19 +143,29 @@ function getChartType(displayType: DisplayType) {
   return chartType;
 }
 
+function getAggregateArguments(yAxis: string): string[] {
+  const parsedFunction = parseFunction(yAxis);
+  if (!parsedFunction) {
+    return [];
+  }
+  const definition = getFieldDefinition(parsedFunction.name, 'span');
+  if (definition?.kind !== FieldKind.FUNCTION) {
+    return [];
+  }
+  return parsedFunction.arguments.filter((_argument, index) => {
+    return definition.parameters?.[index]?.kind === 'column';
+  });
+}
+
 function _getWidgetExploreUrl(
   widget: Widget,
   dashboardFilters: DashboardFilters | undefined,
   selection: PageFilters,
-  organization: Organization
+  organization: Organization,
+  preferMode?: Mode
 ) {
   const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);
   const locationQueryParams = eventView.generateQueryStringObject();
-
-  // Inject the sort field for cases of arbitrary sorting
-  // The sort is not picked up by eventView unless it is
-  // injected into the fields
-  locationQueryParams.sort = widget.queries[0]!.orderby;
 
   // Pull a max of 3 valid Y-Axis from the widget
   const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
@@ -166,48 +179,30 @@ function _getWidgetExploreUrl(
   ].slice(0, 3);
 
   const chartType = getChartType(widget.displayType);
-  let exploreMode: Mode | undefined = undefined;
-  switch (widget.displayType) {
-    case DisplayType.BAR:
-      exploreMode = Mode.AGGREGATE;
-      break;
-    case DisplayType.LINE:
-      exploreMode = Mode.AGGREGATE;
-      break;
-    case DisplayType.AREA:
-      exploreMode = Mode.AGGREGATE;
-      break;
-    case DisplayType.TABLE:
-    case DisplayType.BIG_NUMBER:
-      if (locationQueryParams.yAxes.length > 0) {
+  let exploreMode: Mode | undefined = preferMode;
+  if (!defined(exploreMode)) {
+    switch (widget.displayType) {
+      case DisplayType.BAR:
         exploreMode = Mode.AGGREGATE;
-      } else {
-        exploreMode = Mode.SAMPLES;
-      }
-      break;
-    default:
-      break;
-  }
-
-  // Equation fields need to have their terms explicitly selected as columns in the discover table
-  const fields =
-    Array.isArray(locationQueryParams.field) || !defined(locationQueryParams.field)
-      ? locationQueryParams.field
-      : [locationQueryParams.field];
-
-  const query = widget.queries[0]!;
-  const queryFields =
-    defined(query.fields) && widget.displayType === DisplayType.TABLE
-      ? query.fields.filter(field => !isAggregateFieldOrEquation(field))
-      : [...query.columns];
-
-  // Updates fields by adding any individual terms from equation fields as a column
-  getFieldsFromEquations(queryFields).forEach(term => {
-    if (Array.isArray(fields) && !fields.includes(term)) {
-      fields.unshift(term);
+        break;
+      case DisplayType.LINE:
+        exploreMode = Mode.AGGREGATE;
+        break;
+      case DisplayType.AREA:
+        exploreMode = Mode.AGGREGATE;
+        break;
+      case DisplayType.TABLE:
+      case DisplayType.BIG_NUMBER:
+        if (locationQueryParams.yAxes.length > 0) {
+          exploreMode = Mode.AGGREGATE;
+        } else {
+          exploreMode = Mode.SAMPLES;
+        }
+        break;
+      default:
+        break;
     }
-  });
-  locationQueryParams.field = fields;
+  }
 
   const datetime = {
     end: decodeScalar(locationQueryParams.end) ?? null,
@@ -216,7 +211,12 @@ function _getWidgetExploreUrl(
     utc: decodeBoolean(locationQueryParams.utc) ?? null,
   };
 
-  let groupBy = queryFields?.filter(field => !isAggregateFieldOrEquation(field));
+  const query = widget.queries[0]!;
+
+  let groupBy: string[] =
+    defined(query.fields) && widget.displayType === DisplayType.TABLE
+      ? query.fields.filter(field => !isAggregateFieldOrEquation(field))
+      : [...query.columns];
   if (groupBy && groupBy.length === 0) {
     // Force the groupBy to be an array with a single empty string
     // so that qs.stringify appends the key to the URL. If the key
@@ -224,6 +224,40 @@ function _getWidgetExploreUrl(
     // which we do not want if the user has not specified a groupBy.
     groupBy = [''];
   }
+
+  const yAxisFields: string[] = locationQueryParams.yAxes.flatMap(getAggregateArguments);
+  const fields = [...groupBy, ...yAxisFields].filter(Boolean);
+
+  const sortDirection = widget.queries[0]?.orderby?.startsWith('-') ? '-' : '';
+  const sortColumn = trimStart(widget.queries[0]?.orderby ?? '', '-');
+
+  let sort: string | undefined = undefined;
+  if (isAggregateField(sortColumn)) {
+    if (exploreMode === Mode.SAMPLES) {
+      // if the current sort is on an aggregation, then we should extract its argument
+      // and try to sort on that in samples mode
+      const aggregateArguments = getAggregateArguments(sortColumn);
+      sort = `${sortDirection}${aggregateArguments[0]}`;
+    } else if (exploreMode === Mode.AGGREGATE) {
+      sort = widget.queries[0]?.orderby;
+    }
+  } else if (fields.includes(sortColumn)) {
+    sort = widget.queries[0]?.orderby;
+  }
+
+  const visualize = [
+    {
+      chartType,
+      yAxes: locationQueryParams.yAxes,
+    },
+    // Explore widgets do not allow sorting by arbitrary aggregates
+    // so dashboard widgets need to inject another visualize to plot the sort
+    // and it available for sorting the main chart
+    ...(isAggregateField(sortColumn) &&
+    !_isSortIncluded(sortColumn, locationQueryParams.yAxes)
+      ? [{chartType, yAxes: [sortColumn]}]
+      : []),
+  ].filter(v => v.yAxes.length > 0);
 
   const queryParams = {
     // Page filters should propagate
@@ -233,31 +267,14 @@ function _getWidgetExploreUrl(
     },
     organization,
     mode: exploreMode,
-    visualize: [
-      {
-        chartType,
-        yAxes: locationQueryParams.yAxes,
-      },
-      // Explore widgets do not allow sorting by arbitrary aggregates
-      // so dashboard widgets need to inject another visualize to plot the sort
-      // and it available for sorting the main chart
-      ...(locationQueryParams.sort &&
-      !_isSortIncluded(locationQueryParams.sort, locationQueryParams.yAxes)
-        ? [
-            {
-              chartType,
-              yAxes: toArray(trimStart(locationQueryParams.sort, '-')),
-            },
-          ]
-        : []),
-    ],
-    groupBy: exploreMode === Mode.SAMPLES ? undefined : groupBy,
-    field: exploreMode === Mode.SAMPLES ? decodeList(queryFields) : undefined,
+    visualize,
+    groupBy: visualize.length > 0 ? groupBy : [],
+    field: fields,
     query: applyDashboardFilters(
       decodeScalar(locationQueryParams.query),
       dashboardFilters
     ),
-    sort: locationQueryParams.sort || undefined,
+    sort: sort || undefined,
     interval:
       decodeScalar(locationQueryParams.interval) ??
       getWidgetInterval(widget, selection.datetime),

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -237,11 +237,13 @@ function _getWidgetExploreUrl(
       // if the current sort is on an aggregation, then we should extract its argument
       // and try to sort on that in samples mode
       const aggregateArguments = getAggregateArguments(sortColumn);
-      sort = `${sortDirection}${aggregateArguments[0]}`;
+      if (aggregateArguments.length > 0) {
+        sort = `${sortDirection}${aggregateArguments[0]}`;
+      }
     } else if (exploreMode === Mode.AGGREGATE) {
       sort = widget.queries[0]?.orderby;
     }
-  } else if (fields.includes(sortColumn)) {
+  } else if (!isAggregateFieldOrEquation(sortColumn)) {
     sort = widget.queries[0]?.orderby;
   }
 

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -42,6 +42,7 @@ import {
   getWidgetLogURL,
 } from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {WidgetViewerContext} from 'sentry/views/dashboards/widgetViewer/widgetViewerContext';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
 
@@ -359,7 +360,13 @@ export function getMenuOptions(
     menuOptions.push({
       key: 'open-in-explore',
       label: t('Open in Explore'),
-      to: getWidgetExploreUrl(widget, dashboardFilters, selection, organization),
+      to: getWidgetExploreUrl(
+        widget,
+        dashboardFilters,
+        selection,
+        organization,
+        Mode.SAMPLES
+      ),
     });
   }
 


### PR DESCRIPTION
Opening a span widget in explore should use samples mode when the widget is miniturized and use aggregates mode when widget is expanded.

Closes EXP-372