### PR TITLE
fix(grid-editable): Use regular functions and bind

### DIFF
--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -156,6 +156,18 @@ class GridEditable<
     };
   }
 
+  constructor(props: GridEditableProps<DataRow, ColumnKey>) {
+    super(props);
+    this.onResetColumnSize = this.onResetColumnSize.bind(this);
+    this.onResizeMouseDown = this.onResizeMouseDown.bind(this);
+    this.onResizeMouseUp = this.onResizeMouseUp.bind(this);
+    this.onResizeMouseMove = this.onResizeMouseMove.bind(this);
+    this.redrawGridColumn = this.redrawGridColumn.bind(this);
+    this.resizeGridColumn = this.resizeGridColumn.bind(this);
+    this.renderGridBody = this.renderGridBody.bind(this);
+    this.renderGridBodyRow = this.renderGridBodyRow.bind(this);
+  }
+
   state: GridEditableState = {
     numColumn: 0,
   };
@@ -189,7 +201,7 @@ class GridEditable<
     });
   }
 
-  onResetColumnSize = (e: React.MouseEvent, i: number) => {
+  onResetColumnSize(e: React.MouseEvent, i: number) {
     e.stopPropagation();
 
     const nextColumnOrder = [...this.props.columnOrder];
@@ -206,9 +218,9 @@ class GridEditable<
         width: COL_WIDTH_UNDEFINED,
       });
     }
-  };
+  }
 
-  onResizeMouseDown = (e: React.MouseEvent, i = -1) => {
+  onResizeMouseDown(e: React.MouseEvent, i = -1) {
     e.stopPropagation();
 
     // Block right-click and other funky stuff
@@ -234,9 +246,9 @@ class GridEditable<
 
     window.addEventListener('mouseup', this.onResizeMouseUp);
     this.resizeWindowLifecycleEvents.mouseup!.push(this.onResizeMouseUp);
-  };
+  }
 
-  onResizeMouseUp = (e: MouseEvent) => {
+  onResizeMouseUp(e: MouseEvent) {
     const metadata = this.resizeMetadata;
     const onResizeColumn = this.props.grid.onResizeColumn;
 
@@ -252,16 +264,16 @@ class GridEditable<
 
     this.resizeMetadata = undefined;
     this.clearWindowLifecycleEvents();
-  };
+  }
 
-  onResizeMouseMove = (e: MouseEvent) => {
+  onResizeMouseMove(e: MouseEvent) {
     const {resizeMetadata} = this;
     if (!resizeMetadata) {
       return;
     }
 
     window.requestAnimationFrame(() => this.resizeGridColumn(e, resizeMetadata));
-  };
+  }
 
   resizeGridColumn(e: MouseEvent, metadata: ColResizeMetadata) {
     const grid = this.refGrid.current;
@@ -330,6 +342,7 @@ class GridEditable<
     const prependColumns = grid.renderPrependColumns
       ? grid.renderPrependColumns(true)
       : [];
+
     return (
       <GridRow data-test-id="grid-head-row">
         {prependColumns &&
@@ -382,7 +395,7 @@ class GridEditable<
     return data.map(this.renderGridBodyRow);
   }
 
-  renderGridBodyRow = (dataRow: DataRow, row: number) => {
+  renderGridBodyRow(dataRow: DataRow, row: number) {
     const {columnOrder, grid, onRowMouseOver, onRowMouseOut, highlightedRowKey} =
       this.props;
     const prependColumns = grid.renderPrependColumns
@@ -412,7 +425,7 @@ class GridEditable<
         ))}
       </GridRow>
     );
-  };
+  }
 
   renderError() {
     return (


### PR DESCRIPTION
Since the bump to rspack==1.4 (#94351), there's something strange with the way arrow functions behave with `this`. In this case, when declaring class methods as arrow functions, the `this` inside the arrow functions seems to only refer to the latest instance of the class.