### PR TITLE
chore(pagerduty): add slos for installation redirect for pagerduty + test

### DIFF
--- a/src/sentry/integrations/on_call/metrics.py
+++ b/src/sentry/integrations/on_call/metrics.py
@@ -30,6 +30,7 @@ class OnCallInteractionType(Enum):
 
     # PagerDuty only
     VALIDATE_SERVICE = "VALIDATE_SERVICE"
+    INSTALLATION_REDIRECT = "INSTALLATION_REDIRECT"
 
     def __str__(self) -> str:
         return self.value.lower()

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -230,10 +230,11 @@ class PagerDutyInstallationRedirect:
         return f"https://{account_name}.pagerduty.com/install/integration?app_id={app_id}&redirect_url={setup_url}&version=2"
 
     def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
-        if "config" in request.GET:
-            pipeline.bind_state("config", request.GET["config"])
-            return pipeline.next_step()
+        with record_event(OnCallInteractionType.INSTALLATION_REDIRECT).capture():
+            if "config" in request.GET:
+                pipeline.bind_state("config", request.GET["config"])
+                return pipeline.next_step()
 
-        account_name = request.GET.get("account", None)
+            account_name = request.GET.get("account", None)
 
-        return HttpResponseRedirect(self.get_app_url(account_name))
+            return HttpResponseRedirect(self.get_app_url(account_name))


### PR DESCRIPTION
Pagerduty only has 1 custom pipeline view and it's a redirect form. It's p minor but with this I think we'll have all parts of the pagerduty install process covered.