### PR TITLE
fix(analytics): exclude UUID from Event equality checks to allow for easier testing

### DIFF
--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -129,19 +129,24 @@ class Event:
 
         return self_values == other_values
 
+    def __hash__(self) -> int:
+        return hash(tuple(getattr(self, f.name) for f in fields(self) if f.name != "uuid_"))
+
 
 def serialize_event(event: Event) -> dict[str, Any]:
     # TODO: this is the "old-style" attributes based serializer. Once all events are migrated to the new style,
     # we can remove this.
     if event.data is None:
-        event.data = {
+        data = {
             k: v
             for k, v in asdict(event).items()
             if k not in ("type", "uuid_", "datetime_", "data")
         }
+    else:
+        data = event.data
     return {
         "type": event.type,
         "uuid": b64encode(event.uuid_.bytes),
         "timestamp": event.datetime_.timestamp(),
-        "data": event.data,
+        "data": data,
     }

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -64,7 +64,7 @@ def eventclass(
         # set the Event subclass `type` attribute, if it is set to anything
         if isinstance(event_name_or_class, str):
             cls.type = event_name_or_class
-        return cast(type[Event], dataclass(kw_only=True)(cls))
+        return cast(type[Event], dataclass(kw_only=True, eq=False)(cls))
 
     # for using without parenthesis, wrap the passed class
     if isinstance(event_name_or_class, type) and issubclass(event_name_or_class, Event):
@@ -75,7 +75,7 @@ def eventclass(
 
 
 # unfortunately we cannot directly use `eventclass` here, as it is making a typecheck to Event
-@dataclass(kw_only=True)
+@dataclass(kw_only=True, eq=False)
 class Event:
     """
     Base class for custom analytics Events.
@@ -116,6 +116,18 @@ class Event:
                 if f.name not in ("type", "uuid_", "datetime_")
             }
         )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Event):
+            return False
+
+        self_values = self.serialize()
+        other_values = other.serialize()
+
+        self_values.pop("uuid")
+        other_values.pop("uuid")
+
+        return self_values == other_values
 
 
 def serialize_event(event: Event) -> dict[str, Any]:

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -53,6 +53,21 @@ class EventTest(TestCase):
             "uuid": b"AAEC",
         }
 
+    def test_equality_no_uuid_mock(self):
+        a = ExampleEvent(
+            id="1",  # type: ignore[arg-type]
+            map={"key": "value"},
+            optional=False,
+        )
+        a.datetime_ = datetime(2001, 4, 18, tzinfo=timezone.utc)
+        b = ExampleEvent(
+            id="1",  # type: ignore[arg-type]
+            map={"key": "value"},
+            optional=False,
+        )
+        b.datetime_ = datetime(2001, 4, 18, tzinfo=timezone.utc)
+        assert a == b
+
     @patch("sentry.analytics.event.uuid1")
     def test_simple_old_style(self, mock_uuid1):
         mock_uuid1.return_value = self.get_mock_uuid()


### PR DESCRIPTION
We need to check whether a specific call was made to analytics record. Since every Event gets its unique UUID, these checks fail, requiring a mock for uuid every time we interact with Events.