### PR TITLE
ref: fix nullable group retrieval in seer test

### DIFF
--- a/tests/sentry/seer/fetch_issues/test_fetch_issues_given_exception_type.py
+++ b/tests/sentry/seer/fetch_issues/test_fetch_issues_given_exception_type.py
@@ -38,7 +38,7 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
 
         # Assert only 1 Group object in the database
         assert Group.objects.count() == 1
-        group = Group.objects.first()
+        group = Group.objects.get()
 
         # Assert that KeyError matched the exception type
         group_ids = get_issues_related_to_exception_type(
@@ -187,7 +187,7 @@ class TestGetIssuesGivenExceptionTypes(APITestCase, SnubaTestCase):
 
         # Assert only 1 Group object in the database
         assert Group.objects.count() == 1
-        group = Group.objects.first()
+        group = Group.objects.get()
 
         # Assert that KeyError matched the exception type
         group_ids = get_issues_related_to_exception_type(


### PR DESCRIPTION
upgraded mypy notices this becomes nullable after assignment

<!-- Describe your PR here. -->