### PR TITLE
build(ui): Set only the runtime chunk option

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -228,23 +228,6 @@ const swcReactLoaderConfig: SwcLoaderOptions = {
   isModule: 'unknown',
 };
 
-const minimizer = [
-  new rspack.LightningCssMinimizerRspackPlugin(),
-  new rspack.SwcJsMinimizerRspackPlugin({
-    minimizerOptions: {
-      compress: {
-        // We are turning off these 3 minifier options because it has caused
-        // unexpected behaviour. See the following issues for more details.
-        // - https://github.com/swc-project/swc/issues/10822
-        // - https://github.com/swc-project/swc/issues/10824
-        reduce_vars: false,
-        inline: 0,
-        collapse_vars: false,
-      },
-    },
-  }),
-];
-
 /**
  * Main Webpack config for Sentry React SPA.
  */
@@ -549,7 +532,22 @@ const appConfig: Configuration = {
     },
 
     // This only runs in production mode
-    minimizer,
+    minimizer: [
+      new rspack.LightningCssMinimizerRspackPlugin(),
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: {
+            // We are turning off these 3 minifier options because it has caused
+            // unexpected behaviour. See the following issues for more details.
+            // - https://github.com/swc-project/swc/issues/10822
+            // - https://github.com/swc-project/swc/issues/10824
+            reduce_vars: false,
+            inline: 0,
+            collapse_vars: false,
+          },
+        },
+      }),
+    ],
   },
   devtool: IS_PRODUCTION ? 'source-map' : 'eval-cheap-module-source-map',
 };
@@ -781,10 +779,8 @@ if (IS_UI_DEV_ONLY) {
       rewrites: [{from: /^\/.*$/, to: '/_assets/index.html'}],
     },
   };
-  appConfig.optimization = {
-    runtimeChunk: 'single',
-    minimizer,
-  };
+  // Hot reloading breaks if we aren't using a single runtime chunk
+  appConfig.optimization!.runtimeChunk = 'single';
 }
 
 if (IS_UI_DEV_ONLY || SENTRY_EXPERIMENTAL_SPA) {


### PR DESCRIPTION
We passed the minimizer in because it helps test a production build + dev-ui locally. But I think we only need  to override the one option.

related #95263