### PR TITLE
feat(dashboards): Add reordering to starred sidebar

### DIFF
--- a/static/app/views/dashboards/hooks/useReorderStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useReorderStarredDashboards.tsx
@@ -1,0 +1,29 @@
+import {useCallback} from 'react';
+
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useInvalidateStarredDashboards} from 'sentry/views/dashboards/hooks/useInvalidateStarredDashboards';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+
+export function useReorderStarredDashboards() {
+  const organization = useOrganization();
+  const api = useApi();
+  const invalidateStarredDashboards = useInvalidateStarredDashboards();
+  const reorderStarredDashboards = useCallback(
+    async (dashboards: DashboardListItem[]) => {
+      await api.requestPromise(
+        `/organizations/${organization.slug}/dashboards/starred/order/`,
+        {
+          method: 'PUT',
+          data: {
+            dashboard_ids: dashboards.map(dashboard => dashboard.id),
+          },
+        }
+      );
+      invalidateStarredDashboards();
+    },
+    [api, organization.slug, invalidateStarredDashboards]
+  );
+
+  return reorderStarredDashboards;
+}

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsNavItems.spec.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsNavItems.spec.tsx
@@ -1,0 +1,27 @@
+import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DashboardsNavItems} from 'sentry/views/nav/secondary/sections/dashboards/dashboardsNavItems';
+
+describe('DashboardsNavItems', () => {
+  it('should render', () => {
+    render(
+      <DashboardsNavItems
+        initialDashboards={[
+          DashboardListItemFixture({
+            id: '1',
+            title: 'Dashboard 1',
+          }),
+          DashboardListItemFixture({
+            id: '2',
+            title: 'Dashboard 2',
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Dashboard 1')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard 2')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsNavItems.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsNavItems.tsx
@@ -1,0 +1,201 @@
+import {useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+import {Reorder, useDragControls} from 'framer-motion';
+
+import InteractionStateLayer from 'sentry/components/core/interactionStateLayer';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconGrabbable} from 'sentry/icons/iconGrabbable';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
+import {useReorderStarredDashboards} from 'sentry/views/dashboards/hooks/useReorderStarredDashboards';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
+import ProjectIcon from 'sentry/views/nav/projectIcon';
+import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
+
+type DashboardsNavItemsProps = {
+  initialDashboards: DashboardListItem[];
+};
+
+export function DashboardsNavItems({initialDashboards}: DashboardsNavItemsProps) {
+  const organization = useOrganization();
+  const user = useUser();
+  const location = useLocation();
+  const [savedDashboards, setSavedDashboards] =
+    useState<DashboardListItem[]>(initialDashboards);
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  // Any time the dashboards prop changes (e.g. when the user stars or unstars a dashboard),
+  // we need to reset the savedDashboards state.
+  useEffect(() => {
+    setSavedDashboards(initialDashboards);
+  }, [initialDashboards]);
+
+  const id = getIdFromLocation(location);
+
+  const controls = useDragControls();
+
+  const {projects} = useProjects();
+
+  const reorderStarredDashboards = useReorderStarredDashboards();
+
+  const [isDragging, setIsDragging] = useState<string | null>(null);
+
+  return (
+    <Reorder.Group
+      as="div"
+      axis="y"
+      values={savedDashboards}
+      onReorder={newOrder => {
+        setSavedDashboards(newOrder);
+      }}
+      initial={false}
+      ref={sectionRef}
+    >
+      {savedDashboards?.map(dashboard => {
+        const dashboardProjects = new Set((dashboard?.projects ?? []).map(String));
+        if (!defined(dashboard?.projects)) {
+          Sentry.setTag('organization', organization.id);
+          Sentry.setTag('dashboard.id', dashboard.id);
+          Sentry.setTag('user.id', user.id);
+          Sentry.captureMessage('dashboard.projects is undefined in starred sidebar', {
+            level: 'warning',
+          });
+        }
+        const dashboardProjectPlatforms = projects
+          .filter(p => dashboardProjects.has(p.id))
+          .map(p => p.platform)
+          .filter(defined);
+        return (
+          <StyledReorderItem
+            grabbing={isDragging === dashboard.id}
+            as="div"
+            dragConstraints={sectionRef}
+            dragElastic={0.03}
+            dragTransition={{bounceStiffness: 400, bounceDamping: 40}}
+            // This style is a hack to fix a framer-motion bug that causes views to
+            // jump from the bottom of the nav bar to their correct positions
+            // upon scrolling down on the page and triggering a page navigation.
+            // See: https://github.com/motiondivision/motion/issues/2006
+            style={{
+              ...(isDragging
+                ? {}
+                : {
+                    originY: '0px',
+                  }),
+            }}
+            key={dashboard.id}
+            value={dashboard}
+            onDragStart={() => {
+              setIsDragging(dashboard.id);
+            }}
+            onDragEnd={() => {
+              setIsDragging(null);
+              reorderStarredDashboards(savedDashboards);
+            }}
+          >
+            <StyledSecondaryNavItem
+              leadingItems={
+                <LeadingItemsWrapper>
+                  <GrabHandleWrapper
+                    data-test-id={`grab-handle-${dashboard.id}`}
+                    data-drag-icon
+                    onPointerDown={e => {
+                      controls.start(e);
+                      e.stopPropagation();
+                      e.preventDefault();
+                    }}
+                    onClick={e => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                    }}
+                  >
+                    <StyledInteractionStateLayer
+                      isPressed={isDragging === dashboard.id}
+                    />
+                    <IconGrabbable color="gray300" />
+                  </GrabHandleWrapper>
+                  <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
+                </LeadingItemsWrapper>
+              }
+              key={dashboard.id}
+              to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+              analyticsItemName="dashboard_starred_item"
+              isActive={id === dashboard.id.toString()}
+            >
+              <Tooltip
+                title={dashboard.title}
+                position="top"
+                showOnlyOnOverflow
+                skipWrapper
+              >
+                <TruncatedTitle>{dashboard.title}</TruncatedTitle>
+              </Tooltip>
+            </StyledSecondaryNavItem>
+          </StyledReorderItem>
+        );
+      })}
+    </Reorder.Group>
+  );
+}
+
+const StyledSecondaryNavItem = styled(SecondaryNav.Item)`
+  align-items: center;
+  padding-right: ${space(0.5)};
+  position: relative;
+
+  :not(:hover) {
+    [data-drag-icon] {
+      ${p => p.theme.visuallyHidden}
+    }
+  }
+
+  :hover {
+    [data-project-icon] {
+      ${p => p.theme.visuallyHidden}
+    }
+  }
+`;
+
+const StyledReorderItem = styled(Reorder.Item, {
+  shouldForwardProp: prop => prop !== 'grabbing',
+})<{grabbing: boolean}>`
+  position: relative;
+  background-color: ${p => (p.grabbing ? p.theme.translucentSurface200 : 'transparent')};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const GrabHandleWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  cursor: grab;
+  z-index: 3;
+
+  &:active {
+    cursor: grabbing;
+  }
+`;
+
+const StyledInteractionStateLayer = styled(InteractionStateLayer)`
+  height: 120%;
+  border-radius: 4px;
+`;
+
+const LeadingItemsWrapper = styled('div')`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TruncatedTitle = styled('div')`
+  ${p => p.theme.overflowEllipsis}
+`;

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.spec.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.spec.tsx
@@ -1,0 +1,43 @@
+import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {Organization} from 'sentry/types/organization';
+import {DashboardsSecondaryNav} from 'sentry/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav';
+
+describe('DashboardsSecondaryNav', () => {
+  let organization: Organization;
+
+  beforeEach(() => {
+    organization = OrganizationFixture({
+      features: ['dashboards-starred-reordering'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/starred/`,
+      body: [
+        DashboardListItemFixture({
+          id: '9999',
+          title: 'Dashboard 9999',
+        }),
+        DashboardListItemFixture({
+          id: '1',
+          title: 'Dashboard 1',
+        }),
+      ],
+    });
+  });
+
+  it('should render dashboards in order of response', async () => {
+    render(<DashboardsSecondaryNav />, {organization});
+
+    expect(await screen.findByText('Dashboard 9999')).toBeInTheDocument();
+
+    expect(screen.getAllByRole('link').map(el => el.textContent)).toEqual([
+      'All Dashboards',
+      'Dashboard 9999',
+      'Dashboard 1',
+    ]);
+  });
+});

--- a/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/dashboards/dashboardsSecondaryNav.tsx
@@ -11,6 +11,7 @@ import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarr
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
+import {DashboardsNavItems} from 'sentry/views/nav/secondary/sections/dashboards/dashboardsNavItems';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
 export function DashboardsSecondaryNav() {
@@ -35,38 +36,42 @@ export function DashboardsSecondaryNav() {
         {starredDashboards.length > 0 ? (
           <SecondaryNav.Section id="dashboards-starred" title={t('Starred Dashboards')}>
             <ErrorBoundary mini>
-              {starredDashboards.map(dashboard => {
-                const dashboardProjects = new Set(
-                  (dashboard?.projects ?? []).map(String)
-                );
-                if (!defined(dashboard?.projects)) {
-                  Sentry.setTag('organization', organization.id);
-                  Sentry.setTag('dashboard.id', dashboard.id);
-                  Sentry.setTag('user.id', user.id);
-                  Sentry.captureMessage(
-                    'dashboard.projects is undefined in starred sidebar',
-                    {
-                      level: 'warning',
-                    }
+              {organization.features.includes('dashboards-starred-reordering') ? (
+                <DashboardsNavItems initialDashboards={starredDashboards} />
+              ) : (
+                starredDashboards.map(dashboard => {
+                  const dashboardProjects = new Set(
+                    (dashboard?.projects ?? []).map(String)
                   );
-                }
-                const dashboardProjectPlatforms = projects
-                  .filter(p => dashboardProjects.has(p.id))
-                  .map(p => p.platform)
-                  .filter(defined);
-                return (
-                  <SecondaryNav.Item
-                    key={dashboard.id}
-                    to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
-                    analyticsItemName="dashboard_starred_item"
-                    leadingItems={
-                      <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
-                    }
-                  >
-                    {dashboard.title}
-                  </SecondaryNav.Item>
-                );
-              })}
+                  if (!defined(dashboard?.projects)) {
+                    Sentry.setTag('organization', organization.id);
+                    Sentry.setTag('dashboard.id', dashboard.id);
+                    Sentry.setTag('user.id', user.id);
+                    Sentry.captureMessage(
+                      'dashboard.projects is undefined in starred sidebar',
+                      {
+                        level: 'warning',
+                      }
+                    );
+                  }
+                  const dashboardProjectPlatforms = projects
+                    .filter(p => dashboardProjects.has(p.id))
+                    .map(p => p.platform)
+                    .filter(defined);
+                  return (
+                    <SecondaryNav.Item
+                      key={dashboard.id}
+                      to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+                      analyticsItemName="dashboard_starred_item"
+                      leadingItems={
+                        <ProjectIcon projectPlatforms={dashboardProjectPlatforms} />
+                      }
+                    >
+                      {dashboard.title}
+                    </SecondaryNav.Item>
+                  );
+                })
+              )}
             </ErrorBoundary>
           </SecondaryNav.Section>
         ) : null}


### PR DESCRIPTION
Adds the handles to the starred dashboard items and allows you to drag and reorder them. When the reordering is complete, a request fires to the ordering endpoint with a list of the dashboard IDs in the order the user wants them.

The handles are feature flagged under the `dashboards-starred-reordering` flag.