### PR TITLE
prevent: org-scoped urls

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1209,6 +1209,19 @@ USER_ROLE_URLS = [
     ),
 ]
 
+PREVENT_URLS = [
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results/$",
+        TestResultsEndpoint.as_view(),
+        name="sentry-api-0-test-results",
+    ),
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results-aggregates/$",
+        TestResultsAggregatesEndpoint.as_view(),
+        name="sentry-api-0-test-results-aggregates",
+    ),
+]
+
 ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
     re_path(
         r"^$",
@@ -2390,6 +2403,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-organization-insights-tree",
     ),
     *workflow_urls.organization_urlpatterns,
+    # Prevent
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)prevent/",
+        include(PREVENT_URLS),
+    ),
 ]
 
 PROJECT_URLS: list[URLPattern | URLResolver] = [
@@ -3288,19 +3306,6 @@ INTERNAL_URLS = [
         name="sentry-demo-mode-email-capture",
     ),
     *preprod_urls.preprod_internal_urlpatterns,
-]
-
-PREVENT_URLS = [
-    re_path(
-        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results/$",
-        TestResultsEndpoint.as_view(),
-        name="sentry-api-0-test-results",
-    ),
-    re_path(
-        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results-aggregates/$",
-        TestResultsAggregatesEndpoint.as_view(),
-        name="sentry-api-0-test-results-aggregates",
-    ),
 ]
 
 urlpatterns = [


### PR DESCRIPTION
this is not code to be merged, just opening PR for the purpose of discussion

i'm wondering what it would take to move the prevent urls to be org-scoped

from: /prevent/owner/*
to: /organizations/:orgid/prevent/owner/*

in order to cellularize getsentry, region silo urls should follow this pattern and include the org id/slug as this is will be used as a routing key to the cell.

the urls used for most other org specific features in getsentry already follow this pattern.

