### PR TITLE
ref(analytics): Transform analytics events for TET-836

### DIFF
--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -9,20 +9,22 @@ class FirstEventSentEvent(analytics.Event):
     project_id: int
     platform: str | None = None
     url: str | None = None
-    has_minified_stack_trace: str | None = None
+    has_minified_stack_trace: bool | None = None
     project_platform: str | None = None
 
 
 # first error for a project
-class FirstEventSentEventForProject(FirstEventSentEvent):
-    type = "first_event_for_project.sent"
+@analytics.eventclass("first_event_for_project.sent")
+class FirstEventSentForProjectEvent(FirstEventSentEvent):
+    pass
 
 
 # first error with minified stack trace for a project
+@analytics.eventclass("first_event_with_minified_stack_trace_for_project.sent")
 class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEvent):
-    type = "first_event_with_minified_stack_trace_for_project.sent"
+    pass
 
 
 analytics.register(FirstEventSentEvent)
-analytics.register(FirstEventSentEventForProject)
+analytics.register(FirstEventSentForProjectEvent)
 analytics.register(FirstEventSentEventWithMinifiedStackTraceForProject)

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -4,9 +4,9 @@ from sentry import analytics
 # first error for an organization
 @analytics.eventclass("first_event.sent")
 class FirstEventSentEvent(analytics.Event):
-    user_id: str
-    organization_id: str
-    project_id: str
+    user_id: int
+    organization_id: int
+    project_id: int
     platform: str | None = None
     url: str | None = None
     has_minified_stack_trace: str | None = None

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -2,18 +2,15 @@ from sentry import analytics
 
 
 # first error for an organization
+@analytics.eventclass("first_event.sent")
 class FirstEventSentEvent(analytics.Event):
