### PR TITLE
feat(otlp): Add `span.status.message` alias

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -126,6 +126,11 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="span.status.message",
+            internal_name="sentry.status.message",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="trace",
             internal_name="sentry.trace_id",
             search_type="string",


### PR DESCRIPTION
Added to EAP https://github.com/getsentry/relay/pull/4876, now it needs an alias 🙌🏻 