### PR TITLE
feat(explore-sus-attrs): Virtualizing list of charts.

### DIFF
--- a/static/app/views/explore/components/suspectTags/charts.tsx
+++ b/static/app/views/explore/components/suspectTags/charts.tsx
@@ -19,10 +19,11 @@ const BASELINE_SERIES_NAME = 'baseline';
 
 type Props = {
   rankedAttributes: SuspectAttributesResult['rankedAttributes'];
+  searchQuery: string;
 };
 
 // TODO Abdullah Khan: Add virtualization and search to the list of charts
-export function Charts({rankedAttributes}: Props) {
+export function Charts({rankedAttributes, searchQuery}: Props) {
   const theme = useTheme();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -41,7 +42,7 @@ export function Charts({rankedAttributes}: Props) {
         {virtualItems.map(item => (
           <VirtualOffset key={item.index} offset={item.start}>
             <Chart
-              key={item.key}
+              key={`${item.key}+${searchQuery}`}
               index={item.index}
               virtualizer={virtualizer}
               attribute={rankedAttributes[item.index]!}

--- a/static/app/views/explore/components/suspectTags/charts.tsx
+++ b/static/app/views/explore/components/suspectTags/charts.tsx
@@ -234,6 +234,7 @@ function Chart({
           autoHeightResize
           isGroupedByDate={false}
           tooltip={{
+            trigger: 'axis',
             appendToBody: true,
             renderMode: 'html',
             valueFormatter,

--- a/static/app/views/explore/components/suspectTags/charts.tsx
+++ b/static/app/views/explore/components/suspectTags/charts.tsx
@@ -233,6 +233,7 @@ function Chart({
           autoHeightResize
           isGroupedByDate={false}
           tooltip={{
+            appendToBody: true,
             renderMode: 'html',
             valueFormatter,
             formatAxisLabel,
@@ -318,11 +319,8 @@ const ChartWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   height: 200px;
-  padding-top: ${space(2)};
-
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.border};
-  }
+  padding-top: ${space(1.5)};
+  border-top: 1px solid ${p => p.theme.border};
 `;
 
 const ChartTitle = styled('div')`

--- a/static/app/views/explore/components/suspectTags/charts.tsx
+++ b/static/app/views/explore/components/suspectTags/charts.tsx
@@ -198,7 +198,7 @@ function Chart({
         ? {adjective: 'different', message: 'This is suspicious.'}
         : {adjective: 'similar', message: 'Nothing unusual here.'};
 
-      const name = selectedParam?.name ?? baselineParam?.name;
+      const name = selectedParam?.name ?? baselineParam?.name ?? '';
       const truncatedName = name.length > 300 ? `${name.slice(0, 300)}...` : name;
 
       return `<div style="max-width: 200px; white-space: normal; word-wrap: break-word; line-height: 1.2;">${truncatedName} <span style="color: ${theme.textColor};">is <strong>${status.adjective}</strong> ${isDifferent ? 'between' : 'across'} selected and baseline data. ${status.message}</span></div>`;

--- a/static/app/views/explore/components/suspectTags/drawer.tsx
+++ b/static/app/views/explore/components/suspectTags/drawer.tsx
@@ -7,6 +7,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import BaseSearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import type {ChartInfo} from 'sentry/views/explore/charts';
 import {Charts} from 'sentry/views/explore/components/suspectTags/charts';
 import type {BoxSelectOptions} from 'sentry/views/explore/hooks/useChartBoxSelect';
@@ -38,6 +39,11 @@ export function Drawer({boxSelectOptions, chartInfo}: Props) {
     );
   }, [searchQuery, data?.rankedAttributes]);
 
+  // We use the search query as a key to virtual list items, to correctly re-mount
+  // charts the were invisible before the user searched for it. Debouncing the search
+  // query here to ensure smooth typing, by delaying the re-mounts a little as the user types.
+  const debouncedSearchQuery = useDebouncedValue(searchQuery, 100);
+
   return (
     <DrawerContainer>
       <DrawerHeader hideBar />
@@ -61,7 +67,10 @@ export function Drawer({boxSelectOptions, chartInfo}: Props) {
               size="sm"
             />
             {filteredRankedAttributes.length > 0 ? (
-              <Charts rankedAttributes={filteredRankedAttributes} />
+              <Charts
+                rankedAttributes={filteredRankedAttributes}
+                searchQuery={debouncedSearchQuery}
+              />
             ) : (
               <NoAttributesMessage>
                 {t('No matching attributes found')}

--- a/static/app/views/explore/components/suspectTags/drawer.tsx
+++ b/static/app/views/explore/components/suspectTags/drawer.tsx
@@ -40,7 +40,7 @@ export function Drawer({boxSelectOptions, chartInfo}: Props) {
   }, [searchQuery, data?.rankedAttributes]);
 
   // We use the search query as a key to virtual list items, to correctly re-mount
-  // charts the were invisible before the user searched for it. Debouncing the search
+  // charts that were invisible before the user searched for it. Debouncing the search
   // query here to ensure smooth typing, by delaying the re-mounts a little as the user types.
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 100);
 


### PR DESCRIPTION
The functionality in this PR is under the flag `performance-spans-suspect-attributes`:  
- Virtualizes the list of charts
- Adds search
- Fixes tooltip (we couldn't append tooltip to `document.body` without virtualization. It's too expensive, when we have hundreds of charts, otherwise).

<img width="848" height="805" alt="Screenshot 2025-07-14 at 1 14 35 AM" src="https://github.com/user-attachments/assets/74946b5e-c946-42bf-84c9-4bc406d700fe" />
