### PR TITLE
feat(uptime): Set default name from url

### DIFF
--- a/static/app/components/workflowEngine/form/useFormField.tsx
+++ b/static/app/components/workflowEngine/form/useFormField.tsx
@@ -19,6 +19,7 @@ export function useFormField<Value extends FieldValue = FieldValue>(
 
       // Check if the field exists
       if (!form?.fields.has(field)) {
+        console.log('field not found', field);
         // Allow field to be created later by subscribing to all fields
         return observe(form.fields, () => {
           // Only call callback if our specific field now exists

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx
@@ -342,4 +342,21 @@ describe('Uptime Alert Form', function () {
       })
     );
   });
+
+  it('sets a default name from the url', async function () {
+    render(<UptimeAlertForm organization={organization} project={project} />, {
+      organization,
+    });
+    await userEvent.clear(input('URL'));
+    await userEvent.type(input('URL'), 'http://my-cool-site.com/');
+
+    const simpleName = input('Uptime rule name');
+    expect(simpleName).toHaveValue('Uptime check for my-cool-site.com');
+
+    await userEvent.clear(input('URL'));
+    await userEvent.type(input('URL'), 'http://example.com/with-path');
+
+    const pathName = input('Uptime rule name');
+    expect(pathName).toHaveValue('Uptime check for example.com/with-path');
+  });
 });

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -1,6 +1,5 @@
-import {useContext, useEffect, useRef, useState} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import type {IReactionDisposer} from 'mobx';
 import {autorun} from 'mobx';
 import {Observer} from 'mobx-react';
 
@@ -135,7 +134,7 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
 
   const initialData = rule
     ? getFormDataFromRule(rule)
-    : {projectSlug: project.slug, method: 'GET', headers: []};
+    : {projectSlug: project.slug, method: 'GET', headers: [], name: '', url: ''};
 
   const [formModel] = useState(() => new FormModel());
 
@@ -173,38 +172,6 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
       }),
     [formModel, navigate, organization, projects, rule]
   );
-
-  // When mutating the name field manually, we'll disable automatic name
-  // generation from the URL
-  const [hasCustomName, setHasCustomName] = useState(false);
-  const disposeNameSetter = useRef<IReactionDisposer>(null);
-  const hasRule = !!rule;
-
-  // Suggest rule name from URL
-  // useEffect(() => {
-  //   if (hasRule || hasCustomName) {
-  //     return () => {};
-  //   }
-  //   disposeNameSetter.current = autorun(() => {
-  //     const url = formModel.getValue('url');
-
-  //     if (typeof url !== 'string') {
-  //       return;
-  //     }
-
-  //     try {
-  //       const parsedUrl = new URL(url);
-  //       const path = parsedUrl.pathname === '/' ? '' : parsedUrl.pathname;
-  //       const urlName = `${parsedUrl.hostname}${path}`.replace(/\/$/, '');
-
-  //       formModel.setValue('name', t('Uptime check for %s', urlName));
-  //     } catch {
-  //       // Nothing to do if we failed to parse the URL
-  //     }
-  //   });
-
-  //   return disposeNameSetter.current;
-  // }, [formModel, hasRule, hasCustomName]);
 
   return (
     <Form
@@ -400,14 +367,6 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
             name="name"
             label={t('Uptime rule name')}
             placeholder={t('Uptime rule name')}
-            onChange={() => {
-              // Immediately dispose of the autorun name setter, since it won't
-              // receive the hasCustomName state before the autorun is ran
-              // again after this change (overriding whatever change the user
-              // just made)
-              disposeNameSetter.current?.();
-              setHasCustomName(true);
-            }}
             inline={false}
             flexibleControlStateSize
             stacked

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -1,5 +1,6 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import type {IReactionDisposer} from 'mobx';
 import {autorun} from 'mobx';
 import {Observer} from 'mobx-react';
 
@@ -123,6 +124,38 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
       }),
     [formModel, navigate, organization, projects, rule]
   );
+
+  // When mutating the name field manually, we'll disable automatic name
+  // generation from the URL
+  const [hasCustomName, setHasCustomName] = useState(false);
+  const disposeNameSetter = useRef<IReactionDisposer>(null);
+  const hasRule = !!rule;
+
+  // Suggest rule name from URL
+  useEffect(() => {
+    if (hasRule || hasCustomName) {
+      return () => {};
+    }
+    disposeNameSetter.current = autorun(() => {
+      const url = formModel.getValue('url');
+
+      if (typeof url !== 'string') {
+        return;
+      }
+
+      try {
+        const parsedUrl = new URL(url);
+        const path = parsedUrl.pathname === '/' ? '' : parsedUrl.pathname;
+        const urlName = `${parsedUrl.hostname}${path}`.replace(/\/$/, '');
+
+        formModel.setValue('name', t('Uptime check for %s', urlName));
+      } catch {
+        // Nothing to do if we failed to parse the URL
+      }
+    });
+
+    return disposeNameSetter.current;
+  }, [formModel, hasRule, hasCustomName]);
 
   return (
     <Form
@@ -325,6 +358,14 @@ export function UptimeAlertForm({project, handleDelete, rule}: Props) {
             name="name"
             label={t('Uptime rule name')}
             placeholder={t('Uptime rule name')}
+            onChange={() => {
+              // Immediately dispose of the autorun name setter, since it won't
+              // receive the hasCustomName state before the autorun is ran
+              // again after this change (overriding whatever change the user
+              // just made)
+              disposeNameSetter.current?.();
+              setHasCustomName(true);
+            }}
             inline={false}
             flexibleControlStateSize
             stacked


### PR DESCRIPTION
Split out and added a test from #93042<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
