### PR TITLE
fix(span-buffer): Copy the `event_id` field into attributes

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -31,6 +31,7 @@ FIELD_TO_ATTRIBUTE = {
     "origin": "sentry.origin",
     "kind": "sentry.kind",
     "hash": "sentry.hash",
+    "event_id": "sentry.event_id",
 }
 
 


### PR DESCRIPTION
Closes STREAM-294. The `event_id` field should be copied into the `sentry.event_id` attribute, to copy what Snuba does. I'm not sure why this field is missing, is there a specific reason? I took the liberty of adding a ticket and putting up the PR 🙏🏻 