### PR TITLE
feat: Add image/avif type support to attachments

### DIFF
--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -12,6 +12,7 @@ export const imageMimeTypes = [
   'image/png',
   'image/gif',
   'image/webp',
+  'image/avif',
 ];
 
 const logFileMimeTypes = [


### PR DESCRIPTION
tested it locally and it works perfectly fine with the `<img / >` tag

Contributes to https://linear.app/getsentry/issue/TET-614/attachments-add-support-for-newer-file-formats-such-as-heic

