### PR TITLE
fix(profiling-onboarding): iframe blocked by CSP

### DIFF
--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -199,7 +199,7 @@ function OnboardingPanel({
               <Preview>
                 <BodyTitle>{t('Preview a Sentry Profile')}</BodyTitle>
                 <Arcade
-                  src="https://app.arcade.software/share/IebjOcBKpUHBuFpfGO4f?embed"
+                  src="https://demo.arcade.software/IebjOcBKpUHBuFpfGO4f?embed"
                   loading="lazy"
                   allowFullScreen
                 />


### PR DESCRIPTION
The arcade for the profiling onboarding got blocked by our CSP.
This PR streamlines the embed URL to use the same format as the other arcades.