### PR TITLE
feat(dashboards): Expose All Projects ID through project filter

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -7,7 +7,6 @@ from typing import Any, NotRequired, TypedDict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
 from sentry.models.dashboard_permissions import DashboardPermissions
 from sentry.models.dashboard_widget import (
@@ -359,9 +358,6 @@ class DashboardDetailsModelSerializer(Serializer):
 
         # TODO: The logic for obtaining these filters will be moved to the Dashboard model.
         if obj.filters is not None:
-            if obj.filters.get("all_projects"):
-                data["projects"] = list(ALL_ACCESS_PROJECTS)
-
             for tl_key in ("environment", "period", "utc"):
                 if obj.filters.get(tl_key) is not None:
                     data[tl_key] = obj.filters[tl_key]

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -7,7 +7,7 @@ from typing import Any, NotRequired, TypedDict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
 from sentry.models.dashboard_permissions import DashboardPermissions
 from sentry.models.dashboard_widget import (
@@ -274,6 +274,9 @@ class DashboardListSerializer(Serializer):
             result[dashboard]["created_by"] = serialized_users.get(str(dashboard.created_by_id))
             result[dashboard]["is_favorited"] = dashboard.id in favorited_dashboard_ids
             result[dashboard]["projects"] = list(dashboard.projects.values_list("id", flat=True))
+
+            if dashboard.filters and dashboard.filters.get("all_projects"):
+                result[dashboard]["projects"] = [ALL_ACCESS_PROJECT_ID]
 
         return result
 

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -7,7 +7,7 @@ from typing import Any, NotRequired, TypedDict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS
+from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
 from sentry.models.dashboard_permissions import DashboardPermissions
 from sentry.models.dashboard_widget import (
@@ -275,8 +275,9 @@ class DashboardListSerializer(Serializer):
             result[dashboard]["is_favorited"] = dashboard.id in favorited_dashboard_ids
             result[dashboard]["projects"] = list(dashboard.projects.values_list("id", flat=True))
 
-            if dashboard.filters and dashboard.filters.get("all_projects"):
-                result[dashboard]["projects"] = [ALL_ACCESS_PROJECT_ID]
+            filters = dashboard.get_filters()
+            if filters and filters.get("projects"):
+                result[dashboard]["projects"] = filters["projects"]
 
         return result
 
@@ -343,18 +344,20 @@ class DashboardDetailsModelSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardDetailsResponse:
         from sentry.api.serializers.rest_framework.base import camel_to_snake_case
 
+        dashboard_filters = obj.get_filters()
         data: DashboardDetailsResponse = {
             "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
             "createdBy": user_service.serialize_many(filter={"user_ids": [obj.created_by_id]})[0],
             "widgets": attrs["widgets"],
-            "projects": [project.id for project in obj.projects.all()],
+            "projects": dashboard_filters.get("projects", []),
             "filters": {},
             "permissions": serialize(obj.permissions) if hasattr(obj, "permissions") else None,
             "isFavorited": user.id in obj.favorited_by,
         }
 
+        # TODO: The logic for obtaining these filters will be moved to the Dashboard model.
         if obj.filters is not None:
             if obj.filters.get("all_projects"):
                 data["projects"] = list(ALL_ACCESS_PROJECTS)

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -321,7 +321,7 @@ class Dashboard(Model):
 
         return f"{base_name} copy {next_copy_number}"
 
-    def get_filters(self) -> dict[str, Any] | None:
+    def get_filters(self) -> dict[str, Any]:
         """
         Returns the filters for the dashboard.
 

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -10,6 +10,7 @@ from django.db.models.query import QuerySet
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
+from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_model, sane_repr
 from sentry.db.models.base import DefaultFieldsModel
 from sentry.db.models.fields.bounded import BoundedBigIntegerField
@@ -319,6 +320,23 @@ class Dashboard(Model):
             return f"{base_name} copy"
 
         return f"{base_name} copy {next_copy_number}"
+
+    def get_filters(self) -> dict[str, Any] | None:
+        """
+        Returns the filters for the dashboard.
+
+        This is used to colocate any specific logic for producing dashboard filters,
+        such as handling the all_projects filter.
+        """
+        projects = (
+            [ALL_ACCESS_PROJECT_ID]
+            if self.filters and self.filters.get("all_projects")
+            else list(self.projects.values_list("id", flat=True))
+        )
+
+        return {
+            "projects": projects,
+        }
 
 
 @region_silo_model

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -725,17 +725,17 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         values = [row["title"] for row in response.data]
         assert values == ["General", "Initial dashboard"]
 
-    def test_get_with_filters(self):
+    def test_get_with_all_projects_filter(self):
         Dashboard.objects.create(
-            title="Dashboard with all projects filters",
+            title="Dashboard with all projects filter",
             organization=self.organization,
             created_by_id=self.user.id,
             filters={"all_projects": True},
         )
-        response = self.client.get(self.url, data={"query": "Dashboard with all projects filters"})
+        response = self.client.get(self.url, data={"query": "Dashboard with all projects filter"})
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert response.data[0]["title"] == "Dashboard with all projects filters"
+        assert response.data[0]["title"] == "Dashboard with all projects filter"
         assert response.data[0].get("projects") == [-1]
 
     def test_post(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -47,11 +47,9 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
 
         assert data["widgetDisplay"] == widget_displays
 
-        if dashboard.projects.count() > 0:
-            assert data.get("projects") == list(dashboard.projects.values_list("id", flat=True))
-        if dashboard.filters:
-            if dashboard.filters.get("all_projects"):
-                assert data.get("projects") == [-1]
+        filters = dashboard.get_filters()
+        if filters and filters.get("projects"):
+            assert data.get("projects") == filters["projects"]
 
         assert "widgets" not in data
 

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -46,6 +46,13 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             widget_displays.append(DashboardWidgetDisplayTypes.get_type_name(widget.display_type))
 
         assert data["widgetDisplay"] == widget_displays
+
+        if dashboard.projects.count() > 0:
+            assert data.get("projects") == list(dashboard.projects.values_list("id", flat=True))
+        if dashboard.filters:
+            if dashboard.filters.get("all_projects"):
+                assert data.get("projects") == [-1]
+
         assert "widgets" not in data
 
     def test_get(self):
@@ -717,6 +724,19 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.status_code == 200, response.content
         values = [row["title"] for row in response.data]
         assert values == ["General", "Initial dashboard"]
+
+    def test_get_with_filters(self):
+        Dashboard.objects.create(
+            title="Dashboard with all projects filters",
+            organization=self.organization,
+            created_by_id=self.user.id,
+            filters={"all_projects": True},
+        )
+        response = self.client.get(self.url, data={"query": "Dashboard with all projects filters"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["title"] == "Dashboard with all projects filters"
+        assert response.data[0].get("projects") == [-1]
 
     def test_post(self):
         response = self.do_request("post", self.url, data={"title": "Dashboard from Post"})


### PR DESCRIPTION
Ensures that when a dashboard has "All Projects" selected in their dashboard filters (as opposed to specific projects, or "My Projects"), that the list endpoint also returns `[-1]` in the response.

This was discovered because we weren't exposing the projects data before, but in the new table work it is visible and I noticed it wasn't coming through.