### PR TITLE
chore(seer scanner): Change scanner rate limit window

### DIFF
--- a/src/sentry/autofix/utils.py
+++ b/src/sentry/autofix/utils.py
@@ -182,12 +182,12 @@ def is_seer_scanner_rate_limited(project: Project, organization: Organization) -
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False
 
-    limit = options.get("seer.max_num_scanner_autotriggered_per_minute", 50)
+    limit = options.get("seer.max_num_scanner_autotriggered_per_ten_seconds", 15)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
         key="seer.scanner.auto_triggered",
         limit=limit,
-        window=60,  # 1 minute
+        window=10,  # 10 seconds
     )
     if is_rate_limited:
         logger.info(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -599,9 +599,11 @@ register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("alerts.issue_summary_timeout", default=5, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Issue Summary Auto-trigger rate (max number of autofix runs auto-triggered per project per hour)
 register("seer.max_num_autofix_autotriggered_per_hour", default=20, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per minute)
+# Seer Scanner Auto-trigger rate (max number of scans auto-triggered per project per 10 seconds)
 register(
-    "seer.max_num_scanner_autotriggered_per_minute", default=50, flags=FLAG_AUTOMATOR_MODIFIABLE
+    "seer.max_num_scanner_autotriggered_per_ten_seconds",
+    default=15,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Codecov Integration

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -209,9 +209,9 @@ class TestAutomationRateLimiting(TestCase):
         project = self.create_project()
         organization = project.organization
 
-        mock_is_limited.return_value = (True, 45, None)
+        mock_is_limited.return_value = (True, 10, None)
 
-        with self.options({"seer.max_num_scanner_autotriggered_per_minute": 50}):
+        with self.options({"seer.max_num_scanner_autotriggered_per_ten_seconds": 15}):
             is_rate_limited = is_seer_scanner_rate_limited(project, organization)
 
         assert is_rate_limited is True


### PR DESCRIPTION
Make the rate limit window 10 seconds instead of 60 seconds, and set it to 15 requests per 10 seconds. This should reduce the number of concurrent requests, keeping Snuba and Seer infra happy, while also increasing the volume we can process.