### PR TITLE
ref: Update useListItemCheckboxState to allow toggling lists of items at once

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -20,7 +20,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useFetchInfiniteListData from 'sentry/utils/api/useFetchInfiniteListData';
 import type {FeedbackIssueListItem} from 'sentry/utils/feedback/types';
-import useListItemCheckboxState from 'sentry/utils/list/useListItemCheckboxState';
+import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import useVirtualizedList from 'sentry/views/replays/detail/useVirtualizedList';
 
 // Ensure this object is created once as it is an input to
@@ -57,7 +57,7 @@ export default function FeedbackList() {
     enabled: Boolean(listQueryKey),
   });
 
-  const checkboxState = useListItemCheckboxState({
+  const checkboxState = useListItemCheckboxContext({
     hits,
     knownIds: issues.map(issue => issue.id),
     queryKey: listQueryKey,

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -8,11 +8,11 @@ import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {GroupStatus} from 'sentry/types/group';
-import type useListItemCheckboxState from 'sentry/utils/list/useListItemCheckboxState';
+import type {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 
 interface Props
   extends Pick<
-    ReturnType<typeof useListItemCheckboxState>,
+    ReturnType<typeof useListItemCheckboxContext>,
     'countSelected' | 'deselectAll' | 'selectedIds'
   > {
   mailbox: ReturnType<typeof decodeMailbox>;

--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -11,13 +11,13 @@ import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKey
 import {IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type useListItemCheckboxState from 'sentry/utils/list/useListItemCheckboxState';
+import type {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useUrlParams from 'sentry/utils/url/useUrlParams';
 
 interface Props
   extends Pick<
-    ReturnType<typeof useListItemCheckboxState>,
+    ReturnType<typeof useListItemCheckboxContext>,
     | 'countSelected'
     | 'deselectAll'
     | 'isAllSelected'

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -11,7 +11,7 @@ import useMutateFeedback from 'sentry/components/feedback/useMutateFeedback';
 import {t, tct} from 'sentry/locale';
 import {GroupStatus} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type useListItemCheckboxState from 'sentry/utils/list/useListItemCheckboxState';
+import type {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
 import {decodeList} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -30,7 +30,7 @@ const statusToText: Record<string, string> = {
 
 interface Props
   extends Pick<
-    ReturnType<typeof useListItemCheckboxState>,
+    ReturnType<typeof useListItemCheckboxContext>,
     'deselectAll' | 'selectedIds'
   > {}
 

--- a/static/app/utils/list/useListItemCheckboxState.spec.ts
+++ b/static/app/utils/list/useListItemCheckboxState.spec.ts
@@ -1,0 +1,284 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+
+const queryKey: ApiQueryKey = ['test'];
+
+describe('useListItemCheckboxContext', () => {
+  describe('All hits are already known', () => {
+    it('should return the correct initial state', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 3, knownIds: ['1', '2', '3'], queryKey})
+      );
+      expect(result.current).toEqual({
+        countSelected: 0,
+        deselectAll: expect.any(Function),
+        hits: 3,
+        isAllSelected: false,
+        isAnySelected: false,
+        isSelected: expect.any(Function),
+        knownIds: ['1', '2', '3'],
+        queryKey,
+        selectAll: expect.any(Function),
+        selectedIds: [],
+        toggleSelected: expect.any(Function),
+      });
+    });
+
+    it('should allow selecting an individual item when all hits are known', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 3, knownIds: ['1', '2', '3'], queryKey})
+      );
+
+      // Initially nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+      expect(result.current.isAnySelected).toBe(false);
+      expect(result.current.countSelected).toBe(0);
+
+      // Select item '1'
+      act(() => {
+        result.current.toggleSelected('1');
+      });
+
+      // Check that only item '1' is selected
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(1);
+      expect(result.current.selectedIds).toEqual(['1']);
+
+      // Select item '2' as well
+      act(() => {
+        result.current.toggleSelected('2');
+      });
+
+      // Check that both items are selected
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(2);
+      expect(result.current.selectedIds).toEqual(['1', '2']);
+
+      // Deselect item '1'
+      act(() => {
+        result.current.toggleSelected('1');
+      });
+
+      // Check that only item '2' is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(1);
+      expect(result.current.selectedIds).toEqual(['2']);
+    });
+
+    it('sets isAllSelected to true when all items are selected', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 3, knownIds: ['1', '2', '3'], queryKey})
+      );
+
+      // Initially nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+
+      act(() => {
+        result.current.toggleSelected('1');
+        result.current.toggleSelected('2');
+        result.current.toggleSelected('3');
+      });
+
+      // Check that all items are selected
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(true);
+      expect(result.current.isAllSelected).toBe(true);
+    });
+
+    it('should allow selecting all items with selectAll', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 3, knownIds: ['1', '2', '3'], queryKey})
+      );
+
+      // Initially nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+      expect(result.current.isAnySelected).toBe(false);
+      expect(result.current.countSelected).toBe(0);
+
+      // Select all items
+      act(() => {
+        result.current.selectAll();
+      });
+
+      // Check that all items are selected (including virtual items not yet loaded)
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(true);
+      expect(result.current.isAllSelected).toBe(true);
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(3); // Total hits count
+      expect(result.current.selectedIds).toBe('all'); // Special sentinel value
+
+      // Deselect all
+      act(() => {
+        result.current.deselectAll();
+      });
+
+      // Check that nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+      expect(result.current.isAnySelected).toBe(false);
+      expect(result.current.countSelected).toBe(0);
+      expect(result.current.selectedIds).toEqual([]);
+    });
+  });
+
+  describe('More hits to load', () => {
+    it('should return the correct initial state', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 10, knownIds: ['1', '2', '3'], queryKey})
+      );
+      expect(result.current).toEqual({
+        countSelected: 0,
+        deselectAll: expect.any(Function),
+        hits: 10,
+        isAllSelected: false,
+        isAnySelected: false,
+        isSelected: expect.any(Function),
+        knownIds: ['1', '2', '3'],
+        queryKey,
+        selectAll: expect.any(Function),
+        selectedIds: [],
+        toggleSelected: expect.any(Function),
+      });
+    });
+
+    it('should allow selecting individual items when there are more hits to load', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 10, knownIds: ['1', '2', '3'], queryKey})
+      );
+
+      // Initially nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+      expect(result.current.isAnySelected).toBe(false);
+      expect(result.current.countSelected).toBe(0);
+
+      // Select item '1'
+      act(() => {
+        result.current.toggleSelected('1');
+      });
+
+      // Check that only item '1' is selected
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(1);
+      expect(result.current.selectedIds).toEqual(['1']);
+
+      // Select item '2' as well
+      act(() => {
+        result.current.toggleSelected('2');
+      });
+
+      // Check that both items are selected
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(2);
+      expect(result.current.selectedIds).toEqual(['1', '2']);
+
+      // Select item '3' to select all known items
+      act(() => {
+        result.current.toggleSelected('3');
+      });
+
+      // Check that all known items are selected
+      expect(result.current.isSelected('1')).toBe(true);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(true);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(3);
+      expect(result.current.selectedIds).toEqual(['1', '2', '3']);
+
+      // Deselect item '1'
+      act(() => {
+        result.current.toggleSelected('1');
+      });
+
+      // Check that only items '2' and '3' are selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(true);
+      expect(result.current.isSelected('3')).toBe(true);
+      expect(result.current.isAllSelected).toBe('indeterminate');
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(2);
+      expect(result.current.selectedIds).toEqual(['2', '3']);
+    });
+
+    it('should allow selecting all items with selectAll', () => {
+      const {result} = renderHook(() =>
+        useListItemCheckboxContext({hits: 10, knownIds: ['1', '2', '3'], queryKey})
+      );
+
+      // Initially nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+      expect(result.current.isAnySelected).toBe(false);
+      expect(result.current.countSelected).toBe(0);
+
+      // Select all items
+      act(() => {
+        result.current.selectAll();
+      });
+
+      // Check that all items are selected (including virtual items not yet loaded)
+      expect(result.current.isSelected('1')).toBe('all-selected');
+      expect(result.current.isSelected('2')).toBe('all-selected');
+      expect(result.current.isSelected('3')).toBe('all-selected');
+      expect(result.current.isAllSelected).toBe(true);
+      expect(result.current.isAnySelected).toBe(true);
+      expect(result.current.countSelected).toBe(10); // Total hits count
+      expect(result.current.selectedIds).toBe('all'); // Special sentinel value
+
+      // Deselect all
+      act(() => {
+        result.current.deselectAll();
+      });
+
+      // Check that nothing is selected
+      expect(result.current.isSelected('1')).toBe(false);
+      expect(result.current.isSelected('2')).toBe(false);
+      expect(result.current.isSelected('3')).toBe(false);
+      expect(result.current.isAllSelected).toBe(false);
+      expect(result.current.isAnySelected).toBe(false);
+      expect(result.current.countSelected).toBe(0);
+      expect(result.current.selectedIds).toEqual([]);
+    });
+  });
+});

