### PR TITLE
fix(taskworker) Add a short backoff when fetching tasks

### DIFF
--- a/src/sentry/taskworker/worker.py
+++ b/src/sentry/taskworker/worker.py
@@ -165,6 +165,8 @@ class TaskWorker:
                 "taskworker.worker.add_tasks.child_tasks_full",
                 tags={"processing_pool": self._processing_pool_name},
             )
+            # If we weren't able to add a task, backoff for a bit
+            time.sleep(0.1)
             return False
 
         inflight = self.fetch_task()

--- a/tests/sentry/taskworker/test_worker.py
+++ b/tests/sentry/taskworker/test_worker.py
@@ -357,7 +357,7 @@ class TestTaskWorker(TestCase):
                     break
                 if time.time() - start > max_runtime:
                     taskworker.shutdown()
-                    raise AssertionError("Timeout waiting for get_task to be called")
+                    raise AssertionError("Timeout waiting for update_task to be called")
 
             taskworker.shutdown()
             assert mock_client.get_task.called
@@ -370,7 +370,6 @@ class TestTaskWorker(TestCase):
             assert (
                 mock_client.update_task.call_args.args[0].status == TASK_ACTIVATION_STATUS_COMPLETE
             )
-            assert mock_client.update_task.call_args.args[1] is None
 
             redis = redis_clusters.get("default")
             assert current_task() is None, "should clear current task on completion"


### PR DESCRIPTION
Workers spin here quite a bit, and a short backoff might help reduce contention on child_tasks.
