### PR TITLE
ref(analytics): move client-infra-admin events to typesafe analytics

### DIFF
--- a/src/sentry/analytics/events/api_token_created.py
+++ b/src/sentry/analytics/events/api_token_created.py
@@ -4,7 +4,7 @@ from sentry.analytics import Event, eventclass
 
 @eventclass("api_token.created")
 class ApiTokenCreated(Event):
-    user_id: int
+    user_id: int | None = None
 
 
 analytics.register(ApiTokenCreated)

--- a/src/sentry/analytics/events/api_token_created.py
+++ b/src/sentry/analytics/events/api_token_created.py
@@ -1,10 +1,10 @@
 from sentry import analytics
+from sentry.analytics import Event, eventclass
 
 
-class ApiTokenCreated(analytics.Event):
-    type = "api_token.created"
-
-    attributes = (analytics.Attribute("user_id"),)
+@eventclass("api_token.created")
+class ApiTokenCreated(Event):
+    user_id: int
 
 
 analytics.register(ApiTokenCreated)

--- a/src/sentry/analytics/events/api_token_deleted.py
+++ b/src/sentry/analytics/events/api_token_deleted.py
@@ -4,7 +4,7 @@ from sentry.analytics import Event, eventclass
 
 @eventclass("api_token.deleted")
 class ApiTokenDeleted(Event):
-    user_id: int
+    user_id: int | None = None
 
 
 analytics.register(ApiTokenDeleted)

--- a/src/sentry/analytics/events/api_token_deleted.py
+++ b/src/sentry/analytics/events/api_token_deleted.py
@@ -1,10 +1,10 @@
 from sentry import analytics
+from sentry.analytics import Event, eventclass
 
 
-class ApiTokenDeleted(analytics.Event):
-    type = "api_token.deleted"
-
-    attributes = (analytics.Attribute("user_id"),)
+@eventclass("api_token.deleted")
+class ApiTokenDeleted(Event):
+    user_id: int
 
 
 analytics.register(ApiTokenDeleted)

--- a/src/sentry/analytics/events/org_auth_token_created.py
+++ b/src/sentry/analytics/events/org_auth_token_created.py
@@ -1,13 +1,11 @@
 from sentry import analytics
+from sentry.analytics import Event, eventclass
 
 
-class OrgAuthTokenCreated(analytics.Event):
-    type = "org_auth_token.created"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-    )
+@eventclass("org_auth_token.created")
+class OrgAuthTokenCreated(Event):
+    user_id: int
+    organization_id: int
 
 
 analytics.register(OrgAuthTokenCreated)

--- a/src/sentry/analytics/events/org_auth_token_created.py
+++ b/src/sentry/analytics/events/org_auth_token_created.py
@@ -4,7 +4,7 @@ from sentry.analytics import Event, eventclass
 
 @eventclass("org_auth_token.created")
 class OrgAuthTokenCreated(Event):
-    user_id: int
+    user_id: int | None = None
     organization_id: int
 
 

--- a/src/sentry/analytics/events/org_auth_token_deleted.py
+++ b/src/sentry/analytics/events/org_auth_token_deleted.py
@@ -1,13 +1,11 @@
 from sentry import analytics
+from sentry.analytics import Event, eventclass
 
 
-class OrgAuthTokenDeleted(analytics.Event):
-    type = "org_auth_token.deleted"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-    )
+@eventclass("org_auth_token.deleted")
+class OrgAuthTokenDeleted(Event):
+    user_id: int
+    organization_id: int
 
 
 analytics.register(OrgAuthTokenDeleted)

--- a/src/sentry/analytics/events/org_auth_token_deleted.py
+++ b/src/sentry/analytics/events/org_auth_token_deleted.py
@@ -4,7 +4,7 @@ from sentry.analytics import Event, eventclass
 
 @eventclass("org_auth_token.deleted")
 class OrgAuthTokenDeleted(Event):
-    user_id: int
+    user_id: int | None = None
     organization_id: int
 
 

--- a/src/sentry/analytics/events/release_created.py
+++ b/src/sentry/analytics/events/release_created.py
@@ -9,7 +9,7 @@ class ReleaseCreatedEvent(Event):
     project_ids: list[int]
     user_agent: str | None = None
     auth_type: str | None = None
-    created_status: str
+    created_status: int
 
 
 analytics.register(ReleaseCreatedEvent)

