### PR TITLE
feat(dashboards): Add environment and release filters to endpoint

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -233,7 +233,6 @@ class DashboardFiltersMixin:
         page_filters: PageFilters = {
             "projects": dashboard_filters.get("projects", []),
             "environment": dashboard_filters.get("environment", []),
-            "utc": dashboard_filters.get("utc", ""),
             "expired": dashboard_filters.get("expired", False),
         }
         start, end, period = (
@@ -249,6 +248,9 @@ class DashboardFiltersMixin:
             page_filters["end"] = end
         elif period:
             page_filters["period"] = period
+
+        if dashboard_filters.get("utc"):
+            page_filters["utc"] = dashboard_filters["utc"]
 
         tag_filters: DashboardFilters = {}
         for filter_key in ("release", "releaseId"):

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -187,6 +187,8 @@ class DashboardListResponse(TypedDict):
     title: str
     dateCreated: str
     createdBy: UserSerializerResponse
+    environment: list[str]
+    filters: DashboardFilters
     widgetDisplay: list[str]
     widgetPreview: list[dict[str, str]]
     permissions: DashboardPermissionsResponse | None
@@ -208,7 +210,40 @@ class _Widget(TypedDict):
     projects: list[int]
 
 
-class DashboardListSerializer(Serializer):
+class DashboardFiltersMixin:
+    def get_filters(self, obj: Dashboard) -> dict[str, Any]:
+        from sentry.api.serializers.rest_framework.base import camel_to_snake_case
+
+        dashboard_filters = obj.get_filters()
+        page_filters = {
+            "projects": dashboard_filters.get("projects", []),
+            "environment": dashboard_filters.get("environment", []),
+            "utc": dashboard_filters.get("utc", ""),
+            "expired": dashboard_filters.get("expired", False),
+        }
+        start, end, period = (
+            dashboard_filters.get("start"),
+            dashboard_filters.get("end"),
+            dashboard_filters.get("period"),
+        )
+        if start and end:
+            start, end = parse_timestamp(start), parse_timestamp(end)
+            page_filters["expired"], page_filters["start"] = outside_retention_with_modified_start(
+                start, end, obj.organization
+            )
+            page_filters["end"] = end
+        elif period:
+            page_filters["period"] = period
+
+        tag_filters = {}
+        for filter_key in ("release", "releaseId"):
+            if dashboard_filters.get(camel_to_snake_case(filter_key)):
+                tag_filters[filter_key] = dashboard_filters[camel_to_snake_case(filter_key)]
+
+        return page_filters, tag_filters
+
+
+class DashboardListSerializer(Serializer, DashboardFiltersMixin):
     def get_attrs(self, item_list, user, **kwargs):
         item_dict = {i.id: i for i in item_list}
         prefetch_related_objects(item_list, "projects")
@@ -272,11 +307,11 @@ class DashboardListSerializer(Serializer):
         for dashboard in item_dict.values():
             result[dashboard]["created_by"] = serialized_users.get(str(dashboard.created_by_id))
             result[dashboard]["is_favorited"] = dashboard.id in favorited_dashboard_ids
-            result[dashboard]["projects"] = list(dashboard.projects.values_list("id", flat=True))
 
-            filters = dashboard.get_filters()
-            if filters and filters.get("projects"):
-                result[dashboard]["projects"] = filters["projects"]
+            page_filters, tag_filters = self.get_filters(dashboard)
+            result[dashboard]["projects"] = page_filters.get("projects", [])
+            result[dashboard]["environment"] = page_filters.get("environment", [])
+            result[dashboard]["filters"] = tag_filters
 
         return result
 
@@ -291,6 +326,8 @@ class DashboardListSerializer(Serializer):
             "permissions": attrs.get("permissions", None),
             "isFavorited": attrs.get("is_favorited", False),
             "projects": attrs.get("projects", []),
+            "environment": attrs.get("environment", []),
+            "filters": attrs.get("filters", {}),
         }
 
 
@@ -321,7 +358,7 @@ class DashboardDetailsResponse(DashboardDetailsResponseOptional):
 
 
 @register(Dashboard)
-class DashboardDetailsModelSerializer(Serializer):
+class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
     def get_attrs(self, item_list, user, **kwargs):
         result = {}
 
