### PR TITLE
ref(issues): Reduce rate limit on GroupTagKeyValues and GroupTagKeyDetails Endpoints

### DIFF
--- a/src/sentry/api/endpoints/group_tagkey_details.py
+++ b/src/sentry/api/endpoints/group_tagkey_details.py
@@ -37,7 +37,7 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
             RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
         }
     }
 

--- a/src/sentry/api/endpoints/group_tagkey_values.py
+++ b/src/sentry/api/endpoints/group_tagkey_values.py
@@ -37,7 +37,7 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         "GET": {
             RateLimitCategory.IP: RateLimit(limit=10, window=1, concurrent_limit=10),
             RateLimitCategory.USER: RateLimit(limit=10, window=1, concurrent_limit=10),
-            RateLimitCategory.ORGANIZATION: RateLimit(limit=40, window=1, concurrent_limit=10),
+            RateLimitCategory.ORGANIZATION: RateLimit(limit=20, window=1, concurrent_limit=5),
         }
     }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adjusting the limits on these endpoints again, follows up on https://github.com/getsentry/sentry/pull/94486 and https://github.com/getsentry/sentry/pull/94831