### PR TITLE
feat(dynamic-sampling): add switch for minimumSampleRate bias to existing settings

### DIFF
--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -3,6 +3,7 @@ export enum DynamicSamplingBiasType {
   BOOST_LATEST_RELEASES = 'boostLatestRelease',
   BOOST_LOW_VOLUME_TRANSACTIONS = 'boostLowVolumeTransactions',
   IGNORE_HEALTH_CHECKS = 'ignoreHealthChecks',
+  MINIMUM_SAMPLE_RATE = 'minimumSampleRate',
 }
 
 export type DynamicSamplingBias = {

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -304,7 +304,7 @@ function ProjectPerformance() {
     const fields = [
       {
         name: 'boostLatestRelease',
-        type: 'boolean',
+        type: 'boolean' as const,
         label: retentionPrioritiesLabels.boostLatestRelease,
         help: t(
           'Captures more transactions for your new releases as they are being adopted'
@@ -313,7 +313,7 @@ function ProjectPerformance() {
       },
       {
         name: 'boostEnvironments',
-        type: 'boolean',
+        type: 'boolean' as const,
         label: retentionPrioritiesLabels.boostEnvironments,
         help: t(
           'Captures more traces from environments that contain "debug", "dev", "local", "qa", and "test"'
@@ -322,14 +322,14 @@ function ProjectPerformance() {
       },
       {
         name: 'boostLowVolumeTransactions',
-        type: 'boolean',
+        type: 'boolean' as const,
         label: retentionPrioritiesLabels.boostLowVolumeTransactions,
         help: t("Balance high-volume endpoints so they don't drown out low-volume ones"),
         getData: getRetentionPrioritiesData,
       },
       {
         name: 'ignoreHealthChecks',
-        type: 'boolean',
+        type: 'boolean' as const,
         label: retentionPrioritiesLabels.ignoreHealthChecks,
         help: t('Captures fewer of your health checks transactions'),
         getData: getRetentionPrioritiesData,
@@ -341,7 +341,7 @@ function ProjectPerformance() {
     ) {
       fields.push({
         name: 'minimumSampleRate',
-        type: 'boolean',
+        type: 'boolean' as const,
         label: retentionPrioritiesLabels.minimumSampleRate,
         help: t(
           'If higher than the trace sample rate, use the project sample rate for spans instead of the trace sample rate.'

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -336,7 +336,9 @@ function ProjectPerformance() {
       name: 'minimumSampleRate',
       type: 'boolean',
       label: retentionPrioritiesLabels.minimumSampleRate,
-      help: t('Use the project sample rate for spans instead of the trace sample rate.'),
+      help: t(
+        'If higher than the trace sample rate, use the project sample rate for spans instead of the trace sample rate.'
+      ),
       getData: getRetentionPrioritiesData,
     },
   ];

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -337,7 +337,7 @@ function ProjectPerformance() {
     ];
     if (
       hasDynamicSamplingCustomFeature(organization) &&
-      organization.features.includes('organizations:dynamic-sampling-minimum-sample-rate')
+      organization.features.includes('dynamic-sampling-minimum-sample-rate')
     ) {
       fields.push({
         name: 'minimumSampleRate',

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -49,7 +49,7 @@ export const retentionPrioritiesLabels = {
   boostEnvironments: t('Prioritize dev environments'),
   boostLowVolumeTransactions: t('Prioritize low-volume transactions'),
   ignoreHealthChecks: t('Deprioritize health checks'),
-  minimumSampleRate: t('Override trace sample rate'),
+  minimumSampleRate: t('Always use project sample rate'),
 };
 
 export const allowedDurationValues: number[] = [
@@ -336,9 +336,7 @@ function ProjectPerformance() {
       name: 'minimumSampleRate',
       type: 'boolean',
       label: retentionPrioritiesLabels.minimumSampleRate,
-      help: t(
-        'Sample incoming traces with the project sample rate instead of the trace sample rate'
-      ),
+      help: t('Use the project sample rate for spans instead of the trace sample rate.'),
       getData: getRetentionPrioritiesData,
     },
   ];

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -335,7 +335,10 @@ function ProjectPerformance() {
         getData: getRetentionPrioritiesData,
       },
     ];
-    if (hasDynamicSamplingCustomFeature(organization)) {
+    if (
+      hasDynamicSamplingCustomFeature(organization) &&
+      organization.features.includes('organizations:dynamic-sampling-minimum-sample-rate')
+    ) {
       fields.push({
         name: 'minimumSampleRate',
         type: 'boolean',

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -49,6 +49,7 @@ export const retentionPrioritiesLabels = {
   boostEnvironments: t('Prioritize dev environments'),
   boostLowVolumeTransactions: t('Prioritize low-volume transactions'),
   ignoreHealthChecks: t('Deprioritize health checks'),
+  minimumSampleRate: t('Override trace sample rate'),
 };
 
 export const allowedDurationValues: number[] = [
@@ -329,6 +330,15 @@ function ProjectPerformance() {
       type: 'boolean',
       label: retentionPrioritiesLabels.ignoreHealthChecks,
       help: t('Captures fewer of your health checks transactions'),
+      getData: getRetentionPrioritiesData,
+    },
+    {
+      name: 'minimumSampleRate',
+      type: 'boolean',
+      label: retentionPrioritiesLabels.minimumSampleRate,
+      help: t(
+        'Sample incoming traces with the project sample rate instead of the trace sample rate'
+      ),
       getData: getRetentionPrioritiesData,
     },
   ];


### PR DESCRIPTION
- As a first step, add the new bias to the existing settings page
- Only show when the org is activated for custom dynamic sampling
- Depends on https://github.com/getsentry/sentry/pull/93014


<img width="827" height="428" alt="Screenshot 2025-07-10 at 14 41 09" src="https://github.com/user-attachments/assets/38f807ed-13d3-4a22-9708-afb706bbf60e" />