-    type = "first_event.sent"
-
-    attributes = (
-        analytics.Attribute("user_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("platform", required=False),
-        analytics.Attribute("url", required=False),
-        analytics.Attribute("has_minified_stack_trace", required=False),
-        analytics.Attribute("project_platform", required=False),
-    )
+    user_id: str
+    organization_id: str
+    project_id: str
+    platform: str | None = None
+    url: str | None = None
+    has_minified_stack_trace: str | None = None
+    project_platform: str | None = None
 
 
 # first error for a project

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -16,7 +16,7 @@ class FirstEventSentEvent(analytics.Event):
 # first error for a project
 @analytics.eventclass("first_event_for_project.sent")
 class FirstEventSentForProjectEvent(FirstEventSentEvent):
-    pass
+    sdk_name: str | None = None
 
 
 # first error with minified stack trace for a project

--- a/src/sentry/analytics/events/issue_alert_fired.py
+++ b/src/sentry/analytics/events/issue_alert_fired.py
@@ -1,15 +1,12 @@
 from sentry import analytics
 
 
+@analytics.eventclass("issue_alert.fired")
 class IssueAlertFiredEvent(analytics.Event):
-    type = "issue_alert.fired"
-
-    attributes = (
-        analytics.Attribute("issue_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("rule_id"),
-    )
+    issue_id: str
+    project_id: str
+    organization_id: str
+    rule_id: str
 
 
 analytics.register(IssueAlertFiredEvent)

--- a/src/sentry/analytics/events/issue_alert_fired.py
+++ b/src/sentry/analytics/events/issue_alert_fired.py
@@ -3,10 +3,10 @@ from sentry import analytics
 
 @analytics.eventclass("issue_alert.fired")
 class IssueAlertFiredEvent(analytics.Event):
-    issue_id: str
-    project_id: str
-    organization_id: str
-    rule_id: str
+    issue_id: int
+    project_id: int
+    organization_id: int
+    rule_id: int
 
 
 analytics.register(IssueAlertFiredEvent)

--- a/src/sentry/analytics/events/issue_auto_resolved.py
+++ b/src/sentry/analytics/events/issue_auto_resolved.py
@@ -3,9 +3,9 @@ from sentry import analytics
 
 @analytics.eventclass("issue.auto_resolved")
 class IssueAutoResolvedEvent(analytics.Event):
-    project_id: str | None = None
-    organization_id: str
-    group_id: str
+    project_id: int | None = None
+    organization_id: int
+    group_id: int
     issue_category: str | None = None
     issue_type: str | None = None
 

--- a/src/sentry/analytics/events/issue_auto_resolved.py
+++ b/src/sentry/analytics/events/issue_auto_resolved.py
@@ -1,16 +1,13 @@
 from sentry import analytics
 
 
+@analytics.eventclass("issue.auto_resolved")
 class IssueAutoResolvedEvent(analytics.Event):
-    type = "issue.auto_resolved"
-
-    attributes = (
-        analytics.Attribute("project_id", required=False),
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("issue_category", required=False),
-        analytics.Attribute("issue_type", required=False),
-    )
+    project_id: str | None = None
+    organization_id: str
+    group_id: str
+    issue_category: str | None = None
+    issue_type: str | None = None
 
 
 analytics.register(IssueAutoResolvedEvent)

--- a/src/sentry/analytics/events/manual_issue_assignment.py
+++ b/src/sentry/analytics/events/manual_issue_assignment.py
@@ -1,16 +1,13 @@
 from sentry import analytics
 
 
+@analytics.eventclass("manual.issue_assignment")
 class ManualIssueAssignment(analytics.Event):
-    type = "manual.issue_assignment"
-
-    attributes = (
-        analytics.Attribute("organization_id"),
-        analytics.Attribute("project_id"),
-        analytics.Attribute("group_id"),
-        analytics.Attribute("assigned_by", required=False),
-        analytics.Attribute("had_to_deassign", required=False),
-    )
+    organization_id: str
+    project_id: str
+    group_id: str
+    assigned_by: str | None = None
+    had_to_deassign: str | None = None
 
 
 analytics.register(ManualIssueAssignment)

--- a/src/sentry/analytics/events/manual_issue_assignment.py
+++ b/src/sentry/analytics/events/manual_issue_assignment.py
@@ -3,11 +3,11 @@ from sentry import analytics
 
 @analytics.eventclass("manual.issue_assignment")
 class ManualIssueAssignment(analytics.Event):
-    organization_id: str
-    project_id: str
-    group_id: str
+    organization_id: int
+    project_id: int
+    group_id: int
     assigned_by: str | None = None
-    had_to_deassign: str | None = None
+    had_to_deassign: bool | None = None
 
 
 analytics.register(ManualIssueAssignment)

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -18,6 +18,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import analytics, features, options
+from sentry.analytics.events.manual_issue_assignment import ManualIssueAssignment
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.db.models.query import create_or_update
@@ -1040,23 +1041,25 @@ def handle_assigned_to(
                 group, resolved_actor, acting_user, extra=extra
             )
             analytics.record(
-                "manual.issue_assignment",
-                organization_id=project_lookup[group.project_id].organization_id,
-                project_id=group.project_id,
-                group_id=group.id,
-                assigned_by=assigned_by,
-                had_to_deassign=assignment["updated_assignment"],
+                ManualIssueAssignment(
+                    organization_id=project_lookup[group.project_id].organization_id,
+                    project_id=group.project_id,
+                    group_id=group.id,
+                    assigned_by=assigned_by,
+                    had_to_deassign=assignment["updated_assignment"],
+                )
             )
         return serialize(resolved_actor, acting_user, ActorSerializer())
     else:
         for group in group_list:
             GroupAssignee.objects.deassign(group, acting_user)
             analytics.record(
-                "manual.issue_assignment",
-                organization_id=project_lookup[group.project_id].organization_id,
-                project_id=group.project_id,
-                group_id=group.id,
-                assigned_by=assigned_by,
-                had_to_deassign=True,
+                ManualIssueAssignment(
+                    organization_id=project_lookup[group.project_id].organization_id,
+                    project_id=group.project_id,
+                    group_id=group.id,
+                    assigned_by=assigned_by,
+                    had_to_deassign=True,
+                )
             )
         return None

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -7,7 +7,10 @@ import sentry_sdk
 from django.db.models import F
 
 from sentry import analytics
-from sentry.analytics.events.first_event_sent import FirstEventSentEvent
+from sentry.analytics.events.first_event_sent import (
+    FirstEventSentEvent,
+    FirstEventSentForProjectEvent,
+)
 from sentry.analytics.events.first_profile_sent import FirstProfileSentEvent
 from sentry.integrations.base import IntegrationDomain, get_integration_types
 from sentry.integrations.services.integration import RpcIntegration, integration_service
@@ -133,15 +136,16 @@ def record_first_event(project, event, **kwargs):
         return
 
     analytics.record(
-        "first_event_for_project.sent",
-        user_id=owner_id,
-        organization_id=project.organization_id,
-        project_id=project.id,
-        platform=event.platform,
-        project_platform=project.platform,
-        url=dict(event.tags).get("url", None),
-        has_minified_stack_trace=has_event_minified_stack_trace(event),
-        sdk_name=get_path(event, "sdk", "name"),
+        FirstEventSentForProjectEvent(
+            user_id=owner_id,
+            organization_id=project.organization_id,
+            project_id=project.id,
+            platform=event.platform,
+            project_platform=project.platform,
+            url=dict(event.tags).get("url", None),
+            has_minified_stack_trace=has_event_minified_stack_trace(event),
+            sdk_name=get_path(event, "sdk", "name"),
+        )
     )
 
     if has_completed_onboarding_task(project.organization, OnboardingTask.FIRST_EVENT):

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -7,6 +7,7 @@ import sentry_sdk
 from django.db.models import F
 
 from sentry import analytics
+from sentry.analytics.events.first_event_sent import FirstEventSentEvent
 from sentry.analytics.events.first_profile_sent import FirstProfileSentEvent
 from sentry.integrations.base import IntegrationDomain, get_integration_types
 from sentry.integrations.services.integration import RpcIntegration, integration_service
@@ -155,12 +156,13 @@ def record_first_event(project, event, **kwargs):
 
     if completed:
         analytics.record(
-            "first_event.sent",
-            user_id=owner_id,
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=event.platform,
-            project_platform=project.platform,
+            FirstEventSentEvent(
+                user_id=owner_id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=event.platform,
+                project_platform=project.platform,
+            )
         )
 
 

--- a/src/sentry/rules/processing/processor.py
+++ b/src/sentry/rules/processing/processor.py
@@ -12,6 +12,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from sentry import analytics, buffer, features
+from sentry.analytics.events.issue_alert_fired import IssueAlertFiredEvent
 from sentry.eventstore.models import GroupEvent
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -390,11 +391,12 @@ class RuleProcessor:
 
         if randrange(10) == 0:
             analytics.record(
-                "issue_alert.fired",
-                issue_id=self.group.id,
-                project_id=rule.project.id,
-                organization_id=rule.project.organization.id,
-                rule_id=rule.id,
+                IssueAlertFiredEvent(
+                    issue_id=self.group.id,
+                    project_id=rule.project.id,
+                    organization_id=rule.project.organization.id,
+                    rule_id=rule.id,
+                )
             )
 
         if features.has(

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -8,6 +8,7 @@ from typing import Any
 from django.utils import timezone as django_timezone
 
 from sentry import analytics
+from sentry.analytics.events.issue_auto_resolved import IssueAutoResolvedEvent
 from sentry.integrations.tasks.kick_off_status_syncs import kick_off_status_syncs
 from sentry.issues import grouptype
 from sentry.models.activity import Activity
@@ -138,12 +139,13 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
             )
 
             analytics.record(
-                "issue.auto_resolved",
-                project_id=project.id,
-                organization_id=project.organization_id,
-                group_id=group.id,
-                issue_type=group.issue_type.slug,
-                issue_category=group.issue_category.name.lower(),
+                IssueAutoResolvedEvent(
+                    project_id=project.id,
+                    organization_id=project.organization_id,
+                    group_id=group.id,
+                    issue_type=group.issue_type.slug,
+                    issue_category=group.issue_category.name.lower(),
+                )
             )
             # auto-resolve is a kind of resolve and this signal makes
             # sure all things that need to happen after resolve are triggered

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from django.http import QueryDict
 
+from sentry.analytics.events.manual_issue_assignment import ManualIssueAssignment
 from sentry.api.helpers.group_index import update_groups, validate_search_filter_permissions
 from sentry.api.helpers.group_index.delete import delete_groups
 from sentry.api.helpers.group_index.update import (
@@ -33,6 +34,7 @@ from sentry.models.groupsnooze import GroupSnooze
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -699,13 +701,15 @@ class TestHandleAssignedTo(TestCase):
             "name": self.user.username,
             "type": "user",
         }
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=False,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=False,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -741,13 +745,15 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         assert assigned_to is None
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=True,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=True,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -804,13 +810,15 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         assert assigned_to is None
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=True,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=True,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -856,13 +864,15 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         assert assigned_to is None
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=True,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=True,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -918,13 +928,15 @@ class TestHandleAssignedTo(TestCase):
             "name": user2.username,
             "type": "user",
         }
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=True,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=True,
+            ),
         )
         # pass assignedTo but it's the same as the existing assignee
         assigned_to = handle_assigned_to(
@@ -957,13 +969,15 @@ class TestHandleAssignedTo(TestCase):
             "name": user2.username,
             "type": "user",
         }
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=False,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=False,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -1051,13 +1065,15 @@ class TestHandleAssignedTo(TestCase):
             "name": team2.slug,
             "type": "team",
         }
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=True,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=True,
+            ),
         )
 
     @patch("sentry.analytics.record")
