### PR TITLE
chore(aci): Remove uses of workflow-engine-post-process-async flag

### DIFF
--- a/tests/sentry/incidents/test_metric_issue_post_process.py
+++ b/tests/sentry/incidents/test_metric_issue_post_process.py
@@ -70,7 +70,7 @@ class TestMetricDetectorPostProcess(BaseWorkflowTest):
     @with_feature("organizations:issue-metric-issue-post-process-group")
     @with_feature("organizations:workflow-engine-metric-alert-processing")
     @with_feature("organizations:workflow-engine-process-metric-issue-workflows")
-    @patch("sentry.workflow_engine.processors.workflow.process_workflows")
+    @patch("sentry.workflow_engine.tasks.workflows.process_workflows_event.delay")
     def test_occurrence_post_process(self, mock_process_workflows):
         value = self.critical_detector_trigger.comparison + 1
         packet = QuerySubscriptionUpdate(

--- a/tests/sentry/workflow_engine/test_integration.py
+++ b/tests/sentry/workflow_engine/test_integration.py
@@ -152,7 +152,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
         self.create_event(self.project.id, datetime.utcnow(), str(self.detector.id))
 
         with mock.patch(
-            "sentry.workflow_engine.processors.workflow.process_workflows"
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.delay"
         ) as mock_process_workflow:
             self.call_post_process_group(self.group.id)
             mock_process_workflow.assert_called_once()
@@ -176,7 +176,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
         self.group = Group.objects.get(grouphash__hash=self.occurrence.fingerprint[0])
 
         with mock.patch(
-            "sentry.workflow_engine.processors.workflow.process_workflows"
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.delay"
         ) as mock_process_workflow:
             self.call_post_process_group(error_event.group_id)
 
@@ -189,7 +189,7 @@ class TestWorkflowEngineIntegrationFromIssuePlatform(BaseWorkflowIntegrationTest
         assert self.group
 
         with mock.patch(
-            "sentry.workflow_engine.processors.workflow.process_workflows"
+            "sentry.workflow_engine.tasks.workflows.process_workflows_event.delay"
         ) as mock_process_workflow:
             self.call_post_process_group(self.group.id)
 


### PR DESCRIPTION
Nobody is opted out anymore, turning this off could pose significant operational risk to post_process, and any value as a kill switch is already covered by the more general opt-in flags.

