### PR TITLE
ref(✂️): include nsExports in knip analysis

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -81,7 +81,7 @@ const config: KnipConfig = {
     enumMembers: 'off',
     unlisted: 'off',
   },
-  include: ['nsExports'],
+  include: ['nsExports', 'nsTypes'],
 };
 
 export default config;

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -81,6 +81,7 @@ const config: KnipConfig = {
     enumMembers: 'off',
     unlisted: 'off',
   },
+  include: ['nsExports'],
 };
 
 export default config;

--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -310,7 +310,7 @@ type FetchIssueTagValuesParameters = {
   sort?: string | string[];
 };
 
-export const makeFetchIssueTagValuesQueryKey = ({
+const makeFetchIssueTagValuesQueryKey = ({
   orgSlug,
   groupId,
   tagKey,
@@ -339,7 +339,7 @@ type FetchIssueTagParameters = {
   tagKey: string;
 };
 
-export const makeFetchIssueTagQueryKey = ({
+const makeFetchIssueTagQueryKey = ({
   orgSlug,
   groupId,
   tagKey,

--- a/static/app/components/events/contexts/contextIcon.tsx
+++ b/static/app/components/events/contexts/contextIcon.tsx
@@ -111,6 +111,7 @@ const LOGO_MAPPING = {
   xbox: logoXbox,
 };
 
+/** @internal used in stories **/
 export const NAMES = Object.keys(LOGO_MAPPING);
 
 // The icons in this list will be inverted when the theme is set to dark mode

--- a/static/app/components/group/groupSummary.tsx
+++ b/static/app/components/group/groupSummary.tsx
@@ -32,7 +32,7 @@ export interface GroupSummaryData {
   whatsWrong?: string | null;
 }
 
-export const makeGroupSummaryQueryKey = (
+const makeGroupSummaryQueryKey = (
   organizationSlug: string,
   groupId: string,
   eventId?: string
@@ -59,7 +59,7 @@ export function useGroupSummaryData(group: Group) {
   return {data, isPending};
 }
 
-export function useGroupSummary(
+function useGroupSummary(
   group: Group,
   event: Event | null | undefined,
   project: Project,

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -114,7 +114,7 @@ export const ORG_ROLES: OrgRole[] = [
   },
 ];
 
-export type PermissionChoice = {
+type PermissionChoice = {
   label: 'No Access' | 'Read' | 'Read & Write' | 'Admin';
   scopes: Scope[];
 };

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -215,17 +215,6 @@ export const DEFAULT_DEBOUNCE_DURATION = 300;
 
 export const ALL_ENVIRONMENTS_KEY = '__all_environments__';
 
-// Maps a `type: string` -> `url-prefix: string`
-export const AVATAR_URL_MAP = {
-  team: 'team-avatar',
-  organization: 'organization-avatar',
-  project: 'project-avatar',
-  user: 'avatar',
-  sentryAppColor: 'sentry-app-avatar',
-  sentryAppSimple: 'sentry-app-avatar',
-  docIntegration: 'doc-integration-avatar',
-};
-
 export const MENU_CLOSE_DELAY = 200;
 
 export const SLOW_TOOLTIP_DELAY = 1000;
@@ -237,8 +226,6 @@ export const DEFAULT_STATS_PERIOD = '14d';
 export const DEFAULT_QUERY = 'is:unresolved issue.priority:[high, medium]';
 export const TAXONOMY_DEFAULT_QUERY = 'is:unresolved';
 
-export const DEFAULT_USE_UTC = true;
-
 export const DEFAULT_RELATIVE_PERIODS = {
   '1h': t('Last hour'),
   '24h': t('Last 24 hours'),
@@ -246,14 +233,6 @@ export const DEFAULT_RELATIVE_PERIODS = {
   '14d': t('Last 14 days'),
   '30d': t('Last 30 days'),
   '90d': t('Last 90 days'),
-};
-
-export const DEFAULT_RELATIVE_PERIODS_PAGE_FILTER = {
-  '1h': t('1H'),
-  '24h': t('24H'),
-  '7d': t('7D'),
-  '14d': t('14D'),
-  '30d': t('30D'),
 };
 
 const DEFAULT_STATS_INFO = {
@@ -587,10 +566,6 @@ export const MAX_AUTOCOMPLETE_RELEASES = 5;
 
 export const DEFAULT_PER_PAGE = 50;
 
-// Limit query length so paginated response headers don't
-// go over HTTP header size limits (4Kb)
-export const MAX_QUERY_LENGTH = 400;
-
 // Webpack configures DEPLOY_PREVIEW_CONFIG for deploy preview builds.
 export const DEPLOY_PREVIEW_CONFIG = process.env.DEPLOY_PREVIEW_CONFIG as unknown as
   | undefined
@@ -622,8 +597,6 @@ export const CONFIG_DOCS_URL = 'https://develop.sentry.dev/config/';
 export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/product/discover-queries/';
 export const SPAN_PROPS_DOCS_URL =
   'https://docs.sentry.io/concepts/search/searchable-properties/spans/';
-export const LOGS_PROPS_DOCS_URL =
-  'https://docs.sentry.io/concepts/search/searchable-properties/logs/';
 
 export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
 export const NODE_ENV = process.env.NODE_ENV;

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -22,7 +22,7 @@ export {Profiler};
  * It depends on where it is called but the way we fetch transactions can be empty despite an ongoing transaction existing.
  * This will return an interaction-type transaction held onto by a class static if one exists.
  */
-export function getPerformanceTransaction(): Span | undefined {
+function getPerformanceTransaction(): Span | undefined {
   const span = PerformanceInteraction.getSpan();
   if (span) {
     return span;
@@ -523,7 +523,7 @@ export const setGroupedEntityTag = (
   Sentry.setTag(`${tagName}.grouped`, `<=${groups.find(g => n <= g)}`);
 };
 
-export const addSlowAppInit = (transaction: TransactionEvent) => {
+const addSlowAppInit = (transaction: TransactionEvent) => {
   const appInitSpan = transaction.spans?.find(
     s => s.description === 'sentry-tracing-init'
   );

--- a/static/app/views/discover/savedQuery/utils.tsx
+++ b/static/app/views/discover/savedQuery/utils.tsx
@@ -224,7 +224,7 @@ export function handleResetHomepageQuery(api: Client, organization: Organization
     });
 }
 
-export function getAnalyticsCreateEventKeyName(
+function getAnalyticsCreateEventKeyName(
   // True if this is a brand new query being saved
   // False if this is a modification from a saved query
   isNewQuery: boolean,
@@ -241,7 +241,7 @@ export function getAnalyticsCreateEventKeyName(
  * Takes in a DiscoverV2 NewQuery object and returns a Partial containing
  * the desired fields to populate into reload analytics
  */
-export function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery> {
+function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery> {
   const {projects, fields, query} = payload;
   return {
     projects,


### PR DESCRIPTION
when something is imported as as namespace in `knip` (`import * as foo from 
'./foo'`), and no additional direct property is accessed on that imported namespace, the whole namespace counts as being used.

we often import a namespace completely in tests to mock a certain property, which hides some unused things.

to enforce Knip to consider each export on a namespace individually, we can set `include: ['nsExports']`, which is what this PR does.

see https://knip.dev/guides/namespace-imports