@@ -1128,13 +1144,15 @@ class TestHandleAssignedTo(TestCase):
             "name": team2.slug,
             "type": "team",
         }
-        mock_record.assert_called_with(
-            "manual.issue_assignment",
-            group_id=self.group.id,
-            organization_id=self.group.project.organization_id,
-            project_id=self.group.project_id,
-            assigned_by=None,
-            had_to_deassign=True,
+        assert_last_analytics_event(
+            mock_record,
+            ManualIssueAssignment(
+                group_id=self.group.id,
+                organization_id=self.group.project.organization_id,
+                project_id=self.group.project_id,
+                assigned_by=None,
+                had_to_deassign=True,
+            ),
         )
 
     def test_user_in_reassigned_team(self):

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from sentry import onboarding_tasks
 from sentry.analytics import record
+from sentry.analytics.events.first_event_sent import FirstEventSentEvent
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
     OnboardingTask,
@@ -264,7 +265,9 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         # Ensure "first_event.sent" was called exactly once
         first_event_sent_calls = [
-            call for call in record_analytics.call_args_list if call[0][0] == "first_event.sent"
+            call
+            for call in record_analytics.call_args_list
+            if isinstance(call[0][0], FirstEventSentEvent)
         ]
         assert len(first_event_sent_calls) == 1
 

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -31,6 +31,7 @@ from sentry.signals import (
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import assert_last_analytics_event
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -907,13 +908,15 @@ class OrganizationOnboardingTaskTest(TestCase):
             )
             is not None
         )
