### PR TITLE
feat: Provide releases link only if exists on source maps details page

### DIFF
--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -45,7 +45,6 @@ type Props = {
    * Ellipsis on overflow
    */
   truncate?: boolean;
-
   /**
    * Should we also show package name
    */
@@ -100,7 +99,6 @@ function Version({
           </GlobalSelectionLink>
         );
       }
-
       return (
         <Link {...props}>
           <VersionText truncate={truncate} shouldWrapText={shouldWrapText}>

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -30,6 +30,10 @@ type Props = {
    */
   projectId?: string;
   /**
+   * Should the version be formatted or not
+   */
+  shouldFormatVersion?: boolean;
+  /**
    * Should the release text break and wrap onto the next line
    */
   shouldWrapText?: boolean;
@@ -41,6 +45,7 @@ type Props = {
    * Ellipsis on overflow
    */
   truncate?: boolean;
+
   /**
    * Should we also show package name
    */
@@ -57,10 +62,13 @@ function Version({
   truncate,
   shouldWrapText = false,
   className,
+  shouldFormatVersion = true,
 }: Props) {
   const location = useLocation();
   const organization = useOrganization();
-  const versionToDisplay = formatVersion(version, withPackage);
+  const versionToDisplay = shouldFormatVersion
+    ? formatVersion(version, withPackage)
+    : version;
   const theme = useTheme();
 
   let releaseDetailProjectId: null | undefined | string | string[];
@@ -92,6 +100,7 @@ function Version({
           </GlobalSelectionLink>
         );
       }
+
       return (
         <Link {...props}>
           <VersionText truncate={truncate} shouldWrapText={shouldWrapText}>

--- a/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
+++ b/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
@@ -19,10 +19,7 @@ export function AssociatedReleases({
     <ReleasesWrapper>
       {associations.length
         ? associations.map(association => (
-            <AssociatedReleaseWrapper
-              key={association.release}
-              data-test-id="associated-release"
-            >
+            <AssociatedReleaseWrapper key={association.release}>
               <Tooltip
                 showUnderline={association.exists === false}
                 title={
@@ -36,7 +33,7 @@ export function AssociatedReleases({
                   shouldFormatVersion={shouldFormatVersion}
                 />
               </Tooltip>
-              {` (Dist: ${formatDist(association.dist)})`}
+              {`(Dist: ${formatDist(association.dist)})`}
             </AssociatedReleaseWrapper>
           ))
         : t('No releases associated with this upload.')}
@@ -62,6 +59,7 @@ const ReleasesWrapper = styled('pre')`
 const AssociatedReleaseWrapper = styled('div')`
   display: flex;
   flex-wrap: wrap;
+  gap: ${space(0.5)};
   :not(:last-child) {
     margin-bottom: ${space(0.5)};
   }

--- a/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
+++ b/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
@@ -1,0 +1,75 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Tooltip} from 'sentry/components/core/tooltip';
+import Version from 'sentry/components/version';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {DebugIdBundleAssociation} from 'sentry/types/sourceMaps';
+import {defined} from 'sentry/utils';
+
+export function AssociatedReleases({
+  associations,
+}: {
+  associations: DebugIdBundleAssociation[];
+}) {
+  return (
+    <ReleasesWrapper>
+      {associations.length
+        ? associations.map(association => (
+            <AssociatedReleaseWrapper key={association.release}>
+              <Tooltip
+                showUnderline={association.exists === false}
+                title={
+                  association.exists === false ? t('Release does not exist') : undefined
+                }
+              >
+                <StyledVersion
+                  isPending={!defined(association.exists)}
+                  version={association.release}
+                  anchor={association.exists}
+                />
+              </Tooltip>
+              {association.dist && `(Dist: ${formatDist(association.dist)})`}
+            </AssociatedReleaseWrapper>
+          ))
+        : t('No releases associated with this upload.')}
+    </ReleasesWrapper>
+  );
+}
+
+const formatDist = (dist: string | string[] | null) => {
+  if (Array.isArray(dist)) {
+    return dist.join(', ');
+  }
+  if (dist === null) {
+    return t('none');
+  }
+  return dist;
+};
+
+const ReleasesWrapper = styled('pre')`
+  max-height: 200px;
+  overflow-y: auto !important;
+`;
+
+const AssociatedReleaseWrapper = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(0.5)};
+  :not(:last-child) {
+    margin-bottom: ${space(0.5)};
+  }
+`;
+
+const StyledVersion = styled(Version)<{isPending: boolean}>`
+  ${p =>
+    p.isPending &&
+    css`
+      background-color: ${p.theme.backgroundTertiary};
+      border-radius: ${p.theme.borderRadius};
+      color: transparent;
+      pointer-events: none;
+      user-select: none;
+    `}
+`;

--- a/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
+++ b/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
@@ -36,7 +36,7 @@ export function AssociatedReleases({
                   shouldFormatVersion={shouldFormatVersion}
                 />
               </Tooltip>
-              {`(Dist: ${formatDist(association.dist)})`}
+              {` (Dist: ${formatDist(association.dist)})`}
             </AssociatedReleaseWrapper>
           ))
         : t('No releases associated with this upload.')}
@@ -62,7 +62,6 @@ const ReleasesWrapper = styled('pre')`
 const AssociatedReleaseWrapper = styled('div')`
   display: flex;
   flex-wrap: wrap;
-  gap: ${space(0.5)};
   :not(:last-child) {
     margin-bottom: ${space(0.5)};
   }

--- a/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
+++ b/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
@@ -28,7 +28,6 @@ export function AssociatedReleases({
                 title={
                   association.exists === false ? t('Release does not exist') : undefined
                 }
-                containerDisplayMode="inline-flex"
               >
                 <StyledVersion
                   isPending={!defined(association.exists)}

--- a/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
+++ b/static/app/views/settings/projectSourceMaps/associatedReleases.tsx
@@ -10,27 +10,34 @@ import {defined} from 'sentry/utils';
 
 export function AssociatedReleases({
   associations,
+  shouldFormatVersion,
 }: {
   associations: DebugIdBundleAssociation[];
+  shouldFormatVersion?: boolean;
 }) {
   return (
     <ReleasesWrapper>
       {associations.length
         ? associations.map(association => (
-            <AssociatedReleaseWrapper key={association.release}>
+            <AssociatedReleaseWrapper
+              key={association.release}
+              data-test-id="associated-release"
+            >
               <Tooltip
                 showUnderline={association.exists === false}
                 title={
                   association.exists === false ? t('Release does not exist') : undefined
                 }
+                containerDisplayMode="inline-flex"
               >
                 <StyledVersion
                   isPending={!defined(association.exists)}
                   version={association.release}
                   anchor={association.exists}
+                  shouldFormatVersion={shouldFormatVersion}
                 />
               </Tooltip>
-              {association.dist && `(Dist: ${formatDist(association.dist)})`}
+              {`(Dist: ${formatDist(association.dist)})`}
             </AssociatedReleaseWrapper>
           ))
         : t('No releases associated with this upload.')}

--- a/static/app/views/settings/projectSourceMaps/debugIdBundleDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/debugIdBundleDetails.tsx
@@ -32,7 +32,12 @@ export function DebugIdBundleDetails({
             {showAll ? t('Show Less') : t('Show All')}
           </Button>
         ),
-        value: <AssociatedReleases associations={visibleAssociations} />,
+        value: (
+          <AssociatedReleases
+            associations={visibleAssociations}
+            shouldFormatVersion={false}
+          />
+        ),
       },
       {
         key: 'date',

--- a/static/app/views/settings/projectSourceMaps/debugIdBundleDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/debugIdBundleDetails.tsx
@@ -1,25 +1,13 @@
-import {Fragment, useMemo, useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/core/button';
-import {Link} from 'sentry/components/core/link';
 import {DateTime} from 'sentry/components/dateTime';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import {t} from 'sentry/locale';
 import type {KeyValueListData} from 'sentry/types/group';
 import type {DebugIdBundle, DebugIdBundleArtifact} from 'sentry/types/sourceMaps';
-import useOrganization from 'sentry/utils/useOrganization';
-import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
-
-const formatDist = (dist: string | string[] | null) => {
-  if (Array.isArray(dist)) {
-    return dist.join(', ');
-  }
-  if (dist === null) {
-    return 'none';
-  }
-  return dist;
-};
+import {AssociatedReleases} from 'sentry/views/settings/projectSourceMaps/associatedReleases';
 
 export function DebugIdBundleDetails({
   debugIdBundle,
@@ -27,7 +15,6 @@ export function DebugIdBundleDetails({
   debugIdBundle: DebugIdBundle | DebugIdBundleArtifact;
 }) {
   const [showAll, setShowAll] = useState(false);
-  const organization = useOrganization();
   const detailsData = useMemo<KeyValueListData>(() => {
     const associations = debugIdBundle.associations;
     const visibleAssociations = showAll ? associations : associations.slice(0, 3);
@@ -45,27 +32,7 @@ export function DebugIdBundleDetails({
             {showAll ? t('Show Less') : t('Show All')}
           </Button>
         ),
-        value:
-          associations.length > 0 ? (
-            <ReleasesWrapper className="val-string-multiline">
-              {visibleAssociations.map(association => (
-                <Fragment key={association.release}>
-                  <Link
-                    to={makeReleasesPathname({
-                      organization,
-                      path: `/${association.release}/`,
-                    })}
-                  >
-                    {association.release}
-                  </Link>
-                  {` (Dist: ${formatDist(association.dist)})`}
-                  <br />
-                </Fragment>
-              ))}
-            </ReleasesWrapper>
-          ) : (
-            t('No releases associated with this upload.')
-          ),
+        value: <AssociatedReleases associations={visibleAssociations} />,
       },
       {
         key: 'date',
@@ -77,21 +44,10 @@ export function DebugIdBundleDetails({
         ),
       },
     ];
-  }, [
-    debugIdBundle.associations,
-    debugIdBundle.date,
-    debugIdBundle.fileCount,
-    organization,
-    showAll,
-  ]);
+  }, [debugIdBundle.associations, debugIdBundle.date, debugIdBundle.fileCount, showAll]);
 
   return <StyledKeyValueList data={detailsData} shouldSort={false} />;
 }
-
-const ReleasesWrapper = styled('pre')`
-  max-height: 200px;
-  overflow-y: auto !important;
-`;
 
 const StyledKeyValueList = styled(KeyValueList)`
   && {

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.spec.tsx
@@ -242,12 +242,12 @@ describe('SourceMapsDetails', function () {
       // Release information
       expect(await screen.findByText('Associated Releases')).toBeInTheDocument();
       expect(
-        await screen.findByText(textWithMarkupMatcher('v2.0 (Dist: none)'))
+        await screen.findByText(textWithMarkupMatcher('v2.0(Dist: none)'))
       ).toBeInTheDocument();
       expect(
         await screen.findByText(
           textWithMarkupMatcher(
-            'frontend@2e318148eac9298ec04a662ae32b4b093b027f0a (Dist: android, iOS)'
+            'frontend@2e318148eac9298ec04a662ae32b4b093b027f0a(Dist: android, iOS)'
           )
         )
       ).toBeInTheDocument();

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.spec.tsx
@@ -12,7 +12,6 @@ import {
   userEvent,
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
@@ -75,6 +74,11 @@ function renderDebugIdBundlesMockRequests({
   const artifactBundlesDeletion = MockApiClient.addMockResponse({
     url: `/projects/${orgSlug}/${projectSlug}/files/artifact-bundles/`,
     method: 'DELETE',
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${orgSlug}/releases/`,
+    body: [],
   });
 
   return {artifactBundlesFiles, artifactBundlesDeletion};
@@ -236,16 +240,13 @@ describe('SourceMapsDetails', function () {
       expect(await screen.findByText('22')).toBeInTheDocument();
       // Release information
       expect(await screen.findByText('Associated Releases')).toBeInTheDocument();
-      expect(
-        await screen.findByText(textWithMarkupMatcher('v2.0 (Dist: none)'))
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText(
-          textWithMarkupMatcher(
-            'frontend@2e318148eac9298ec04a662ae32b4b093b027f0a (Dist: android, iOS)'
-          )
-        )
-      ).toBeInTheDocument();
+      const associatedReleases = screen.getAllByTestId('associated-release');
+      expect(associatedReleases).toHaveLength(2);
+      expect(associatedReleases[0]).toHaveTextContent('v2.0(Dist: none)');
+      expect(associatedReleases[1]).toHaveTextContent(
+        'frontend@2e318148eac9298ec04a662ae32b4b093b027f0a(Dist: android, iOS)'
+      );
+
       // Date Uploaded
       expect(await screen.findByText('Date Uploaded')).toBeInTheDocument();
       expect(await screen.findByText('Mar 8, 2023 9:53 AM UTC')).toBeInTheDocument();

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.spec.tsx
@@ -12,6 +12,7 @@ import {
   userEvent,
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
@@ -240,12 +241,16 @@ describe('SourceMapsDetails', function () {
       expect(await screen.findByText('22')).toBeInTheDocument();
       // Release information
       expect(await screen.findByText('Associated Releases')).toBeInTheDocument();
-      const associatedReleases = screen.getAllByTestId('associated-release');
-      expect(associatedReleases).toHaveLength(2);
-      expect(associatedReleases[0]).toHaveTextContent('v2.0(Dist: none)');
-      expect(associatedReleases[1]).toHaveTextContent(
-        'frontend@2e318148eac9298ec04a662ae32b4b093b027f0a(Dist: android, iOS)'
-      );
+      expect(
+        await screen.findByText(textWithMarkupMatcher('v2.0 (Dist: none)'))
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          textWithMarkupMatcher(
+            'frontend@2e318148eac9298ec04a662ae32b4b093b027f0a (Dist: android, iOS)'
+          )
+        )
+      ).toBeInTheDocument();
 
       // Date Uploaded
       expect(await screen.findByText('Date Uploaded')).toBeInTheDocument();

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
@@ -175,8 +175,7 @@ export function SourceMapsDetails({params, location, router, project}: Props) {
     {
       staleTime: Infinity,
       retry: false,
-      enabled:
-        isDebugIdBundle && !debugIdBundlesArtifactsLoading && !!releaseVersions?.length,
+      enabled: !!releaseVersions?.length,
     }
   );
 

--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
@@ -168,14 +168,15 @@ export function SourceMapsDetails({params, location, router, project}: Props) {
       {
         query: {
           project: [project.id],
-          query: releaseVersions ? `release:[${releaseVersions.join(',')}]` : undefined,
+          query: `release:[${releaseVersions?.join(',')}]`,
         },
       },
     ],
     {
       staleTime: Infinity,
       retry: false,
-      enabled: isDebugIdBundle && !debugIdBundlesArtifactsLoading,
+      enabled:
+        isDebugIdBundle && !debugIdBundlesArtifactsLoading && !!releaseVersions?.length,
     }
   );
 

--- a/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
@@ -20,7 +20,6 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import SearchBar from 'sentry/components/searchBar';
-import Version from 'sentry/components/version';
 import {IconDelete, IconUpload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -36,6 +35,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import useOrganization from 'sentry/utils/useOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
+import {AssociatedReleases} from 'sentry/views/settings/projectSourceMaps/associatedReleases';
 import {useDeleteDebugIdBundle} from 'sentry/views/settings/projectSourceMaps/useDeleteDebugIdBundle';
 
 type Props = RouteComponentProps<{
@@ -422,46 +422,13 @@ function SourceMapUploadDetails({sourceMapUpload}: {sourceMapUpload: SourceMapUp
             {showAll ? t('Show Less') : t('Show All')}
           </Button>
         ),
-        value:
-          rows.length > 0 ? (
-            <ReleasesWrapper>
-              {visibleAssociations.map(release => (
-                <AssociatedReleaseWrapper key={release.release}>
-                  <Tooltip
-                    showUnderline={release.exists === false}
-                    title={
-                      release.exists === false ? t('Release does not exist') : undefined
-                    }
-                  >
-                    <StyledVersion
-                      isPending={!defined(release.exists)}
-                      version={release.release}
-                      anchor={release.exists}
-                    />
-                  </Tooltip>
-                  {release.dist && `(Dist: ${formatDist(release.dist)})`}
-                </AssociatedReleaseWrapper>
-              ))}
-            </ReleasesWrapper>
-          ) : (
-            t('No releases associated with this upload.')
-          ),
+        value: <AssociatedReleases associations={visibleAssociations} />,
       },
     ];
   }, [sourceMapUpload, showAll]);
 
   return <StyledKeyValueList data={detailsData} shouldSort={false} />;
 }
-
-const formatDist = (dist: string | string[] | null) => {
-  if (Array.isArray(dist)) {
-    return dist.join(', ');
-  }
-  if (dist === null) {
-    return t('none');
-  }
-  return dist;
-};
 
 interface SourceMapUploadDeleteButtonProps {
   onDelete?: () => void;
@@ -501,19 +468,6 @@ function SourceMapUploadDeleteButton({onDelete}: SourceMapUploadDeleteButtonProp
   );
 }
 
-const ReleasesWrapper = styled('pre')`
-  max-height: 200px;
-`;
-
-const AssociatedReleaseWrapper = styled('div')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${space(0.5)};
-  :not(:last-child) {
-    margin-bottom: ${space(0.5)};
-  }
-`;
-
 const StyledKeyValueList = styled(KeyValueList)`
   && {
     margin-bottom: 0;
@@ -552,16 +506,4 @@ const ItemContent = styled('div')`
 
 const SearchBarWithMarginBottom = styled(SearchBar)`
   margin-bottom: ${space(3)};
-`;
-
-const StyledVersion = styled(Version)<{isPending: boolean}>`
-  ${p =>
-    p.isPending &&
-    css`
-      background-color: ${p.theme.backgroundTertiary};
-      border-radius: ${p.theme.borderRadius};
-      color: transparent;
-      pointer-events: none;
-      user-select: none;
-    `}
 `;


### PR DESCRIPTION
Similar to the [PR](https://github.com/getsentry/sentry/pull/95097) but now on the details page.


https://github.com/user-attachments/assets/3f0c5ab8-5628-45ff-8159-a4c67e778ed2

