### PR TITLE
chore(eap): make seer tests not sample

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -349,6 +349,7 @@ def get_attribute_values_with_substring(
     fields_with_substrings: list[dict[str, str]],
     stats_period: str = "48h",
     limit: int = 100,
+    sampled: bool = True,
 ) -> dict:
     """
     Get attribute values with substring.
@@ -369,6 +370,12 @@ def get_attribute_values_with_substring(
     start_time_proto.FromDatetime(start)
     end_time_proto = ProtobufTimestamp()
     end_time_proto.FromDatetime(end)
+
+    sampling_mode = (
+        DownsampledStorageConfig.MODE_NORMAL
+        if sampled
+        else DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+    )
 
     resolver = SearchResolver(
         params=SnubaParams(
@@ -394,6 +401,7 @@ def get_attribute_values_with_substring(
                     start_timestamp=start_time_proto,
                     end_timestamp=end_time_proto,
                     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    downsampled_storage_config=DownsampledStorageConfig(mode=sampling_mode),
                 ),
                 key=resolved_field.proto_definition,
                 limit=limit,

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -449,11 +449,6 @@ def get_attributes_and_values(
         trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
         downsampled_storage_config=DownsampledStorageConfig(mode=sampling_mode),
     )
-    if not sampled:
-        meta.downsampled_storage_config = DownsampledStorageConfig(
-            mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
-        )
-
     filter = TraceItemFilter()
     stats_type = StatsType(
         attribute_distributions=AttributeDistributionsRequest(

--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -19,6 +19,7 @@ from rest_framework.exceptions import (
 )
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeNamesRequest,
     TraceItemAttributeValuesRequest,
@@ -286,6 +287,7 @@ def get_attribute_values(
     project_ids: list[int],
     stats_period: str,
     limit: int = 100,
+    sampled: bool = True,
 ) -> dict:
     period = parse_stats_period(stats_period)
     if period is None:
@@ -298,6 +300,12 @@ def get_attribute_values(
     start_time_proto.FromDatetime(start)
     end_time_proto = ProtobufTimestamp()
     end_time_proto.FromDatetime(end)
+
+    sampling_mode = (
+        DownsampledStorageConfig.MODE_NORMAL
+        if sampled
+        else DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+    )
 
     values = {}
     resolver = SearchResolver(
@@ -322,6 +330,7 @@ def get_attribute_values(
                     start_timestamp=start_time_proto,
                     end_timestamp=end_time_proto,
                     trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+                    downsampled_storage_config=DownsampledStorageConfig(mode=sampling_mode),
                 ),
                 key=resolved_field.proto_definition,
                 limit=limit,
@@ -407,6 +416,7 @@ def get_attributes_and_values(
     stats_period: str,
     max_values: int = 100,
     max_attributes: int = 1000,
+    sampled: bool = True,
 ) -> dict:
     """
     Fetches all string attributes and the corresponding values with counts for a given period.
@@ -423,6 +433,12 @@ def get_attributes_and_values(
     end_time_proto = ProtobufTimestamp()
     end_time_proto.FromDatetime(end)
 
+    sampling_mode = (
+        DownsampledStorageConfig.MODE_NORMAL
+        if sampled
+        else DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+    )
+
     meta = RequestMeta(
         organization_id=org_id,
         cogs_category="events_analytics_platform",
@@ -431,7 +447,12 @@ def get_attributes_and_values(
         start_timestamp=start_time_proto,
         end_timestamp=end_time_proto,
         trace_item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+        downsampled_storage_config=DownsampledStorageConfig(mode=sampling_mode),
     )
+    if not sampled:
+        meta.downsampled_storage_config = DownsampledStorageConfig(
+            mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+        )
 
     filter = TraceItemFilter()
     stats_type = StatsType(

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -164,6 +164,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             org_id=self.organization.id,
             project_ids=[self.project.id],
             stats_period="7d",
+            sampled=False,
         )
 
         assert result == {

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -74,6 +74,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             org_id=self.organization.id,
             project_ids=[self.project.id],
             stats_period="7d",
+            sampled=False,
         )
 
         assert result == {
@@ -122,6 +123,7 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                     "substring": "b",
                 },
             ],
+            sampled=False,
         )
 
         assert result == {


### PR DESCRIPTION
In order to merge https://github.com/getsentry/snuba/pull/7267 we want to make sure that these tests don't break. These tests insert two items and get their data back. Not indicative of the usual workflow of things. Make them pass the `HIGHEST_ACCURACY` downsampling mode into the RPC in order to assure no sampling happens