### PR TITLE
fix(equations): Handle incorrect alias

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -899,9 +899,6 @@ class SearchResolver:
         ResolvedFormula | ResolvedAggregate | ResolvedConditionalAggregate,
         VirtualColumnDefinition | None,
     ]:
-        if column in self._resolved_function_cache:
-            return self._resolved_function_cache[column]
-        # Check if the column looks like a function (matches a pattern), parse the function name and args out
         if match is None:
             match = fields.is_function(column)
             if match is None:
@@ -913,6 +910,10 @@ class SearchResolver:
         alias = match.group("alias") or column
         if public_alias_override is not None:
             alias = public_alias_override
+
+        if alias in self._resolved_function_cache:
+            return self._resolved_function_cache[column]
+        # Check if the column looks like a function (matches a pattern), parse the function name and args out
 
         function_definition = self.get_function_definition(function_name)
         if function_definition.private and function_name not in self.config.fields_acl.functions:
@@ -1014,8 +1015,8 @@ class SearchResolver:
         )
 
         resolved_context = None
-        self._resolved_function_cache[column] = (resolved_function, resolved_context)
-        return self._resolved_function_cache[column]
+        self._resolved_function_cache[alias] = (resolved_function, resolved_context)
+        return self._resolved_function_cache[alias]
 
     def resolve_equations(self, equations: list[str]) -> tuple[
         list[AnyResolved],

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -912,7 +912,7 @@ class SearchResolver:
             alias = public_alias_override
 
         if alias in self._resolved_function_cache:
-            return self._resolved_function_cache[column]
+            return self._resolved_function_cache[alias]
         # Check if the column looks like a function (matches a pattern), parse the function name and args out
 
         function_definition = self.get_function_definition(function_name)

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5009,6 +5009,47 @@ class OrganizationEventsEAPRPCSpanEndpointTest(OrganizationEventsSpanIndexedEndp
         assert meta["dataset"] == self.dataset
         assert meta["fields"][equation] == "number"
 
+    def test_equation_with_orderby_using_same_alias(self):
+        self.store_spans(
+            [
+                self.create_span(
+                    {"description": "foo", "sentry_tags": {"status": "success"}},
+                    start_ts=self.ten_mins_ago,
+                ),
+                self.create_span(
+                    {
+                        "description": "bar",
+                        "sentry_tags": {"status": "invalid_argument"},
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+            is_eap=self.is_eap,
+        )
+        equation = "equation|count(span.duration)"
+        response = self.do_request(
+            {
+                "field": ["count(span.duration)", equation],
+                "query": "",
+                "orderby": "count_span_duration",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+        assert len(data) == 1
+        assert data == [
+            {
+                "count(span.duration)": 2,
+                equation: 2,
+            },
+        ]
+        assert meta["dataset"] == self.dataset
+        assert meta["fields"][equation] == "integer"
+
     def test_equation_single_function_term(self):
         self.store_spans(
             [


### PR DESCRIPTION
- When a field name overlapped with an equation, we were using the cached equation since its column would be the same, we don't want this behaviour since it breaks orderby (this is because equations don't resolve to be the same function under the hood and the RPC complains we're ordering by a field that was not selected)