### PR TITLE
feat(mcp-insights): Add traffic and traffic by transport

### DIFF
--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -188,6 +188,8 @@ const CHART_MAP = {
     import(
       'sentry/views/insights/common/components/widgets/overviewSlowQueriesChartWidget'
     ),
+  mcpTrafficWidget: () =>
+    import('sentry/views/insights/common/components/widgets/mcpTrafficWidget'),
 } satisfies Record<string, () => Promise<{default: React.FC<LoadableChartWidgetProps>}>>;
 
 /**

--- a/static/app/views/insights/common/components/widgets/mcpTrafficWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/mcpTrafficWidget.tsx
@@ -1,0 +1,19 @@
+import {t} from 'sentry/locale';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
+import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {BaseTrafficWidget} from 'sentry/views/insights/pages/platform/shared/baseTrafficWidget';
+
+export default function McpTrafficWidget(props: LoadableChartWidgetProps) {
+  const query = useCombinedQuery('span.op:mcp.server');
+  return (
+    <BaseTrafficWidget
+      id="mcpTrafficWidget"
+      title={t('Traffic')}
+      trafficSeriesName={t('Requests')}
+      query={query}
+      referrer={MCPReferrer.MCP_TRAFFIC_WIDGET}
+      {...props}
+    />
+  );
+}

--- a/static/app/views/insights/common/components/widgets/overviewJobsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewJobsChartWidget.tsx
@@ -60,14 +60,14 @@ export default function OverviewJobsChartWidget(props: LoadableChartWidgetProps)
     return [
       new Bars(convertSeriesToTimeseries(data['count(span.duration)']), {
         alias: ALIASES['count(span.duration)'],
-        color: theme.gray200,
+        color: theme.chart.neutral,
       }),
       new Line(convertSeriesToTimeseries(data['trace_status_rate(internal_error)']), {
         alias: ALIASES['trace_status_rate(internal_error)'],
         color: theme.error,
       }),
     ];
-  }, [data, theme.error, theme.gray200]);
+  }, [data, theme.error, theme.chart.neutral]);
 
   const isEmpty = useMemo(
     () =>

--- a/static/app/views/insights/mcp/components/mcpTransportWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpTransportWidget.tsx
@@ -1,0 +1,173 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import Count from 'sentry/components/count';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
+import {AI_MODEL_ID_ATTRIBUTE} from 'sentry/views/insights/agentMonitoring/utils/query';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import {SpanFields} from 'sentry/views/insights/types';
+import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+export default function LLMGenerationsWidget() {
+  const organization = useOrganization();
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+  });
+
+  const theme = useTheme();
+  const fullQuery = useCombinedQuery('span.op:mcp.server');
+
+  const topEventsRequest = useEAPSpans(
+    {
+      fields: [SpanFields.MCP_TRANSPORT, 'count()'],
+      sorts: [{field: 'count()', kind: 'desc'}],
+      search: fullQuery,
+      limit: 3,
+    },
+    MCPReferrer.MCP_TRANSPORT_WIDGET
+  );
+
+  const timeSeriesRequest = useTopNSpanEAPSeries(
+    {
+      ...pageFilterChartParams,
+      search: fullQuery,
+      fields: [SpanFields.MCP_TRANSPORT, 'count(span.duration)'],
+      yAxis: ['count(span.duration)'],
+      sort: {field: 'count(span.duration)', kind: 'desc'},
+      topN: 3,
+      enabled: !!topEventsRequest.data && topEventsRequest.data.length > 0,
+    },
+    MCPReferrer.MCP_TRANSPORT_WIDGET
+  );
+
+  const timeSeries = timeSeriesRequest.data;
+
+  const isLoading = timeSeriesRequest.isLoading || topEventsRequest.isLoading;
+  const error = timeSeriesRequest.error || topEventsRequest.error;
+
+  // TODO(telex): Add model id attribute to Fields and get rid of this cast
+  const models = topEventsRequest.data as unknown as Array<
+    Record<string, string | number>
+  >;
+
+  const hasData = models && models.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={
+        <GenericWidgetEmptyStateWarning
+          message={tct(
+            'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
+            {
+              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+            }
+          )}
+        />
+      }
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        showLegend: 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Bars(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName,
+              stack: 'stack',
+            })
+        ),
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {models?.map((item, index) => {
+        const modelId = `${item[AI_MODEL_ID_ATTRIBUTE]}`;
+        return (
+          <Fragment key={modelId}>
+            <div>
+              <SeriesColorIndicator
+                style={{
+                  backgroundColor: colorPalette[index],
+                }}
+              />
+            </div>
+            <div>{item[SpanFields.MCP_TRANSPORT] ?? t('(none)')}</div>
+            <span>
+              <Count value={item['count()'] ?? 0} />
+            </span>
+          </Fragment>
+        );
+      })}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={t('Transport Distribution')} />}
+      Visualization={visualization}
+      Actions={
+        organization.features.includes('visibility-explore-view') &&
+        hasData && (
+          <Toolbar
+            showCreateAlert
+            referrer={MCPReferrer.MCP_TRANSPORT_WIDGET}
+            exploreParams={{
+              mode: Mode.AGGREGATE,
+              visualize: [
+                {
+                  chartType: ChartType.BAR,
+                  yAxes: ['count(span.duration)'],
+                },
+              ],
+              groupBy: [SpanFields.MCP_TRANSPORT],
+              query: fullQuery,
+              sort: `-count(span.duration)`,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: t('Transport Distribution'),
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
+        )
+      }
+      noFooterPadding
+      Footer={footer}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpTransportWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpTransportWidget.tsx
@@ -11,7 +11,6 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
-import {AI_MODEL_ID_ATTRIBUTE} from 'sentry/views/insights/agentMonitoring/utils/query';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
@@ -29,7 +28,7 @@ import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
 import {SpanFields} from 'sentry/views/insights/types';
 import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
 
-export default function LLMGenerationsWidget() {
+export default function McpTransportWidget() {
   const organization = useOrganization();
   const pageFilterChartParams = usePageFilterChartParams({
     granularity: 'spans-low',
@@ -109,9 +108,9 @@ export default function LLMGenerationsWidget() {
   const footer = hasData && (
     <WidgetFooterTable>
       {models?.map((item, index) => {
-        const modelId = `${item[AI_MODEL_ID_ATTRIBUTE]}`;
+        const transportName = item[SpanFields.MCP_TRANSPORT] ?? t('(none)');
         return (
-          <Fragment key={modelId}>
+          <Fragment key={transportName}>
             <div>
               <SeriesColorIndicator
                 style={{
@@ -119,7 +118,7 @@ export default function LLMGenerationsWidget() {
                 }}
               />
             </div>
-            <div>{item[SpanFields.MCP_TRANSPORT] ?? t('(none)')}</div>
+            <div>{transportName}</div>
             <span>
               <Count value={item['count()'] ?? 0} />
             </span>

--- a/static/app/views/insights/mcp/components/placeholders.tsx
+++ b/static/app/views/insights/mcp/components/placeholders.tsx
@@ -28,28 +28,10 @@ function PlaceholderText() {
   return <PlaceholderContent>{t('Placeholder')}</PlaceholderContent>;
 }
 
-export function McpTrafficWidget() {
-  return (
-    <Widget
-      Title={<Widget.WidgetTitle title={t('Traffic + Error rate')} />}
-      Visualization={<PlaceholderText />}
-    />
-  );
-}
-
 export function RequestsBySourceWidget() {
   return (
     <Widget
       Title={<Widget.WidgetTitle title={t('Requests by source')} />}
-      Visualization={<PlaceholderText />}
-    />
-  );
-}
-
-export function TransportDistributionWidget() {
-  return (
-    <Widget
-      Title={<Widget.WidgetTitle title={t('Transport distribution')} />}
       Visualization={<PlaceholderText />}
     />
   );

--- a/static/app/views/insights/mcp/components/styles.tsx
+++ b/static/app/views/insights/mcp/components/styles.tsx
@@ -7,7 +7,7 @@ const StyledGrid = styled('div')`
   gap: ${space(2)};
 
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: 300px 300px 300px;
+  grid-template-rows: 260px 260px 260px;
   grid-template-areas:
     'pos1'
     'pos2'
@@ -15,7 +15,7 @@ const StyledGrid = styled('div')`
 
   @media (min-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    grid-template-rows: 300px 300px;
+    grid-template-rows: 260px 260px;
     grid-template-areas:
       'pos1 pos2'
       'pos3 pos3';
@@ -23,7 +23,7 @@ const StyledGrid = styled('div')`
 
   @media (min-width: ${p => p.theme.breakpoints.lg}) {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
-    grid-template-rows: 300px;
+    grid-template-rows: 260px;
     grid-template-areas: 'pos1 pos2 pos3';
   }
 `;

--- a/static/app/views/insights/mcp/utils/referrer.tsx
+++ b/static/app/views/insights/mcp/utils/referrer.tsx
@@ -1,0 +1,4 @@
+export enum MCPReferrer {
+  MCP_TRAFFIC_WIDGET = 'mcp-traffic-widget',
+  MCP_TRANSPORT_WIDGET = 'mcp-transport-widget',
+}

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -29,16 +29,16 @@ import {ModulesOnboardingPanel} from 'sentry/views/insights/common/components/mo
 import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/moduleUpsellHookWrapper';
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
+import McpTrafficWidget from 'sentry/views/insights/common/components/widgets/mcpTrafficWidget';
+import McpTransportWidget from 'sentry/views/insights/mcp/components/mcpTransportWidget';
 import {
   GroupedDurationWidget,
   GroupedErrorRateWidget,
   GroupedTrafficWidget,
-  McpTrafficWidget,
   PromptsTable,
   RequestsBySourceWidget,
   ResourcesTable,
   ToolsTable,
-  TransportDistributionWidget,
 } from 'sentry/views/insights/mcp/components/placeholders';
 import {WidgetGrid} from 'sentry/views/insights/mcp/components/styles';
 import {MODULE_TITLE} from 'sentry/views/insights/mcp/settings';
@@ -142,7 +142,7 @@ function McpOverviewPage() {
                         <RequestsBySourceWidget />
                       </WidgetGrid.Position2>
                       <WidgetGrid.Position3>
-                        <TransportDistributionWidget />
+                        <McpTransportWidget />
                       </WidgetGrid.Position3>
                     </WidgetGrid>
                     <ControlsWrapper>

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -111,6 +111,7 @@ export enum SpanFields {
   GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens',
   GEN_AI_USAGE_TOTAL_COST = 'gen_ai.usage.total_cost',
   GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens',
+  MCP_TRANSPORT = 'mcp.transport',
 }
 
 type WebVitalsMeasurements =
@@ -168,6 +169,7 @@ type SpanStringFields =
   | SpanFields.GEN_AI_REQUEST_MODEL
   | SpanFields.GEN_AI_RESPONSE_MODEL
   | SpanFields.GEN_AI_TOOL_NAME
+  | SpanFields.MCP_TRANSPORT
   | 'span_id'
   | 'span.op'
   | 'span.description'


### PR DESCRIPTION
Add traffic and traffic by transport distribution widgets.
Adding a list of top issues to the traffic widget will be done in a follow up.

- closes [TET-851: Widget: Transport distribution](https://linear.app/getsentry/issue/TET-851/widget-transport-distribution)