### PR TITLE
chore(stories): add codeowners for /stories infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -675,4 +675,5 @@ tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py     @ge
 /static/app/utils/theme/                              @getsentry/design-engineering
 /static/app/components/core/                          @getsentry/design-engineering
 /static/app/icons/                                    @getsentry/design-engineering
+/static/app/stories/                                  @getsentry/design-engineering
 ## End of Frontend Platform


### PR DESCRIPTION
The @getsentry/design-engineering team is now maintaining the infrastructure of our `/stories` tool, which was previously a collective frontend responsibility. Updating `CODEOWNERS` to reflect this!

Considered adding `/static/app/**/*.mdx` as well, but product teams will still own component stories relevant to their areas and Design Engineering already owns `/components/core/`.