### PR TITLE
feat(codecov): Use term query param for test results endpoint

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1122,3 +1122,10 @@ Available fields are:
         description="""The cursor to start the query from. Will return results after the cursor if used with `first` or before the cursor if used with `last`.
         """,
     )
+    TERM = OpenApiParameter(
+        name="term",
+        location="query",
+        required=False,
+        type=str,
+        description="""The term to search for in the results.""",
+    )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1127,5 +1127,5 @@ Available fields are:
         location="query",
         required=False,
         type=str,
-        description="""The term to search for in the results.""",
+        description="""The term substring to filter test name strings by using the `contains` operator.""",
     )

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -41,6 +41,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             PreventParams.FIRST,
             PreventParams.LAST,
             PreventParams.CURSOR,
+            PreventParams.TERM,
         ],
         request=None,
         responses={
@@ -95,7 +96,7 @@ class TestResultsEndpoint(CodecovEndpoint):
                     request.query_params.get("interval", MeasurementInterval.INTERVAL_30_DAY.value)
                 ),
                 "flags": None,
-                "term": None,
+                "term": request.query_params.get("term"),
                 "test_suites": None,
             },
             "ordering": {

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -7,6 +7,73 @@ from sentry.codecov.endpoints.TestResults.serializers import (
 )
 from sentry.testutils.cases import APITestCase
 
+mock_graphql_response_empty = {
+    "data": {
+        "owner": {
+            "repository": {
+                "__typename": "Repository",
+                "testAnalytics": {
+                    "testResults": {
+                        "edges": [],
+                        "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        "totalCount": 0,
+                    }
+                },
+            }
+        }
+    }
+}
+
+mock_graphql_response_populated = {
+    "data": {
+        "owner": {
+            "repository": {
+                "__typename": "Repository",
+                "testAnalytics": {
+                    "testResults": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "updatedAt": "2025-05-22T16:21:18.763951+00:00",
+                                    "avgDuration": 0.04066228070175437,
+                                    "totalDuration": 1.0,
+                                    "lastDuration": 0.04066228070175437,
+                                    "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_no_yaml",
+                                    "failureRate": 0.0,
+                                    "flakeRate": 0.0,
+                                    "commitsFailed": 0,
+                                    "totalFailCount": 0,
+                                    "totalFlakyFailCount": 0,
+                                    "totalSkipCount": 0,
+                                    "totalPassCount": 70,
+                                }
+                            },
+                            {
+                                "node": {
+                                    "updatedAt": "2025-05-22T16:21:18.763961+00:00",
+                                    "avgDuration": 0.034125877192982455,
+                                    "totalDuration": 1.0,
+                                    "lastDuration": 0.034125877192982455,
+                                    "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_yaml",
+                                    "failureRate": 0.0,
+                                    "flakeRate": 0.0,
+                                    "commitsFailed": 0,
+                                    "totalFailCount": 0,
+                                    "totalFlakyFailCount": 0,
+                                    "totalSkipCount": 0,
+                                    "totalPassCount": 70,
+                                }
+                            },
+                        ],
+                        "pageInfo": {"endCursor": "cursor123", "hasNextPage": False},
+                        "totalCount": 2,
+                    }
+                },
+            }
+        }
+    }
+}
+
 
 class TestResultsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-test-results"
@@ -28,58 +95,9 @@ class TestResultsEndpointTest(APITestCase):
 
     @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
     def test_get_returns_mock_response_with_default_variables(self, mock_codecov_client_class):
