### PR TITLE
fix(autofix): Add feature flag check for starred view onboarding step

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -127,7 +127,7 @@ describe('SeerNotices', function () {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['trigger-autofix-on-issue-summary'],
+        features: ['trigger-autofix-on-issue-summary', 'issue-views'],
       },
     });
     await waitFor(() => {

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -23,6 +23,7 @@ import {FieldKey} from 'sentry/utils/fields';
 import {useDetailedProject} from 'sentry/utils/useDetailedProject';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useHasIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useHasIssueViews';
 import {useStarredIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useStarredIssueViews';
 import {usePrefersStackedNav} from 'sentry/views/nav/usePrefersStackedNav';
 
@@ -74,8 +75,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const isAutomationAllowed = organization.features.includes(
     'trigger-autofix-on-issue-summary'
   );
-  const prefersStackedNav = usePrefersStackedNav();
-  const isStarredViewAllowed = prefersStackedNav;
+  const hasStackedNav = usePrefersStackedNav();
+  const hasIssueViews = useHasIssueViews();
+  const isStarredViewAllowed = hasStackedNav && hasIssueViews;
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
   const githubRepos = unreadableRepos.filter(repo => repo.provider.includes('github'));


### PR DESCRIPTION
We were missing the feature flag check for this onboarding step, causing an unusable step