### PR TITLE
fix(release-health): Show descriptions for ANR scorecards

### DIFF
--- a/static/app/views/releases/utils/sessionTerm.tsx
+++ b/static/app/views/releases/utils/sessionTerm.tsx
@@ -117,6 +117,12 @@ function getTermDescriptions(platform: PlatformKey | null) {
         [SessionTerm.CRASHED]: t(
           'An unhandled exception that resulted in the application crashing'
         ),
+        [SessionTerm.ANR_RATE]: t(
+          'Percentage of unique users that experienced an App Not Responding (ANR) error'
+        ),
+        [SessionTerm.FOREGROUND_ANR_RATE]: t(
+          'Percentage of unique users that experienced an App Not Responding (ANR) error when the app was running in the foreground'
+        ),
       };
     case 'apple': {
       return {


### PR DESCRIPTION
Descriptions were not shown:

### Before

<img width="883" height="347" alt="Google Chrome 2025-07-14 08 53 24" src="https://github.com/user-attachments/assets/2cd3c589-e4e1-4106-b031-232b605cd79e" />

### After

<img width="959" height="341" alt="image" src="https://github.com/user-attachments/assets/98ccc464-4ae2-432c-b1f2-91cc34dc24ae" />