-        mock_graphql_response = {
-            "data": {
-                "owner": {
-                    "repository": {
-                        "__typename": "Repository",
-                        "testAnalytics": {
-                            "testResults": {
-                                "edges": [
-                                    {
-                                        "node": {
-                                            "updatedAt": "2025-05-22T16:21:18.763951+00:00",
-                                            "avgDuration": 0.04066228070175437,
-                                            "totalDuration": 1.0,
-                                            "lastDuration": 0.04066228070175437,
-                                            "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_no_yaml",
-                                            "failureRate": 0.0,
-                                            "flakeRate": 0.0,
-                                            "commitsFailed": 0,
-                                            "totalFailCount": 0,
-                                            "totalFlakyFailCount": 0,
-                                            "totalSkipCount": 0,
-                                            "totalPassCount": 70,
-                                        }
-                                    },
-                                    {
-                                        "node": {
-                                            "updatedAt": "2025-05-22T16:21:18.763961+00:00",
-                                            "avgDuration": 0.034125877192982455,
-                                            "totalDuration": 1.0,
-                                            "lastDuration": 0.034125877192982455,
-                                            "name": "../usr/local/lib/python3.13/site-packages/asgiref/sync.py::GetFinalYamlInteractorTest::test_when_commit_has_yaml",
-                                            "failureRate": 0.0,
-                                            "flakeRate": 0.0,
-                                            "commitsFailed": 0,
-                                            "totalFailCount": 0,
-                                            "totalFlakyFailCount": 0,
-                                            "totalSkipCount": 0,
-                                            "totalPassCount": 70,
-                                        }
-                                    },
-                                ],
-                                "pageInfo": {"endCursor": "cursor123", "hasNextPage": False},
-                                "totalCount": 2,
-                            }
-                        },
-                    }
-                }
-            }
-        }
         mock_codecov_client_instance = Mock()
         mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
+        mock_response.json.return_value = mock_graphql_response_populated
         mock_codecov_client_instance.query.return_value = mock_response
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
@@ -129,25 +147,9 @@ class TestResultsEndpointTest(APITestCase):
 
     @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
     def test_get_with_query_parameters(self, mock_codecov_client_class):
-        mock_graphql_response = {
-            "data": {
-                "owner": {
-                    "repository": {
-                        "__typename": "Repository",
-                        "testAnalytics": {
-                            "testResults": {
-                                "edges": [],
-                                "pageInfo": {"endCursor": None, "hasNextPage": False},
-                                "totalCount": 0,
-                            }
-                        },
-                    }
-                }
-            }
-        }
         mock_codecov_client_instance = Mock()
         mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
+        mock_response.json.return_value = mock_graphql_response_empty
         mock_codecov_client_instance.query.return_value = mock_response
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
@@ -189,25 +191,9 @@ class TestResultsEndpointTest(APITestCase):
 
     @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
     def test_get_with_last_parameter(self, mock_codecov_client_class):
-        mock_graphql_response = {
-            "data": {
-                "owner": {
-                    "repository": {
-                        "__typename": "Repository",
-                        "testAnalytics": {
-                            "testResults": {
-                                "edges": [],
-                                "pageInfo": {"endCursor": None, "hasNextPage": False},
-                                "totalCount": 0,
-                            }
-                        },
-                    }
-                }
-            }
-        }
         mock_codecov_client_instance = Mock()
         mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
+        mock_response.json.return_value = mock_graphql_response_empty
         mock_codecov_client_instance.query.return_value = mock_response
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
@@ -252,31 +238,15 @@ class TestResultsEndpointTest(APITestCase):
 
     @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
     def test_get_with_term_filter(self, mock_codecov_client_class):
-        mock_graphql_response = {
-            "data": {
-                "owner": {
-                    "repository": {
-                        "__typename": "Repository",
-                        "testAnalytics": {
-                            "testResults": {
-                                "edges": [],
-                                "pageInfo": {"endCursor": None, "hasNextPage": False},
-                                "totalCount": 0,
-                            }
-                        },
-                    }
-                }
-            }
-        }
         mock_codecov_client_instance = Mock()
         mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
+        mock_response.json.return_value = mock_graphql_response_empty
         mock_codecov_client_instance.query.return_value = mock_response
         mock_codecov_client_class.return_value = mock_codecov_client_instance
 
         url = self.reverse_url()
         query_params = {
-            "term": "sample_term",
+            "term": "test::function_with_underscores-and-dashes",
             "branch": "develop",
             "filterBy": "FLAKY_TESTS",
             "sortBy": "AVG_DURATION",
@@ -293,7 +263,7 @@ class TestResultsEndpointTest(APITestCase):
                 "parameter": "FLAKY_TESTS",
                 "interval": "INTERVAL_7_DAY",
                 "flags": None,
-                "term": "sample_term",
+                "term": "test::function_with_underscores-and-dashes",
                 "test_suites": None,
             },
             "ordering": {
@@ -301,112 +271,6 @@ class TestResultsEndpointTest(APITestCase):
                 "parameter": "AVG_DURATION",
             },
             "first": 15,
