### PR TITLE
feat(proguard): Store obfuscated exception types

### DIFF
--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -329,6 +329,8 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
             }
 
     for raw_exc, exc in zip(processable_exceptions, response["exceptions"]):
+        raw_exc["raw_module"] = raw_exc["module"]
+        raw_exc["raw_type"] = raw_exc["type"]
         raw_exc["module"] = exc["module"]
         raw_exc["type"] = exc["type"]
 


### PR DESCRIPTION
This stores the obfuscated (pre-symbolication) module and type of an exception as `"raw_module"` and `"raw_type"`, respectively.

Closes #95023. Closes INGEST-440.