### PR TITLE
fix(discover): Extend export task deadline

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
             times=3,
             delay=60,
         ),
+        processing_deadline_duration=120,
     ),
 )
 def assemble_download(


### PR DESCRIPTION
Fix SENTRY-447D
Fix #94802