### PR TITLE
feat(rr6): Create migration strategy to remove legacy Route component

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -15,6 +15,11 @@ type CustomProps = {
    */
   name?: string;
   /**
+   * XXX(epurkhiser): This should ONLY be used as we migrate routes away from
+   * the legacy `Route` style tree.
+   */
+  newStyleChildren?: SentryRouteObject[];
+  /**
    * Ensure this route renders two routes, one for the "org" path which
    * includes the :orgId slug, and one without.
    *
@@ -28,6 +33,35 @@ type CustomProps = {
    */
   withOrgPath?: boolean;
 };
+
+/**
+ * This is our "custom" route object. It varies a bit from react-router 6's
+ * routing object in that it doesn't take a rendered component, but instead a
+ * component type and handles the rendering itself.
+ */
+export interface SentryRouteObject extends CustomProps {
+  /**
+   * child components to render under this route
+   */
+  children?: SentryRouteObject[];
+  /**
+   * A react component to render or a import promise that will be lazily loaded
+   */
+  component?: React.ComponentType<any>;
+  /**
+   * Is a index route
+   */
+  index?: boolean;
+  /**
+   * The react router path of this component
+   */
+  path?: string;
+
+  // XXX(epurkhiser): In the future we can introduce a `requiresLegacyProps`
+  // prop here that will pass in the react-router 3 style routing props. We can
+  // use this as a way to slowly get rid of react router 3 style prosp in favor
+  // of using the route hooks.
+}
 
 interface SentryRouteProps extends React.PropsWithChildren<RouteProps & CustomProps> {}
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2188,60 +2188,70 @@ function buildRoutes(
     <Route
       path="/manage/"
       component={make(() => import('sentry/views/admin/adminLayout'))}
-    >
-      <IndexRoute component={make(() => import('sentry/views/admin/adminOverview'))} />
-      <Route
-        path="buffer/"
-        component={make(() => import('sentry/views/admin/adminBuffer'))}
-      />
-      <Route
-        path="relays/"
-        component={make(() => import('sentry/views/admin/adminRelays'))}
-      />
-      <Route
-        path="organizations/"
-        component={make(() => import('sentry/views/admin/adminOrganizations'))}
-      />
-      <Route
-        path="projects/"
-        component={make(() => import('sentry/views/admin/adminProjects'))}
-      />
-      <Route
-        path="queue/"
-        component={make(() => import('sentry/views/admin/adminQueue'))}
-      />
-      <Route
-        path="quotas/"
-        component={make(() => import('sentry/views/admin/adminQuotas'))}
-      />
-      <Route
-        path="settings/"
-        component={make(() => import('sentry/views/admin/adminSettings'))}
-      />
-      <Route path="users/">
-        <IndexRoute component={make(() => import('sentry/views/admin/adminUsers'))} />
-        <Route
-          path=":id"
-          component={make(() => import('sentry/views/admin/adminUserEdit'))}
-        />
-      </Route>
-      <Route
-        path="status/mail/"
-        component={make(() => import('sentry/views/admin/adminMail'))}
-      />
-      <Route
-        path="status/environment/"
-        component={make(() => import('sentry/views/admin/adminEnvironment'))}
-      />
-      <Route
-        path="status/packages/"
-        component={make(() => import('sentry/views/admin/adminPackages'))}
-      />
-      <Route
-        path="status/warnings/"
-        component={make(() => import('sentry/views/admin/adminWarnings'))}
-      />
-    </Route>
+      newStyleChildren={[
+        {
+          index: true,
+          component: make(() => import('sentry/views/admin/adminOverview')),
+        },
+        {
+          path: 'buffer/',
+          component: make(() => import('sentry/views/admin/adminBuffer')),
+        },
+        {
+          path: 'relays/',
+          component: make(() => import('sentry/views/admin/adminRelays')),
+        },
+        {
+          path: 'organizations/',
+          component: make(() => import('sentry/views/admin/adminOrganizations')),
+        },
+        {
+          path: 'projects/',
+          component: make(() => import('sentry/views/admin/adminProjects')),
+        },
+        {
+          path: 'queue/',
+          component: make(() => import('sentry/views/admin/adminQueue')),
+        },
+        {
+          path: 'quotas/',
+          component: make(() => import('sentry/views/admin/adminQuotas')),
+        },
+        {
+          path: 'settings/',
+          component: make(() => import('sentry/views/admin/adminSettings')),
+        },
+        {
+          path: 'users/',
+          children: [
+            {
+              index: true,
+              component: make(() => import('sentry/views/admin/adminUsers')),
+            },
+            {
+              path: ':id',
+              component: make(() => import('sentry/views/admin/adminUserEdit')),
+            },
+          ],
+        },
+        {
+          path: 'status/mail/',
+          component: make(() => import('sentry/views/admin/adminMail')),
+        },
+        {
+          path: 'status/environment/',
+          component: make(() => import('sentry/views/admin/adminEnvironment')),
+        },
+        {
+          path: 'status/packages/',
+          component: make(() => import('sentry/views/admin/adminPackages')),
+        },
+        {
+          path: 'status/warnings/',
+          component: make(() => import('sentry/views/admin/adminWarnings')),
+        },
+      ]}
+    />
   );
 
   const legacyOrganizationRootRoutes = (


### PR DESCRIPTION
This introduces a new prop `newStyleChildren` to the "fake" `Route`
component. The newstyle children object is very similar to the react
router 6 `RouteObject`, however we have some custom differences:

 - Name is a top-level key on the object, we use this for breadcrumbs in
   settings and we want to consistently store this in the handler.
   `path` is also stored here for use in the legacy `useMatches` hook.

- Instead of passing an `element` we pass a `component`. This is both
  due to react-router 3 having this interface, as well the use of
  withDomainRequired and withDomainRedirect which wrap the component
  itself (and would need to work differently if it was passed an already
  rendered element)