### PR TITLE
feat: add organization to prevent url paths and update related FE hooks

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1054,6 +1054,20 @@ RELAY_URLS = [
     ),
 ]
 
+PREVENT_URLS = [
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results/$",
+        TestResultsEndpoint.as_view(),
+        name="sentry-api-0-test-results",
+    ),
+    re_path(
+        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results-aggregates/$",
+        TestResultsAggregatesEndpoint.as_view(),
+        name="sentry-api-0-test-results-aggregates",
+    ),
+]
+
+
 USER_URLS = [
     re_path(
         r"^$",
@@ -2395,6 +2409,10 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         OrganizationInsightsTreeEndpoint.as_view(),
         name="sentry-api-0-organization-insights-tree",
     ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/prevent/",
+        include(PREVENT_URLS),
+    ),
     *workflow_urls.organization_urlpatterns,
 ]
 
@@ -3296,19 +3314,6 @@ INTERNAL_URLS = [
     *preprod_urls.preprod_internal_urlpatterns,
 ]
 
-PREVENT_URLS = [
-    re_path(
-        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results/$",
-        TestResultsEndpoint.as_view(),
-        name="sentry-api-0-test-results",
-    ),
-    re_path(
-        r"^owner/(?P<owner>[^/]+)/repository/(?P<repository>[^/]+)/test-results-aggregates/$",
-        TestResultsAggregatesEndpoint.as_view(),
-        name="sentry-api-0-test-results-aggregates",
-    ),
-]
-
 urlpatterns = [
     # Relay
     re_path(
@@ -3373,11 +3378,6 @@ urlpatterns = [
     re_path(
         r"^broadcasts/",
         include(BROADCAST_URLS),
-    ),
-    # Prevent
-    re_path(
-        r"^prevent/",
-        include(PREVENT_URLS),
     ),
     #
     #

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -7,7 +7,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
-from sentry.apidocs.parameters import PreventParams
+from sentry.apidocs.parameters import GlobalParams, PreventParams
 from sentry.codecov.base import CodecovEndpoint
 from sentry.codecov.client import CodecovApiClient
 from sentry.codecov.endpoints.TestResults.query import query
@@ -29,8 +29,9 @@ class TestResultsEndpoint(CodecovEndpoint):
         return True
 
     @extend_schema(
-        operation_id="Retrieve paginated list of test results for repository and owner",
+        operation_id="Retrieve paginated list of test results for repository, owner, and organization",
         parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
             PreventParams.TEST_RESULTS_SORT_BY,
@@ -49,7 +50,9 @@ class TestResultsEndpoint(CodecovEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
+    def get(
+        self, request: Request, organization_id_or_slug: str, owner: str, repository: str, **kwargs
+    ) -> Response:
         """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
 
         sort_by = request.query_params.get(

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
@@ -6,7 +6,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
-from sentry.apidocs.parameters import PreventParams
+from sentry.apidocs.parameters import GlobalParams, PreventParams
 from sentry.codecov.base import CodecovEndpoint
 from sentry.codecov.client import CodecovApiClient
 from sentry.codecov.endpoints.TestResultsAggregates.query import query
@@ -27,8 +27,9 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
     }
 
     @extend_schema(
-        operation_id="Retrieve aggregated test result metrics for repository and owner",
+        operation_id="Retrieve aggregated test result metrics for repository, owner, and organization",
         parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
             PreventParams.OWNER,
             PreventParams.REPOSITORY,
             PreventParams.INTERVAL,
@@ -41,7 +42,9 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
+    def get(
+        self, request: Request, organization_id_or_slug: str, owner: str, repository: str, **kwargs
+    ) -> Response:
         """
         Retrieves aggregated test result metrics for a given repository and owner.
         Also accepts a query parameter to specify the time period for the metrics.

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -9,6 +9,7 @@ import {
   type QueryKeyEndpointOptions,
   useInfiniteQuery,
 } from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 import type {
   SummaryFilterKey,
   SummaryTAFilterKey,
@@ -61,6 +62,7 @@ type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 
 export function useInfiniteTestResults() {
   const {integratedOrg, repository, branch, codecovPeriod} = useCodecovContext();
+  const organization = useOrganization();
   const [searchParams] = useSearchParams();
 
   const sortBy = searchParams.get('sort') || '-commitsFailed';
@@ -79,7 +81,7 @@ export function useInfiniteTestResults() {
     QueryKey
   >({
     queryKey: [
-      `/prevent/owner/${integratedOrg}/repository/${repository}/test-results/`,
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrg}/repository/${repository}/test-results/`,
       {query: {branch, codecovPeriod, signedSortBy, mappedFilterBy}},
     ],
     queryFn: async ({

--- a/static/app/views/codecov/tests/queries/useTestResultsAggregates.ts
+++ b/static/app/views/codecov/tests/queries/useTestResultsAggregates.ts
@@ -4,6 +4,7 @@ import {useCodecovContext} from 'sentry/components/codecov/context/codecovContex
 import type {QueryKeyEndpointOptions} from 'sentry/utils/queryClient';
 import {useQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 import {DATE_TO_QUERY_INTERVAL} from 'sentry/views/codecov/tests/config';
 
 type TestResultAggregate = {
@@ -27,6 +28,7 @@ type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
 
 export function useTestResultsAggregates() {
   const api = useApi();
+  const organization = useOrganization();
   const {integratedOrg, repository, codecovPeriod} = useCodecovContext();
 
   const {data, ...rest} = useQuery<
@@ -36,7 +38,7 @@ export function useTestResultsAggregates() {
     QueryKey
   >({
     queryKey: [
-      `/prevent/owner/${integratedOrg}/repository/${repository}/test-results-aggregates/`,
+      `/organizations/${organization.slug}/prevent/owner/${integratedOrg}/repository/${repository}/test-results-aggregates/`,
       {query: {codecovPeriod}},
     ],
     queryFn: async ({queryKey: [url]}): Promise<TestResultAggregate> => {

--- a/static/app/views/codecov/tests/summaries/summaries.spec.tsx
+++ b/static/app/views/codecov/tests/summaries/summaries.spec.tsx
@@ -25,7 +25,7 @@ const mockTestResultAggregates = [
 
 const mockApiCall = () =>
   MockApiClient.addMockResponse({
-    url: `/prevent/owner/some-org-name/repository/some-repository/test-results-aggregates/`,
+    url: `/organizations/org-slug/prevent/owner/some-org-name/repository/some-repository/test-results-aggregates/`,
     method: 'GET',
     body: {
       results: mockTestResultAggregates,

--- a/static/app/views/codecov/tests/tests.spec.tsx
+++ b/static/app/views/codecov/tests/tests.spec.tsx
@@ -41,7 +41,7 @@ const mockTestResultAggregates = [
 
 const mockApiCall = () => {
   MockApiClient.addMockResponse({
-    url: `/prevent/owner/some-org-name/repository/some-repository/test-results/`,
+    url: `/organizations/org-slug/prevent/owner/some-org-name/repository/some-repository/test-results/`,
     method: 'GET',
     body: {
       results: mockTestResultsData,
@@ -54,7 +54,7 @@ const mockApiCall = () => {
   });
 
   MockApiClient.addMockResponse({
-    url: `/prevent/owner/some-org-name/repository/some-repository/test-results-aggregates/`,
+    url: `/organizations/org-slug/prevent/owner/some-org-name/repository/some-repository/test-results-aggregates/`,
     method: 'GET',
     body: {
       results: mockTestResultAggregates,

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -123,16 +123,16 @@ export function PrimaryNavigationItems() {
           </NavTourElement>
         </Feature>
 
-        {/* <Feature features={['codecov-ui']}> */}
-        <SidebarLink
-          to={`/${prefix}/${CODECOV_BASE_URL}/${COVERAGE_BASE_URL}/commits/`}
-          activeTo={`/${prefix}/${CODECOV_BASE_URL}/`}
-          analyticsKey="codecov"
-          group={PrimaryNavGroup.CODECOV}
-        >
-          <IconPrevent />
-        </SidebarLink>
-        {/* </Feature> */}
+        <Feature features={['codecov-ui']}>
+          <SidebarLink
+            to={`/${prefix}/${CODECOV_BASE_URL}/${COVERAGE_BASE_URL}/commits/`}
+            activeTo={`/${prefix}/${CODECOV_BASE_URL}/`}
+            analyticsKey="codecov"
+            group={PrimaryNavGroup.CODECOV}
+          >
+            <IconPrevent />
+          </SidebarLink>
+        </Feature>
 
         <SeparatorItem />
 

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -123,16 +123,16 @@ export function PrimaryNavigationItems() {
           </NavTourElement>
         </Feature>
 
-        <Feature features={['codecov-ui']}>
-          <SidebarLink
-            to={`/${prefix}/${CODECOV_BASE_URL}/${COVERAGE_BASE_URL}/commits/`}
-            activeTo={`/${prefix}/${CODECOV_BASE_URL}/`}
-            analyticsKey="codecov"
-            group={PrimaryNavGroup.CODECOV}
-          >
-            <IconPrevent />
-          </SidebarLink>
-        </Feature>
+        {/* <Feature features={['codecov-ui']}> */}
+        <SidebarLink
+          to={`/${prefix}/${CODECOV_BASE_URL}/${COVERAGE_BASE_URL}/commits/`}
+          activeTo={`/${prefix}/${CODECOV_BASE_URL}/`}
+          analyticsKey="codecov"
+          group={PrimaryNavGroup.CODECOV}
+        >
+          <IconPrevent />
+        </SidebarLink>
+        {/* </Feature> */}
 
         <SeparatorItem />
 

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -17,6 +17,7 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         return reverse(
             self.endpoint_name,
             kwargs={
+                "organization_id_or_slug": self.organization.slug,
                 "owner": owner,
                 "repository": repository,
             },

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -20,6 +20,7 @@ class TestResultsEndpointTest(APITestCase):
         return reverse(
             self.endpoint,
             kwargs={
+                "organization_id_or_slug": self.organization.slug,
                 "owner": owner,
                 "repository": repository,
             },


### PR DESCRIPTION
This PR updates the paths for the prevent URLs to include the organization id / slug and updates the frontend hooks to pull this new URL consequently.

Closes https://linear.app/getsentry/issue/CCMRG-1349/add-organization-slug-to-endpoint-path

Couple postman responses, also tested locally on FE and updated the related UTs.

<img width="1195" alt="Screenshot 2025-07-09 at 1 51 35 PM" src="https://github.com/user-attachments/assets/6cc4df5b-131b-472d-91fa-00afe63ebc9a" />
<img width="1203" alt="Screenshot 2025-07-09 at 11 31 10 AM" src="https://github.com/user-attachments/assets/32ae10c0-fba2-484e-b978-463664200e70" />

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
