### PR TITLE
:wrench: chore(ecosystem): resolve SENTRY-3Y8W

### DIFF
--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -225,6 +225,9 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 or (exc.code is not None and (401 <= exc.code <= 404))
                 # 502s are too noisy.
                 or exc.code == 502
+                or exc.code == 405
+                # Method not allowed for the url
+                # This is caused by webhook being misconfigured, something we can't fix.
             ):
                 return False
             raise


### PR DESCRIPTION
resolves [SENTRY-3Y8W](https://sentry.sentry.io/issues/6646040240/events/bf16ca5a50f7402197a4f44f84899bfb/)

Part of auditing ecosystem's most frequent issues

We just needed to capture another type of exception since this is also not actionable.

closes ECO-851