### PR TITLE
fix(reports): Make weekly report emails more reliable

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -130,6 +130,7 @@ def schedule_organizations(
         processing_deadline_duration=60 * 10,
         retry=Retry(
             times=5,
+            delay=5,
         ),
     ),
 )


### PR DESCRIPTION
Weekly email reports seem to be unreliable due to rate limits being hit.
This is hard to fix structurally given that we do try to send them all at same time.
However, by backing off on generation retries and by recognizing and retrying temporary email errors we should hopefully reduce our failure rate a bit.
