### PR TITLE
ref(feedback): add user reports task to snuba referrer enum

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -1004,6 +1004,7 @@ class Referrer(StrEnum):
     TAGSTORE_GET_RELEASE_TAGS = "tagstore.get_release_tags"
     TAGSTORE_GET_TAG_VALUE_PAGINATOR_FOR_PROJECTS = "tagstore.get_tag_value_paginator_for_projects"
     TASKS_MONITOR_RELEASE_ADOPTION = "tasks.monitor_release_adoption"
+    TASKS_UPDATE_USER_REPORTS = "tasks.update_user_reports"
     TASKS_PERFORMANCE_SPLIT_DISCOVER_DATASET = "tasks.performance.split_discover_dataset"
     TASKS_PERFORMANCE_SPLIT_DISCOVER_DATASET_METRICS_ENHANCED = (
         "tasks.performance.split_discover_dataset.metrics-enhanced"


### PR DESCRIPTION
Found from the logs on [this issue](https://sentry.sentry.io/issues/6739459216/events/14ccde90fe9644429f125bf752cd87de/?project=1&referrer=issue_details.related_trace_issue). AFAIK this isn't causing breaking errors