### PR TITLE
feat: Add name field to OrganizationTraceEndpoint span data

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -54,6 +54,7 @@ class SerializedSpan(SerializedEvent):
     end_timestamp: datetime
     measurements: dict[str, Any]
     op: str
+    name: str
     parent_span_id: str | None
     profile_id: str
     profiler_id: str
@@ -158,6 +159,7 @@ class OrganizationTraceEndpoint(OrganizationEventsV2EndpointBase):
                 description=event["description"],
                 sdk_name=event["sdk.name"],
                 op=event["span.op"],
+                name=event["span.name"],
                 event_type="span",
             )
         else:

--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -187,6 +187,7 @@ def run_trace_query(
         "parent_span",
         "description",
         "span.op",
+        "span.name",
         "is_transaction",
         "transaction.span_id",
         "transaction.event_id",

--- a/tests/sentry/api/endpoints/test_organization_trace_summary.py
+++ b/tests/sentry/api/endpoints/test_organization_trace_summary.py
@@ -21,6 +21,7 @@ class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
         self.mock_trace_tree = [
             SerializedSpan(
                 description="http.request",
+                name="GET *",
                 event_id="span1",
                 event_type="span",
                 project_id=1,
@@ -43,6 +44,7 @@ class OrganizationTraceSummaryEndpointTest(APITestCase, SnubaTestCase):
             ),
             SerializedSpan(
                 description="db.query",
+                name="SELECT users",
                 event_id="span2",
                 event_type="span",
                 project_id=1,

--- a/tests/sentry/seer/test_trace_summary.py
+++ b/tests/sentry/seer/test_trace_summary.py
@@ -24,6 +24,7 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
         self.trace_tree = [
             SerializedSpan(
                 description="http.request",
+                name="GET *",
                 event_id="span1",
                 event_type="span",
                 project_id=1,
@@ -46,6 +47,7 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
             ),
             SerializedSpan(
                 description="db.query",
+                name="SELECT users",
                 event_id="span2",
                 event_type="span",
                 project_id=1,


### PR DESCRIPTION
Making some moves on Span First Sentry (the UI). We'd like to render the span waterfall using `span.name` rather than `span.op` and `span.description`. First step is to return `span.name` from the backend!

I opted not to feature flag this because feature-flagging is a rigamarole in this case, but you tell me! I can actually go and verify whether `sentry.name` uses the same string key in EAP as any of the other attributes.

I also thought about maybe making `name` optional, but again, you tell me!

Contributes to OPE-22