### PR TITLE
ref(aci): fix n+1 query on Group in delayed workflow

### DIFF
--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -518,7 +518,9 @@ def get_group_to_groupevent(
     groups_to_dcgs: dict[GroupId, set[DataConditionGroup]],
     project_id: int,
 ) -> dict[Group, GroupEvent]:
-    groups = Group.objects.filter(id__in=event_data.group_ids)
+    groups = Group.objects.filter(id__in=event_data.group_ids).select_related(
+        "project__organization"
+    )
     group_id_to_group = {group.id: group for group in groups}
 
     bulk_event_id_to_events = bulk_fetch_events(list(event_data.event_ids), project_id)


### PR DESCRIPTION
Fixes SENTRY-43RN

When evaluating conditions and triggering actions, we access `group.project` and/or `group.project.organization` from the group in `WorkflowEventData`. If we don't use `select_related`, each of these calls will take an additional query. If we preload project and organization, they won't make extra queries 🤓