### PR TITLE
ref(grouping): Use single default for config

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -21,14 +21,7 @@ DEFAULT_GROUPING_CONFIG = "newstyle:2023-01-11"
 # `mobile` strategy via grouping auto-updates.
 BETA_GROUPING_CONFIG = ""
 # This registers the option as a valid project option
-register(
-    key="sentry:grouping_config",
-    epoch_defaults={
-        1: LEGACY_GROUPING_CONFIG,
-        3: "newstyle:2019-05-08",
-        4: DEFAULT_GROUPING_CONFIG,
-    },
-)
+register(key="sentry:grouping_config", default=DEFAULT_GROUPING_CONFIG)
 
 register(key="sentry:grouping_enhancements", default="")
 register(key="sentry:derived_grouping_enhancements", default="")


### PR DESCRIPTION
It used to be that we didn't upgrade grouping config unless the customer did it manually. We therefore had different default configs based on when the project was created. Since that's no longer the case, we no longer need a split default. (In fact, it's caused problems, because it's the reason we keep ending up with new projects entering the transition period.)

This therefore replaces the tiered defaults with a single one.