### PR TITLE
ref(ourlogs): add an indicator option for logs launch

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -535,6 +535,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# GA has launched for ourlogs
+register(
+    "ourlogs.ga-launched",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Extract logs from breadcrumbs only for a random fraction of sent breadcrumbs.
 #
 # NOTE: Any value below 1.0 will break the product. Do not override in production.


### PR DESCRIPTION
Add a new option that will be flipped on logs launch.

See https://github.com/getsentry/getsentry/pull/17911 and https://linear.app/getsentry/issue/ID-724/enable-cross-project-selection-for-all-plans for more motivating details.