### PR TITLE
fix(agent-insights): Correctly set feedback source and owner

### DIFF
--- a/static/app/views/insights/pages/domainViewHeader.tsx
+++ b/static/app/views/insights/pages/domainViewHeader.tsx
@@ -21,6 +21,7 @@ import {
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
 import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
 import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {
   isModuleConsideredNew,
   isModuleEnabled,
@@ -59,7 +60,12 @@ export function DomainViewHeader({
   const location = useLocation();
   const moduleURLBuilder = useModuleURLBuilder();
   const isLaravelInsightsAvailable = useIsLaravelInsightsAvailable();
-  const isNextJsInsightsEnabled = useIsNextJsInsightsAvailable();
+  const isNextJsInsightsAvailable = useIsNextJsInsightsAvailable();
+  const {view, isInOverviewPage} = useDomainViewFilters();
+
+  const isLaravelInsights = isLaravelInsightsAvailable && isInOverviewPage;
+  const isNextJsInsights = isNextJsInsightsAvailable && isInOverviewPage;
+  const isAgentMonitoring = view === 'agents';
 
   const crumbs: Crumb[] = [
     {
@@ -100,6 +106,19 @@ export function DomainViewHeader({
       })),
   ];
 
+  const feedbackOptions =
+    isAgentMonitoring || isLaravelInsights || isNextJsInsights
+      ? {
+          tags: {
+            ['feedback.source']: isAgentMonitoring
+              ? 'agent-monitoring'
+              : isLaravelInsights
+                ? 'laravel-insights'
+                : 'nextjs-insights',
+            ['feedback.owner']: 'telemetry-experience',
+          },
+        }
+      : undefined;
   return (
     <Fragment>
       <Layout.Header>
@@ -112,20 +131,7 @@ export function DomainViewHeader({
             {selectedModule === ModuleName.SESSIONS ? (
               <FeedbackButtonTour />
             ) : (
-              <FeedbackWidgetButton
-                optionOverrides={
-                  isLaravelInsightsAvailable || isNextJsInsightsEnabled
-                    ? {
-                        tags: {
-                          ['feedback.source']: isLaravelInsightsAvailable
-                            ? 'laravel-insights'
-                            : 'nextjs-insights',
-                          ['feedback.owner']: 'telemetry-experience',
-                        },
-                      }
-                    : undefined
-                }
-              />
+              <FeedbackWidgetButton optionOverrides={feedbackOptions} />
             )}
             {additonalHeaderActions}
           </ButtonBar>

--- a/static/app/views/insights/pages/platform/laravel/features.tsx
+++ b/static/app/views/insights/pages/platform/laravel/features.tsx
@@ -3,15 +3,20 @@ import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHa
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import type {DomainView} from 'sentry/views/insights/pages/useFilters';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
-function hasLaravelInsightsFeature(organization: Organization) {
+export function hasLaravelInsightsFeature(organization: Organization) {
   return organization.features.includes('laravel-insights');
 }
+
+const laravelViews: DomainView[] = ['backend'];
 
 export function useIsLaravelInsightsAvailable() {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
+  const {view, isInOverviewPage} = useDomainViewFilters();
 
   const selectedProjects = getSelectedProjectList(selection.projects, projects);
 
@@ -19,5 +24,11 @@ export function useIsLaravelInsightsAvailable() {
     project => project.platform === 'php-laravel'
   );
 
-  return hasLaravelInsightsFeature(organization) && isOnlyLaravelSelected;
+  return (
+    hasLaravelInsightsFeature(organization) &&
+    isOnlyLaravelSelected &&
+    view &&
+    laravelViews.includes(view) &&
+    isInOverviewPage
+  );
 }

--- a/static/app/views/insights/pages/platform/nextjs/features.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/features.tsx
@@ -3,8 +3,9 @@ import {getSelectedProjectList} from 'sentry/utils/project/useSelectedProjectsHa
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
-function hasNextJsInsightsFeature(organization: Organization) {
+export function hasNextJsInsightsFeature(organization: Organization) {
   return organization.features.includes('nextjs-insights');
 }
 
@@ -12,6 +13,7 @@ export function useIsNextJsInsightsAvailable() {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
+  const {view} = useDomainViewFilters();
 
   const selectedProjects = getSelectedProjectList(selection.projects, projects);
 
@@ -19,5 +21,9 @@ export function useIsNextJsInsightsAvailable() {
     project => project.platform === 'javascript-nextjs'
   );
 
-  return hasNextJsInsightsFeature(organization) && isOnlyNextJsSelected;
+  return (
+    hasNextJsInsightsFeature(organization) &&
+    isOnlyNextJsSelected &&
+    (view === 'frontend' || view === 'backend')
+  );
 }

--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -13,8 +13,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
-import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
-import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {hasLaravelInsightsFeature} from 'sentry/views/insights/pages/platform/laravel/features';
+import {hasNextJsInsightsFeature} from 'sentry/views/insights/pages/platform/nextjs/features';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {
@@ -36,8 +36,8 @@ function ProjectQuickLinks({organization, project}: Props) {
     ? platformToDomainView([project], [parseInt(project.id, 10)])
     : 'backend';
 
-  const isLaravelInsightsAvailable = useIsLaravelInsightsAvailable();
-  const isNextJsInsightsAvailable = useIsNextJsInsightsAvailable();
+  const isLaravelInsightsAvailable = hasLaravelInsightsFeature(organization);
+  const isNextJsInsightsAvailable = hasNextJsInsightsFeature(organization);
 
   const quickLinks = [
     ...(isLaravelInsightsAvailable && project?.platform === 'php-laravel'


### PR DESCRIPTION
- closes [TET-785: feedback widget on agents page attaches source nextjs-insights](https://linear.app/getsentry/issue/TET-785/feedback-widget-on-agents-page-attaches-source-nextjs-insights)