### PR TITLE
fix: remove CategoryInfo.apiName

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -246,7 +246,6 @@ const GIGABYTE = 10 ** 9;
 export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.ERROR]: {
     name: DataCategoryExact.ERROR,
-    apiName: 'error',
     plural: DataCategory.ERRORS,
     singular: 'error',
     displayName: 'error',
@@ -262,7 +261,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.TRANSACTION]: {
     name: DataCategoryExact.TRANSACTION,
-    apiName: 'transaction',
     plural: DataCategory.TRANSACTIONS,
     singular: 'transaction',
     displayName: 'transaction',
@@ -278,7 +276,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.ATTACHMENT]: {
     name: DataCategoryExact.ATTACHMENT,
-    apiName: 'attachment',
     plural: DataCategory.ATTACHMENTS,
     singular: 'attachment',
     displayName: 'attachment',
@@ -295,7 +292,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PROFILE]: {
     name: DataCategoryExact.PROFILE,
-    apiName: 'profile',
     plural: DataCategory.PROFILES,
     singular: 'profile',
     displayName: 'profile',
@@ -311,7 +307,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PROFILE_INDEXED]: {
     name: DataCategoryExact.PROFILE_INDEXED,
-    apiName: 'profileIndexed',
     plural: DataCategory.PROFILES_INDEXED,
     singular: 'profileIndexed',
     displayName: 'indexed profile',
@@ -323,7 +318,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.REPLAY]: {
     name: DataCategoryExact.REPLAY,
-    apiName: 'replay',
     plural: DataCategory.REPLAYS,
     singular: 'replay',
     displayName: 'replay',
@@ -339,7 +333,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.USER_REPORT_V2]: {
     name: DataCategoryExact.USER_REPORT_V2,
-    apiName: 'feedback',
     plural: DataCategory.USER_REPORT_V2,
     singular: 'feedback',
     displayName: 'user feedback',
@@ -355,7 +348,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.TRANSACTION_PROCESSED]: {
     name: DataCategoryExact.TRANSACTION_PROCESSED,
-    apiName: 'transactions',
     plural: DataCategory.TRANSACTIONS_PROCESSED,
     singular: 'transactionProcessed',
     displayName: 'transaction',
@@ -370,7 +362,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.TRANSACTION_INDEXED]: {
     name: DataCategoryExact.TRANSACTION_INDEXED,
-    apiName: 'transactionIndexed',
     plural: DataCategory.TRANSACTIONS_INDEXED,
     singular: 'transactionIndexed',
     displayName: 'indexed transaction',
@@ -382,7 +373,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.MONITOR]: {
     name: DataCategoryExact.MONITOR,
-    apiName: 'monitor',
     plural: DataCategory.MONITOR,
     singular: 'monitor',
     displayName: 'monitor check-in',
@@ -397,7 +387,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.SPAN]: {
     name: DataCategoryExact.SPAN,
-    apiName: 'span',
     plural: DataCategory.SPANS,
     singular: 'span',
     displayName: 'span',
@@ -413,7 +402,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.MONITOR_SEAT]: {
     name: DataCategoryExact.MONITOR_SEAT,
-    apiName: 'monitorSeat',
     plural: DataCategory.MONITOR_SEATS,
     singular: 'monitorSeat',
     displayName: 'cron monitor',
@@ -429,7 +417,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.SPAN_INDEXED]: {
     name: DataCategoryExact.SPAN_INDEXED,
-    apiName: 'span_indexed',
     plural: DataCategory.SPANS_INDEXED,
     singular: 'spanIndexed',
     displayName: 'stored span',
@@ -442,7 +429,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PROFILE_DURATION]: {
     name: DataCategoryExact.PROFILE_DURATION,
-    apiName: 'profile_duration',
     plural: DataCategory.PROFILE_DURATION,
     singular: 'profileDuration',
     displayName: 'continuous profile hour',
@@ -459,7 +445,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PROFILE_CHUNK]: {
     name: DataCategoryExact.PROFILE_CHUNK,
-    apiName: 'profile_chunk',
     plural: DataCategory.PROFILE_CHUNKS,
     singular: 'profileChunk',
     displayName: 'profile chunk',
@@ -471,7 +456,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PROFILE_DURATION_UI]: {
     name: DataCategoryExact.PROFILE_DURATION_UI,
-    apiName: 'profile_duration_ui',
     plural: DataCategory.PROFILE_DURATION_UI,
     singular: 'profileDurationUI',
     displayName: 'UI profile hour',
@@ -488,7 +472,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.PROFILE_CHUNK_UI]: {
     name: DataCategoryExact.PROFILE_CHUNK_UI,
-    apiName: 'profile_chunk_ui',
     plural: DataCategory.PROFILE_CHUNKS_UI,
     singular: 'profileChunkUI',
     displayName: 'UI profile chunk',
@@ -501,7 +484,6 @@ export const DATA_CATEGORY_INFO = {
 
   [DataCategoryExact.UPTIME]: {
     name: DataCategoryExact.UPTIME,
-    apiName: 'uptime',
     plural: DataCategory.UPTIME,
     singular: 'uptime',
     displayName: 'uptime monitor',
@@ -517,7 +499,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.LOG_ITEM]: {
     name: DataCategoryExact.LOG_ITEM,
-    apiName: 'log_item',
     plural: DataCategory.LOG_ITEM,
     singular: 'logItem',
     displayName: 'log',
@@ -532,7 +513,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.LOG_BYTE]: {
     name: DataCategoryExact.LOG_BYTE,
-    apiName: 'log_byte',
     plural: DataCategory.LOG_BYTE,
     singular: 'logByte',
     displayName: 'log byte',
@@ -548,7 +528,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.SEER_AUTOFIX]: {
     name: DataCategoryExact.SEER_AUTOFIX,
-    apiName: 'seer_autofix',
     plural: DataCategory.SEER_AUTOFIX,
     singular: 'seerAutofix',
     displayName: 'issue fix',
@@ -563,7 +542,6 @@ export const DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.SEER_SCANNER]: {
     name: DataCategoryExact.SEER_SCANNER,
-    apiName: 'seer_scanner',
     plural: DataCategory.SEER_SCANNER,
     singular: 'seerScanner',
     displayName: 'issue scan',

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -127,7 +127,6 @@ export enum DataCategoryExact {
 }
 
 export interface DataCategoryInfo {
-  apiName: string;
   displayName: string;
   isBilledCategory: boolean;
   name: DataCategoryExact;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -90,7 +90,7 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
     ) {
       return {
         ...info,
-        apiName: 'span_indexed',
+        name: DataCategoryExact.SPAN_INDEXED,
       };
     }
 
@@ -104,6 +104,10 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
 
   get dataCategoryName() {
     return this.dataCategoryInfo.titleName;
+  }
+
+  get dataCategoryApiName() {
+    return this.dataCategoryInfo.name;
   }
 
   get dataDatetime(): DateTimeObject {
@@ -330,8 +334,8 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
         projectIds={this.projectIds}
         organization={organization}
         dataCategory={this.dataCategory}
-        dataCategoryName={this.dataCategoryInfo.titleName}
-        dataCategoryApiName={this.dataCategoryInfo.apiName}
+        dataCategoryName={this.dataCategoryName}
+        dataCategoryApiName={this.dataCategoryApiName}
         dataDatetime={this.dataDatetime}
         chartTransform={this.chartTransform}
         clientDiscard={this.clientDiscard}

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -20,7 +20,12 @@ import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {DataCategory, DataCategoryInfo, IntervalPeriod} from 'sentry/types/core';
+import type {
+  DataCategory,
+  DataCategoryExact,
+  DataCategoryInfo,
+  IntervalPeriod,
+} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {shouldUse24Hours} from 'sentry/utils/dates';
@@ -292,8 +297,8 @@ function ChartContainer({children}: {children: React.ReactNode}) {
 
 export interface UsageStatsOrganizationProps {
   dataCategory: DataCategory;
-  dataCategoryApiName: DataCategoryInfo['apiName'];
-  dataCategoryName: string;
+  dataCategoryApiName: DataCategoryExact;
+  dataCategoryName: DataCategoryInfo['titleName'];
   dataDatetime: DateTimeObject;
   handleChangeState: (state: {
     clientDiscard?: boolean;

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
-import {DataCategory, DataCategoryExact, Outcome} from 'sentry/types/core';
+import type {DataCategory} from 'sentry/types/core';
+import {DataCategoryExact, Outcome} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
@@ -67,7 +68,7 @@ function UsageStatsPerMin({
       const {category, outcome} = group.by;
 
       if (dataCategoryApiName === DataCategoryExact.SPAN_INDEXED) {
-        if (category !== DataCategory.SPANS_INDEXED || outcome !== Outcome.ACCEPTED) {
+        if (category !== DataCategoryExact.SPAN_INDEXED || outcome !== Outcome.ACCEPTED) {
           return count;
         }
       } else {

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
-import type {DataCategory, DataCategoryInfo} from 'sentry/types/core';
-import {Outcome} from 'sentry/types/core';
+import {DataCategory, DataCategoryExact, Outcome} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
@@ -11,7 +10,7 @@ import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 
 type Props = {
   dataCategory: DataCategory;
-  dataCategoryApiName: DataCategoryInfo['apiName'];
+  dataCategoryApiName: DataCategoryExact;
   organization: Organization;
   projectIds: number[];
 };
@@ -67,13 +66,12 @@ function UsageStatsPerMin({
     const eventsLastMin = groups.reduce((count, group) => {
       const {category, outcome} = group.by;
 
-      if (dataCategoryApiName === 'span_indexed') {
-        if (category !== 'span_indexed' || outcome !== Outcome.ACCEPTED) {
+      if (dataCategoryApiName === DataCategoryExact.SPAN_INDEXED) {
+        if (category !== DataCategory.SPANS_INDEXED || outcome !== Outcome.ACCEPTED) {
           return count;
         }
       } else {
-        // HACK: The backend enum are singular, but the frontend enums are plural
-        if (!dataCategory.includes(`${category}`) || outcome !== Outcome.ACCEPTED) {
+        if (dataCategoryApiName !== category || outcome !== Outcome.ACCEPTED) {
           return count;
         }
       }

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -17,7 +17,7 @@ import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {DataCategoryInfo} from 'sentry/types/core';
-import {Outcome} from 'sentry/types/core';
+import {DataCategoryExact, Outcome} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {hasDynamicSamplingCustomFeature} from 'sentry/utils/dynamicSampling/features';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -89,22 +89,24 @@ export function UsageStatsProjects({
           };
 
     const groupBy = ['outcome', 'project'];
-    const category: string[] = [dataCategory.apiName];
+    const category: string[] = [dataCategory.name];
 
     if (
       hasDynamicSamplingCustomFeature(organization) &&
-      dataCategory.apiName === 'span'
+      dataCategory.name === DataCategoryExact.SPAN
     ) {
       groupBy.push('category');
-      category.push('span_indexed');
+      category.push(DataCategoryExact.SPAN_INDEXED);
     }
     if (
-      dataCategory.apiName === 'profile_duration' ||
-      dataCategory.apiName === 'profile_duration_ui'
+      dataCategory.name === DataCategoryExact.PROFILE_DURATION ||
+      dataCategory.name === DataCategoryExact.PROFILE_DURATION_UI
     ) {
       groupBy.push('category');
       category.push(
-        dataCategory.apiName === 'profile_duration' ? 'profile_chunk' : 'profile_chunk_ui'
+        dataCategory.name === DataCategoryExact.PROFILE_DURATION
+          ? DataCategoryExact.PROFILE_CHUNK
+          : DataCategoryExact.PROFILE_CHUNK_UI
       );
     }
 
@@ -458,7 +460,7 @@ export function UsageStatsProjects({
   const tableData = useMemo(() => {
     const showStoredOutcome =
       hasDynamicSamplingCustomFeature(organization) &&
-      dataCategory.apiName === 'span' &&
+      dataCategory.name === DataCategoryExact.SPAN &&
       seriesData.hasStoredOutcome;
 
     return {

--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -2,7 +2,6 @@ import {Fragment, memo, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
-import snakeCase from 'lodash/snakeCase';
 import startCase from 'lodash/startCase';
 import moment from 'moment-timezone';
 
@@ -394,7 +393,7 @@ export const CustomerStats = memo(
             interval: getInterval(dataDatetime),
             groupBy: ['outcome', 'reason'],
             field: 'sum(quantity)',
-            category: snakeCase(dataType), // TODO(isabella): remove snakeCase when .apiName is consistent
+            category: dataType,
             ...(projectId ? {project: projectId} : {}),
           },
         },

--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -14,6 +14,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {space} from 'sentry/styles/space';
+import type {DataCategoryExact} from 'sentry/types/core';
 import type {DataPoint} from 'sentry/types/echarts';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -21,8 +22,6 @@ import {defined} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useRouter from 'sentry/utils/useRouter';
-
-import type {DataType} from 'admin/components/customers/customerStatsFilters';
 
 enum SeriesName {
   ACCEPTED = 'Accepted',
@@ -325,7 +324,7 @@ function FooterLegend({points}: LegendProps) {
 }
 
 type Props = {
-  dataType: DataType;
+  dataType: DataCategoryExact;
   orgSlug: Organization['slug'];
   onDemandPeriodEnd?: string;
   onDemandPeriodStart?: string;

--- a/static/gsAdmin/components/customers/customerStatsFilters.tsx
+++ b/static/gsAdmin/components/customers/customerStatsFilters.tsx
@@ -16,12 +16,9 @@ import useRouter from 'sentry/utils/useRouter';
 
 const ON_DEMAND_PERIOD_KEY = 'onDemand';
 
-export type DataType =
-  (typeof DATA_CATEGORY_INFO)[keyof typeof DATA_CATEGORY_INFO]['apiName'];
-
 type Props = {
-  dataType: DataType;
-  onChange: (dataType: DataType) => void;
+  dataType: DataCategoryExact;
+  onChange: (dataType: DataCategoryExact) => void;
   organization: Organization;
   onDemandPeriodEnd?: string;
   onDemandPeriodStart?: string;

--- a/static/gsAdmin/components/customers/customerStatsFilters.tsx
+++ b/static/gsAdmin/components/customers/customerStatsFilters.tsx
@@ -110,7 +110,7 @@ export function CustomerStatsFilters({
         options={Object.entries(DATA_CATEGORY_INFO)
           .filter(([_, categoryInfo]) => categoryInfo.statsInfo.showInternalStats)
           .map(([category, categoryInfo]) => ({
-            value: categoryInfo.apiName,
+            value: categoryInfo.name,
             label:
               category === DataCategoryExact.SPAN
                 ? 'Accepted Spans'

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -13,6 +13,7 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import ConfigStore from 'sentry/stores/configStore';
 import type {DataCategory} from 'sentry/types/core';
+import {DataCategoryExact} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
@@ -50,7 +51,6 @@ import CustomerPlatforms from 'admin/components/customers/customerPlatforms';
 import CustomerPolicies from 'admin/components/customers/customerPolicies';
 import CustomerProjects from 'admin/components/customers/customerProjects';
 import {CustomerStats} from 'admin/components/customers/customerStats';
-import type {DataType} from 'admin/components/customers/customerStatsFilters';
 import {CustomerStatsFilters} from 'admin/components/customers/customerStatsFilters';
 import OrganizationStatus from 'admin/components/customers/organizationStatus';
 import PendingChanges from 'admin/components/customers/pendingChanges';
@@ -179,7 +179,8 @@ export default function CustomerDetails() {
     return null;
   }
 
-  const activeDataType = (location.query.dataType as DataType) ?? 'error';
+  const activeDataType =
+    (location.query.dataType as DataCategoryExact) ?? DataCategoryExact.ERROR;
 
   const userPermissions = ConfigStore.get('user')?.permissions;
 
@@ -235,7 +236,7 @@ export default function CustomerDetails() {
     );
   };
 
-  const handleStatsTypeChange = (dataType: DataType) => {
+  const handleStatsTypeChange = (dataType: DataCategoryExact) => {
     navigate({
       pathname: location.pathname,
       query: {...location.query, dataType},

--- a/static/gsAdmin/views/projectDetails.tsx
+++ b/static/gsAdmin/views/projectDetails.tsx
@@ -8,6 +8,7 @@ import ListItem from 'sentry/components/list/listItem';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import ConfigStore from 'sentry/stores/configStore';
+import {DataCategoryExact} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -16,7 +17,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 
 import {CustomerStats} from 'admin/components/customers/customerStats';
-import type {DataType} from 'admin/components/customers/customerStatsFilters';
 import {CustomerStatsFilters} from 'admin/components/customers/customerStatsFilters';
 import DetailLabel from 'admin/components/detailLabel';
 import DetailList from 'admin/components/detailList';
@@ -61,11 +61,11 @@ function ProjectDetails() {
     return <LoadingError />;
   }
 
-  const activeDataType = (): DataType => {
-    return (location.query.dataType as DataType) ?? 'error';
+  const activeDataType = (): DataCategoryExact => {
+    return (location.query.dataType as DataCategoryExact) ?? DataCategoryExact.ERROR;
   };
 
-  const handleStatsTypeChange = (dataType: DataType) => {
+  const handleStatsTypeChange = (dataType: DataCategoryExact) => {
     navigate({
       pathname: location.pathname,
       query: {...location.query, dataType},

--- a/static/gsApp/hooks/spendVisibility/enhancedIndex.tsx
+++ b/static/gsApp/hooks/spendVisibility/enhancedIndex.tsx
@@ -22,7 +22,7 @@ class EnhancedOrganizationStats extends OrganizationStats {
         chartTransform={this.chartTransform}
         handleChangeState={this.setStateOnUrl}
         spikeCursor={this.spikeCursor}
-        dataCategoryApiName={this.dataCategoryInfo.apiName}
+        dataCategoryApiName={this.dataCategoryApiName}
         clientDiscard={this.clientDiscard}
       />
     );


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-1036/make-datacategoryinfoapiname-consistent

None of the categories have an `apiName` different from `name` so might as well just get rid of `apiName`.