### PR TITLE
ref(aci): Fully separate detector types

### DIFF
--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -25,6 +25,9 @@ interface SnubaQuery {
   environment?: string;
 }
 
+/**
+ * See DataSourceSerializer
+ */
 interface BaseDataSource {
   id: string;
   organizationId: string;
@@ -62,11 +65,6 @@ interface UptimeSubscriptionDataSource extends BaseDataSource {
   };
   type: 'uptime_subscription';
 }
-
-/**
- * See DataSourceSerializer
- */
-export type DataSource = SnubaQueryDataSource | UptimeSubscriptionDataSource;
 
 export type DetectorType =
   | 'error'
@@ -139,7 +137,7 @@ export interface UptimeDetector extends BaseDetector {
   readonly type: 'uptime_domain_failure';
 }
 
-export interface CronDetector extends BaseDetector {
+interface CronDetector extends BaseDetector {
   // TODO: Add cron detector type fields
   readonly type: 'uptime_subscription';
 }
@@ -151,7 +149,7 @@ export interface ErrorDetector extends BaseDetector {
 
 export type Detector = MetricDetector | UptimeDetector | CronDetector | ErrorDetector;
 
-export interface UpdateConditionGroupPayload {
+interface UpdateConditionGroupPayload {
   conditions: Array<Omit<DataCondition, 'id'>>;
   logicType: DataConditionGroup['logicType'];
 }

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -59,8 +59,6 @@ interface UptimeSubscriptionDataSource extends BaseDataSource {
     timeoutMs: number;
     traceSampling: boolean;
     url: string;
-    urlDomain: string;
-    urlDomainSuffix: string;
   };
   type: 'uptime_subscription';
 }
@@ -114,29 +112,46 @@ interface UptimeDetectorConfig {
   environment: string;
 }
 
-export type DetectorConfig = MetricDetectorConfig | UptimeDetectorConfig;
-
-interface NewDetector {
-  conditionGroup: DataConditionGroup | null;
-  config: DetectorConfig;
-  dataSources: DataSource[] | null;
+type BaseDetector = Readonly<{
+  createdBy: string | null;
+  dateCreated: string;
+  dateUpdated: string;
   disabled: boolean;
+  id: string;
+  lastTriggered: string;
   name: string;
+  owner: string | null;
   projectId: string;
   type: DetectorType;
   workflowIds: string[];
+}>;
+
+export interface MetricDetector extends BaseDetector {
+  readonly conditionGroup: DataConditionGroup | null;
+  readonly config: MetricDetectorConfig;
+  readonly dataSources: SnubaQueryDataSource[];
+  readonly type: 'metric_issue';
 }
 
-export interface Detector extends Readonly<NewDetector> {
-  readonly createdBy: string | null;
-  readonly dateCreated: string;
-  readonly dateUpdated: string;
-  readonly id: string;
-  readonly lastTriggered: string;
-  readonly owner: string | null;
+export interface UptimeDetector extends BaseDetector {
+  readonly config: UptimeDetectorConfig;
+  readonly dataSources: UptimeSubscriptionDataSource[];
+  readonly type: 'uptime_domain_failure';
 }
 
-interface UpdateConditionGroupPayload {
+export interface CronDetector extends BaseDetector {
+  // TODO: Add cron detector type fields
+  readonly type: 'uptime_subscription';
+}
+
+export interface ErrorDetector extends BaseDetector {
+  // TODO: Add error detector type fields
+  readonly type: 'error';
+}
+
+export type Detector = MetricDetector | UptimeDetector | CronDetector | ErrorDetector;
+
+export interface UpdateConditionGroupPayload {
   conditions: Array<Omit<DataCondition, 'id'>>;
   logicType: DataConditionGroup['logicType'];
 }
@@ -172,7 +187,7 @@ export interface UptimeDetectorUpdatePayload extends BaseDetectorUpdatePayload {
 
 export interface MetricDetectorUpdatePayload extends BaseDetectorUpdatePayload {
   conditionGroup: UpdateConditionGroupPayload;
-  config: DetectorConfig;
+  config: MetricDetectorConfig;
   dataSource: UpdateSnubaDataSourcePayload;
   type: 'metric_issue';
 }

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -1,5 +1,5 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
-import {DetectorFixture} from 'sentry-fixture/detectors';
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -32,7 +32,7 @@ describe('AutomationsList', function () {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/1/',
-      body: [DetectorFixture({name: 'Detector 1'})],
+      body: [MetricDetectorFixture({name: 'Detector 1'})],
     });
     PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}), new Set());
   });
@@ -59,7 +59,7 @@ describe('AutomationsList', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
       body: [
-        DetectorFixture({
+        MetricDetectorFixture({
           id: '1',
           name: 'Detector 1',
           workflowIds: ['100'],

--- a/static/app/views/detectors/components/detailsPanel.tsx
+++ b/static/app/views/detectors/components/detailsPanel.tsx
@@ -41,9 +41,11 @@ function SnubaQueryDetails({dataSource}: {dataSource: SnubaQueryDataSource}) {
 }
 
 function DetailsPanel({detector}: DetailsPanelProps) {
-  const dataSource = detector.dataSources?.[0];
-  if (dataSource?.type === 'snuba_query_subscription') {
-    return <SnubaQueryDetails dataSource={dataSource} />;
+  if (detector.type === 'metric_issue') {
+    const dataSource = detector.dataSources?.[0];
+    if (dataSource?.type === 'snuba_query_subscription') {
+      return <SnubaQueryDetails dataSource={dataSource} />;
+    }
   }
 
   return (

--- a/static/app/views/detectors/components/detectorDetailsSidebar.tsx
+++ b/static/app/views/detectors/components/detectorDetailsSidebar.tsx
@@ -26,6 +26,11 @@ import {getResolutionDescription} from 'sentry/views/detectors/utils/getDetector
 import {getMetricDetectorSuffix} from 'sentry/views/detectors/utils/metricDetectorSuffix';
 
 function getDetectorEnvironment(detector: Detector) {
+  // TODO: Add support for other detector types
+  if (detector.type !== 'metric_issue') {
+    return '<placeholder>';
+  }
+
   return (
     detector.dataSources?.find(ds => ds.type === 'snuba_query_subscription')?.queryObj
       ?.snubaQuery.environment ?? t('All environments')
@@ -67,6 +72,10 @@ function AssignToUser({userId}: {userId: string}) {
 }
 
 function DetectorPriorities({detector}: {detector: Detector}) {
+  if (detector.type !== 'metric_issue') {
+    return null;
+  }
+
   // TODO: Add support for other detector types
   if (!('detectionType' in detector.config)) {
     return null;
@@ -126,7 +135,7 @@ function DetectorPriorities({detector}: {detector: Detector}) {
 
 function DetectorResolve({detector}: {detector: Detector}) {
   // TODO: Add support for other detector types
-  if (!('detectionType' in detector.config)) {
+  if (detector.type !== 'metric_issue') {
     return null;
   }
 

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -11,7 +11,11 @@ import {
   DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL,
   DetectorPriorityLevel,
 } from 'sentry/types/workflowEngine/dataConditions';
-import type {DataSource, Detector} from 'sentry/types/workflowEngine/detectors';
+import type {
+  Detector,
+  MetricDetector,
+  UptimeDetector,
+} from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
@@ -76,12 +80,7 @@ function DetailItem({children}: {children: React.ReactNode}) {
   );
 }
 
-function ConfigDetails({detector}: {detector: Detector}) {
-  // TODO: Use a MetricDetector type to avoid checking for this
-  if (!('detectionType' in detector.config)) {
-    return null;
-  }
-
+function MetricDetectorConfigDetails({detector}: {detector: MetricDetector}) {
   const type = detector.config.detectionType;
   const conditions = detector.conditionGroup?.conditions;
   if (!conditions?.length) {
@@ -118,52 +117,58 @@ function ConfigDetails({detector}: {detector: Detector}) {
   }
 }
 
-function DataSourceDetails({dataSource}: {dataSource: DataSource}) {
-  const type = dataSource.type;
-  switch (type) {
-    case 'snuba_query_subscription':
-      if (!dataSource.queryObj) {
-        return <DetailItem>{t('Query not found.')}</DetailItem>;
-      }
-      return (
-        <Fragment>
-          <DetailItem>{dataSource.queryObj.snubaQuery.environment}</DetailItem>
-          <DetailItem>{dataSource.queryObj.snubaQuery.aggregate}</DetailItem>
-          <DetailItem>
-            {middleEllipsis(dataSource.queryObj.snubaQuery.query, 40)}
-          </DetailItem>
-        </Fragment>
-      );
-    case 'uptime_subscription':
-      return (
-        <Fragment>
-          <DetailItem>
-            {dataSource.queryObj.urlDomain + '.' + dataSource.queryObj.urlDomainSuffix}
-          </DetailItem>
-          <DetailItem>{getDuration(dataSource.queryObj.intervalSeconds)}</DetailItem>
-        </Fragment>
-      );
-    default:
-      unreachable(type);
-      return null;
-  }
+function MetricDetectorDetails({detector}: {detector: MetricDetector}) {
+  return (
+    <Fragment>
+      {detector.dataSources.map(dataSource => {
+        if (!dataSource.queryObj) {
+          return null;
+        }
+        return (
+          <Fragment key={dataSource.id}>
+            <DetailItem>{dataSource.queryObj.snubaQuery.environment}</DetailItem>
+            <DetailItem>{dataSource.queryObj.snubaQuery.aggregate}</DetailItem>
+            <DetailItem>
+              {middleEllipsis(dataSource.queryObj.snubaQuery.query, 40)}
+            </DetailItem>
+          </Fragment>
+        );
+      })}
+      <MetricDetectorConfigDetails detector={detector} />
+    </Fragment>
+  );
+}
+
+function UptimeDetectorDetails({detector}: {detector: UptimeDetector}) {
+  return (
+    <Fragment>
+      {detector.dataSources.map(dataSource => {
+        return (
+          <Fragment key={dataSource.id}>
+            <DetailItem>{middleEllipsis(dataSource.queryObj.url, 40)}</DetailItem>
+            <DetailItem>{getDuration(dataSource.queryObj.intervalSeconds)}</DetailItem>
+          </Fragment>
+        );
+      })}
+    </Fragment>
+  );
 }
 
 function Details({detector}: {detector: Detector}) {
-  if (!detector.dataSources?.length) {
-    return null;
+  const detectorType = detector.type;
+  switch (detectorType) {
+    case 'metric_issue':
+      return <MetricDetectorDetails detector={detector} />;
+    case 'uptime_domain_failure':
+      return <UptimeDetectorDetails detector={detector} />;
+    // TODO: Implement details for Cron detectors
+    case 'uptime_subscription':
+    case 'error':
+      return null;
+    default:
+      unreachable(detectorType);
+      return null;
   }
-
-  return (
-    <Fragment>
-      {detector.dataSources.map(dataSource => (
-        <Fragment key={dataSource.id}>
-          <DataSourceDetails dataSource={dataSource} />
-        </Fragment>
-      ))}
-      <ConfigDetails detector={detector} />
-    </Fragment>
-  );
 }
 
 export function DetectorLink({detector, className}: DetectorLinkProps) {

--- a/static/app/views/detectors/components/forms/editDetectorActions.spec.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorActions.spec.tsx
@@ -1,4 +1,4 @@
-import {DetectorFixture} from 'sentry-fixture/detectors';
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
@@ -13,7 +13,7 @@ import {EditDetectorActions} from './editDetectorActions';
 
 describe('EditDetectorActions', () => {
   it('calls delete mutation when deletion is confirmed', async () => {
-    const detector = DetectorFixture();
+    const detector = MetricDetectorFixture();
     const organization = OrganizationFixture();
 
     const mockDeleteDetector = MockApiClient.addMockResponse({

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -10,7 +10,8 @@ import {
 } from 'sentry/types/workflowEngine/dataConditions';
 import type {
   Detector,
-  DetectorConfig,
+  MetricDetector,
+  MetricDetectorConfig,
   MetricDetectorUpdatePayload,
 } from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
@@ -325,7 +326,7 @@ export function metricDetectorFormDataToEndpointPayload(
   const dataSource = createDataSource(data);
 
   // Create config based on detection type
-  let config: DetectorConfig;
+  let config: MetricDetectorConfig;
   switch (data.kind) {
     case 'percent':
       config = {
@@ -368,7 +369,7 @@ export function metricDetectorFormDataToEndpointPayload(
  * Convert the detector conditions array to the flattened form data
  */
 function processDetectorConditions(
-  detector: Detector
+  detector: MetricDetector
 ): PrioritizeLevelFormData &
   Pick<MetricDetectorFormData, 'conditionValue' | 'conditionType'> {
   // Get conditions from the condition group
@@ -422,6 +423,11 @@ function processDetectorConditions(
 export function metricSavedDetectorToFormData(
   detector: Detector
 ): MetricDetectorFormData {
+  if (detector.type !== 'metric_issue') {
+    // This should never happen
+    throw new Error('Detector type mismatch');
+  }
+
   // Get the first data source (assuming metric detectors have one)
   const dataSource = detector.dataSources?.[0];
 

--- a/static/app/views/detectors/components/forms/uptime/fields.tsx
+++ b/static/app/views/detectors/components/forms/uptime/fields.tsx
@@ -70,6 +70,11 @@ export function uptimeFormDataToEndpointPayload(
 export function uptimeSavedDetectorToFormData(
   detector: Detector
 ): UptimeDetectorFormData {
+  if (detector.type !== 'uptime_domain_failure') {
+    // This should never happen
+    throw new Error('Detector type mismatch');
+  }
+
   const dataSource = detector.dataSources?.[0];
   const environment = 'environment' in detector.config ? detector.config.environment : '';
 

--- a/static/app/views/detectors/detail.spec.tsx
+++ b/static/app/views/detectors/detail.spec.tsx
@@ -1,5 +1,8 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
-import {DetectorFixture, SnubaQueryDataSourceFixture} from 'sentry-fixture/detectors';
+import {
+  MetricDetectorFixture,
+  SnubaQueryDataSourceFixture,
+} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
@@ -26,7 +29,7 @@ describe('DetectorDetails', function () {
       },
     },
   });
-  const snubaQueryDetector = DetectorFixture({
+  const snubaQueryDetector = MetricDetectorFixture({
     projectId: project.id,
     dataSources: [dataSource],
     owner: `team:${ownerTeam.id}`,

--- a/static/app/views/detectors/list.spec.tsx
+++ b/static/app/views/detectors/list.spec.tsx
@@ -1,5 +1,5 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
-import {DetectorFixture} from 'sentry-fixture/detectors';
+import {ErrorDetectorFixture, MetricDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {UserFixture} from 'sentry-fixture/user';
@@ -32,7 +32,7 @@ describe('DetectorsList', function () {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
-      body: [DetectorFixture({name: 'Detector 1'})],
+      body: [MetricDetectorFixture({name: 'Detector 1'})],
     });
     PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [1]}), new Set());
   });
@@ -41,7 +41,7 @@ describe('DetectorsList', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
       body: [
-        DetectorFixture({
+        MetricDetectorFixture({
           name: 'Detector 1',
           owner: null,
           type: 'metric_issue',
@@ -108,7 +108,7 @@ describe('DetectorsList', function () {
   it('displays connected automations', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
-      body: [DetectorFixture({id: '1', name: 'Detector 1', workflowIds: ['100']})],
+      body: [MetricDetectorFixture({id: '1', name: 'Detector 1', workflowIds: ['100']})],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/workflows/',
@@ -128,7 +128,7 @@ describe('DetectorsList', function () {
   it('can filter by project', async function () {
     const mockDetectorsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/detectors/',
-      body: [DetectorFixture({name: 'Detector 1'})],
+      body: [MetricDetectorFixture({name: 'Detector 1'})],
     });
 
     render(<DetectorsList />, {organization});
@@ -149,7 +149,7 @@ describe('DetectorsList', function () {
     it('can filter by type', async function () {
       const mockDetectorsRequestErrorType = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
-        body: [DetectorFixture({type: 'error', name: 'Error Detector'})],
+        body: [ErrorDetectorFixture({name: 'Error Detector'})],
         match: [MockApiClient.matchQuery({query: 'type:error'})],
       });
 
@@ -174,7 +174,7 @@ describe('DetectorsList', function () {
     it('can sort the table', async function () {
       const mockDetectorsRequest = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/detectors/',
-        body: [DetectorFixture({name: 'Detector 1'})],
+        body: [MetricDetectorFixture({name: 'Detector 1'})],
       });
       const {router} = render(<DetectorsList />, {organization});
       await screen.findByText('Detector 1');

--- a/static/app/views/detectors/utils/metricDetectorSuffix.spec.tsx
+++ b/static/app/views/detectors/utils/metricDetectorSuffix.spec.tsx
@@ -1,4 +1,4 @@
-import {DetectorFixture} from 'sentry-fixture/detectors';
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
 
 import {
   getMetricDetectorSuffix,
@@ -34,7 +34,7 @@ describe('getStaticDetectorThresholdSuffix', function () {
 
 describe('getMetricDetectorSuffix', function () {
   it('returns % for percent detection type', function () {
-    const detector = DetectorFixture({
+    const detector = MetricDetectorFixture({
       id: '1',
       name: 'test',
       config: {
@@ -48,7 +48,7 @@ describe('getMetricDetectorSuffix', function () {
   });
 
   it('returns ms as default for static detection type without data source', function () {
-    const detector = DetectorFixture({
+    const detector = MetricDetectorFixture({
       config: {
         detectionType: 'static',
         thresholdPeriod: 1,
@@ -59,7 +59,7 @@ describe('getMetricDetectorSuffix', function () {
   });
 
   it('returns ms as default for dynamic detection type without data source', function () {
-    const detector = DetectorFixture({
+    const detector = MetricDetectorFixture({
       config: {
         detectionType: 'dynamic',
         thresholdPeriod: 1,

--- a/static/app/views/detectors/utils/metricDetectorSuffix.tsx
+++ b/static/app/views/detectors/utils/metricDetectorSuffix.tsx
@@ -1,4 +1,4 @@
-import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {unreachable} from 'sentry/utils/unreachable';
 
@@ -25,12 +25,7 @@ export function getStaticDetectorThresholdSuffix(aggregate: string) {
   }
 }
 
-export function getMetricDetectorSuffix(detector: Detector) {
-  // TODO: Use a MetricDetector type to avoid checking for this
-  if (!('detectionType' in detector.config)) {
-    return '';
-  }
-
+export function getMetricDetectorSuffix(detector: MetricDetector) {
   switch (detector.config.detectionType) {
     case 'static':
     case 'dynamic':

--- a/tests/js/fixtures/detectors.ts
+++ b/tests/js/fixtures/detectors.ts
@@ -1,10 +1,16 @@
 import {DataConditionGroupFixture} from 'sentry-fixture/dataConditions';
 import {UserFixture} from 'sentry-fixture/user';
 
-import type {Detector, SnubaQueryDataSource} from 'sentry/types/workflowEngine/detectors';
+import type {
+  ErrorDetector,
+  MetricDetector,
+  SnubaQueryDataSource,
+} from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 
-export function DetectorFixture(params: Partial<Detector> = {}): Detector {
+export function MetricDetectorFixture(
+  params: Partial<MetricDetector> = {}
+): MetricDetector {
   return {
     id: '1',
     name: 'detector',
@@ -23,6 +29,23 @@ export function DetectorFixture(params: Partial<Detector> = {}): Detector {
     conditionGroup: params.conditionGroup ?? DataConditionGroupFixture(),
     dataSources: params.dataSources ?? [SnubaQueryDataSourceFixture()],
     owner: null,
+    ...params,
+  };
+}
+
+export function ErrorDetectorFixture(params: Partial<ErrorDetector> = {}): ErrorDetector {
+  return {
+    name: 'Error Detector',
+    createdBy: null,
+    dateCreated: '2025-01-01T00:00:00.000Z',
+    dateUpdated: '2025-01-01T00:00:00.000Z',
+    disabled: false,
+    id: '1',
+    lastTriggered: '2025-01-01T00:00:00.000Z',
+    owner: null,
+    projectId: '1',
+    workflowIds: [],
+    type: 'error',
     ...params,
   };
 }


### PR DESCRIPTION
We were using a shared `Detector` type everywhere, which meant that there were a lot of type guards sprinkled around. This introduces more concrete types for each kind of detector to make type checking more useful.