### PR TITLE
ref(issue-views): move cross-project selection to flagpole-configured

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -48,8 +48,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:dynamic-sampling": False,
         # Enable attaching arbitrary files to events.
         "organizations:event-attachments": True,
-        # Enable multi project selection
-        "organizations:global-views": False,
         # Enable incidents feature
         "organizations:incidents": False,
         # Enable integration functionality to work with alert rules

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -133,7 +133,7 @@ def register_temporary_features(manager: FeatureManager):
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable multi project selection
-    manager.add("organizations:global-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:global-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -132,6 +132,8 @@ def register_temporary_features(manager: FeatureManager):
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable disabling gitlab integrations when broken is detected
     manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable multi project selection
+    manager.add("organizations:global-views", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Starfish: extract metrics from the spans


### PR DESCRIPTION
`organizations:global-views` enables cross-project selection - move this to `temporary` so that it can be configured by flagpole instead. No immediate effect, since `getsentry` will set it first.

See https://linear.app/getsentry/issue/ID-724/enable-cross-project-selection-for-all-plans