### PR TITLE
feat(spans): Track indexed spans outcomes in process-segments

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from sentry_kafka_schemas.schema_types.buffered_segments_v1 import SegmentSpan
 
 from sentry import options
-from sentry.constants import INSIGHT_MODULE_FILTERS
+from sentry.constants import INSIGHT_MODULE_FILTERS, DataCategory
 from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_release
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
@@ -32,7 +32,7 @@ from sentry.spans.consumers.process_segments.enrichment import (
 from sentry.spans.grouping.api import load_span_grouping_config
 from sentry.utils import metrics
 from sentry.utils.dates import to_datetime
-from sentry.utils.outcomes import DataCategory, Outcome, track_outcome
+from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.projectflags import set_project_flag_and_signal
 
 logger = logging.getLogger(__name__)
@@ -273,7 +273,7 @@ def _track_outcomes(segment_span: Span, spans: list[Span]) -> None:
     track_outcome(
         org_id=segment_span["organization_id"],
         project_id=segment_span["project_id"],
-        key_id=segment_span.get("key_id", None),
+        key_id=cast(int | None, segment_span.get("key_id", None)),
         outcome=Outcome.ACCEPTED,
         reason=None,
         timestamp=to_datetime(segment_span["received"]),


### PR DESCRIPTION
Relay will stop producing ACCEPTED outcomes for indexed spans. This should
instead be handled by the component closest to storage. Eventually, EAP will
support metadata to track outcomes internally. Until this is available, we track
them in the `process-segments` consumer.

This is a first iteration, in which we track an aggregate outcome for all spans
in a segment. Ideally, we move this into a strategy following the produce step
to ensure that we do not track outcomes if producing fails.

