### PR TITLE
chore(suspect flags): Include filtered flag in output

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_suspect_flags.py
+++ b/src/sentry/issues/endpoints/organization_group_suspect_flags.py
@@ -21,6 +21,7 @@ class ResponseDataItem(TypedDict):
     score: float
     baseline_percent: float
     distribution: Distribution
+    is_filtered: bool
 
 
 class ResponseData(TypedDict):
@@ -78,6 +79,7 @@ class OrganizationGroupSuspectFlagsEndpoint(GroupEndpoint):
                         "flag": item["flag"],
                         "score": item["score"],
                         "issue_id": group.id,
+                        "is_filtered": item["is_filtered"],
                     },
                 )
 

--- a/src/sentry/seer/math.py
+++ b/src/sentry/seer/math.py
@@ -101,20 +101,30 @@ def boxcox_transform(
     Returns:
         Tuple of (transformed values, lambda parameter used)
     """
+    min_value = min(values) if values else 0
+    if min_value <= 0:
+        shift_amount = -min_value + 1
+        shifted_values = [v + shift_amount for v in values]
+    else:
+        shifted_values = values
 
     if lambda_param is not None:
         if lambda_param == 0.0:
-            transformed = [math.log(max(v, 1e-10)) for v in values]
+            transformed = [math.log(max(v, 1e-10)) for v in shifted_values]
         else:
-            transformed = [(pow(max(v, 1e-10), lambda_param) - 1) / lambda_param for v in values]
+            transformed = [
+                (pow(max(v, 1e-10), lambda_param) - 1) / lambda_param for v in shifted_values
+            ]
         return transformed, lambda_param
 
     optimal_lambda = _boxcox_normmax(values)
 
     if optimal_lambda == 0.0:
-        transformed = [math.log(max(v, 1e-10)) for v in values]
+        transformed = [math.log(max(v, 1e-10)) for v in shifted_values]
     else:
-        transformed = [(pow(max(v, 1e-10), optimal_lambda) - 1) / optimal_lambda for v in values]
+        transformed = [
+            (pow(max(v, 1e-10), optimal_lambda) - 1) / optimal_lambda for v in shifted_values
+        ]
 
     return transformed, optimal_lambda
 

--- a/src/sentry/seer/math.py
+++ b/src/sentry/seer/math.py
@@ -223,7 +223,7 @@ def calculate_z_scores(values: list[float]) -> list[float]:
 
 
 def filter_by_z_score_threshold(
-    values: list[float], z_threshold: float = 1.5, lambda_param: float = 0.0
+    values: list[float], z_threshold: float = 1.5, lambda_param: float | None = None
 ) -> list[int]:
     """
     Get indices of values that pass BoxCox + z-score filtering.
@@ -234,7 +234,7 @@ def filter_by_z_score_threshold(
     Parameters:
         values: List of numerical values to filter
         z_threshold: Minimum z-score threshold for inclusion
-        lambda_param: BoxCox lambda parameter (0 for log transformation)
+        lambda_param: BoxCox lambda parameter (None for automatic selection)
 
     Returns:
         List of indices that pass the filtering criteria
@@ -242,11 +242,7 @@ def filter_by_z_score_threshold(
     if not values:
         return []
 
-    # Apply BoxCox transformation - unpack the tuple to get just the transformed values
     transformed_values, _ = boxcox_transform(values, lambda_param)
-
-    # Calculate z-scores on transformed data
     z_scores = calculate_z_scores(transformed_values)
 
-    # Return indices that meet the threshold
     return [i for i, z_score in enumerate(z_scores) if z_score >= z_threshold]

--- a/src/sentry/seer/math.py
+++ b/src/sentry/seer/math.py
@@ -173,8 +173,9 @@ def _boxcox_normmax(values: list[float], max_iters: int = 100) -> float:
     if not values:
         return 0.0
 
-    if any(v <= 0 for v in values):
-        raise ValueError("All values must be positive for BoxCox transformation")
+    min_value = min(values)
+    if min_value <= 0:
+        values = [v - min_value + 1 for v in values]
 
     left = -2.0
     right = 2.0

--- a/src/sentry/seer/math.py
+++ b/src/sentry/seer/math.py
@@ -161,7 +161,7 @@ def _boxcox_normmax(values: list[float], max_iters: int = 100) -> float:
     """
     Calculate the approximate optimal lambda parameter for BoxCox transformation that maximizes the log-likelihood.
 
-    Uses MLE method with ternary search rather than Brent's methodfor efficient optimization.
+    Uses MLE method with ternary search rather than Brent's method for efficient optimization.
 
     Parameters:
         values: List of positive values

--- a/src/sentry/seer/workflows/compare.py
+++ b/src/sentry/seer/workflows/compare.py
@@ -207,7 +207,7 @@ def keyed_rrf_score_with_filter(
 ) -> list[tuple[str, float, bool]]:
     """
     RRF score a multi-dimensional distribution of values. Returns a list of key, score pairs, and a mapping of if the key was filtered.
-    The filtered keys are those that have a normalized entropy or kl score greater than the z_threshold.
+    The filtered keys are those that have a normalized entropy and kl score less than the z_threshold.
     Duplicates are not tolerated.
 
     Sample distribution:
@@ -243,7 +243,7 @@ def keyed_rrf_score_with_filter(
     kl_z_scores = calculate_z_scores(normalized_kl_scores)
 
     filtered_keys = [
-        entropy_z_score <= z_threshold or kl_z_score <= z_threshold
+        entropy_z_score <= z_threshold and kl_z_score <= z_threshold
         for entropy_z_score, kl_z_score in zip(entropy_z_scores, kl_z_scores)
     ]
 

--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
@@ -69,6 +69,7 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
                             "true": 1,
                         },
                     },
+                    "is_filtered": True,
                 },
                 {
                     "flag": "other",
@@ -82,6 +83,7 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
                             "false": 1,
                         },
                     },
