### PR TITLE
feat(relay): Tag project config invalidations with option

### DIFF
--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -116,7 +116,7 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
 
     def unset_value(self, project: Project, key: str) -> None:
         self.filter(project=project, key=key).delete()
-        self.reload_cache(project.id, "projectoption.unset_value")
+        self.reload_cache(project.id, "projectoption.unset_value", key)
 
     def set_value(self, project: int | Project, key: str, value: Any) -> bool:
         if isinstance(project, models.Model):
@@ -127,7 +127,7 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
         inst, created = self.create_or_update(
             project_id=project_id, key=key, values={"value": value}
         )
-        self.reload_cache(project_id, "projectoption.set_value")
+        self.reload_cache(project_id, "projectoption.set_value", key)
 
         return created or inst > 0
 
@@ -147,11 +147,15 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
 
         return self._option_cache.get(cache_key, {})
 
-    def reload_cache(self, project_id: int, update_reason: str) -> Mapping[str, Any]:
+    def reload_cache(
+        self, project_id: int, update_reason: str, option_key: str | None = None
+    ) -> Mapping[str, Any]:
         from sentry.tasks.relay import schedule_invalidate_project_config
 
         if update_reason != "projectoption.get_all_values":
-            schedule_invalidate_project_config(project_id=project_id, trigger=update_reason)
+            schedule_invalidate_project_config(
+                project_id=project_id, trigger=update_reason, project_option_key=option_key
+            )
         cache_key = self._make_key(project_id)
         result = {i.key: i.value for i in self.filter(project=project_id)}
         cache.set(cache_key, result)
@@ -159,10 +163,10 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
         return result
 
     def post_save(self, *, instance: ProjectOption, created: bool, **kwargs: object) -> None:
-        self.reload_cache(instance.project_id, "projectoption.post_save")
+        self.reload_cache(instance.project_id, "projectoption.post_save", option_key=instance.key)
 
     def post_delete(self, instance: ProjectOption, **kwargs: Any) -> None:
-        self.reload_cache(instance.project_id, "projectoption.post_delete")
+        self.reload_cache(instance.project_id, "projectoption.post_delete", option_key=instance.key)
 
     def isset(self, project: Project, key: str) -> bool:
         return self.get_value(project, key, default=Ellipsis) is not Ellipsis

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -154,7 +154,7 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
 
         if update_reason != "projectoption.get_all_values":
             schedule_invalidate_project_config(
-                project_id=project_id, trigger=update_reason, project_option_key=option_key
+                project_id=project_id, trigger=update_reason, trigger_details=option_key
             )
         cache_key = self._make_key(project_id)
         result = {i.key: i.value for i in self.filter(project=project_id)}

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -215,7 +215,7 @@ def invalidate_project_config(
     project_id=None,
     public_key=None,
     trigger="invalidated",
-    project_option_key=None,
+    trigger_details=None,
     **kwargs,
 ):
     """Task which re-computes an invalidated project config.
@@ -252,7 +252,7 @@ def invalidate_project_config(
     if public_key:
         sentry_sdk.set_tag("public_key", public_key)
     sentry_sdk.set_tag("trigger", trigger)
-    sentry_sdk.set_tag("project_option", project_option_key)
+    sentry_sdk.set_tag("trigger_details", trigger_details)
     sentry_sdk.set_context("kwargs", kwargs)
 
     updated_configs = compute_configs(
@@ -265,7 +265,7 @@ def invalidate_project_config(
 def schedule_invalidate_project_config(
     *,
     trigger,
-    project_option_key=None,
+    trigger_details=None,
     organization_id=None,
     project_id=None,
     public_key=None,
@@ -298,8 +298,8 @@ def schedule_invalidate_project_config(
     the project config task is executed immediately.
 
     :param trigger: The reason for the invalidation.  This is used to tag metrics.
-    :param project_option_key: If this function was called because of a project option update,
-        this is the key of the option.
+    :param trigger_details: Additional information about what triggered the invalidation.
+        This is used to tag metrics.
     :param organization_id: Invalidates all project keys for all projects in an organization.
     :param project_id: Invalidates all project keys for a project.
     :param public_key: Invalidate a single public key.
@@ -326,7 +326,7 @@ def schedule_invalidate_project_config(
         transaction.on_commit(
             lambda: _schedule_invalidate_project_config(
                 trigger=trigger,
-                project_option_key=project_option_key,
+                trigger_details=trigger_details,
                 organization_id=organization_id,
                 project_id=project_id,
                 public_key=public_key,
@@ -339,7 +339,7 @@ def schedule_invalidate_project_config(
 def _schedule_invalidate_project_config(
     *,
     trigger,
-    project_option_key=None,
+    trigger_details=None,
     organization_id=None,
     project_id=None,
     public_key=None,
@@ -390,7 +390,7 @@ def _schedule_invalidate_project_config(
         "relay.projectconfig_cache.scheduled",
         tags={
             "update_reason": trigger,
-            "project_option": project_option_key,
+            "update_reason_details": trigger_details,
             "task": "invalidation",
         },
     )
@@ -402,7 +402,7 @@ def _schedule_invalidate_project_config(
             "organization_id": organization_id,
             "public_key": public_key,
             "trigger": trigger,
-            "project_option_key": project_option_key,
+            "trigger_details": trigger_details,
         },
     )
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -397,12 +397,14 @@ class TestInvalidationTask:
                 "organization_id": None,
                 "public_key": None,
                 "trigger": "test",
+                "project_option_key": None,
             },
             {
                 "project_id": None,
                 "organization_id": default_organization.id,
                 "public_key": None,
                 "trigger": "test",
+                "project_option_key": None,
             },
         ]
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -388,8 +388,12 @@ class TestInvalidationTask:
         invalidation_debounce_cache.mark_task_done(
             public_key=None, project_id=None, organization_id=default_organization.id
         )
-        schedule_invalidate_project_config(organization_id=default_organization.id, trigger="test")
-        schedule_invalidate_project_config(organization_id=default_organization.id, trigger="test")
+        schedule_invalidate_project_config(
+            organization_id=default_organization.id, trigger="test", trigger_details="more test"
+        )
+        schedule_invalidate_project_config(
+            organization_id=default_organization.id, trigger="test", trigger_details="more test"
+        )
 
         assert tasks == [
             {
@@ -397,14 +401,14 @@ class TestInvalidationTask:
                 "organization_id": None,
                 "public_key": None,
                 "trigger": "test",
-                "project_option_key": None,
+                "trigger_details": None,
             },
             {
                 "project_id": None,
                 "organization_id": default_organization.id,
                 "public_key": None,
                 "trigger": "test",
-                "project_option_key": None,
+                "trigger_details": "more test",
             },
         ]
 
@@ -475,7 +479,7 @@ class TestInvalidationTask:
         assert schedule_inner.call_count == 1
         assert schedule_inner.call_args == call(
             trigger="test",
-            project_option_key=None,
+            trigger_details=None,
             organization_id=None,
             project_id=default_project.id,
             public_key=None,

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -473,6 +473,7 @@ class TestInvalidationTask:
         assert schedule_inner.call_count == 1
         assert schedule_inner.call_args == call(
             trigger="test",
+            project_option_key=None,
             organization_id=None,
             project_id=default_project.id,
             public_key=None,


### PR DESCRIPTION
In cases where a project config is invalidated because a project option was set or deleted, we now add a tag `project_option` to the Sentry scope and the metrics for the invalidation.

Ref INGEST-444.