### PR TITLE
feat: Remove video/quicktime support

### DIFF
--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -30,7 +30,7 @@ const jsonMimeTypes = [
   'text/x-json',
 ];
 
-export const webmMimeTypes = ['video/webm', 'video/mp4', 'video/quicktime'];
+export const webmMimeTypes = ['video/webm', 'video/mp4'];
 
 type AttachmentRenderer =
   | typeof ImageViewer


### PR DESCRIPTION
I initially added support for "video/quicktime" in the [PR](https://github.com/getsentry/sentry/pull/94903), but after a second thought - since it's only supported by Safari (similar to the HEIC format) - I've decided it's better not to support it at all. So I'm removing it.


contributes to https://linear.app/getsentry/issue/TET-614/attachments-add-support-for-newer-file-formats-such-as-heic