### PR TITLE
fix(detectors): Another potential TypeError

### DIFF
--- a/src/sentry/performance_issues/detectors/sql_injection_detector.py
+++ b/src/sentry/performance_issues/detectors/sql_injection_detector.py
@@ -92,7 +92,7 @@ class SQLInjectionDetector(PerformanceDetector):
 
         for query_pair in request_data:
             # Skip None values or pairs that don't have at least 2 elements
-            if not query_pair or len(query_pair) < 2:
+            if not query_pair or not isinstance(query_pair, Sequence) or len(query_pair) < 2:
                 continue
             query_value = query_pair[1]
             query_key = query_pair[0]


### PR DESCRIPTION
The defensive check `len(query_pair)` can raise a `TypeError` if `query_pair` is a truthy non-sequence type (e.g., integers, booleans). This occurs with malformed input data, causing a crash by replacing a potential "not subscriptable" error with a "has no len()" error. The fix, intended to prevent one `TypeError`, introduces another.

Reported [here](https://github.com/getsentry/sentry/pull/95356#pullrequestreview-3011391773).