### PR TITLE
fix(agent-monitoring): Hotfix wrong LLM costs

### DIFF
--- a/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/formatLLMCosts.tsx
@@ -1,8 +1,13 @@
 import {formatAbbreviatedNumberWithDynamicPrecision} from 'sentry/utils/formatters';
 
 export function formatLLMCosts(cost: string | number) {
-  if (Number(cost) < 0.01) {
+  let number = Number(cost);
+  // TODO: remove this hotfix for bug on BE that results in costs sometimes being multiplied by 1000000
+  if (number > 100) {
+    number = number / 1_000_000;
+  }
+  if (number < 0.01) {
     return `<$${(0.01).toLocaleString()}`;
   }
-  return `$${formatAbbreviatedNumberWithDynamicPrecision(cost)}`;
+  return `$${formatAbbreviatedNumberWithDynamicPrecision(number)}`;
 }


### PR DESCRIPTION
This is a temporary cosmetic measure to correct faulty cost calculation for LLM generation spans which results in costs being multiplied by `1_000_000`.