### PR TITLE
fix(dashboards-comparison): Always pass widget viewer url for all failure types

### DIFF
--- a/src/sentry/discover/compare_tables.py
+++ b/src/sentry/discover/compare_tables.py
@@ -121,10 +121,19 @@ def compare_tables_for_dashboard_widget_queries(
         organization_id=dashboard.organization.id, status=ObjectStatus.ACTIVE
     )
 
+    widget_viewer_url = (
+        generate_organization_url(organization.slug)
+        + f"/dashboard/{dashboard.id}/widget/{widget.id}/"
+    )
+
     if len(list(projects)) == 0:
         with sentry_sdk.isolation_scope() as scope:
             scope.set_tag("passed", False)
             scope.set_tag("failed_reason", CompareTableResult.NO_PROJECT.value)
+            scope.set_tag(
+                "widget_viewer_url",
+                widget_viewer_url,
+            )
             sentry_sdk.capture_message(
                 "dashboard_widget_comparison_done", level="info", scope=scope
             )
@@ -143,6 +152,10 @@ def compare_tables_for_dashboard_widget_queries(
             scope.set_tag("passed", False)
             scope.set_tag("failed_reason", CompareTableResult.NO_FIELDS.value)
             scope.set_tag("widget_fields", fields)
+            scope.set_tag(
+                "widget_viewer_url",
+                widget_viewer_url,
+            )
             sentry_sdk.capture_message(
                 "dashboard_widget_comparison_done", level="info", scope=scope
             )
@@ -223,11 +236,6 @@ def compare_tables_for_dashboard_widget_queries(
     except Exception as e:
         logger.info("EAP query failed: %s", e)
         has_eap_error = True
-
-    widget_viewer_url = (
-        generate_organization_url(organization.slug)
-        + f"/dashboard/{dashboard.id}/widget/{widget.id}/"
-    )
 
     if has_metrics_error and has_eap_error:
         with sentry_sdk.isolation_scope() as scope:


### PR DESCRIPTION
Had a `no_project` failure a couple of runs ago and I had to go hunting for the widget and dashboard through redash. Just adding this in to every sentry message we send back for failures so it's easier to debug.
