### PR TITLE
ref(workflow_engine): Fix `config` values to be camel cased

### DIFF
--- a/src/sentry/workflow_engine/endpoints/serializers.py
+++ b/src/sentry/workflow_engine/endpoints/serializers.py
@@ -12,6 +12,7 @@ from django.db.models.functions import TruncHour
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
@@ -51,7 +52,7 @@ class ActionSerializer(Serializer):
             "type": obj.type,
             "integrationId": str(obj.integration_id) if obj.integration_id else None,
             "data": obj.data,
-            "config": obj.config,
+            "config": convert_dict_key_case(obj.config, snake_to_camel_case),
         }
 
 
@@ -353,7 +354,7 @@ class DetectorSerializer(Serializer):
             "dateUpdated": obj.date_updated,
             "dataSources": attrs.get("data_sources"),
             "conditionGroup": attrs.get("condition_group"),
-            "config": attrs.get("config"),
+            "config": convert_dict_key_case(attrs.get("config"), snake_to_camel_case),
             "enabled": obj.enabled,
         }
 
@@ -424,7 +425,7 @@ class WorkflowSerializer(Serializer):
             "triggers": attrs.get("triggers"),
             "actionFilters": attrs.get("actionFilters"),
             "environment": obj.environment.name if obj.environment else None,
-            "config": obj.config,
+            "config": convert_dict_key_case(obj.config, snake_to_camel_case),
             "detectorIds": attrs.get("detectorIds"),
             "enabled": obj.enabled,
             "lastTriggered": attrs.get("lastTriggered"),

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -89,7 +89,14 @@ class WorkflowValidator(CamelSnakeSerializer):
 
         validator = BaseActionValidator(context=self.context)
         for action in actions_data:
-            self._update_or_create(action, validator, Action)
+            action_instance = self._update_or_create(action, validator, Action)
+
+            # If this is a new action, associate it to the condition group
+            if action.get("id") is None:
+                DataConditionGroupAction.objects.create(
+                    action=action_instance,
+                    condition_group=condition_group,
+                )
 
     def update_or_create_data_condition_group(
         self,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -309,8 +309,8 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
                 ],
             },
             "config": {
-                "threshold_period": 1,
-                "detection_type": AlertRuleDetectionType.STATIC.value,
+                "thresholdPeriod": 1,
+                "detectionType": AlertRuleDetectionType.STATIC.value,
             },
         }
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -359,7 +359,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
             "enabled": True,
             "config": {},
             "triggers": {"logicType": "any", "conditions": []},
-            "action_filters": [],
+            "actionFilters": [],
         }
 
     def test_create_workflow__basic(self):
@@ -390,7 +390,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
                 {
                     "type": "eq",
                     "comparison": 1,
-                    "condition_result": True,
+                    "conditionResult": True,
                 }
             ],
         }
@@ -408,23 +408,23 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
         )
 
     def test_create_workflow__with_actions(self):
-        self.valid_workflow["action_filters"] = [
+        self.valid_workflow["actionFilters"] = [
             {
                 "logicType": "any",
                 "conditions": [
                     {
                         "type": "eq",
                         "comparison": 1,
-                        "condition_result": True,
+                        "conditionResult": True,
                     }
                 ],
                 "actions": [
                     {
                         "type": Action.Type.SLACK,
                         "config": {
-                            "target_identifier": "test",
-                            "target_display": "Test",
-                            "target_type": 0,
+                            "targetIdentifier": "test",
+                            "targetDisplay": "Test",
+                            "targetType": 0,
                         },
                         "data": {},
                         "integrationId": 1,
@@ -461,7 +461,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
             "conditions": [
                 {
                     "comparison": 1,
-                    "condition_result": True,
+                    "conditionResult": True,
                 }
             ],
         }
@@ -480,7 +480,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase):
                 "conditions": [
                     {
                         "comparison": 1,
-                        "condition_result": True,
+                        "conditionResult": True,
                     }
                 ],
                 "actions": [

--- a/tests/sentry/workflow_engine/endpoints/test_serializers.py
+++ b/tests/sentry/workflow_engine/endpoints/test_serializers.py
@@ -10,7 +10,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscriptionDataSourceHandler, SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
-from sentry.testutils.factories import default_detector_config_data
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
 from sentry.workflow_engine.endpoints.serializers import (
@@ -45,7 +44,10 @@ class TestDetectorSerializer(TestCase):
             "dataSources": None,
             "conditionGroup": None,
             "workflowIds": [],
-            "config": default_detector_config_data[MetricIssue.slug],
+            "config": {
+                "thresholdPeriod": 1,
+                "detectionType": "static",
+            },
             "owner": None,
             "enabled": detector.enabled,
         }
@@ -151,12 +153,15 @@ class TestDetectorSerializer(TestCase):
                         "type": "email",
                         "data": {},
                         "integrationId": None,
-                        "config": {"target_type": 1, "target_identifier": "123"},
+                        "config": {"targetType": 1, "targetIdentifier": "123"},
                     }
                 ],
             },
             "workflowIds": [str(workflow.id)],
-            "config": default_detector_config_data[MetricIssue.slug],
+            "config": {
+                "thresholdPeriod": 1,
+                "detectionType": "static",
+            },
             "owner": self.user.get_actor_identifier(),
             "enabled": detector.enabled,
         }
