### PR TITLE
fix(dynamic-sampling): fix audit logging for biases

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1028,7 +1028,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         new_biases = {bias["id"]: bias for bias in new_raw_dynamic_sampling_biases}
         for bias_id, new_bias in new_biases.items():
             old_bias = old_biases.get(bias_id)
-            if new_bias["active"] != old_bias["active"]:
+            if old_bias is None or new_bias["active"] != old_bias["active"]:
                 self.create_audit_entry(
                     request=request,
                     organization=project.organization,

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1024,15 +1024,18 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if old_raw_dynamic_sampling_biases is None:
             return
 
-        for index, rule in enumerate(new_raw_dynamic_sampling_biases):
-            if rule["active"] != old_raw_dynamic_sampling_biases[index]["active"]:
+        old_biases = {bias["id"]: bias for bias in old_raw_dynamic_sampling_biases}
+        new_biases = {bias["id"]: bias for bias in new_raw_dynamic_sampling_biases}
+        for bias_id, new_bias in new_biases.items():
+            old_bias = old_biases.get(bias_id)
+            if new_bias["active"] != old_bias["active"]:
                 self.create_audit_entry(
                     request=request,
                     organization=project.organization,
                     target_object=project.id,
                     event=audit_log.get_event_id(
-                        "SAMPLING_BIAS_ENABLED" if rule["active"] else "SAMPLING_BIAS_DISABLED"
+                        "SAMPLING_BIAS_ENABLED" if new_bias["active"] else "SAMPLING_BIAS_DISABLED"
                     ),
-                    data={**project.get_audit_log_data(), "name": rule["id"]},
+                    data={**project.get_audit_log_data(), "name": bias_id},
                 )
                 return

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1028,7 +1028,9 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         new_biases = {bias["id"]: bias for bias in new_raw_dynamic_sampling_biases}
         for bias_id, new_bias in new_biases.items():
             old_bias = old_biases.get(bias_id)
-            if old_bias is None or new_bias["active"] != old_bias["active"]:
+            if (old_bias is None and new_bias["active"]) or (
+                old_bias is not None and new_bias["active"] != old_bias["active"]
+            ):
                 self.create_audit_entry(
                     request=request,
                     organization=project.organization,

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1893,7 +1893,7 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsBase):
                     target_object=self.project.id,
                 )
                 assert audit_entry is not None
-                assert audit_entry.data["name"] == "minimumSampleRate"
+                assert audit_entry.data["name"] == RuleType.MINIMUM_SAMPLE_RATE_RULE.value
 
     def test_dynamic_sampling_bias_disable_audit_log(self):
         """Test that disabling a dynamic sampling bias creates the correct audit log entry."""

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1954,6 +1954,38 @@ class TestProjectDetailsDynamicSamplingBiases(TestProjectDetailsBase):
                 assert audit_entry is not None
                 assert audit_entry.data["name"] == RuleType.MINIMUM_SAMPLE_RATE_RULE.value
 
+    def test_dynamic_sampling_bias_add_new_inactive_bias_no_audit_log(self):
+        """Test that adding a new bias as inactive does not create an audit log entry."""
+        with self.feature("organizations:dynamic-sampling"):
+            # Start with some initial biases
+            initial_biases = [
+                {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
+                {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
+            ]
+            with outbox_runner():
+                self.get_success_response(
+                    self.org_slug, self.proj_slug, dynamicSamplingBiases=initial_biases
+                )
+
+                # Add a new bias that's inactive
+                expanded_biases = [
+                    {"id": RuleType.BOOST_ENVIRONMENTS_RULE.value, "active": False},
+                    {"id": RuleType.BOOST_LATEST_RELEASES_RULE.value, "active": False},
+                    {"id": RuleType.MINIMUM_SAMPLE_RATE_RULE.value, "active": False},
+                ]
+                self.get_success_response(
+                    self.org_slug, self.proj_slug, dynamicSamplingBiases=expanded_biases
+                )
+
+            # Check that no audit log entry was created for the inactive bias
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                audit_entries = AuditLogEntry.objects.filter(
+                    organization_id=self.organization.id,
+                    event=audit_log.get_event_id("SAMPLING_BIAS_ENABLED"),
+                    target_object=self.project.id,
+                )
+                assert audit_entries.count() == 0
+
 
 class TestTempestProjectDetails(TestProjectDetailsBase):
     endpoint = "sentry-api-0-project-details"


### PR DESCRIPTION
- Fix the previous implementation of audit logging, which assumed the incoming set of dynamic sampling biases to be of equal length as the existing ones, failing when they were not. The biases were still saved as they came in, but the audit log failed.
- Add tests for the audit log functionality for dynamic sampling biases


Fixes SENTRY-47BQ