### PR TITLE
:wrench: chore(data-secrecy v2): remove option to configure data secrecy waivers from FE

### DIFF
--- a/static/app/views/settings/components/dataSecrecy/index.spec.tsx
+++ b/static/app/views/settings/components/dataSecrecy/index.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import DataSecrecy from 'sentry/views/settings/components/dataSecrecy';
 
@@ -15,117 +15,62 @@ describe('DataSecrecy', function () {
     jest.clearAllMocks();
   });
 
-  it('renders default state with no waiver', async function () {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/data-secrecy/`,
-      body: null,
+  it('renders with access disabled', function () {
+    const orgWithoutAccess = {
+      ...organization,
+      allowSuperuserAccess: false,
+    };
+
+    render(<DataSecrecy />, {organization: orgWithoutAccess});
+
+    expect(screen.getByText('Support Access')).toBeInTheDocument();
+    expect(
+      screen.getByText('Sentry employees do not have access to your organization')
+    ).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /Sentry employees will not have access to your data unless granted permission/,
     });
-
-    render(<DataSecrecy />, {organization});
-
-    await waitFor(() => {
-      expect(screen.getByText('Support Access')).toBeInTheDocument();
-    });
-
-    organization.allowSuperuserAccess = false;
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/sentry employees do not have access to your organization/i)
-      ).toBeInTheDocument();
-    });
+    expect(checkbox).not.toBeChecked();
   });
 
-  it('renders default state with waiver', async function () {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/data-secrecy/`,
-      body: null,
+  it('renders with access enabled', function () {
+    const orgWithAccess = {
+      ...organization,
+      allowSuperuserAccess: true,
+    };
+
+    render(<DataSecrecy />, {organization: orgWithAccess});
+
+    expect(screen.getByText('Support Access')).toBeInTheDocument();
+    expect(
+      screen.getByText('Sentry employees have access to your organization')
+    ).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /Sentry employees will not have access to your data unless granted permission/,
     });
-
-    render(<DataSecrecy />, {organization});
-
-    await waitFor(() => {
-      expect(screen.getByText('Support Access')).toBeInTheDocument();
-    });
-
-    organization.allowSuperuserAccess = true;
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/sentry employees do not have access to your organization/i)
-      ).toBeInTheDocument();
-    });
+    expect(checkbox).toBeChecked();
   });
 
-  it('renders no access state with waiver present', async function () {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/data-secrecy/`,
-      body: {
-        accessStart: '2022-08-29T01:05:00+00:00',
-        accessEnd: '2023-08-29T01:05:00+00:00',
-      },
-    });
-
-    render(<DataSecrecy />, {organization});
-
-    await waitFor(() => {
-      expect(screen.getByText('Support Access')).toBeInTheDocument();
-    });
-
-    organization.allowSuperuserAccess = false;
-
-    // we should see no access message
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          /sentry employees will not have access to your organization unless granted permission/i
-        )
-      ).toBeInTheDocument();
-    });
-  });
-
-  it('renders current waiver state', async function () {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/data-secrecy/`,
-      body: {
-        accessStart: '2023-08-29T01:05:00+00:00',
-        accessEnd: '2024-08-29T01:05:00+00:00',
-      },
-    });
-
-    organization.allowSuperuserAccess = false;
-    render(<DataSecrecy />, {organization});
-
-    await waitFor(() => {
-      const accessMessage = screen.getByText(
-        /Sentry employees has access to your organization until/i
-      );
-      expect(accessMessage).toBeInTheDocument();
-    });
-  });
-
-  it('can update permanent access', async function () {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/data-secrecy/`,
-      body: {
-        accessStart: '2023-08-29T01:05:00+00:00',
-        accessEnd: '2024-08-29T01:05:00+00:00',
-      },
-    });
-
+  it('can toggle access on', async function () {
     const mockUpdate = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
     });
 
-    organization.allowSuperuserAccess = false;
-    render(<DataSecrecy />, {organization});
+    const orgWithoutAccess = {
+      ...organization,
+      allowSuperuserAccess: false,
+    };
 
-    // Toggle permanent access on
-    const allowAccessToggle = screen.getByRole('checkbox', {
+    render(<DataSecrecy />, {organization: orgWithoutAccess});
+
+    const checkbox = screen.getByRole('checkbox', {
       name: /Sentry employees will not have access to your data unless granted permission/,
     });
-    allowAccessToggle.click();
+
+    await userEvent.click(checkbox);
 
     await waitFor(() => {
       expect(mockUpdate).toHaveBeenCalledWith(
@@ -136,5 +81,50 @@ describe('DataSecrecy', function () {
         })
       );
     });
+  });
+
+  it('can toggle access off', async function () {
+    const mockUpdate = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      method: 'PUT',
+    });
+
+    const orgWithAccess = {
+      ...organization,
+      allowSuperuserAccess: true,
+    };
+
+    render(<DataSecrecy />, {organization: orgWithAccess});
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /Sentry employees will not have access to your data unless granted permission/,
+    });
+
+    await userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/`,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {allowSuperuserAccess: false},
+        })
+      );
+    });
+  });
+
+  it('disables checkbox when user lacks org:write permission', function () {
+    const orgWithoutWriteAccess = {
+      ...organization,
+      allowSuperuserAccess: false,
+      access: [], // Remove 'org:write' permission
+    };
+
+    render(<DataSecrecy />, {organization: orgWithoutWriteAccess});
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /Sentry employees will not have access to your data unless granted permission/,
+    });
+    expect(checkbox).toBeDisabled();
   });
 });

