### PR TITLE
ref: Make video render comp. more generic by renaming it

### DIFF
--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -2,7 +2,7 @@ import ImageViewer from 'sentry/components/events/attachmentViewers/imageViewer'
 import JsonViewer from 'sentry/components/events/attachmentViewers/jsonViewer';
 import LogFileViewer from 'sentry/components/events/attachmentViewers/logFileViewer';
 import RRWebJsonViewer from 'sentry/components/events/attachmentViewers/rrwebJsonViewer';
-import {WebMViewer} from 'sentry/components/events/attachmentViewers/webmViewer';
+import {VideoViewer} from 'sentry/components/events/attachmentViewers/webmViewer';
 import type {IssueAttachment} from 'sentry/types/group';
 
 export const imageMimeTypes = [
@@ -35,7 +35,7 @@ type AttachmentRenderer =
   | typeof ImageViewer
   | typeof LogFileViewer
   | typeof RRWebJsonViewer
-  | typeof WebMViewer;
+  | typeof VideoViewer;
 
 export const getImageAttachmentRenderer = (
   attachment: IssueAttachment
@@ -44,7 +44,7 @@ export const getImageAttachmentRenderer = (
     return ImageViewer;
   }
   if (webmMimeType === attachment.mimetype) {
-    return WebMViewer;
+    return VideoViewer;
   }
   return undefined;
 };

--- a/static/app/components/events/attachmentViewers/webmViewer.tsx
+++ b/static/app/components/events/attachmentViewers/webmViewer.tsx
@@ -11,7 +11,12 @@ interface WebMViewerProps
   onCanPlay?: React.ReactEventHandler<HTMLVideoElement>;
 }
 
-export function WebMViewer({controls = true, onCanPlay, ...props}: WebMViewerProps) {
+export function VideoViewer({
+  controls = true,
+  attachment,
+  onCanPlay,
+  ...props
+}: WebMViewerProps) {
   return (
     <PanelItem>
       <video
@@ -22,7 +27,10 @@ export function WebMViewer({controls = true, onCanPlay, ...props}: WebMViewerPro
           max-width: 100%;
         `}
       >
-        <source src={getAttachmentUrl(props, true)} type="video/webm" />
+        <source
+          src={getAttachmentUrl({attachment, ...props}, true)}
+          type={attachment.mimetype}
+        />
         {t('Your browser does not support the video tag.')}
       </video>
     </PanelItem>


### PR DESCRIPTION
Maybe we want to support additional file types in the future - for example, `.mp4`, so I'm renaming the component to avoid tying it specifically to `.webm`