### PR TITLE
chore(aci): read from WorkflowFireHistory when single processing is on

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1011,9 +1011,7 @@ def process_rules(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
 
-    if only_process_workflows := features.has(
-        "organizations:workflow-engine-single-process-workflows", org
-    ):
+    if features.has("organizations:workflow-engine-single-process-workflows", org):
         # we are only processing through the workflow engine
         return
 
@@ -1041,17 +1039,7 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
-        # Determine when to fire rule actions:
-        # - Fire if we're NOT in single processing mode (i.e., we're in dual processing mode)
-        # - OR if we're in dual processing mode but NOT using workflow engine to trigger actions
-        is_dual_processing = not only_process_workflows
-        is_workflow_engine_triggering_actions = features.has(
-            "organizations:workflow-engine-trigger-actions", org
-        )
-
-        should_fire_rule_actions = is_dual_processing or not is_workflow_engine_triggering_actions
-
-        if should_fire_rule_actions:
+        if not features.has("organizations:workflow-engine-trigger-actions", org):
             for callback, futures in callback_and_futures:
                 has_alert = True
                 safe_execute(callback, group_event, futures)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1011,7 +1011,9 @@ def process_rules(job: PostProcessJob) -> None:
 
     org = job["event"].project.organization
 
-    if features.has("organizations:workflow-engine-single-process-workflows", org):
+    if only_process_workflows := features.has(
+        "organizations:workflow-engine-single-process-workflows", org
+    ):
         # we are only processing through the workflow engine
         return
 
@@ -1039,7 +1041,17 @@ def process_rules(job: PostProcessJob) -> None:
         # objects back and forth isn't super efficient
         callback_and_futures = rp.apply()
 
-        if not features.has("organizations:workflow-engine-trigger-actions", org):
+        # Determine when to fire rule actions:
+        # - Fire if we're NOT in single processing mode (i.e., we're in dual processing mode)
+        # - OR if we're in dual processing mode but NOT using workflow engine to trigger actions
+        is_dual_processing = not only_process_workflows
+        is_workflow_engine_triggering_actions = features.has(
+            "organizations:workflow-engine-trigger-actions", org
+        )
+
+        should_fire_rule_actions = is_dual_processing or not is_workflow_engine_triggering_actions
+
+        if should_fire_rule_actions:
             for callback, futures in callback_and_futures:
                 has_alert = True
                 safe_execute(callback, group_event, futures)

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -12,7 +12,7 @@ from celery import Task
 from django.utils import timezone
 from pydantic import BaseModel, validator
 
-from sentry import buffer, nodestore
+from sentry import buffer, features, nodestore
 from sentry.buffer.base import BufferField
 from sentry.db import models
 from sentry.eventstore.models import Event, GroupEvent

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -12,7 +12,7 @@ from celery import Task
 from django.utils import timezone
 from pydantic import BaseModel, validator
 
-from sentry import buffer, features, nodestore
+from sentry import buffer, nodestore
 from sentry.buffer.base import BufferField
 from sentry.db import models
 from sentry.eventstore.models import Event, GroupEvent
@@ -747,7 +747,7 @@ def fire_actions_for_groups(
                 )
                 total_actions += len(filtered_actions)
 
-                if should_trigger_actions:
+                if should_fire_workflow_actions(organization):
                     for action in filtered_actions:
                         if should_trigger_actions_async:
                             task_params = build_trigger_action_task_params(


### PR DESCRIPTION
When we flip single processing on, we will solely be writing to the `WorkflowFireHistory` table. Thus the charts being powered by `RuleFireHistory` should be reading from `WorkflowFireHistory`.

This is not enough though, as there will be a period where the alert DID fire but we weren't writing to `WorkflowFireHistory`, and the chart needs to provide up to 90 days worth of data. Ideally, we'll be shadow processing under the hood for long enough that we have that data, but if that doesn't happen we'll need to backfill `WorkflowFireHistory` with `RuleFireHistory` data.