### PR TITLE
feat(explore): Stretch free text to remaining space per row

### DIFF
--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -523,6 +523,13 @@ const Row = styled('div')`
   height: 24px;
   max-width: 100%;
 
+  /* Ensure that every free text token just before the line wrap
+   * stretches to use all the remaining space by setting flex-row
+   * to 1 for the very last one and auto for the rest.
+   */
+  &:not(:last-child) {
+    flex-grow: auto;
+  }
   &:last-child {
     flex-grow: 1;
   }


### PR DESCRIPTION
When the equation requires multiple lines and wraps, the last free text token in each row needs to be stretched to take up the remaining space. Otherwise, there is a big gap that is not clickable.