--- a/static/app/views/settings/components/dataSecrecy/index.tsx
+++ b/static/app/views/settings/components/dataSecrecy/index.tsx
@@ -1,26 +1,16 @@
-import {useEffect, useState} from 'react';
-import moment from 'moment-timezone';
+import {useState} from 'react';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import BooleanField, {
   type BooleanFieldProps,
 } from 'sentry/components/forms/fields/booleanField';
-import DateTimeField, {
-  type DateTimeFieldProps,
-} from 'sentry/components/forms/fields/dateTimeField';
 import Panel from 'sentry/components/panels/panel';
 import PanelAlert from 'sentry/components/panels/panelAlert';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
-import {t, tct} from 'sentry/locale';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-
-type WaiverData = {
-  accessEnd: string | null;
-  accessStart: string | null;
-};
 
 export default function DataSecrecy() {
   const api = useApi();
@@ -29,29 +19,6 @@ export default function DataSecrecy() {
   // state for the allowSuperuserAccess bit field
   const [allowAccess, setAllowAccess] = useState(organization.allowSuperuserAccess);
 
-  // state of the data secrecy waiver
-  const [waiver, setWaiver] = useState<WaiverData>();
-
-  // state for the allowDateFormData field
-  const [allowDateFormData, setAllowDateFormData] = useState<string>('');
-
-  const {data, refetch} = useApiQuery<WaiverData>(
-    [`/organizations/${organization.slug}/data-secrecy/`],
-    {
-      staleTime: 3000,
-      retry: (failureCount, error) => failureCount < 3 && error.status !== 404,
-    }
-  );
-
-  useEffect(() => {
-    if (data?.accessEnd) {
-      setWaiver(data);
-      // slice it to yyyy-MM-ddThh:mm format (be aware of the timezone)
-      const localDate = moment(data.accessEnd).local();
-      setAllowDateFormData(localDate.format('YYYY-MM-DDTHH:mm'));
-    }
-  }, [data]);
-
   const updateAllowedAccess = async (value: boolean) => {
     try {
       await api.requestPromise(`/organizations/${organization.slug}/`, {
@@ -59,68 +26,14 @@ export default function DataSecrecy() {
         data: {allowSuperuserAccess: value},
       });
       setAllowAccess(value);
-
-      // if the user has allowed access, we need to remove the temporary access window
-      // only if there is an existing waiver
-      if (value && waiver) {
-        await api.requestPromise(`/organizations/${organization.slug}/data-secrecy/`, {
-          method: 'DELETE',
-        });
-        setAllowDateFormData('');
-        setWaiver(undefined);
-      }
       addSuccessMessage(
         value
-          ? waiver
-            ? t(
-                'Successfully removed temporary access window and allowed support access.'
-              )
-            : t('Successfully allowed support access.')
+          ? t('Successfully allowed support access.')
           : t('Successfully removed support access.')
       );
     } catch (error) {
       addErrorMessage(t('Unable to save changes.'));
     }
-
-    // refetch to get the latest waiver data
-    refetch();
-  };
-
-  const updateTempAccessDate = async () => {
-    if (!allowDateFormData) {
-      try {
-        await api.requestPromise(`/organizations/${organization.slug}/data-secrecy/`, {
-          method: 'DELETE',
-        });
-        setWaiver({accessStart: '', accessEnd: ''});
-        addSuccessMessage(t('Successfully removed temporary access window.'));
-      } catch (error) {
-        addErrorMessage(t('Unable to remove temporary access window.'));
-      }
-
-      return;
-    }
-
-    // maintain the standard format of storing the date in UTC
-    // even though the api should be able to handle the local time
-    const nextData: WaiverData = {
-      accessStart: moment().utc().toISOString(),
-      accessEnd: moment.tz(allowDateFormData, moment.tz.guess()).utc().toISOString(),
-    };
-
-    try {
-      await api.requestPromise(`/organizations/${organization.slug}/data-secrecy/`, {
-        method: 'PUT',
-        data: nextData,
-      });
-      setWaiver(nextData);
-      addSuccessMessage(t('Successfully updated temporary access window.'));
-    } catch (error) {
-      addErrorMessage(t('Unable to save changes.'));
-      setAllowDateFormData('');
-    }
-    // refetch to get the latest waiver data
-    refetch();
   };
 
   const allowAccessProps: BooleanFieldProps = {
@@ -137,64 +50,18 @@ export default function DataSecrecy() {
     onBlur: updateAllowedAccess,
   };
 
-  const allowTempAccessProps: DateTimeFieldProps = {
-    name: 'allowTemporarySuperuserAccess',
-    label: t('Allow temporary access to Sentry employees'),
-    help: t(
-      'Open a temporary time window for Sentry employees to access your organization'
-    ),
-    // disable the field if the user has allowed access or if the user does not have org:write access
-    disabled: allowAccess || !organization.access.includes('org:write'),
-    disabledReason: allowAccess
-      ? t('Disable permanent access first to set temporary access')
-      : organization.access.includes('org:write')
-        ? undefined
-        : t('You do not have permission to modify access settings'),
-    value: allowDateFormData,
-    onBlur: updateTempAccessDate,
-    onChange: (v: any) => {
-      // Don't allow the user to set the date if they have allowed access
-      if (allowAccess) {
-        return;
-      }
-      // the picker doesn't like having a datetime string with seconds+ and a timezone,
-      // so we remove it -- we will add it back when we save the date
-      const formattedDate = v ? moment(v).format('YYYY-MM-DDTHH:mm') : '';
-      setAllowDateFormData(formattedDate);
-    },
-  };
-
   return (
     <Panel>
       <PanelHeader>{t('Support Access')}</PanelHeader>
       <PanelBody>
-        {!allowAccess && (
-          <PanelAlert type="info">
-            {waiver?.accessEnd && moment().isBefore(moment(waiver.accessEnd))
-              ? tct(`Sentry employees has access to your organization until [date]`, {
-                  date: formatDateTime(waiver?.accessEnd),
-                })
-              : t('Sentry employees do not have access to your organization')}
-          </PanelAlert>
-        )}
+        <PanelAlert type="info">
+          {allowAccess
+            ? t('Sentry employees have access to your organization')
+            : t('Sentry employees do not have access to your organization')}
+        </PanelAlert>
 
         <BooleanField {...allowAccessProps} />
-        <DateTimeField {...allowTempAccessProps} />
       </PanelBody>
     </Panel>
   );
 }
-
-const formatDateTime = (dateString: string) => {
-  const date = new Date(dateString);
-  const options: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    hour12: true,
-    timeZoneName: 'short',
-  };
-  return new Intl.DateTimeFormat('en-US', options).format(date);
-};


### PR DESCRIPTION
Before we start building Data Secrecy V2, lets first remove the old models and logic. Currently there are no waivers being created so its safe to remove this logic.

After removing, the form looks like:


https://github.com/user-attachments/assets/70811637-7f50-4de6-919d-8d5295bf5e3d

contributes to ECO-824
