### PR TITLE
Chunk task creation for record deletion

### DIFF
--- a/chunking_changes.md
+++ b/chunking_changes.md
@@ -1,0 +1,54 @@
+# Chunking Changes for Seer Grouping Records Deletion
+
+## Summary
+Modified the `call_delete_seer_grouping_records_by_hash` function in `src/sentry/tasks/delete_seer_grouping_records.py` to chunk large numbers of group hashes into separate tasks with a maximum of 1000 hashes per task.
+
+## Changes Made
+
+### 1. Added import for chunking utility
+```python
+from sentry.utils.iterators import chunked
+```
+
+### 2. Modified task creation logic
+**Before:**
+```python
+if group_hashes:
+    delete_seer_grouping_records_by_hash.apply_async(args=[project.id, group_hashes, 0])
+```
+
+**After:**
+```python
+if group_hashes:
+    # Chunk the group_hashes into batches of 1000 and create separate tasks
+    for hash_chunk in chunked(group_hashes, 1000):
+        delete_seer_grouping_records_by_hash.apply_async(args=[project.id, hash_chunk, 0])
+```
+
+### 3. Added test case
+Added `test_call_delete_seer_grouping_records_by_hash_chunked` to verify that:
+- Large numbers of hashes (2500) are correctly chunked into multiple tasks
+- Each task receives a maximum of 1000 hashes
+- The correct number of tasks are created (3 tasks for 2500 hashes)
+- Each task receives the correct parameters (project_id, hash_chunk, 0)
+
+## Benefits
+- **Memory efficiency**: Prevents creation of tasks with excessively large hash lists
+- **Task distribution**: Enables better distribution of work across multiple workers
+- **Scalability**: Handles large group deletions more efficiently
+- **Maintainability**: Uses existing chunking utilities for consistency
+
+## Implementation Details
+- **Chunk size**: 1000 hashes per task (configurable if needed)
+- **Backward compatibility**: Existing behavior is preserved for small numbers of hashes
+- **Error handling**: Maintains existing error handling and killswitch logic
+- **Logging**: Existing logging continues to work, showing all hashes in the log message
+
+## Testing
+The new test case `test_call_delete_seer_grouping_records_by_hash_chunked` verifies:
+1. Correct number of tasks created based on total hashes
+2. Each task receives the correct chunk size
+3. Remainder chunks are handled correctly
+4. All tasks receive the correct project_id and starting index (0)
+
+The existing test `test_call_delete_seer_grouping_records_by_hash_simple` continues to work for small numbers of hashes (< 1000), but now expects multiple calls to `apply_async` when the chunk size is exceeded.

--- a/chunking_changes.md
+++ b/chunking_changes.md
@@ -1,23 +1,28 @@
 # Chunking Changes for Seer Grouping Records Deletion
 
 ## Summary
+
 Modified the `call_delete_seer_grouping_records_by_hash` function in `src/sentry/tasks/delete_seer_grouping_records.py` to chunk large numbers of group hashes into separate tasks with a maximum of 1000 hashes per task.
 
 ## Changes Made
 
 ### 1. Added import for chunking utility
+
 ```python
 from sentry.utils.iterators import chunked
 ```
 
 ### 2. Modified task creation logic
+
 **Before:**
+
 ```python
 if group_hashes:
     delete_seer_grouping_records_by_hash.apply_async(args=[project.id, group_hashes, 0])
 ```
 
 **After:**
+
 ```python
 if group_hashes:
     # Chunk the group_hashes into batches of 1000 and create separate tasks
@@ -26,26 +31,32 @@ if group_hashes:
 ```
 
 ### 3. Added test case
+
 Added `test_call_delete_seer_grouping_records_by_hash_chunked` to verify that:
+
 - Large numbers of hashes (2500) are correctly chunked into multiple tasks
 - Each task receives a maximum of 1000 hashes
 - The correct number of tasks are created (3 tasks for 2500 hashes)
 - Each task receives the correct parameters (project_id, hash_chunk, 0)
 
 ## Benefits
+
 - **Memory efficiency**: Prevents creation of tasks with excessively large hash lists
 - **Task distribution**: Enables better distribution of work across multiple workers
 - **Scalability**: Handles large group deletions more efficiently
 - **Maintainability**: Uses existing chunking utilities for consistency
 
 ## Implementation Details
+
 - **Chunk size**: 1000 hashes per task (configurable if needed)
 - **Backward compatibility**: Existing behavior is preserved for small numbers of hashes
 - **Error handling**: Maintains existing error handling and killswitch logic
 - **Logging**: Existing logging continues to work, showing all hashes in the log message
 
 ## Testing
+
 The new test case `test_call_delete_seer_grouping_records_by_hash_chunked` verifies:
+
 1. Correct number of tasks created based on total hashes
 2. Each task receives the correct chunk size
 3. Remainder chunks are handled correctly

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -81,3 +81,48 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     ) -> None:
         call_delete_seer_grouping_records_by_hash([])
         mock_apply_async.assert_not_called()
+
+    @patch(
+        "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
+    )
+    def test_call_delete_seer_grouping_records_by_hash_chunked(
+        self, mock_apply_async: MagicMock
+    ) -> None:
+        """
+        Test that call_delete_seer_grouping_records_by_hash chunks large numbers of hashes
+        into separate tasks with a maximum of 1000 hashes per task.
+        """
+        self.project.update_option("sentry:similarity_backfill_completed", int(time()))
+
+        # Create 2500 group hashes to test chunking
+        group_ids, expected_hashes = [], []
+        for i in range(2500):
+            group = self.create_group(project=self.project)
+            group_ids.append(group.id)
+            group_hash = GroupHash.objects.create(
+                project=self.project, hash=str(i) * 32, group_id=group.id
+            )
+            expected_hashes.append(group_hash.hash)
+
+        call_delete_seer_grouping_records_by_hash(group_ids)
+
+        # Verify that the task was called 3 times (2500 hashes / 1000 per chunk = 3 chunks)
+        assert mock_apply_async.call_count == 3
+
+        # Verify the first chunk has 1000 hashes
+        first_call_args = mock_apply_async.call_args_list[0][1]["args"]
+        assert len(first_call_args[1]) == 1000
+        assert first_call_args[0] == self.project.id
+        assert first_call_args[2] == 0
+
+        # Verify the second chunk has 1000 hashes
+        second_call_args = mock_apply_async.call_args_list[1][1]["args"]
+        assert len(second_call_args[1]) == 1000
+        assert second_call_args[0] == self.project.id
+        assert second_call_args[2] == 0
+
+        # Verify the third chunk has 500 hashes (remainder)
+        third_call_args = mock_apply_async.call_args_list[2][1]["args"]
+        assert len(third_call_args[1]) == 500
+        assert third_call_args[0] == self.project.id
+        assert third_call_args[2] == 0


### PR DESCRIPTION
<!-- Describe your PR here. -->
Chunks the task creation for deleting Seer grouping records to improve performance and resource utilization.

Previously, `call_delete_seer_grouping_records_by_hash` would dispatch a single task with all group hashes, which could be inefficient for large numbers. This change modifies the function to chunk group hashes into batches of 1000, dispatching a separate `delete_seer_grouping_records_by_hash` task for each batch.

This enhances memory efficiency, improves task distribution across workers, and increases scalability for large-scale deletions.

A new test `test_call_delete_seer_grouping_records_by_hash_chunked` has been added to verify the chunking logic.