### PR TITLE
chore: attempt to fix flaky trace items test

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -124,6 +124,16 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsV2Endpoin
         totals_1_result = totals_1_future.result()
         totals_2_result = totals_2_future.result()
 
+        if (
+            not cohort_1_data.results
+            or not cohort_2_data.results
+            or not totals_1_result.get("data")
+            or not totals_2_result.get("data")
+            or not totals_1_result["data"]
+            or not totals_2_result["data"]
+        ):
+            return Response({"rankedAttributes": []})
+
         cohort_1_distribution = []
         cohort_1_distribution_map = defaultdict(list)
         for attribute in cohort_1_data.results[0].attribute_distributions.attributes:


### PR DESCRIPTION
https://github.com/getsentry/sentry/actions/runs/16156271300/job/45601678305?pr=95081

FAILED tests/sentry/api/endpoints/test_organization_trace_item_attributes_ranked.py::OrganizationTraceItemsAttributesRankedEndpointTest::test_distribution_values - IndexError: list index out of range

seems to be failing inconsistently in CI because the API endpoint assumes that query results will always contain data, but when spans aren't indexed yet (like in CI it may be), the results arrays are empty, causing the IndexError exception
