### PR TITLE
chore(aci): update IssueAlertMigrator to handle existing AlertRuleDetector lookup case

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -131,15 +131,10 @@ class IssueAlertMigrator:
     def _create_detector_lookup(self) -> Detector:
 
         if self.is_dry_run:
-            created = True
             error_detector = Detector.objects.filter(
                 type=ErrorGroupType.slug, project=self.project
             ).first()
-            if error_detector:
-                created = not AlertRuleDetector.objects.filter(
-                    detector=error_detector, rule_id=self.rule.id
-                ).exists()
-            else:
+            if not error_detector:
                 error_detector = Detector(type=ErrorGroupType.slug, project=self.project)
 
         else:
@@ -148,12 +143,7 @@ class IssueAlertMigrator:
                 project=self.project,
                 defaults={"config": {}, "name": ERROR_DETECTOR_NAME},
             )
-            _, created = AlertRuleDetector.objects.get_or_create(
-                detector=error_detector, rule_id=self.rule.id
-            )
-
-        if not created:
-            raise Exception("Issue alert already migrated")
+            AlertRuleDetector.objects.get_or_create(detector=error_detector, rule_id=self.rule.id)
 
         return error_detector
 

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -276,6 +276,8 @@ class IssueAlertMigrator:
             workflow = Workflow(**kwargs)
             workflow.full_clean(exclude=["when_condition_group"])
             workflow.validate_config(workflow.config_schema)
+            if AlertRuleWorkflow.objects.filter(rule_id=self.rule.id).exists():
+                raise Exception("Issue alert already migrated")
         else:
             workflow = Workflow.objects.create(**kwargs)
             workflow.update(date_added=self.rule.date_added)

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -327,6 +327,14 @@ class IssueAlertMigratorTest(TestCase):
         detector = Detector.objects.get(project_id=self.project.id)
         assert detector == project_detector
 
+    def test_run__detector_lookup_exists(self):
+        AlertRuleDetector.objects.create(
+            detector=self.create_detector(project=self.project),
+            rule_id=self.issue_alert.id,
+        )
+        IssueAlertMigrator(self.issue_alert, self.user.id).run()
+        AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id).workflow
+
     def test_run__with_conditions(self):
         issue_alert = self.create_project_rule(
             condition_data=self.conditions,


### PR DESCRIPTION
I did not migrate the remaining unmigrated issue alerts before we squashed a ton of migrations (original PR to fix in a migration https://github.com/getsentry/sentry/pull/90855).

Now I'm doing this in a script that is using `IssueAlertMigrator`, which hasn't been updated with the logic I changed in the original PR. The existing logic assumes that if the `AlertRuleDetector` lookup exists, then we've already migrated the alert. However, there are some remaining issue alerts where this is true but we HAVEN'T migrated the alert... this PR fixes that.

The last unmigrated issue alert in US was created on 5/14/2025.

```
SELECT sr.*
FROM sentry_rule sr
LEFT JOIN workflow_engine_alertruleworkflow we
  ON sr.id = we.rule_id
WHERE we.rule_id IS NULL
ORDER BY sr.id
```

```
SELECT sr.*
FROM sentry_rule sr
LEFT JOIN workflow_engine_alertruledetector we
  ON sr.id = we.rule_id
WHERE we.rule_id IS NULL
ORDER BY sr.id
```