### PR TITLE
feat(taskworker) Collect another metric from workers

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -160,7 +160,10 @@ class TaskWorker:
             # causing processing deadline expiration.
             # Whereas in pools that have consistent short tasks, this happens
             # more frequently, allowing workers to run more smoothly.
-            metrics.incr("taskworker.worker.add_tasks.child_tasks_full")
+            metrics.incr(
+                "taskworker.worker.add_tasks.child_tasks_full",
+                tags={"processing_pool": self._processing_pool_name},
+            )
             return False
 
         inflight = self.fetch_task()


### PR DESCRIPTION
We have some pools that run really smoothly, and other that don't run as smoothly. I think that the number of times after startup that we call this method to fill the child_tasks queue is contributing to broker processing deadlines occurring.