### PR TITLE
feat(explore): Support functions with no arguments

### DIFF
--- a/static/app/components/arithmeticBuilder/grammar.pegjs
+++ b/static/app/components/arithmeticBuilder/grammar.pegjs
@@ -10,8 +10,20 @@ token
   }
 
 func
-  = func:name "(" spaces attr:attr spaces ")" {
-    return tc.tokenFunction(func, attr, location());
+  = func:name "(" attrs:attrs spaces ")" {
+    return tc.tokenFunction(func, attrs, location());
+  }
+
+attrs = yes_attr / no_attr
+
+yes_attr
+  = spaces attr:attr spaces {
+      return [attr];
+    }
+
+no_attr
+  = spaces {
+    return [];
   }
 
 attr = typed_attr / untyped_attr

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -38,16 +38,17 @@ export function ArithmeticTokenFunction({
   state,
   token,
 }: ArithmeticTokenFunctionProps) {
-  if (token.attributes.length !== 1) {
-    throw new Error('Only functions with 1 argument supported.');
+  if (token.attributes.length > 1) {
+    throw new Error('Only functions with at most 1 argument supported.');
   }
-  const attribute = token.attributes[0]!;
+  const attribute = token.attributes[0];
 
   const ref = useRef<HTMLDivElement>(null);
   const {rowProps, gridCellProps} = useGridListItem({
     item,
     ref,
     state,
+    focusable: defined(attribute), // if there are no attributes, it's not focusable
   });
 
   const isFocused = item.key === state.selectionManager.focusedKey;
@@ -59,27 +60,29 @@ export function ArithmeticTokenFunction({
       {...rowProps}
       ref={ref}
       tabIndex={isFocused ? 0 : -1}
-      aria-label={`${token.function}(${attribute.text})`}
+      aria-label={`${token.function}(${attribute?.text ?? ''})`}
       aria-invalid={false}
       state={'valid'}
     >
       <FunctionGridCell {...gridCellProps}>{token.function}</FunctionGridCell>
       {'('}
-      <BaseGridCell {...gridCellProps}>
-        <InternalInput
-          item={item}
-          state={state}
-          token={token}
-          attribute={attribute}
-          rowRef={ref}
-          argumentIndex={0}
-        />
-        {showUnfocusedState && (
-          // Inject a floating span with the attribute name so when it's
-          // not focused, it doesn't look like the placeholder text
-          <FunctionArgumentOverlay>{attribute.attribute}</FunctionArgumentOverlay>
-        )}
-      </BaseGridCell>
+      {defined(attribute) && (
+        <BaseGridCell {...gridCellProps}>
+          <InternalInput
+            item={item}
+            state={state}
+            token={token}
+            attribute={attribute}
+            rowRef={ref}
+            argumentIndex={0}
+          />
+          {showUnfocusedState && (
+            // Inject a floating span with the attribute name so when it's
+            // not focused, it doesn't look like the placeholder text
+            <FunctionArgumentOverlay>{attribute.attribute}</FunctionArgumentOverlay>
+          )}
+        </BaseGridCell>
+      )}
       {')'}
       <BaseGridCell {...gridCellProps}>
         <DeleteFunction token={token} />

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -20,7 +20,7 @@ import {
 import {TokenGrid} from 'sentry/components/arithmeticBuilder/token/grid';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 
-const aggregations = ['avg', 'sum', 'count', 'count_unique'];
+const aggregations = ['avg', 'sum', 'epm', 'count_unique'];
 
 const functionArguments = [
   {name: 'span.duration', kind: FieldKind.MEASUREMENT},
@@ -93,7 +93,7 @@ describe('token', function () {
       expect(input).toHaveValue('');
     });
 
-    it('allow selecting function on mouse', async function () {
+    it('allow selecting function using mouse', async function () {
       render(<Tokens expression="" />);
 
       const input = screen.getByRole('combobox', {
@@ -143,7 +143,49 @@ describe('token', function () {
       });
     });
 
-    it('allows selection parenthesis using mouse', async function () {
+    it('allows selecting function with no arguments using mouse', async function () {
+      render(<Tokens expression="" />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Add a term',
+      });
+      expect(input).toBeInTheDocument();
+
+      await userEvent.click(input);
+
+      // typing should reduce the options avilable in the autocomplete
+      expect(screen.getAllByRole('option')).toHaveLength(5);
+      await userEvent.type(input, 'epm');
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+
+      await userEvent.click(screen.getByRole('option', {name: 'epm'}));
+      expect(await screen.findByLabelText('epm()')).toBeInTheDocument();
+
+      await waitFor(() => expect(getLastInput()).toHaveFocus());
+    });
+
+    it('allows selecting function with no arguments using keyboard', async function () {
+      render(<Tokens expression="" />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Add a term',
+      });
+      expect(input).toBeInTheDocument();
+
+      await userEvent.click(input);
+
+      // typing should reduce the options avilable in the autocomplete
+      expect(screen.getAllByRole('option')).toHaveLength(5);
+      await userEvent.type(input, 'epm');
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+
+      await userEvent.type(input, '{ArrowDown}{Enter}');
+      expect(await screen.findByLabelText('epm()')).toBeInTheDocument();
+
+      await waitFor(() => expect(getLastInput()).toHaveFocus());
+    });
+
+    it('allows selecting parenthesis using mouse', async function () {
       render(<Tokens expression="" />);
 
       const input = screen.getByRole('combobox', {
@@ -165,7 +207,7 @@ describe('token', function () {
       await waitFor(() => expect(getLastInput()).toHaveFocus());
     });
 
-    it('allows selection parenthesis using keyboard', async function () {
+    it('allows selecting parenthesis using keyboard', async function () {
       render(<Tokens expression="" />);
 
       const input = screen.getByRole('combobox', {
@@ -230,6 +272,27 @@ describe('token', function () {
       await waitFor(() => {
         expect(screen.getByLabelText('Select an attribute')).toHaveFocus();
       });
+    });
+
+    it('autocompletes function token with no arguments when they reach the open parenthesis', async function () {
+      render(<Tokens expression="" />);
+
+      const input = screen.getByRole('combobox', {
+        name: 'Add a term',
+      });
+      expect(input).toBeInTheDocument();
+
+      await userEvent.click(input);
+      await userEvent.type(input, 'epm(');
+
+      await waitFor(() => expect(getLastInput()).toHaveFocus());
+      await userEvent.keyboard('{Escape}');
+
+      expect(
+        await screen.findByRole('row', {
+          name: 'epm()',
+        })
+      ).toBeInTheDocument();
     });
 
     it('autocompletes addition', async function () {
@@ -536,6 +599,17 @@ describe('token', function () {
       expect(options[1]).toHaveTextContent('span.description');
       await userEvent.type(input, 'desc');
       expect(screen.getByRole('option')).toHaveTextContent('span.description');
+    });
+
+    it('skips input when function has no arguments', async function () {
+      render(<Tokens expression="epm()" />);
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('combobox', {
+            name: 'Select an attribute',
+          })
+        ).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/static/app/components/arithmeticBuilder/tokenizer.spec.tsx
+++ b/static/app/components/arithmeticBuilder/tokenizer.spec.tsx
@@ -74,6 +74,7 @@ describe('tokenizeExpression', function () {
       'avg(   tags[foo,  number]   )',
       [s(0, ''), f(0, 'avg', [a(0, 'foo', 'number')]), s(1, '')],
     ],
+    ['epm()', [s(0, ''), f(0, 'epm', []), s(1, '')]],
   ])('tokenizes function `%s`', function (expression, expected) {
     expect(tokenizeExpression(expression)).toEqual(expected);
   });

--- a/static/app/components/arithmeticBuilder/tokenizer.tsx
+++ b/static/app/components/arithmeticBuilder/tokenizer.tsx
@@ -185,10 +185,10 @@ class TokenConverter {
 
   tokenFunction(
     func: string,
-    attribute: TokenAttribute,
+    attributes: TokenAttribute[],
     location: LocationRange
   ): TokenFunction {
-    return new TokenFunction(location, func, [attribute]);
+    return new TokenFunction(location, func, attributes);
   }
 }
 

--- a/static/app/components/tokenizedInput/grid/useGridListItem.tsx
+++ b/static/app/components/tokenizedInput/grid/useGridListItem.tsx
@@ -7,19 +7,27 @@ import type {Node} from '@react-types/shared';
 import {shiftFocusToChild} from 'sentry/components/tokenizedInput/token/utils';
 
 interface UseGridListItemOptions<T> {
+  focusable: boolean;
   item: Node<T>;
   ref: RefObject<HTMLDivElement | null>;
   state: ListState<T>;
 }
 
-export function useGridListItem<T>({item, ref, state}: UseGridListItemOptions<T>) {
+export function useGridListItem<T>({
+  focusable,
+  item,
+  ref,
+  state,
+}: UseGridListItemOptions<T>) {
   const {rowProps, gridCellProps} = useGridListItemAria({node: item}, state, ref);
 
   const onFocus = useCallback(
     (evt: FocusEvent<HTMLDivElement>) => {
-      shiftFocusToChild(evt.currentTarget, item, state);
+      if (focusable) {
+        shiftFocusToChild(evt.currentTarget, item, state);
+      }
     },
-    [item, state]
+    [focusable, item, state]
   );
 
   return useMemo(() => {

--- a/static/app/components/tokenizedInput/token/deletableToken.tsx
+++ b/static/app/components/tokenizedInput/token/deletableToken.tsx
@@ -32,6 +32,7 @@ export function DeletableToken<T>({
     item,
     ref,
     state,
+    focusable: true,
   });
 
   const onKeyDownCapture = useCallback(


### PR DESCRIPTION
We now have functions like epm and failure_rate that have no arguments.