### PR TITLE
ref(producers): Use build_kafka_producer_configuration

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -10,7 +10,7 @@ import orjson
 import sentry_sdk
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_producer_configuration
 from arroyo.processing.strategies.abstract import MessageRejected, ProcessingStrategy
 from arroyo.types import FilteredPayload, Message
 from django.conf import settings
@@ -54,7 +54,7 @@ class MultiProducer:
 
     def _default_producer_factory(self, producer_config: Mapping[str, object]) -> KafkaProducer:
         """Default factory that creates real KafkaProducers."""
-        return KafkaProducer(build_kafka_configuration(default_config=producer_config))
+        return KafkaProducer(build_kafka_producer_configuration(default_config=producer_config))
 
     def _setup_producers(self):
         """Setup producers based on SLICED_KAFKA_TOPICS configuration."""

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import orjson
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaProducer, build_kafka_configuration
+from arroyo.backends.kafka import KafkaProducer, build_kafka_producer_configuration
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.dlq import InvalidMessage
 from arroyo.processing.strategies.abstract import ProcessingStrategy, ProcessingStrategyFactory
@@ -63,7 +63,8 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         producer_config["queue.buffering.max.messages"] = self.kafka_queue_size
 
         self.producer = KafkaProducer(
-            build_kafka_configuration(default_config=producer_config), use_simple_futures=True
+            build_kafka_producer_configuration(default_config=producer_config),
+            use_simple_futures=True,
         )
         self.output_topic = ArroyoTopic(topic_definition["real_topic_name"])
 


### PR DESCRIPTION
Every producer should use this function, see https://github.com/getsentry/snuba/pull/7270. Right now we only need it for
consumers talking to the spans broker.
