### PR TITLE
:wrench: chore(ecosystem): close SQS Plugin Related Sentry Issues

### DIFF
--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -181,8 +181,10 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
 
             sqs_send_message(message)
         except ClientError as e:
-            if str(e).startswith("An error occurred (InvalidClientTokenId)") or str(e).startswith(
-                "An error occurred (AccessDenied)"
+            if (
+                str(e).startswith("An error occurred (InvalidClientTokenId)")
+                or str(e).startswith("An error occurred (AccessDenied)")
+                or str(e).startswith("An error occurred (InvalidAccessKeyId)")
             ):
                 # If there's an issue with the user's token then we can't do
                 # anything to recover. Just continue.

--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -195,5 +195,8 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
                 # If there's an issue with the user's s3 bucket then we can't do
                 # anything to recover. Just continue.
                 return False
+            elif "AWS.SimpleQueueService.NonExistentQueue" in str(e):
+                # If the specified queue doesn't exist, we can't do anything to recover
+                return False
             raise
         return True


### PR DESCRIPTION
Resolves [SENTRY-3Y8D](https://sentry.sentry.io/issues/6646034137/events/2c03efe200ec4125acc82a2ee728b576/) 
Resolves [SENTRY-3YC4](https://sentry.sentry.io/issues/6646258066/events/6286ad1791144f2c80e80e7b8fbf0ac9/)
Resolves [SENTRY-3Y8X](https://sentry.sentry.io/issues/6646040593/events/adc40417dfb2424fb1e338c8ed8ea95c/)
Resolves [SENTRY-3YB2](https://sentry.sentry.io/issues/6646163025/events/c6b728baf3ac4b478db9abd9f6f4ede9/)

Part of auditing ecosystem's most frequent issues

We just needed to capture another type of exception.

Closes ECO-846
Closes ECO-847
Closes ECO-848
Closes ECO-849