--- a/src/sentry/analytics/events/release_created.py
+++ b/src/sentry/analytics/events/release_created.py
@@ -1,17 +1,15 @@
 from sentry import analytics
+from sentry.analytics import Event, eventclass
 
 
-class ReleaseCreatedEvent(analytics.Event):
-    type = "release.created"
-
-    attributes = (
-        analytics.Attribute("user_id", required=False),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_ids"),
-        analytics.Attribute("user_agent", required=False),
-        analytics.Attribute("auth_type", required=False),
-        analytics.Attribute("created_status"),
-    )
+@eventclass("release.created")
+class ReleaseCreatedEvent(Event):
+    user_id: int | None = None
+    organization_id: int
+    project_ids: list[int]
+    user_agent: str | None = None
+    auth_type: str | None = None
+    created_status: str
 
 
 analytics.register(ReleaseCreatedEvent)

--- a/src/sentry/api/endpoints/api_token_details.py
+++ b/src/sentry/api/endpoints/api_token_details.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.analytics.events.api_token_deleted import ApiTokenDeleted
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
@@ -87,7 +88,8 @@ class ApiTokenDetailsEndpoint(Endpoint):
 
         token_to_delete.delete()
         analytics.record(
-            "api_token.deleted",
-            user_id=user_id,
+            ApiTokenDeleted(
+                user_id=user_id,
+            )
         )
         return Response(status=204)

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -8,6 +8,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.analytics.events.api_token_created import ApiTokenCreated
+from sentry.analytics.events.api_token_deleted import ApiTokenDeleted
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import SessionNoAuthTokenAuthentication
@@ -101,7 +103,7 @@ class ApiTokensEndpoint(Endpoint):
                 send_email=True,
             )
 
-            analytics.record("api_token.created", user_id=request.user.id)
+            analytics.record(ApiTokenCreated(user_id=request.user.id))
 
             return Response(serialize(token, request.user), status=201)
         return Response(serializer.errors, status=400)
@@ -126,6 +128,6 @@ class ApiTokensEndpoint(Endpoint):
 
             token_to_delete.delete()
 
-        analytics.record("api_token.deleted", user_id=request.user.id)
+        analytics.record(ApiTokenDeleted(user_id=request.user.id))
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_auth_token_details.py
+++ b/src/sentry/api/endpoints/organization_auth_token_details.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, audit_log
+from sentry.analytics.events.org_auth_token_deleted import OrgAuthTokenDeleted
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
@@ -95,9 +96,10 @@ class OrganizationAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
         )
 
         analytics.record(
-            "org_auth_token.deleted",
-            user_id=request.user.id,
-            organization_id=organization.id,
+            OrgAuthTokenDeleted(
+                user_id=request.user.id,
+                organization_id=organization.id,
+            )
         )
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_auth_tokens.py
+++ b/src/sentry/api/endpoints/organization_auth_tokens.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, audit_log, roles
+from sentry.analytics.events.org_auth_token_created import OrgAuthTokenCreated
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
@@ -135,9 +136,10 @@ class OrganizationAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
             )
 
         analytics.record(
-            "org_auth_token.created",
-            user_id=request.user.id,
-            organization_id=organization.id,
+            OrgAuthTokenCreated(
+                user_id=request.user.id,
+                organization_id=organization.id,
+            )
         )
 
         # This is THE ONLY TIME that the token is available

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ListField
 
 from sentry import analytics, release_health
+from sentry.analytics.events.release_created import ReleaseCreatedEvent
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import ReleaseAnalyticsMixin, region_silo_endpoint
 from sentry.api.bases import NoProjects
