### PR TITLE
fix(eap): Move timestamp to common eap column

### DIFF
--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -1,5 +1,5 @@
 from sentry.search.eap import constants
-from sentry.search.eap.columns import ResolvedAttribute
+from sentry.search.eap.columns import ResolvedAttribute, datetime_processor
 
 COMMON_COLUMNS = [
     ResolvedAttribute(
@@ -29,5 +29,12 @@ COMMON_COLUMNS = [
         search_type="integer",
         internal_name="sentry.organization_id",
         private=True,
+    ),
+    ResolvedAttribute(
+        public_alias="timestamp",
+        internal_name="sentry.timestamp",
+        internal_type=constants.DOUBLE,
+        search_type="string",
+        processor=datetime_processor,
     ),
 ]

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -4,7 +4,6 @@ from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     ResolvedAttribute,
     VirtualColumnDefinition,
-    datetime_processor,
     project_context_constructor,
     project_term_resolver,
     simple_sentry_field,
@@ -36,12 +35,6 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id_or_list,
-        ),
-        ResolvedAttribute(
-            public_alias="timestamp",
-            internal_name="sentry.timestamp",
-            search_type="string",
-            processor=datetime_processor,
         ),
         simple_sentry_field("browser.name"),
         simple_sentry_field("browser.version"),

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -10,7 +10,6 @@ from sentry.search.eap import constants
 from sentry.search.eap.columns import (
     ResolvedAttribute,
     VirtualColumnDefinition,
-    datetime_processor,
     project_context_constructor,
     project_term_resolver,
     simple_measurements_field,
@@ -235,13 +234,6 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="sampling_rate",
             internal_name="sentry.sampling_factor",
             search_type="percentage",
-        ),
-        ResolvedAttribute(
-            public_alias="timestamp",
-            internal_name="sentry.timestamp",
-            internal_type=constants.DOUBLE,
-            search_type="string",
-            processor=datetime_processor,
         ),
         ResolvedAttribute(
             public_alias="cache.hit",


### PR DESCRIPTION
Timestamp gets special treatment and should be the same across eap datasets. This moves it into the common columns so the behaviour is shared.

Fixes LOGS-210