### PR TITLE
fix(aci): Retry process_delayed_workflows timeouts

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -330,7 +330,7 @@ def _process_resource_change(
             except model.DoesNotExist as e:
                 # Explicitly requeue the task, so we don't report this to Sentry until
                 # we hit the max number of retries.
-                return retry_task(e)
+                retry_task(e)
 
         org = None
 

--- a/src/sentry/taskworker/retry.py
+++ b/src/sentry/taskworker/retry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 from multiprocessing.context import TimeoutError
+from typing import NoReturn
 
 from celery import current_task
 from sentry_protos.taskbroker.v1.taskbroker_pb2 import (
@@ -41,7 +42,7 @@ class LastAction(Enum):
         raise ValueError(f"Unknown LastAction: {self}")
 
 
-def retry_task(exc: Exception | None = None) -> None:
+def retry_task(exc: Exception | None = None) -> NoReturn:
     """
     Helper for triggering retry errors.
     If all retries have been consumed, this will raise a
@@ -55,6 +56,7 @@ def retry_task(exc: Exception | None = None) -> None:
     celery_retry = getattr(current_task, "retry", None)
     if celery_retry:
         current_task.retry(exc=exc)
+        assert False, "unreachable"
     else:
         current = taskworker_current_task()
         if current and not current.retries_remaining:

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -65,6 +65,7 @@ from sentry.workflow_engine.processors.workflow import (
 )
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
+from sentry.workflow_engine.tasks.utils import retry_timeouts
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 from sentry.workflow_engine.utils import log_context
 
@@ -760,6 +761,7 @@ def repr_keys[T, V](d: dict[T, V]) -> dict[str, V]:
     ),
 )
 @retry
+@retry_timeouts
 @log_context.root()
 def process_delayed_workflows(
     project_id: int, batch_key: str | None = None, *args: Any, **kwargs: Any


### PR DESCRIPTION
Timeouts are expected here and assumed transient, and the existing `retry` decorator and config don't support retrying `ProcessingDeadlineExceeded`.
So, we add a new task decorator to trigger retries on timeouts. This avoids opening the door to other BaseExceptions and keeps it opt-in as designed.