### PR TITLE
ref(replay): add experimental return_raw_logs param to summary endpoint

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -321,6 +321,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:release-comparison-performance", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable replay AI summaries
     manager.add("organizations:replay-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable queries for logs used to prompt replay AI summaries (experimental)
+    manager.add("organizations:replay-ai-summaries-raw-logs-access", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
     # Enable replay list selection
     manager.add("organizations:replay-list-select", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable version 2 of reprocessing (completely distinct from v1)


### PR DESCRIPTION
Allows us to get the logs used to generate replay summaries, for prompt experiment purposes. @billyvg and @michellewzhang were doing this a while back in https://github.com/getsentry/sentry/pull/93988, but that involves copying all the event parsing logic to typescript and keeping it up to date. 

We can enable this for just our team, then use this flow for testing prompts:
- from dev-ui, call this prod endpoint for a replay's logs
- from dev-ui, post the logs to your **local** seer endpoint in similar fashion as https://github.com/getsentry/sentry/pull/93988

