### PR TITLE
fix(agent-insights): fix tooltip

### DIFF
--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -104,7 +104,7 @@ export default function LLMGenerationsWidget() {
             new Bars(convertSeriesToTimeseries(ts), {
               color:
                 ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
-              alias: ts.seriesName,
+              alias: ts.seriesName, // Ensures that the tooltip shows the full series name
               stack: 'stack',
             })
         ),

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -104,6 +104,7 @@ export default function TokenUsageWidget() {
             new Bars(convertSeriesToTimeseries(ts), {
               color:
                 ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName,
               stack: 'stack',
             })
         ),

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -104,7 +104,7 @@ export default function TokenUsageWidget() {
             new Bars(convertSeriesToTimeseries(ts), {
               color:
                 ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
-              alias: ts.seriesName,
+              alias: ts.seriesName, // Ensures that the tooltip shows the full series name
               stack: 'stack',
             })
         ),

--- a/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
@@ -102,7 +102,7 @@ export default function ToolUsageWidget() {
             new Bars(convertSeriesToTimeseries(ts), {
               color:
                 ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
-              alias: ts.seriesName,
+              alias: ts.seriesName, // Ensures that the tooltip shows the full series name
               stack: 'stack',
             })
         ),


### PR DESCRIPTION
closes [TET-874: Fix formatting of claude in tooltips](https://linear.app/getsentry/issue/TET-874/fix-formatting-of-claude-in-tooltips)