### PR TITLE
fix(ourlogs): Fix hover state on rows

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -239,7 +239,6 @@ export const LogRowContent = memo(function LogRowContent({
         data-test-id="log-table-row"
         {...rowInteractProps}
         onMouseEnter={() => setShouldRenderHoverElements(true)}
-        onMouseLeave={() => setShouldRenderHoverElements(false)}
       >
         <LogsTableBodyFirstCell key={'first'}>
           <LogFirstCellContent>


### PR DESCRIPTION
### Summary
To improve performance when rendering thousands of rows, we only add hoverable actions once you've hovered a row for the first time. This keeps the hoverable elements always rendered so a re-render doesn't cause the dropdown to disappear.
