### PR TITLE
Add metrics for various file/blob uploads

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -45,6 +45,10 @@ class EventProcessingStore(Service):
         if unprocessed:
             key = self.__get_unprocessed_key(key)
         self.inner.set(key, event, self.timeout)
+        # TODO(swatinem): we would like to gather size metrics for things stored
+        # in the processing store, though we need `bytes` for that, and it looks
+        # like the processing store is used with `dict`s directly, for which the
+        # encoding is non-obvious.
         return key
 
     def get(self, key: str, unprocessed: bool = False) -> MutableMapping[str, Any] | None:

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -35,7 +35,7 @@ from sentry.db.models import (
 from sentry.db.models.manager.base import BaseManager
 from sentry.models.files.file import File
 from sentry.models.files.utils import clear_cached_files
-from sentry.utils import json
+from sentry.utils import json, metrics
 from sentry.utils.zip import safe_extract_zip
 
 if TYPE_CHECKING:
@@ -314,6 +314,13 @@ def create_dif_from_id(
         file.type = "project.dif"
         file.headers["Content-Type"] = DIF_MIMETYPES[meta.file_format]
         file.save()
+
+    metrics.distribution(
+        "storage.put.size",
+        file.size,
+        tags={"usecase": "debug-files", "compression": "none"},
+        unit="byte",
+    )
 
     dif = ProjectDebugFile.objects.create(
         file=file,

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -17,6 +17,7 @@ from sentry.db.models import BoundedBigIntegerField, Model, region_silo_model, s
 from sentry.db.models.fields.bounded import BoundedIntegerField
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.models.files.utils import get_size_and_checksum, get_storage
+from sentry.utils import metrics
 
 # Attachment file types that are considered a crash report (PII relevant)
 CRASH_REPORT_TYPES = ("event.minidump", "event.applecrashreport")
@@ -147,14 +148,29 @@ class EventAttachment(Model):
         blob = BytesIO(data)
         size, checksum = get_size_and_checksum(blob)
 
+        metrics.distribution(
+            "storage.put.size",
+            size,
+            tags={"usecase": "attachments", "compression": "none"},
+            unit="byte",
+        )
+
         if can_store_inline(data):
             blob_path = ":" + data.decode()
         else:
             blob_path = "eventattachments/v1/" + FileBlob.generate_unique_path()
 
             storage = get_storage()
-            compressed_blob = BytesIO(zstandard.compress(data))
-            storage.save(blob_path, compressed_blob)
+            compressed_blob = zstandard.compress(data)
+
+            metrics.distribution(
+                "storage.put.size",
+                len(compressed_blob),
+                tags={"usecase": "attachments", "compression": "zstd"},
+                unit="byte",
+            )
+            with metrics.timer("storage.put.latency", tags={"usecase": "attachments"}):
+                storage.save(blob_path, BytesIO(compressed_blob))
 
         return PutfileResult(
             content_type=content_type, size=size, sha1=checksum, blob_path=blob_path

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -515,10 +515,19 @@ class ArtifactBundlePostAssembler:
 
         # In case there is not ArtifactBundle with a specific bundle_id, we just create it and return.
         if existing_artifact_bundle is None:
+            file = self.assemble_result.bundle
+
+            metrics.distribution(
+                "storage.put.size",
+                file.size,
+                tags={"usecase": "artifact-bundles", "compression": "none"},
+                unit="byte",
+            )
+
             artifact_bundle = ArtifactBundle.objects.create(
                 organization_id=self.organization.id,
                 bundle_id=bundle_id,
-                file=self.assemble_result.bundle,
+                file=file,
                 artifact_count=self.archive.artifact_count,
                 # By default, a bundle is not indexed.
                 indexing_state=ArtifactBundleIndexingState.NOT_INDEXED.value,

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -15,6 +15,7 @@ from google.cloud.bigtable.row_data import DEFAULT_RETRY_READ_ROWS
 from google.cloud.bigtable.row_set import RowSet
 from google.cloud.bigtable.table import Table
 
+from sentry.utils import metrics
 from sentry.utils.codecs import Codec, ZlibCodec, ZstdCodec
 from sentry.utils.kvstore.abstract import KVStorage
 
@@ -235,10 +236,23 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         # tracking now is whether compression is on or not for the data column.
         flags = self.Flags(0)
 
+        metrics.distribution(
+            "storage.put.size",
+            len(value),
+            tags={"usecase": "nodestore", "compression": "none"},
+            unit="byte",
+        )
         if self.compression:
             compression_flag, strategy = self.compression_strategies[self.compression]
             flags |= compression_flag
             value = strategy.encode(value)
+
+            metrics.distribution(
+                "storage.put.size",
+                len(value),
+                tags={"usecase": "nodestore", "compression": self.compression},
+                unit="byte",
+            )
 
         # Only need to write the column at all if any flags are enabled. And if
         # so, pack it into a single byte.


### PR DESCRIPTION
This adds `PUT` size and latency metrics to all the use-cases that we care about:
- Attachments
- Debug Files and Artifact Bundles
- Replays
- Profiles
- Nodestore

The size metrics are being emitted for both compressed and uncompressed sizes, tagged with the used compression algorithm. The `latency` metric is only relevant for the compressed payload however.