### PR TITLE
chore(bitbucket): Truncate issue link title length

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -17,10 +17,12 @@ from sentry.silo.base import all_silo_function
 from sentry.users.models.identity import Identity
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.utils.strings import truncatechars
 
 # Generated based on the response from the Bitbucket API
 # Example: {"type": "error", "error": {"message": "Repository has no issue tracker."}}
 BITBUCKET_HALT_ERROR_CODES = ["Repository has no issue tracker.", "Resource not found"]
+BITBUCKET_MAX_TITLE_LENGTH = 255
 
 
 ISSUE_TYPES = (
@@ -71,6 +73,13 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
         autocomplete_url = reverse(
             "sentry-extensions-bitbucket-search", args=[org.slug, self.model.id]
         )
+
+        title_field = next(field for field in fields if field["name"] == "title")
+        if title_field:
+            title_field["maxLength"] = BITBUCKET_MAX_TITLE_LENGTH
+            title_field["default"] = truncatechars(
+                title_field["default"], BITBUCKET_MAX_TITLE_LENGTH
+            )
 
         return [
             {

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -74,7 +74,7 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
             "sentry-extensions-bitbucket-search", args=[org.slug, self.model.id]
         )
 
-        title_field = next(field for field in fields if field["name"] == "title")
+        title_field = next((field for field in fields if field["name"] == "title"), None)
         if title_field:
             title_field["maxLength"] = BITBUCKET_MAX_TITLE_LENGTH
             title_field["default"] = truncatechars(

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -212,6 +212,7 @@ class BitbucketIssueTest(APITestCase):
                 "default": "message",
                 "type": "string",
                 "required": True,
+                "maxLength": BITBUCKET_MAX_TITLE_LENGTH,
             },
             {
                 "name": "description",


### PR DESCRIPTION
Should reduce failures in SLOs

From GCP logs:
```
event: "integrations.slo.failure"
exception_summary: "IntegrationError('Error Communicating with Bitbucket (HTTP 400): title: Ensure this value has at most 255 characters (it has 288).')"
```