-            "last": None,
-            "before": None,
-            "after": None,
-        }
-
-        call_args = mock_codecov_client_instance.query.call_args
-        assert call_args[1]["variables"] == expected_variables
-        assert response.status_code == 200
-
-    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
-    def test_get_with_empty_term_filter(self, mock_codecov_client_class):
-        mock_graphql_response = {
-            "data": {
-                "owner": {
-                    "repository": {
-                        "__typename": "Repository",
-                        "testAnalytics": {
-                            "testResults": {
-                                "edges": [],
-                                "pageInfo": {"endCursor": None, "hasNextPage": False},
-                                "totalCount": 0,
-                            }
-                        },
-                    }
-                }
-            }
-        }
-        mock_codecov_client_instance = Mock()
-        mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
-        mock_codecov_client_instance.query.return_value = mock_response
-        mock_codecov_client_class.return_value = mock_codecov_client_instance
-
-        url = self.reverse_url()
-        query_params = {"term": ""}
-        response = self.client.get(url, query_params)
-
-        expected_variables = {
-            "owner": "testowner",
-            "repo": "testrepo",
-            "filters": {
-                "branch": "main",
-                "parameter": None,
-                "interval": "INTERVAL_30_DAY",
-                "flags": None,
-                "term": "",
-                "test_suites": None,
-            },
-            "ordering": {
-                "direction": "DESC",
-                "parameter": "COMMITS_WHERE_FAIL",
-            },
-            "first": 20,
-            "last": None,
-            "before": None,
-            "after": None,
-        }
-
-        call_args = mock_codecov_client_instance.query.call_args
-        assert call_args[1]["variables"] == expected_variables
-        assert response.status_code == 200
-
-    @patch("sentry.codecov.endpoints.TestResults.test_results.CodecovApiClient")
-    def test_get_with_term_filter_special_characters(self, mock_codecov_client_class):
-        mock_graphql_response = {
-            "data": {
-                "owner": {
-                    "repository": {
-                        "__typename": "Repository",
-                        "testAnalytics": {
-                            "testResults": {
-                                "edges": [],
-                                "pageInfo": {"endCursor": None, "hasNextPage": False},
-                                "totalCount": 0,
-                            }
-                        },
-                    }
-                }
-            }
-        }
-        mock_codecov_client_instance = Mock()
-        mock_response = Mock()
-        mock_response.json.return_value = mock_graphql_response
-        mock_codecov_client_instance.query.return_value = mock_response
-        mock_codecov_client_class.return_value = mock_codecov_client_instance
-
-        url = self.reverse_url()
-        query_params = {"term": "test::function_with_underscores-and-dashes"}
-        response = self.client.get(url, query_params)
-
-        expected_variables = {
-            "owner": "testowner",
-            "repo": "testrepo",
-            "filters": {
-                "branch": "main",
-                "parameter": None,
-                "interval": "INTERVAL_30_DAY",
-                "flags": None,
-                "term": "test::function_with_underscores-and-dashes",
-                "test_suites": None,
-            },
-            "ordering": {
-                "direction": "DESC",
-                "parameter": "COMMITS_WHERE_FAIL",
-            },
-            "first": 20,
             "last": None,
             "before": None,
             "after": None,


### PR DESCRIPTION
This PR adds a search "term" query parameter into the test results endpoint to pass along to the Codecov API.

Closes https://linear.app/getsentry/issue/CCMRG-1305/add-search-query-param-to-test-results-endpoint

This is a screenshot of postman with the term query parameter:
<img width="1343" alt="Screenshot 2025-07-09 at 3 43 02 PM" src="https://github.com/user-attachments/assets/cb9db5f9-f6bc-4a4e-956a-4791c618c4dc" />

And one without:
<img width="1303" alt="Screenshot 2025-07-09 at 3 44 18 PM" src="https://github.com/user-attachments/assets/a1cda3e0-824e-4c3d-a219-16bb399270a8" />