-        record_analytics.assert_called_with(
-            "first_event.sent",
-            user_id=self.user.id,
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=error_event.platform,
-            project_platform=project.platform,
+        assert_last_analytics_event(
+            record_analytics,
+            FirstEventSentEvent(
+                user_id=self.user.id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=error_event.platform,
+                project_platform=project.platform,
+            ),
         )
 
         # Configure an issue alert

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -6,7 +6,10 @@ from django.utils import timezone
 
 from sentry import onboarding_tasks
 from sentry.analytics import record
-from sentry.analytics.events.first_event_sent import FirstEventSentEvent
+from sentry.analytics.events.first_event_sent import (
+    FirstEventSentEvent,
+    FirstEventSentForProjectEvent,
+)
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import (
     OnboardingTask,
@@ -31,7 +34,10 @@ from sentry.signals import (
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.analytics import assert_last_analytics_event
+from sentry.testutils.helpers.analytics import (
+    assert_any_analytics_event,
+    assert_last_analytics_event,
+)
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -206,28 +212,30 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         # Ensure analytics events are called in the right order
         assert len(record_analytics.call_args_list) >= 2  # Ensure at least two calls
-
-        record_analytics.call_args_list[-2].assert_called_with(
-            "first_event_for_project.sent",
-            user_id=self.user.id,
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=event.platform,
-            project_platform=project.platform,
-            url=dict(event.tags).get("url", None),
-            has_minified_stack_trace=has_event_minified_stack_trace(event),
-            sdk_name=None,
+        assert_any_analytics_event(
+            record_analytics,
+            FirstEventSentForProjectEvent(
+                user_id=self.user.id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=event.platform,
+                project_platform=project.platform,
+                url=dict(event.tags).get("url", None),
+                has_minified_stack_trace=has_event_minified_stack_trace(event),
+                sdk_name=None,
+            ),
         )
 
-        record_analytics.call_args_list[-1].assert_called_with(
-            "first_event.sent",
-            user_id=self.user.id,
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=event.platform,
-            project_platform=project.platform,
+        assert_any_analytics_event(
+            record_analytics,
+            FirstEventSentEvent(
+                user_id=self.user.id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=event.platform,
+                project_platform=project.platform,
+            ),
         )
-
         # Create second project and send event
         second_project = self.create_project(first_event=now, platform="python")
         project_created.send(project=second_project, user=self.user, sender=None)
@@ -253,22 +261,22 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         # Ensure "first_event_for_project.sent" was called again for second project
         record_analytics.call_args_list[-1].assert_called_with(
-            "first_event_for_project.sent",
-            user_id=self.user.id,
-            organization_id=second_project.organization_id,
-            project_id=second_project.id,
-            platform=event.platform,
-            project_platform=second_project.platform,
-            url=dict(event.tags).get("url", None),
-            has_minified_stack_trace=has_event_minified_stack_trace(event),
-            sdk_name=None,
+            FirstEventSentForProjectEvent(
+                user_id=self.user.id,
+                organization_id=second_project.organization_id,
+                project_id=second_project.id,
+                platform=event.platform,
+                project_platform=second_project.platform,
+                url=dict(event.tags).get("url", None),
+                has_minified_stack_trace=has_event_minified_stack_trace(event),
+                sdk_name=None,
+            )
         )
-
         # Ensure "first_event.sent" was called exactly once
         first_event_sent_calls = [
             call
             for call in record_analytics.call_args_list
-            if isinstance(call[0][0], FirstEventSentEvent)
+            if type(call[0][0]) is FirstEventSentEvent
         ]
         assert len(first_event_sent_calls) == 1
 


### PR DESCRIPTION
- Transform event classes to use @analytics.eventclass decorator
- Transform analytics.record calls to use event class instances
- Update imports as needed

Closes TET-836
