### PR TITLE
chore(ui): Increase contrast on issues chart

### DIFF
--- a/static/app/views/issueDetails/streamline/eventGraph.tsx
+++ b/static/app/views/issueDetails/streamline/eventGraph.tsx
@@ -377,7 +377,7 @@ export function EventGraph({
         itemStyle: {
           borderRadius: [2, 2, 0, 0],
           borderColor: theme.translucentGray200,
-          color: theme.purple200,
+          color: isUnfilteredStatsEnabled ? theme.purple300 : translucentGray300,
         },
         data: userSeries,
         animation: false,
@@ -403,7 +403,7 @@ export function EventGraph({
         itemStyle: {
           borderRadius: [2, 2, 0, 0],
           borderColor: theme.translucentGray200,
-          color: isUnfilteredStatsEnabled ? theme.purple200 : translucentGray300,
+          color: isUnfilteredStatsEnabled ? theme.purple300 : translucentGray300,
         },
         data: eventSeries,
         animation: false,


### PR DESCRIPTION
Before:
<img width="1006" height="112" alt="image" src="https://github.com/user-attachments/assets/5af095d1-6811-4877-91b3-d9e7bcffe320" />

After:
<img width="535" height="122" alt="image" src="https://github.com/user-attachments/assets/034e525f-ac38-435c-bf6c-7812ff611126" />


Before UI2:
<img width="802" height="108" alt="image" src="https://github.com/user-attachments/assets/47709268-9170-41d7-904e-6e33027d03ce" />

After UI2:
<img width="482" height="108" alt="image" src="https://github.com/user-attachments/assets/75be04fa-701a-44c7-8aa2-35f69bc0f026" />
