### PR TITLE
chore: Remove performance team from issue detection CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -257,9 +257,6 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 /src/sentry/search/events/                                                  @getsentry/visibility
 /src/sentry/search/eap/                                                  @getsentry/visibility
 
-/src/sentry/performance_issues/                                             @getsentry/performance @getsentry/issue-detection-backend
-/tests/sentry/performance_issues/                                           @getsentry/performance @getsentry/issue-detection-backend
-
 /static/app/components/events/eventStatisticalDetector/                     @getsentry/visibility @getsentry/profiling
 
 /src/sentry/statistical_detectors                                           @getsentry/visibility @getsentry/profiling
@@ -628,6 +625,9 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /tests/sentry/tasks/test_post_process.py                    @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_weekly_escalating_forecast.py      @getsentry/issue-detection-backend
 /tests/snuba/search/                                        @getsentry/issue-workflow
+/src/sentry/performance_issues/                             @getsentry/issue-detection-backend
+/tests/sentry/performance_issues/                           @getsentry/issue-detection-backend
+
 ## End of Issues
 
 ## Billing


### PR DESCRIPTION
The issue detection team has taken this work over, so the performance team isn't directly involved (though we're happy to help if we're needed).
