### PR TITLE
chore: Disable transactions dataset in widget builder

### DIFF
--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -31,6 +31,7 @@ interface BaseRadioGroupProps<C extends string> {
    * Switch the radio items to flow left to right, instead of vertically.
    */
   orientInline?: boolean;
+  tooltipIsHoverable?: boolean;
   tooltipPosition?: PopperProps<any>['placement'];
 }
 
@@ -59,6 +60,7 @@ function RadioGroup<C extends string>({
   onChange,
   orientInline,
   tooltipPosition,
+  tooltipIsHoverable,
   ...props
 }: RadioGroupProps<C>) {
   return (
@@ -84,6 +86,7 @@ function RadioGroup<C extends string>({
             disabled={!disabledChoiceReason}
             title={disabledChoiceReason}
             position={tooltipPosition}
+            isHoverable={tooltipIsHoverable}
           >
             <RadioLineItem index={index} aria-checked={value === id} disabled={disabled}>
               <Radio

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -90,9 +90,7 @@ export function DataSetStep({
     if (organization.features.includes('discover-saved-queries-deprecation')) {
       disabledChoices.push([
         DataSet.TRANSACTIONS,
-        t(
-          'This dataset is is no longer supported. Please use the Spans dataset with filter is_transaction:True to make transaction queries.'
-        ),
+        t('This dataset is is no longer supported. Please use the Spans dataset.'),
       ]);
     }
     datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -94,9 +94,8 @@ export function DataSetStep({
           'This dataset is is no longer supported. Please use the Spans dataset with filter is_transaction:True to make transaction queries.'
         ),
       ]);
-    } else {
-      datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));
     }
+    datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));
   }
 
   if (!hasDatasetSelectorFeature) {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/dataSetStep.tsx
@@ -87,7 +87,16 @@ export function DataSetStep({
   if (hasDatasetSelectorFeature) {
     // TODO: Finalize description copy
     datasetChoices.set(DataSet.ERRORS, t('Errors (TypeError, InvalidSearchQuery, etc)'));
-    datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));
+    if (organization.features.includes('discover-saved-queries-deprecation')) {
+      disabledChoices.push([
+        DataSet.TRANSACTIONS,
+        t(
+          'This dataset is is no longer supported. Please use the Spans dataset with filter is_transaction:True to make transaction queries.'
+        ),
+      ]);
+    } else {
+      datasetChoices.set(DataSet.TRANSACTIONS, t('Transactions'));
+    }
   }
 
   if (!hasDatasetSelectorFeature) {

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -2,7 +2,12 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {FeatureBadge} from 'sentry/components/core/badge/featureBadge';
-import RadioGroup, {type RadioOption} from 'sentry/components/forms/controls/radioGroup';
+import {Link} from 'sentry/components/core/link';
+import type {
+  RadioGroupProps,
+  RadioOption,
+} from 'sentry/components/forms/controls/radioGroup';
+import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -15,6 +20,7 @@ import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/con
 import {useCacheBuilderState} from 'sentry/views/dashboards/widgetBuilder/hooks/useCacheBuilderState';
 import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
+import {useSegmentSpanWidgetState} from 'sentry/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState';
 
 function WidgetBuilderDatasetSelector() {
   const organization = useOrganization();
@@ -22,9 +28,29 @@ function WidgetBuilderDatasetSelector() {
   const source = useDashboardWidgetSource();
   const isEditing = useIsEditingWidget();
   const {cacheBuilderState, restoreOrSetBuilderState} = useCacheBuilderState();
+  const {setSegmentSpanBuilderState} = useSegmentSpanWidgetState();
+  const disabledChoices: RadioGroupProps<WidgetType>['disabledChoices'] = [];
 
   const datasetChoices: Array<RadioOption<WidgetType>> = [];
   datasetChoices.push([WidgetType.ERRORS, t('Errors')]);
+  if (organization.features.includes('discover-saved-queries-deprecation')) {
+    disabledChoices.push([
+      WidgetType.TRANSACTIONS,
+      tct('This dataset is is no longer supported. Please use the [spans] dataset.', {
+        spans: (
+          <Link
+            to=""
+            onClick={() => {
+              cacheBuilderState(state.dataset ?? WidgetType.ERRORS);
+              setSegmentSpanBuilderState();
+            }}
+          >
+            {t('Spans')}
+          </Link>
+        ),
+      }),
+    ]);
+  }
   datasetChoices.push([WidgetType.TRANSACTIONS, t('Transactions')]);
 
   if (organization.features.includes('visibility-explore-view')) {
@@ -66,6 +92,8 @@ function WidgetBuilderDatasetSelector() {
         label={t('Dataset')}
         value={state.dataset ?? WidgetType.ERRORS}
         choices={datasetChoices}
+        disabledChoices={disabledChoices}
+        tooltipIsHoverable
         onChange={(newDataset: WidgetType) => {
           // Set the current dataset state in local storage for recovery
           // when the user navigates back to this dataset

--- a/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState.tsx
@@ -1,0 +1,21 @@
+import {useCallback} from 'react';
+
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+export function useSegmentSpanWidgetState() {
+  const {dispatch} = useWidgetBuilderContext();
+
+  const setSegmentSpanBuilderState = useCallback(() => {
+    const nextDataset = WidgetType.SPANS;
+    dispatch({
+      type: BuilderStateAction.SET_STATE,
+      payload: {dataset: nextDataset, query: ['is_transaction:true']},
+    });
+  }, [dispatch]);
+
+  return {
+    setSegmentSpanBuilderState,
+  };
+}


### PR DESCRIPTION
Disable transaction dataset in widget builder. This is feature flagged.
Disabling edits on existing transaction widgets in a follow up.