### PR TITLE
fix(teamStats): Fix "Invalid Period" showing on custom date range

### DIFF
--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -233,7 +233,6 @@ function TeamStatsControls({
           ...relativeOptions,
           ...props.arbitraryOptions,
         })}
-        disallowArbitraryRelativeRanges={false}
         triggerLabel={
           period &&
           // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -8,6 +8,7 @@ import {Select} from 'sentry/components/core/select';
 import TeamSelector from 'sentry/components/teamSelector';
 import type {ChangeData} from 'sentry/components/timeRangeSelector';
 import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
+import {getArbitraryRelativePeriod} from 'sentry/components/timeRangeSelector/utils';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DateString} from 'sentry/types/core';
@@ -24,7 +25,7 @@ import {dataDatetime} from './utils';
 const INSIGHTS_DEFAULT_STATS_PERIOD = '8w';
 
 const relativeOptions = {
-  '14d': t('Last 2 weeks'),
+  '2w': t('Last 2 weeks'),
   '4w': t('Last 4 weeks'),
   [INSIGHTS_DEFAULT_STATS_PERIOD]: t('Last 8 weeks'),
   '12w': t('Last 12 weeks'),
@@ -228,9 +229,16 @@ function TeamStatsControls({
         utc={utc ?? null}
         onChange={handleUpdateDatetime}
         showAbsolute={false}
-        relativeOptions={relativeOptions}
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        triggerLabel={period && relativeOptions[period]}
+        relativeOptions={props => ({
+          ...relativeOptions,
+          ...props.arbitraryOptions,
+        })}
+        disallowArbitraryRelativeRanges={false}
+        triggerLabel={
+          period &&
+          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+          (relativeOptions[period] || getArbitraryRelativePeriod(period)[period])
+        }
         triggerProps={{prefix: t('Date Range')}}
       />
     </ControlsWrapper>


### PR DESCRIPTION
The Team Stats page allows users to query custom time ranges. Currently, _actually_ doing so makes the selector UI show "Invalid Period". (This is purely a visual bug with the selector — the actual data / graphs rendered are correct to the user-selected time range.)

Fix the selector to treat custom time ranges the same way it treats default ranges.