### PR TITLE
feat(mcp-insights): Add grouped by type widgets

### DIFF
--- a/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
@@ -1,0 +1,172 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
+import getDuration from 'sentry/utils/duration/getDuration';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import type {SpanStringFields} from 'sentry/views/insights/types';
+import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+interface GroupedDurationWidgetProps {
+  groupBy: SpanStringFields;
+  query: string;
+  referrer: string;
+  title: string;
+}
+
+export default function GroupedDurationWidget(props: GroupedDurationWidgetProps) {
+  const organization = useOrganization();
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+  });
+
+  const theme = useTheme();
+  const fullQuery = useCombinedQuery(props.query);
+
+  const topEventsRequest = useEAPSpans(
+    {
+      fields: [props.groupBy, 'avg(span.duration)'],
+      sorts: [{field: 'avg(span.duration)', kind: 'desc'}],
+      search: fullQuery,
+      limit: 3,
+    },
+    props.referrer
+  );
+
+  const timeSeriesRequest = useTopNSpanEAPSeries(
+    {
+      ...pageFilterChartParams,
+      search: fullQuery,
+      fields: [props.groupBy, 'avg(span.duration)'],
+      yAxis: ['avg(span.duration)'],
+      sort: {field: 'avg(span.duration)', kind: 'desc'},
+      topN: 3,
+      enabled: !!topEventsRequest.data && topEventsRequest.data.length > 0,
+    },
+    props.referrer
+  );
+
+  const timeSeries = timeSeriesRequest.data;
+
+  const isLoading = timeSeriesRequest.isLoading || topEventsRequest.isLoading;
+  const error = timeSeriesRequest.error || topEventsRequest.error;
+
+  const events = topEventsRequest.data;
+
+  const hasData = events && events.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={
+        <GenericWidgetEmptyStateWarning
+          message={tct(
+            'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
+            {
+              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+            }
+          )}
+        />
+      }
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        showLegend: 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Line(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName,
+            })
+        ),
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {events?.map((item, index) => {
+        const groupName = item[props.groupBy] ?? t('Other');
+        return (
+          <Fragment key={groupName}>
+            <div>
+              <SeriesColorIndicator
+                style={{
+                  backgroundColor: colorPalette[index],
+                }}
+              />
+            </div>
+            <div>{groupName}</div>
+            <span>{getDuration((item['avg(span.duration)'] ?? 0) / 1000, 2, true)}</span>
+          </Fragment>
+        );
+      })}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={props.title} />}
+      Visualization={visualization}
+      Actions={
+        organization.features.includes('visibility-explore-view') &&
+        hasData && (
+          <Toolbar
+            showCreateAlert
+            referrer={props.referrer}
+            exploreParams={{
+              mode: Mode.AGGREGATE,
+              visualize: [
+                {
+                  chartType: ChartType.BAR,
+                  yAxes: ['avg(span.duration)'],
+                },
+              ],
+              groupBy: [props.groupBy],
+              query: fullQuery,
+              sort: `-avg(span.duration)`,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: props.title,
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
+        )
+      }
+      noFooterPadding
+      Footer={footer}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
@@ -1,0 +1,173 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
+import {formatPercentage} from 'sentry/utils/number/formatPercentage';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import type {SpanStringFields} from 'sentry/views/insights/types';
+import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+interface GroupedErrorRateWidgetProps {
+  groupBy: SpanStringFields;
+  query: string;
+  referrer: string;
+  title: string;
+}
+
+export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProps) {
+  const organization = useOrganization();
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+  });
+
+  const theme = useTheme();
+  const fullQuery = useCombinedQuery(props.query);
+
+  const topEventsRequest = useEAPSpans(
+    {
+      fields: [props.groupBy, 'failure_rate()'],
+      sorts: [{field: 'failure_rate()', kind: 'desc'}],
+      search: fullQuery,
+      limit: 3,
+    },
+    props.referrer
+  );
+
+  const timeSeriesRequest = useTopNSpanEAPSeries(
+    {
+      ...pageFilterChartParams,
+      search: fullQuery,
+      fields: [props.groupBy, 'failure_rate()'],
+      yAxis: ['failure_rate()'],
+      sort: {field: 'failure_rate()', kind: 'desc'},
+      topN: 3,
+      enabled: !!topEventsRequest.data && topEventsRequest.data.length > 0,
+    },
+    props.referrer
+  );
+
+  const timeSeries = timeSeriesRequest.data;
+
+  const isLoading = timeSeriesRequest.isLoading || topEventsRequest.isLoading;
+  const error = timeSeriesRequest.error || topEventsRequest.error;
+
+  const events = topEventsRequest.data;
+
+  const hasData = events && events.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={
+        <GenericWidgetEmptyStateWarning
+          message={tct(
+            'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
+            {
+              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+            }
+          )}
+        />
+      }
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        showLegend: 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Bars(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName,
+              stack: 'stack',
+            })
+        ),
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {events?.map((item, index) => {
+        const groupName = item[props.groupBy] ?? t('Other');
+        return (
+          <Fragment key={groupName}>
+            <div>
+              <SeriesColorIndicator
+                style={{
+                  backgroundColor: colorPalette[index],
+                }}
+              />
+            </div>
+            <div>{groupName}</div>
+            <span>{formatPercentage(item['failure_rate()'] ?? 0, 2)}</span>
+          </Fragment>
+        );
+      })}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={props.title} />}
+      Visualization={visualization}
+      Actions={
+        organization.features.includes('visibility-explore-view') &&
+        hasData && (
+          <Toolbar
+            showCreateAlert
+            referrer={props.referrer}
+            exploreParams={{
+              mode: Mode.AGGREGATE,
+              visualize: [
+                {
+                  chartType: ChartType.BAR,
+                  yAxes: ['failure_rate()'],
+                },
+              ],
+              groupBy: [props.groupBy],
+              query: fullQuery,
+              sort: `-failure_rate()`,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: props.title,
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
+        )
+      }
+      noFooterPadding
+      Footer={footer}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
@@ -1,0 +1,175 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+
+import {openInsightChartModal} from 'sentry/actionCreators/modal';
+import Count from 'sentry/components/count';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
+import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
+import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
+import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
+import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
+import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
+import {
+  ModalChartContainer,
+  ModalTableWrapper,
+  SeriesColorIndicator,
+  WidgetFooterTable,
+} from 'sentry/views/insights/pages/platform/shared/styles';
+import {Toolbar} from 'sentry/views/insights/pages/platform/shared/toolbar';
+import type {SpanStringFields} from 'sentry/views/insights/types';
+import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+interface GroupedTrafficWidgetProps {
+  groupBy: SpanStringFields;
+  query: string;
+  referrer: string;
+  title: string;
+}
+
+export default function GroupedTrafficWidget(props: GroupedTrafficWidgetProps) {
+  const organization = useOrganization();
+  const pageFilterChartParams = usePageFilterChartParams({
+    granularity: 'spans-low',
+  });
+
+  const theme = useTheme();
+  const fullQuery = useCombinedQuery(props.query);
+
+  const topEventsRequest = useEAPSpans(
+    {
+      fields: [props.groupBy, 'count()'],
+      sorts: [{field: 'count()', kind: 'desc'}],
+      search: fullQuery,
+      limit: 3,
+    },
+    props.referrer
+  );
+
+  const timeSeriesRequest = useTopNSpanEAPSeries(
+    {
+      ...pageFilterChartParams,
+      search: fullQuery,
+      fields: [props.groupBy, 'count(span.duration)'],
+      yAxis: ['count(span.duration)'],
+      sort: {field: 'count(span.duration)', kind: 'desc'},
+      topN: 3,
+      enabled: !!topEventsRequest.data && topEventsRequest.data.length > 0,
+    },
+    props.referrer
+  );
+
+  const timeSeries = timeSeriesRequest.data;
+
+  const isLoading = timeSeriesRequest.isLoading || topEventsRequest.isLoading;
+  const error = timeSeriesRequest.error || topEventsRequest.error;
+
+  const events = topEventsRequest.data;
+
+  const hasData = events && events.length > 0 && timeSeries.length > 0;
+
+  const colorPalette = theme.chart.getColorPalette(timeSeries.length - 1);
+
+  const visualization = (
+    <WidgetVisualizationStates
+      isEmpty={!hasData}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage={
+        <GenericWidgetEmptyStateWarning
+          message={tct(
+            'No MCP spans found. Try updating your filters or learn more about MCP monitoring in our [link:documentation].',
+            {
+              link: <ExternalLink href="https://docs.sentry.io/product/insights/mcp/" />,
+            }
+          )}
+        />
+      }
+      VisualizationType={TimeSeriesWidgetVisualization}
+      visualizationProps={{
+        showLegend: 'never',
+        plottables: timeSeries.map(
+          (ts, index) =>
+            new Bars(convertSeriesToTimeseries(ts), {
+              color:
+                ts.seriesName === 'Other' ? theme.chart.neutral : colorPalette[index],
+              alias: ts.seriesName,
+              stack: 'stack',
+            })
+        ),
+      }}
+    />
+  );
+
+  const footer = hasData && (
+    <WidgetFooterTable>
+      {events?.map((item, index) => {
+        const groupName = item[props.groupBy] ?? t('Other');
+        return (
+          <Fragment key={groupName}>
+            <div>
+              <SeriesColorIndicator
+                style={{
+                  backgroundColor: colorPalette[index],
+                }}
+              />
+            </div>
+            <div>{groupName}</div>
+            <span>
+              <Count value={item['count()'] ?? 0} />
+            </span>
+          </Fragment>
+        );
+      })}
+    </WidgetFooterTable>
+  );
+
+  return (
+    <Widget
+      Title={<Widget.WidgetTitle title={props.title} />}
+      Visualization={visualization}
+      Actions={
+        organization.features.includes('visibility-explore-view') &&
+        hasData && (
+          <Toolbar
+            showCreateAlert
+            referrer={props.referrer}
+            exploreParams={{
+              mode: Mode.AGGREGATE,
+              visualize: [
+                {
+                  chartType: ChartType.BAR,
+                  yAxes: ['count(span.duration)'],
+                },
+              ],
+              groupBy: [props.groupBy],
+              query: fullQuery,
+              sort: `-count(span.duration)`,
+              interval: pageFilterChartParams.interval,
+            }}
+            onOpenFullScreen={() => {
+              openInsightChartModal({
+                title: props.title,
+                children: (
+                  <Fragment>
+                    <ModalChartContainer>{visualization}</ModalChartContainer>
+                    <ModalTableWrapper>{footer}</ModalTableWrapper>
+                  </Fragment>
+                ),
+              });
+            }}
+          />
+        )
+      }
+      noFooterPadding
+      Footer={footer}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpPromptDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptDurationWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import GroupedDurationWidget from 'sentry/views/insights/mcp/components/groupedDurationWidget';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export default function McpPromptDurationWidget() {
+  return (
+    <GroupedDurationWidget
+      groupBy={SpanFields.MCP_PROMPT_NAME}
+      referrer={MCPReferrer.MCP_PROMPT_TRAFFIC_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`}
+      title={t('Slowest Prompts')}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpPromptDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptDurationWidget.tsx
@@ -7,7 +7,7 @@ export default function McpPromptDurationWidget() {
   return (
     <GroupedDurationWidget
       groupBy={SpanFields.MCP_PROMPT_NAME}
-      referrer={MCPReferrer.MCP_PROMPT_TRAFFIC_WIDGET}
+      referrer={MCPReferrer.MCP_PROMPT_DURATION_WIDGET}
       query={`span.op:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`}
       title={t('Slowest Prompts')}
     />

--- a/static/app/views/insights/mcp/components/mcpPromptErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptErrorRateWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import GroupedErrorRateWidget from 'sentry/views/insights/mcp/components/groupedErrorRateWidget';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export default function McpPromptErrorRateWidget() {
+  return (
+    <GroupedErrorRateWidget
+      groupBy={SpanFields.MCP_PROMPT_NAME}
+      referrer={MCPReferrer.MCP_PROMPT_ERROR_RATE_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`}
+      title={t('Most Failing Prompts')}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpPromptTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptTrafficWidget.tsx
@@ -3,13 +3,13 @@ import GroupedTrafficWidget from 'sentry/views/insights/mcp/components/groupedTr
 import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {SpanFields} from 'sentry/views/insights/types';
 
-export default function McpTransportWidget() {
+export default function McpResourceTrafficWidget() {
   return (
     <GroupedTrafficWidget
-      groupBy={SpanFields.MCP_TRANSPORT}
-      referrer={MCPReferrer.MCP_TRANSPORT_WIDGET}
-      query={`has:${SpanFields.MCP_TRANSPORT}`}
-      title={t('Transport Distribution')}
+      groupBy={SpanFields.MCP_PROMPT_NAME}
+      referrer={MCPReferrer.MCP_PROMPT_TRAFFIC_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_PROMPT_NAME}`}
+      title={t('Most Used Prompts')}
     />
   );
 }

--- a/static/app/views/insights/mcp/components/mcpPromptTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpPromptTrafficWidget.tsx
@@ -3,7 +3,7 @@ import GroupedTrafficWidget from 'sentry/views/insights/mcp/components/groupedTr
 import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {SpanFields} from 'sentry/views/insights/types';
 
-export default function McpResourceTrafficWidget() {
+export default function McpPromptTrafficWidget() {
   return (
     <GroupedTrafficWidget
       groupBy={SpanFields.MCP_PROMPT_NAME}

--- a/static/app/views/insights/mcp/components/mcpResourceDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourceDurationWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import GroupedDurationWidget from 'sentry/views/insights/mcp/components/groupedDurationWidget';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export default function McpResourceDurationWidget() {
+  return (
+    <GroupedDurationWidget
+      groupBy={SpanFields.MCP_RESOURCE_URI}
+      referrer={MCPReferrer.MCP_RESOURCE_TRAFFIC_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`}
+      title={t('Slowest Resources')}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpResourceDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourceDurationWidget.tsx
@@ -7,7 +7,7 @@ export default function McpResourceDurationWidget() {
   return (
     <GroupedDurationWidget
       groupBy={SpanFields.MCP_RESOURCE_URI}
-      referrer={MCPReferrer.MCP_RESOURCE_TRAFFIC_WIDGET}
+      referrer={MCPReferrer.MCP_RESOURCE_DURATION_WIDGET}
       query={`span.op:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`}
       title={t('Slowest Resources')}
     />

--- a/static/app/views/insights/mcp/components/mcpResourceErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourceErrorRateWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import GroupedErrorRateWidget from 'sentry/views/insights/mcp/components/groupedErrorRateWidget';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export default function McpResourceErrorRateWidget() {
+  return (
+    <GroupedErrorRateWidget
+      groupBy={SpanFields.MCP_RESOURCE_URI}
+      referrer={MCPReferrer.MCP_RESOURCE_ERROR_RATE_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`}
+      title={t('Most Failing Resources')}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpResourceTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpResourceTrafficWidget.tsx
@@ -3,13 +3,13 @@ import GroupedTrafficWidget from 'sentry/views/insights/mcp/components/groupedTr
 import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {SpanFields} from 'sentry/views/insights/types';
 
-export default function McpTransportWidget() {
+export default function McpResourceTrafficWidget() {
   return (
     <GroupedTrafficWidget
-      groupBy={SpanFields.MCP_TRANSPORT}
-      referrer={MCPReferrer.MCP_TRANSPORT_WIDGET}
-      query={`has:${SpanFields.MCP_TRANSPORT}`}
-      title={t('Transport Distribution')}
+      groupBy={SpanFields.MCP_RESOURCE_URI}
+      referrer={MCPReferrer.MCP_RESOURCE_TRAFFIC_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_RESOURCE_URI}`}
+      title={t('Most Used Resources')}
     />
   );
 }

--- a/static/app/views/insights/mcp/components/mcpToolDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolDurationWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import GroupedDurationWidget from 'sentry/views/insights/mcp/components/groupedDurationWidget';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export default function McpToolDurationWidget() {
+  return (
+    <GroupedDurationWidget
+      groupBy={SpanFields.MCP_TOOL_NAME}
+      referrer={MCPReferrer.MCP_TOOL_DURATION_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_TOOL_NAME}`}
+      title={t('Slowest Tools')}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpToolErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolErrorRateWidget.tsx
@@ -1,0 +1,15 @@
+import {t} from 'sentry/locale';
+import GroupedErrorRateWidget from 'sentry/views/insights/mcp/components/groupedErrorRateWidget';
+import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
+import {SpanFields} from 'sentry/views/insights/types';
+
+export default function McpToolErrorRateWidget() {
+  return (
+    <GroupedErrorRateWidget
+      groupBy={SpanFields.MCP_TOOL_NAME}
+      referrer={MCPReferrer.MCP_TOOL_ERROR_RATE_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_TOOL_NAME}`}
+      title={t('Most Failing Tools')}
+    />
+  );
+}

--- a/static/app/views/insights/mcp/components/mcpToolTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpToolTrafficWidget.tsx
@@ -3,13 +3,13 @@ import GroupedTrafficWidget from 'sentry/views/insights/mcp/components/groupedTr
 import {MCPReferrer} from 'sentry/views/insights/mcp/utils/referrer';
 import {SpanFields} from 'sentry/views/insights/types';
 
-export default function McpTransportWidget() {
+export default function McpToolTrafficWidget() {
   return (
     <GroupedTrafficWidget
-      groupBy={SpanFields.MCP_TRANSPORT}
-      referrer={MCPReferrer.MCP_TRANSPORT_WIDGET}
-      query={`has:${SpanFields.MCP_TRANSPORT}`}
-      title={t('Transport Distribution')}
+      groupBy={SpanFields.MCP_TOOL_NAME}
+      referrer={MCPReferrer.MCP_TOOL_TRAFFIC_WIDGET}
+      query={`span.op:mcp.server has:${SpanFields.MCP_TOOL_NAME}`}
+      title={t('Most Used Tools')}
     />
   );
 }

--- a/static/app/views/insights/mcp/components/mcpTransportWidget.tsx
+++ b/static/app/views/insights/mcp/components/mcpTransportWidget.tsx
@@ -8,7 +8,7 @@ export default function McpTransportWidget() {
     <GroupedTrafficWidget
       groupBy={SpanFields.MCP_TRANSPORT}
       referrer={MCPReferrer.MCP_TRANSPORT_WIDGET}
-      query={`has:${SpanFields.MCP_TRANSPORT}`}
+      query={`span.op:mcp.server has:${SpanFields.MCP_TRANSPORT}`}
       title={t('Transport Distribution')}
     />
   );

--- a/static/app/views/insights/mcp/components/placeholders.tsx
+++ b/static/app/views/insights/mcp/components/placeholders.tsx
@@ -37,45 +37,6 @@ export function RequestsBySourceWidget() {
   );
 }
 
-export function GroupedTrafficWidget({
-  groupBy,
-}: {
-  groupBy: 'tool' | 'resource' | 'prompt';
-}) {
-  return (
-    <Widget
-      Title={<Widget.WidgetTitle title={`Traffic by ${groupBy}`} />}
-      Visualization={<PlaceholderText />}
-    />
-  );
-}
-
-export function GroupedDurationWidget({
-  groupBy,
-}: {
-  groupBy: 'tool' | 'resource' | 'prompt';
-}) {
-  return (
-    <Widget
-      Title={<Widget.WidgetTitle title={`Duration by ${groupBy}`} />}
-      Visualization={<PlaceholderText />}
-    />
-  );
-}
-
-export function GroupedErrorRateWidget({
-  groupBy,
-}: {
-  groupBy: 'tool' | 'resource' | 'prompt';
-}) {
-  return (
-    <Widget
-      Title={<Widget.WidgetTitle title={`Error rate by ${groupBy}`} />}
-      Visualization={<PlaceholderText />}
-    />
-  );
-}
-
 export function ToolsTable() {
   return (
     <TableContainer>

--- a/static/app/views/insights/mcp/utils/referrer.tsx
+++ b/static/app/views/insights/mcp/utils/referrer.tsx
@@ -1,4 +1,13 @@
 export enum MCPReferrer {
-  MCP_TRAFFIC_WIDGET = 'mcp-traffic-widget',
-  MCP_TRANSPORT_WIDGET = 'mcp-transport-widget',
+  MCP_TRAFFIC_WIDGET = 'api.performance.mcp.traffic-widget',
+  MCP_TRANSPORT_WIDGET = 'api.performance.mcp.transport-widget',
+  MCP_TOOL_TRAFFIC_WIDGET = 'api.performance.mcp.tool-traffic-widget',
+  MCP_PROMPT_TRAFFIC_WIDGET = 'api.performance.mcp.prompt-traffic-widget',
+  MCP_RESOURCE_TRAFFIC_WIDGET = 'api.performance.mcp.resource-traffic-widget',
+  MCP_TOOL_DURATION_WIDGET = 'api.performance.mcp.tool-duration-widget',
+  MCP_PROMPT_DURATION_WIDGET = 'api.performance.mcp.prompt-duration-widget',
+  MCP_RESOURCE_DURATION_WIDGET = 'api.performance.mcp.resource-duration-widget',
+  MCP_TOOL_ERROR_RATE_WIDGET = 'api.performance.mcp.tool-error-rate-widget',
+  MCP_PROMPT_ERROR_RATE_WIDGET = 'api.performance.mcp.prompt-error-rate-widget',
+  MCP_RESOURCE_ERROR_RATE_WIDGET = 'api.performance.mcp.resource-error-rate-widget',
 }

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -30,11 +30,17 @@ import {ModuleBodyUpsellHook} from 'sentry/views/insights/common/components/modu
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import McpTrafficWidget from 'sentry/views/insights/common/components/widgets/mcpTrafficWidget';
+import McpPromptDurationWidget from 'sentry/views/insights/mcp/components/mcpPromptDurationWidget';
+import McpPromptErrorRateWidget from 'sentry/views/insights/mcp/components/mcpPromptErrorRateWidget';
+import McpPromptTrafficWidget from 'sentry/views/insights/mcp/components/mcpPromptTrafficWidget';
+import McpResourceDurationWidget from 'sentry/views/insights/mcp/components/mcpResourceDurationWidget';
+import McpResourceErrorRateWidget from 'sentry/views/insights/mcp/components/mcpResourceErrorRateWidget';
+import McpResourceTrafficWidget from 'sentry/views/insights/mcp/components/mcpResourceTrafficWidget';
+import McpToolDurationWidget from 'sentry/views/insights/mcp/components/mcpToolDurationWidget';
+import McpToolErrorRateWidget from 'sentry/views/insights/mcp/components/mcpToolErrorRateWidget';
+import McpToolTrafficWidget from 'sentry/views/insights/mcp/components/mcpToolTrafficWidget';
 import McpTransportWidget from 'sentry/views/insights/mcp/components/mcpTransportWidget';
 import {
-  GroupedDurationWidget,
-  GroupedErrorRateWidget,
-  GroupedTrafficWidget,
   PromptsTable,
   RequestsBySourceWidget,
   ResourcesTable,
@@ -53,6 +59,24 @@ enum ViewType {
   RESOURCE = 'resource',
   PROMPT = 'prompt',
 }
+
+const viewTrafficWidgets: Record<ViewType, React.ComponentType> = {
+  [ViewType.TOOL]: McpToolTrafficWidget,
+  [ViewType.RESOURCE]: McpResourceTrafficWidget,
+  [ViewType.PROMPT]: McpPromptTrafficWidget,
+};
+
+const viewDurationWidgets: Record<ViewType, React.ComponentType> = {
+  [ViewType.TOOL]: McpToolDurationWidget,
+  [ViewType.RESOURCE]: McpResourceDurationWidget,
+  [ViewType.PROMPT]: McpPromptDurationWidget,
+};
+
+const viewErrorRateWidgets: Record<ViewType, React.ComponentType> = {
+  [ViewType.TOOL]: McpToolErrorRateWidget,
+  [ViewType.RESOURCE]: McpResourceErrorRateWidget,
+  [ViewType.PROMPT]: McpPromptErrorRateWidget,
+};
 
 function useShowOnboarding() {
   const {projects} = useProjects();
@@ -98,6 +122,10 @@ function McpOverviewPage() {
   const eapSpanSearchQueryProviderProps = useEAPSpanSearchQueryBuilderProps(
     eapSpanSearchQueryBuilderProps
   );
+
+  const ViewTrafficWidget = viewTrafficWidgets[activeTable];
+  const ViewDurationWidget = viewDurationWidgets[activeTable];
+  const ViewErrorRateWidget = viewErrorRateWidgets[activeTable];
 
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
@@ -164,13 +192,13 @@ function McpOverviewPage() {
                     </ControlsWrapper>
                     <WidgetGrid>
                       <WidgetGrid.Position1>
-                        <GroupedTrafficWidget groupBy={activeTable} />
+                        <ViewTrafficWidget />
                       </WidgetGrid.Position1>
                       <WidgetGrid.Position2>
-                        <GroupedDurationWidget groupBy={activeTable} />
+                        <ViewDurationWidget />
                       </WidgetGrid.Position2>
                       <WidgetGrid.Position3>
-                        <GroupedErrorRateWidget groupBy={activeTable} />
+                        <ViewErrorRateWidget />
                       </WidgetGrid.Position3>
                     </WidgetGrid>
                     {activeTable === ViewType.TOOL && <ToolsTable />}

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -112,6 +112,9 @@ export enum SpanFields {
   GEN_AI_USAGE_TOTAL_COST = 'gen_ai.usage.total_cost',
   GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens',
   MCP_TRANSPORT = 'mcp.transport',
+  MCP_TOOL_NAME = 'mcp.tool.name',
+  MCP_RESOURCE_URI = 'mcp.resource.uri',
+  MCP_PROMPT_NAME = 'mcp.prompt.name',
 }
 
 type WebVitalsMeasurements =
@@ -157,7 +160,7 @@ type SpanNumberFields =
   | SpanFields.GEN_AI_USAGE_TOTAL_COST
   | DiscoverNumberFields;
 
-type SpanStringFields =
+export type SpanStringFields =
   | SpanMetricsField.RESOURCE_RENDER_BLOCKING_STATUS
   | SpanFields.RAW_DOMAIN
   | SpanFields.ID
@@ -170,6 +173,9 @@ type SpanStringFields =
   | SpanFields.GEN_AI_RESPONSE_MODEL
   | SpanFields.GEN_AI_TOOL_NAME
   | SpanFields.MCP_TRANSPORT
+  | SpanFields.MCP_TOOL_NAME
+  | SpanFields.MCP_RESOURCE_URI
+  | SpanFields.MCP_PROMPT_NAME
   | 'span_id'
   | 'span.op'
   | 'span.description'


### PR DESCRIPTION
Added widgets that are grouped by type (tool, resource, prompt).


https://github.com/user-attachments/assets/dd7a5b16-e744-4fab-acd0-2a7fb930d8b6

- closes [TET-855: Widget: Error rate by (tool/resource/prompt)](https://linear.app/getsentry/issue/TET-855/widget-error-rate-by-toolresourceprompt)
- closes [TET-854: Widget: Duration by (tool/resource/prompt)](https://linear.app/getsentry/issue/TET-854/widget-duration-by-toolresourceprompt)
- closes [TET-853: Widget: Traffic by (tool/resource/prompt)](https://linear.app/getsentry/issue/TET-853/widget-traffic-by-toolresourceprompt)


Note: We still don't have data for everything that is why some charts are empty.