### PR TITLE
fix(api): Increase project keys rate limit to 40

### DIFF
--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -34,14 +34,14 @@ class ProjectKeysEndpoint(ProjectEndpoint):
 
     rate_limits = {
         "GET": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            RateLimitCategory.IP: RateLimit(limit=40, window=1),
+            RateLimitCategory.USER: RateLimit(limit=40, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
         },
         "POST": {
-            RateLimitCategory.IP: RateLimit(limit=5, window=1),
-            RateLimitCategory.USER: RateLimit(limit=5, window=1),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=5, window=1),
+            RateLimitCategory.IP: RateLimit(limit=40, window=1),
+            RateLimitCategory.USER: RateLimit(limit=40, window=1),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1),
         },
     }
 


### PR DESCRIPTION
Addresses 429 errors fetching project keys by increasing the rate limit for the `/api/0/projects/{organization_slug}/{project_slug}/keys/` endpoint from 5 to 40 requests per second. This resolves a regression where the previous limit was insufficient for users with many keys.

Follow-up to #94099.

[Slack Thread](https://sentry.slack.com/archives/CD4NYFD34/p1752018891833399?thread_ts=1752018891.833399&cid=CD4NYFD34)