### PR TITLE
fix(stories): remove automatic media query

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -301,7 +301,14 @@ const appConfig: Configuration = {
                 remarkGfm,
                 remarkCallout,
               ],
-              rehypePlugins: [rehypeExpressiveCode],
+              rehypePlugins: [
+                [
+                  rehypeExpressiveCode,
+                  {
+                    useDarkModeMediaQuery: false,
+                  },
+                ],
+              ],
             },
           },
         ],


### PR DESCRIPTION
Sets [`useDarkModeMediaQuery `](https://expressive-code.com/reference/configuration/#usedarkmodemediaquery) to fix a visual bug with codeblocks for light mode users.

**Before**
<img width="848" alt="codeblock-before" src="https://github.com/user-attachments/assets/314d6c71-ccd4-49be-acc6-bc60e11d4d29" />

**After**
<img width="834" alt="codeblock-after" src="https://github.com/user-attachments/assets/b2ac33ee-6085-4d29-abca-75ec66b22466" />
