### PR TITLE
chore(dynamic-sampling): remove unused function get_sampling_value

### DIFF
--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -150,16 +150,6 @@ def get_rule_hash(rule: PolymorphicRule) -> int:
     )
 
 
-def get_sampling_value(rule: PolymorphicRule) -> tuple[str, float] | None:
-    sampling = rule["samplingValue"]
-    if sampling["type"] == "reservoir":
-        return sampling["type"], float(sampling["limit"])
-    elif sampling["type"] in ("sampleRate", "factor"):
-        return sampling["type"], float(sampling["value"])
-    else:
-        return None
-
-
 def get_user_biases(user_set_biases: list[ActivatableBias] | None) -> list[ActivatableBias]:
     if user_set_biases is None:
         return DEFAULT_BIASES


### PR DESCRIPTION
- Was used only in a logging script that was deleted in https://github.com/getsentry/sentry/pull/70718/files#diff-1a4f1954b069feb3e3b1263c9f55a89d6d6a1263a5307b8ef2a99c8a19db6255L11