### PR TITLE
fix(issues-trace-timestamp): Fixing timestamp passed to the trace end…

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -3,7 +3,10 @@ import styled from '@emotion/styled';
 
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfaces/performance/utils';
+import {
+  getTimestampFromEvent,
+  TRACE_WATERFALL_PREFERENCES_KEY,
+} from 'sentry/components/events/interfaces/performance/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -60,7 +63,7 @@ interface EventTraceViewInnerProps {
 }
 
 function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
-  const timestamp = new Date(event.dateReceived).getTime() / 1e3;
+  const timestamp = getTimestampFromEvent(event);
 
   const trace = useTrace({
     timestamp,

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -3,10 +3,8 @@ import styled from '@emotion/styled';
 
 import {ButtonBar} from 'sentry/components/core/button/buttonBar';
 import {LinkButton} from 'sentry/components/core/button/linkButton';
-import {
-  getTimestampFromEvent,
-  TRACE_WATERFALL_PREFERENCES_KEY,
-} from 'sentry/components/events/interfaces/performance/utils';
+import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfaces/performance/utils';
+import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -63,7 +61,7 @@ interface EventTraceViewInnerProps {
 }
 
 function EventTraceViewInner({event, organization, traceId}: EventTraceViewInnerProps) {
-  const timestamp = getTimestampFromEvent(event);
+  const timestamp = getEventTimestampInSeconds(event);
 
   const trace = useTrace({
     timestamp,

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
@@ -1,10 +1,8 @@
 import {lazy, Suspense, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {
-  getTimestampFromEvent,
-  TRACE_WATERFALL_PREFERENCES_KEY,
-} from 'sentry/components/events/interfaces/performance/utils';
+import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfaces/performance/utils';
+import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import type {Event} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {useIssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useIssuesTraceTree';
@@ -77,7 +75,7 @@ function SpanEvidenceTraceViewImpl({
   organization,
   traceId,
 }: SpanEvidenceTraceViewProps) {
-  const timestamp = getTimestampFromEvent(event);
+  const timestamp = getEventTimestampInSeconds(event);
 
   const trace = useTrace({
     timestamp,

--- a/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceTraceView.tsx
@@ -1,7 +1,10 @@
 import {lazy, Suspense, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {TRACE_WATERFALL_PREFERENCES_KEY} from 'sentry/components/events/interfaces/performance/utils';
+import {
+  getTimestampFromEvent,
+  TRACE_WATERFALL_PREFERENCES_KEY,
+} from 'sentry/components/events/interfaces/performance/utils';
 import type {Event} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
 import {useIssuesTraceTree} from 'sentry/views/performance/newTraceDetails/traceApi/useIssuesTraceTree';
@@ -74,7 +77,7 @@ function SpanEvidenceTraceViewImpl({
   organization,
   traceId,
 }: SpanEvidenceTraceViewProps) {
-  const timestamp = new Date(event.dateReceived).getTime() / 1e3;
+  const timestamp = getTimestampFromEvent(event);
 
   const trace = useTrace({
     timestamp,

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -107,7 +107,7 @@ export function getTimestampFromEvent(event: Event): number | undefined {
   }
 
   if (typeof timestamp === 'string') {
-    return new Date(timestamp).getTime() / 1e3;
+    return new Date(timestamp).getTime() / 1_000;
   }
 
   return undefined;

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -5,8 +5,7 @@ import type {
   RawSpanType,
   TraceContextSpanProxy,
 } from 'sentry/components/events/interfaces/spans/types';
-import {getEventTimestamp} from 'sentry/components/quickTrace/utils';
-import type {EntrySpans, Event, EventTransaction} from 'sentry/types/event';
+import type {EntrySpans, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {getIssueTypeFromOccurrenceType, IssueType} from 'sentry/types/group';
 
@@ -97,18 +96,4 @@ export function getProblemSpansForSpanTree(event: EventTransaction): {
   }
 
   return {affectedSpanIds, focusedSpanIds};
-}
-
-export function getTimestampFromEvent(event: Event): number | undefined {
-  const timestamp = getEventTimestamp(event);
-
-  if (typeof timestamp === 'number') {
-    return timestamp;
-  }
-
-  if (typeof timestamp === 'string') {
-    return new Date(timestamp).getTime() / 1_000;
-  }
-
-  return undefined;
 }

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -5,7 +5,8 @@ import type {
   RawSpanType,
   TraceContextSpanProxy,
 } from 'sentry/components/events/interfaces/spans/types';
-import type {EntrySpans, EventTransaction} from 'sentry/types/event';
+import {getEventTimestamp} from 'sentry/components/quickTrace/utils';
+import type {EntrySpans, Event, EventTransaction} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
 import {getIssueTypeFromOccurrenceType, IssueType} from 'sentry/types/group';
 
@@ -96,4 +97,18 @@ export function getProblemSpansForSpanTree(event: EventTransaction): {
   }
 
   return {affectedSpanIds, focusedSpanIds};
+}
+
+export function getTimestampFromEvent(event: Event): number | undefined {
+  const timestamp = getEventTimestamp(event);
+
+  if (typeof timestamp === 'number') {
+    return timestamp;
+  }
+
+  if (typeof timestamp === 'string') {
+    return new Date(timestamp).getTime() / 1e3;
+  }
+
+  return undefined;
 }

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -440,3 +440,28 @@ export function inferPlatform(event: Event, thread?: Thread): PlatformKey {
 
   return event.platform ?? 'other';
 }
+
+const timestampsFieldCandidates = [
+  'dateCreated',
+  'startTimestamp',
+  'timestamp',
+  'endTimestamp',
+];
+
+export function getEventTimestampInSeconds(event: Event): number | undefined {
+  for (const key of timestampsFieldCandidates) {
+    if (key in event) {
+      const value = event[key as keyof Event];
+
+      if (typeof value === 'number') {
+        return value;
+      }
+
+      if (typeof value === 'string') {
+        return new Date(value).getTime() / 1_000;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -1,5 +1,6 @@
 import type {Location, LocationDescriptor} from 'history';
 
+import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import type {Event} from 'sentry/types/event';
@@ -82,28 +83,6 @@ export function generateSingleErrorTarget(
   }
 }
 
-const timestampsFieldCandidates = [
-  'dateCreated',
-  'startTimestamp',
-  'timestamp',
-  'endTimestamp',
-];
-
-export function getEventTimestamp(event: Event): string | number | undefined {
-  for (const key of timestampsFieldCandidates) {
-    if (
-      key in event &&
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      (typeof event[key] === 'string' || typeof event[key] === 'number')
-    ) {
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      return event[key];
-    }
-  }
-
-  return undefined;
-}
-
 export function generateTraceTarget(
   event: Event,
   organization: Organization,
@@ -120,7 +99,7 @@ export function generateTraceTarget(
       organization,
       traceSlug: traceId,
       dateSelection,
-      timestamp: getEventTimestamp(event),
+      timestamp: getEventTimestampInSeconds(event),
       eventId: event.eventID,
       location,
       source,

--- a/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
+++ b/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
@@ -1,7 +1,7 @@
 import type {LocationDescriptorObject} from 'history';
 
+import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import {getEventTimestamp} from 'sentry/components/quickTrace/utils';
 import type {Event} from 'sentry/types/event';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -25,7 +25,8 @@ function TraceDetailsRouting(props: Props) {
     return children;
   }
 
-  if (!shouldForceRouteToOldView(organization, getEventTimestamp(event))) {
+  const timestamp = getEventTimestampInSeconds(event);
+  if (!shouldForceRouteToOldView(organization, timestamp)) {
     if (event?.groupID && event?.eventID) {
       const issuesLocation = `/organizations/${organization.slug}/issues/${event.groupID}/events/${event.eventID}`;
       browserHistory.replace({
@@ -36,7 +37,7 @@ function TraceDetailsRouting(props: Props) {
         organization,
         traceSlug: traceId,
         dateSelection: datetimeSelection,
-        timestamp: getEventTimestamp(event),
+        timestamp,
         eventId: event.eventID,
         location,
       });


### PR DESCRIPTION
…points

Aligns with the timestamp used to load the trace view. Without this change, there's is a mismatch in events count in the issue details trace-preview vs trace view. 
