### PR TITLE
chore: replace python.json with python-modern.json and clean up associated tests

### DIFF
--- a/src/sentry/data/samples/python.json
+++ b/src/sentry/data/samples/python.json
@@ -1,245 +1,155 @@
 {
+  "platform": "python",
   "tags": [
+    ["environment", "production"],
+    ["handled", "no"],
     ["level", "error"],
-    ["server_name", "web01.example.org"],
-    ["environment", "prod"]
+    ["mechanism", "excepthook"],
+    ["runtime", "CPython 3.13.5"],
+    ["runtime.name", "CPython"],
+    ["server_name", "web01.example.org"]
   ],
-  "stacktrace": {
-    "frames": [
+  "breadcrumbs": {
+    "values": [
       {
-        "function": "build_msg",
-        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
-        "pre_context": [
-          "                frames = stack",
-          "",
-          "            data.update({",
-          "                'sentry.interfaces.Stacktrace': {",
-          "                    'frames': get_stack_info(frames,"
-        ],
-        "vars": {
-          "'event_id'": "'54a322436e1b47b88e239b78998ae742'",
-          "'culprit'": null,
-          "'event_type'": "'raven.events.Message'",
-          "'date'": "datetime.datetime(2013, 8, 13, 3, 8, 24, 880386)",
-          "'extra'": {
-            "'loadavg'": [0.37255859375, 0.5341796875, 0.62939453125],
-            "'user'": "'dcramer'",
-            "'go_deeper'": [
-              [
-                {
-                  "'foo'": "'bar'",
-                  "'bar'": ["'baz'"]
-                }
-              ]
-            ]
-          },
-          "'v'": {
-            "'message'": "u'This is a test message generated using ``raven test``'",
-            "'params'": []
-          },
-          "'kwargs'": {
-            "'message'": "'This is a test message generated using ``raven test``'",
-            "'level'": 20
-          },
-          "'stack'": true,
-          "'frames'": "<generator object iter_stack_frames at 0x107bcc3c0>",
-          "'tags'": null,
-          "'time_spent'": null,
-          "'self'": "<raven.base.Client object at 0x107bb8210>",
-          "'data'": {
-            "'sentry.interfaces.Message'": {
-              "'message'": "u'This is a test message generated using ``raven test``'",
-              "'params'": []
-            },
-            "'message'": "u'This is a test message generated using ``raven test``'"
-          },
-          "'result'": {
-            "'sentry.interfaces.Message'": {
-              "'message'": "u'This is a test message generated using ``raven test``'",
-              "'params'": []
-            },
-            "'message'": "u'This is a test message generated using ``raven test``'"
-          },
-          "'handler'": "<raven.events.Message object at 0x107bd0890>",
-          "'k'": "'sentry.interfaces.Message'",
-          "'public_key'": null
-        },
-        "module": "raven.base",
-        "filename": "raven/base.py",
-        "post_context": [
-          "                },",
-          "            })",
-          "",
-          "        if 'sentry.interfaces.Stacktrace' in data:",
-          "            if self.include_paths:"
-        ],
-        "colno": null,
-        "in_app": false,
-        "data": {},
-        "context_line": "                        transformer=self.transform)",
-        "lineno": 303
-      },
-      {
-        "function": "capture",
-        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
-        "pre_context": [
-          "        if not self.is_enabled():",
-          "            return",
-          "",
-          "        data = self.build_msg(",
-          "            event_type, data, date, time_spent, extra, stack, tags=tags,"
-        ],
-        "vars": {
-          "'event_type'": "'raven.events.Message'",
-          "'date'": null,
-          "'extra'": {
-            "'loadavg'": [0.37255859375, 0.5341796875, 0.62939453125],
-            "'user'": "'dcramer'",
-            "'go_deeper'": [
-              [
-                {
-                  "'foo'": "'bar'",
-                  "'bar'": ["'baz'"]
-                }
-              ]
-            ]
-          },
-          "'stack'": true,
-          "'tags'": null,
-          "'time_spent'": null,
-          "'self'": "<raven.base.Client object at 0x107bb8210>",
-          "'data'": null,
-          "'kwargs'": {
-            "'message'": "'This is a test message generated using ``raven test``'",
-            "'level'": 20
-          }
-        },
-        "module": "raven.base",
-        "filename": "raven/base.py",
-        "post_context": [
-          "",
-          "        self.send(**data)",
-          "",
-          "        return (data.get('event_id'),)",
-          ""
-        ],
-        "colno": null,
-        "in_app": false,
-        "data": {},
-        "context_line": "            **kwargs)",
-        "lineno": 459
-      },
-      {
-        "function": "captureMessage",
-        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py",
-        "pre_context": [
-          "        \"\"\"",
-          "        Creates an event from ``message``.",
-          "",
-          "        >>> client.captureMessage('My event just happened!')",
-          "        \"\"\""
-        ],
-        "vars": {
-          "'message'": "'This is a test message generated using ``raven test``'",
-          "'kwargs'": {
-            "'extra'": {
-              "'loadavg'": [0.37255859375, 0.5341796875, 0.62939453125],
-              "'user'": "'dcramer'",
-              "'go_deeper'": [
-                [
-                  {
-                    "'foo'": "'bar'",
-                    "'bar'": ["'baz'"]
-                  }
-                ]
-              ]
-            },
-            "'stack'": true,
-            "'data'": null,
-            "'level'": 20,
-            "'tags'": null
-          },
-          "'self'": "<raven.base.Client object at 0x107bb8210>"
-        },
-        "module": "raven.base",
-        "filename": "raven/base.py",
-        "post_context": [
-          "",
-          "    def captureException(self, exc_info=None, **kwargs):",
-          "        \"\"\"",
-          "        Creates an event from an exception.",
-          ""
-        ],
-        "colno": null,
-        "in_app": false,
-        "data": {},
-        "context_line": "        return self.capture('raven.events.Message', message=message, **kwargs)",
-        "lineno": 577
-      },
-      {
-        "function": "send_test_message",
-        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/scripts/runner.py",
-        "pre_context": [
-          "        level=logging.INFO,",
-          "        stack=True,",
-          "        tags=options.get('tags', {}),",
-          "        extra={",
-          "            'user': get_uid(),"
-        ],
-        "vars": {
-          "'client'": "<raven.base.Client object at 0x107bb8210>",
-          "'options'": {
-            "'tags'": null,
-            "'data'": null
-          },
-          "'data'": null,
-          "'k'": "'secret_key'"
-        },
-        "module": "raven.scripts.runner",
-        "filename": "raven/scripts/runner.py",
-        "post_context": [
-          "        },",
-          "    ))",
-          "",
-          "    if client.state.did_fail():",
-          "        print('error!')"
-        ],
-        "colno": null,
-        "in_app": false,
-        "data": {},
-        "context_line": "            'loadavg': get_loadavg(),",
-        "lineno": 77
-      },
-      {
-        "function": "main",
-        "abs_path": "/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/scripts/runner.py",
-        "pre_context": [
-          "    print(\"Using DSN configuration:\")",
-          "    print(\" \", dsn)",
-          "    print()",
-          "",
-          "    client = Client(dsn, include_paths=['raven'])"
-        ],
-        "vars": {
-          "'root'": "<logging.Logger object at 0x107ba5b10>",
-          "'parser'": "<optparse.OptionParser instance at 0x107ba3368>",
-          "'dsn'": "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'",
-          "'opts'": "<Values at 0x107ba3b00: {'data': None, 'tags': None}>",
-          "'client'": "<raven.base.Client object at 0x107bb8210>",
-          "'args'": [
-            "'test'",
-            "'https://ebc35f33e151401f9deac549978bda11:f3403f81e12e4c24942d505f086b2cad@sentry.io/1'"
-          ]
-        },
-        "module": "raven.scripts.runner",
-        "filename": "raven/scripts/runner.py",
-        "post_context": [],
-        "colno": null,
-        "in_app": false,
-        "data": {},
-        "context_line": "    send_test_message(client, opts.__dict__)",
-        "lineno": 112
+        "timestamp": 1751006912.86641,
+        "type": "default",
+        "category": "test",
+        "level": "info",
+        "message": "This is an example breadcrumb"
       }
     ]
-  }
+  },
+  "contexts": {
+    "runtime": {
+      "runtime": "CPython 3.13.5",
+      "name": "CPython",
+      "version": "3.13.5",
+      "build": "3.13.5 (main, Jun 11 2025, 15:36:57) [Clang 17.0.0 (clang-1700.0.13.3)]",
+      "type": "runtime"
+    }
+  },
+  "culprit": "__main__ in main",
+  "environment": "production",
+  "exception": {
+    "values": [
+      {
+        "type": "Exception",
+        "value": "This is an example Python exception",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "\u003Cmodule\u003E",
+              "module": "__main__",
+              "filename": "main.py",
+              "abs_path": "/Users/user/test/main.py",
+              "lineno": 28,
+              "pre_context": [
+                "        'key3': 'value3',",
+                "    }",
+                "    list_var = [1, 2, 3]",
+                "    raise Exception('This is an example Python exception')",
+                ""
+              ],
+              "context_line": "main()",
+              "in_app": true,
+              "vars": {
+                "__annotations__": {},
+                "__builtins__": "\u003Cmodule 'builtins' (built-in)\u003E",
+                "__cached__": "None",
+                "__doc__": "None",
+                "__file__": "'/Users/user/test/main.py'",
+                "__loader__": "\u003C_frozen_importlib_external.SourceFileLoader object at 0x1029bcf70\u003E",
+                "__name__": "'__main__'",
+                "__package__": "None",
+                "__spec__": "None",
+                "sentry_sdk": "\u003Cmodule 'sentry_sdk' from '/Users/user/test/.venv/lib/python3.13/site-packages/sentry_sdk/__init__.py'\u003E"
+              },
+              "data": {
+                "client_in_app": true
+              }
+            },
+            {
+              "function": "main",
+              "module": "__main__",
+              "filename": "main.py",
+              "abs_path": "/Users/user/test/main.py",
+              "lineno": 26,
+              "pre_context": [
+                "        'key1': 'value1',",
+                "        'key2': 'value2',",
+                "        'key3': 'value3',",
+                "    }",
+                "    list_var = [1, 2, 3]"
+              ],
+              "context_line": "    raise Exception('This is an example Python exception')",
+              "post_context": ["", "main()"],
+              "in_app": true,
+              "vars": {
+                "dict_var": {
+                  "key1": "'value1'",
+                  "key2": "'value2'",
+                  "key3": "'value3'"
+                },
+                "int_var": "1",
+                "list_var": ["1", "2", "3"],
+                "str_var": "'Hello, world!'"
+              },
+              "data": {
+                "client_in_app": true
+              }
+            }
+          ]
+        },
+        "mechanism": {
+          "type": "excepthook",
+          "handled": false
+        }
+      }
+    ]
+  },
+  "extra": {
+    "sys.argv": ["/Users/user/test/main.py"]
+  },
+  "key_id": "4616216",
+  "level": "error",
+  "logger": "",
+  "metadata": {
+    "filename": "main.py",
+    "function": "main",
+    "in_app_frame_mix": "in-app-only",
+    "type": "Exception",
+    "value": "This is an example Python exception"
+  },
+  "modules": {
+    "certifi": "2025.6.15",
+    "pip": "25.1.1",
+    "sentry-sdk": "2.31.0",
+    "urllib3": "2.5.0"
+  },
+  "received": 1751006913.10689,
+  "sdk": {
+    "name": "sentry.python",
+    "version": "2.31.0",
+    "integrations": [
+      "argv",
+      "atexit",
+      "dedupe",
+      "excepthook",
+      "logging",
+      "modules",
+      "stdlib",
+      "threading"
+    ],
+    "packages": [
+      {
+        "name": "pypi:sentry-sdk",
+        "version": "2.31.0"
+      }
+    ]
+  },
+  "timestamp": 1751006912.86742,
+  "transaction_info": {},
+  "type": "error",
+  "version": "7"
 }


### PR DESCRIPTION
- https://github.com/getsentry/sentry/pull/94512 added a new example event because tests were failing for the modern version. This PR aims to clean up the associated tests and fully replace the old version, as we should not be relying on specific event properties.