### PR TITLE
feat(taskworker): Compress send_resource_change_webhook task parameters

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -46,6 +46,7 @@ from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError,
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.config import TaskworkerConfig
+from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.namespaces import sentryapp_control_tasks, sentryapp_tasks
 from sentry.taskworker.retry import Retry, retry_task
 from sentry.types.rules import RuleFuture
@@ -654,6 +655,7 @@ def get_webhook_data(
             times=3,
             delay=60 * 5,
         ),
+        compression_type=CompressionType.ZSTD,
     ),
     **TASK_OPTIONS,
 )

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -207,6 +207,7 @@ def instrumented_task(
                 processing_deadline_duration=taskworker_config.processing_deadline_duration,
                 at_most_once=taskworker_config.at_most_once,
                 wait_for_delivery=taskworker_config.wait_for_delivery,
+                compression_type=taskworker_config.compression_type,
             )(func)
 
             task = override_task(task, taskworker_task, taskworker_config, name)

--- a/src/sentry/taskworker/config.py
+++ b/src/sentry/taskworker/config.py
@@ -1,5 +1,6 @@
 import datetime
 
+from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.registry import TaskNamespace
 from sentry.taskworker.retry import Retry
 
@@ -18,6 +19,7 @@ class TaskworkerConfig:
         processing_deadline_duration: int | datetime.timedelta | None = None,
         at_most_once: bool = False,
         wait_for_delivery: bool = False,
+        compression_type: CompressionType = CompressionType.PLAINTEXT,
     ):
         self.namespace = namespace
         self.retry = retry
@@ -25,3 +27,4 @@ class TaskworkerConfig:
         self.processing_deadline_duration = processing_deadline_duration
         self.at_most_once = at_most_once
         self.wait_for_delivery = wait_for_delivery
+        self.compression_type = compression_type


### PR DESCRIPTION
In our US region, the `send_resource_change_webhook` is sending large task payloads to kafka. As we observed, this has negative effects on the taskbroker system. Now that taskworker supports compression, this PR is responsible for compressing the task parameters of this task before producing to kafka.

Rollout:
When this PR is merged and deployed, it should be a no-op to start. Since compression is gated behind a sentry option, the only difference is that we should see more options checks in postgres. When ready, we can incrementally sample tasks to be compressed in smaller environments first before reaching US region.