### PR TITLE
feat(uptime): Directly call process_detectors

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -45,13 +45,13 @@ from sentry.uptime.subscriptions.tasks import (
     send_uptime_config_deletion,
     update_remote_uptime_subscription,
 )
-from sentry.uptime.types import DATA_SOURCE_UPTIME_SUBSCRIPTION, IncidentStatus, UptimeMonitorMode
+from sentry.uptime.types import IncidentStatus, UptimeMonitorMode
 from sentry.utils import metrics
 from sentry.utils.arroyo_producer import SingletonProducer
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
-from sentry.workflow_engine.processors.data_packet import process_data_packets
+from sentry.workflow_engine.processors.detector import process_detectors
 
 logger = logging.getLogger(__name__)
 
@@ -312,9 +312,9 @@ def handle_active_result(
             subscription=uptime_subscription,
             metric_tags=metric_tags,
         )
-        process_data_packets(
-            [DataPacket(source_id=str(uptime_subscription.id), packet=packet)],
-            DATA_SOURCE_UPTIME_SUBSCRIPTION,
+        process_detectors(
+            DataPacket(source_id=str(uptime_subscription.id), packet=packet),
+            [detector],
         )
 
         # Bail if we're doing issue creation via detectors, we don't want to


### PR DESCRIPTION
We already have the Detector object, there's no reason we need to look
it up again via the process_data_packets interface.