### PR TITLE
chore(dynamic-sampling): remove unused function get_rule_type

### DIFF
--- a/src/sentry/dynamic_sampling/rules/utils.py
+++ b/src/sentry/dynamic_sampling/rules/utils.py
@@ -111,28 +111,6 @@ class DecayingRule(Rule):
 PolymorphicRule = Union[Rule, DecayingRule]
 
 
-def get_rule_type(rule: Rule) -> RuleType | None:
-    # Edge case handled naively in which we check if the ID is within the possible bounds. This is done because the
-    # latest release rules have ids from 1500 to 1500 + (limit - 1). For example if the limit is 2, we will only have
-    # ids: 1500, 1501.
-    #
-    # This implementation MUST be changed in case we change the logic of rule ids.
-    if (
-        RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE]
-        <= rule["id"]
-        < RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE] + BOOSTED_RELEASES_LIMIT
-    ):
-        return RuleType.BOOST_LATEST_RELEASES_RULE
-    elif (
-        RESERVED_IDS[RuleType.BOOST_LOW_VOLUME_TRANSACTIONS_RULE]
-        <= rule["id"]
-        < RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE]
-    ):
-        return RuleType.BOOST_LOW_VOLUME_TRANSACTIONS_RULE
-
-    return REVERSE_RESERVED_IDS.get(rule["id"], None)
-
-
 def get_rule_hash(rule: PolymorphicRule) -> int:
     # We want to be explicit in what we use for computing the hash. In addition, we need to remove certain fields like
     # the sampleRate.


### PR DESCRIPTION
- Was used only in a logging script that was deleted in [#70718 (files)](https://github.com/getsentry/sentry/pull/70718/files#diff-1a4f1954b069feb3e3b1263c9f55a89d6d6a1263a5307b8ef2a99c8a19db6255L11)