### PR TITLE
ref(aci): fix N+1 query for DataConditionGroups in delayed workflow

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -664,7 +664,7 @@ def fire_actions_for_groups(
                         event_data.dcg_to_workflow[dcg.id] for dcg in workflow_triggers_for_group
                     }
 
-                    workflows_filters: dict[DataConditionGroup, int] = {
+                    filter_dcg_to_workflow_id: dict[DataConditionGroup, int] = {
                         dcg: workflow_id
                         for dcg, workflow_id in dcg_to_workflow_id.items()
                         if workflow_id in triggered_workflow_ids
@@ -672,7 +672,7 @@ def fire_actions_for_groups(
 
                     workflows_actions = evaluate_action_filters(
                         workflow_event_data,
-                        workflows_filters,
+                        filter_dcg_to_workflow_id,
                         workflows_by_id,
                     )
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -574,16 +574,16 @@ def get_dcgs_by_group(
     dcg_type: DataConditionHandler.Group,
 ) -> dict[GroupId, set[DataConditionGroup]]:
     """
-    Extract workflow triggers from groups_to_fire, grouped by group ID.
-    Returns a dict mapping GroupId to set of workflow trigger DCGs.
+    Extract DataConditionGroups from groups_to_fire, grouped by group ID.
+    Returns a dict mapping GroupId to set of DCGs.
     """
     workflow_dcg_ids = set(event_data.trigger_group_to_dcg_model[dcg_type].keys())
 
     workflow_dcgs_by_group = {}
     for group_id, dcgs in groups_to_fire.items():
-        workflow_triggers = {dcg for dcg in dcgs if dcg.id in workflow_dcg_ids}
-        if workflow_triggers:  # Only include groups that have workflow triggers
-            workflow_dcgs_by_group[group_id] = workflow_triggers
+        workflow_dcgs = {dcg for dcg in dcgs if dcg.id in workflow_dcg_ids}
+        if workflow_dcgs:
+            workflow_dcgs_by_group[group_id] = workflow_dcgs
 
     return workflow_dcgs_by_group
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -56,7 +56,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
 )
-from sentry.workflow_engine.processors.detector import get_detectors_by_events_bulk
+from sentry.workflow_engine.processors.detector import get_detectors_by_groupevents_bulk
 from sentry.workflow_engine.processors.log_util import log_if_slow, track_batch_performance
 from sentry.workflow_engine.processors.workflow import (
     WORKFLOW_ENGINE_BUFFER_LIST_KEY,
@@ -574,7 +574,8 @@ def get_dcgs_by_group(
     dcg_type: DataConditionHandler.Group,
 ) -> dict[GroupId, set[DataConditionGroup]]:
     """
-    Extract DataConditionGroups from groups_to_fire, grouped by group ID.
+    Extract DataConditionGroups from groups_to_fire, grouped by group ID, for a particular DataConditionGroup type (e.g. workflow trigger)
+    trigger_group_to_dcg_model is the mapping from DataConditionGroup type to DataConditionGroup id to Workflow id
     Returns a dict mapping GroupId to set of DCGs.
     """
     workflow_dcg_ids = set(event_data.trigger_group_to_dcg_model[dcg_type].keys())
@@ -615,7 +616,7 @@ def fire_actions_for_groups(
     all_workflow_triggers = set().union(*list(workflow_triggers.values()))
 
     # Bulk fetch detectors
-    event_id_to_detector = get_detectors_by_events_bulk(list(group_to_groupevent.values()))
+    event_id_to_detector = get_detectors_by_groupevents_bulk(list(group_to_groupevent.values()))
 
     # Bulk fetch action filters for workflow triggers
     workflows = Workflow.objects.filter(when_condition_group_id__in=all_workflow_triggers)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -62,7 +62,7 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
 
 def _split_events_by_occurrence(
     event_list: list[GroupEvent],
-) -> tuple[list[GroupEvent], list[GroupEvent], list[GroupEvent]]:
+) -> tuple[list[tuple[GroupEvent, int]], list[GroupEvent], list[GroupEvent]]:
     events_with_occurrences: list[tuple[GroupEvent, int]] = []
     events_without_occurrences: list[GroupEvent] = []  # only error events don't have occurrences
     events_missing_detectors: list[GroupEvent] = []

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -63,22 +63,24 @@ def get_detector_by_event(event_data: WorkflowEventData) -> Detector:
 
 class _SplitEvents(NamedTuple):
     events_with_occurrences: list[tuple[GroupEvent, int]]
-    events_without_occurrences: list[GroupEvent]
+    error_events: list[GroupEvent]
     events_missing_detectors: list[GroupEvent]
 
 
 def _split_events_by_occurrence(
     event_list: list[GroupEvent],
 ) -> _SplitEvents:
+    from sentry.grouping.grouptype import ErrorGroupType
+
     events_with_occurrences: list[tuple[GroupEvent, int]] = []
-    events_without_occurrences: list[GroupEvent] = []  # only error events don't have occurrences
+    error_events: list[GroupEvent] = []  # only error events don't have occurrences
     events_missing_detectors: list[GroupEvent] = []
 
     for event in event_list:
         issue_occurrence = event.occurrence
-
         if issue_occurrence is None:
-            events_without_occurrences.append(event)
+            assert event.group.issue_type.slug == ErrorGroupType.slug
+            error_events.append(event)
         elif detector_id := issue_occurrence.evidence_data.get("detector_id"):
             events_with_occurrences.append((event, detector_id))
         else:
@@ -86,12 +88,12 @@ def _split_events_by_occurrence(
 
     return _SplitEvents(
         events_with_occurrences,
-        events_without_occurrences,
+        error_events,
         events_missing_detectors,
     )
 
 
-def _update_event_detector_map(
+def _create_event_detector_map(
     detectors: BaseQuerySet[Detector],
     key_event_map: dict[int, list[GroupEvent]],
     detector_key_extractor: Callable[[Detector], int],
@@ -116,6 +118,7 @@ def get_detectors_by_groupevents_bulk(
     """
     Given a list of GroupEvents, return a mapping of event_id to Detector.
     """
+    from sentry.grouping.grouptype import ErrorGroupType
 
     if not event_list:
         return {}
@@ -123,8 +126,8 @@ def get_detectors_by_groupevents_bulk(
     result: dict[str, Detector] = {}
 
     # Separate events by whether they have occurrences or not
-    events_with_occurrences, events_without_occurrences, events_missing_detectors = (
-        _split_events_by_occurrence(event_list)
+    events_with_occurrences, error_events, events_missing_detectors = _split_events_by_occurrence(
+        event_list
     )
 
     # Fetch detectors for events with occurrences (by detector_id)
@@ -140,7 +143,7 @@ def get_detectors_by_groupevents_bulk(
 
         if detector_id_to_events:
             detectors = Detector.objects.filter(id__in=list(detector_id_to_events.keys()))
-            mapping, found_detector_ids = _update_event_detector_map(
+            mapping, found_detector_ids = _create_event_detector_map(
                 detectors,
                 key_event_map=detector_id_to_events,
                 detector_key_extractor=_extract_events_lookup_key,
@@ -151,31 +154,28 @@ def get_detectors_by_groupevents_bulk(
 
     # Fetch detectors for events without occurrences (by project_id)
     projects_missing_detectors = set()
-    if events_without_occurrences:
+    if error_events:
         # Group events by project_id
         project_to_events: dict[int, list[GroupEvent]] = defaultdict(list)
 
-        for event in events_without_occurrences:
+        for event in error_events:
             project_to_events[event.project_id].append(event)
 
         def _extract_events_lookup_key(detector: Detector) -> int:
             return detector.project_id
 
-        if project_to_events:
-            detectors = Detector.objects.filter(
-                project_id__in=project_to_events.keys(),
-                type=events_without_occurrences[0].group.issue_type.slug,  # error type
-            )
-            mapping, projects_with_error_detectors = _update_event_detector_map(
-                detectors,
-                key_event_map=project_to_events,
-                detector_key_extractor=_extract_events_lookup_key,
-            )
-            result.update(mapping)
+        detectors = Detector.objects.filter(
+            project_id__in=project_to_events.keys(),
+            type=ErrorGroupType.slug,
+        )
+        mapping, projects_with_error_detectors = _create_event_detector_map(
+            detectors,
+            key_event_map=project_to_events,
+            detector_key_extractor=_extract_events_lookup_key,
+        )
+        result.update(mapping)
 
-            projects_missing_detectors = (
-                set(project_to_events.keys()) - projects_with_error_detectors
-            )
+        projects_missing_detectors = set(project_to_events.keys()) - projects_with_error_detectors
 
     # Log all missing detectors
     if missing_detector_ids or projects_missing_detectors or events_missing_detectors:

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -197,6 +197,13 @@ def evaluate_action_filters(
     dcg_to_workflow_id: dict[DataConditionGroup, int],
     workflows_by_id: dict[int, Workflow],
 ) -> set[DataConditionGroup]:
+    """
+    Evaluate the action filters for the given mapping of DataConditionGroup to Workflow. (dcg_to_workflow_id)
+    Returns a set of DataConditionGroups that were evaluated to True.
+
+    Use this function if you are repeatedly evaluating action filters in a loop --
+    query for all the DataConditionGroups in a single query before using this function to avoid N+1s queries.
+    """
     filtered_action_groups: set[DataConditionGroup] = set()
     queue_items_by_project_id = DefaultDict[int, list[DelayedWorkflowItem]](list)
     current_time = timezone.now()
@@ -274,6 +281,12 @@ def evaluate_workflows_action_filters(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
 ) -> set[DataConditionGroup]:
+    """
+    Evaluate the action filters for the given workflows.
+    Returns a set of DataConditionGroups that were evaluated to True.
+
+    Use this function if you only have a set of workflows to evaluate and will not repeatedly evaluate action filters in a loop.
+    """
     action_conditions = (
         DataConditionGroup.objects.filter(workflowdataconditiongroup__workflow__in=workflows)
         .annotate(workflow_id=F("workflowdataconditiongroup__workflow_id"))

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1,18 +1,36 @@
 import unittest
+import uuid
 from datetime import UTC, datetime
 from unittest import mock
 from unittest.mock import call
 
+import pytest
+from django.utils import timezone
+
+from sentry.eventstore.models import GroupEvent
+from sentry.incidents.grouptype import MetricIssue
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType
 from sentry.issues.status_change_message import StatusChangeMessage
+from sentry.models.activity import Activity
 from sentry.models.group import GroupStatus
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.handlers.detector import DetectorStateData
 from sentry.workflow_engine.handlers.detector.stateful import get_redis_client
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
-from sentry.workflow_engine.processors.detector import process_detectors
-from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel
+from sentry.workflow_engine.processors.detector import (
+    get_detector_by_event,
+    get_detectors_by_events_bulk,
+    process_detectors,
+)
+from sentry.workflow_engine.types import (
+    DetectorEvaluationResult,
+    DetectorPriorityLevel,
+    WorkflowEventData,
+)
 from tests.sentry.workflow_engine.handlers.detector.test_base import (
     BaseDetectorHandlerTest,
     MockDetectorStateHandler,
@@ -792,3 +810,168 @@ class TestEvaluateGroupValue(BaseDetectorHandlerTest):
                 },
             )
         }
+
+
+class TestGetDetectorByEvent(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+        self.detector = self.create_detector(project=self.project, type="metric_issue")
+        self.error_detector = self.create_detector(project=self.project, type="error")
+        self.event = self.store_event(project_id=self.project.id, data={})
+        self.occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            project_id=1,
+            event_id="asdf",
+            fingerprint=["asdf"],
+            issue_title="title",
+            subtitle="subtitle",
+            resource_id=None,
+            evidence_data={"detector_id": self.detector.id},
+            evidence_display=[],
+            type=MetricIssue,
+            detection_time=timezone.now(),
+            level="error",
+            culprit="",
+        )
+
+    def test_with_occurrence(self):
+        group_event = GroupEvent.from_event(self.event, self.group)
+        group_event.occurrence = self.occurrence
+
+        event_data = WorkflowEventData(event=group_event, group=self.group)
+
+        result = get_detector_by_event(event_data)
+
+        assert result == self.detector
+
+    def test_without_occurrence(self):
+        group_event = GroupEvent.from_event(self.event, self.group)
+        group_event.occurrence = None
+
+        event_data = WorkflowEventData(event=group_event, group=self.group)
+
+        result = get_detector_by_event(event_data)
+
+        assert result == self.error_detector
+
+    def test_activity_not_supported(self):
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            user_id=self.user.id,
+        )
+
+        event_data = WorkflowEventData(event=activity, group=self.group)
+
+        with pytest.raises(TypeError):
+            get_detector_by_event(event_data)
+
+    def test_no_detector_id(self):
+        occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            project_id=1,
+            event_id="asdf",
+            fingerprint=["asdf"],
+            issue_title="title",
+            subtitle="subtitle",
+            resource_id=None,
+            evidence_data={},
+            evidence_display=[],
+            type=MetricIssue,
+            detection_time=timezone.now(),
+            level="error",
+            culprit="",
+        )
+
+        group_event = GroupEvent.from_event(self.event, self.group)
+        group_event.occurrence = occurrence
+
+        event_data = WorkflowEventData(event=group_event, group=self.group)
+
+        with pytest.raises(Detector.DoesNotExist):
+            get_detector_by_event(event_data)
+
+
+class TestGetDetectorsByEventsBulk(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project1 = self.create_project()
+        self.project2 = self.create_project()
+        self.group1 = self.create_group(project=self.project1)
+        self.group2 = self.create_group(project=self.project2)
+
+        self.detector1 = self.create_detector(project=self.project1, type="metric_issue")
+        self.detector2 = self.create_detector(project=self.project2, type="error")
+        self.detector3 = self.create_detector(project=self.project2, type="metric_issue")
+
+        self.event1 = self.store_event(project_id=self.project1.id, data={})
+        self.event2 = self.store_event(project_id=self.project2.id, data={})
+
+    def test_empty_list(self):
+        result = get_detectors_by_events_bulk([])
+        assert result == {}
+
+    def test_mixed_occurrences(self):
+        """Test bulk fetch with mixed events (some with occurrences, some without)"""
+        occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            project_id=1,
+            event_id="asdf",
+            fingerprint=["asdf"],
+            issue_title="title",
+            subtitle="subtitle",
+            resource_id=None,
+            evidence_data={"detector_id": self.detector1.id},
+            evidence_display=[],
+            type=MetricIssue,
+            detection_time=timezone.now(),
+            level="error",
+            culprit="",
+        )
+
+        group_event1 = GroupEvent.from_event(self.event1, self.group1)
+        group_event1.occurrence = occurrence
+
+        group_event2 = GroupEvent.from_event(self.event2, self.group2)
+        group_event2.occurrence = None
+
+        events = [group_event1, group_event2]
+        result = get_detectors_by_events_bulk(events)
+
+        assert result[group_event1.event_id] == self.detector1
+        assert result[group_event2.event_id] == self.detector2
+        assert len(result) == 2
+
+    def test_mixed_occurrences_missing_detectors(self):
+        occurrence = IssueOccurrence(
+            id=uuid.uuid4().hex,
+            project_id=1,
+            event_id="asdf",
+            fingerprint=["asdf"],
+            issue_title="title",
+            subtitle="subtitle",
+            resource_id=None,
+            evidence_data={},
+            evidence_display=[],
+            type=MetricIssue,
+            detection_time=timezone.now(),
+            level="error",
+            culprit="",
+        )
+        self.detector2.delete()
+
+        group_event1 = GroupEvent.from_event(self.event1, self.group1)
+        group_event1.occurrence = occurrence
+
+        group_event2 = GroupEvent.from_event(self.event2, self.group2)
+        group_event2.occurrence = None
+
+        events = [group_event1, group_event2]
+
+        with mock.patch("sentry.workflow_engine.processors.detector.metrics") as mock_metrics:
+            result = get_detectors_by_events_bulk(events)
+
+            assert result == {}
+            mock_metrics.incr.assert_called_with("workflow_engine.detectors.error")

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -23,7 +23,7 @@ from sentry.workflow_engine.handlers.detector.stateful import get_redis_client
 from sentry.workflow_engine.models import DataPacket, Detector, DetectorState
 from sentry.workflow_engine.processors.detector import (
     get_detector_by_event,
-    get_detectors_by_events_bulk,
+    get_detectors_by_groupevents_bulk,
     process_detectors,
 )
 from sentry.workflow_engine.types import (
@@ -894,7 +894,7 @@ class TestGetDetectorByEvent(TestCase):
             get_detector_by_event(event_data)
 
 
-class TestGetDetectorsByEventsBulk(TestCase):
+class TestGetDetectorsByGroupEventsBulk(TestCase):
     def setUp(self):
         super().setUp()
         self.project1 = self.create_project()
@@ -910,7 +910,7 @@ class TestGetDetectorsByEventsBulk(TestCase):
         self.event2 = self.store_event(project_id=self.project2.id, data={})
 
     def test_empty_list(self):
-        result = get_detectors_by_events_bulk([])
+        result = get_detectors_by_groupevents_bulk([])
         assert result == {}
 
     def test_mixed_occurrences(self):
@@ -938,7 +938,7 @@ class TestGetDetectorsByEventsBulk(TestCase):
         group_event2.occurrence = None
 
         events = [group_event1, group_event2]
-        result = get_detectors_by_events_bulk(events)
+        result = get_detectors_by_groupevents_bulk(events)
 
         assert result[group_event1.event_id] == self.detector1
         assert result[group_event2.event_id] == self.detector2
@@ -971,7 +971,7 @@ class TestGetDetectorsByEventsBulk(TestCase):
         events = [group_event1, group_event2]
 
         with mock.patch("sentry.workflow_engine.processors.detector.metrics") as mock_metrics:
-            result = get_detectors_by_events_bulk(events)
+            result = get_detectors_by_groupevents_bulk(events)
 
             assert result == {}
-            mock_metrics.incr.assert_called_with("workflow_engine.detectors.error")
+            mock_metrics.incr.assert_called_with("workflow_engine.detectors.error", amount=1)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -577,11 +577,10 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
 
     def test_basic__no_filter(self) -> None:
-        triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
-        assert set(triggered_actions) == {self.action_group}
-        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
-            self.workflow.id
-        }
+        triggered_action_filters = evaluate_workflows_action_filters(
+            {self.workflow}, self.event_data
+        )
+        assert set(triggered_action_filters) == {self.action_group}
 
     def test_basic__with_filter__passes(self):
         self.create_data_condition(
@@ -591,11 +590,10 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
-        assert set(triggered_actions) == {self.action_group}
-        assert {getattr(action, "workflow_id") for action in triggered_actions} == {
-            self.workflow.id
-        }
+        triggered_action_filters = evaluate_workflows_action_filters(
+            {self.workflow}, self.event_data
+        )
+        assert set(triggered_action_filters) == {self.action_group}
 
     def test_basic__with_filter__filtered(self):
         # Add a filter to the action's group
@@ -605,8 +603,10 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             comparison=self.detector.id + 1,
         )
 
-        triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
-        assert not triggered_actions
+        triggered_action_filters = evaluate_workflows_action_filters(
+            {self.workflow}, self.event_data
+        )
+        assert not triggered_action_filters
 
     def test_with_slow_conditions(self):
         self.action_group.logic_type = DataConditionGroup.Type.ALL
@@ -625,14 +625,16 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
         self.action_group.save()
 
-        triggered_actions = evaluate_workflows_action_filters({self.workflow}, self.event_data)
+        triggered_action_filters = evaluate_workflows_action_filters(
+            {self.workflow}, self.event_data
+        )
 
         assert self.action_group.conditions.count() == 2
 
         # The first condition passes, but the second is enqueued for later evaluation
-        assert not triggered_actions
+        assert not triggered_action_filters
 
-    def test_activty__with_slow_conditions(self):
+    def test_activity__with_slow_conditions(self):
         # Create a condition group with fast and slow conditions
         self.action_group.logic_type = DataConditionGroup.Type.ALL
 


### PR DESCRIPTION
Fixes SENTRY-40ZE

There is an N+1 query in which we repeatedly query the `DataConditionGroup` table from the delayed workflow task when processing action filters for triggered workflows for each group being processed. This is because the existing `evaluate_workflows_action_filters` function queries the `DataConditionGroup` table each time it is called, and we call it for every event we process in delayed workflows.

We can remove the additional queries by:
1. Making a single query for all triggered workflows across all group
2. Making a single query for all action filters for those triggered workflows
3. & some refactoring to share code with `process_workflows` to avoid the repeated queries

We can also remove repeated queries to get a single detector for each group+group_event by bulk querying for detectors.

Lastly, I added tests for `get_detector_by_event` and `get_detectors_by_events_bulk`.