### PR TITLE
chore(explore): Migrate explore off old feature flag

### DIFF
--- a/static/app/components/sidebar/index.spec.tsx
+++ b/static/app/components/sidebar/index.spec.tsx
@@ -35,8 +35,8 @@ const ALL_AVAILABLE_FEATURES = [
   'user-feedback-ui',
   'session-replay-ui',
   'performance-view',
-  'performance-trace-explorer',
   'profiling',
+  'visibility-explore-view',
 ];
 
 jest.mock('sentry/utils/demoMode');

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -212,14 +212,19 @@ function Sidebar() {
   );
 
   const traces = hasOrganization && (
-    <Feature features={['performance-trace-explorer', 'performance-view']}>
-      <SidebarItem
-        {...sidebarItemProps}
-        label={<GuideAnchor target="traces">{t('Traces')}</GuideAnchor>}
-        to={`/organizations/${organization.slug}/traces/`}
-        id="performance-trace-explorer"
-        icon={<SubitemDot collapsed />}
-      />
+    <Feature features={['performance-view']}>
+      <Feature
+        features={['performance-trace-explorer', 'visibility-explore-view']}
+        requireAll={false}
+      >
+        <SidebarItem
+          {...sidebarItemProps}
+          label={<GuideAnchor target="traces">{t('Traces')}</GuideAnchor>}
+          to={`/organizations/${organization.slug}/traces/`}
+          id="performance-trace-explorer"
+          icon={<SubitemDot collapsed />}
+        />
+      </Feature>
     </Feature>
   );
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -415,7 +415,10 @@ export function limitMaxPickableDays(organization: Organization): PickableDays {
 }
 
 export function getDefaultExploreRoute(organization: Organization) {
-  if (organization.features.includes('performance-trace-explorer')) {
+  if (
+    organization.features.includes('performance-trace-explorer') ||
+    organization.features.includes('visibility-explore-view')
+  ) {
     return 'traces';
   }
 

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -38,6 +38,7 @@ const ALL_AVAILABLE_FEATURES = [
   'performance-trace-explorer',
   'profiling',
   'enforce-stacked-navigation',
+  'visibility-explore-view',
 ];
 
 const mockUsingCustomerDomain = jest.fn();

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -36,14 +36,19 @@ export function ExploreSecondaryNav() {
       </SecondaryNav.Header>
       <SecondaryNav.Body>
         <SecondaryNav.Section id="explore-main">
-          <Feature features={['performance-trace-explorer', 'performance-view']}>
-            <SecondaryNav.Item
-              to={`${baseUrl}/traces/`}
-              analyticsItemName="explore_traces"
-              isActive={isLinkActive(`${baseUrl}/traces/`, location.pathname)}
+          <Feature features={['performance-view']}>
+            <Feature
+              features={['performance-trace-explorer', 'visibility-explore-view']}
+              requireAll={false}
             >
-              {t('Traces')}
-            </SecondaryNav.Item>
+              <SecondaryNav.Item
+                to={`${baseUrl}/traces/`}
+                analyticsItemName="explore_traces"
+                isActive={isLinkActive(`${baseUrl}/traces/`, location.pathname)}
+              >
+                {t('Traces')}
+              </SecondaryNav.Item>
+            </Feature>
           </Feature>
           <Feature features="ourlogs-enabled">
             <SecondaryNav.Item

--- a/static/app/views/traces/index.tsx
+++ b/static/app/views/traces/index.tsx
@@ -23,7 +23,8 @@ export default function TracesPage({children}: Props) {
 
   return (
     <Feature
-      features={['performance-trace-explorer']}
+      features={['performance-trace-explorer', 'visibility-explore-view']}
+      requireAll={false}
       organization={organization}
       renderDisabled={NoAccess}
     >


### PR DESCRIPTION
Previously, to turn on explore, one must have `performance-trace-explorer` as well as `visiblity-explore-view`. However, `performance-trace-explorer` was meant enable the old trace explorer. This change decouples the flags. `performance-trace-explorer` will only enable the old trace explorer view (this is to be removed in the near future) while `visibility-explore-view` enables the new explore view.