### PR TITLE
fix(aci): fix Group N+1 query in delayed workflow query handlers

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from typing import Any, ClassVar, Literal, Protocol, TypedDict
 
 from django.core.cache import cache
-from django.db.models import QuerySet
 from snuba_sdk import Op
 
 from sentry import release_health, tsdb
@@ -16,7 +15,6 @@ from sentry.issues.constants import (
     get_issue_tsdb_user_group_model,
 )
 from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
-from sentry.models.group import Group
 from sentry.rules.conditions.event_attribute import ATTR_CHOICES
 from sentry.rules.conditions.event_frequency import (
     MIN_SESSIONS_TO_FIRE,
@@ -33,6 +31,13 @@ from sentry.workflow_engine.models.data_condition import Condition
 
 QueryFilter = dict[str, Any]
 QueryResult = dict[int, int | float]
+
+
+class GroupValues(TypedDict):
+    id: int
+    type: int
+    project_id: int
+    project__organization_id: int
 
 
 class TSDBFunction(Protocol):
@@ -59,13 +64,6 @@ class InvalidFilter(Exception):
     """
 
     pass
-
-
-class _QSTypedDict(TypedDict):
-    id: int
-    type: int
-    project_id: int
-    project__organization_id: int
 
 
 class BaseEventFrequencyQueryHandler(ABC):
@@ -154,7 +152,7 @@ class BaseEventFrequencyQueryHandler(ABC):
 
     def get_group_ids_by_category(
         self,
-        groups: QuerySet[Group, _QSTypedDict],
+        groups: list[GroupValues],
     ) -> dict[GroupCategory, list[int]]:
         """
         Separate group ids into error group ids and generic group ids
@@ -170,7 +168,7 @@ class BaseEventFrequencyQueryHandler(ABC):
 
     def get_value_from_groups(
         self,
-        groups: QuerySet[Group, _QSTypedDict] | None,
+        groups: list[GroupValues],
         value: Literal["id", "project_id", "project__organization_id"],
     ) -> int | None:
         result = None
@@ -270,7 +268,7 @@ class BaseEventFrequencyQueryHandler(ABC):
     @abstractmethod
     def batch_query(
         self,
-        group_ids: set[int],
+        groups: list[GroupValues],
         start: datetime,
         end: datetime,
         environment_id: int | None,
@@ -285,7 +283,7 @@ class BaseEventFrequencyQueryHandler(ABC):
     def get_rate_bulk(
         self,
         duration: timedelta,
-        group_ids: set[int],
+        groups: list[GroupValues],
         environment_id: int | None,
         current_time: datetime,
         comparison_interval: timedelta | None,
@@ -306,7 +304,7 @@ class BaseEventFrequencyQueryHandler(ABC):
 
         with self.disable_consistent_snuba_mode(duration):
             result = self.batch_query(
-                group_ids=group_ids,
+                groups=groups,
                 start=start,
                 end=end,
                 environment_id=environment_id,
@@ -325,16 +323,13 @@ slow_condition_query_handler_registry = Registry[type[BaseEventFrequencyQueryHan
 class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
     def batch_query(
         self,
-        group_ids: set[int],
+        groups: list[GroupValues],
         start: datetime,
         end: datetime,
         environment_id: int | None,
         filters: list[QueryFilter] | None = None,
     ) -> QueryResult:
         batch_sums: QueryResult = defaultdict(int)
-        groups = Group.objects.filter(id__in=group_ids).values(
-            "id", "type", "project_id", "project__organization_id"
-        )
         category_group_ids = self.get_group_ids_by_category(groups)
         organization_id = self.get_value_from_groups(groups, "project__organization_id")
 
@@ -371,16 +366,13 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
     def batch_query(
         self,
-        group_ids: set[int],
+        groups: list[GroupValues],
         start: datetime,
         end: datetime,
         environment_id: int | None,
         filters: list[QueryFilter] | None = None,
     ) -> QueryResult:
         batch_sums: QueryResult = defaultdict(int)
-        groups = Group.objects.filter(id__in=group_ids).values(
-            "id", "type", "project_id", "project__organization_id"
-        )
         category_group_ids = self.get_group_ids_by_category(groups)
         organization_id = self.get_value_from_groups(groups, "project__organization_id")
 
@@ -442,16 +434,13 @@ class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
 
     def batch_query(
         self,
-        group_ids: set[int],
+        groups: list[GroupValues],
         start: datetime,
         end: datetime,
         environment_id: int | None,
         filters: list[QueryFilter] | None = None,
     ) -> QueryResult:
         batch_percents: QueryResult = {}
-        groups = Group.objects.filter(id__in=group_ids).values(
-            "id", "type", "project_id", "project__organization_id"
-        )
         category_group_ids = self.get_group_ids_by_category(groups)
         project_id = self.get_value_from_groups(groups, "project_id")
 

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -425,7 +425,7 @@ def get_condition_group_results(
 
     all_group_ids: set[GroupId] = set()
     # bulk gather groups and fetch them
-    for unique_condition, time_and_groups in queries_to_groups.items():
+    for time_and_groups in queries_to_groups.values():
         all_group_ids.update(time_and_groups.group_ids)
 
     all_groups: list[GroupValues] = list(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -39,6 +39,7 @@ from sentry.utils.registry import NoRegistrationExistsError
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
     BaseEventFrequencyQueryHandler,
+    GroupValues,
     QueryFilter,
     QueryResult,
     slow_condition_query_handler_registry,
@@ -422,9 +423,21 @@ def get_condition_group_results(
     condition_group_results = {}
     current_time = timezone.now()
 
+    all_group_ids: set[GroupId] = set()
+    # bulk gather groups and fetch them
+    for unique_condition, time_and_groups in queries_to_groups.items():
+        all_group_ids.update(time_and_groups.group_ids)
+
+    all_groups: list[GroupValues] = list(
+        Group.objects.filter(id__in=all_group_ids).values(
+            "id", "type", "project_id", "project__organization_id"
+        )
+    )
+
     for unique_condition, time_and_groups in queries_to_groups.items():
         handler = unique_condition.handler()
         group_ids = time_and_groups.group_ids
+        groups_to_query = [group for group in all_groups if group["id"] in group_ids]
         time = time_and_groups.timestamp or current_time
 
         _, duration = handler.intervals[unique_condition.interval]
@@ -437,7 +450,7 @@ def get_condition_group_results(
 
         result = handler.get_rate_bulk(
             duration=duration,
-            group_ids=group_ids,
+            groups=groups_to_query,
             environment_id=unique_condition.environment_id,
             current_time=time,
             comparison_interval=comparison_interval,

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -3,6 +3,7 @@ from typing import Any
 from uuid import uuid4
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
+from sentry.models.group import Group
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
@@ -129,3 +130,14 @@ class EventFrequencyQueryTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueT
             fingerprint=fingerprint,
         )
         self.data = {"interval": "5m", "value": 30}
+
+        self.groups = list(
+            Group.objects.filter(
+                id__in={self.event.group_id, self.event2.group_id, self.perf_event.group_id}
+            ).values("id", "type", "project_id", "project__organization_id")
+        )
+        self.group_3 = list(
+            Group.objects.filter(id=self.event3.group_id).values(
+                "id", "type", "project_id", "project__organization_id"
+            )
+        )

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -23,7 +23,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -35,7 +35,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -44,7 +44,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__equal(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -58,7 +58,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__not_equal(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -72,7 +72,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__starts_with(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -86,7 +86,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__not_starts_with(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -100,7 +100,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__ends_with(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -114,7 +114,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__not_ends_with(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -128,7 +128,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__contains(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -138,7 +138,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__not_contains(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -148,7 +148,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__is_set(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -162,7 +162,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__is_not_set(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -176,7 +176,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__is_in(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -190,7 +190,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__tag_conditions__is_not_in(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -205,7 +205,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
     def test_batch_query__tag_conditions__invalid(self):
         with pytest.raises(ValueError):
             self.handler().batch_query(
-                group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+                groups=self.groups,
                 start=self.start,
                 end=self.end,
                 environment_id=self.environment.id,
@@ -214,7 +214,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__attribute_conditions(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -227,7 +227,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -240,7 +240,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         # error.handled is only available for errors, not issue platform
         # perf event should not have any events that match the criteria
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -253,10 +253,7 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
     def test_get_error_and_generic_group_ids(self):
-        groups = Group.objects.filter(
-            id__in=[self.event.group_id, self.event2.group_id, self.perf_event.group_id]
-        ).values("id", "type", "project_id", "project__organization_id")
-        category_group_ids = self.handler().get_group_ids_by_category(groups)
+        category_group_ids = self.handler().get_group_ids_by_category(self.groups)
         error_group_ids = category_group_ids[GroupCategory.ERROR]
         assert self.event.group_id in error_group_ids
         assert self.event2.group_id in error_group_ids
@@ -268,7 +265,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query_user(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -280,7 +277,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -289,7 +286,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query_user__tag_conditions(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -302,7 +299,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -312,7 +309,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
 
     def test_batch_query__attribute_conditions(self):
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -325,7 +322,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
         }
 
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -338,7 +335,7 @@ class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):
         # error.handled is only available for errors, not issue platform
         # perf event should not have any events that match the criteria
         batch_query = self.handler().batch_query(
-            group_ids={self.event.group_id, self.event2.group_id, self.perf_event.group_id},
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -361,12 +358,9 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
     def test_batch_query_percent(self):
         self._make_sessions(60, self.environment2.name)
         self._make_sessions(60, self.environment.name)
-        group_ids = {self.event.group_id, self.event2.group_id, self.perf_event.group_id}
-        for group_id in group_ids:
-            assert group_id
 
         batch_query = self.handler().batch_query(
-            group_ids=group_ids,
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -380,7 +374,7 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
 
         assert self.event3.group_id
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,
@@ -391,13 +385,17 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
         self._make_sessions(600, self.environment.name)
 
         assert self.event.group_id
-        group_ids = {self.event.group_id}
+        groups = list(
+            Group.objects.filter(id=self.event.group_id).values(
+                "id", "type", "project_id", "project__organization_id"
+            )
+        )
 
         self.start = before_now(hours=1)
         self.end = self.start + timedelta(hours=1)
 
         batch_query = self.handler().batch_query(
-            group_ids=group_ids,
+            groups=groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -411,12 +409,8 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
     def test_batch_query_percent_no_avg_sessions_in_interval(self):
         self._make_sessions(60, self.environment2.name)
         self._make_sessions(60, self.environment.name)
-        group_ids = {self.event.group_id, self.event2.group_id, self.perf_event.group_id}
-        for group_id in group_ids:
-            assert group_id
-
         batch_query = self.handler().batch_query(
-            group_ids=group_ids,
+            groups=self.groups,
             start=self.start,
             end=self.end,
             environment_id=self.environment.id,
@@ -430,7 +424,7 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
 
         assert self.event3.group_id
         batch_query = self.handler().batch_query(
-            group_ids={self.event3.group_id},
+            groups=self.group_3,
             start=self.start,
             end=self.end,
             environment_id=self.environment2.id,


### PR DESCRIPTION
Fixes SENTRY-43RN

We currently make a query to the `Group` table for every unique Snuba query we make in a delayed workflow task. We can save these extra queries by making a single query to the `Group` table per task.