### PR TITLE
chore(ecosystem): Bitbucket SLOs for get_repos

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -66,7 +66,7 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
             org = org_context.organization
 
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params, **kwargs)
+        default_repo, repo_choices = self.get_repository_choices(group, params)
 
         autocomplete_url = reverse(
             "sentry-extensions-bitbucket-search", args=[org.slug, self.model.id]
@@ -102,7 +102,7 @@ class BitbucketIssuesSpec(SourceCodeIssueIntegration):
 
     def get_link_issue_config(self, group: Group, **kwargs) -> list[dict[str, Any]]:
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params, **kwargs)
+        default_repo, repo_choices = self.get_repository_choices(group, params)
 
         org = group.organization
         autocomplete_url = reverse(

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -162,7 +162,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             org = org_context.organization
 
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params, **kwargs)
+        default_repo, repo_choices = self.get_repository_choices(group, params)
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []
         labels: Sequence[tuple[str, str]] = []
@@ -238,7 +238,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
     def get_link_issue_config(self, group: Group, **kwargs: Any) -> list[dict[str, Any]]:
         params = kwargs.pop("params", {})
-        default_repo, repo_choices = self.get_repository_choices(group, params, **kwargs)
+        default_repo, repo_choices = self.get_repository_choices(group, params)
 
         org = group.organization
         autocomplete_url = reverse(

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -45,7 +45,7 @@ class GitlabIssuesSpec(SourceCodeIssueIntegration):
         params_mut = dict(params)
         params_mut["repo"] = params.get("project") or defaults.get("project")
 
-        default_project, project_choices = self.get_repository_choices(group, params_mut, **kwargs)
+        default_project, project_choices = self.get_repository_choices(group, params_mut)
         return default_project, project_choices
 
     def create_default_repo_choice(self, default_repo):

--- a/src/sentry/integrations/source_code_management/issues.py
+++ b/src/sentry/integrations/source_code_management/issues.py
@@ -14,9 +14,9 @@ from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.models.group import Group
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
-SOURCE_CODE_ISSUE_HALT_PATTERNS = [
+SOURCE_CODE_ISSUE_HALT_PATTERNS = {
     "No workspace with identifier",  # Bitbucket
-]
+}
 
 
 class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegration, ABC):
@@ -36,7 +36,8 @@ class SourceCodeIssueIntegration(IssueBasicIntegration, BaseRepositoryIntegratio
         except ApiError as exc:
             if any(pattern in str(exc) for pattern in SOURCE_CODE_ISSUE_HALT_PATTERNS):
                 lifecycle.record_halt(exc)
-            lifecycle.record_failure(exc)
+            else:
+                lifecycle.record_failure(exc)
             raise IntegrationError("Unable to retrieve repositories. Please try again later.")
         else:
             repo_choices = [(repo["identifier"], repo["name"]) for repo in repos]

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -1,11 +1,14 @@
+from unittest.mock import patch
 from urllib.parse import quote, urlencode
 
+import pytest
 import responses
 from django.urls import reverse
 
 from sentry.integrations.bitbucket.integration import BitbucketIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -203,3 +206,39 @@ class BitbucketIntegrationTest(APITestCase):
             installation.extract_source_path_from_source_url(repo, source_url)
             == "src/sentry/integrations/bitbucket/integration.py"
         )
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_failure")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_get_repository_choices_halt_lifecycle(self, mock_record_halt, mock_record_failure):
+        responses.add(
+            responses.GET,
+            "https://api.bitbucket.org/2.0/repositories/sentryuser",
+            status=404,
+            json={"error": {"message": "No workspace with identifier sentryuser"}},
+        )
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(
+            IntegrationError, match="Unable to retrieve repositories. Please try again later."
+        ):
+            installation.get_repository_choices(None, {})
+        assert mock_record_halt.call_count == 1
+        assert mock_record_failure.call_count == 0
+
+    @responses.activate
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_failure")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_halt")
+    def test_get_repository_choices_failure_lifecycle(self, mock_record_halt, mock_record_failure):
+        responses.add(
+            responses.GET,
+            "https://api.bitbucket.org/2.0/repositories/sentryuser",
+            status=404,
+            json={"error": {"message": "Some other error, sentry is responsible"}},
+        )
+        installation = self.integration.get_installation(self.organization.id)
+        with pytest.raises(
+            IntegrationError, match="Unable to retrieve repositories. Please try again later."
+        ):
+            installation.get_repository_choices(None, {})
+        assert mock_record_halt.call_count == 0
+        assert mock_record_failure.call_count == 1


### PR DESCRIPTION
It's a bit odd, but the exception raised here doesn't need to adjust our SLOs just to fail to the user, especially since we actually care about the API error.

Maybe theres tooling to designate exception that would be processed as halts, but I couldn't find it. Instead, I essentially wrapped the business logic in a try/catch to produce a failure I could bubble up after the lifecycle could be closed. 

We still capture the failure in the internal function, so nothing should change coverage wise.