### PR TITLE
fix(detectors): TypeError

### DIFF
--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -91,6 +91,9 @@ class SQLInjectionDetector(PerformanceDetector):
             request_data.extend(self.request_body.items())
 
         for query_pair in request_data:
+            # Skip None values or pairs that don't have at least 2 elements
+            if not query_pair or len(query_pair) < 2:
+                continue
             query_value = query_pair[1]
             query_key = query_pair[0]
 


### PR DESCRIPTION
Fixes `TypeError: 'NoneType' object is not subscriptable` in `SQLInjectionDetector`.

This error occurred when `extract_request_data` encountered `None` or malformed entries in the request query parameters or body, leading to a crash when attempting to access `query_pair[1]`.

The fix adds a defensive check to skip `None` or insufficiently sized `query_pair` entries, making the detector more robust against unexpected input data.

[SENTRY-FOR-SENTRY-5ZQH](https://sentry.my.sentry.io/organizations/sentry/issues/2313274/)