### PR TITLE
chore(tests): Remove redundant op from acceptance tests

### DIFF
--- a/tests/acceptance/test_link_team.py
+++ b/tests/acceptance/test_link_team.py
@@ -69,7 +69,6 @@ class SlackLinkTeamTest(AcceptanceTestCase):
         self.browser.click('[name="team"]')
         self.browser.click(f'[value="{self.team.id}"]')
         self.browser.click('[type="submit"]')
-        self.browser.wait_until_not(".loading")
         # Ensure we get to the next page before checking for the ExternalActor
         self.browser.wait_until_test_id("back-to-slack")
 
@@ -97,7 +96,6 @@ class SlackLinkTeamTest(AcceptanceTestCase):
 
         self.browser.click(f'[value="{self.team.id}"]')
         self.browser.click('[type="submit"]')
-        self.browser.wait_until_not(".loading")
         # Ensure we get to the next page before checking for the ExternalActor
         self.browser.wait_until_test_id("back-to-slack")
 


### PR DESCRIPTION
These lines are made redundant by the following ones I added in https://github.com/getsentry/sentry/pull/94869, and can be removed (as per review, but I merged eagerly).