@@ -341,37 +378,17 @@ class DashboardDetailsModelSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardDetailsResponse:
-        from sentry.api.serializers.rest_framework.base import camel_to_snake_case
-
-        dashboard_filters = obj.get_filters()
+        page_filters, tag_filters = self.get_filters(obj)
         data: DashboardDetailsResponse = {
             "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
             "createdBy": user_service.serialize_many(filter={"user_ids": [obj.created_by_id]})[0],
             "widgets": attrs["widgets"],
-            "projects": dashboard_filters.get("projects", []),
-            "filters": {},
+            "filters": tag_filters,
             "permissions": serialize(obj.permissions) if hasattr(obj, "permissions") else None,
             "isFavorited": user.id in obj.favorited_by,
+            **page_filters,
         }
-
-        # TODO: The logic for obtaining these filters will be moved to the Dashboard model.
-        if obj.filters is not None:
-            for tl_key in ("environment", "period", "utc"):
-                if obj.filters.get(tl_key) is not None:
-                    data[tl_key] = obj.filters[tl_key]
-
-            for filter_key in ("release", "releaseId"):
-                if obj.filters.get(camel_to_snake_case(filter_key)):
-                    data["filters"][filter_key] = obj.filters[camel_to_snake_case(filter_key)]
-
-            start, end = obj.filters.get("start"), obj.filters.get("end")
-            if start and end:
-                start, end = parse_timestamp(start), parse_timestamp(end)
-                data["expired"], data["start"] = outside_retention_with_modified_start(
-                    start, end, obj.organization
-                )
-                data["end"] = end
 
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -249,7 +249,7 @@ class DashboardFiltersMixin:
         elif period:
             page_filters["period"] = period
 
-        if dashboard_filters.get("utc"):
+        if dashboard_filters.get("utc") is not None:
             page_filters["utc"] = dashboard_filters["utc"]
 
         tag_filters: DashboardFilters = {}

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -67,6 +67,7 @@ DASHBOARD_OBJECT = {
     ],
     "projects": [1],
     "filters": {},
+    "environment": ["alpha"],
     "period": "7d",
     "permissions": {
         "isEditableByEveryone": True,
@@ -81,6 +82,13 @@ DASHBOARDS_OBJECT = [
         "title": "Dashboard",
         "dateCreated": "2024-06-20T14:38:03.498574Z",
         "projects": [1],
+        "environment": ["alpha"],
+        "filters": {
+            "release": [
+                "frontend@a02311a400636ff9640b3e4ca2991ee153dbbdcc",
+                "frontend@36934c05140c16df93aa8ebf671f9386e916b501",
+            ]
+        },
         "createdBy": {
             "id": "1",
             "name": "Admin",
@@ -114,6 +122,13 @@ DASHBOARDS_OBJECT = [
         "title": "Dashboard",
         "dateCreated": "2024-06-20T14:38:03.498574Z",
         "projects": [],
+        "environment": ["alpha"],
+        "filters": {
+            "release": [
+                "frontend@a02311a400636ff9640b3e4ca2991ee153dbbdcc",
+                "frontend@36934c05140c16df93aa8ebf671f9386e916b501",
+            ]
+        },
         "createdBy": {
             "id": "1",
             "name": "Admin",

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -335,8 +335,8 @@ class Dashboard(Model):
         )
 
         return {
-            "projects": projects,
             **(self.filters or {}),
+            "projects": projects,
         }
 
 

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -336,6 +336,7 @@ class Dashboard(Model):
 
         return {
             "projects": projects,
+            **(self.filters or {}),
         }
 
 

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -723,18 +723,20 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         values = [row["title"] for row in response.data]
         assert values == ["General", "Initial dashboard"]
 
-    def test_get_with_all_projects_filter(self):
+    def test_get_with_filters(self):
         Dashboard.objects.create(
             title="Dashboard with all projects filter",
             organization=self.organization,
             created_by_id=self.user.id,
-            filters={"all_projects": True},
+            filters={"all_projects": True, "environment": ["alpha"], "release": ["v1"]},
         )
         response = self.client.get(self.url, data={"query": "Dashboard with all projects filter"})
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["title"] == "Dashboard with all projects filter"
         assert response.data[0].get("projects") == [-1]
+        assert response.data[0].get("environment") == ["alpha"]
+        assert response.data[0].get("filters") == {"release": ["v1"]}
 
     def test_post(self):
         response = self.do_request("post", self.url, data={"title": "Dashboard from Post"})


### PR DESCRIPTION
Since these fields need to be displayed on the list view now, we are exposing `environment` and `releases` in the same way as the details endpoint.

The details endpoint needs other data like start, end, period, etc but I've made a mixin that can be shared across the two serializer classes to fetch filter information that we can expose as we need in the response. The keys are split into page filters and tag filters because we hope to extend this list in the future.

Requires https://github.com/getsentry/sentry/pull/95246

Closes DAIN-712