### PR TITLE
fix(analytics): missing 'data' attribute exclusion

### DIFF
--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -113,7 +113,13 @@ class Event:
             **{
                 f.name: kwargs.get(f.name, getattr(instance, f.name, None))
                 for f in fields(cls)
-                if f.name not in ("type", "uuid_", "datetime_")
+                if f.name
+                not in (
+                    "type",
+                    "uuid_",
+                    "datetime_",
+                    "data",  # TODO: remove this data field once migrated
+                )
             }
         )
 

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -54,6 +54,29 @@ class EventTest(TestCase):
         }
 
     @patch("sentry.analytics.event.uuid1")
+    def test_simple_from_instance(self, mock_uuid1):
+        mock_uuid1.return_value = self.get_mock_uuid()
+
+        result = ExampleEvent.from_instance(
+            None,
+            id="1",  # type: ignore[arg-type]
+            map={"key": "value"},
+            optional=False,
+        )
+        result.datetime_ = datetime(2001, 4, 18, tzinfo=timezone.utc)
+
+        assert result.serialize() == {
+            "data": {
+                "id": 1,
+                "map": {"key": "value"},
+                "optional": False,
+            },
+            "type": "example",
+            "timestamp": 987552000,
+            "uuid": b"AAEC",
+        }
+
+    @patch("sentry.analytics.event.uuid1")
     def test_simple_old_style(self, mock_uuid1):
         mock_uuid1.return_value = self.get_mock_uuid()
 

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -59,7 +59,7 @@ class EventTest(TestCase):
 
         result = ExampleEvent.from_instance(
             None,
-            id="1",  # type: ignore[arg-type]
+            id="1",
             map={"key": "value"},
             optional=False,
         )


### PR DESCRIPTION
The `data` attribute is just there for backwards compatibility, and needs special treatment