### PR TITLE
fix(tasks) Bump deadline on update_user_reports

### DIFF
--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
     silo_mode=SiloMode.REGION,
     taskworker_config=TaskworkerConfig(
         namespace=issues_tasks,
+        processing_deadline_duration=30,
     ),
 )
 def update_user_reports(


### PR DESCRIPTION
Fixes [SENTRY-41A4](https://sentry.sentry.io/issues/6679583479/events/1831d54ab3e64335a5bae25f24141186/)
Fixes [SENTRY-470R](https://sentry.sentry.io/issues/6739459216/events/14ccde90fe9644429f125bf752cd87de/)