### PR TITLE
feat(dashboards): Allow sorting dashboard by user visited

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -169,7 +169,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                         if desc
                         else F("user_last_visited").desc(nulls_last=True)
                     ),
-                    "title",
+                    "-date_added",
                 ]
             else:
                 order_by = ["last_visited" if desc else "-last_visited"]

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from django.db import IntegrityError, router, transaction
-from django.db.models import Case, DateTimeField, Exists, F, IntegerField, OuterRef, Value, When
+from django.db.models import (
+    Case,
+    DateTimeField,
+    Exists,
+    F,
+    IntegerField,
+    OrderBy,
+    OuterRef,
+    Value,
+    When,
+)
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -133,7 +143,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         else:
             desc = False
 
-        order_by: list[Case | str]
+        order_by: list[Case | str | OrderBy]
         if sort_by == "title":
             order_by = [
                 "-title" if desc else "title",

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -156,7 +156,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 dashboards = dashboards.annotate(
                     user_last_visited=Case(
                         When(
-                            dashboardlastvisited__member_id=request.user.id,
+                            dashboardlastvisited__member__user_id=request.user.id,
                             then=F("dashboardlastvisited__last_visited"),
                         ),
                         default=None,

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -210,8 +210,8 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 expected = list(reversed(expected))
 
             # Only A, B are sorted by their last visited entry, Dashboard 1
-            # and Dashboard 2 are by default sorted by their title
-            assert values == ["General"] + expected + ["Dashboard 1", "Dashboard 2"]
+            # and Dashboard 2 are by default sorted by their date created
+            assert values == ["General"] + expected + ["Dashboard 2", "Dashboard 1"]
 
     def test_get_sortby_mydashboards(self):
         user_1 = self.create_user(username="user_1")


### PR DESCRIPTION
Update `recentlyViewed` to use the user's last visited instance instead of the global dashboard field. I want the default ordering to be by date created (desc) if there is no last visited entry because the most recent ones should be higher.