### PR TITLE
fix(traceview): Fix issue with standalone span measurement trace indicators not being properly aligned

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceGuards.tsx
+++ b/static/app/views/performance/newTraceDetails/traceGuards.tsx
@@ -246,3 +246,18 @@ export function isEAPMeasurements(
 
   return Object.values(value).every(isEAPMeasurementValue);
 }
+
+export function isStandaloneSpanMeasurementNode(
+  node: TraceTreeNode<TraceTree.NodeValue>
+) {
+  if (node.value && 'op' in node.value && node.value.op) {
+    if (
+      node.value.op.startsWith('ui.webvital.') ||
+      node.value.op.startsWith('ui.interaction.')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
@@ -3,6 +3,7 @@ import {MobileVital, WebVital} from 'sentry/utils/fields';
 import {
   isEAPMeasurements,
   isEAPMeasurementValue,
+  isStandaloneSpanMeasurementNode,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 
 import type {TraceTree} from './traceTree';
@@ -148,9 +149,15 @@ export function collectTraceMeasurements(
       continue;
     }
 
+    // Standalone span measurements occur at the exact start timestamp of the span.
+    // We pass in 0 as the measurement value to prevent applying any unnecessary offset.
     const timestamp = traceMeasurementToTimestamp(
       start_timestamp,
-      isEAPMeasurementValue(value) ? value : value.value,
+      isStandaloneSpanMeasurementNode(node)
+        ? 0
+        : isEAPMeasurementValue(value)
+          ? value
+          : value.value,
       isEAPMeasurementValue(value) ? 'millisecond' : (value.unit ?? 'millisecond')
     );
 


### PR DESCRIPTION
For standalone span measurements, the start timestamp of the span is the exact timestamp of occurrence for the measurement (no offset needed to be applied)