### PR TITLE
fix(flex): Prevent internal `<Flex>` props from being printed to html

### DIFF
--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -14,7 +14,10 @@ interface FlexProps {
   wrap?: CSSProperties['flexWrap'];
 }
 
-export const Flex = styled('div')<FlexProps>`
+export const Flex = styled('div', {
+  shouldForwardProp: prop =>
+    !['align', 'direction', 'flex', 'gap', 'inline', 'justify', 'wrap'].includes(prop),
+})<FlexProps>`
   display: ${p => (p.inline ? 'inline-flex' : 'flex')};
   flex-direction: ${p => p.direction};
   justify-content: ${p => p.justify};


### PR DESCRIPTION
Before we would see stuff like `<div wrap="wrap">` and we don't want any props like that exposed. 

<img width="439" alt="SCR-20250709-oejn" src="https://github.com/user-attachments/assets/afb1b166-c5a8-4efb-9884-182cf82ea302" />
