### PR TITLE
fix(ui): Make self-hosted setup wizard page wider

### DIFF
--- a/static/app/views/admin/installWizard/index.tsx
+++ b/static/app/views/admin/installWizard/index.tsx
@@ -186,8 +186,8 @@ const SetupWizard = styled('div')`
   background: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};
-  margin-top: 40px;
   padding: 40px 40px 20px;
-  width: 600px;
+  max-width: 1000px;
+  margin: ${space(3)};
   z-index: ${p => p.theme.zIndex.initial};
 `;


### PR DESCRIPTION
Didn't take any screenshots when I saw this, but the page is quite small and uses our form components. it generally looks kinda janky