### PR TITLE
fix(dashboards): Invalidate starred query data using correct queryKey

### DIFF
--- a/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
@@ -4,7 +4,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
-function getQueryKey(organization: Organization): ApiQueryKey {
+export function getQueryKey(organization: Organization): ApiQueryKey {
   const DASHBOARDS_QUERY_KEY = [
     `/organizations/${organization.slug}/dashboards/`,
     {

--- a/static/app/views/dashboards/hooks/useInvalidateStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useInvalidateStarredDashboards.tsx
@@ -2,17 +2,13 @@ import {useCallback} from 'react';
 
 import {useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
+import {getQueryKey} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
 
 export function useInvalidateStarredDashboards() {
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
   return useCallback(() => {
-    queryClient.invalidateQueries({
-      queryKey: [
-        `/organizations/${organization.slug}/dashboards/`,
-        {query: {filter: 'onlyFavorites'}},
-      ],
-    });
-  }, [queryClient, organization.slug]);
+    queryClient.invalidateQueries({queryKey: getQueryKey(organization)});
+  }, [queryClient, organization]);
 }


### PR DESCRIPTION
The helper does a feature flag check to invalidate the correct key since the URLs are different. Fixes the scenario where the sidebar is in its dynamic state, you rearrange, and when you hover out and back onto the dashboards list, the dashboards should be in the new order.

They were in the old order because we didn't invalidate the cache with the new query key. After the feature flag gets removed I'll just hardcode the query key instead of exporting it/getting it through the helper