### PR TITLE
fix(platform-insights): Neutral chart color too light

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -31,6 +31,7 @@ import {
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useNeutralChartColor} from 'sentry/views/insights/pages/platform/shared/useNeutralChartColor';
 import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 export default function LLMGenerationsWidget() {
@@ -40,6 +41,7 @@ export default function LLMGenerationsWidget() {
   });
 
   const theme = useTheme();
+  const neutralChartColor = useNeutralChartColor();
   const fullQuery = useCombinedQuery(getAIGenerationsFilter());
 
   const generationsRequest = useEAPSpans(
@@ -102,7 +104,7 @@ export default function LLMGenerationsWidget() {
         plottables: timeSeries.map(
           (ts, index) =>
             new Bars(convertSeriesToTimeseries(ts), {
-              color: ts.seriesName === 'Other' ? theme.gray200 : colorPalette[index],
+              color: ts.seriesName === 'Other' ? neutralChartColor : colorPalette[index],
               alias: ts.seriesName,
               stack: 'stack',
             })

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -32,11 +32,13 @@ import {
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useNeutralChartColor} from 'sentry/views/insights/pages/platform/shared/useNeutralChartColor';
 import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 export default function TokenUsageWidget() {
   const theme = useTheme();
   const organization = useOrganization();
+  const neutralChartColor = useNeutralChartColor();
   const pageFilterChartParams = usePageFilterChartParams({
     granularity: 'spans-low',
   });
@@ -102,7 +104,7 @@ export default function TokenUsageWidget() {
         plottables: timeSeries.map(
           (ts, index) =>
             new Bars(convertSeriesToTimeseries(ts), {
-              color: ts.seriesName === 'Other' ? theme.gray200 : colorPalette[index],
+              color: ts.seriesName === 'Other' ? neutralChartColor : colorPalette[index],
               stack: 'stack',
             })
         ),

--- a/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
@@ -30,6 +30,7 @@ import {
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useNeutralChartColor} from 'sentry/views/insights/pages/platform/shared/useNeutralChartColor';
 import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
 export default function ToolUsageWidget() {
@@ -39,6 +40,7 @@ export default function ToolUsageWidget() {
   });
 
   const theme = useTheme();
+  const neutralChartColor = useNeutralChartColor();
 
   const fullQuery = useCombinedQuery(getAIToolCallsFilter());
 
@@ -100,7 +102,7 @@ export default function ToolUsageWidget() {
         plottables: timeSeries.map(
           (ts, index) =>
             new Bars(convertSeriesToTimeseries(ts), {
-              color: ts.seriesName === 'Other' ? theme.gray200 : colorPalette[index],
+              color: ts.seriesName === 'Other' ? neutralChartColor : colorPalette[index],
               alias: ts.seriesName,
               stack: 'stack',
             })

--- a/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
@@ -18,6 +18,7 @@ import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/la
 import {useReleaseBubbleProps} from 'sentry/views/insights/pages/platform/shared/getReleaseBubbleProps';
 import {ModalChartContainer} from 'sentry/views/insights/pages/platform/shared/styles';
 import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {useNeutralChartColor} from 'sentry/views/insights/pages/platform/shared/useNeutralChartColor';
 
 interface TrafficWidgetProps extends LoadableChartWidgetProps {
   referrer: string;
@@ -41,6 +42,7 @@ export function BaseTrafficWidget({
   });
 
   const theme = useTheme();
+  const neutralChartColor = useNeutralChartColor();
 
   const {data, isLoading, error} = useEAPSeries(
     {
@@ -61,14 +63,14 @@ export function BaseTrafficWidget({
     return [
       new Bars(convertSeriesToTimeseries(data['count(span.duration)']), {
         alias: trafficSeriesName,
-        color: theme.gray200,
+        color: neutralChartColor,
       }),
       new Line(convertSeriesToTimeseries(data['trace_status_rate(internal_error)']), {
         alias: t('Error Rate'),
         color: theme.error,
       }),
     ];
-  }, [data, theme.error, theme.gray200, trafficSeriesName]);
+  }, [data, theme.error, neutralChartColor, trafficSeriesName]);
 
   const isEmpty = useMemo(
     () =>

--- a/static/app/views/insights/pages/platform/shared/useNeutralChartColor.tsx
+++ b/static/app/views/insights/pages/platform/shared/useNeutralChartColor.tsx
@@ -1,0 +1,21 @@
+import {useTheme} from '@emotion/react';
+import Color from 'color';
+
+import ConfigStore from 'sentry/stores/configStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+
+export function useNeutralChartColor() {
+  const theme = useTheme();
+  const config = useLegacyStore(ConfigStore);
+
+  if (!theme.isChonk) {
+    return theme.gray200;
+  }
+
+  const neutralColor =
+    config.theme === 'dark'
+      ? Color(theme.gray400).darken(0.35)
+      : Color(theme.gray400).lighten(1.3);
+
+  return neutralColor.toString();
+}


### PR DESCRIPTION
In the new UI the color gray200 is much lighter than before and unfit for usage in chart. This PR adds a hook for calculating a neutral chart color until the new theme supports this natively.

### Light mode
![Screenshot 2025-07-09 at 12 01 18](https://github.com/user-attachments/assets/48c0c1da-fb1a-4c8e-8e84-048cf0dc6b7a)


### Dark mode
![Screenshot 2025-07-09 at 12 01 07](https://github.com/user-attachments/assets/c0d46ce6-a5f7-4f26-a034-2b299a6e7901)
