### PR TITLE
ref(deletions): Simplify seer deletion tests

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -19,7 +19,7 @@ from sentry.models.grouphash import GroupHash
 from sentry.models.groupinbox import GroupInbox
 from sentry.models.project import Project
 from sentry.signals import issue_deleted
-from sentry.tasks.delete_seer_grouping_records import call_delete_seer_grouping_records_by_hash
+from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
 from sentry.utils.audit import create_audit_entry
 
 from . import BULK_MUTATION_LIMIT, SearchFunction
@@ -85,7 +85,7 @@ def delete_group_list(
     create_audit_entries(request, project, group_list, delete_type, transaction_id)
 
     # Tell seer to delete grouping records for these groups
-    call_delete_seer_grouping_records_by_hash(error_ids)
+    may_schedule_task_to_delete_hashes_from_seer(error_ids)
 
     # Removing GroupHash rows prevents new events from associating to the groups
     # we just deleted.

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -15,7 +15,7 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.notifications.models.notificationmessage import NotificationMessage
 from sentry.snuba.dataset import Dataset
-from sentry.tasks.delete_seer_grouping_records import call_delete_seer_grouping_records_by_hash
+from sentry.tasks.delete_seer_grouping_records import may_schedule_task_to_delete_hashes_from_seer
 from sentry.utils.snuba import bulk_snuba_queries
 
 from ..base import BaseDeletionTask, BaseRelation, ModelDeletionTask, ModelRelation
@@ -273,7 +273,7 @@ class GroupDeletionTask(ModelDeletionTask[Group]):
             except InvalidGroupTypeError:
                 pass
         # Tell seer to delete grouping records with these group hashes
-        call_delete_seer_grouping_records_by_hash(error_group_ids)
+        may_schedule_task_to_delete_hashes_from_seer(error_group_ids)
 
         self._delete_children(instance_list)
 

--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -85,7 +85,7 @@ def post_bulk_grouping_records(
         return {"success": False, "reason": response.reason}
 
 
-def delete_project_grouping_records(
+def call_seer_to_delete_project_grouping_records(
     project_id: int,
 ) -> bool:
     try:

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -69,7 +69,7 @@ def delete_seer_grouping_records_by_hash(
             delete_seer_grouping_records_by_hash.apply_async(args=[project_id, chunked_hashes, 0])
 
 
-def call_delete_seer_grouping_records_by_hash(
+def may_schedule_task_to_delete_hashes_from_seer(
     group_ids: Sequence[int],
 ) -> None:
     project = None

--- a/src/sentry/tasks/delete_seer_grouping_records.py
+++ b/src/sentry/tasks/delete_seer_grouping_records.py
@@ -6,8 +6,8 @@ from sentry import options
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.seer.similarity.grouping_records import (
+    call_seer_to_delete_project_grouping_records,
     call_seer_to_delete_these_hashes,
-    delete_project_grouping_records,
 )
 from sentry.seer.similarity.utils import ReferrerOptions, killswitch_enabled
 from sentry.silo.base import SiloMode
@@ -124,4 +124,4 @@ def call_seer_delete_project_grouping_records(
         return
 
     logger.info("calling seer delete records by project", extra={"project_id": project_id})
-    delete_project_grouping_records(project_id)
+    call_seer_to_delete_project_grouping_records(project_id)

--- a/src/sentry/tasks/embeddings_grouping/utils.py
+++ b/src/sentry/tasks/embeddings_grouping/utils.py
@@ -22,7 +22,7 @@ from sentry.seer.similarity.grouping_records import (
     BulkCreateGroupingRecordsResponse,
     CreateGroupingRecordData,
     CreateGroupingRecordsRequest,
-    delete_project_grouping_records,
+    call_seer_to_delete_project_grouping_records,
     post_bulk_grouping_records,
 )
 from sentry.seer.similarity.types import (
@@ -770,7 +770,7 @@ def delete_seer_grouping_records(
         "backfill_seer_grouping_records.delete_all_seer_records",
         extra={"project_id": project_id},
     )
-    delete_project_grouping_records(project_id)
+    call_seer_to_delete_project_grouping_records(project_id)
 
     for groups in chunked(
         RangeQuerySetWrapper(

--- a/tests/sentry/tasks/test_backfill_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_backfill_seer_grouping_records.py
@@ -868,7 +868,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         ]
         assert mock_utils_logger.info.call_args_list == expected_utils_call_args_list
 
-    @patch("sentry.tasks.embeddings_grouping.utils.delete_project_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.call_seer_to_delete_project_grouping_records")
     def test_only_delete(self, mock_project_delete_grouping_records):
         """
         Test that when the only_delete flag is on, seer_similarity is deleted from the metadata
@@ -906,7 +906,7 @@ class TestBackfillSeerGroupingRecords(SnubaTestCase, TestCase):
         for group in groups:
             assert group.data["metadata"] == default_metadata
 
-    @patch("sentry.tasks.embeddings_grouping.utils.delete_project_grouping_records")
+    @patch("sentry.tasks.embeddings_grouping.utils.call_seer_to_delete_project_grouping_records")
     @patch("sentry.tasks.embeddings_grouping.utils.post_bulk_grouping_records")
     def test_cohort_only_delete(
         self, mock_post_bulk_grouping_records, mock_delete_grouping_records

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -117,9 +117,9 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )
-    def test_no_hashes(self, mock_apply_async: MagicMock) -> None:
-        group_ids, _ = self._setup_groups_and_hashes(number_of_groups=5)
-        may_schedule_task_to_delete_hashes_from_seer(group_ids)
+    def test_group_without_hashes(self, mock_apply_async: MagicMock) -> None:
+        group = self.create_group(project=self.project)
+        may_schedule_task_to_delete_hashes_from_seer([group.id])
         mock_apply_async.assert_not_called()
 
     @patch(

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -31,18 +31,6 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )
-    def test_does_not_schedule_task_if_missing_option(self, mock_apply_async: MagicMock) -> None:
-        """
-        Test that when the project option is not set, the task is not scheduled.
-        """
-        self.project.delete_option("sentry:similarity_backfill_completed")
-        group_ids, _ = self._setup_groups_and_hashes(number_of_groups=5)
-        may_schedule_task_to_delete_hashes_from_seer(group_ids)
-        assert mock_apply_async.call_count == 0
-
-    @patch(
-        "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
-    )
     def test_simple(self, mock_apply_async: MagicMock) -> None:
         """
         Test that it correctly collects hashes and schedules a task.
@@ -131,3 +119,15 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
         """
         may_schedule_task_to_delete_hashes_from_seer([])
         mock_apply_async.assert_not_called()
+
+    @patch(
+        "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
+    )
+    def test_does_not_schedule_task_if_missing_option(self, mock_apply_async: MagicMock) -> None:
+        """
+        Test that when the project option is not set, the task is not scheduled.
+        """
+        self.project.delete_option("sentry:similarity_backfill_completed")
+        group_ids, _ = self._setup_groups_and_hashes(number_of_groups=5)
+        may_schedule_task_to_delete_hashes_from_seer(group_ids)
+        assert mock_apply_async.call_count == 0

--- a/tests/sentry/tasks/test_delete_seer_grouping_records.py
+++ b/tests/sentry/tasks/test_delete_seer_grouping_records.py
@@ -2,7 +2,10 @@ from time import time
 from unittest.mock import MagicMock, patch
 
 from sentry.models.grouphash import GroupHash
-from sentry.tasks.delete_seer_grouping_records import call_delete_seer_grouping_records_by_hash
+from sentry.tasks.delete_seer_grouping_records import (
+    delete_seer_grouping_records_by_hash,
+    may_schedule_task_to_delete_hashes_from_seer,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -11,7 +14,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 class TestDeleteSeerGroupingRecordsByHash(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        # Needed for call_delete_seer_grouping_records_by_hash to allow the task to be scheduled
+        # Needed for may_schedule_task_to_delete_hashes_from_seer to allow the task to be scheduled
         self.project.update_option("sentry:similarity_backfill_completed", int(time()))
 
     def _setup_groups_and_hashes(self, number_of_groups: int = 5) -> tuple[list[int], list[str]]:
@@ -34,7 +37,7 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
         """
         self.project.delete_option("sentry:similarity_backfill_completed")
         group_ids, _ = self._setup_groups_and_hashes(number_of_groups=5)
-        call_delete_seer_grouping_records_by_hash(group_ids)
+        may_schedule_task_to_delete_hashes_from_seer(group_ids)
         assert mock_apply_async.call_count == 0
 
     @patch(
@@ -42,19 +45,18 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     )
     def test_simple(self, mock_apply_async: MagicMock) -> None:
         """
-        Test that call_delete_seer_grouping_records_by_hash correctly collects hashes
-        and calls the deletion task with the expected parameters.
+        Test that it correctly collects hashes and schedules a task.
         """
         group_ids, expected_hashes = self._setup_groups_and_hashes(number_of_groups=5)
 
-        call_delete_seer_grouping_records_by_hash(group_ids)
+        may_schedule_task_to_delete_hashes_from_seer(group_ids)
 
         # Verify that the task was called with the correct parameters
         mock_apply_async.assert_called_once_with(args=[self.project.id, expected_hashes, 0])
 
     def test_chunked(self) -> None:
         """
-        Test that call_delete_seer_grouping_records_by_hash chunks large numbers of hashes
+        Test that it chunks large numbers of hashes
         into separate tasks with a maximum of batch_size hashes per task.
         """
         batch_size = 10
@@ -67,7 +69,7 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
             # Create 15 group hashes to test chunking (10 + 5 with batch size of 10)
             group_ids, expected_hashes = self._setup_groups_and_hashes(batch_size + 5)
 
-            call_delete_seer_grouping_records_by_hash(group_ids)
+            may_schedule_task_to_delete_hashes_from_seer(group_ids)
 
             # Verify that the task was called 2 times (15 hashes / 10 per chunk = 2 chunks)
             assert mock_apply_async.call_count == 2
@@ -89,9 +91,35 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
     @patch(
         "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
     )
+    def test_called_task_with_too_many_hashes(self, mock_apply_async: MagicMock) -> None:
+        """This tests the built-in logic of spreading hashes across multiple tasks."""
+        batch_size = 10
+        with self.options({"embeddings-grouping.seer.delete-record-batch-size": batch_size}):
+            # Create 15 group hashes to test chunking (10 + 5 with batch size of 10)
+            _, expected_hashes = self._setup_groups_and_hashes(batch_size + 5)
+            # Call function directly rather than scheduling a task
+            delete_seer_grouping_records_by_hash(self.project.id, expected_hashes, 0)
+
+            # Verify the first chunk has batch_size hashes
+            first_call_args = mock_apply_async.call_args_list[0][1]["args"]
+            assert len(first_call_args[1]) == batch_size
+            assert first_call_args[0] == self.project.id
+            assert first_call_args[1] == expected_hashes[0:batch_size]
+            assert first_call_args[2] == 0
+
+            # Verify the second chunk has 5 hashes (remainder)
+            second_call_args = mock_apply_async.call_args_list[1][1]["args"]
+            assert len(second_call_args[1]) == 5
+            assert second_call_args[0] == self.project.id
+            assert second_call_args[1] == expected_hashes[batch_size:]
+            assert second_call_args[2] == 0
+
+    @patch(
+        "sentry.tasks.delete_seer_grouping_records.delete_seer_grouping_records_by_hash.apply_async"
+    )
     def test_no_hashes(self, mock_apply_async: MagicMock) -> None:
         group_ids, _ = self._setup_groups_and_hashes(number_of_groups=5)
-        call_delete_seer_grouping_records_by_hash(group_ids)
+        may_schedule_task_to_delete_hashes_from_seer(group_ids)
         mock_apply_async.assert_not_called()
 
     @patch(
@@ -101,5 +129,5 @@ class TestDeleteSeerGroupingRecordsByHash(TestCase):
         """
         Test that when no group ids are provided, the task is not scheduled.
         """
-        call_delete_seer_grouping_records_by_hash([])
+        may_schedule_task_to_delete_hashes_from_seer([])
         mock_apply_async.assert_not_called()

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1636,7 +1636,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             assert response.status_code == 204
             self.assert_groups_are_gone(groups)
 
-    @patch("sentry.api.helpers.group_index.delete.call_delete_seer_grouping_records_by_hash")
+    @patch("sentry.api.helpers.group_index.delete.may_schedule_task_to_delete_hashes_from_seer")
     @patch("sentry.utils.audit.log_service.record_audit_log")
     def test_audit_log_even_if_exception_raised(
         self, mock_record_audit_log: Mock, mock_seer_delete: Mock


### PR DESCRIPTION
This simplifies the tests for deletions of hashes from Seer and it also adds a test for #95156.