### PR TITLE
:wrench: chore(ecosystem): handle SENTRY-44YY

### DIFF
--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import quote
 
 import orjson
-import sentry_sdk
 
 from sentry.integrations.gitlab.utils import (
     GitLabApiClientPath,
@@ -102,24 +101,11 @@ def _fetch_file_blame(
             extra=extra,
         )
     else:
-        try:
-            response = client.get(
-                request_path,
-                params=params,
-            )
-            client.set_cache(cache_key, response, 60)
-        except ApiError as e:
-            sentry_sdk.set_context(
-                "fetch_file_blame_ApiError",
-                {
-                    "file_path": file.path,
-                    "request_path": request_path,
-                    "repo_org_id": file.repo.organization_id,
-                    "repo_integration_id": file.repo.integration_id,
-                },
-            )
-            sentry_sdk.capture_exception(error=e, level="warning")
-            raise
+        response = client.get(
+            request_path,
+            params=params,
+        )
+        client.set_cache(cache_key, response, 60)
 
     if not isinstance(response, SequenceApiResponse):
         raise ApiError("Response is not in expected format", code=500)


### PR DESCRIPTION
Resolves [SENTRY-44YY](https://sentry.sentry.io/issues/6723530557/events/6da0fc29c8714e1cbac3aec850fc775f/)

Part of auditing ecosystem's most frequent issues

We don't action on this exception (the git blame says we were capturing to debug an issue).

We also already emit a log for this error at the callsite of the method:
https://github.com/getsentry/sentry/blob/1d9e3359926ae17f8b7155e74453730933d861dc/src/sentry/integrations/gitlab/blame.py#L56-L61

and

https://github.com/getsentry/sentry/blob/1d9e3359926ae17f8b7155e74453730933d861dc/src/sentry/integrations/gitlab/blame.py#L128-L130


Closes ECO-850