### PR TITLE
Add permissions to the Codecov API endpoints

### DIFF
--- a/src/sentry/codecov/base.py
+++ b/src/sentry/codecov/base.py
@@ -2,17 +2,34 @@ from __future__ import annotations
 
 from rest_framework.request import Request
 
-from sentry.api.base import Endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
 
 
-class CodecovEndpoint(Endpoint):
+class CodecovEndpoint(OrganizationEndpoint):
     """
-    Used for endpoints that are specific to Codecov / Prevent.
+    Used for endpoints that are specific to Codecov / Prevent. These endpoints are region-scoped.
     """
-
-    permission_classes = ()
 
     def convert_args(self, request: Request, *args, **kwargs):
+        # Check and validate the organization
         parsed_args, parsed_kwargs = super().convert_args(request, *args, **kwargs)
-        # TODO: in case we need to modify args, do it here
+
+        owner = parsed_kwargs.get("owner")
+        organization = parsed_kwargs.get("organization")
+
+        if owner and organization:
+            integration = integration_service.get_integration(
+                provider=IntegrationProviderSlug.GITHUB,
+                external_id=owner,
+                organization_id=organization.id,
+            )
+            if not integration:
+                raise ResourceDoesNotExist
+
+        # Note: Currently we will allow all users to access all the repos of the org.
+        # We might want to add a permission check for the repos that the user have acces to in the future.
+
         return (parsed_args, parsed_kwargs)

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -56,9 +56,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(
-        self, request: Request, organization_id_or_slug: str, owner: str, repository: str, **kwargs
-    ) -> Response:
+    def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
         """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
 
         sort_by = request.query_params.get(

--- a/src/sentry/codecov/endpoints/TestResults/test_results.py
+++ b/src/sentry/codecov/endpoints/TestResults/test_results.py
@@ -18,6 +18,7 @@ from sentry.codecov.enums import (
     OrderingDirection,
     OrderingParameter,
 )
+from sentry.integrations.services.integration.model import RpcIntegration
 
 
 @extend_schema(tags=["Prevent"])
@@ -56,8 +57,10 @@ class TestResultsEndpoint(CodecovEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
+    def get(self, request: Request, owner: RpcIntegration, repository: str, **kwargs) -> Response:
         """Retrieves the list of test results for a given repository and owner. Also accepts a number of query parameters to filter the results."""
+
+        owner_slug = owner.name
 
         sort_by = request.query_params.get(
             "sortBy", f"-{OrderingParameter.COMMITS_WHERE_FAIL.value}"
@@ -91,7 +94,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             )
 
         variables = {
-            "owner": owner,
+            "owner": owner_slug,
             "repo": repository,
             "filters": {
                 "branch": request.query_params.get("branch", "main"),
@@ -113,7 +116,7 @@ class TestResultsEndpoint(CodecovEndpoint):
             "after": cursor if cursor and navigation == NavigationParameter.NEXT.value else None,
         }
 
-        client = CodecovApiClient(git_provider_org=owner)
+        client = CodecovApiClient(git_provider_org=owner_slug)
         graphql_response = client.query(query=query, variables=variables)
 
         test_results = TestResultSerializer().to_representation(graphql_response.json())

--- a/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
+++ b/src/sentry/codecov/endpoints/TestResultsAggregates/test_results_aggregates.py
@@ -42,9 +42,7 @@ class TestResultsAggregatesEndpoint(CodecovEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def get(
-        self, request: Request, organization_id_or_slug: str, owner: str, repository: str, **kwargs
-    ) -> Response:
+    def get(self, request: Request, owner: str, repository: str, **kwargs) -> Response:
         """
         Retrieves aggregated test result metrics for a given repository and owner.
         Also accepts a query parameter to specify the time period for the metrics.

--- a/tests/sentry/codecov/endpoints/test_branches.py
+++ b/tests/sentry/codecov/endpoints/test_branches.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 from django.urls import reverse
 
 from sentry.codecov.endpoints.Branches.serializers import BranchNodeSerializer as NodeSerializer
