### PR TITLE
feat(dashboards): add column resizing to table widget visualization

### DIFF
--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -199,7 +199,12 @@ describe('TableWidgetVisualization', function () {
       );
       const $header = screen.getAllByRole('columnheader')[0]?.children[0]!;
       await userEvent.click($header);
-      await waitFor(() => expect(onChangeSortMock).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(onChangeSortMock).toHaveBeenCalledWith({
+          field: 'count(span.duration)',
+          kind: 'desc',
+        })
+      );
     });
   });
 
@@ -221,15 +226,17 @@ describe('TableWidgetVisualization', function () {
         {target: $gridResizer, coords: {x: 100}},
         {keys: '[/MouseLeft]'},
       ]);
-      await waitFor(() => expect(testRouter.location.query.width).toBeDefined());
+      await waitFor(() =>
+        expect(testRouter.location.query.width).toStrictEqual(['100', '-1'])
+      );
     });
 
     it('Uses onChangeResizeColumn if supplied on column resize', async function () {
-      const onChangeResizeColumnMock = jest.fn((_widths: number[]) => {});
+      const onResizeColumnMock = jest.fn((_columns: TabularColumn[]) => {});
       render(
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
-          onChangeResizeColumn={onChangeResizeColumnMock}
+          onResizeColumn={onResizeColumnMock}
         />
       );
 
@@ -239,7 +246,22 @@ describe('TableWidgetVisualization', function () {
         {target: $gridResizer, coords: {x: 100}},
         {keys: '[/MouseLeft]'},
       ]);
-      await waitFor(() => expect(onChangeResizeColumnMock).toHaveBeenCalled());
+      await waitFor(() =>
+        expect(onResizeColumnMock).toHaveBeenCalledWith([
+          {
+            key: 'http.request_method',
+            name: 'http.request_method',
+            type: 'string',
+            width: 100,
+          },
+          {
+            key: 'count(span.duration)',
+            name: 'count(span.duration)',
+            type: 'integer',
+            width: -1,
+          },
+        ])
+      );
     });
   });
 });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -35,167 +35,211 @@ describe('TableWidgetVisualization', function () {
   ];
   const sortableColumns = columns.map(column => ({...column, sortable: true}));
 
-  it('Basic table renders correctly', async function () {
-    render(<TableWidgetVisualization tableData={sampleHTTPRequestTableData} />);
+  describe('Basic table functionality', function () {
+    it('Renders correctly', async function () {
+      render(<TableWidgetVisualization tableData={sampleHTTPRequestTableData} />);
 
-    expect(await screen.findByText('http.request_method')).toBeInTheDocument();
-    expect(await screen.findByText('count(span.duration)')).toBeInTheDocument();
-    expect(await screen.findByText('PATCH')).toBeInTheDocument();
-    expect(await screen.findByText('14k')).toBeInTheDocument();
-  });
+      expect(await screen.findByText('http.request_method')).toBeInTheDocument();
+      expect(await screen.findByText('count(span.duration)')).toBeInTheDocument();
+      expect(await screen.findByText('PATCH')).toBeInTheDocument();
+      expect(await screen.findByText('14k')).toBeInTheDocument();
+    });
 
-  it('Table applies custom order and column name if provided', function () {
-    render(
-      <TableWidgetVisualization
-        tableData={sampleHTTPRequestTableData}
-        columns={TabularColumnsFixture(columns)}
-      />
-    );
+    it('Applies custom order and column name if provided', function () {
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          columns={TabularColumnsFixture(columns)}
+        />
+      );
 
-    const $headers = screen.getAllByRole('columnheader');
-    expect($headers[0]).toHaveTextContent(columns[0]!.name!);
-    expect($headers[1]).toHaveTextContent(columns[1]!.name!);
-  });
+      const $headers = screen.getAllByRole('columnheader');
+      expect($headers[0]).toHaveTextContent(columns[0]!.name!);
+      expect($headers[1]).toHaveTextContent(columns[1]!.name!);
+    });
 
-  it('Table renders unique number fields correctly', async function () {
-    const tableData: TabularData = {
-      data: [{'span.duration': 123, failure_rate: 0.1, epm: 6}],
-      meta: {
-        fields: {'span.duration': 'duration', failure_rate: 'percentage', epm: 'rate'},
-        units: {
-          'span.duration': DurationUnit.MILLISECOND,
-          failure_rate: null,
-          epm: RateUnit.PER_MINUTE,
+    it('Renders unique number fields correctly', async function () {
+      const tableData: TabularData = {
+        data: [{'span.duration': 123, failure_rate: 0.1, epm: 6}],
+        meta: {
+          fields: {'span.duration': 'duration', failure_rate: 'percentage', epm: 'rate'},
+          units: {
+            'span.duration': DurationUnit.MILLISECOND,
+            failure_rate: null,
+            epm: RateUnit.PER_MINUTE,
+          },
         },
-      },
-    };
-    render(<TableWidgetVisualization tableData={tableData} />);
+      };
+      render(<TableWidgetVisualization tableData={tableData} />);
 
-    expect(await screen.findByText('span.duration')).toBeInTheDocument();
-    expect(await screen.findByText('failure_rate')).toBeInTheDocument();
-    expect(await screen.findByText('epm')).toBeInTheDocument();
+      expect(await screen.findByText('span.duration')).toBeInTheDocument();
+      expect(await screen.findByText('failure_rate')).toBeInTheDocument();
+      expect(await screen.findByText('epm')).toBeInTheDocument();
 
-    expect(await screen.findByText('123.00ms')).toBeInTheDocument();
-    expect(await screen.findByText('10%')).toBeInTheDocument();
-    expect(await screen.findByText('6.00/min')).toBeInTheDocument();
-  });
+      expect(await screen.findByText('123.00ms')).toBeInTheDocument();
+      expect(await screen.findByText('10%')).toBeInTheDocument();
+      expect(await screen.findByText('6.00/min')).toBeInTheDocument();
+    });
 
-  it('Uses custom renderer over fallback renderer', async function () {
-    const tableData: TabularData = {
-      data: [{date: '2025-06-20T15:14:52+00:00'}],
-      meta: {
-        fields: {date: 'date'},
-        units: {
-          date: null,
+    it('Uses custom renderer over fallback renderer', async function () {
+      const tableData: TabularData = {
+        data: [{date: '2025-06-20T15:14:52+00:00'}],
+        meta: {
+          fields: {date: 'date'},
+          units: {
+            date: null,
+          },
         },
-      },
-    };
+      };
 
-    function getRenderer(fieldName: string): FieldRenderer {
-      if (fieldName === 'date') {
-        return (_dataRow: TabularRow, baggage: RenderFunctionBaggage) => {
-          if (baggage.projectSlug === 'sentry') {
-            return 'relax, soon';
-          }
+      function getRenderer(fieldName: string): FieldRenderer {
+        if (fieldName === 'date') {
+          return (_dataRow: TabularRow, baggage: RenderFunctionBaggage) => {
+            if (baggage.projectSlug === 'sentry') {
+              return 'relax, soon';
+            }
 
-          return 'soon';
+            return 'soon';
+          };
+        }
+
+        return dataRow => dataRow[fieldName];
+      }
+
+      function makeBaggage(): RenderFunctionBaggage {
+        return {
+          location: LocationFixture(),
+          organization: OrganizationFixture(),
+          theme: ThemeFixture(),
+          projectSlug: 'sentry',
         };
       }
 
-      return dataRow => dataRow[fieldName];
-    }
+      render(
+        <TableWidgetVisualization
+          tableData={tableData}
+          makeBaggage={makeBaggage}
+          getRenderer={getRenderer}
+        />
+      );
 
-    function makeBaggage(): RenderFunctionBaggage {
-      return {
-        location: LocationFixture(),
-        organization: OrganizationFixture(),
-        theme: ThemeFixture(),
-        projectSlug: 'sentry',
+      const $cells = await screen.findAllByRole('cell');
+      expect($cells[0]).toHaveTextContent('relax, soon');
+    });
+
+    it('Uses aliases for column names if supplied', function () {
+      const aliases = {
+        'count(span.duration)': 'span duration count',
+        'http.request_method': 'request method http',
       };
-    }
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          aliases={aliases}
+          columns={TabularColumnsFixture(columns)}
+        />
+      );
 
-    render(
-      <TableWidgetVisualization
-        tableData={tableData}
-        makeBaggage={makeBaggage}
-        getRenderer={getRenderer}
-      />
-    );
-
-    const $cells = await screen.findAllByRole('cell');
-    expect($cells[0]).toHaveTextContent('relax, soon');
+      const $headers = screen.getAllByRole('columnheader');
+      expect($headers[0]).toHaveTextContent(aliases['count(span.duration)']);
+      expect($headers[1]).toHaveTextContent(aliases['http.request_method']);
+    });
   });
 
-  it('Uses aliases for column names if supplied', function () {
-    const aliases = {
-      'count(span.duration)': 'span duration count',
-      'http.request_method': 'request method http',
-    };
-    render(
-      <TableWidgetVisualization
-        tableData={sampleHTTPRequestTableData}
-        aliases={aliases}
-        columns={TabularColumnsFixture(columns)}
-      />
-    );
+  describe('Sorting functionality', function () {
+    it('Sort URL parameter is set and correct arrow direction appears on column header click', async function () {
+      const {router: testRouter} = render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          columns={TabularColumnsFixture(sortableColumns)}
+        />,
+        {
+          initialRouterConfig: {},
+        }
+      );
 
-    const $headers = screen.getAllByRole('columnheader');
-    expect($headers[0]).toHaveTextContent(aliases['count(span.duration)']);
-    expect($headers[1]).toHaveTextContent(aliases['http.request_method']);
+      const $header = screen.getAllByRole('columnheader')[0]?.children[0]!;
+      await userEvent.click($header);
+      await waitFor(() =>
+        expect(IconArrow).toHaveBeenCalledWith(
+          expect.objectContaining({direction: 'down'}),
+          undefined
+        )
+      );
+      await waitFor(() =>
+        expect(testRouter.location.query.sort).toBe('-count(span.duration)')
+      );
+    });
+
+    it('Sort arrow appears and has correct direction if sort is provided', async function () {
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          sort={{field: 'count(span.duration)', kind: 'asc'}}
+          columns={TabularColumnsFixture(sortableColumns)}
+        />
+      );
+
+      await waitFor(() =>
+        expect(IconArrow).toHaveBeenCalledWith(
+          expect.objectContaining({direction: 'up'}),
+          undefined
+        )
+      );
+    });
+
+    it('Uses onChangeSort if supplied on column header click', async function () {
+      const onChangeSortMock = jest.fn((_sort: Sort) => {});
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          onChangeSort={onChangeSortMock}
+          columns={TabularColumnsFixture(sortableColumns)}
+        />
+      );
+      const $header = screen.getAllByRole('columnheader')[0]?.children[0]!;
+      await userEvent.click($header);
+      await waitFor(() => expect(onChangeSortMock).toHaveBeenCalled());
+    });
   });
 
-  it('Sort URL parameter is set and correct arrow direction appears on column header click', async function () {
-    const {router: testRouter} = render(
-      <TableWidgetVisualization
-        tableData={sampleHTTPRequestTableData}
-        columns={TabularColumnsFixture(sortableColumns)}
-      />,
-      {
-        initialRouterConfig: {},
-      }
-    );
+  describe('Column resizing functionality', function () {
+    it('Width URL parameter is set as default on column resize', async function () {
+      const {router: testRouter} = render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          columns={TabularColumnsFixture(columns)}
+        />,
+        {
+          initialRouterConfig: {},
+        }
+      );
 
-    const $header = screen.getAllByRole('columnheader')[0]?.children[0]!;
-    await userEvent.click($header);
-    await waitFor(() =>
-      expect(IconArrow).toHaveBeenCalledWith(
-        expect.objectContaining({direction: 'down'}),
-        undefined
-      )
-    );
-    await waitFor(() =>
-      expect(testRouter.location.query.sort).toBe('-count(span.duration)')
-    );
-  });
+      const $gridResizer = screen.getAllByRole('columnheader')[0]?.children[1]!;
+      await userEvent.pointer([
+        {keys: '[MouseLeft>]', target: $gridResizer},
+        {target: $gridResizer, coords: {x: 100}},
+        {keys: '[/MouseLeft]'},
+      ]);
+      await waitFor(() => expect(testRouter.location.query.width).toBeDefined());
+    });
 
-  it('Sort arrow appears and has correct direction if sort is provided', async function () {
-    render(
-      <TableWidgetVisualization
-        tableData={sampleHTTPRequestTableData}
-        sort={{field: 'count(span.duration)', kind: 'asc'}}
-        columns={TabularColumnsFixture(sortableColumns)}
-      />
-    );
+    it('Uses onChangeColumnResize if supplied on column resize', async function () {
+      const onChangeColumnResizeMock = jest.fn((_widths: number[]) => {});
+      render(
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          onChangeColumnResize={onChangeColumnResizeMock}
+        />
+      );
 
-    await waitFor(() =>
-      expect(IconArrow).toHaveBeenCalledWith(
-        expect.objectContaining({direction: 'up'}),
-        undefined
-      )
-    );
-  });
-
-  it('Uses onChangeSort if supplied on column header click', async function () {
-    const onChangeSortMock = jest.fn((_sort: Sort) => {});
-    render(
-      <TableWidgetVisualization
-        tableData={sampleHTTPRequestTableData}
-        onChangeSort={onChangeSortMock}
-        columns={TabularColumnsFixture(sortableColumns)}
-      />
-    );
-    const $header = screen.getAllByRole('columnheader')[0]?.children[0]!;
-    await userEvent.click($header);
-    await waitFor(() => expect(onChangeSortMock).toHaveBeenCalled());
+      const $gridResizer = screen.getAllByRole('columnheader')[0]?.children[1]!;
+      await userEvent.pointer([
+        {keys: '[MouseLeft>]', target: $gridResizer},
+        {target: $gridResizer, coords: {x: 100}},
+        {keys: '[/MouseLeft]'},
+      ]);
+      await waitFor(() => expect(onChangeColumnResizeMock).toHaveBeenCalled());
+    });
   });
 });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -224,12 +224,12 @@ describe('TableWidgetVisualization', function () {
       await waitFor(() => expect(testRouter.location.query.width).toBeDefined());
     });
 
-    it('Uses onChangeColumnResize if supplied on column resize', async function () {
-      const onChangeColumnResizeMock = jest.fn((_widths: number[]) => {});
+    it('Uses onChangeResizeColumn if supplied on column resize', async function () {
+      const onChangeResizeColumnMock = jest.fn((_widths: number[]) => {});
       render(
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
-          onChangeColumnResize={onChangeColumnResizeMock}
+          onChangeResizeColumn={onChangeResizeColumnMock}
         />
       );
 
@@ -239,7 +239,7 @@ describe('TableWidgetVisualization', function () {
         {target: $gridResizer, coords: {x: 100}},
         {keys: '[/MouseLeft]'},
       ]);
-      await waitFor(() => expect(onChangeColumnResizeMock).toHaveBeenCalled());
+      await waitFor(() => expect(onChangeResizeColumnMock).toHaveBeenCalled());
     });
   });
 });

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -291,7 +291,8 @@ function onChangeSort(newSort: Sort) {
         <p>
           Also by default, is managing column widths and resizing via <code>width</code>{' '}
           URL parameters. E.g., <code>?width=-1&width=512</code> will set the first column
-          to have automatic width, and the second column to have a width of 512px.
+          to have automatic width, and the second column to have a width of 512px. Note:
+          this behavior only applies if the table columns are resizable.
         </p>
         <p>
           If both the URL parameters and <code>width</code>field in the{' '}

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -261,6 +261,112 @@ function onChangeSort(newSort: Sort) {
     );
   });
 
+  story('Column resizing', () => {
+    const location = useLocation();
+    const noWidthColumns = customColumns.map(column => ({...column, width: undefined}));
+    const [columns, setColumns] = useState<TabularColumn[]>(noWidthColumns);
+
+    function onChangeColumnResize(widths: number[]) {
+      const newColumns = columns.map((column, index) => ({
+        ...column,
+        width: widths[index],
+      }));
+      setColumns(newColumns);
+    }
+
+    return (
+      <Fragment>
+        <p>
+          By default, table column widths are assumed to be resizable, mainly because most
+          use cases allow for this. If no resizing is required, pass the
+          <code>{'resizable={false}'}</code> to disable it. As a side note, resizing
+          requires at least two columns to take effect. Having only one column means{' '}
+          <code>resizable</code>prop does nothing. Widths are represented with numbers
+          which are further interpreted as pixels.
+        </p>
+        <p>
+          There are two methods this table uses to set widths. The first is to provide the
+          <code>width</code>
+          field when passing <code>columns</code> prop. One use case of this prop is to
+          set the width of non-resizable table columns.
+        </p>
+        <p>Below is an example of a non column resizable table with preset widths.</p>
+        <TableWidgetVisualization
+          columns={customColumns}
+          tableData={sampleHTTPRequestTableData}
+          resizable={false}
+        />
+        <p>
+          The second method is to automatically parse it from the <code>width</code> URL
+          query parameters if it exists. Note that this requires the table columns to be
+          resizable. This is behaviour occurs in the following situations:
+        </p>
+        <ol>
+          <li>
+            <code>columns</code>prop is not passed
+          </li>
+          <li>
+            <code>columns</code>prop is passed AND no column in <code>columns</code> has
+            defined the field<code>width</code>
+          </li>
+        </ol>
+        <p>
+          To elaborate on point two, if you want to use the default url parameters and
+          need to pass <code>columns</code>prop, then do not add the <code>width</code>
+          field to all columns or set the field to be <code>undefined</code>
+          for all columns.
+        </p>
+        <p>
+          Try interacting with the columns and making note of the url parameter. Use the
+          button to clear the width parameters.
+        </p>
+        <ButtonContainer>
+          <LinkButton to={{...location, query: {...location.query, width: undefined}}}>
+            Clear width parameters
+          </LinkButton>
+        </ButtonContainer>
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          columns={noWidthColumns}
+        />
+        If the table encounters an undefined width (e.g., neither the prop or url
+        parameters are provided), then the column defaults to a width of
+        <code>-1</code>. The table will fallback on the default behaviour
+        <Storybook.JSXNode name="GridEditable" /> uses for undefined widths.
+        <p>
+          Similar to sorting, the default behavior when a column is resized is to update
+          the <code>width</code>url query parameters. If you wish to override this
+          behaviour pass the callback function <code>onChangeColumnResize</code>, which
+          accepts a number array representing the new widths of each column. This and the{' '}
+          <code>width</code>field in <code>columns</code>is useful if you need to manage
+          internal state:
+        </p>
+        <p>
+          Current widths are{' '}
+          <b>[{columns.map(column => column.width ?? 'undefined').toString()}]</b>
+        </p>
+        <TableWidgetVisualization
+          tableData={sampleHTTPRequestTableData}
+          columns={columns}
+          onChangeColumnResize={onChangeColumnResize}
+        />
+        <CodeSnippet language="jsx">
+          {`
+const [columns, setColumns] = useState<TabularColumn[]>(...);
+
+function onChangeColumnResize(widths: number[]) {
+  const newColumns = columns.map((column, index) => ({
+    ...column,
+    width: widths[index],
+  }));
+  setColumns(newColumns);
+}
+`}
+        </CodeSnippet>
+      </Fragment>
+    );
+  });
+
   story('Using Custom Cell Rendering', () => {
     function getRenderer(fieldName: string) {
       if (fieldName === 'http.request_method') {

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -266,7 +266,7 @@ function onChangeSort(newSort: Sort) {
     const noWidthColumns = customColumns.map(column => ({...column, width: undefined}));
     const [columns, setColumns] = useState<TabularColumn[]>(noWidthColumns);
 
-    function onChangeColumnResize(widths: number[]) {
+    function onChangeResizeColumn(widths: number[]) {
       const newColumns = columns.map((column, index) => ({
         ...column,
         width: widths[index],
@@ -336,7 +336,7 @@ function onChangeSort(newSort: Sort) {
         <p>
           Similar to sorting, the default behavior when a column is resized is to update
           the <code>width</code>url query parameters. If you wish to override this
-          behaviour pass the callback function <code>onChangeColumnResize</code>, which
+          behaviour pass the callback function <code>onChangeResizeColumn</code>, which
           accepts a number array representing the new widths of each column. This and the{' '}
           <code>width</code>field in <code>columns</code>is useful if you need to manage
           internal state:
@@ -348,7 +348,7 @@ function onChangeSort(newSort: Sort) {
         <TableWidgetVisualization
           tableData={sampleHTTPRequestTableData}
           columns={columns}
-          onChangeColumnResize={onChangeColumnResize}
+          onChangeResizeColumn={onChangeResizeColumn}
         />
         <CodeSnippet language="jsx">
           {`

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -289,16 +289,17 @@ function onChangeSort(newSort: Sort) {
           resizable={false}
         />
         <p>
-          Also by default, is managing column widths and resizing via <code>width</code>{' '}
-          URL parameters. E.g., <code>?width=-1&width=512</code> will set the first column
-          to have automatic width, and the second column to have a width of 512px. Note:
-          this behavior only applies if the table columns are resizable.
+          Also by default, is <Storybook.JSXNode name="TableWidgetVisualization" />{' '}
+          managing column widths and resizing via <code>width</code> URL parameters. E.g.,{' '}
+          <code>?width=-1&width=512</code> will set the first column to have automatic
+          width, and the second column to have a width of 512px. Note: this behavior only
+          applies if the table columns are resizable.
         </p>
         <p>
           If both the URL parameters and <code>width</code>field in the{' '}
           <code>columns</code>prop are supplied, the table will prioritize the prop. If
-          you want the default behaviour and need to pass <code>columns</code>, then
-          ensure that the <code>width</code>field does not exist or is set to{' '}
+          you want the default behavior and need to pass <code>columns</code>, then ensure
+          that the <code>width</code>field does not exist or is set to{' '}
           <code>undefined</code>for every column.
         </p>
         <p>
@@ -316,10 +317,9 @@ function onChangeSort(newSort: Sort) {
         />
         <p>
           If you wish to override default behavior of updating the URL, pass the callback
-          function <code>onResizeColumn</code>, which accepts a{' '}
-          <code>TabularColumn[]</code> representing the columns with new widths. This and
-          the <code>width</code>field in <code>columns</code>is useful if you need to
-          manage internal state:
+          function <code>onResizeColumn</code>, which accepts <code>TabularColumn[]</code>{' '}
+          representing the columns with new widths. This and the <code>width</code>field
+          in <code>columns</code>is useful if you need to manage internal state:
         </p>
         <p>
           Current widths are{' '}

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -277,8 +277,8 @@ function onChangeSort(newSort: Sort) {
     return (
       <Fragment>
         <p>
-          By default, table column widths are assumed to be resizable, mainly because most
-          use cases allow for this. If no resizing is required, pass the
+          By default, table column widths are assumed to be resizable as most use cases
+          utilize this. If no resizing is required, pass the
           <code>{'resizable={false}'}</code> to disable it. As a side note, resizing
           requires at least two columns to take effect. Having only one column means{' '}
           <code>resizable</code>prop does nothing. Widths are represented with numbers
@@ -314,7 +314,8 @@ function onChangeSort(newSort: Sort) {
           To elaborate on point two, if you want to use the default url parameters and
           need to pass <code>columns</code>prop, then do not add the <code>width</code>
           field to all columns or set the field to be <code>undefined</code>
-          for all columns.
+          for all columns. If you need to set initial widths as well, then add them to the
+          URL parameters directly.
         </p>
         <p>
           Try interacting with the columns and making note of the url parameter. Use the

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -155,18 +155,20 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
 
   const {data, meta} = tableData;
   const locationSort = decodeSorts(location?.query?.sort)[0];
-  const numColumns = Math.max(
-    Object.keys(columns || {}).length,
-    Object.keys(meta.fields).length
-  );
+  const numColumns = Math.max(columns?.length ?? 0, Object.keys(meta.fields).length);
 
   let widths = new Array(numColumns).fill(COL_WIDTH_UNDEFINED);
   const locationWidths = location.query?.width;
   // If at least one column has the width key and that key is defined, take that over url widths
   if (columns?.some(column => defined(column.width))) {
-    widths = columns.map(column => column.width ?? COL_WIDTH_UNDEFINED);
+    widths = columns.map(column =>
+      defined(column.width) ? column.width : COL_WIDTH_UNDEFINED
+    );
   } else if (resizable && Array.isArray(locationWidths)) {
-    widths = locationWidths.map(width => parseInt(width, 10));
+    widths = locationWidths.map(width => {
+      const val = parseInt(width, 10);
+      return isNaN(val) ? COL_WIDTH_UNDEFINED : val;
+    });
   }
 
   // Fallback to extracting fields from the tableData if no columns are provided

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -78,7 +78,7 @@ interface TableWidgetVisualizationProps {
    */
   makeBaggage?: BaggageMaker;
   /**
-   * A callback function on column resize that is invoked when a user resizes a column. If omitted, resizing will update the width in the URL
+   * A callback function that is invoked after a user resizes a column. If omitted, resizing will update the width parameters in the URL
    * @param widths an array of numbers containing the widths by column order
    */
   onChangeResizeColumn?: (widths: number[]) => void;
@@ -155,8 +155,12 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
 
   const {data, meta} = tableData;
   const locationSort = decodeSorts(location?.query?.sort)[0];
+  const numColumns = Math.max(
+    Object.keys(columns || {}).length,
+    Object.keys(meta.fields).length
+  );
 
-  let widths = new Array(Object.keys(meta.fields).length).fill(COL_WIDTH_UNDEFINED);
+  let widths = new Array(numColumns).fill(COL_WIDTH_UNDEFINED);
   const locationWidths = location.query?.width;
   // If at least one column has the width key and that key is defined, take that over url widths
   if (columns?.some(column => defined(column.width))) {

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Tooltip} from 'sentry/components/core/tooltip';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import SortLink from 'sentry/components/tables/gridEditable/sortLink';
+import {defined} from 'sentry/utils';
 import {getSortField} from 'sentry/utils/dashboards/issueFieldRenderers';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
@@ -158,7 +159,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
   let widths = new Array(Object.keys(meta.fields).length).fill(COL_WIDTH_UNDEFINED);
   const locationWidths = location.query?.width;
   // If at least one column has the width key and that key is defined, take that over url widths
-  if (columns?.some(column => Object.hasOwn(column, 'width') && column.width)) {
+  if (columns?.some(column => defined(column.width))) {
     widths = columns.map(column => column.width ?? COL_WIDTH_UNDEFINED);
   } else if (resizable && Array.isArray(locationWidths)) {
     widths = locationWidths.map(width => parseInt(width, 10));

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -155,9 +155,10 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
 
   const {data, meta} = tableData;
   const locationSort = decodeSorts(location?.query?.sort)[0];
-  const numColumns = Math.max(columns?.length ?? 0, Object.keys(meta.fields).length);
 
-  let widths = new Array(numColumns).fill(COL_WIDTH_UNDEFINED);
+  let widths = new Array(columns?.length ?? Object.keys(meta.fields).length).fill(
+    COL_WIDTH_UNDEFINED
+  );
   const locationWidths = location.query?.width;
   // If at least one column has the width key and that key is defined, take that over url widths
   if (columns?.some(column => defined(column.width))) {
@@ -165,9 +166,10 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
       defined(column.width) ? column.width : COL_WIDTH_UNDEFINED
     );
   } else if (resizable && Array.isArray(locationWidths)) {
-    widths = locationWidths.map(width => {
+    locationWidths.forEach((width, index) => {
+      if (index >= widths.length) return;
       const val = parseInt(width, 10);
-      return isNaN(val) ? COL_WIDTH_UNDEFINED : val;
+      widths[index] = isNaN(val) ? COL_WIDTH_UNDEFINED : val;
     });
   }
 

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -175,12 +175,10 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     }));
 
   const onResizeColumn = (columnIndex: number, nextColumn: TabularColumn) => {
-    const newWidth = nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED;
-    const newWidths: number[] = new Array(Math.max(columnIndex, widths.length)).fill(
-      COL_WIDTH_UNDEFINED
-    );
-    widths.forEach((width, index) => (newWidths[index] = width));
-    newWidths[columnIndex] = newWidth;
+    const newWidths: number[] = [...widths];
+    newWidths[columnIndex] = nextColumn.width
+      ? Number(nextColumn.width)
+      : COL_WIDTH_UNDEFINED;
 
     if (onChangeResizeColumn) {
       onChangeResizeColumn(newWidths);

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -80,7 +80,7 @@ interface TableWidgetVisualizationProps {
    * A callback function on column resize that is invoked when a user resizes a column. If omitted, resizing will update the width in the URL
    * @param widths an array of numbers containing the widths by column order
    */
-  onChangeColumnResize?: (widths: number[]) => void;
+  onChangeResizeColumn?: (widths: number[]) => void;
 
   /**
    * A callback function that is invoked after a user clicks a sortable column header. If omitted, clicking a column header updates the sort in the URL
@@ -123,7 +123,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     aliases,
     onChangeSort,
     sort,
-    onChangeColumnResize,
+    onChangeResizeColumn,
     resizable = true,
   } = props;
 
@@ -182,8 +182,8 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
     widths.forEach((width, index) => (newWidths[index] = width));
     newWidths[columnIndex] = newWidth;
 
-    if (onChangeColumnResize) {
-      onChangeColumnResize(newWidths);
+    if (onChangeResizeColumn) {
+      onChangeResizeColumn(newWidths);
       return;
     }
 

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -185,7 +185,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
 
   const onResizeColumn = (columnIndex: number, nextColumn: TabularColumn) => {
     const newWidths: number[] = [...widths];
-    newWidths[columnIndex] = nextColumn.width
+    newWidths[columnIndex] = defined(nextColumn.width)
       ? Number(nextColumn.width)
       : COL_WIDTH_UNDEFINED;
 


### PR DESCRIPTION
### Changes

Adds column resizing functionality to table widget visualization component. See the story to try it out. Also reformatted some of the tests to group related tests together. The new tests for resizing are at the bottom of the spec file.

This is part 1 of implementing the feature into dashboards. The second PR will be adding the feature to widgets and widget preview.
