### PR TITLE
Opacity Removed from Crons & Monitor Visualisations

### DIFF
--- a/static/app/components/checkInTimeline/checkInTimeline.tsx
+++ b/static/app/components/checkInTimeline/checkInTimeline.tsx
@@ -161,7 +161,6 @@ const JobTick = styled('div')<{
   position: absolute;
   width: 4px;
   height: 14px;
-  opacity: 0.7;
 
   ${p =>
     p.roundedLeft &&

--- a/static/app/components/checkInTimeline/utils/getTickStyle.tsx
+++ b/static/app/components/checkInTimeline/utils/getTickStyle.tsx
@@ -18,7 +18,6 @@ export function getTickStyle<Status extends string>(
   return css`
     border: 1px solid ${style.tickColor};
     background-size: 3px 3px;
-    opacity: 0.5;
     background-image:
       linear-gradient(
         -45deg,


### PR DESCRIPTION
### Light Before
<img width="2880" height="1801" alt="CleanShot 2025-07-11 at 12 12 58@2x" src="https://github.com/user-attachments/assets/fd293f24-94b5-4464-bcdd-9c6faa9135aa" />
### Light After
<img width="2880" height="1801" alt="CleanShot 2025-07-11 at 12 13 15@2x" src="https://github.com/user-attachments/assets/a1cdfe35-1c43-4d32-8e53-45a4abc8f4c0" />
### Dark Before
<img width="2880" height="1801" alt="CleanShot 2025-07-11 at 12 12 11@2x" src="https://github.com/user-attachments/assets/0557f7c2-3624-484e-b866-bca022ee8be6" />
### Dark After
<img width="2880" height="1801" alt="CleanShot 2025-07-11 at 12 12 30@2x" src="https://github.com/user-attachments/assets/72f8e9ea-0c3f-4547-879d-ec6c6ec653b4" />
