### PR TITLE
feat(aci): add data condition warning about occurrence-based monitors

### DIFF
--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -297,7 +297,9 @@ describe('DataConditionNodeList', function () {
       <AutomationBuilderErrorContext.Provider
         value={{errors: {}, setErrors: jest.fn(), removeError: jest.fn()}}
       >
-        <DataConditionNodeList {...defaultProps} />
+        <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+          <DataConditionNodeList {...defaultProps} />
+        </AutomationBuilderConflictContext.Provider>
       </AutomationBuilderErrorContext.Provider>,
       {organization}
     );

--- a/static/app/views/automations/components/dataConditionNodeList.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.tsx
@@ -4,6 +4,8 @@ import styled from '@emotion/styled';
 import {Alert} from 'sentry/components/core/alert';
 import {Checkbox} from 'sentry/components/core/checkbox';
 import {Select} from 'sentry/components/core/select';
+import {Tooltip} from 'sentry/components/core/tooltip';
+import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
@@ -17,7 +19,6 @@ import AutomationBuilderRow from 'sentry/views/automations/components/automation
 import {
   DataConditionNodeContext,
   dataConditionNodesMap,
-  frequencyTypeMapping,
   useDataConditionNodeContext,
 } from 'sentry/views/automations/components/dataConditionNodes';
 import {useDataConditionsQuery} from 'sentry/views/automations/hooks';
@@ -80,10 +81,19 @@ export default function DataConditionNodeList({
       }
 
       const conditionType = frequencyTypeMapping[handler.type] || handler.type;
+      const conditionLabel = dataConditionNodesMap.get(conditionType)?.label;
+      const WarningMessage = dataConditionNodesMap.get(conditionType)?.warningMessage;
 
       const newDataCondition: Option = {
         value: conditionType,
-        label: dataConditionNodesMap.get(handler.type)?.label || handler.type,
+        label: conditionLabel || handler.type,
+        ...(WarningMessage && {
+          trailingItems: (
+            <Tooltip title={<WarningMessage />}>
+              <IconWarning />
+            </Tooltip>
+          ),
+        }),
       };
 
       if (handler.handlerSubgroup === DataConditionHandlerSubgroupType.EVENT_ATTRIBUTES) {
@@ -221,6 +231,21 @@ function Node() {
   const Component = node?.dataCondition;
   return Component ? <Component /> : node?.label;
 }
+
+/**
+ * Maps COUNT and PERCENT frequency conditions to their base frequency type.
+ * This is used in the UI to show both conditions as a single branching condition.
+ */
+const frequencyTypeMapping: Partial<Record<DataConditionType, DataConditionType>> = {
+  [DataConditionType.PERCENT_SESSIONS_COUNT]: DataConditionType.PERCENT_SESSIONS,
+  [DataConditionType.PERCENT_SESSIONS_PERCENT]: DataConditionType.PERCENT_SESSIONS,
+  [DataConditionType.EVENT_FREQUENCY_COUNT]: DataConditionType.EVENT_FREQUENCY,
+  [DataConditionType.EVENT_FREQUENCY_PERCENT]: DataConditionType.EVENT_FREQUENCY,
+  [DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT]:
+    DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
+  [DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT]:
+    DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
+};
 
 const StyledSelectControl = styled(Select)`
   width: 100%;

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -1,7 +1,9 @@
 import type React from 'react';
 import {createContext, useContext} from 'react';
 
+import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {
   type DataCondition,
   DataConditionType,
@@ -109,6 +111,7 @@ type DataConditionNode = {
   dataCondition?: React.ComponentType<any>;
   defaultComparison?: any;
   details?: React.ComponentType<any>;
+  warningMessage?: React.ComponentType<any>;
 };
 
 export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNode>([
@@ -212,6 +215,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
         environment: '',
       },
       validate: validateLatestAdoptedReleaseCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -221,6 +225,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       dataCondition: LatestReleaseNode,
       details: LatestReleaseNode,
       validate: undefined,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -234,6 +239,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
         match: MatchType.CONTAINS,
       },
       validate: validateEventAttributeCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -264,6 +270,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       label: t('Number of events'),
       dataCondition: EventFrequencyNode,
       validate: validateEventFrequencyCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -274,6 +281,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       details: EventFrequencyCountDetails,
       defaultComparison: {value: 100, interval: Interval.ONE_HOUR},
       validate: validateEventFrequencyCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -288,6 +296,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
         comparison_interval: Interval.ONE_WEEK,
       },
       validate: validateEventFrequencyCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -296,6 +305,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       label: t('Number of users affected'),
       dataCondition: EventUniqueUserFrequencyNode,
       validate: validateEventUniqueUserFrequencyCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -306,6 +316,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       details: EventUniqueUserFrequencyCountDetails,
       defaultComparison: {value: 100, interval: Interval.ONE_HOUR},
       validate: validateEventUniqueUserFrequencyCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -320,6 +331,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
         comparison_interval: Interval.ONE_WEEK,
       },
       validate: validateEventUniqueUserFrequencyCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -328,6 +340,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       label: t('Percentage of sessions affected'),
       dataCondition: PercentSessionsNode,
       validate: validatePercentSessionsCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -338,6 +351,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       details: PercentSessionsCountDetails,
       defaultComparison: {value: 100, interval: Interval.ONE_HOUR},
       validate: validatePercentSessionsCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
   [
@@ -352,18 +366,22 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
         comparison_interval: Interval.ONE_WEEK,
       },
       validate: validatePercentSessionsCondition,
+      warningMessage: OccurenceBasedMonitorsWarning,
     },
   ],
 ]);
 
-export const frequencyTypeMapping: Partial<Record<DataConditionType, DataConditionType>> =
-  {
-    [DataConditionType.PERCENT_SESSIONS_COUNT]: DataConditionType.PERCENT_SESSIONS,
-    [DataConditionType.PERCENT_SESSIONS_PERCENT]: DataConditionType.PERCENT_SESSIONS,
-    [DataConditionType.EVENT_FREQUENCY_COUNT]: DataConditionType.EVENT_FREQUENCY,
-    [DataConditionType.EVENT_FREQUENCY_PERCENT]: DataConditionType.EVENT_FREQUENCY,
-    [DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT]:
-      DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
-    [DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT]:
-      DataConditionType.EVENT_UNIQUE_USER_FREQUENCY,
-  };
+function OccurenceBasedMonitorsWarning() {
+  return (
+    <Flex direction="column" gap={space(1)}>
+      <span>
+        {t('These filters will only apply to some of your monitors and triggers.')}
+      </span>
+      <span>
+        {t(
+          'They are only available for occurrence-based monitors \(errors, N+1, and replay\) and only apply to the triggers "A new event is captured for an issue" and "A new issue is created."'
+        )}
+      </span>
+    </Flex>
+  );
+}

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import {createContext, useContext} from 'react';
+import styled from '@emotion/styled';
 
 import {Flex} from 'sentry/components/core/layout';
 import {t} from 'sentry/locale';
@@ -374,14 +375,18 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
 function OccurenceBasedMonitorsWarning() {
   return (
     <Flex direction="column" gap={space(1)}>
-      <span>
+      <WarningLine>
         {t('These filters will only apply to some of your monitors and triggers.')}
-      </span>
-      <span>
+      </WarningLine>
+      <WarningLine>
         {t(
           'They are only available for occurrence-based monitors \(errors, N+1, and replay\) and only apply to the triggers "A new event is captured for an issue" and "A new issue is created."'
         )}
-      </span>
+      </WarningLine>
     </Flex>
   );
 }
+
+const WarningLine = styled('p')`
+  margin: 0;
+`;


### PR DESCRIPTION
added a `warningMessage` field to the data condition map so that we can add other/different messages in the future if necessary

<img width="942" height="405" alt="Screenshot 2025-07-11 at 1 34 24 PM" src="https://github.com/user-attachments/assets/83171270-363d-4b0f-bf0e-613ad9c1ebe0" />
