### PR TITLE
fix(insights): avoid using the `default` transaction.op filter in the transaction summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
       "current node"
     ]
   },
-  "packageManager": "pnpm@10.10.0",
+  "packageManager": "pnpm@10.13.1",
   "prettier": {
     "bracketSpacing": false,
     "bracketSameLine": false,

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
       "current node"
     ]
   },
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@10.10.0",
   "prettier": {
     "bracketSpacing": false,
     "bracketSameLine": false,

--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -221,11 +221,15 @@ function renderBodyCell(
   }
 
   if (column.key === 'transaction') {
+    // In eap, blank transaction ops are set to `default` but not in non-eap.
+    // The transaction summary is not eap yet, so we should exclude the `default` transaction.op filter
+    const spanOp =
+      row['span.op'].toLowerCase() === 'default' ? undefined : row['span.op'];
     return (
       <TransactionCell
         project={row.project}
         transaction={row.transaction}
-        transactionMethod={row['span.op']}
+        transactionMethod={spanOp}
       />
     );
   }

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -203,11 +203,15 @@ function renderBodyCell(
   }
 
   if (column.key === 'transaction') {
+    // In eap, blank transaction ops are set to `default` but not in non-eap.
+    // The transaction summary is not eap yet, so we should exclude the `default` transaction.op filter
+    const spanOp =
+      row['span.op'].toLowerCase() === 'default' ? undefined : row['span.op'];
     return (
       <TransactionCell
         project={row.project}
         transaction={row.transaction}
-        transactionMethod={row['span.op']}
+        transactionMethod={spanOp}
       />
     );
   }


### PR DESCRIPTION
In eap, blank transaction ops are set to `default` but in non-eap they are just empty strings. On the insights overview page, there was an issue where clicking on a transaction with op of `default` would yield no results on the transaction summary page. This is because we automatically applied a `transaction.op:default` filter, but the summary page is not eap yet.

This PR remove the transaction.op filter when navigating to the summary page if the op is `default`. This is only done on backend and mobile overview pages because the frontend page does not group by op