### PR TITLE
ref(aci): highlight conflicting conditions in migrated automations

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -109,6 +109,7 @@ export interface DataConditionHandler {
 
 // for keeping track of conflicting condition ids in the UI
 export interface ConflictingConditions {
-  conflictingActionFilters: Record<string, string[]>;
-  conflictingTriggers: string[];
+  conflictReason: string | null;
+  conflictingActionFilters: Record<string, Set<string>>;
+  conflictingTriggers: Set<string>;
 }

--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -106,10 +106,3 @@ export interface DataConditionHandler {
   type: DataConditionType;
   handlerSubgroup?: DataConditionHandlerSubgroupType;
 }
-
-// for keeping track of conflicting condition ids in the UI
-export interface ConflictingConditions {
-  conflictReason: string | null;
-  conflictingActionFilters: Record<string, Set<string>>;
-  conflictingTriggers: Set<string>;
-}

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -12,7 +12,6 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {
-  ConflictingConditions,
   DataConditionGroup,
   DataConditionGroupLogicType,
 } from 'sentry/types/workflowEngine/dataConditions';
@@ -21,6 +20,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import {FILTER_MATCH_OPTIONS} from 'sentry/views/automations/components/actionFilters/constants';
 import ActionNodeList from 'sentry/views/automations/components/actionNodeList';
+import {AutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
 import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import DataConditionNodeList from 'sentry/views/automations/components/dataConditionNodeList';
 import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
@@ -36,92 +36,83 @@ export default function AutomationBuilder() {
     fetchOrgMembers(api, organization.slug);
   }, [api, organization]);
 
-  const {conflictingTriggers, conflictingActionFilters, conflictReason} =
-    useMemo((): ConflictingConditions => {
-      return findConflictingConditions(state.triggers, state.actionFilters);
-    }, [state]);
+  const conflictData = useMemo(() => {
+    return findConflictingConditions(state.triggers, state.actionFilters);
+  }, [state]);
 
   return (
-    <Flex direction="column" gap={space(1)}>
-      <Step>
-        <StepLead>
-          {/* TODO: Only make this a selector of "all" is originally selected */}
-          {tct('[when:When] [selector] of the following occur', {
-            when: <ConditionBadge />,
-            selector: (
-              <EmbeddedWrapper>
-                <EmbeddedSelectField
-                  styles={{
-                    control: (provided: any) => ({
-                      ...provided,
-                      minHeight: '21px',
-                      height: '21px',
-                    }),
-                  }}
-                  inline={false}
-                  isSearchable={false}
-                  isClearable={false}
-                  name="triggers.logicType"
-                  value={state.triggers.logicType}
-                  onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
-                    actions.updateWhenLogicType(option.value)
-                  }
-                  required
-                  flexibleControlStateSize
-                  options={TRIGGER_MATCH_OPTIONS}
-                  size="xs"
-                />
-              </EmbeddedWrapper>
-            ),
-          })}
-        </StepLead>
-      </Step>
-      <DataConditionNodeList
-        handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
-        placeholder={t('Select a trigger...')}
-        conditions={state.triggers.conditions}
-        group="triggers"
-        onAddRow={type => actions.addWhenCondition(type)}
-        onDeleteRow={index => actions.removeWhenCondition(index)}
-        updateCondition={(id, comparison) => actions.updateWhenCondition(id, comparison)}
-        conflictingConditionIds={conflictingTriggers}
-        conflictReason={conflictReason}
-      />
-      {state.actionFilters.map(actionFilter => (
-        <ActionFilterBlock
-          key={`actionFilters.${actionFilter.id}`}
-          actionFilter={actionFilter}
-          conflictingConditions={
-            conflictingActionFilters[actionFilter.id] || new Set<string>()
+    <AutomationBuilderConflictContext.Provider value={conflictData}>
+      <Flex direction="column" gap={space(1)}>
+        <Step>
+          <StepLead>
+            {/* TODO: Only make this a selector of "all" is originally selected */}
+            {tct('[when:When] [selector] of the following occur', {
+              when: <ConditionBadge />,
+              selector: (
+                <EmbeddedWrapper>
+                  <EmbeddedSelectField
+                    styles={{
+                      control: (provided: any) => ({
+                        ...provided,
+                        minHeight: '21px',
+                        height: '21px',
+                      }),
+                    }}
+                    inline={false}
+                    isSearchable={false}
+                    isClearable={false}
+                    name={`${state.triggers.id}.logicType`}
+                    value={state.triggers.logicType}
+                    onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
+                      actions.updateWhenLogicType(option.value)
+                    }
+                    required
+                    flexibleControlStateSize
+                    options={TRIGGER_MATCH_OPTIONS}
+                    size="xs"
+                  />
+                </EmbeddedWrapper>
+              ),
+            })}
+          </StepLead>
+        </Step>
+        <DataConditionNodeList
+          handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+          placeholder={t('Select a trigger...')}
+          conditions={state.triggers.conditions}
+          groupId={state.triggers.id}
+          onAddRow={type => actions.addWhenCondition(type)}
+          onDeleteRow={index => actions.removeWhenCondition(index)}
+          updateCondition={(id, comparison) =>
+            actions.updateWhenCondition(id, comparison)
           }
-          conflictReason={conflictReason}
         />
-      ))}
-      <span>
-        <PurpleTextButton
-          borderless
-          icon={<IconAdd />}
-          size="xs"
-          onClick={() => actions.addIf()}
-        >
-          {t('If/Then Block')}
-        </PurpleTextButton>
-      </span>
-    </Flex>
+        {state.actionFilters.map(actionFilter => (
+          <ActionFilterBlock
+            key={`actionFilters.${actionFilter.id}`}
+            actionFilter={actionFilter}
+          />
+        ))}
+        <span>
+          <PurpleTextButton
+            borderless
+            icon={<IconAdd />}
+            size="xs"
+            onClick={() => actions.addIf()}
+          >
+            {t('If/Then Block')}
+          </PurpleTextButton>
+        </span>
+      </Flex>
+    </AutomationBuilderConflictContext.Provider>
   );
 }
 
 interface ActionFilterBlockProps {
   actionFilter: DataConditionGroup;
-  conflictReason: string | null;
-  conflictingConditions: Set<string>;
 }
 
