### PR TITLE
fix(detectors): Fix type error in uncompressed asset detector

### DIFF
--- a/src/sentry/performance_issues/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/performance_issues/detectors/uncompressed_asset_detector.py
@@ -143,7 +143,10 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
             (
                 tag[1]
                 for tag in tags
-                if tag is not None and tag[0] == "browser.name" and len(tag) == 2
+                if tag is not None
+                and tag[0] == "browser.name"
+                and len(tag) == 2
+                and tag[1] is not None
             ),
             "",
         )


### PR DESCRIPTION
Fixes SENTRY-FOR-SENTRY-62R1