### PR TITLE
fix(stories): remove header scrollbar

### DIFF
--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -181,8 +181,6 @@ const StoryContainer = styled('div')`
   flex-direction: column;
   gap: ${space(4)};
   padding-inline: ${space(2)};
-  overflow-y: auto;
-  height: 100%;
 `;
 
 const StoryContent = styled('main')`

--- a/static/app/stories/view/storySidebar.tsx
+++ b/static/app/stories/view/storySidebar.tsx
@@ -83,6 +83,8 @@ const SidebarContainer = styled('nav')`
   width: 256px;
   background: ${p => p.theme.tokens.background.primary};
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: ${p => p.theme.tokens.border.primary} ${p => p.theme.background};
   ul,
   li {
     list-style: none;


### PR DESCRIPTION
Fixes overflow issue in stories header. Also tweaks the sidebar scrollbar for better visuals.

**Before**
<img width="844" alt="header-before" src="https://github.com/user-attachments/assets/6dc701ea-abd3-46c1-af36-1b437c50b896" />
<img width="273" alt="scroll-after" src="https://github.com/user-attachments/assets/523cfa94-d3ef-4a58-8433-7764cd7047db" />

**After**
<img width="835" alt="header-after" src="https://github.com/user-attachments/assets/09e391cf-2635-4535-9634-08f5de5e610f" />
<img width="273" alt="scroll-after" src="https://github.com/user-attachments/assets/16f60f29-bb31-4c9f-9ab6-e6a00dc77728" />