--- a/static/app/utils/list/useListItemCheckboxState.tsx
+++ b/static/app/utils/list/useListItemCheckboxState.tsx
@@ -1,8 +1,17 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import type {Dispatch, SetStateAction} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
+import toArray from 'sentry/utils/array/toArray';
 import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/queryClient';
 
-interface Props {
+interface PublicProps {
   /**
    * The total number of items the query could return
    */
@@ -22,97 +31,166 @@ interface Props {
   queryKey: undefined | ApiQueryKey | InfiniteApiQueryKey;
 }
 
+interface InternalProps {
+  setState: Dispatch<SetStateAction<State>>;
+  state: State;
+}
+type MergedProps = PublicProps & InternalProps;
+
 /**
  * We can either have a list of ids, or have all selected.
  * When all is selected we may, or may not, have all ids loaded into the browser
  */
 type State = {ids: Set<string>} | {all: true};
 
-interface Return {
+interface Return extends PublicProps {
   /**
    * How many ids are selected
    */
   countSelected: number;
+
   /**
    * Ensure nothing is selected, no matter the state prior
    */
   deselectAll: () => void;
+
   /**
    * True if all are selected
    *
    * When some are selected returns 'indeterminate'
+   *
+   * Useful at the top of a list of items: <Checkbox checked={isAllSelected}/>
    */
   isAllSelected: 'indeterminate' | boolean;
+
   /**
    * True if one or more are selected
+   *
+   * Useful to show bulk-actions at the top of a list whenever anything is selected
    */
   isAnySelected: boolean;
+
   /**
    * True if this specific id is selected
+   *
+   * Useful for individual list items: <Checkbox checked={isSelected(id) !== false}/>
    */
   isSelected: (id: string) => 'all-selected' | boolean;
+
   /**
    * Record that all are selected, wether or not all feedback ids are loaded or not
    */
   selectAll: () => void;
+
   /**
    * The list of specifically selected ids, or 'all' to save space
    */
   selectedIds: 'all' | string[];
+
   /**
    * Toggle if a feedback is selected or not
    * It's not possible to toggle when all are selected, but not all are loaded
    */
-  toggleSelected: (id: string) => void;
+  toggleSelected: (id: string | string[]) => void;
 }
 
-export default function useListItemCheckboxState({
+const ListItemCheckboxContext = createContext<{
+  hits: number;
+  knownIds: string[];
+  queryKey: undefined | ApiQueryKey | InfiniteApiQueryKey;
+  setState?: Dispatch<SetStateAction<State>>;
+  state?: State;
+}>({
+  hits: 0,
+  knownIds: [],
+  queryKey: undefined,
+});
+
+/**
+ * @public
+ */
+export function ListItemCheckboxProvider({
+  children,
   hits,
   knownIds,
   queryKey,
-}: Props): Return {
+}: {
+  children: React.ReactNode;
+  hits: number;
+  knownIds: string[];
+  queryKey: undefined | ApiQueryKey | InfiniteApiQueryKey;
+}) {
   const [state, setState] = useState<State>({ids: new Set()});
+  return (
+    <ListItemCheckboxContext.Provider value={{state, setState, hits, knownIds, queryKey}}>
+      {children}
+    </ListItemCheckboxContext.Provider>
+  );
+}
 
+export function useListItemCheckboxContext(props: undefined | PublicProps = undefined) {
+  const [localState, localSetState] = useState<State>({ids: new Set()});
+  const context = useContext(ListItemCheckboxContext);
+  return useListItemCheckboxState({
+    state: localState,
+    setState: localSetState,
+    ...context,
+    ...props,
+  });
+}
+
+function useListItemCheckboxState({
+  hits,
+  knownIds,
+  queryKey,
+  state,
+  setState,
+}: MergedProps): Return {
   useEffect(() => {
     // Reset the state when the list changes
     setState({ids: new Set()});
-  }, [queryKey]);
+  }, [queryKey, setState]);
 
   const selectAll = useCallback(() => {
     // Record that the virtual "all" list is enabled.
     setState({all: true});
-  }, []);
+  }, [setState]);
 
   const deselectAll = useCallback(() => {
     setState({ids: new Set()});
-  }, []);
+  }, [setState]);
 
   const toggleSelected = useCallback(
-    (id: string) => {
+    (id: string | string[]) => {
       setState(prev => {
         if ('all' in prev && hits !== knownIds.length) {
           // Unable to toggle individual items when "all" are selected, but not
           // all items are loaded. We can't omit one item from this virtual list.
+          return prev;
         }
 
-        // If all is selected, then we're toggling this one off
+        const ids = toArray(id);
+
+        // If all is selected, then we're toggling these off
         if ('all' in prev) {
-          const ids = new Set(knownIds);
-          ids.delete(id);
-          return {ids};
+          const cloneKnownIds = new Set(knownIds);
+          ids.forEach(i => cloneKnownIds.delete(i));
+          return {ids: cloneKnownIds};
         }
 
         // We have a list of ids, so we enable/disable as needed
-        const ids = prev.ids;
-        if (ids.has(id)) {
-          ids.delete(id);
-        } else {
-          ids.add(id);
-        }
-        return {ids};
+        const clonePrevIds = new Set(prev.ids);
+        ids.forEach(i => {
+          if (clonePrevIds.has(i)) {
+            clonePrevIds.delete(i);
+          } else {
+            clonePrevIds.add(i);
+          }
+        });
+        return {ids: clonePrevIds};
       });
     },
-    [hits, knownIds]
+    [hits, knownIds, setState]
   );
 
   const isSelected = useCallback(
@@ -156,9 +234,12 @@ export default function useListItemCheckboxState({
   return {
     countSelected: 'all' in state ? hits : selectedIds.length,
     deselectAll,
+    hits,
     isAllSelected,
     isAnySelected,
     isSelected,
+    knownIds,
+    queryKey,
     selectAll,
     selectedIds,
     toggleSelected,


### PR DESCRIPTION
The two big things are that `toggleSelected` now accepts `(id: string | string[])` instead of only `string`. And there's a provider now, to hoist the state up and share it between multiple children. 

The provider/state change means that we can avoid prop-drilling everything all over the place now. It's still optional though, without a provider it'll use it's own internal state as before.

Related to REPLAY-509