### PR TITLE
fix(dashboards): Create button icon styling and title

### DIFF
--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -66,7 +66,7 @@ describe('Dashboards > Detail', function () {
       organization: mockAuthorizedOrg,
     });
 
-    expect(await screen.findByText('Dashboards')).toBeInTheDocument();
+    expect(await screen.findByText('All Dashboards')).toBeInTheDocument();
 
     expect(await screen.findByText('Test Dashboard')).toBeInTheDocument();
 

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -422,7 +422,7 @@ function ManageDashboards() {
       features="dashboards-edit"
       renderDisabled={renderNoAccess}
     >
-      <SentryDocumentTitle title={t('Dashboards')} orgSlug={organization.slug}>
+      <SentryDocumentTitle title={t('All Dashboards')} orgSlug={organization.slug}>
         <ErrorBoundary>
           {isError ? (
             <Layout.Page withPadding>
@@ -434,7 +434,7 @@ function ManageDashboards() {
                 <Layout.Header unified={prefersStackedNav}>
                   <Layout.HeaderContent unified={prefersStackedNav}>
                     <Layout.Title>
-                      {t('Dashboards')}
+                      {t('All Dashboards')}
                       <PageHeadingQuestionTooltip
                         docsUrl="https://docs.sentry.io/product/dashboards/"
                         title={t(
@@ -462,7 +462,7 @@ function ManageDashboards() {
                         }}
                         size="sm"
                         priority="primary"
-                        icon={<IconAdd isCircled />}
+                        icon={<IconAdd />}
                       >
                         {t('Create Dashboard')}
                       </Button>


### PR DESCRIPTION
Fixes the title so it says "All Dashboards", which is consistent with the "All Views" and "All Queries" views. As well as removes the circle border around the icon for the "Create Dashboard" button to similarly keep the buttons consistent.