### PR TITLE
fix(agent-insights): format zero cost as dash

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/llmCosts.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmCosts.tsx
@@ -1,7 +1,7 @@
 import {formatLLMCosts} from 'sentry/views/insights/agentMonitoring/utils/formatLLMCosts';
 
 interface LLMCostsProps {
-  cost: number | string;
+  cost: number | string | null;
   className?: string;
 }
 
@@ -15,7 +15,7 @@ export function LLMCosts({cost, className}: LLMCostsProps) {
         maximumFractionDigits: 8,
       })}
     >
-      {formatLLMCosts(cost)}
+      {cost ? formatLLMCosts(cost) : '-'}
     </span>
   );
 }

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -44,7 +44,7 @@ interface TableData {
   llmCalls: number;
   timestamp: number;
   toolCalls: number;
-  totalCost: number;
+  totalCost: number | null;
   totalTokens: number;
   traceId: string;
   transaction: string;
@@ -164,7 +164,7 @@ export function TracesTable() {
       llmCalls: spanDataMap[span.trace]?.llmCalls ?? 0,
       toolCalls: spanDataMap[span.trace]?.toolCalls ?? 0,
       totalTokens: spanDataMap[span.trace]?.totalTokens ?? 0,
-      totalCost: spanDataMap[span.trace]?.totalCost ?? 0,
+      totalCost: spanDataMap[span.trace]?.totalCost ?? null,
       timestamp: span.start,
       isSpanDataLoading: spansRequest.isLoading,
     }));


### PR DESCRIPTION
closes [TET-870: Cost shown as <0.01 when it is not present](https://linear.app/getsentry/issue/TET-870/cost-shown-as-001-when-it-is-not-present)