### PR TITLE
ref(insights): Improve `TimeSeriesWidgetVisualization` series name rendering

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.spec.tsx
@@ -1,4 +1,6 @@
-import {formatSeriesName} from './formatSeriesName';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+
+import {formatTimeSeriesName} from './formatTimeSeriesName';
 
 describe('formatSeriesName', () => {
   describe('releases', () => {
@@ -6,7 +8,11 @@ describe('formatSeriesName', () => {
       ['p75(span.duration);11762', 'p75(span.duration)'],
       ['Releases;', 'Releases'],
     ])('Formats %s as %s', (name, result) => {
-      expect(formatSeriesName(name)).toEqual(result);
+      const timeSeries = TimeSeriesFixture({
+        yAxis: name,
+      });
+
+      expect(formatTimeSeriesName(timeSeries)).toEqual(result);
     });
   });
 
@@ -16,7 +22,11 @@ describe('formatSeriesName', () => {
       ['apdex(200)', 'apdex(200)'],
       ['p75(span.duration)', 'p75(span.duration)'],
     ])('Formats %s as %s', (name, result) => {
-      expect(formatSeriesName(name)).toEqual(result);
+      const timeSeries = TimeSeriesFixture({
+        yAxis: name,
+      });
+
+      expect(formatTimeSeriesName(timeSeries)).toEqual(result);
     });
   });
 
@@ -26,7 +36,11 @@ describe('formatSeriesName', () => {
       ['android@5.3.1', '5.3.1'],
       ['ios@5.3.1-rc1', '5.3.1-rc1'],
     ])('Formats %s as %s', (name, result) => {
-      expect(formatSeriesName(name)).toEqual(result);
+      const timeSeries = TimeSeriesFixture({
+        yAxis: name,
+      });
+
+      expect(formatTimeSeriesName(timeSeries)).toEqual(result);
     });
   });
 
@@ -35,7 +49,11 @@ describe('formatSeriesName', () => {
       ['p75(measurements.lcp)', 'LCP'],
       ['p50(measurements.lcp)', 'LCP'],
     ])('Formats %s as %s', (name, result) => {
-      expect(formatSeriesName(name)).toEqual(result);
+      const timeSeries = TimeSeriesFixture({
+        yAxis: name,
+      });
+
+      expect(formatTimeSeriesName(timeSeries)).toEqual(result);
     });
   });
 
@@ -44,7 +62,11 @@ describe('formatSeriesName', () => {
       ['equation|p75(measurements.cls) + 1', 'p75(measurements.cls) + 1'],
       ['equation|p75(measurements.cls)', 'p75(measurements.cls)'],
     ])('Formats %s as %s', (name, result) => {
-      expect(formatSeriesName(name)).toEqual(result);
+      const timeSeries = TimeSeriesFixture({
+        yAxis: name,
+      });
+
+      expect(formatTimeSeriesName(timeSeries)).toEqual(result);
     });
   });
 
@@ -53,7 +75,11 @@ describe('formatSeriesName', () => {
       ['equation|p75(measurements.cls) + 1;76123', 'p75(measurements.cls) + 1'],
       ['equation|p75(measurements.cls);76123', 'p75(measurements.cls)'],
     ])('Formats %s as %s', (name, result) => {
-      expect(formatSeriesName(name)).toEqual(result);
+      const timeSeries = TimeSeriesFixture({
+        yAxis: name,
+      });
+
+      expect(formatTimeSeriesName(timeSeries)).toEqual(result);
     });
   });
 });

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.tsx
@@ -6,8 +6,10 @@ import {
 } from 'sentry/utils/discover/fields';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
-export function formatSeriesName(seriesName: string): string {
+export function formatTimeSeriesName(timeSeries: TimeSeries): string {
+  let {yAxis: seriesName} = timeSeries;
   // Decode from series name disambiguation
   seriesName = WidgetLegendNameEncoderDecoder.decodeSeriesNameForLegend(seriesName)!;
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries.tsx
@@ -6,7 +6,7 @@ import type {
   TimeSeries,
   TimeSeriesValueUnit,
 } from 'sentry/views/dashboards/widgets/common/types';
-import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
+import {formatTimeSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName';
 import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/settings';
 
 import type {PlottableTimeSeriesValueType} from './plottable';
@@ -63,7 +63,7 @@ export abstract class ContinuousTimeSeries<
   }
 
   get label(): string {
-    return this.config?.alias ?? formatSeriesName(this.timeSeries.yAxis);
+    return this.config?.alias ?? formatTimeSeriesName(this.timeSeries);
   }
 
   get isEmpty(): boolean {

--- a/static/app/views/insights/common/components/widgets/crashFreeSessionsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/crashFreeSessionsChartWidget.tsx
@@ -1,6 +1,6 @@
 import ExternalLink from 'sentry/components/links/externalLink';
 import {tct} from 'sentry/locale';
-import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
@@ -16,7 +16,7 @@ export default function CrashFreeSessionsChartWidget(props: LoadableChartWidgetP
   const aliases = Object.fromEntries(
     releases?.map(release => [
       `crash_free_session_rate_${release}`,
-      formatSeriesName(release),
+      formatVersion(release),
     ]) ?? []
   );
 

--- a/static/app/views/insights/common/components/widgets/releaseSessionCountChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/releaseSessionCountChartWidget.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
@@ -13,8 +13,7 @@ export default function ReleaseSessionCountChartwidget(props: LoadableChartWidge
   });
 
   const aliases = Object.fromEntries(
-    releases?.map(release => [`${release}_total_sessions`, formatSeriesName(release)]) ??
-      []
+    releases?.map(release => [`${release}_total_sessions`, formatVersion(release)]) ?? []
   );
 
   return (

--- a/static/app/views/insights/common/components/widgets/releaseSessionPercentageChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/releaseSessionPercentageChartWidget.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import {formatSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatSeriesName';
+import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import {InsightsAreaChartWidget} from 'sentry/views/insights/common/components/insightsAreaChartWidget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
 import ChartSelectionTitle from 'sentry/views/insights/sessions/components/chartSelectionTitle';
@@ -15,8 +15,7 @@ export default function ReleaseSessionPercentageChartWidget(
   });
 
   const aliases = Object.fromEntries(
-    releases?.map(release => [`${release}_session_percent`, formatSeriesName(release)]) ??
-      []
+    releases?.map(release => [`${release}_session_percent`, formatVersion(release)]) ?? []
   );
 
   return (


### PR DESCRIPTION
Preparation for an incoming refactor.

1. `formatSeriesName` is now called `formatTimeSeriesName`, because it accepts a `TimeSeries`! This is an important change because soon I will take `TimeSeries.groupBy` into account when formatting the names
2. Remove direct usage for `formatSeriesName` from Release Health charts. That's a very specific usage, it's _only_ doing version formatting, so it should use the underlying helper