@@ -283,7 +288,7 @@ class TestDataConditionGroupSerializer(TestCase):
                     "type": "email",
                     "data": {},
                     "integrationId": None,
-                    "config": {"target_type": 1, "target_identifier": "123"},
+                    "config": {"targetType": 1, "targetIdentifier": "123"},
                 }
             ],
         }
@@ -335,11 +340,10 @@ class TestActionSerializer(TestCase):
             "type": "opsgenie",
             "data": {"priority": "P1"},
             "integrationId": str(self.integration.id),
-            "config": {"target_type": 0, "target_identifier": "123"},
+            "config": {"targetType": 0, "targetIdentifier": "123"},
         }
 
     def test_serialize_with_integration_and_config(self):
-
         action2 = self.create_action(
             type=Action.Type.SLACK,
             data={"tags": "bar"},
@@ -359,9 +363,9 @@ class TestActionSerializer(TestCase):
             "data": {"tags": "bar"},
             "integrationId": str(self.integration.id),
             "config": {
-                "target_type": 0,
-                "target_display": "freddy frog",
-                "target_identifier": "123-id",
+                "targetType": 0,
+                "targetDisplay": "freddy frog",
+                "targetIdentifier": "123-id",
             },
         }
 
@@ -492,7 +496,7 @@ class TestWorkflowSerializer(TestCase):
                             "type": "email",
                             "data": {},
                             "integrationId": None,
-                            "config": {"target_type": 1, "target_identifier": "123"},
+                            "config": {"targetType": 1, "targetIdentifier": "123"},
                         }
                     ],
                 },

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -443,9 +443,9 @@ class TestWorkflowValidatorUpdate(TestCase):
                     {
                         "type": Action.Type.SLACK,
                         "config": {
-                            "target_identifier": "foo",
-                            "target_display": "bar",
-                            "target_type": 0,
+                            "targetIdentifier": "bar",
+                            "targetDisplay": "baz",
+                            "targetType": 0,
                         },
                         "data": {},
                         "integrationId": 1,

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -568,9 +568,9 @@ class TestWorkflowValidatorUpdate(TestCase):
             {
                 "type": Action.Type.SLACK,
                 "config": {
-                    "target_identifier": "foo",
-                    "target_display": "bar",
-                    "target_type": 0,
+                    "targetIdentifier": "foo",
+                    "targetDisplay": "bar",
+                    "targetType": 0,
                 },
                 "data": {},
                 "integrationId": 1,
@@ -598,8 +598,8 @@ class TestWorkflowValidatorUpdate(TestCase):
                 "id": action.id,
                 "type": Action.Type.EMAIL,
                 "config": {
-                    "target_identifier": "foo",
-                    "target_type": 0,
+                    "targetIdentifier": "foo",
+                    "targetType": 0,
                 },
                 "data": {},
             }

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -14,6 +14,7 @@ from sentry.workflow_engine.models import (
     DataConditionGroup,
     DataConditionGroupAction,
     Workflow,
+    WorkflowDataConditionGroup,
 )
 from tests.sentry.workflow_engine.test_base import MockActionHandler
 
@@ -464,6 +465,26 @@ class TestWorkflowValidatorUpdate(TestCase):
         self.workflow.refresh_from_db()
 
         assert self.workflow.workflowdataconditiongroup_set.count() == 2
+        new_action_filter = (
+            WorkflowDataConditionGroup.objects.filter(workflow=self.workflow)
+            .order_by("-date_added")
+            .first()
+        )
+
+        assert new_action_filter is not None
+        assert new_action_filter.condition_group is not None
+
+        new_actions = Action.objects.filter(
+            dataconditiongroupaction__condition_group__in=[new_action_filter.condition_group.id]
+        )
+
+        assert new_actions.count() == 1
+        assert new_actions[0].type == Action.Type.SLACK
+        assert new_actions[0].config == {
+            "target_identifier": "bar",
+            "target_display": "baz",
+            "target_type": 0,
+        }
 
     def test_update__remove_one_filter(self):
         # Configuration for the test


### PR DESCRIPTION
# Description
- Updated all the tests I could find related to this to ensure cases were working as expected
- Started adding a new test and found the action wasn't being correctly created in a PUT request if there's a new action. (https://github.com/getsentry/sentry/commit/0b74ddca4cd52cec48558b039bf812bface3ecf2 - is the isolated fix, can pull out as a separate PR if that's helpful for reviewing)
- The solution for the `config` feels not quite right; `"config": convert_dict_key_case(obj.config, snake_to_camel_case),` -- it works, but this only ensures the config is camel cased correctly. when using the `CamelSnakeSerializer` it would throw errors though 🤔 