### PR TITLE
feat(trace-details): Improve span attributes filtering in trace drawer

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -120,14 +120,11 @@ export function Attributes({
       return true;
     });
 
-    // Filter attributes based on OTEL-friendly UI flag
     const filteredByOTelMode = onlyAllowedAttributes.filter(attribute => {
       if (shouldUseOTelFriendlyUI) {
-        // Hide span.description and span.op when OTEL-friendly UI is enabled
         return !['span.description', 'span.op'].includes(attribute.name);
       }
 
-      // Hide span.name when OTEL-friendly UI is disabled
       return attribute.name !== 'span.name';
     });
 


### PR DESCRIPTION
Improve the span attributes filtering in the trace drawer details. Closes OPE-24

1. Hide internal attributes from non-staff users
2. Conditionally hide span attributes based on OTEL-friendly UI