### PR TITLE
feat(otlp): Add `span.status_message` field definition

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1932,6 +1932,13 @@ const SPAN_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
+  [SpanFields.STATUS_MESSAGE]: {
+    desc: t(
+      'Span status message. If the span operation was not successful, this contains an error message.'
+    ),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
 };
 
 const LOG_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {};

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -95,6 +95,7 @@ export enum SpanFields {
   NAME = 'span.name',
   KIND = 'span.kind',
   STATUS = 'span.status',
+  STATUS_MESSAGE = 'span.status_message',
   RELEASE = 'release',
   PROJECT_ID = 'project.id',
   RESPONSE_CODE = 'span.status_code',

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -162,6 +162,7 @@ type SpanStringFields =
   | SpanFields.NAME
   | SpanFields.KIND
   | SpanFields.STATUS
+  | SpanFields.STATUS_MESSAGE
   | SpanFields.GEN_AI_AGENT_NAME
   | SpanFields.GEN_AI_REQUEST_MODEL
   | SpanFields.GEN_AI_RESPONSE_MODEL


### PR DESCRIPTION
Alias added in https://github.com/getsentry/sentry/pull/94929/, this is the definition that shows up in the autocomplete in Explore in the query builder.