### PR TITLE
ref(agent-monitoring): Update legacy data banner

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/legacyLlmMonitoringAlert.tsx
+++ b/static/app/views/insights/agentMonitoring/components/legacyLlmMonitoringAlert.tsx
@@ -1,23 +1,28 @@
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import useFeedbackWidget from 'sentry/components/feedback/widget/useFeedbackWidget';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
-import {useTogglePreferedAiModule} from 'sentry/views/insights/agentMonitoring/utils/features';
 
 const LOCAL_STORAGE_KEY = 'llm-monitoring-info-alert-dismissed';
 
 export function LegacyLLMMonitoringInfoAlert() {
   const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
-  const [_, togglePreferedModule] = useTogglePreferedAiModule();
-
-  const handleSwitchUI = () => {
-    dismiss();
-    togglePreferedModule();
-  };
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const feedback = useFeedbackWidget({
+    buttonRef,
+    optionOverrides: {
+      tags: {
+        ['feedback.source']: 'agent-monitoring',
+        ['feedback.owner']: 'telemetry-experience',
+      },
+    },
+  });
 
   if (isDismissed) {
     return null;
@@ -39,10 +44,14 @@ export function LegacyLLMMonitoringInfoAlert() {
       }
     >
       <Message>
-        {t('Looking for the old LLM Monitoring Experience?')}
-        <Button size="xs" priority="primary" onClick={handleSwitchUI}>
-          {t('Switch UI')}
-        </Button>
+        {t(
+          'Expecting to see data for your AI Agent here? Let us know if something is missing!'
+        )}
+        {feedback && (
+          <Button ref={buttonRef} size="xs" priority="primary">
+            {t('Give Feedback')}
+          </Button>
+        )}
       </Message>
     </StyledAlert>
   );


### PR DESCRIPTION
Update copy and add button to give feedback.

- closes [TET-787: Change Looking for the old LLM banner](https://linear.app/getsentry/issue/TET-787/change-looking-for-the-old-llm-banner)