### PR TITLE
fix(sourcemaps): list rather than concatenate release IDs

### DIFF
--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -686,7 +686,8 @@ span.val {
 }
 
 .val-string-multiline {
-  display: block;
+  display: flex;
+  flex-direction: column;
   overflow: auto;
 }
 


### PR DESCRIPTION
In the UI, multiple releases against one source map upload were concatenated. This lists them one per line, improving readability. 

Fixes #94944.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
