### PR TITLE
feat(aci): add action validation to automation builder

### DIFF
--- a/static/app/views/automations/components/actionNodeList.spec.tsx
+++ b/static/app/views/automations/components/actionNodeList.spec.tsx
@@ -11,6 +11,7 @@ import {
   ActionType,
 } from 'sentry/types/workflowEngine/actions';
 import ActionNodeList from 'sentry/views/automations/components/actionNodeList';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 
 const slackActionHandler = ActionHandlerFixture();
 const actionHandlers: ActionHandler[] = [
@@ -68,9 +69,16 @@ describe('ActionNodeList', function () {
   });
 
   it('renders correct action options', async function () {
-    render(<ActionNodeList {...defaultProps} />, {
-      organization,
-    });
+    render(
+      <AutomationBuilderErrorContext.Provider
+        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
+      >
+        <ActionNodeList {...defaultProps} />
+      </AutomationBuilderErrorContext.Provider>,
+      {
+        organization,
+      }
+    );
     await userEvent.click(screen.getByRole('textbox', {name: 'Add action'}));
 
     expect(screen.getAllByRole('menuitemradio')).toHaveLength(5);
@@ -87,9 +95,16 @@ describe('ActionNodeList', function () {
   });
 
   it('adds actions', async function () {
-    render(<ActionNodeList {...defaultProps} />, {
-      organization,
-    });
+    render(
+      <AutomationBuilderErrorContext.Provider
+        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
+      >
+        <ActionNodeList {...defaultProps} />
+      </AutomationBuilderErrorContext.Provider>,
+      {
+        organization,
+      }
+    );
     await userEvent.click(screen.getByRole('textbox', {name: 'Add action'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Slack'}));
 
@@ -98,9 +113,16 @@ describe('ActionNodeList', function () {
 
   it('updates existing actions', async function () {
     const slackAction = ActionFixture();
-    render(<ActionNodeList {...defaultProps} actions={[slackAction]} />, {
-      organization,
-    });
+    render(
+      <AutomationBuilderErrorContext.Provider
+        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
+      >
+        <ActionNodeList {...defaultProps} actions={[slackAction]} />
+      </AutomationBuilderErrorContext.Provider>,
+      {
+        organization,
+      }
+    );
 
     await screen.findByText(textWithMarkupMatcher('Slack message'));
     await userEvent.type(screen.getByRole('textbox', {name: 'Tags'}), 's');
@@ -111,9 +133,16 @@ describe('ActionNodeList', function () {
 
   it('deletes existing actions', async function () {
     const slackAction = ActionFixture();
-    render(<ActionNodeList {...defaultProps} actions={[slackAction]} />, {
-      organization,
-    });
+    render(
+      <AutomationBuilderErrorContext.Provider
+        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
+      >
+        <ActionNodeList {...defaultProps} actions={[slackAction]} />
+      </AutomationBuilderErrorContext.Provider>,
+      {
+        organization,
+      }
+    );
 
     await screen.findByText(textWithMarkupMatcher('Slack message'));
     await userEvent.click(screen.getByRole('button', {name: 'Delete row'}));

--- a/static/app/views/automations/components/actionNodeList.spec.tsx
+++ b/static/app/views/automations/components/actionNodeList.spec.tsx
@@ -52,7 +52,7 @@ describe('ActionNodeList', function () {
 
   const defaultProps = {
     actions: [],
-    group: '0',
+    conditionGroupId: '0',
     onAddRow: mockOnAddRow,
     onDeleteRow: mockOnDeleteRow,
     placeholder: 'Select an action',

--- a/static/app/views/automations/components/actionNodes.tsx
+++ b/static/app/views/automations/components/actionNodes.tsx
@@ -11,8 +11,13 @@ import {
 import {
   DiscordDetails,
   DiscordNode,
+  validateDiscordAction,
 } from 'sentry/views/automations/components/actions/discord';
-import {EmailDetails, EmailNode} from 'sentry/views/automations/components/actions/email';
+import {
+  EmailDetails,
+  EmailNode,
+  validateEmailAction,
+} from 'sentry/views/automations/components/actions/email';
 import {
   GithubDetails,
   GithubNode,
@@ -29,22 +34,30 @@ import {
 import {
   MSTeamsDetails,
   MSTeamsNode,
+  validateMSTeamsAction,
 } from 'sentry/views/automations/components/actions/msTeams';
 import {
   OpsgenieDetails,
   OpsgenieNode,
+  validateOpsgenieAction,
 } from 'sentry/views/automations/components/actions/opsgenie';
 import {
   PagerdutyDetails,
   PagerdutyNode,
+  validatePagerdutyAction,
 } from 'sentry/views/automations/components/actions/pagerduty';
 import {PluginNode} from 'sentry/views/automations/components/actions/plugin';
 import {
   SentryAppDetails,
   SentryAppNode,
 } from 'sentry/views/automations/components/actions/sentryApp';
-import {SlackDetails, SlackNode} from 'sentry/views/automations/components/actions/slack';
 import {
+  SlackDetails,
+  SlackNode,
+  validateSlackAction,
+} from 'sentry/views/automations/components/actions/slack';
+import {
+  validateWebhookAction,
   WebhookDetails,
   WebhookNode,
 } from 'sentry/views/automations/components/actions/webhook';
@@ -68,6 +81,7 @@ export function useActionNodeContext(): ActionNodeProps {
 
 type ActionNode = {
   action: React.ComponentType<any>;
+  validate: ((action: Action) => string | undefined) | undefined;
   defaultData?: Record<string, any>;
   details?: React.ComponentType<any>;
   label?: string;
@@ -84,6 +98,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       details: AzureDevOpsDetails,
       ticketType: t('an Azure DevOps work item'),
       link: 'https://docs.sentry.io/product/integrations/source-code-mgmt/azure-devops/#issue-sync',
+      validate: validateIntegrationId,
     },
   ],
   [
@@ -93,6 +108,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       action: EmailNode,
       details: EmailDetails,
       defaultData: {fallthroughType: 'ActiveMembers'},
+      validate: validateEmailAction,
     },
   ],
   [
@@ -101,6 +117,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       label: t('Discord'),
       action: DiscordNode,
       details: DiscordDetails,
+      validate: validateDiscordAction,
     },
   ],
   [
@@ -110,6 +127,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       action: GithubNode,
       details: GithubDetails,
       ticketType: t('a GitHub issue'),
+      validate: validateIntegrationId,
     },
   ],
   [
@@ -119,6 +137,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       action: GithubEnterpriseNode,
       details: GithubEnterpriseDetails,
       ticketType: t('a GitHub Enterprise issue'),
+      validate: validateIntegrationId,
     },
   ],
   [
@@ -129,6 +148,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       details: JiraDetails,
       ticketType: t('a Jira issue'),
       link: 'https://docs.sentry.io/product/integrations/issue-tracking/jira/#issue-sync',
+      validate: validateIntegrationId,
     },
   ],
   [
@@ -139,6 +159,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       details: JiraServerDetails,
       ticketType: t('a Jira Server issue'),
       link: 'https://docs.sentry.io/product/integrations/issue-tracking/jira/#issue-sync',
+      validate: validateIntegrationId,
     },
   ],
   [
@@ -147,6 +168,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       label: t('MS Teams'),
       action: MSTeamsNode,
       details: MSTeamsDetails,
+      validate: validateMSTeamsAction,
     },
   ],
   [
@@ -156,6 +178,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       action: OpsgenieNode,
       details: OpsgenieDetails,
       defaultData: {priority: 'P1'},
+      validate: validateOpsgenieAction,
     },
   ],
   [
@@ -165,6 +188,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       action: PagerdutyNode,
       details: PagerdutyDetails,
       defaultData: {priority: 'default'},
+      validate: validatePagerdutyAction,
     },
   ],
   [
@@ -173,6 +197,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       label: t('Legacy integrations'),
       action: PluginNode,
       details: PluginNode,
+      validate: undefined,
     },
   ],
   [
@@ -180,6 +205,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
     {
       action: SentryAppNode,
       details: SentryAppDetails,
+      validate: undefined,
     },
   ],
   [
@@ -188,6 +214,7 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       label: t('Slack'),
       action: SlackNode,
       details: SlackDetails,
+      validate: validateSlackAction,
     },
   ],
   [
@@ -196,6 +223,14 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
       label: t('Send a notification via an integration'),
       action: WebhookNode,
       details: WebhookDetails,
+      validate: validateWebhookAction,
     },
   ],
 ]);
+
+function validateIntegrationId(action: Action): string | undefined {
+  if (!action.integrationId) {
+    return t('You must specify an integration installation.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -66,3 +66,13 @@ export function DiscordNode() {
     </Flex>
   );
 }
+
+export function validateDiscordAction(action: Action): string | undefined {
+  if (!action.integrationId) {
+    return t('You must specify a Discord server.');
+  }
+  if (!action.config.target_display) {
+    return t('You must specify a channel ID or URL.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/actions/msTeams.tsx
+++ b/static/app/views/automations/components/actions/msTeams.tsx
@@ -1,5 +1,5 @@
 import {ActionMetadata} from 'sentry/components/workflowEngine/ui/actionMetadata';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {
   type Action,
   type ActionHandler,
@@ -19,7 +19,7 @@ export function MSTeamsDetails({
     handler.integrations?.find(i => i.id === action.integrationId)?.name ||
     action.integrationId;
 
-  return tct('Send a [logo] Microsoft Teams notification to [team] Team, to [channel]', {
+  return tct('Send a [logo] Microsoft Teams notification to [team] team, to [channel]', {
     logo: ActionMetadata[ActionType.MSTEAMS]?.icon,
     team: integrationName,
     channel: String(action.config.target_identifier),
@@ -27,9 +27,19 @@ export function MSTeamsDetails({
 }
 
 export function MSTeamsNode() {
-  return tct('Send a [logo] Microsoft Teams notification to [team] Team, to [channel]', {
+  return tct('Send a [logo] Microsoft Teams notification to [team] team, to [channel]', {
     logo: ActionMetadata[ActionType.MSTEAMS]?.icon,
     team: <IntegrationField />,
     channel: <TargetDisplayField />,
   });
+}
+
+export function validateMSTeamsAction(action: Action): string | undefined {
+  if (!action.integrationId) {
+    return t('You must specify a Microsoft Teams team.');
+  }
+  if (!action.config.target_display) {
+    return t('You must specify a channel.');
+  }
+  return undefined;
 }

--- a/static/app/views/automations/components/actions/opsgenie.tsx
+++ b/static/app/views/automations/components/actions/opsgenie.tsx
@@ -64,3 +64,16 @@ function PriorityField() {
     />
   );
 }
+
+export function validateOpsgenieAction(action: Action): string | undefined {
+  if (!action.integrationId) {
+    return t('You must specify an Opsgenie configuration.');
+  }
+  if (!action.config.target_identifier) {
+    return t('You must specify a team.');
+  }
+  if (!action.data.priority) {
+    return t('You must specify a priority.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/actions/pagerduty.tsx
+++ b/static/app/views/automations/components/actions/pagerduty.tsx
@@ -64,3 +64,16 @@ function SeverityField() {
     />
   );
 }
+
+export function validatePagerdutyAction(action: Action): string | undefined {
+  if (!action.integrationId) {
+    return t('You must specify a PagerDuty integration.');
+  }
+  if (!action.config.target_identifier) {
+    return t('You must specify a service.');
+  }
+  if (!action.data.priority) {
+    return t('You must specify a severity.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -102,3 +102,13 @@ function NotesField() {
     />
   );
 }
+
+export function validateSlackAction(action: Action): string | undefined {
+  if (!action.integrationId) {
+    return t('You must specify a Slack workspace.');
+  }
+  if (!action.config.target_display) {
+    return t('You must specify a channel name or ID.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/actions/targetDisplayField.tsx
+++ b/static/app/views/automations/components/actions/targetDisplayField.tsx
@@ -1,9 +1,12 @@
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
 import {t} from 'sentry/locale';
 import {useActionNodeContext} from 'sentry/views/automations/components/actionNodes';
+import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 
 export function TargetDisplayField({placeholder}: {placeholder?: string}) {
   const {action, actionId, onUpdate} = useActionNodeContext();
+  const {removeError} = useAutomationBuilderErrorContext();
+
   return (
     <AutomationBuilderInput
       name={`${actionId}.config.target_display`}
@@ -14,6 +17,7 @@ export function TargetDisplayField({placeholder}: {placeholder?: string}) {
         onUpdate({
           config: {...action.config, target_display: e.target.value},
         });
+        removeError(action.id);
       }}
     />
   );

--- a/static/app/views/automations/components/actions/webhook.tsx
+++ b/static/app/views/automations/components/actions/webhook.tsx
@@ -50,3 +50,10 @@ function ServicesField() {
     />
   );
 }
+
+export function validateWebhookAction(action: Action): string | undefined {
+  if (!action.config.target_identifier) {
+    return t('You must specify an integration.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -182,10 +182,9 @@ function ActionFilterBlock({
             then: <ConditionBadge />,
           })}
         </StepLead>
-        {/* TODO: add actions dropdown here */}
         <ActionNodeList
           placeholder={t('Select an action')}
-          group={`actionFilters.${actionFilter.id}`}
+          conditionGroupId={actionFilter.id}
           actions={actionFilter?.actions || []}
           onAddRow={handler => actions.addIfAction(actionFilter.id, handler)}
           onDeleteRow={id => actions.removeIfAction(actionFilter.id, id)}

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -193,6 +193,7 @@ export const initialAutomationBuilderState: AutomationBuilderState = {
       id: '0',
       logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
       conditions: [],
+      actions: [],
     },
   ],
 };
@@ -369,6 +370,7 @@ function addIf(
       {
         id: uuid4(),
         conditions: [],
+        actions: [],
         logicType: DataConditionGroupLogicType.ALL,
       },
     ],
@@ -404,7 +406,6 @@ function addIfCondition(
           {
             id: uuid4(),
             type: conditionType,
-            // comparison: true,
             comparison:
               dataConditionNodesMap.get(conditionType)?.defaultComparison || true,
             conditionResult: true,

--- a/static/app/views/automations/components/automationBuilderErrorContext.tsx
+++ b/static/app/views/automations/components/automationBuilderErrorContext.tsx
@@ -1,0 +1,17 @@
+import {createContext, useContext} from 'react';
+
+export const AutomationBuilderErrorContext = createContext<{
+  errors: Record<string, string>;
+  removeError: (errorId: string) => void;
+  setErrors: (errors: Record<string, string>) => void;
+} | null>(null);
+
+export const useAutomationBuilderErrorContext = () => {
+  const context = useContext(AutomationBuilderErrorContext);
+  if (!context) {
+    throw new Error(
+      'useAutomationBuilderErrorContext was called outside of AutomationBuilder'
+    );
+  }
+  return context;
+};

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 
+import {Alert} from 'sentry/components/core/alert';
 import {Button} from 'sentry/components/core/button';
+import {Flex} from 'sentry/components/core/layout';
 import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -9,26 +11,35 @@ import {space} from 'sentry/styles/space';
 interface RowProps {
   children: React.ReactNode;
   onDelete: () => void;
-  isConflicting?: boolean;
+  errorMessage?: string;
+  hasError?: boolean;
 }
 
 export default function AutomationBuilderRow({
   onDelete,
   children,
-  isConflicting,
+  hasError,
+  errorMessage,
 }: RowProps) {
   return (
-    <RowContainer incompatible={isConflicting}>
-      <RowLine>{children}</RowLine>
-      <DeleteButton
-        aria-label={t('Delete row')}
-        size="sm"
-        icon={<IconDelete />}
-        borderless
-        onClick={onDelete}
-        className={'delete-row'}
-      />
-    </RowContainer>
+    <Flex direction="column" gap={space(0.5)}>
+      <RowContainer incompatible={hasError}>
+        <RowLine>{children}</RowLine>
+        <DeleteButton
+          aria-label={t('Delete row')}
+          size="sm"
+          icon={<IconDelete />}
+          borderless
+          onClick={onDelete}
+          className={'delete-row'}
+        />
+      </RowContainer>
+      {hasError && errorMessage && (
+        <Alert type={'error'} showIcon>
+          {errorMessage}
+        </Alert>
+      )}
+    </Flex>
   );
 }
 

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -158,7 +158,7 @@ export default function DataConditionNodeList({
             <AutomationBuilderRow
               key={`${group}.conditions.${condition.id}`}
               onDelete={() => onDeleteRowHandler(condition)}
-              isConflicting={conflictingConditionIds.includes(condition.id)}
+              hasError={conflictingConditionIds.includes(condition.id)}
             >
               <DataConditionNodeContext.Provider
                 value={{

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -155,6 +155,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       label: t('Issue frequency'),
       dataCondition: IssueOccurrencesNode,
       details: IssueOccurrencesDetails,
+      defaultComparison: {value: 10},
     },
   ],
   [

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -28,6 +28,7 @@ import {
   initialAutomationBuilderState,
   useAutomationBuilderReducer,
 } from 'sentry/views/automations/components/automationBuilderContext';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import AutomationForm from 'sentry/views/automations/components/automationForm';
 import {getAutomationFormData} from 'sentry/views/automations/components/automationFormData';
 import {EditableAutomationName} from 'sentry/views/automations/components/editableAutomationName';
@@ -94,6 +95,16 @@ export default function AutomationEdit() {
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer(initialState);
 
+  const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
+    Record<string, string>
+  >({});
+  const removeError = useCallback((errorId: string) => {
+    setAutomationBuilderErrors(prev => {
+      const {[errorId]: _removedError, ...remainingErrors} = prev;
+      return remainingErrors;
+    });
+  }, []);
+
   if (isPending && !initialData) {
     return <LoadingIndicator />;
   }
@@ -116,9 +127,17 @@ export default function AutomationEdit() {
         </StyledLayoutHeader>
         <Layout.Body>
           <Layout.Main fullWidth>
-            <AutomationBuilderContext.Provider value={{state, actions}}>
-              <AutomationForm model={model} />
-            </AutomationBuilderContext.Provider>
+            <AutomationBuilderErrorContext.Provider
+              value={{
+                errors: automationBuilderErrors,
+                setErrors: setAutomationBuilderErrors,
+                removeError,
+              }}
+            >
+              <AutomationBuilderContext.Provider value={{state, actions}}>
+                <AutomationForm model={model} />
+              </AutomationBuilderContext.Provider>
+            </AutomationBuilderErrorContext.Provider>
           </Layout.Main>
         </Layout.Body>
       </Layout.Page>

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -93,6 +93,12 @@ export default function AutomationNewSettings() {
   const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
     Record<string, string>
   >({});
+  const removeError = useCallback((errorId: string) => {
+    setAutomationBuilderErrors(prev => {
+      const {[errorId]: _removedError, ...remainingErrors} = prev;
+      return remainingErrors;
+    });
+  }, []);
 
   const initialConnectedIds = useMemo(() => {
     const connectedIdsQuery = location.query.connectedIds as
@@ -109,13 +115,6 @@ export default function AutomationNewSettings() {
   }, [location.query.connectedIds]);
 
   const {mutateAsync: createAutomation} = useCreateAutomation();
-
-  const removeError = useCallback((errorId: string) => {
-    setAutomationBuilderErrors(prev => {
-      const {[errorId]: _removedError, ...remainingErrors} = prev;
-      return remainingErrors;
-    });
-  }, []);
 
   const handleSubmit = useCallback<OnSubmitCallback>(
     async (data, _, __, ___, ____) => {

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -123,7 +123,7 @@ export default function AutomationNewSettings() {
       const errors = validateAutomationBuilderState(state);
       setAutomationBuilderErrors(errors);
 
-      if (!errors) {
+      if (Object.keys(errors).length === 0) {
         const automation = await createAutomation(
           getNewAutomationData(data as AutomationFormData, state)
         );

--- a/static/app/views/automations/new-settings.tsx
+++ b/static/app/views/automations/new-settings.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -21,10 +21,13 @@ import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {actionNodesMap} from 'sentry/views/automations/components/actionNodes';
+import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
 import {
   AutomationBuilderContext,
   useAutomationBuilderReducer,
 } from 'sentry/views/automations/components/automationBuilderContext';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import AutomationForm from 'sentry/views/automations/components/automationForm';
 import type {AutomationFormData} from 'sentry/views/automations/components/automationFormData';
 import {getNewAutomationData} from 'sentry/views/automations/components/automationFormData';
@@ -62,6 +65,23 @@ const initialData = {
   frequency: 1440,
 };
 
+function validateAutomationBuilderState(state: AutomationBuilderState) {
+  const errors: Record<string, string> = {};
+  for (const actionFilter of state.actionFilters) {
+    if (actionFilter.actions?.length === 0) {
+      errors[actionFilter.id] = t('You must add an action for this automation to run.');
+      continue;
+    }
+    for (const action of actionFilter.actions || []) {
+      const validationResult = actionNodesMap.get(action.type)?.validate?.(action);
+      if (validationResult) {
+        errors[action.id] = validationResult;
+      }
+    }
+  }
+  return errors;
+}
+
 export default function AutomationNewSettings() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -69,6 +89,10 @@ export default function AutomationNewSettings() {
   useWorkflowEngineFeatureGate({redirect: true});
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
+
+  const [automationBuilderErrors, setAutomationBuilderErrors] = useState<
+    Record<string, string>
+  >({});
 
   const initialConnectedIds = useMemo(() => {
     const connectedIdsQuery = location.query.connectedIds as
@@ -86,13 +110,25 @@ export default function AutomationNewSettings() {
 
   const {mutateAsync: createAutomation} = useCreateAutomation();
 
+  const removeError = useCallback((errorId: string) => {
+    setAutomationBuilderErrors(prev => {
+      const {[errorId]: _removedError, ...remainingErrors} = prev;
+      return remainingErrors;
+    });
+  }, []);
+
   const handleSubmit = useCallback<OnSubmitCallback>(
     async (data, _, __, ___, ____) => {
       // TODO: add form validation
-      const automation = await createAutomation(
-        getNewAutomationData(data as AutomationFormData, state)
-      );
-      navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
+      const errors = validateAutomationBuilderState(state);
+      setAutomationBuilderErrors(errors);
+
+      if (!errors) {
+        const automation = await createAutomation(
+          getNewAutomationData(data as AutomationFormData, state)
+        );
+        navigate(makeAutomationDetailsPathname(organization.slug, automation.id));
+      }
     },
     [createAutomation, state, navigate, organization.slug]
   );
@@ -116,9 +152,17 @@ export default function AutomationNewSettings() {
         </StyledLayoutHeader>
         <Layout.Body>
           <Layout.Main fullWidth>
-            <AutomationBuilderContext.Provider value={{state, actions}}>
-              <AutomationForm model={model} />
-            </AutomationBuilderContext.Provider>
+            <AutomationBuilderErrorContext.Provider
+              value={{
+                errors: automationBuilderErrors,
+                setErrors: setAutomationBuilderErrors,
+                removeError,
+              }}
+            >
+              <AutomationBuilderContext.Provider value={{state, actions}}>
+                <AutomationForm model={model} />
+              </AutomationBuilderContext.Provider>
+            </AutomationBuilderErrorContext.Provider>
           </Layout.Main>
         </Layout.Body>
       </Layout.Page>


### PR DESCRIPTION
- created simple validation functions for each action type
- added an `AutomationBuilderErrorsContext` to store error state
- on form submission, the validation function is ran for each action. if there are any errors, these are saved to the `errors` Record
- if an action has an error in the `errors` mapping, the error is displayed until `onChange` is triggered
    - just a note that only certain fields clear the errors `onChange`. we expect most fields to have a default value already filled, so these fields would not be causing validation errors

https://github.com/user-attachments/assets/4ae672d9-83c3-477d-817f-52c8f5ecc896

