### PR TITLE
feat: Add apdex and user misery to translation layer

### DIFF
--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -7,7 +7,7 @@ from sentry.api.event_search import event_search_grammar
 from sentry.search.events import fields
 from sentry.snuba.metrics import parse_mri
 
-APDEX_USER_MISERY_PATTERN = r"(apdex|user_misery)\(([^)]+)\)"
+APDEX_USER_MISERY_PATTERN = r"(apdex|user_misery)\((\d+)\)"
 
 
 class QueryParts(TypedDict):

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -77,6 +77,10 @@ def function_switcheroo(term):
         swapped_term = "count(span.duration)"
     elif term.startswith("percentile("):
         swapped_term = format_percentile_term(term)
+    elif term.startswith("apdex"):
+        swapped_term = "apdex(span.duration,300)"
+    elif term.startswith("user_misery"):
+        swapped_term = "user_misery(span.duration,300)"
 
     return swapped_term, swapped_term != term
 

--- a/src/sentry/discover/translation/mep_to_eap.py
+++ b/src/sentry/discover/translation/mep_to_eap.py
@@ -84,8 +84,6 @@ def function_switcheroo(term):
         swapped_term = "apdex(span.duration,300)"
     elif term == "user_misery()":
         swapped_term = "user_misery(span.duration,300)"
-    elif term == "apdex()":
-        swapped_term = "apdex(span.duration,300)"
 
     match = re.match(APDEX_USER_MISERY_PATTERN, term)
     if match:

--- a/tests/sentry/discover/test_compare_tables.py
+++ b/tests/sentry/discover/test_compare_tables.py
@@ -80,24 +80,6 @@ class CompareTablesTestCase(BaseMetricsLayerTestCase, TestCase, BaseSpansTestCas
             fields=["count()", "transaction"],
         )
 
-        self.error_field_widget = DashboardWidget.objects.create(
-            dashboard=self.dashboard,
-            title="Test Empty Field Widget",
-            order=1,
-            display_type=DashboardWidgetDisplayTypes.TABLE,
-            widget_type=DashboardWidgetTypes.TRANSACTION_LIKE,
-        )
-
-        self.error_field_widget_query = DashboardWidgetQuery.objects.create(
-            widget=self.error_field_widget,
-            name="Test Empty Field Widget Query",
-            order=1,
-            conditions="",
-            aggregates=["apdex()"],
-            columns=["apdex()", "http.status_code"],
-            fields=["apdex()", "http.status_code"],
-        )
-
         self.empty_field_widget = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             title="Test Empty Field Widget",
@@ -300,14 +282,6 @@ class CompareTablesTestCase(BaseMetricsLayerTestCase, TestCase, BaseSpansTestCas
         )
         assert comparison_result["passed"]
         assert comparison_result["mismatches"] == []
-
-    def test_compare_error_field_tables(self):
-        # testing with apdex() field, which is not supported in EAP and throw an error
-        comparison_result = compare_tables_for_dashboard_widget_queries(
-            self.error_field_widget_query
-        )
-        assert comparison_result["passed"] is False
-        assert comparison_result["reason"] == CompareTableResult.EAP_FAILED
 
     def test_compare_empty_field_tables(self):
         # testing with failure_rate() field, which is not supported in EAP

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -55,12 +55,12 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "(p50(span.duration):>100 AND percentile(span.duration, 0.25):>20) AND is_transaction:1",
         ),
         pytest.param(
-            "user_misery(300):>0.5",
-            "(user_misery(span.duration,300):>0.5) AND is_transaction:1",
+            "user_misery():>0.5 OR apdex():>0.5",
+            "(user_misery(span.duration,300):>0.5 OR apdex(span.duration,300):>0.5) AND is_transaction:1",
         ),
         pytest.param(
-            "apdex(300):>0.5",
-            "(apdex(span.duration,300):>0.5) AND is_transaction:1",
+            "apdex(1000):>0.5 OR user_misery(1000):>0.5",
+            "(apdex(span.duration,1000):>0.5 OR user_misery(span.duration,1000):>0.5) AND is_transaction:1",
         ),
     ],
 )

--- a/tests/sentry/discover/translation/test_mep_to_eap.py
+++ b/tests/sentry/discover/translation/test_mep_to_eap.py
@@ -54,6 +54,14 @@ from sentry.discover.translation.mep_to_eap import QueryParts, translate_mep_to_
             "percentile(transaction.duration,0.5000):>100 AND percentile(transaction.duration, 0.25):>20",
             "(p50(span.duration):>100 AND percentile(span.duration, 0.25):>20) AND is_transaction:1",
         ),
+        pytest.param(
+            "user_misery(300):>0.5",
+            "(user_misery(span.duration,300):>0.5) AND is_transaction:1",
+        ),
+        pytest.param(
+            "apdex(300):>0.5",
+            "(apdex(span.duration,300):>0.5) AND is_transaction:1",
+        ),
     ],
 )
 def test_mep_to_eap_simple_query(input: str, expected: str):
@@ -96,6 +104,10 @@ def test_mep_to_eap_simple_query(input: str, expected: str):
         pytest.param(
             ["percentile(transaction.duration,0.5000)", "percentile(transaction.duration,0.94)"],
             ["p50(span.duration)", "percentile(span.duration,0.94)"],
+        ),
+        pytest.param(
+            ["user_misery(300)", "apdex(300)"],
+            ["user_misery(span.duration,300)", "apdex(span.duration,300)"],
         ),
     ],
 )


### PR DESCRIPTION
If it's parameter-less, use default threshold. If it's a function with a parameter, use the provided threshold.