### PR TITLE
ref(trace-view): Split `AttributesTreeValue` into its own file

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.spec.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.spec.tsx
@@ -1,0 +1,132 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ThemeFixture} from 'sentry-fixture/theme';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import {AttributesTreeValue} from 'sentry/views/explore/components/traceItemAttributes/attributesTreeValue';
+
+jest.mock('sentry/actionCreators/modal', () => ({
+  openNavigateToExternalLinkModal: jest.fn(),
+}));
+
+describe('AttributesTreeValue', function () {
+  const organization = OrganizationFixture();
+  const location = LocationFixture();
+  const theme = ThemeFixture();
+
+  const defaultProps = {
+    content: {
+      subtree: {},
+      value: 'test-value',
+      originalAttribute: {
+        attribute_key: 'test.key',
+        attribute_value: 'test-value',
+        original_attribute_key: 'test.key',
+      },
+    },
+    rendererExtra: {
+      organization,
+      location,
+      theme,
+    },
+    theme,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when originalAttribute is missing', function () {
+    const {container} = render(
+      <AttributesTreeValue
+        {...defaultProps}
+        content={{
+          subtree: {},
+          value: 'test-value',
+          originalAttribute: undefined,
+        }}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders with custom renderer when available', function () {
+    const customRenderer = () => <div>Custom Rendered Content</div>;
+    const renderers = {
+      'test.key': customRenderer,
+    };
+
+    render(<AttributesTreeValue {...defaultProps} renderers={renderers} />);
+
+    expect(screen.getByText('Custom Rendered Content')).toBeInTheDocument();
+    expect(screen.queryByText('test-value')).not.toBeInTheDocument();
+  });
+
+  it('renders URL value as a link with correct destination', function () {
+    const urlContent = {
+      ...defaultProps.content,
+      value: 'https://example.com',
+    };
+
+    render(<AttributesTreeValue {...defaultProps} content={urlContent} />);
+
+    const link = screen.getByText('https://example.com').closest('a');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+
+  it('renders URL value as plain string when rich values are disabled', function () {
+    const urlContent = {
+      ...defaultProps.content,
+      value: 'https://example.com',
+    };
+
+    render(
+      <AttributesTreeValue
+        {...defaultProps}
+        content={urlContent}
+        config={{disableRichValue: true}}
+      />
+    );
+
+    expect(screen.getByText('https://example.com')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('calls openNavigateToExternalLinkModal when URL link is clicked', function () {
+    const urlContent = {
+      ...defaultProps.content,
+      value: 'https://example.com',
+    };
+
+    render(<AttributesTreeValue {...defaultProps} content={urlContent} />);
+
+    const $link = screen.getByText('https://example.com').closest('a')!;
+    $link.click();
+
+    expect(openNavigateToExternalLinkModal).toHaveBeenCalledWith({
+      linkText: 'https://example.com',
+    });
+  });
+
+  it('renders non-URL values as plain spans', function () {
+    render(<AttributesTreeValue {...defaultProps} />);
+
+    expect(screen.getByText('test-value')).toBeInTheDocument();
+  });
+
+  it('handles null values correctly', function () {
+    const nullContent = {
+      ...defaultProps.content,
+      value: null,
+    };
+
+    render(<AttributesTreeValue {...defaultProps} content={nullContent} />);
+
+    expect(screen.getByText('null')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.tsx
@@ -1,0 +1,76 @@
+import {type Theme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {openNavigateToExternalLinkModal} from 'sentry/actionCreators/modal';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {type RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import {isUrl} from 'sentry/utils/string/isUrl';
+import {getAttributeItem} from 'sentry/views/explore/components/traceItemAttributes/utils';
+
+import type {
+  AttributesFieldRender,
+  AttributesTreeContent,
+  AttributesTreeRowConfig,
+} from './attributesTree';
+
+export function AttributesTreeValue<RendererExtra extends RenderFunctionBaggage>({
+  config,
+  content,
+  renderers = {},
+  rendererExtra: renderExtra,
+}: {
+  content: AttributesTreeContent;
+  config?: AttributesTreeRowConfig;
+} & AttributesFieldRender<RendererExtra> & {theme: Theme}) {
+  const {originalAttribute} = content;
+  if (!originalAttribute) {
+    return null;
+  }
+
+  // Check if we have a custom renderer for this attribute
+  const attributeKey = originalAttribute.original_attribute_key;
+  const renderer = renderers[attributeKey];
+
+  const defaultValue = <span>{String(content.value)}</span>;
+
+  if (config?.disableRichValue) {
+    return String(content.value);
+  }
+
+  if (renderer) {
+    return renderer({
+      item: getAttributeItem(attributeKey, content.value),
+      basicRendered: defaultValue,
+      extra: renderExtra,
+    });
+  }
+
+  return isUrl(String(content.value)) ? (
+    <AttributeLinkText>
+      <ExternalLink
+        onClick={e => {
+          e.preventDefault();
+          openNavigateToExternalLinkModal({linkText: String(content.value)});
+        }}
+      >
+        {defaultValue}
+      </ExternalLink>
+    </AttributeLinkText>
+  ) : (
+    defaultValue
+  );
+}
+
+const AttributeLinkText = styled('span')`
+  color: ${p => p.theme.linkColor};
+  text-decoration: ${p => p.theme.linkUnderline} underline dotted;
+  margin: 0;
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  div {
+    white-space: normal;
+  }
+`;


### PR DESCRIPTION
I'm about to do a bit of work in this code, thought it'd be nice to split this out and add some specs while I'm there.
