### PR TITLE
ref: replace space function with p.theme.space in core/button

### DIFF
--- a/static/app/components/core/button/index.tsx
+++ b/static/app/components/core/button/index.tsx
@@ -5,8 +5,6 @@ import InteractionStateLayer from 'sentry/components/core/interactionStateLayer'
 import {Tooltip} from 'sentry/components/core/tooltip';
 // eslint-disable-next-line boundaries/element-types
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
-// eslint-disable-next-line boundaries/element-types
-import {space} from 'sentry/styles/space';
 
 import {
   DO_NOT_USE_BUTTON_ICON_SIZES as BUTTON_ICON_SIZES,
@@ -100,8 +98,8 @@ const Icon = styled('span')<{
   margin-right: ${p =>
     p.hasChildren
       ? p.size === 'xs' || p.size === 'zero'
-        ? space(0.75)
-        : space(1)
+        ? p.theme.space.sm
+        : p.theme.space.md
       : '0'};
   flex-shrink: 0;
 `;

--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -6,8 +6,6 @@ import {Link} from 'sentry/components/core/link';
 import {Tooltip} from 'sentry/components/core/tooltip';
 // eslint-disable-next-line boundaries/element-types
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
-// eslint-disable-next-line boundaries/element-types
-import {space} from 'sentry/styles/space';
 
 import {
   DO_NOT_USE_BUTTON_ICON_SIZES as BUTTON_ICON_SIZES,
@@ -124,8 +122,8 @@ const Icon = styled('span')<{
   margin-right: ${p =>
     p.hasChildren
       ? p.size === 'xs' || p.size === 'zero'
-        ? space(0.75)
-        : space(1)
+        ? p.theme.space.sm
+        : p.theme.space.md
       : '0'};
   flex-shrink: 0;
 `;

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -3,8 +3,6 @@ import {css} from '@emotion/react';
 
 // eslint-disable-next-line boundaries/element-types
 import {type SVGIconProps} from 'sentry/icons/svgIcon';
-// eslint-disable-next-line boundaries/element-types
-import {space} from 'sentry/styles/space';
 
 import type {
   DO_NOT_USE_ButtonProps as ButtonProps,
@@ -211,7 +209,7 @@ export function DO_NOT_USE_getButtonStyles(
     css`
       height: auto;
       min-height: auto;
-      padding: ${space(0.25)};
+      padding: ${p.theme.space['2xs']};
     `}
 
   &:focus {

--- a/static/app/styles/space.tsx
+++ b/static/app/styles/space.tsx
@@ -11,6 +11,9 @@ const SPACES = {
 
 export type ValidSize = keyof typeof SPACES;
 
+/**
+ * @deprecated prefer using `theme.space`
+ */
 function space<S extends ValidSize>(size: S): (typeof SPACES)[S] {
   return SPACES[size];
 }

--- a/static/app/utils/theme/theme.chonk.tsx
+++ b/static/app/utils/theme/theme.chonk.tsx
@@ -539,18 +539,6 @@ function generateChonkTokens(colorScheme: typeof lightColors) {
   };
 }
 
-const space = {
-  none: '0px',
-  '2xs': '2px',
-  xs: '4px',
-  sm: '6px',
-  md: '8px',
-  lg: '12px',
-  xl: '16px',
-  '2xl': '24px',
-  '3xl': '32px',
-} as const;
-
 const radius = {
   none: '0px',
   '2xs': '2px',
@@ -1100,8 +1088,6 @@ interface ChonkTheme extends Omit<SentryTheme, 'isChonk' | 'chart'> {
   };
   isChonk: true;
   radius: typeof radius;
-
-  space: typeof space;
   tokens: typeof lightTokens;
 }
 
@@ -1125,8 +1111,6 @@ export const DO_NOT_USE_lightChonkTheme: ChonkTheme = {
     ...darkAliases,
     tokens: darkTokens,
   },
-
-  space,
   radius,
   focusRing: {
     outline: 'none',
@@ -1204,7 +1188,6 @@ export const DO_NOT_USE_darkChonkTheme: ChonkTheme = {
     tokens: lightTokens,
   },
 
-  space,
   radius,
   focusRing: {
     outline: 'none',

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -1090,6 +1090,18 @@ const iconSizes: Record<Size, string> = {
   '2xl': '72px',
 } as const;
 
+const space = {
+  none: '0px',
+  '2xs': '2px',
+  xs: '4px',
+  sm: '6px',
+  md: '8px',
+  lg: '12px',
+  xl: '16px',
+  '2xl': '24px',
+  '3xl': '32px',
+} as const;
+
 /**
  * Values shared between light and dark theme
  */
@@ -1098,6 +1110,8 @@ const commonTheme = {
 
   ...lightColors,
   ...lightShadows,
+
+  space,
 
   // Icons
   iconSizes,


### PR DESCRIPTION
This PR hoists `theme.space` up to the `commonTheme` so that we have it available without being narrowed to a `chonk` theme. This allows us to use it everywhere in place of the `space` function, which has been deprecated.

`buttonBar` needs to be done in a follow-up, because it needs an API change including many call-side changes.
