### PR TITLE
feat(mcp-insights): Rename nav entries

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -56,7 +56,7 @@ import {AIInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/fea
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {
   AGENTS_LANDING_SUB_PATH,
-  AGENTS_SIDEBAR_LABEL,
+  getAgentsSidebarLabel,
 } from 'sentry/views/insights/pages/agents/settings';
 import {
   AI_LANDING_SUB_PATH,
@@ -390,7 +390,7 @@ function Sidebar() {
         >
           <SidebarItem
             {...sidebarItemProps}
-            label={AGENTS_SIDEBAR_LABEL}
+            label={getAgentsSidebarLabel(organization)}
             to={`/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}/${AGENTS_LANDING_SUB_PATH}/${MODULE_BASE_URLS[AGENTS_LANDING_SUB_PATH]}/`}
             id="performance-domains-agents"
             icon={<SubitemDot collapsed />}

--- a/static/app/views/insights/agentMonitoring/utils/features.tsx
+++ b/static/app/views/insights/agentMonitoring/utils/features.tsx
@@ -11,6 +11,10 @@ export function hasAgentInsightsFeature(organization: Organization) {
   return organization.features.includes('agents-insights');
 }
 
+export function hasMCPInsightsFeature(organization: Organization) {
+  return organization.features.includes('mcp-insights');
+}
+
 export function usePreferedAiModule() {
   const organization = useOrganization();
   const user = useUser();

--- a/static/app/views/insights/common/utils/useModuleTitle.tsx
+++ b/static/app/views/insights/common/utils/useModuleTitle.tsx
@@ -1,19 +1,27 @@
 import {useMemo} from 'react';
 
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {hasMCPInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
 import {DOMAIN_VIEW_MODULE_TITLES} from 'sentry/views/insights/common/utils/moduleTitles';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {MODULE_TITLES} from 'sentry/views/insights/settings';
-import type {ModuleName} from 'sentry/views/insights/types';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export const useModuleTitles = (): Record<ModuleName, string> => {
   const {isInDomainView, view} = useDomainViewFilters();
+  const organization = useOrganization();
   const moduleTitles = useMemo(() => {
     let titles = {...MODULE_TITLES};
     if (isInDomainView && view) {
       titles = {...MODULE_TITLES, ...DOMAIN_VIEW_MODULE_TITLES[view]};
     }
+    // TODO: Rename the respective constant when removing the feature flag
+    if (hasMCPInsightsFeature(organization)) {
+      titles = {...titles, [ModuleName.AGENTS]: t('Agents')};
+    }
     return titles;
-  }, [isInDomainView, view]);
+  }, [isInDomainView, organization, view]);
 
   return moduleTitles;
 };

--- a/static/app/views/insights/pages/agents/settings.ts
+++ b/static/app/views/insights/pages/agents/settings.ts
@@ -1,8 +1,18 @@
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {hasMCPInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/features';
 import {ModuleName} from 'sentry/views/insights/types';
 
 export const AGENTS_LANDING_SUB_PATH = 'agents';
 export const AGENTS_LANDING_TITLE = t('AI Agents');
-export const AGENTS_SIDEBAR_LABEL = t('AI Agents');
+const AGENTS_SIDEBAR_LABEL = t('AI Agents');
+const AI_SIDEBAR_LABEL = t('AI');
+
+export const getAgentsSidebarLabel = (organization: Organization) => {
+  if (hasMCPInsightsFeature(organization)) {
+    return AI_SIDEBAR_LABEL;
+  }
+  return AGENTS_SIDEBAR_LABEL;
+};
 
 export const MODULES = [ModuleName.AGENTS];

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -10,7 +10,7 @@ import {AIInsightsFeature} from 'sentry/views/insights/agentMonitoring/utils/fea
 import {MODULE_BASE_URLS} from 'sentry/views/insights/common/utils/useModuleURL';
 import {
   AGENTS_LANDING_SUB_PATH,
-  AGENTS_SIDEBAR_LABEL,
+  getAgentsSidebarLabel,
 } from 'sentry/views/insights/pages/agents/settings';
 import {
   AI_LANDING_SUB_PATH,
@@ -92,7 +92,7 @@ export function InsightsSecondaryNav() {
               analyticsItemName="insights_agents"
               trailingItems={<FeatureBadge type="beta" />}
             >
-              {AGENTS_SIDEBAR_LABEL}
+              {getAgentsSidebarLabel(organization)}
             </SecondaryNav.Item>
           </AIInsightsFeature>
         </SecondaryNav.Section>


### PR DESCRIPTION
- closes [TET-845: rename Overview tab to Agents (only if MCP feature flag present)](https://linear.app/getsentry/issue/TET-845/rename-overview-tab-to-agents-only-if-mcp-feature-flag-present)
- closes [TET-844: rename AI Agents to AI (only if MCP feature flag present)](https://linear.app/getsentry/issue/TET-844/rename-ai-agents-to-ai-only-if-mcp-feature-flag-present)