### PR TITLE
ref(replay): Inline getUserBadgeUser()

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -485,7 +485,16 @@ export const ReplaySessionColumn: ReplayTableColumn = {
 
     return (
       <Flex key="session" align="center" gap={space(1)}>
-        <UserAvatar user={getUserBadgeUser(replay)} size={24} />
+        <UserAvatar
+          user={{
+            username: replay.user?.display_name || '',
+            email: replay.user?.email || '',
+            id: replay.user?.id || '',
+            ip_address: replay.user?.ip || '',
+            name: replay.user?.username || '',
+          }}
+          size={24}
+        />
         <SubText>
           <Flex gap={space(0.5)} align="flex-start">
             <DisplayNameLink
@@ -551,24 +560,6 @@ export const ReplaySlowestTransactionColumn: ReplayTableColumn = {
     );
   },
 };
-
-function getUserBadgeUser(replay: ListRecord) {
-  return replay.is_archived
-    ? {
-        username: '',
-        email: '',
-        id: '',
-        ip_address: '',
-        name: '',
-      }
-    : {
-        username: replay.user?.display_name || '',
-        email: replay.user?.email || '',
-        id: replay.user?.id || '',
-        ip_address: replay.user?.ip || '',
-        name: replay.user?.username || '',
-      };
-}
 
 const DropdownContainer = styled(Flex)`
   flex-direction: column;


### PR DESCRIPTION
The types are not perfect but at this callsite it looks like this:

<img width="525" height="415" alt="SCR-20250714-jpda" src="https://github.com/user-attachments/assets/37cc4da1-ba5e-4890-8958-6ce1826acf1e" />

The `is_archived` case doesn't matter because we're checking for that earlier in this cell component. Ideally the types would be refined at this point, but we havn't defined an `ArchivedReplayListRecord` type yet.
