### PR TITLE
fix(integrations): hide integration slug when no access to it

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -245,7 +245,6 @@ class SentryAppPermission(SentryPermission):
                     message="User must be in the app owner's organization for unpublished apps",
                     status_code=403,
                     public_context={
-                        "integration": sentry_app.slug,
                         "user_organizations": [org.slug for org in organizations],
                     },
                 )

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -91,7 +91,6 @@ class GetSentryAppDetailsTest(SentryAppDetailsTest):
             == "User must be in the app owner's organization for unpublished apps"
         )
         assert response.data["context"] == {
-            "integration": self.internal_integration.slug,
             "user_organizations": [],
         }
 
@@ -102,7 +101,6 @@ class GetSentryAppDetailsTest(SentryAppDetailsTest):
             == "User must be in the app owner's organization for unpublished apps"
         )
         assert response.data["context"] == {
-            "integration": self.unowned_unpublished_app.slug,
             "user_organizations": [self.organization.slug],
         }
 
@@ -468,7 +466,6 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             == "User must be in the app owner's organization for unpublished apps"
         )
         assert response.data["context"] == {
-            "integration": app.slug,
             "user_organizations": [self.organization.slug],
         }
 
@@ -773,7 +770,6 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
             == "User must be in the app owner's organization for unpublished apps"
         )
         assert response.data["context"] == {
-            "integration": self.unpublished_app.slug,
             "user_organizations": [],
         }
 


### PR DESCRIPTION
Fixes https://linear.app/getsentry/issue/CORE-5/