### PR TITLE
chore(aci): Use camel-cased detector config properties

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -77,32 +77,32 @@ export type DetectorType =
   | 'uptime_domain_failure';
 
 interface BaseMetricDetectorConfig {
-  threshold_period: number;
+  thresholdPeriod: number;
 }
 
 /**
  * Configuration for static/threshold-based detection
  */
 interface MetricDetectorConfigStatic extends BaseMetricDetectorConfig {
-  detection_type: 'static';
+  detectionType: 'static';
 }
 
 /**
  * Configuration for percentage-based change detection
  */
 interface MetricDetectorConfigPercent extends BaseMetricDetectorConfig {
-  comparison_delta: number;
-  detection_type: 'percent';
+  comparisonDelta: number;
+  detectionType: 'percent';
 }
 
 /**
  * Configuration for dynamic/anomaly detection
  */
 interface MetricDetectorConfigDynamic extends BaseMetricDetectorConfig {
-  detection_type: 'dynamic';
+  detectionType: 'dynamic';
   seasonality?: 'auto' | 'daily' | 'weekly' | 'monthly';
   sensitivity?: AlertRuleSensitivity;
-  threshold_type?: AlertRuleThresholdType;
+  thresholdType?: AlertRuleThresholdType;
 }
 
 export type MetricDetectorConfig =

