### PR TITLE
fix(uptime): Allow failures in broken_monitor_checker task

### DIFF
--- a/src/sentry/uptime/subscriptions/tasks.py
+++ b/src/sentry/uptime/subscriptions/tasks.py
@@ -232,7 +232,10 @@ def broken_monitor_checker(**kwargs):
         detector = get_detector(uptime_subscription)
         assert detector
         if detector.config["mode"] == UptimeMonitorMode.AUTO_DETECTED_ACTIVE:
-            disable_uptime_detector(detector)
-            count += 1
+            try:
+                disable_uptime_detector(detector)
+                count += 1
+            except Exception:
+                logger.exception("uptime.subscriptions.disable_broken_failed")
 
     metrics.incr("uptime.subscriptions.disable_broken", amount=count, sample_rate=1.0)


### PR DESCRIPTION
Fixes: [NEW-449: Fix broken task that automatically deactivates long-running failing uptime monitors](https://linear.app/getsentry/issue/NEW-449/fix-broken-task-that-automatically-deactivates-long-running-failing)
Fixes: [SENTRY-454Z](https://sentry.sentry.io/issues/6725517791/events/780f7d6b2c4e48a5aa14abb7db722aba/)