### PR TITLE
ci(mdx) run frontend checks for mdx

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -31,7 +31,7 @@ typecheckable_rules_changed: &typecheckable_rules_changed
 # Trigger to apply the 'Scope: Frontend' label to PRs
 frontend_all: &frontend_all
   - added|modified: '**/*.{ts,tsx,js,jsx,mjs}'
-  - added|modified: 'static/**/*.{less,json,yml,md}'
+  - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
   - added|modified: '{.volta,vercel,tsconfig,biome,package}.json'
 
 # Also used in `getsentry-dispatch.yml` to dispatch backend tests on getsentry


### PR DESCRIPTION
Ensure frontend CI runs when we modify mdx files (they require linting + removing old stories will impact knip)