-function ActionFilterBlock({
-  actionFilter,
-  conflictingConditions,
-  conflictReason,
-}: ActionFilterBlockProps) {
+function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
   const {actions} = useAutomationBuilderContext();
 
   return (
@@ -171,15 +162,13 @@ function ActionFilterBlock({
           <DataConditionNodeList
             handlerGroup={DataConditionHandlerGroupType.ACTION_FILTER}
             placeholder={t('Any event')}
-            group={`actionFilters.${actionFilter.id}`}
+            groupId={actionFilter.id}
             conditions={actionFilter?.conditions || []}
             onAddRow={type => actions.addIfCondition(actionFilter.id, type)}
             onDeleteRow={id => actions.removeIfCondition(actionFilter.id, id)}
             updateCondition={(id, params) =>
               actions.updateIfCondition(actionFilter.id, id, params)
             }
-            conflictingConditionIds={conflictingConditions}
-            conflictReason={conflictReason}
           />
         </Flex>
       </Step>

--- a/static/app/views/automations/components/automationBuilderConflictContext.tsx
+++ b/static/app/views/automations/components/automationBuilderConflictContext.tsx
@@ -1,0 +1,19 @@
+import {createContext, useContext} from 'react';
+
+export interface ConflictingConditions {
+  conflictReason: string | null;
+  conflictingConditionGroups: Record<string, Set<string>>;
+}
+
+export const AutomationBuilderConflictContext =
+  createContext<ConflictingConditions | null>(null);
+
+export const useAutomationBuilderConflictContext = () => {
+  const context = useContext(AutomationBuilderConflictContext);
+  if (!context) {
+    throw new Error(
+      'useAutomationBuilderConflictContext was called outside of AutomationBuilder'
+    );
+  }
+  return context;
+};

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -37,7 +37,8 @@ describe('DataConditionNodeList', function () {
 
   const defaultProps = {
     conditions: [],
-    conflictingConditionIds: [],
+    conflictingConditionIds: new Set<string>(),
+    conflictReason: null,
     group: '0',
     handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
     onAddRow: mockOnAddRow,
@@ -185,25 +186,27 @@ describe('DataConditionNodeList', function () {
   });
 
   it('shows conflicting condition warning for action filters', function () {
+    const conflictReason = 'The conditions highlighted in red are in conflict.';
     render(
       <AutomationBuilderErrorContext.Provider
         value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
       >
-        <DataConditionNodeList {...defaultProps} conflictingConditionIds={['1']} />
+        <DataConditionNodeList
+          {...defaultProps}
+          conflictingConditionIds={new Set(['1'])}
+          conflictReason={conflictReason}
+        />
       </AutomationBuilderErrorContext.Provider>,
       {
         organization,
       }
     );
 
-    expect(
-      screen.getByText(
-        'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.'
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(conflictReason)).toBeInTheDocument();
   });
 
   it('only shows conflicting condition warning for two or more workflow triggers', function () {
+    const conflictReason = 'The conditions highlighted in red are in conflict.';
     // Only one conflicting condition should not show the warning
     render(
       <AutomationBuilderErrorContext.Provider
@@ -211,18 +214,15 @@ describe('DataConditionNodeList', function () {
       >
         <DataConditionNodeList
           {...defaultProps}
-          conflictingConditionIds={['1']}
+          conflictingConditionIds={new Set(['1'])}
+          conflictReason={conflictReason}
           handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
         />
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );
 
-    expect(
-      screen.queryByText(
-        'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.'
-      )
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(conflictReason)).not.toBeInTheDocument();
 
     // Two or more conflicting conditions should show the warning
     render(
@@ -231,18 +231,15 @@ describe('DataConditionNodeList', function () {
       >
         <DataConditionNodeList
           {...defaultProps}
-          conflictingConditionIds={['1', '2']}
+          conflictingConditionIds={new Set(['1', '2'])}
+          conflictReason={conflictReason}
           handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
         />
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );
 
-    expect(
-      screen.getByText(
-        'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.'
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(conflictReason)).toBeInTheDocument();
   });
 
   it('displays error message when error context contains an error for a condition', function () {

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -11,6 +11,7 @@ import {
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
 import {MatchType} from 'sentry/views/automations/components/actionFilters/constants';
+import {AutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
 import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import DataConditionNodeList from 'sentry/views/automations/components/dataConditionNodeList';
 
@@ -35,16 +36,26 @@ describe('DataConditionNodeList', function () {
   const mockOnDeleteRow = jest.fn();
   const mockUpdateCondition = jest.fn();
 
+  const groupId = '0';
   const defaultProps = {
     conditions: [],
     conflictingConditionIds: new Set<string>(),
     conflictReason: null,
-    group: '0',
+    groupId,
     handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
     onAddRow: mockOnAddRow,
     onDeleteRow: mockOnDeleteRow,
     placeholder: 'Any event',
     updateCondition: mockUpdateCondition,
+  };
+  const defaultConflictContextProps = {
+    conflictingConditionGroups: {},
+    conflictReason: null,
+  };
+  const defaultErrorContextProps = {
+    errors: {},
+    setErrors: jest.fn(),
+    removeError: jest.fn(),
   };
 
   beforeEach(function () {
@@ -57,10 +68,11 @@ describe('DataConditionNodeList', function () {
 
   it('renders correct condition options', async function () {
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList {...defaultProps} />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList {...defaultProps} />
+        </AutomationBuilderConflictContext.Provider>
+        ,
       </AutomationBuilderErrorContext.Provider>,
       {
         organization,
@@ -79,10 +91,10 @@ describe('DataConditionNodeList', function () {
 
   it('adds conditions', async function () {
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList {...defaultProps} />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList {...defaultProps} />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {
         organization,
@@ -97,10 +109,13 @@ describe('DataConditionNodeList', function () {
 
   it('updates existing conditions', async function () {
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList {...defaultProps} conditions={[DataConditionFixture()]} />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList
+            {...defaultProps}
+            conditions={[DataConditionFixture()]}
+          />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );
@@ -113,10 +128,13 @@ describe('DataConditionNodeList', function () {
 
   it('deletes existing condition', async function () {
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList {...defaultProps} conditions={[DataConditionFixture()]} />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList
+            {...defaultProps}
+            conditions={[DataConditionFixture()]}
+          />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );
@@ -127,17 +145,17 @@ describe('DataConditionNodeList', function () {
 
   it('handles adding issue priority deescalating condition', async function () {
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList
-          {...defaultProps}
-          conditions={[
-            DataConditionFixture({
-              type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
-            }),
-          ]}
-        />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList
+            {...defaultProps}
+            conditions={[
+              DataConditionFixture({
+                type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+              }),
+            ]}
+          />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {
         organization,
@@ -152,22 +170,22 @@ describe('DataConditionNodeList', function () {
 
   it('handles deleting issue priority deescalating condition', async function () {
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList
-          {...defaultProps}
-          conditions={[
-            DataConditionFixture({
-              id: 'issue-priority',
-              type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
-            }),
-            DataConditionFixture({
-              id: 'deescalating',
-              type: DataConditionType.ISSUE_PRIORITY_DEESCALATING,
-            }),
-          ]}
-        />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList
+            {...defaultProps}
+            conditions={[
+              DataConditionFixture({
+                id: 'issue-priority',
+                type: DataConditionType.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+              }),
+              DataConditionFixture({
+                id: 'deescalating',
+                type: DataConditionType.ISSUE_PRIORITY_DEESCALATING,
+              }),
+            ]}
+          />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {
         organization,
@@ -188,14 +206,15 @@ describe('DataConditionNodeList', function () {
   it('shows conflicting condition warning for action filters', function () {
     const conflictReason = 'The conditions highlighted in red are in conflict.';
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList
-          {...defaultProps}
-          conflictingConditionIds={new Set(['1'])}
-          conflictReason={conflictReason}
-        />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider
+          value={{
+            conflictingConditionGroups: {[groupId]: new Set(['1'])},
+            conflictReason,
+          }}
+        >
+          <DataConditionNodeList {...defaultProps} />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {
         organization,
@@ -209,15 +228,18 @@ describe('DataConditionNodeList', function () {
     const conflictReason = 'The conditions highlighted in red are in conflict.';
     // Only one conflicting condition should not show the warning
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList
-          {...defaultProps}
-          conflictingConditionIds={new Set(['1'])}
-          conflictReason={conflictReason}
-          handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
-        />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider
+          value={{
+            conflictingConditionGroups: {[groupId]: new Set(['1'])},
+            conflictReason,
+          }}
+        >
+          <DataConditionNodeList
+            {...defaultProps}
+            handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+          />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );
@@ -226,15 +248,18 @@ describe('DataConditionNodeList', function () {
 
     // Two or more conflicting conditions should show the warning
     render(
-      <AutomationBuilderErrorContext.Provider
-        value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
-      >
-        <DataConditionNodeList
-          {...defaultProps}
-          conflictingConditionIds={new Set(['1', '2'])}
-          conflictReason={conflictReason}
-          handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
-        />
+      <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+        <AutomationBuilderConflictContext.Provider
+          value={{
+            conflictingConditionGroups: {[groupId]: new Set(['1', '2'])},
+            conflictReason,
+          }}
+        >
+          <DataConditionNodeList
+            {...defaultProps}
+            handlerGroup={DataConditionHandlerGroupType.WORKFLOW_TRIGGER}
+          />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );
@@ -251,9 +276,8 @@ describe('DataConditionNodeList', function () {
     render(
       <AutomationBuilderErrorContext.Provider
         value={{
+          ...defaultErrorContextProps,
           errors: {'condition-with-error': errorMessage},
-          setErrors: jest.fn(),
-          removeError: jest.fn(),
         }}
       >
         <DataConditionNodeList {...defaultProps} conditions={[conditionWithError]} />

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -280,7 +280,9 @@ describe('DataConditionNodeList', function () {
           errors: {'condition-with-error': errorMessage},
         }}
       >
-        <DataConditionNodeList {...defaultProps} conditions={[conditionWithError]} />
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList {...defaultProps} conditions={[conditionWithError]} />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -23,7 +23,8 @@ import {useDataConditionsQuery} from 'sentry/views/automations/hooks';
 
 interface DataConditionNodeListProps {
   conditions: DataCondition[];
-  conflictingConditionIds: string[];
+  conflictReason: string | null;
+  conflictingConditionIds: Set<string>;
   group: string;
   handlerGroup: DataConditionHandlerGroupType;
   onAddRow: (type: DataConditionType) => void;
@@ -46,6 +47,7 @@ export default function DataConditionNodeList({
   onDeleteRow,
   updateCondition,
   conflictingConditionIds,
+  conflictReason,
 }: DataConditionNodeListProps) {
   const {data: dataConditionHandlers = []} = useDataConditionsQuery(handlerGroup);
   const {errors} = useAutomationBuilderErrorContext();
@@ -165,7 +167,7 @@ export default function DataConditionNodeList({
           <AutomationBuilderRow
             key={`${group}.conditions.${condition.id}`}
             onDelete={() => onDeleteRowHandler(condition)}
-            hasError={conflictingConditionIds.includes(condition.id) || !!error}
+            hasError={conflictingConditionIds.has(condition.id) || !!error}
             errorMessage={error}
           >
             <DataConditionNodeContext.Provider
@@ -192,12 +194,10 @@ export default function DataConditionNodeList({
       })}
       {/* Always show alert for conflicting action filters, but only show alert for triggers when the trigger conditions conflict with each other */}
       {((handlerGroup === DataConditionHandlerGroupType.ACTION_FILTER &&
-        conflictingConditionIds.length > 0) ||
-        conflictingConditionIds.length > 1) && (
+        conflictingConditionIds.size > 0) ||
+        conflictingConditionIds.size > 1) && (
         <Alert type="error" showIcon>
-          {t(
-            'The conditions highlighted in red are in conflict.  They may prevent the alert from ever being triggered.'
-          )}
+          {conflictReason}
         </Alert>
       )}
       <StyledSelectControl

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -11,6 +11,7 @@ import {
   DataConditionHandlerSubgroupType,
   DataConditionType,
 } from 'sentry/types/workflowEngine/dataConditions';
+import {useAutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import AutomationBuilderRow from 'sentry/views/automations/components/automationBuilderRow';
 import {
@@ -23,9 +24,7 @@ import {useDataConditionsQuery} from 'sentry/views/automations/hooks';
 
 interface DataConditionNodeListProps {
   conditions: DataCondition[];
-  conflictReason: string | null;
-  conflictingConditionIds: Set<string>;
-  group: string;
+  groupId: string;
   handlerGroup: DataConditionHandlerGroupType;
   onAddRow: (type: DataConditionType) => void;
   onDeleteRow: (id: string) => void;
@@ -40,16 +39,17 @@ interface Option {
 
 export default function DataConditionNodeList({
   handlerGroup,
-  group,
+  groupId,
   placeholder,
   conditions,
   onAddRow,
   onDeleteRow,
   updateCondition,
-  conflictingConditionIds,
-  conflictReason,
 }: DataConditionNodeListProps) {
   const {data: dataConditionHandlers = []} = useDataConditionsQuery(handlerGroup);
+  const {conflictingConditionGroups, conflictReason} =
+    useAutomationBuilderConflictContext();
+  const conflictingConditions = conflictingConditionGroups[groupId];
   const {errors} = useAutomationBuilderErrorContext();
 
   const options = useMemo(() => {
@@ -165,15 +165,15 @@ export default function DataConditionNodeList({
 
         return (
           <AutomationBuilderRow
-            key={`${group}.conditions.${condition.id}`}
+            key={condition.id}
             onDelete={() => onDeleteRowHandler(condition)}
-            hasError={conflictingConditionIds.has(condition.id) || !!error}
+            hasError={conflictingConditions?.has(condition.id) || !!error}
             errorMessage={error}
           >
             <DataConditionNodeContext.Provider
               value={{
                 condition,
-                condition_id: `${group}.conditions.${condition.id}`,
+                condition_id: condition.id,
                 onUpdate: params => updateCondition(condition.id, params),
               }}
             >
@@ -193,13 +193,14 @@ export default function DataConditionNodeList({
         );
       })}
       {/* Always show alert for conflicting action filters, but only show alert for triggers when the trigger conditions conflict with each other */}
-      {((handlerGroup === DataConditionHandlerGroupType.ACTION_FILTER &&
-        conflictingConditionIds.size > 0) ||
-        conflictingConditionIds.size > 1) && (
-        <Alert type="error" showIcon>
-          {conflictReason}
-        </Alert>
-      )}
+      {conflictingConditions &&
+        ((handlerGroup === DataConditionHandlerGroupType.ACTION_FILTER &&
+          conflictingConditions.size > 0) ||
+          conflictingConditions.size > 1) && (
+          <Alert type="error" showIcon>
+            {conflictReason}
+          </Alert>
+        )}
       <StyledSelectControl
         options={options}
         onChange={(obj: any) => {

--- a/static/app/views/automations/hooks/utils.spec.tsx
+++ b/static/app/views/automations/hooks/utils.spec.tsx
@@ -40,8 +40,9 @@ describe('findConflictingConditions', () => {
 
     const result = findConflictingConditions(triggers, actionFilters);
     expect(result).toEqual({
-      conflictingTriggers: [],
+      conflictingTriggers: new Set(),
       conflictingActionFilters: {},
+      conflictReason: null,
     });
   });
 
@@ -73,8 +74,10 @@ describe('findConflictingConditions', () => {
 
     const anyShortCircuitResult = findConflictingConditions(triggers, actionFilters);
     expect(anyShortCircuitResult).toEqual({
-      conflictingTriggers: ['1'],
-      conflictingActionFilters: {actionFilter1: ['2']},
+      conflictingTriggers: new Set(['1']),
+      conflictingActionFilters: {actionFilter1: new Set(['2'])},
+      conflictReason:
+        'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
 
     const allResult = findConflictingConditions(
@@ -82,8 +85,10 @@ describe('findConflictingConditions', () => {
       actionFilters
     );
     expect(allResult).toEqual({
-      conflictingTriggers: ['1'],
-      conflictingActionFilters: {actionFilter1: ['2']},
+      conflictingTriggers: new Set(['1']),
+      conflictingActionFilters: {actionFilter1: new Set(['2'])},
+      conflictReason:
+        'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
   });
 
@@ -121,8 +126,10 @@ describe('findConflictingConditions', () => {
 
     const result = findConflictingConditions(triggers, actionFilters);
     expect(result).toEqual({
-      conflictingTriggers: ['1', '2'],
+      conflictingTriggers: new Set(['1', '2']),
       conflictingActionFilters: {},
+      conflictReason:
+        'The triggers highlighted in red are in conflict with "A new issue is created."',
     });
   });
 
@@ -183,8 +190,10 @@ describe('findConflictingConditions', () => {
       anyShortCircuitActionFilters
     );
     expect(anyShortCircuitResult).toEqual({
-      conflictingTriggers: ['1'],
-      conflictingActionFilters: {actionFilter1: ['2', '3', '4', '5', '6', '7']},
+      conflictingTriggers: new Set(['1']),
+      conflictingActionFilters: {actionFilter1: new Set(['2', '3', '4', '5', '6', '7'])},
+      conflictReason:
+        'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
 
     const allActionFilters = [
@@ -196,8 +205,10 @@ describe('findConflictingConditions', () => {
     ];
     const allResult = findConflictingConditions(triggers, allActionFilters);
     expect(allResult).toEqual({
-      conflictingTriggers: ['1'],
-      conflictingActionFilters: {actionFilter1: ['2', '3', '4', '5', '6', '7']},
+      conflictingTriggers: new Set(['1']),
+      conflictingActionFilters: {actionFilter1: new Set(['2', '3', '4', '5', '6', '7'])},
+      conflictReason:
+        'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
   });
 
@@ -238,8 +249,9 @@ describe('findConflictingConditions', () => {
     ];
     const result = findConflictingConditions(triggers, anyShortCircuitActionFilters);
     expect(result).toEqual({
-      conflictingTriggers: [],
+      conflictingTriggers: new Set(),
       conflictingActionFilters: {},
+      conflictReason: null,
     });
 
     // Test with ALL logic type
@@ -253,8 +265,10 @@ describe('findConflictingConditions', () => {
     ];
     const resultWithAllLogic = findConflictingConditions(triggers, allActionFilters);
     expect(resultWithAllLogic).toEqual({
-      conflictingTriggers: ['1'],
-      conflictingActionFilters: {actionFilter1: ['2']},
+      conflictingTriggers: new Set(['1']),
+      conflictingActionFilters: {actionFilter1: new Set(['2'])},
+      conflictReason:
+        'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
   });
 
@@ -315,12 +329,14 @@ describe('findConflictingConditions', () => {
 
     const result = findConflictingConditions(triggers, actionFilters);
     expect(result).toEqual({
-      conflictingTriggers: ['1'],
+      conflictingTriggers: new Set(['1']),
       conflictingActionFilters: {
-        actionFilter1: ['2'],
-        actionFilter2: ['3'],
-        actionFilter3: ['4'],
+        actionFilter1: new Set(['2']),
+        actionFilter2: new Set(['3']),
+        actionFilter3: new Set(['4']),
       },
+      conflictReason:
+        'The conditions highlighted in red are in conflict with \"A new issue is created.\"',
     });
   });
 });

--- a/static/app/views/automations/hooks/utils.spec.tsx
+++ b/static/app/views/automations/hooks/utils.spec.tsx
@@ -40,8 +40,7 @@ describe('findConflictingConditions', () => {
 
     const result = findConflictingConditions(triggers, actionFilters);
     expect(result).toEqual({
-      conflictingTriggers: new Set(),
-      conflictingActionFilters: {},
+      conflictingConditionGroups: {},
       conflictReason: null,
     });
   });
@@ -74,8 +73,10 @@ describe('findConflictingConditions', () => {
 
     const anyShortCircuitResult = findConflictingConditions(triggers, actionFilters);
     expect(anyShortCircuitResult).toEqual({
-      conflictingTriggers: new Set(['1']),
-      conflictingActionFilters: {actionFilter1: new Set(['2'])},
+      conflictingConditionGroups: {
+        triggers: new Set(['1']),
+        actionFilter1: new Set(['2']),
+      },
       conflictReason:
         'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
@@ -85,8 +86,10 @@ describe('findConflictingConditions', () => {
       actionFilters
     );
     expect(allResult).toEqual({
-      conflictingTriggers: new Set(['1']),
-      conflictingActionFilters: {actionFilter1: new Set(['2'])},
+      conflictingConditionGroups: {
+        triggers: new Set(['1']),
+        actionFilter1: new Set(['2']),
+      },
       conflictReason:
         'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
@@ -126,8 +129,9 @@ describe('findConflictingConditions', () => {
 
     const result = findConflictingConditions(triggers, actionFilters);
     expect(result).toEqual({
-      conflictingTriggers: new Set(['1', '2']),
-      conflictingActionFilters: {},
+      conflictingConditionGroups: {
+        triggers: new Set(['1', '2']),
+      },
       conflictReason:
         'The triggers highlighted in red are in conflict with "A new issue is created."',
     });
@@ -190,8 +194,10 @@ describe('findConflictingConditions', () => {
       anyShortCircuitActionFilters
     );
     expect(anyShortCircuitResult).toEqual({
-      conflictingTriggers: new Set(['1']),
-      conflictingActionFilters: {actionFilter1: new Set(['2', '3', '4', '5', '6', '7'])},
+      conflictingConditionGroups: {
+        triggers: new Set(['1']),
+        actionFilter1: new Set(['2', '3', '4', '5', '6', '7']),
+      },
       conflictReason:
         'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
@@ -205,8 +211,10 @@ describe('findConflictingConditions', () => {
     ];
     const allResult = findConflictingConditions(triggers, allActionFilters);
     expect(allResult).toEqual({
-      conflictingTriggers: new Set(['1']),
-      conflictingActionFilters: {actionFilter1: new Set(['2', '3', '4', '5', '6', '7'])},
+      conflictingConditionGroups: {
+        triggers: new Set(['1']),
+        actionFilter1: new Set(['2', '3', '4', '5', '6', '7']),
+      },
       conflictReason:
         'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
@@ -249,8 +257,7 @@ describe('findConflictingConditions', () => {
     ];
     const result = findConflictingConditions(triggers, anyShortCircuitActionFilters);
     expect(result).toEqual({
-      conflictingTriggers: new Set(),
-      conflictingActionFilters: {},
+      conflictingConditionGroups: {},
       conflictReason: null,
     });
 
@@ -265,8 +272,10 @@ describe('findConflictingConditions', () => {
     ];
     const resultWithAllLogic = findConflictingConditions(triggers, allActionFilters);
     expect(resultWithAllLogic).toEqual({
-      conflictingTriggers: new Set(['1']),
-      conflictingActionFilters: {actionFilter1: new Set(['2'])},
+      conflictingConditionGroups: {
+        triggers: new Set(['1']),
+        actionFilter1: new Set(['2']),
+      },
       conflictReason:
         'The conditions highlighted in red are in conflict with "A new issue is created."',
     });
@@ -329,8 +338,8 @@ describe('findConflictingConditions', () => {
 
     const result = findConflictingConditions(triggers, actionFilters);
     expect(result).toEqual({
-      conflictingTriggers: new Set(['1']),
-      conflictingActionFilters: {
+      conflictingConditionGroups: {
+        triggers: new Set(['1']),
         actionFilter1: new Set(['2']),
         actionFilter2: new Set(['3']),
         actionFilter3: new Set(['4']),


### PR DESCRIPTION
- instead of having a `findConflictingActionFilterConditions` helper to find conflicts in action filters specifically, i made this function more generic so that it can also be used by triggers.
    - this properly accounts for migrated automations since event frequency conditions used to be in the WHEN (triggers) but have been moved to the IF (action filters)
- added a `AutomationBuilderConflictContext`
    - updated conflicting condition arrays to be sets, since we're only using them for lookups
    - added a `conflictReason` prop so that we can add more specific reasons, such as duplicate triggers
<img width="1158" alt="Screenshot 2025-07-09 at 4 56 47 PM" src="https://github.com/user-attachments/assets/46ac2b6d-41ee-472c-94cb-3cab007353c9" />
