### PR TITLE
fix(relay): Add `connection.rtt` as a builtin measurement

### DIFF
--- a/src/sentry/relay/config/measurements.py
+++ b/src/sentry/relay/config/measurements.py
@@ -27,6 +27,7 @@ BUILTIN_MEASUREMENTS: Sequence[BuiltinMeasurementKey] = [
     {"name": "app_start_cold", "unit": "millisecond"},
     {"name": "app_start_warm", "unit": "millisecond"},
     {"name": "cls", "unit": "none"},
+    {"name": "connection.rtt", "unit": "millisecond"},
     {"name": "fcp", "unit": "millisecond"},
     {"name": "fid", "unit": "millisecond"},
     {"name": "fp", "unit": "millisecond"},


### PR DESCRIPTION
While investigating a customer support issue, I noticed that we don't list `connection.rtt` as a builtin measurement in the Relay measurement config. This is a "builtin" measurement, in the sense that the SDK sends it on the pageload transaction, whenever the browser emits the RTT information: https://github.com/getsentry/sentry-javascript/blob/006b7a6bd83176dd0296a4e2173a39fbdbf05af8/packages/browser-utils/src/metrics/browserMetrics.ts#L752-L754

I'm not at all sure if this fixes the customer issues of all measurements being dropped because of Relay handling the the "Too many measurements" case. But I think it makes sense to add this for completeness anyway.