### PR TITLE
fix(Jira-Server): Adds halts, better exceptions for failed syncs

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1275,7 +1275,7 @@ class JiraServerIntegration(IssueSyncIntegration):
         try:
             id_field = client.user_id_field()
             client.assign_issue(external_issue.key, jira_user and jira_user.get(id_field))
-        except ApiUnauthorized:
+        except ApiUnauthorized as e:
             logger.info(
                 "jira_server.user-assignment-unauthorized",
                 extra={
@@ -1284,7 +1284,7 @@ class JiraServerIntegration(IssueSyncIntegration):
             )
             raise IntegrationInstallationConfigurationError(
                 "Insufficient permissions to assign user to Jira Server issue"
-            )
+            ) from e
         except ApiError as e:
             logger.info(
                 "jira_server.user-assignment-request-error",
@@ -1293,7 +1293,7 @@ class JiraServerIntegration(IssueSyncIntegration):
                     "error": str(e),
                 },
             )
-            raise IntegrationError("Failed to assign user to Jira Server issue")
+            raise IntegrationError("Failed to assign user to Jira Server issue") from e
 
     def sync_status_outbound(
         self, external_issue: ExternalIssue, is_resolved: bool, project_id: int

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -24,6 +24,7 @@ from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.models.project import Project
 from sentry.notifications.utils import get_notification_group_title
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import all_silo_function
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -368,6 +369,10 @@ class IssueBasicIntegration(IntegrationInstallation, ABC):
 
     def update_comment(self, issue_id, user_id, group_note):
         pass
+
+
+class IntegrationSyncTargetNotFound(IntegrationError):
+    pass
 
 
 class IssueSyncIntegration(IssueBasicIntegration, ABC):

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from sentry import analytics, features
 from sentry.constants import ObjectStatus
-from sentry.exceptions import InvalidConfiguration
 from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration import Integration
@@ -107,7 +106,6 @@ def sync_assignee_outbound(
         except (
             OrganizationIntegrationNotFound,
             ApiUnauthorized,
-            InvalidConfiguration,
             IntegrationSyncTargetNotFound,
             IntegrationInstallationConfigurationError,
         ) as e:

--- a/src/sentry/integrations/tasks/sync_assignee_outbound.py
+++ b/src/sentry/integrations/tasks/sync_assignee_outbound.py
@@ -13,7 +13,11 @@ from sentry.integrations.project_management.metrics import (
 from sentry.integrations.services.assignment_source import AssignmentSource
 from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
-from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    ApiUnauthorized,
+    IntegrationError,
+    IntegrationInstallationConfigurationError,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
@@ -53,6 +57,8 @@ def sync_assignee_outbound(
     assign: bool,
     assignment_source_dict: dict[str, Any] | None = None,
 ) -> None:
+    from sentry.integrations.mixins.issues import IntegrationSyncTargetNotFound
+
     # Sync Sentry assignee to an external issue.
     external_issue = ExternalIssue.objects.get(id=external_issue_id)
 
@@ -98,5 +104,11 @@ def sync_assignee_outbound(
                     id=integration.id,
                     organization_id=external_issue.organization_id,
                 )
-        except (OrganizationIntegrationNotFound, ApiUnauthorized, InvalidConfiguration) as e:
+        except (
+            OrganizationIntegrationNotFound,
+            ApiUnauthorized,
+            InvalidConfiguration,
+            IntegrationSyncTargetNotFound,
+            IntegrationInstallationConfigurationError,
+        ) as e:
             lifecycle.record_halt(halt_reason=e)

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.mixins import ResolveSyncAction
-from sentry.integrations.mixins.issues import IssueSyncIntegration
+from sentry.integrations.mixins.issues import IntegrationSyncTargetNotFound, IssueSyncIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
 from sentry.models.activity import Activity
@@ -20,6 +20,7 @@ from sentry.shared_integrations.exceptions import (
     ApiUnauthorized,
     IntegrationError,
     IntegrationFormError,
+    IntegrationInstallationConfigurationError,
 )
 from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
@@ -294,11 +295,11 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
                         "issue_key": external_issue.key,
                     },
                 )
-                return
+                raise IntegrationSyncTargetNotFound("No matching VSTS user found.")
 
         try:
             client.update_work_item(external_issue.key, assigned_to=assignee)
-        except (ApiUnauthorized, ApiError):
+        except (ApiUnauthorized, ApiError) as e:
             self.logger.info(
                 "vsts.failed-to-assign",
                 extra={
@@ -307,6 +308,11 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
                     "issue_key": external_issue.key,
                 },
             )
+            if isinstance(e, ApiUnauthorized):
+                raise IntegrationInstallationConfigurationError(
+                    "Insufficient permissions to assign user to the VSTS issue."
+                ) from e
+            raise IntegrationError("There was an error assigning the issue.") from e
         except Exception as e:
             self.raise_error(e)
 

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -169,7 +169,7 @@ class IntegrationError(Exception):
     pass
 
 
-class IntegrationInstallationConfigurationError(Exception):
+class IntegrationInstallationConfigurationError(IntegrationError):
     """
     Error when external API access is blocked due to configuration issues
     like permissions, visibility changes, or invalid project settings.

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from fixtures.integrations.jira.stub_client import StubJiraApiClient
 from fixtures.integrations.stub_service import StubService
 from sentry.integrations.jira_server.integration import JiraServerIntegration
+from sentry.integrations.mixins.issues import IntegrationSyncTargetNotFound
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
@@ -824,9 +825,9 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
             ],
         )
 
-        with pytest.raises(IntegrationError) as e:
+        with pytest.raises(IntegrationSyncTargetNotFound) as e:
             self.installation.sync_assignee_outbound(external_issue, user)
-        assert str(e.value) == "Failed to assign user to Jira Server issue"
+        assert str(e.value) == "No matching Jira Server user found"
 
         # No sync made as jira users don't have email addresses
         assert len(responses.calls) == 1

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -19,7 +19,12 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import ExternalProviders
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupmeta import GroupMeta
-from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiUnauthorized,
+    IntegrationError,
+    IntegrationInstallationConfigurationError,
+)
 from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import APITestCase
@@ -877,7 +882,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 }
             ],
         )
-        with pytest.raises(IntegrationError) as exc_info:
+        with pytest.raises(IntegrationInstallationConfigurationError) as exc_info:
             self.installation.sync_assignee_outbound(
                 external_issue=external_issue, user=user, assign=True
             )
@@ -902,7 +907,7 @@ class JiraServerRegionIntegrationTest(JiraServerIntegrationBaseTest):
                 {
                     "accountId": "deadbeef123",
                     "displayName": "Dead Beef",
-                    "username": "bob@example.com",
+                    "emailAddress": "bob@example.com",
                 }
             ],
         )


### PR DESCRIPTION
Adds distinct error handling for different assignment failures: 
1. Target user not found
2. Authentication (configuration) errors
3. Invalid request formatting

Also renames the logs generated by Jira Server, since these are currently identical to the Jira SaaS logs, making it difficult to differentiate between the two when triaging failures.
