### PR TITLE
feat: add term parameter to useInfiniteTestResults hook

### DIFF
--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -68,6 +68,8 @@ export function useInfiniteTestResults() {
   const sortBy = searchParams.get('sort') || '-commitsFailed';
   const signedSortBy = sortValueToSortKey(sortBy);
 
+  const term = searchParams.get('term');
+
   const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
   let mappedFilterBy = null;
   if (filterBy in SUMMARY_TO_TA_TABLE_FILTER_KEY) {
@@ -82,7 +84,7 @@ export function useInfiniteTestResults() {
   >({
     queryKey: [
       `/organizations/${organization.slug}/prevent/owner/${integratedOrg}/repository/${repository}/test-results/`,
-      {query: {branch, codecovPeriod, signedSortBy, mappedFilterBy}},
+      {query: {branch, codecovPeriod, signedSortBy, mappedFilterBy, term}},
     ],
     queryFn: async ({
       queryKey: [url],
@@ -102,6 +104,7 @@ export function useInfiniteTestResults() {
               sortBy: signedSortBy,
               branch,
               ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
+              ...(term ? {term} : {}),
             },
           },
         ],

--- a/static/app/views/codecov/tests/queries/useGetTestResults.ts
+++ b/static/app/views/codecov/tests/queries/useGetTestResults.ts
@@ -68,7 +68,7 @@ export function useInfiniteTestResults() {
   const sortBy = searchParams.get('sort') || '-commitsFailed';
   const signedSortBy = sortValueToSortKey(sortBy);
 
-  const term = searchParams.get('term');
+  const term = searchParams.get('term') || '';
 
   const filterBy = searchParams.get('filterBy') as SummaryFilterKey;
   let mappedFilterBy = null;
@@ -103,8 +103,8 @@ export function useInfiniteTestResults() {
                 ],
               sortBy: signedSortBy,
               branch,
+              term,
               ...(mappedFilterBy ? {filterBy: mappedFilterBy} : {}),
-              ...(term ? {term} : {}),
             },
           },
         ],


### PR DESCRIPTION
Add search term to `useInfiniteTestResults` hook.

https://github.com/user-attachments/assets/e1416769-d09a-4808-b900-4f6fa0aafc2b

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