+from sentry.constants import ObjectStatus
 from sentry.testutils.cases import APITestCase
 
 mock_graphql_response_populated: dict[str, Any] = {
@@ -53,15 +54,23 @@ class BranchesEndpointTest(APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1234",
+            name="testowner",
+            provider="github",
+            status=ObjectStatus.ACTIVE,
+        )
         self.login_as(user=self.user)
 
-    def reverse_url(self, owner="testowner", repository="testrepo"):
+    def reverse_url(self, repository="testrepo"):
         """Custom reverse URL method to handle required URL parameters"""
         return reverse(
             self.endpoint,
             kwargs={
                 "organization_id_or_slug": self.organization.slug,
-                "owner": owner,
+                "owner": self.integration.id,
                 "repository": repository,
             },
         )

--- a/tests/sentry/codecov/endpoints/test_codecov_endpoint.py
+++ b/tests/sentry/codecov/endpoints/test_codecov_endpoint.py
@@ -1,0 +1,45 @@
+from django.urls import reverse
+from rest_framework import status
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.factories import Factories
+
+
+class CodecovEndpointPermissionTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = Factories.create_user(email="user@example.com")
+        self.organization = Factories.create_organization(owner=self.user)
+        self.owner_slug = "testowner"
+        self.endpoint_url = reverse(
+            "sentry-api-0-test-results",  # One of the endpoints that inherits the CodecovEndpoint
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "owner": self.owner_slug,
+                "repository": "testrepo",
+            },
+        )
+
+    def test_unauthenticated_user_denied(self):
+        response = self.client.get(self.endpoint_url)
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    def test_user_not_in_org_denied(self):
+        other_user = Factories.create_user(email="other@example.com")
+        self.login_as(other_user)
+        response = self.client.get(self.endpoint_url)
+        assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+
+    def test_user_in_org_no_integration_denied(self):
+        self.login_as(self.user)
+        response = self.client.get(self.endpoint_url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_auth_token_denied(self):
+        token = Factories.create_user_auth_token(self.user, scope_list=["org:read"])
+        response = self.client.get(self.endpoint_url, HTTP_AUTHORIZATION=f"Bearer {token.token}")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+        )

--- a/tests/sentry/codecov/endpoints/test_repositories.py
+++ b/tests/sentry/codecov/endpoints/test_repositories.py
@@ -74,7 +74,7 @@ class RepositoriesEndpointTest(APITestCase):
             self.endpoint,
             kwargs={
                 "organization_id_or_slug": self.organization.slug,
-                "owner": owner,
+                "owner": self.integration.id,
             },
         )
 

--- a/tests/sentry/codecov/endpoints/test_repositories.py
+++ b/tests/sentry/codecov/endpoints/test_repositories.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from sentry.codecov.endpoints.Repositories.serializers import (
     RepositoryNodeSerializer as NodeSerializer,
 )
+from sentry.constants import ObjectStatus
 from sentry.testutils.cases import APITestCase
 
 mock_graphql_response_populated: dict[str, Any] = {
@@ -57,6 +58,14 @@ class RepositoriesEndpointTest(APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="1234",
+            name="testowner",
+            provider="github",
+            status=ObjectStatus.ACTIVE,
+        )
         self.login_as(user=self.user)
 
     def reverse_url(self, owner="testowner"):

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -14,7 +14,8 @@ class TestResultsAggregatesEndpointTest(APITestCase):
         self.organization = self.create_organization(owner=self.user)
         self.integration = self.create_integration(
             organization=self.organization,
-            external_id="testowner",
+            external_id="1234",
+            name="testowner",
             provider="github",
         )
         self.login_as(user=self.user)
@@ -25,7 +26,7 @@ class TestResultsAggregatesEndpointTest(APITestCase):
             self.endpoint_name,
             kwargs={
                 "organization_id_or_slug": self.organization.slug,
-                "owner": owner,
+                "owner": self.integration.id,
                 "repository": repository,
             },
         )

--- a/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
+++ b/tests/sentry/codecov/endpoints/test_test_result_aggregates.py
@@ -10,6 +10,13 @@ class TestResultsAggregatesEndpointTest(APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.user = self.create_user(email="user@example.com")
+        self.organization = self.create_organization(owner=self.user)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="testowner",
+            provider="github",
+        )
         self.login_as(user=self.user)
 
     def reverse_url(self, owner="testowner", repository="testrepo"):

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -90,6 +90,12 @@ class TestResultsEndpointTest(APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="testowner",
+            provider="github",
+        )
         self.login_as(user=self.user)
 
     def reverse_url(self, owner="testowner", repository="testrepo"):

--- a/tests/sentry/codecov/endpoints/test_test_results.py
+++ b/tests/sentry/codecov/endpoints/test_test_results.py
@@ -93,7 +93,8 @@ class TestResultsEndpointTest(APITestCase):
         self.organization = self.create_organization(owner=self.user)
         self.integration = self.create_integration(
             organization=self.organization,
-            external_id="testowner",
+            external_id="1234",
+            name="testowner",
             provider="github",
         )
         self.login_as(user=self.user)
@@ -104,7 +105,7 @@ class TestResultsEndpointTest(APITestCase):
             self.endpoint,
             kwargs={
                 "organization_id_or_slug": self.organization.slug,
-                "owner": owner,
+                "owner": self.integration.id,
                 "repository": repository,
             },
         )


### PR DESCRIPTION
Adding some permissions to ensure that Codecov Endpoints checks the following:

1. User is authenticated
2. User has permissions on the org
3. And the integration is associated with the org

Tagging the @getsentry/ecosystem team for review because we're inheriting the `OrganizationEndpoint` to do permissions check, and the integrations check.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
