### PR TITLE
fix(eap): Normal mode should be default if no sampling mode defined

### DIFF
--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -108,7 +108,7 @@ def transform_column_to_expression(column: Column) -> Expression:
 
 def validate_sampling(sampling_mode: SAMPLING_MODES | None) -> DownsampledStorageConfig:
     if sampling_mode is None:
-        return DownsampledStorageConfig(mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY)
+        return DownsampledStorageConfig(mode=DownsampledStorageConfig.MODE_NORMAL)
     if sampling_mode not in SAMPLING_MODE_MAP:
         raise InvalidSearchQuery(f"sampling mode: {sampling_mode} is not supported")
     else:


### PR DESCRIPTION
The normal mode should be the default since it avoids timeouts better. All of the frontend uses the progressive query or they specify `NORMAL` mode. This allows us to clean up the code and assume normal mode by default, to remove any explicit passing down when unnecessary.

Afaik no request requires `HIGH_ACCURACY` from the beginning by explicitly omitting the `samplingMode` param.