### PR TITLE
chore(explore): Remove equations from save as toolbar

### DIFF
--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -60,7 +60,10 @@ export function ToolbarSaveAs() {
   const mode = useExploreMode();
   const id = useExploreId();
   const visualizeYAxes = useMemo(
-    () => dedupeArray(visualizes.map(v => v.yAxis)),
+    () =>
+      dedupeArray(
+        visualizes.filter(visualize => !visualize.isEquation).map(v => v.yAxis)
+      ),
     [visualizes]
   );
 


### PR DESCRIPTION
Equations only work in explore right now. In the future, it will work with dashboards but for now, hide it from the save as toolbar.