### PR TITLE
feat(explore-sus-attrs): Adding charts skeleton

### DIFF
--- a/static/app/views/explore/components/suspectTags/charts.tsx
+++ b/static/app/views/explore/components/suspectTags/charts.tsx
@@ -1,0 +1,116 @@
+import type {Theme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import BaseChart from 'sentry/components/charts/baseChart';
+import {space} from 'sentry/styles/space';
+import type {SuspectAttributesResult} from 'sentry/views/explore/hooks/useSuspectAttributes';
+
+type Props = {
+  rankedAttributes: SuspectAttributesResult['rankedAttributes'];
+};
+
+// TODO Abdullah Khan: Add virtualization and search to the list of charts
+export function Charts({rankedAttributes}: Props) {
+  const theme = useTheme();
+  return (
+    <ChartsWrapper>
+      {rankedAttributes.map(attribute => (
+        <Chart key={attribute.attributeName} attribute={attribute} theme={theme} />
+      ))}
+    </ChartsWrapper>
+  );
+}
+
+function Chart({
+  attribute,
+  theme,
+}: {
+  attribute: SuspectAttributesResult['rankedAttributes'][number];
+  theme: Theme;
+}) {
+  const cohort1Color = theme.chart.getColorPalette(0)?.[0];
+  const cohort2Color = '#dddddd';
+
+  return (
+    <ChartWrapper>
+      <ChartTitle>{attribute.attributeName}</ChartTitle>
+      <BaseChart
+        autoHeightResize
+        isGroupedByDate={false}
+        tooltip={{
+          trigger: 'axis',
+          confine: true,
+        }}
+        grid={{
+          left: 2,
+          right: 8,
+          containLabel: true,
+        }}
+        xAxis={{
+          show: true,
+          type: 'category',
+          data: attribute.cohort1.map(cohort => cohort.label),
+          truncate: 14,
+          axisLabel: {
+            hideOverlap: true,
+            showMaxLabel: false,
+            showMinLabel: false,
+            color: '#000',
+            interval: 0,
+            formatter: (value: string) => value,
+          },
+        }}
+        yAxis={{
+          type: 'value',
+          axisLabel: {
+            show: false,
+            width: 0,
+          },
+        }}
+        series={[
+          {
+            type: 'bar',
+            data: attribute.cohort1.map(cohort => cohort.value),
+            name: 'Selected',
+            itemStyle: {
+              color: cohort1Color,
+            },
+          },
+          {
+            type: 'bar',
+            data: attribute.cohort2.map(cohort => cohort.value),
+            name: 'Baseline',
+            itemStyle: {
+              color: cohort2Color,
+            },
+          },
+        ]}
+      />
+    </ChartWrapper>
+  );
+}
+
+const ChartsWrapper = styled('div')`
+  flex: 1;
+  overflow: auto;
+  overflow-y: scroll;
+  overscroll-behavior: none;
+`;
+
+const ChartWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  height: 200px;
+  padding: ${space(2)} ${space(2)} 0 ${space(2)};
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.border};
+  }
+`;
+
+const ChartTitle = styled('div')`
+  font-size: ${p => p.theme.fontSize.md};
+  font-weight: 600;
+  color: ${p => p.theme.gray500};
+`;

--- a/static/app/views/explore/components/suspectTags/drawer.tsx
+++ b/static/app/views/explore/components/suspectTags/drawer.tsx
@@ -6,6 +6,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {ChartInfo} from 'sentry/views/explore/charts';
+import {Charts} from 'sentry/views/explore/components/suspectTags/charts';
 import type {BoxSelectOptions} from 'sentry/views/explore/hooks/useChartBoxSelect';
 import useSuspectAttributes from 'sentry/views/explore/hooks/useSuspectAttributes';
 
@@ -32,14 +33,7 @@ export function Drawer({boxSelectOptions, chartInfo}: Props) {
         ) : isError ? (
           <LoadingError message={t('Failed to load suspect attributes')} />
         ) : (
-          <AttributeNames>
-            {/* TODO Abdullah Khan: Add suspect attributes distribution charts, just listing the names for now */}
-            {data?.rankedAttributes.map(a => (
-              <div key={a.attributeName}>
-                {a.attributeName} <br />
-              </div>
-            ))}
-          </AttributeNames>
+          <Charts rankedAttributes={data!.rankedAttributes} />
         )}
       </StyledDrawerBody>
     </DrawerContainer>
@@ -69,11 +63,4 @@ const DrawerContainer = styled('div')`
   > header {
     flex-shrink: 0;
   }
-`;
-
-const AttributeNames = styled('div')`
-  flex: 1;
-  overflow: hidden;
-  overflow-y: scroll;
-  overscroll-behavior: none;
 `;

--- a/static/app/views/explore/components/suspectTags/floatingTrigger.tsx
+++ b/static/app/views/explore/components/suspectTags/floatingTrigger.tsx
@@ -82,6 +82,7 @@ export function FloatingTrigger({boxSelectOptions, triggerWrapperRef, chartInfo}
         position: 'absolute',
         top: triggerPosition.top,
         left: triggerPosition.left,
+        zIndex: 1000,
       }}
     >
       <List>

--- a/static/app/views/explore/hooks/useSuspectAttributes.tsx
+++ b/static/app/views/explore/hooks/useSuspectAttributes.tsx
@@ -14,7 +14,7 @@ import {useExploreDataset} from 'sentry/views/explore/contexts/pageParamsContext
 import type {BoxSelectOptions} from 'sentry/views/explore/hooks/useChartBoxSelect';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 
-type SuspectAttributesResult = {
+export type SuspectAttributesResult = {
   rankedAttributes: Array<{
     attributeName: string;
     cohort1: Array<{


### PR DESCRIPTION
- This is a WIP, I will add sorting among the cohorts, fixing axis label overlaps, add search and virtualization of the list of charts in following PRs.
- This is all under the flag: `performance-spans-suspect-attributes`, only enabled for devs

https://github.com/user-attachments/assets/e70ed45e-fe5e-46ac-9aa4-eb1c6c854ee7

