### PR TITLE
fix(theme): Neutral chart color is white

### DIFF
--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -1222,7 +1222,7 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
   },
 
   chart: {
-    neutral: color(lightColors.gray400).lighten(1.3).toString(),
+    neutral: color(lightColors.gray400).lighten(0.8).toString(),
     colors: CHART_PALETTE_LIGHT,
     getColorPalette: makeChartColorPalette(CHART_PALETTE_LIGHT),
   },


### PR DESCRIPTION
Not sure why the same logic returns a different result now that is not in a hook anymore. However, the color ended up being white after moving this to the theme and this PR fixes it.