### PR TITLE
feat(relay): Send string instead of boolean for ingestion through trusted relays only

### DIFF
--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -101,6 +101,18 @@ export function RelayWrapper() {
                   visible: organization.features.includes(
                     'ingest-through-trusted-relays-only'
                   ),
+                  getData: (data: Record<string, any>) => {
+                    // Transform boolean to enabled/disabled string for API
+                    const value = data.ingestThroughTrustedRelaysOnly;
+                    return {
+                      ingestThroughTrustedRelaysOnly:
+                        typeof value === 'boolean'
+                          ? value
+                            ? 'enabled'
+                            : 'disabled'
+                          : value,
+                    };
+                  },
                 },
               ],
             },


### PR DESCRIPTION
Keeps switch component in the UI, but sends string to the API.

This allows us to easily extend this in the future, but for now, for simplicity, we want to keep the simplest component (switch) since it can have only 2 values:
- enabled
- disabled
