### PR TITLE
chore(aci): setup single processing flag for issue alerts in workflow engine

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -491,6 +491,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:workflow-engine-process-metric-issue-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable workflow engine for issue alerts
     manager.add("organizations:workflow-engine-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable single processing through workflow engine for issue alerts
+    manager.add("organizations:workflow-engine-single-process-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logging to debug workflow engine process workflows
     manager.add("organizations:workflow-engine-process-workflows-logs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable firing actions for workflow engine issue alerts

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -503,6 +503,8 @@ def generate_incident_trigger_email_context(
     user: User | RpcUser | None = None,
     notification_uuid: str | None = None,
 ):
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     snuba_query = metric_issue_context.snuba_query
     is_active = trigger_status == TriggerStatus.ACTIVE
     is_threshold_type_above = alert_context.threshold_type == AlertRuleThresholdType.ABOVE
@@ -579,7 +581,7 @@ def generate_incident_trigger_email_context(
             ),
             query=urlencode(alert_link_params),
         )
-    elif features.has("organizations:workflow-engine-trigger-actions", organization):
+    elif should_fire_workflow_actions(organization):
         # lookup the incident_id from the open_period_identifier
         try:
             incident_group_open_period = IncidentGroupOpenPeriod.objects.get(

--- a/src/sentry/integrations/discord/message_builder/issues.py
+++ b/src/sentry/integrations/discord/message_builder/issues.py
@@ -22,6 +22,7 @@ from sentry.integrations.types import ExternalProviders
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.models.rule import Rule
+from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.utils.rules import get_key_from_rule_data
 
@@ -60,9 +61,7 @@ class DiscordIssuesMessageBuilder(DiscordMessageBuilder):
             rule_environment_id = self.rules[0].environment_id
             if features.has("organizations:workflow-engine-ui-links", self.group.organization):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
-            elif features.has(
-                "organizations:workflow-engine-trigger-actions", self.group.organization
-            ):
+            elif should_fire_workflow_actions(self.group.organization):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
             else:
                 rule_id = self.rules[0].id

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -14,6 +14,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.models.team import Team
+from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.links import create_link_to_workflow
@@ -109,7 +110,7 @@ def get_rule_environment_param_from_rule(
     rule_id: int, rule_environment_id: int | None, organization: Organization
 ) -> dict[str, str]:
     params = {}
-    if features.has("organizations:workflow-engine-trigger-actions", organization):
+    if should_fire_workflow_actions(organization):
         if (
             rule_environment_id is not None
             and (environment_name := fetch_environment_name(rule_environment_id)) is not None
@@ -269,7 +270,7 @@ def build_attachment_replay_link(
 def build_rule_url(rule: Any, group: Group, project: Project) -> str:
     org_slug = group.organization.slug
     project_slug = project.slug
-    if features.has("organizations:workflow-engine-trigger-actions", group.organization):
+    if should_fire_workflow_actions(group.organization):
         rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
         rule_url = f"/organizations/{org_slug}/alerts/rules/{project_slug}/{rule_id}/details/"
     else:

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -194,6 +194,8 @@ def incident_attachment_info(
     referrer: str = "metric_alert",
     notification_uuid: str | None = None,
 ) -> AttachmentInfo:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     status = get_status_text(metric_issue_context.new_status)
 
     text = ""
@@ -220,7 +222,7 @@ def incident_attachment_info(
     if notification_uuid:
         title_link_params["notification_uuid"] = notification_uuid
 
-    if features.has("organizations:workflow-engine-trigger-actions", organization):
+    if should_fire_workflow_actions(organization):
         try:
             alert_rule_id = AlertRuleDetector.objects.values_list("alert_rule_id", flat=True).get(
                 detector_id=alert_context.action_identifier_id

--- a/src/sentry/integrations/opsgenie/client.py
+++ b/src/sentry/integrations/opsgenie/client.py
@@ -11,6 +11,7 @@ from sentry.integrations.opsgenie.metrics import record_event, record_lifecycle_
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
+from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.links import create_link_to_workflow
 from sentry.notifications.utils.rules import get_key_from_rule_data
 from sentry.shared_integrations.exceptions import ApiError
@@ -58,7 +59,7 @@ class OpsgenieClient(ApiClient):
         rule_urls = []
         for rule in rules:
             rule_id = rule.id
-            if features.has("organizations:workflow-engine-trigger-actions", organization):
+            if should_fire_workflow_actions(organization):
                 rule_id = get_key_from_rule_data(rule, "legacy_rule_id")
 
             path = f"/organizations/{organization.slug}/alerts/rules/{group.project.slug}/{rule_id}/details/"

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -9,7 +9,6 @@ import orjson
 import sentry_sdk
 from slack_sdk.errors import SlackApiError
 
-from sentry import features
 from sentry.api.serializers.rest_framework.rule import ACTION_UUID_KEY
 from sentry.constants import ISSUE_ALERTS_THREAD_DEFAULT
 from sentry.eventstore.models import GroupEvent
@@ -38,6 +37,7 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.rule import Rule
 from sentry.notifications.additional_attachment_manager import get_additional_attachment
+from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.open_period import open_period_start_for_group
 from sentry.rules.actions import IntegrationEventAction
 from sentry.rules.base import CallbackFuture
@@ -478,7 +478,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             },
             skip_internal=False,
         )
-        if features.has("organizations:workflow-engine-trigger-actions", self.project.organization):
+        if should_fire_workflow_actions(self.project.organization):
             yield self.future(send_notification_noa, key=key)
         else:
             yield self.future(send_notification, key=key)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -53,6 +53,7 @@ from sentry.models.release import Release
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
 from sentry.models.team import Team
+from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.notifications.utils.participants import (
@@ -615,9 +616,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self.rules:
             if features.has("organizations:workflow-engine-ui-links", self.group.organization):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "workflow_id"))
-            elif features.has(
-                "organizations:workflow-engine-trigger-actions", self.group.organization
-            ):
+            elif should_fire_workflow_actions(self.group.organization):
                 rule_id = int(get_key_from_rule_data(self.rules[0], "legacy_rule_id"))
             else:
                 rule_id = self.rules[0].id

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -51,6 +51,7 @@ from sentry.integrations.slack.utils.threads import NotificationActionThreadUtil
 from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
+from sentry.notifications.notification_action.utils import should_fire_workflow_actions
 from sentry.notifications.utils.open_period import open_period_start_for_group
 from sentry.workflow_engine.models.action import Action
 
@@ -435,7 +436,7 @@ def send_incident_alert_notification(
         notification_uuid=notification_uuid,
     )
 
-    if features.has("organizations:workflow-engine-trigger-actions", organization):
+    if should_fire_workflow_actions(organization):
         return _handle_workflow_engine_notification(
             organization=organization,
             notification_context=notification_context,

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -1,6 +1,8 @@
 import logging
 
+from sentry import features
 from sentry.models.activity import Activity
+from sentry.models.organization import Organization
 from sentry.notifications.notification_action.registry import (
     group_type_notification_registry,
     issue_alert_handler_registry,
@@ -10,6 +12,12 @@ from sentry.workflow_engine.models import Action, Detector
 from sentry.workflow_engine.types import WorkflowEventData
 
 logger = logging.getLogger(__name__)
+
+
+def should_fire_workflow_actions(org: Organization) -> bool:
+    return features.has(
+        "organizations:workflow-engine-single-process-workflows", org
+    ) or features.has("organizations:workflow-engine-trigger-actions", org)
 
 
 def execute_via_group_type_registry(

--- a/src/sentry/notifications/utils/links.py
+++ b/src/sentry/notifications/utils/links.py
@@ -106,9 +106,11 @@ def get_issue_replay_link(group: Group, sentry_query_params: str = ""):
 def get_rules(
     rules: Sequence[Rule], organization: Organization, project: Project
 ) -> Sequence[NotificationRuleDetails]:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     if features.has("organizations:workflow-engine-ui-links", organization):
         return get_workflow_links(rules, organization, project)
-    elif features.has("organizations:workflow-engine-trigger-actions", organization):
+    elif should_fire_workflow_actions(organization):
         return get_rules_with_legacy_ids(rules, organization, project)
     return [
         NotificationRuleDetails(
@@ -162,7 +164,9 @@ def get_snooze_url(
     project: Project,
     sentry_query_params: str,
 ) -> str:
-    if features.has("organizations:workflow-engine-trigger-actions", organization):
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
+    if should_fire_workflow_actions(organization):
         rule_id = int(get_key_from_rule_data(rule, "legacy_rule_id"))
     else:
         rule_id = rule.id

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -106,6 +106,8 @@ def build_description(
 
 
 def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     """Create an issue for a given event"""
     organization = event.group.project.organization
 
@@ -118,7 +120,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
 
         # If we invoked this handler from the notification action, we need to replace the rule_id with the legacy_rule_id, so we link notifications correctly
         action_id = None
-        if features.has("organizations:workflow-engine-trigger-actions", organization):
+        if should_fire_workflow_actions(organization):
             # In the Notification Action, we store the rule_id in the action_id field
             action_id = rule_id
             rule_id = data.get("legacy_rule_id")

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -493,6 +493,8 @@ def fire_rules(
     alert_rules: list[Rule],
     project: Project,
 ) -> None:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     now = datetime.now(tz=timezone.utc)
     project_id = project.id
     with track_batch_performance(
@@ -596,9 +598,7 @@ def fire_rules(
                         is_post_process=False,
                     ).values()
 
-                    if not features.has(
-                        "organizations:workflow-engine-trigger-actions", group.organization
-                    ):
+                    if not should_fire_workflow_actions(group.organization):
                         for callback, futures in callback_and_futures:
                             try:
                                 callback(groupevent, futures)

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -678,6 +678,8 @@ def send_resource_change_webhook(
 
 
 def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     for f in futures:
         if not f.kwargs.get("sentry_app"):
             logger.info(
@@ -700,9 +702,7 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         if int(id) != -1:
             if features.has("organizations:workflow-engine-ui-links", event.group.organization):
                 id = get_key_from_rule_data(f.rule, "workflow_id")
-            elif features.has(
-                "organizations:workflow-engine-trigger-actions", event.group.organization
-            ):
+            elif should_fire_workflow_actions(event.group.organization):
                 id = get_key_from_rule_data(f.rule, "legacy_rule_id")
 
         settings = f.kwargs.get("schema_defined_settings")

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1011,9 +1011,7 @@ def process_rules(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
 
-    if only_process_workflows := features.has(
-        "organizations:workflow-engine-single-process-workflows", org
-    ):
+    if features.has("organizations:workflow-engine-single-process-workflows", org):
         # we are only processing through the workflow engine
         return
 
@@ -1041,17 +1039,7 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
-        # Determine when to fire rule actions:
-        # - Fire if we're NOT in single processing mode (i.e., we're in dual processing mode)
-        # - OR if we're in dual processing mode but NOT using workflow engine to trigger actions
-        is_dual_processing = not only_process_workflows
-        is_workflow_engine_triggering_actions = features.has(
-            "organizations:workflow-engine-trigger-actions", org
-        )
-
-        should_fire_rule_actions = is_dual_processing or not is_workflow_engine_triggering_actions
-
-        if should_fire_rule_actions:
+        if not features.has("organizations:workflow-engine-trigger-actions", org):
             for callback, futures in callback_and_futures:
                 has_alert = True
                 safe_execute(callback, group_event, futures)

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -597,6 +597,8 @@ def fire_actions_for_groups(
     event_data: EventRedisData,
     group_to_groupevent: dict[Group, GroupEvent],
 ) -> None:
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     serialized_groups = {
         group.id: group_event.event_id for group, group_event in group_to_groupevent.items()
     }
@@ -630,9 +632,7 @@ def fire_actions_for_groups(
     }
 
     # Feature check caching to keep us within the trace budget.
-    should_trigger_actions = features.has(
-        "organizations:workflow-engine-trigger-actions", organization
-    )
+    should_trigger_actions = should_fire_workflow_actions(organization)
     should_trigger_actions_async = features.has(
         "organizations:workflow-engine-action-trigger-async", organization
     )

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -374,6 +374,8 @@ def process_workflows(
 
     Finally, each of the triggered workflows will have their actions evaluated and executed.
     """
+    from sentry.notifications.notification_action.utils import should_fire_workflow_actions
+
     try:
         if detector is None and isinstance(event_data.event, GroupEvent):
             detector = get_detector_by_event(event_data)
@@ -433,10 +435,7 @@ def process_workflows(
     create_workflow_fire_histories(detector, actions, event_data)
 
     with sentry_sdk.start_span(op="workflow_engine.process_workflows.trigger_actions"):
-        if features.has(
-            "organizations:workflow-engine-trigger-actions",
-            organization,
-        ):
+        if should_fire_workflow_actions(organization):
             for action in actions:
                 if features.has(
                     "organizations:workflow-engine-action-trigger-async",


### PR DESCRIPTION
Add a new feature flag to toggle single processing of issue alerts through workflow engine.

We currently have 2 feature flags: 1 that controls dual processing, and 1 that controls where the notifications fire from (the current system or workflow engine).

The new flag will act as an override of the two flags such that only a single system will process and notify about events. If the new flag is disabled, then we will revert to the dual processing flag logic.

![image](https://github.com/user-attachments/assets/a83ae7d9-beb9-41d4-9f5f-b7038a5bab4b)