+                    "is_filtered": False,
                 },
             ]
         }

--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
@@ -83,7 +83,7 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
                             "false": 1,
                         },
                     },
-                    "is_filtered": False,
+                    "is_filtered": True,
                 },
             ]
         }

--- a/tests/sentry/issues/test_suspect_flags.py
+++ b/tests/sentry/issues/test_suspect_flags.py
@@ -139,6 +139,6 @@ class SnubaTest(TestCase, SnubaTestCase):
                 "score": 0.016181914331041776,
                 "baseline_percent": 0,
                 "distribution": {"baseline": {"false": 2}, "outliers": {"false": 1}},
-                "is_filtered": False,
+                "is_filtered": True,
             },
         ]

--- a/tests/sentry/issues/test_suspect_flags.py
+++ b/tests/sentry/issues/test_suspect_flags.py
@@ -132,11 +132,13 @@ class SnubaTest(TestCase, SnubaTestCase):
                     "baseline": {"false": 1, "true": 1},
                     "outliers": {"true": 1},
                 },
+                "is_filtered": True,
             },
             {
                 "flag": "other",
                 "score": 0.016181914331041776,
                 "baseline_percent": 0,
                 "distribution": {"baseline": {"false": 2}, "outliers": {"false": 1}},
+                "is_filtered": False,
             },
         ]

--- a/tests/sentry/seer/workflows/test_compare.py
+++ b/tests/sentry/seer/workflows/test_compare.py
@@ -258,13 +258,13 @@ def test_keyed_rrf_score_with_filter_threshold_behavior():
     ]
     outliers = [("key", "true", 10), ("other", "true", 100), ("other", "false", 500)]
 
-    # With high threshold, no keys should be filtered
+    # With low threshold, no keys should be filtered
     high_threshold_scores = keyed_rrf_score_with_filter(
         baseline,
         outliers,
         total_baseline=sum(i[2] for i in baseline),
         total_outliers=sum(i[2] for i in outliers),
-        z_threshold=10.0,
+        z_threshold=-10.0,
     )
 
     for key, score, filtered in high_threshold_scores:


### PR DESCRIPTION
- Performs a filtering step prior to RRF
  - Normalizes KL and Entropy scores with Box Cox transform then takes scores which have a z-score >= threshold
  	- Threshold is currently 1.5 but can be adjusted if over/under filtering on RRF
- Exposes if the flag has been filtered out in the JSON response as a boolean such that all flags are still visible on the frontend if required

TODO:
- Update frontend to use these filtered scores when sorting by `Heuristic + RRF` or `RRF` 