### PR TITLE
feat: Add more video types support

### DIFF
--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -30,7 +30,7 @@ const jsonMimeTypes = [
   'text/x-json',
 ];
 
-export const webmMimeType = 'video/webm';
+export const webmMimeTypes = ['video/webm', 'video/mp4', 'video/quicktime'];
 
 type AttachmentRenderer =
   | typeof ImageViewer
@@ -44,7 +44,7 @@ export const getImageAttachmentRenderer = (
   if (imageMimeTypes.includes(attachment.mimetype)) {
     return ImageViewer;
   }
-  if (webmMimeType === attachment.mimetype) {
+  if (webmMimeTypes.includes(attachment.mimetype)) {
     return VideoViewer;
   }
   return undefined;

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -12,7 +12,7 @@ import ImageViewer from 'sentry/components/events/attachmentViewers/imageViewer'
 import {
   getImageAttachmentRenderer,
   imageMimeTypes,
-  webmMimeType,
+  webmMimeTypes,
 } from 'sentry/components/events/attachmentViewers/previewAttachmentTypes';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
@@ -56,7 +56,8 @@ function Screenshot({
   openVisualizationModal,
 }: Props) {
   const [loadingImage, setLoadingImage] = useState(
-    imageMimeTypes.includes(screenshot.mimetype) || webmMimeType === screenshot.mimetype
+    imageMimeTypes.includes(screenshot.mimetype) ||
+      webmMimeTypes.includes(screenshot.mimetype)
   );
 
   const {hasRole} = useRole({role: 'attachmentsRole'});


### PR DESCRIPTION
expanding our range to accept `video/mp4` and `video/quicktime`

contributes to https://linear.app/getsentry/issue/TET-614/attachments-add-support-for-newer-file-formats-such-as-heic