### PR TITLE
ref(uptime): Remove unused host provider keys from frontend types

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -55,8 +55,6 @@ interface UptimeSubscriptionDataSource extends BaseDataSource {
   queryObj: {
     body: string | null;
     headers: Array<[string, string]>;
-    hostProviderId: string;
-    hostProviderName: string;
     intervalSeconds: number;
     method: string;
     timeoutMs: number;


### PR DESCRIPTION
These were removed in https://github.com/getsentry/sentry/pull/95064