### PR TITLE
ref: implement bulk_delete_objects using the orm

### DIFF
--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -519,7 +519,7 @@ def validate_protected_queries(queries: Sequence[Mapping[str, str | None]]) -> N
                     "operation that generates this query with the `unguarded_write()` ",
                     "context manager to resolve this failure. For example:",
                     "",
-                    "with unguarded_write(using=router.db_for_write(OrganizationMembership):",
+                    "with unguarded_write(using=router.db_for_write(OrganizationMembership)):",
                     "    member.delete()",
                     "",
                     "Query logs:",


### PR DESCRIPTION
checked using the query logger and it appears to generate the same query as the manual query:

```python
                       {'sql': 'DELETE FROM "sentry_userreport" WHERE '
                               '"sentry_userreport"."id" IN (SELECT U0."id" AS '
                               '"pk" FROM "sentry_userreport" U0 LIMIT 3)',
                        'time': '0.002'}
```

adding this so I can utilize this helper to do a bulk delete with filter by timestamp

<!-- Describe your PR here. -->
