### PR TITLE
fix(deletions): Try next available group and abort if none found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -464,6 +464,7 @@ module = [
     "tests.sentry.api.endpoints.test_project_repo_path_parsing",
     "tests.sentry.api.helpers.test_error_upsampling",
     "tests.sentry.audit_log.services.*",
+    "tests.sentry.deletions.tasks.test_groups",
     "tests.sentry.deletions.test_group",
     "tests.sentry.event_manager.test_event_manager",
     "tests.sentry.grouping.seer_similarity.test_get_seer_similar_issues",

--- a/src/sentry/deletions/tasks/groups.py
+++ b/src/sentry/deletions/tasks/groups.py
@@ -39,7 +39,11 @@ def delete_groups(
     from sentry import deletions, eventstream
     from sentry.models.group import Group
 
-    first_group = Group.objects.get(id=object_ids[0])
+    # We have encountered cases where the first group is already gone
+    first_group = Group.objects.filter(id__in=object_ids).first()
+    if not first_group:
+        raise DeleteAborted("delete_groups.no_group_found")
+
     # The tags can be used if we want to find errors for when a task fails
     sentry_sdk.set_tags(
         {

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -1,8 +1,11 @@
 from uuid import uuid4
 
+import pytest
+
 from sentry import nodestore
 from sentry.deletions.tasks.groups import delete_groups
 from sentry.eventstore.models import Event
+from sentry.exceptions import DeleteAborted
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.grouphash import GroupHash
@@ -17,7 +20,7 @@ pytestmark = [requires_snuba]
 
 
 class DeleteGroupTest(TestCase):
-    def test_simple(self):
+    def test_simple(self) -> None:
         event_id = "a" * 32
         event_id_2 = "b" * 32
         project = self.create_project()
@@ -65,3 +68,22 @@ class DeleteGroupTest(TestCase):
         assert not Group.objects.filter(id=group.id).exists()
         assert not nodestore.backend.get(node_id)
         assert not nodestore.backend.get(node_id_2)
+
+    def test_first_group_not_found(self) -> None:
+        group = self.create_group()
+        group2 = self.create_group()
+        group_ids = [group.id, group2.id]
+
+        with self.tasks():
+            group.delete()
+            delete_groups(object_ids=group_ids)
+
+        assert not Group.objects.all() == []
+
+    def test_no_first_group_found(self) -> None:
+        group = self.create_group()
+        group_ids = [group.id]
+
+        with self.tasks(), pytest.raises(DeleteAborted):
+            group.delete()
+            delete_groups(object_ids=group_ids)

--- a/tests/sentry/deletions/tasks/test_groups.py
+++ b/tests/sentry/deletions/tasks/test_groups.py
@@ -73,17 +73,17 @@ class DeleteGroupTest(TestCase):
         group = self.create_group()
         group2 = self.create_group()
         group_ids = [group.id, group2.id]
+        group.delete()
 
         with self.tasks():
-            group.delete()
             delete_groups(object_ids=group_ids)
 
-        assert not Group.objects.all() == []
+        assert Group.objects.count() == 0
 
     def test_no_first_group_found(self) -> None:
         group = self.create_group()
         group_ids = [group.id]
+        group.delete()
 
         with self.tasks(), pytest.raises(DeleteAborted):
-            group.delete()
             delete_groups(object_ids=group_ids)


### PR DESCRIPTION
Fixes [SENTRY-45X2](https://sentry.sentry.io/issues/6731915490/)
Fixes [SENTRY-43KR](https://sentry.sentry.io/issues/6710200116/)