### PR TITLE
ref(consumers): Add min-partition-id

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -474,6 +474,7 @@ def get_stream_processor(
     group_instance_id: str | None = None,
     max_dlq_buffer_length: int | None = None,
     kafka_slice_id: int | None = None,
+    add_global_tags: bool = False,
 ) -> StreamProcessor:
     from sentry.utils import kafka_config
 
@@ -586,8 +587,8 @@ def get_stream_processor(
             stale_threshold_sec, strategy_factory
         )
 
-    # Always wrap with MinPartitionMetricTagWrapper to track partition assignment
-    strategy_factory = MinPartitionMetricTagWrapper(strategy_factory)
+    if add_global_tags:
+        strategy_factory = MinPartitionMetricTagWrapper(strategy_factory)
 
     if healthcheck_file_path is not None:
         strategy_factory = HealthcheckStrategyFactoryWrapper(

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -638,7 +638,12 @@ def basic_consumer(
         kafka_topic=topic, consumer_group=options["group_id"], kafka_slice_id=kafka_slice_id
     )
     processor = get_stream_processor(
-        consumer_name, consumer_args, topic=topic, kafka_slice_id=kafka_slice_id, **options
+        consumer_name,
+        consumer_args,
+        topic=topic,
+        kafka_slice_id=kafka_slice_id,
+        add_global_tags=True,
+        **options,
     )
 
     # for backwards compat: should eventually be removed


### PR DESCRIPTION
consumer_member_id is too high cardinality and cannot be deployed
globally.
