### PR TITLE
fix(ui): cleanup IntersectionObserver and overflowing tabs when theme changes

### DIFF
--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -1,5 +1,5 @@
 import {useContext, useEffect, useMemo, useRef, useState} from 'react';
-import {css} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {AriaTabListOptions} from '@react-aria/tabs';
 import {useTabList} from '@react-aria/tabs';
@@ -45,6 +45,7 @@ function useOverflowTabs({
   tabListRef: React.RefObject<HTMLUListElement | null>;
 }) {
   const [overflowTabs, setOverflowTabs] = useState<Array<string | number>>([]);
+  const theme = useTheme();
 
   useEffect(() => {
     if (disabled) {
@@ -82,8 +83,11 @@ function useOverflowTabs({
       element => element && observer.observe(element)
     );
 
-    return () => observer.disconnect();
-  }, [tabListRef, tabItemsRef, disabled]);
+    return () => {
+      observer.disconnect();
+      setOverflowTabs([]);
+    };
+  }, [tabListRef, tabItemsRef, disabled, theme]);
 
   const tabItemKeyToHiddenMap = tabItems.reduce<Record<string | number, boolean>>(
     (acc, next) => ({


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/ae7eedf8-9582-42e8-b3db-80be4d4cff2f


after:

https://github.com/user-attachments/assets/1bcd5c89-f977-4042-ba4f-028798db6462

