### PR TITLE
fix(replay): Adjust sizing/padding of replay tabs

### DIFF
--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -148,7 +148,7 @@ const PlayerContainer = styled('div')`
   display: grid;
   grid-auto-flow: row;
   grid-template-rows: auto 1fr;
-  gap: 10px;
+  gap: ${space(1)};
   flex-grow: 1;
 `;
 

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -24,7 +24,7 @@ function getReplayTabs({
   return {
     [TabKey.AI]: organization.features.includes('replay-ai-summaries') ? (
       <Flex align="center" gap={space(0.75)}>
-        {t('Chapters')}
+        {t('Summary')}
         <Tooltip title={t('experimental')}>
           <IconLab isSolid />
         </Tooltip>

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -1,9 +1,11 @@
 import {type ReactNode} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
 import {Flex} from 'sentry/components/core/layout';
 import {TabList, Tabs} from 'sentry/components/core/tabs';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconLab} from 'sentry/icons/iconLab';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -22,8 +24,10 @@ function getReplayTabs({
   return {
     [TabKey.AI]: organization.features.includes('replay-ai-summaries') ? (
       <Flex align="center" gap={space(0.75)}>
-        {t('AI')}
-        <FeatureBadge type="experimental" />
+        {t('Chapters')}
+        <Tooltip title={t('experimental')}>
+          <IconLab isSolid />
+        </Tooltip>
       </Flex>
     ) : null,
     [TabKey.BREADCRUMBS]: t('Breadcrumbs'),
@@ -52,6 +56,7 @@ export default function FocusTabs({isVideoReplay}: Props) {
   return (
     <TabContainer>
       <Tabs
+        size="xs"
         value={activeTab}
         onChange={tab => {
           // Navigation is handled by setActiveTab
@@ -76,6 +81,12 @@ export default function FocusTabs({isVideoReplay}: Props) {
 }
 
 const TabContainer = styled('div')`
-  ${p => (p.theme.isChonk ? '' : `padding-inline: ${space(1)};`)}
-  border-bottom: 1px solid ${p => p.theme.border};
+  ${p =>
+    p.theme.isChonk
+      ? ''
+      : css`
+          padding-inline: ${space(1)};
+          border-bottom: 1px solid ${p.theme.border};
+          margin-bottom: -1px;
+        `}
 `;


### PR DESCRIPTION
I chose the `xs + summary + no-border` version but added images for a few other variants to see what they look like too.

In UI1 everything looks fine, in all these variants. So I only took UI2 screenshots, and tweaked that.

More notes below....

| | XS | SM |
| --- | --- | --- |
| "AI" | <img width="1355" alt="xs - ai" src="https://github.com/user-attachments/assets/dfc76f5d-15ab-41dd-90a7-580de27142bd" /> | <img width="1355" alt="sm - ai" src="https://github.com/user-attachments/assets/be0ab4d2-1634-45fc-83bf-65a23ae639fd" />
| "Summary" | <img width="1355" alt="xs - summary" src="https://github.com/user-attachments/assets/bdfd0a1d-29a8-463d-9143-7291a3d8ab38" /> | <img width="1355" alt="sm - summary" src="https://github.com/user-attachments/assets/1ce991e0-0b08-47b8-9c03-4ed7036bea66" />
| "Chapters" | <img width="1355" alt="xs - chapters" src="https://github.com/user-attachments/assets/de3eedc5-79a9-4d2d-95ca-6fe3eb4dafe4" /> | <img width="1355" alt="sm - chapters" src="https://github.com/user-attachments/assets/6121e9d8-4ac4-4510-805c-50fe860787b6" />
| "Chapters" (no border) | <img width="1355" alt="xs - chapters - noline" src="https://github.com/user-attachments/assets/62f24c83-9294-4860-8065-78f276c73a22" /> | <img width="1355" alt="sm - chapters - noline" src="https://github.com/user-attachments/assets/c7d0b3f4-99cf-4e5f-ad11-676683e8235f" />


**Sizes**
With `xs` text is a smaller than before, which is weird to look at, but i like how it lets the left & right sides of the page line up.
<img width="249" alt="SCR-20250709-jzev" src="https://github.com/user-attachments/assets/0af6da97-da9f-4f4f-a72a-d75a433a0e5a" />


**Label**
The label 'chapters' is already visible when one of these expando's is opened, but nothing is inside it. 
However 'replay summary' is used as the title inside the tab, so naming the tab 'summary' aligns with that
So it could go either way.
<img width="608" alt="sm - chapters -item open" src="https://github.com/user-attachments/assets/78cbe3ba-f487-47db-96da-5d7a0e1b9181" />



**Border**
The border question looks a bit different on the other tabs, where there's a filter+search box instead of the Panel
<img width="636" alt="SCR-20250709-jyxd" src="https://github.com/user-attachments/assets/1f51c2f8-540a-448c-a983-961b8407ce2e" />


Fixes REPLAY-476
