### PR TITLE
:wrench: chore: handle more types of plugin related api errors

### DIFF
--- a/src/sentry_plugins/amazon_sqs/plugin.py
+++ b/src/sentry_plugins/amazon_sqs/plugin.py
@@ -191,7 +191,9 @@ class AmazonSQSPlugin(CorePluginMixin, DataForwardingPlugin):
                 return False
             elif str(e).endswith("must contain the parameter MessageGroupId."):
                 return False
-            elif str(e).startswith("An error occurred (NoSuchBucket)"):
+            elif str(e).startswith("An error occurred (NoSuchBucket)") or str(e).startswith(
+                "An error occurred (IllegalLocationConstraintException)"
+            ):
                 # If there's an issue with the user's s3 bucket then we can't do
                 # anything to recover. Just continue.
                 return False

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -222,7 +222,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 # These two are already handled by the API client, Just log and return.
                 isinstance(exc, (ApiHostError, ApiTimeoutError))
                 # Most 4xxs are not errors or actionable for us do not re-raise.
-                or (exc.code is not None and (401 <= exc.code <= 405))
+                or (exc.code is not None and (401 <= exc.code <= 405) or exc.code in (502, 504))
             ):
                 return False
             raise

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -222,12 +222,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 # These two are already handled by the API client, Just log and return.
                 isinstance(exc, (ApiHostError, ApiTimeoutError))
                 # Most 4xxs are not errors or actionable for us do not re-raise.
-                or (exc.code is not None and (401 <= exc.code <= 404))
-                # 502s are too noisy.
-                or exc.code == 502
-                or exc.code == 405
-                # Method not allowed for the url
-                # This is caused by webhook being misconfigured, something we can't fix.
+                or (exc.code is not None and (401 <= exc.code <= 405))
             ):
                 return False
             raise


### PR DESCRIPTION
SENTRY-3YC4 and  SENTRY-3Y8W regressed after my last fix because of more types of client errors, so capturing them.