### PR TITLE
ref(features): Remove "option backed" feature flag support

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -57,7 +57,6 @@ register_temporary_features(default_manager)
 # expose public api
 add = default_manager.add
 entity_features = default_manager.entity_features
-option_features = default_manager.option_features
 get = default_manager.get
 has = default_manager.has
 batch_has = default_manager.batch_has

--- a/src/sentry/features/base.py
+++ b/src/sentry/features/base.py
@@ -92,12 +92,11 @@ class FeatureHandlerStrategy(Enum):
     """
 
     INTERNAL = 1
-    """Handle the feature using a logic within a FeatureHandler subclass"""
-    FLAGPOLE = 2
-    """Handle the feature using Flagpole and option backed rules based features.
-    Features will automatically have options registered for them.
     """
-    OPTIONS = 3
-    """Handle the feature using options. see https://develop.sentry.dev/feature-flags/#building-your-options-based-feature
-    for more information.
+    Handle the feature using a logic within a FeatureHandler subclass
+    """
+    FLAGPOLE = 2
+    """
+    Handle the feature using Flagpole and option backed rules based features.
+    Features will automatically have options registered for them.
     """

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -147,7 +147,6 @@ class FeatureManager(RegisteredFeatureManager):
         # Deprecated: Remove entity_features once flagr has been removed.
         self.entity_features: set[str] = set()
         self.exposed_features: set[str] = set()
-        self.option_features: set[str] = set()
         self.flagpole_features: set[str] = set()
         self._entity_handler: FeatureHandler | None = None
 
@@ -192,12 +191,6 @@ class FeatureManager(RegisteredFeatureManager):
             if name.startswith("users:"):
                 raise NotImplementedError("User flags not allowed with entity_feature=True")
             self.entity_features.add(name)
-        if entity_feature_strategy == FeatureHandlerStrategy.OPTIONS:
-            if name.startswith("users:"):
-                raise NotImplementedError(
-                    "OPTIONS feature handler strategy only supports organizations (for now)"
-                )
-            self.option_features.add(name)
 
         # Register all flagpole features with options automator,
         # so long as they haven't already been registered.

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -1,7 +1,6 @@
 from typing import Any
 from unittest import mock
 
-import pytest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
@@ -404,14 +403,3 @@ class FeatureManagerTest(TestCase):
 
         assert list(manager.all().keys()) == ["feat:org", "feat:project", "feat:system"]
         assert list(manager.all(OrganizationFeature).keys()) == ["feat:org"]
-
-    def test_option_features(self):
-        manager = features.FeatureManager()
-        manager.add("organizations:some-test", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
-        manager.add("projects:some-test", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)
-        assert manager.option_features == {"organizations:some-test", "projects:some-test"}
-
-    def test_invalid_option_features(self):
-        manager = features.FeatureManager()
-        with pytest.raises(NotImplementedError):
-            manager.add("users:some-test", OrganizationFeature, FeatureHandlerStrategy.OPTIONS)


### PR DESCRIPTION
Part of [CORE-24: Remove "option backed" feature flags](https://linear.app/getsentry/issue/CORE-24/remove-option-backed-feature-flags)