--- a/static/app/views/detectors/components/detectorDetailsSidebar.tsx
+++ b/static/app/views/detectors/components/detectorDetailsSidebar.tsx
@@ -68,11 +68,11 @@ function AssignToUser({userId}: {userId: string}) {
 
 function DetectorPriorities({detector}: {detector: Detector}) {
   // TODO: Add support for other detector types
-  if (!('detection_type' in detector.config)) {
+  if (!('detectionType' in detector.config)) {
     return null;
   }
 
-  const detectionType = detector.config?.detection_type || 'static';
+  const detectionType = detector.config?.detectionType || 'static';
 
   // For dynamic detectors, show the automatic priority message
   if (detectionType === 'dynamic') {
@@ -126,11 +126,11 @@ function DetectorPriorities({detector}: {detector: Detector}) {
 
 function DetectorResolve({detector}: {detector: Detector}) {
   // TODO: Add support for other detector types
-  if (!('detection_type' in detector.config)) {
+  if (!('detectionType' in detector.config)) {
     return null;
   }
 
-  const detectionType = detector.config?.detection_type || 'static';
+  const detectionType = detector.config?.detectionType || 'static';
   const conditions = detector.conditionGroup?.conditions || [];
 
   // Get the main condition (first non-OK condition)

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -78,11 +78,11 @@ function DetailItem({children}: {children: React.ReactNode}) {
 
 function ConfigDetails({detector}: {detector: Detector}) {
   // TODO: Use a MetricDetector type to avoid checking for this
-  if (!('detection_type' in detector.config)) {
+  if (!('detectionType' in detector.config)) {
     return null;
   }
 
-  const type = detector.config.detection_type;
+  const type = detector.config.detectionType;
   const conditions = detector.conditionGroup?.conditions;
   if (!conditions?.length) {
     return null;

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -329,23 +329,23 @@ export function metricDetectorFormDataToEndpointPayload(
   switch (data.kind) {
     case 'percent':
       config = {
-        threshold_period: 1,
-        detection_type: 'percent',
-        comparison_delta: data.conditionComparisonAgo || 3600,
+        thresholdPeriod: 1,
+        detectionType: 'percent',
+        comparisonDelta: data.conditionComparisonAgo || 3600,
       };
       break;
     case 'dynamic':
       config = {
-        threshold_period: 1,
-        detection_type: 'dynamic',
+        thresholdPeriod: 1,
+        detectionType: 'dynamic',
         sensitivity: data.sensitivity,
       };
       break;
     case 'static':
     default:
       config = {
-        threshold_period: 1,
-        detection_type: 'static',
+        thresholdPeriod: 1,
+        detectionType: 'static',
       };
       break;
   }
@@ -442,11 +442,11 @@ export function metricSavedDetectorToFormData(
     : DetectorDataset.SPANS;
 
   const metricDetectorConfig =
-    'detection_type' in detector.config
+    'detectionType' in detector.config
       ? detector.config
       : {
-          detection_type: 'static' as const,
-          threshold_period: 1,
+          detectionType: 'static' as const,
+          thresholdPeriod: 1,
         };
 
   return {
@@ -462,22 +462,22 @@ export function metricSavedDetectorToFormData(
 
     // Priority level and condition fields from processed conditions
     ...conditionData,
-    kind: metricDetectorConfig.detection_type,
+    kind: metricDetectorConfig.detectionType,
 
     // Condition fields - get comparison delta from detector config (already in seconds)
     conditionComparisonAgo:
-      (metricDetectorConfig.detection_type === 'percent'
-        ? metricDetectorConfig.comparison_delta
+      (metricDetectorConfig.detectionType === 'percent'
+        ? metricDetectorConfig.comparisonDelta
         : null) || 3600,
 
     // Dynamic fields - extract from config for dynamic detectors
     sensitivity:
-      metricDetectorConfig.detection_type === 'dynamic'
+      metricDetectorConfig.detectionType === 'dynamic'
         ? metricDetectorConfig.sensitivity || AlertRuleSensitivity.LOW
         : AlertRuleSensitivity.LOW,
     thresholdType:
-      metricDetectorConfig.detection_type === 'dynamic'
-        ? metricDetectorConfig.threshold_type || AlertRuleThresholdType.ABOVE
+      metricDetectorConfig.detectionType === 'dynamic'
+        ? metricDetectorConfig.thresholdType || AlertRuleThresholdType.ABOVE
         : AlertRuleThresholdType.ABOVE,
   };
 }

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -46,9 +46,9 @@ describe('DetectorsList', function () {
           owner: null,
           type: 'metric_issue',
           config: {
-            detection_type: 'percent',
-            comparison_delta: 10,
-            threshold_period: 10,
+            detectionType: 'percent',
+            comparisonDelta: 10,
+            thresholdPeriod: 10,
           },
           conditionGroup: {
             id: '1',

--- a/static/app/views/detectors/utils/getDetectorResolutionDescription.tsx
+++ b/static/app/views/detectors/utils/getDetectorResolutionDescription.tsx
@@ -4,7 +4,7 @@ import type {MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
 import getDuration from 'sentry/utils/duration/getDuration';
 
 interface BaseDetectionParams {
-  detectionType: MetricDetectorConfig['detection_type'];
+  detectionType: MetricDetectorConfig['detectionType'];
   /**
    * Formatting units for the condition value.
    */

--- a/static/app/views/detectors/utils/metricDetectorSuffix.spec.tsx
+++ b/static/app/views/detectors/utils/metricDetectorSuffix.spec.tsx
@@ -38,9 +38,9 @@ describe('getMetricDetectorSuffix', function () {
       id: '1',
       name: 'test',
       config: {
-        detection_type: 'percent',
-        comparison_delta: 10,
-        threshold_period: 1,
+        detectionType: 'percent',
+        comparisonDelta: 10,
+        thresholdPeriod: 1,
       },
     });
 
@@ -50,8 +50,8 @@ describe('getMetricDetectorSuffix', function () {
   it('returns ms as default for static detection type without data source', function () {
     const detector = DetectorFixture({
       config: {
-        detection_type: 'static',
-        threshold_period: 1,
+        detectionType: 'static',
+        thresholdPeriod: 1,
       },
     });
 
@@ -61,8 +61,8 @@ describe('getMetricDetectorSuffix', function () {
   it('returns ms as default for dynamic detection type without data source', function () {
     const detector = DetectorFixture({
       config: {
-        detection_type: 'dynamic',
-        threshold_period: 1,
+        detectionType: 'dynamic',
+        thresholdPeriod: 1,
       },
     });
 

--- a/static/app/views/detectors/utils/metricDetectorSuffix.tsx
+++ b/static/app/views/detectors/utils/metricDetectorSuffix.tsx
@@ -27,11 +27,11 @@ export function getStaticDetectorThresholdSuffix(aggregate: string) {
 
 export function getMetricDetectorSuffix(detector: Detector) {
   // TODO: Use a MetricDetector type to avoid checking for this
-  if (!('detection_type' in detector.config)) {
+  if (!('detectionType' in detector.config)) {
     return '';
   }
 
-  switch (detector.config.detection_type) {
+  switch (detector.config.detectionType) {
     case 'static':
     case 'dynamic':
       if (

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -15,8 +15,8 @@ export function DetectorFixture(params: Partial<Detector> = {}): Detector {
     lastTriggered: '2025-01-01T00:00:00.000Z',
     workflowIds: [],
     config: {
-      detection_type: 'static',
-      threshold_period: 1,
+      detectionType: 'static',
+      thresholdPeriod: 1,
     },
     type: 'metric_issue',
     disabled: false,


### PR DESCRIPTION
The detector `config` object is being serialized with camelcased keys now, so this changes frontend references to match