@@ -623,13 +624,14 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
                 status = 201
 
             analytics.record(
-                "release.created",
-                user_id=request.user.id if request.user and request.user.id else None,
-                organization_id=organization.id,
-                project_ids=[project.id for project in projects],
-                user_agent=request.META.get("HTTP_USER_AGENT", ""),
-                created_status=status,
-                auth_type=get_auth_api_token_type(request.auth),
+                ReleaseCreatedEvent(
+                    user_id=request.user.id if request.user and request.user.id else None,
+                    organization_id=organization.id,
+                    project_ids=[project.id for project in projects],
+                    user_agent=request.META.get("HTTP_USER_AGENT", ""),
+                    created_status=status,
+                    auth_type=get_auth_api_token_type(request.auth),
+                )
             )
 
             if is_org_auth_token_auth(request.auth):

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -7,6 +7,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics
+from sentry.analytics.events.release_created import ReleaseCreatedEvent
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
@@ -190,13 +191,14 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
                 status = 201
 
             analytics.record(
-                "release.created",
-                user_id=request.user.id if request.user and request.user.id else None,
-                organization_id=project.organization_id,
-                project_ids=[project.id],
-                user_agent=request.META.get("HTTP_USER_AGENT", "")[:256],
-                created_status=status,
-                auth_type=get_auth_api_token_type(request.auth),
+                ReleaseCreatedEvent(
+                    user_id=request.user.id if request.user and request.user.id else None,
+                    organization_id=project.organization_id,
+                    project_ids=[project.id],
+                    user_agent=request.META.get("HTTP_USER_AGENT", "")[:256],
+                    created_status=status,
+                    auth_type=get_auth_api_token_type(request.auth),
+                )
             )
 
             if is_org_auth_token_auth(request.auth):

--- a/src/sentry/web/frontend/analytics.py
+++ b/src/sentry/web/frontend/analytics.py
@@ -1,19 +1,19 @@
+from packaging.version import Version
+
 from sentry import analytics
+from sentry.analytics import Event, eventclass
 
 
-class JsSdkLoaderRendered(analytics.Event):
-    type = "js_sdk_loader.rendered"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("is_lazy"),
-        analytics.Attribute("has_performance"),
-        analytics.Attribute("has_replay"),
-        analytics.Attribute("has_debug"),
-        analytics.Attribute("sdk_version"),
-        analytics.Attribute("tmpl"),
-    )
+@eventclass("js_sdk_loader.rendered")
+class JsSdkLoaderRendered(Event):
+    organization_id: int
+    project_id: int
+    is_lazy: bool
+    has_performance: bool
+    has_replay: bool
+    has_debug: bool
+    sdk_version: Version | None
+    tmpl: str
 
 
 analytics.register(JsSdkLoaderRendered)

--- a/src/sentry/web/frontend/analytics.py
+++ b/src/sentry/web/frontend/analytics.py
@@ -1,5 +1,3 @@
-from packaging.version import Version
-
 from sentry import analytics
 from sentry.analytics import Event, eventclass
 
@@ -12,7 +10,7 @@ class JsSdkLoaderRendered(Event):
     has_performance: bool
     has_replay: bool
     has_debug: bool
-    sdk_version: Version | None
+    sdk_version: str | None
     tmpl: str
 
 

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -15,6 +15,7 @@ from sentry.loader.dynamic_sdk_options import DynamicSdkLoaderOption, get_dynami
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
 from sentry.utils import metrics
+from sentry.web.frontend.analytics import JsSdkLoaderRendered
 from sentry.web.frontend.base import region_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -190,15 +191,16 @@ class JavaScriptSdkLoader(View):
 
         (
             analytics.record(
-                "js_sdk_loader.rendered",
-                organization_id=key.project.organization_id,
-                project_id=key.project_id,
-                is_lazy=loader_config["isLazy"],
-                has_performance=loader_config["hasPerformance"],
-                has_replay=loader_config["hasReplay"],
-                has_debug=loader_config["hasDebug"],
-                sdk_version=sdk_version,
-                tmpl=tmpl,
+                JsSdkLoaderRendered(
+                    organization_id=key.project.organization_id,
+                    project_id=key.project_id,
+                    is_lazy=loader_config["isLazy"],
+                    has_performance=loader_config["hasPerformance"],
+                    has_replay=loader_config["hasReplay"],
+                    has_debug=loader_config["hasDebug"],
+                    sdk_version=sdk_version,
+                    tmpl=tmpl,
+                )
             )
             if key
             else None

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -198,7 +198,7 @@ class JavaScriptSdkLoader(View):
                     has_performance=loader_config["hasPerformance"],
                     has_replay=loader_config["hasReplay"],
                     has_debug=loader_config["hasDebug"],
-                    sdk_version=sdk_version,
+                    sdk_version=str(sdk_version) if sdk_version else None,
                     tmpl=tmpl,
                 )
             )


### PR DESCRIPTION
Move these Analytics events to the new, type-safe architecture:
- api_token.created
- release.created
- org_auth_token.created
- org_auth_token.deleted
- api_token.created
- js_sdk_loader.rendered

