### PR TITLE
feat(trace): Removing useSpans as param to events-trace endpoint

### DIFF
--- a/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.spec.tsx
@@ -78,27 +78,4 @@ describe('TraceFullQuery', function () {
     expect(await screen.findByTestId('type')).toHaveTextContent('full');
     expect(getMock).toHaveBeenCalledTimes(1);
   });
-
-  it('fetches data on mount with useSpans param', async function () {
-    const getMock = MockApiClient.addMockResponse({
-      url: `/organizations/test-org/events-trace/${traceId}/`,
-      body: [],
-      match: [MockApiClient.matchQuery({useSpans: '1'})],
-    });
-    render(
-      <TraceFullDetailedQuery
-        type="spans"
-        traceId={traceId}
-        eventId={eventId}
-        location={location}
-        orgSlug="test-org"
-        statsPeriod="24h"
-      >
-        {renderTraceFull}
-      </TraceFullDetailedQuery>
-    );
-
-    expect(await screen.findByTestId('type')).toHaveTextContent('full');
-    expect(getMock).toHaveBeenCalledTimes(1);
-  });
 });

--- a/static/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/static/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -36,18 +36,13 @@ type QueryProps<T> = Omit<TraceRequestProps, 'eventView'> &
   };
 
 function getTraceFullRequestPayload({
-  type,
   eventId,
   limit,
   ...props
 }: DiscoverQueryProps & AdditionalQueryProps) {
   const additionalApiPayload: any = getTraceRequestPayload(props);
 
-  if (type === 'spans') {
-    additionalApiPayload.useSpans = '1';
-  } else {
-    additionalApiPayload.detailed = '1';
-  }
+  additionalApiPayload.detailed = '1';
 
   if (eventId) {
     additionalApiPayload.event_id = eventId;

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -28,7 +28,6 @@ export function getTraceQueryParams(
   limit: number;
   targetId: string | undefined;
   timestamp: string | undefined;
-  useSpans: number;
   demo?: string;
   pageEnd?: string;
   pageStart?: string;
@@ -71,7 +70,6 @@ export function getTraceQueryParams(
     limit,
     timestamp: timestamp?.toString(),
     targetId,
-    useSpans: 1,
   };
   for (const key in queryParams) {
     if (

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.incremental.spec.tsx
@@ -40,7 +40,7 @@ describe('incremental trace fetch', () => {
     // Mock the API calls
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug1/?limit=10000&timestamp=1&useSpans=1',
+      url: '/organizations/org-slug/events-trace/slug1/?limit=10000&timestamp=1',
       body: {
         transactions: [
           makeTransaction({
@@ -54,7 +54,7 @@ describe('incremental trace fetch', () => {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug2/?limit=10000&timestamp=2&useSpans=1',
+      url: '/organizations/org-slug/events-trace/slug2/?limit=10000&timestamp=2',
       body: {
         transactions: [
           makeTransaction({
@@ -109,12 +109,12 @@ describe('incremental trace fetch', () => {
     // Mock the API calls
     const mockedResponse1 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug1/?limit=10000&timestamp=1&useSpans=1',
+      url: '/organizations/org-slug/events-trace/slug1/?limit=10000&timestamp=1',
       statusCode: 400,
     });
     const mockedResponse2 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug2/?limit=10000&timestamp=2&useSpans=1',
+      url: '/organizations/org-slug/events-trace/slug2/?limit=10000&timestamp=2',
       body: {
         transactions: [
           makeTransaction({
@@ -128,7 +128,7 @@ describe('incremental trace fetch', () => {
     });
     const mockedResponse3 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trace/slug3/?limit=10000&timestamp=3&useSpans=1',
+      url: '/organizations/org-slug/events-trace/slug3/?limit=10000&timestamp=3',
       body: {
         transactions: [
           makeTransaction({
@@ -194,7 +194,7 @@ describe('incremental trace fetch', () => {
     // Mock the API calls
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/trace/slug1/?limit=10000&timestamp=1&useSpans=1',
+      url: '/organizations/org-slug/trace/slug1/?limit=10000&timestamp=1',
       body: makeEAPTrace([
         makeEAPSpan({
           event_id: '3',
@@ -215,7 +215,7 @@ describe('incremental trace fetch', () => {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/trace/slug2/?limit=10000&timestamp=2&useSpans=1',
+      url: '/organizations/org-slug/trace/slug2/?limit=10000&timestamp=2',
       body: makeEAPTrace([
         makeEAPSpan({
           event_id: '5',
@@ -279,12 +279,12 @@ describe('incremental trace fetch', () => {
     // Mock the API calls
     const mockedResponse1 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/trace/slug1/?limit=10000&timestamp=1&useSpans=1',
+      url: '/organizations/org-slug/trace/slug1/?limit=10000&timestamp=1',
       statusCode: 400,
     });
     const mockedResponse2 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/trace/slug2/?limit=10000&timestamp=2&useSpans=1',
+      url: '/organizations/org-slug/trace/slug2/?limit=10000&timestamp=2',
       body: makeEAPTrace([
         makeEAPSpan({
           event_id: '5',
@@ -296,7 +296,7 @@ describe('incremental trace fetch', () => {
     });
     const mockedResponse3 = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/trace/slug3/?limit=10000&timestamp=3&useSpans=1',
+      url: '/organizations/org-slug/trace/slug3/?limit=10000&timestamp=3',
       body: makeEAPTrace([
         makeEAPSpan({
           event_id: '7',

--- a/static/app/views/performance/newTraceDetails/useTraceQueryParams.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceQueryParams.tsx
@@ -9,7 +9,6 @@ export interface TraceViewQueryParams {
   start: string | undefined;
   statsPeriod: string | undefined;
   timestamp: number | undefined;
-  useSpans: number;
 }
 
 export function useTraceQueryParams(
@@ -30,7 +29,6 @@ export function useTraceQueryParams(
       end: end ?? params?.end,
       statsPeriod: statsPeriod ?? params?.statsPeriod,
       timestamp: numberTimestamp ?? params?.timestamp,
-      useSpans: 1,
     };
   }, [params]);
 }

--- a/static/app/views/replays/detail/trace/replayTransactionContext.tsx
+++ b/static/app/views/replays/detail/trace/replayTransactionContext.tsx
@@ -108,7 +108,6 @@ export default function ReplayTransactionContext({children, replayRecord}: Optio
           TraceSplitResults<TraceFullDetailed> | TraceFullDetailed[]
         >(api, `/organizations/${orgSlug}/events-trace/${traceId}/`, {
           limit: 10000,
-          useSpans: 1,
           timestamp,
         } as any);
 


### PR DESCRIPTION
We no longer want to use the old spans dataset. 