### PR TITLE
ref(insights): rename `useEapSpans` to `useSpans`

### DIFF
--- a/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
+++ b/static/app/components/charts/chartWidgetLoader-unmocked-imports.spec.tsx
@@ -173,7 +173,7 @@ jest.mock('sentry/views/insights/common/queries/useDiscover', () => ({
     isPending: false,
     error: null,
   })),
-  useEAPSpans: jest.fn(() => ({
+  useSpans: jest.fn(() => ({
     data: [
       {
         'avg(span.duration)': 123,
@@ -201,7 +201,7 @@ jest.mock('sentry/views/insights/common/queries/useTopNDiscoverSeries', () => ({
   })),
 }));
 jest.mock('sentry/views/insights/common/queries/useDiscoverSeries', () => ({
-  useEAPSeries: jest.fn(() => ({
+  useSpanSeries: jest.fn(() => ({
     data: {
       'count(span.duration)': mockDiscoverSeries('count(span.duration)'),
       'avg(span.duration)': mockDiscoverSeries('avg(span.duration)'),

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -15,7 +15,7 @@ import {space} from 'sentry/styles/space';
 import {getShortEventId} from 'sentry/utils/events';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {UptimeCheck, UptimeRule} from 'sentry/views/alerts/rules/uptime/types';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   reasonToText,
   statusToText,
@@ -36,7 +36,7 @@ const EMPTY_TRACE = '00000000000000000000000000000000';
 export function UptimeChecksGrid({uptimeRule, uptimeChecks}: Props) {
   const traceIds = uptimeChecks?.map(check => check.traceId) ?? [];
 
-  const {data: spanCounts, isPending: spanCountLoading} = useEAPSpans(
+  const {data: spanCounts, isPending: spanCountLoading} = useSpans(
     {
       limit: 10,
       enabled: traceIds.length > 0,

--- a/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
+++ b/static/app/views/insights/agentMonitoring/components/aiSpanList.tsx
@@ -28,7 +28,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import type {AITraceSpanNode} from 'sentry/views/insights/agentMonitoring/utils/types';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {
   isEAPSpanNode,
   isSpanNode,
@@ -201,7 +201,7 @@ function useEAPSpanAttributes(nodes: Array<TraceTreeNode<TraceTree.NodeValue>>) 
     ...spans.map(span => new Date(span.value.end_timestamp * 1000).getTime())
   );
 
-  const spanAttributesRequest = useEAPSpans(
+  const spanAttributesRequest = useSpans(
     {
       search: `span_id:[${spans.map(span => `"${span.value.event_id}"`).join(',')}]`,
       fields: [

--- a/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/llmGenerationsWidget.tsx
@@ -19,7 +19,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -42,7 +42,7 @@ export default function LLMGenerationsWidget() {
   const theme = useTheme();
   const fullQuery = useCombinedQuery(getAIGenerationsFilter());
 
-  const generationsRequest = useEAPSpans(
+  const generationsRequest = useSpans(
     {
       fields: [AI_MODEL_ID_ATTRIBUTE, 'count()'],
       sorts: [{field: 'count()', kind: 'desc'}],

--- a/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/modelsTable.tsx
@@ -36,7 +36,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 // import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
@@ -95,7 +95,7 @@ export function ModelsTable() {
 
   const {sortField, sortOrder} = useTableSortParams();
 
-  const modelsRequest = useEAPSpans(
+  const modelsRequest = useSpans(
     {
       fields: [
         AI_MODEL_ID_ATTRIBUTE,

--- a/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tokenUsageWidget.tsx
@@ -20,7 +20,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -43,7 +43,7 @@ export default function TokenUsageWidget() {
 
   const fullQuery = useCombinedQuery(getAIGenerationsFilter());
 
-  const tokensRequest = useEAPSpans(
+  const tokensRequest = useSpans(
     {
       fields: [AI_MODEL_ID_ATTRIBUTE, AI_TOKEN_USAGE_ATTRIBUTE_SUM],
       sorts: [{field: AI_TOKEN_USAGE_ATTRIBUTE_SUM, kind: 'desc'}],

--- a/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolUsageWidget.tsx
@@ -18,7 +18,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -42,7 +42,7 @@ export default function ToolUsageWidget() {
 
   const fullQuery = useCombinedQuery(getAIToolCallsFilter());
 
-  const toolsRequest = useEAPSpans(
+  const toolsRequest = useSpans(
     {
       fields: [AI_TOOL_NAME_ATTRIBUTE, 'count()'],
       sorts: [{field: 'count()', kind: 'desc'}],

--- a/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/toolsTable.tsx
@@ -32,7 +32,7 @@ import {
 } from 'sentry/views/insights/agentMonitoring/utils/query';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 // import {ErrorRateCell} from 'sentry/views/insights/pages/platform/shared/table/ErrorRateCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
@@ -86,7 +86,7 @@ export function ToolsTable() {
 
   const {sortField, sortOrder} = useTableSortParams();
 
-  const toolsRequest = useEAPSpans(
+  const toolsRequest = useSpans(
     {
       fields: [
         AI_TOOL_NAME_ATTRIBUTE,

--- a/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
+++ b/static/app/views/insights/agentMonitoring/components/tracesTable.tsx
@@ -34,7 +34,7 @@ import {
   OverflowEllipsisTextContainer,
   TextAlignRight,
 } from 'sentry/views/insights/common/components/textAlign';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {DurationCell} from 'sentry/views/insights/pages/platform/shared/table/DurationCell';
 import {NumberCell} from 'sentry/views/insights/pages/platform/shared/table/NumberCell';
 
@@ -96,7 +96,7 @@ export function TracesTable() {
 
   const pageLinks = tracesRequest.getResponseHeader?.('Link') ?? undefined;
 
-  const spansRequest = useEAPSpans(
+  const spansRequest = useSpans(
     {
       // Exclude agent runs as they include aggregated data which would lead to double counting e.g. token usage
       search: `${getAgentRunsFilter({negated: true})} trace:[${tracesRequest.data?.data.map(span => span.trace).join(',')}]`,

--- a/static/app/views/insights/agentMonitoring/views/onboarding.tsx
+++ b/static/app/views/insights/agentMonitoring/views/onboarding.tsx
@@ -42,7 +42,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 
 function useOnboardingProject() {
   const {projects} = useProjects();
@@ -65,7 +65,7 @@ function useAiSpanWaiter(project: Project) {
   const {selection} = usePageFilters();
   const [refetchKey, setRefetchKey] = useState(0);
 
-  const request = useEAPSpans(
+  const request = useSpans(
     {
       search: 'span.op:"gen_ai.*"',
       fields: ['id'],

--- a/static/app/views/insights/browser/resources/components/sampleImages.tsx
+++ b/static/app/views/insights/browser/resources/components/sampleImages.tsx
@@ -18,7 +18,7 @@ import useProjects from 'sentry/utils/useProjects';
 import ResourceSize from 'sentry/views/insights/browser/resources/components/resourceSize';
 import {useResourceModuleFilters} from 'sentry/views/insights/browser/resources/utils/useResourceFilters';
 import ChartPanel from 'sentry/views/insights/common/components/chartPanel';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {EAPSpanResponse} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 import {usePerformanceGeneralProjectSettings} from 'sentry/views/performance/utils';
@@ -45,7 +45,7 @@ function SampleImages({groupId, projectId}: Props) {
     usePerformanceGeneralProjectSettings(projectId);
   const isImagesEnabled = settings?.enable_images ?? false;
 
-  const {data: imageResources, isPending: isLoadingImages} = useEAPSpans(
+  const {data: imageResources, isPending: isLoadingImages} = useSpans(
     {
       fields: [
         SpanFields.PROJECT,

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
@@ -7,7 +7,7 @@ import {
 import {mapWebVitalToOrderBy} from 'sentry/views/insights/browser/webVitals/utils/mapWebVitalToOrderBy';
 import type {BrowserType} from 'sentry/views/insights/browser/webVitals/utils/queryParameterDecoders/browserType';
 import {useWebVitalsSort} from 'sentry/views/insights/browser/webVitals/utils/useWebVitalsSort';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanIndexedField, type SubregionCode} from 'sentry/views/insights/types';
 
 type Props = {
@@ -60,7 +60,7 @@ export const useTransactionSamplesWebVitalsScoresQuery = ({
     );
   }
 
-  const result = useEAPSpans(
+  const result = useSpans(
     {
       sorts: [sort],
       search: mutableSearch.formatString(),

--- a/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
+++ b/static/app/views/insights/cache/components/charts/transactionDurationChartWithSamples.tsx
@@ -7,7 +7,7 @@ import {Referrer} from 'sentry/views/insights/cache/referrers';
 // TODO(release-drawer): Only used in cache/components/samplePanel
 // eslint-disable-next-line no-restricted-imports
 import {InsightsLineChartWidget} from 'sentry/views/insights/common/components/insightsLineChartWidget';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import type {SpanQueryFilters} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -29,7 +29,7 @@ export function TransactionDurationChartWithSamples({samples}: Props) {
   } satisfies SpanQueryFilters);
   const referrer = Referrer.SAMPLES_CACHE_TRANSACTION_DURATION_CHART;
 
-  const {data, isPending, error} = useEAPSeries(
+  const {data, isPending, error} = useSpanSeries(
     {
       search,
       yAxis: [`avg(${SpanFields.SPAN_DURATION})`],

--- a/static/app/views/insights/cache/components/samplePanel.tsx
+++ b/static/app/views/insights/cache/components/samplePanel.tsx
@@ -31,8 +31,8 @@ import {SampleDrawerBody} from 'sentry/views/insights/common/components/sampleDr
 import {SampleDrawerHeaderTransaction} from 'sentry/views/insights/common/components/sampleDrawerHeaderTransaction';
 import {
   useDiscoverOrEap,
-  useEAPSpans,
   useSpanMetrics,
+  useSpans,
   useSpansIndexed,
 } from 'sentry/views/insights/common/queries/useDiscover';
 import {
@@ -115,7 +115,7 @@ export function CacheSamplePanel() {
     );
 
   const {data: transactionDurationData, isPending: isTransactionDurationLoading} =
-    useEAPSpans(
+    useSpans(
       {
         search: MutableSearch.fromQueryObject({
           transaction: query.transaction,

--- a/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewAgentsDurationChartWidget.tsx
@@ -13,7 +13,7 @@ import {Referrer} from 'sentry/views/insights/agentMonitoring/utils/referrers';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {ModalChartContainer} from 'sentry/views/insights/common/components/insightsChartContainer';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -31,7 +31,7 @@ export default function OverviewAgentsDurationChartWidget(
 
   const fullQuery = useCombinedQuery(getAgentRunsFilter());
 
-  const {data, isLoading, error} = useEAPSeries(
+  const {data, isLoading, error} = useSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewApiLatencyChartWidget.tsx
@@ -9,7 +9,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -29,7 +29,7 @@ export default function OverviewApiLatencyChartWidget(props: LoadableChartWidget
 
   const fullQuery = `span.op:http.server ${query}`.trim();
 
-  const {data, isLoading, error} = useEAPSeries(
+  const {data, isLoading, error} = useSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/common/components/widgets/overviewCacheMissChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewCacheMissChartWidget.tsx
@@ -12,7 +12,7 @@ import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
@@ -40,7 +40,7 @@ export default function OverviewCacheMissChartWidget(props: LoadableChartWidgetP
   const releaseBubbleProps = useReleaseBubbleProps(props);
   const pageFilterChartParams = usePageFilterChartParams(props);
 
-  const cachesRequest = useEAPSpans(
+  const cachesRequest = useSpans(
     {
       fields: ['transaction', 'project.id', 'cache_miss_rate()', 'count()'],
       sorts: [{field: 'cache_miss_rate()', kind: 'desc'}],

--- a/static/app/views/insights/common/components/widgets/overviewJobsChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewJobsChartWidget.tsx
@@ -12,7 +12,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -45,7 +45,7 @@ export default function OverviewJobsChartWidget(props: LoadableChartWidgetProps)
 
   const fullQuery = `span.op:queue.process ${query}`.trim();
 
-  const {data, isLoading, error} = useEAPSeries(
+  const {data, isLoading, error} = useSpanSeries(
     {
       ...pageFilterChartParams,
       search: fullQuery,

--- a/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowNextjsSSRWidget.tsx
@@ -14,7 +14,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
@@ -40,7 +40,7 @@ export default function OverviewSlowNextjsSSRWidget(props: LoadableChartWidgetPr
 
   const fullQuery = `span.op:function.nextjs ${query}`;
 
-  const spansRequest = useEAPSpans(
+  const spansRequest = useSpans(
     {
       search: fullQuery,
       fields: ['span.group', 'project.id', 'span.description', 'avg(span.duration)'],

--- a/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
@@ -13,7 +13,7 @@ import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {SpanDescriptionCell} from 'sentry/views/insights/common/components/tableCells/spanDescriptionCell';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
@@ -44,7 +44,7 @@ export default function OverviewSlowQueriesChartWidget(props: LoadableChartWidge
 
   const fullQuery = `has:db.system has:span.group ${query}`;
 
-  const queriesRequest = useEAPSpans(
+  const queriesRequest = useSpans(
     {
       fields: [
         'span.op',

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -60,7 +60,7 @@ export const useSpansIndexed = <Fields extends SpanIndexedProperty[]>(
   );
 };
 
-export const useEAPSpans = <Fields extends EAPSpanProperty[]>(
+export const useSpans = <Fields extends EAPSpanProperty[]>(
   options: UseDiscoverOptions<Fields> = {},
   referrer: string
 ) => {

--- a/static/app/views/insights/common/queries/useDiscoverSeries.ts
+++ b/static/app/views/insights/common/queries/useDiscoverSeries.ts
@@ -57,7 +57,7 @@ export const useSpanMetricsSeries = <Fields extends SpanMetricsProperty[]>(
   );
 };
 
-export const useEAPSeries = <
+export const useSpanSeries = <
   Fields extends
     | MetricsProperty[]
     | SpanMetricsProperty[]

--- a/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedDurationWidget.tsx
@@ -12,7 +12,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -43,7 +43,7 @@ export default function GroupedDurationWidget(props: GroupedDurationWidgetProps)
   const theme = useTheme();
   const fullQuery = useCombinedQuery(props.query);
 
-  const topEventsRequest = useEAPSpans(
+  const topEventsRequest = useSpans(
     {
       fields: [props.groupBy, 'avg(span.duration)'],
       sorts: [{field: 'avg(span.duration)', kind: 'desc'}],

--- a/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedErrorRateWidget.tsx
@@ -12,7 +12,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -43,7 +43,7 @@ export default function GroupedErrorRateWidget(props: GroupedErrorRateWidgetProp
   const theme = useTheme();
   const fullQuery = useCombinedQuery(props.query);
 
-  const topEventsRequest = useEAPSpans(
+  const topEventsRequest = useSpans(
     {
       fields: [props.groupBy, 'failure_rate()'],
       sorts: [{field: 'failure_rate()', kind: 'desc'}],

--- a/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
+++ b/static/app/views/insights/mcp/components/groupedTrafficWidget.tsx
@@ -12,7 +12,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useCombinedQuery} from 'sentry/views/insights/agentMonitoring/hooks/useCombinedQuery';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTopNSpanEAPSeries} from 'sentry/views/insights/common/queries/useTopNDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
@@ -43,7 +43,7 @@ export default function GroupedTrafficWidget(props: GroupedTrafficWidgetProps) {
   const theme = useTheme();
   const fullQuery = useCombinedQuery(props.query);
 
-  const topEventsRequest = useEAPSpans(
+  const topEventsRequest = useSpans(
     {
       fields: [props.groupBy, 'count()'],
       sorts: [{field: 'count()', kind: 'desc'}],

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
@@ -8,7 +8,7 @@ import type {MetaType} from 'sentry/utils/discover/eventView';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {MetricReadout} from 'sentry/views/insights/common/components/metricReadout';
 import {ReadoutRibbon} from 'sentry/views/insights/common/components/ribbon';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useReleaseSelection} from 'sentry/views/insights/common/queries/useReleases';
 import {appendReleaseFilters} from 'sentry/views/insights/common/utils/releaseComparison';
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
@@ -62,7 +62,7 @@ export function MobileMetricsRibbon({
     selectedPlatform,
   ]);
 
-  const {isPending, data, meta} = useEAPSpans(
+  const {isPending, data, meta} = useSpans(
     {
       fields,
       search: queryString,

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -28,7 +28,7 @@ import OverviewCacheMissChartWidget from 'sentry/views/insights/common/component
 import OverviewJobsChartWidget from 'sentry/views/insights/common/components/widgets/overviewJobsChartWidget';
 import OverviewRequestsChartWidget from 'sentry/views/insights/common/components/widgets/overviewRequestsChartWidget';
 import OverviewSlowQueriesChartWidget from 'sentry/views/insights/common/components/widgets/overviewSlowQueriesChartWidget';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -160,7 +160,7 @@ function EAPBackendOverviewPage() {
 
   existingQuery.addFilterValue('is_transaction', 'true');
 
-  const response = useEAPSpans(
+  const response = useSpans(
     {
       search: existingQuery,
       sorts,

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -30,7 +30,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -212,7 +212,7 @@ function EAPOverviewPage() {
 
   const displayPerfScore = ['pageload', 'all'].includes(spanOp);
 
-  const response = useEAPSpans(
+  const response = useSpans(
     {
       search: existingQuery,
       sorts,

--- a/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewPage.tsx
@@ -26,7 +26,7 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {InsightsProjectSelector} from 'sentry/views/insights/common/components/projectSelector';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useOnboardingProject} from 'sentry/views/insights/common/queries/useOnboardingProject';
 import {useInsightsEap} from 'sentry/views/insights/common/utils/useEap';
 import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
@@ -190,7 +190,7 @@ function EAPMobileOverviewPage() {
 
   existingQuery.addFilterValue('is_transaction', 'true');
 
-  const response = useEAPSpans(
+  const response = useSpans(
     {
       search: existingQuery,
       sorts,

--- a/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/webVitalsWidget.tsx
@@ -11,7 +11,7 @@ import PerformanceScoreRingWithTooltips from 'sentry/views/insights/browser/webV
 import type {ProjectData} from 'sentry/views/insights/browser/webVitals/components/webVitalMeters';
 import {getWebVitalScoresFromTableDataRow} from 'sentry/views/insights/browser/webVitals/queries/storedScoreQueries/getWebVitalScoresFromTableDataRow';
 import type {ProjectScore} from 'sentry/views/insights/browser/webVitals/types';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {Referrer} from 'sentry/views/insights/pages/platform/laravel/referrers';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -63,7 +63,7 @@ type ProjectScoreQuery = {
 function usePerformanceScoreData({query}: {query?: string}): ProjectScoreQuery {
   const {interval: _, ...pageFilterChartParams} = usePageFilterChartParams();
 
-  const currentRequest = useEAPSpans(
+  const currentRequest = useSpans(
     {
       search: query,
       fields: FIELDS,
@@ -85,7 +85,7 @@ function usePerformanceScoreData({query}: {query?: string}): ProjectScoreQuery {
     ]
   );
 
-  const previousRequest = useEAPSpans(
+  const previousRequest = useSpans(
     {
       pageFilters: {
         projects: pageFilterChartParams.project,

--- a/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/baseTrafficWidget.tsx
@@ -11,7 +11,7 @@ import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {convertSeriesToTimeseries} from 'sentry/views/insights/common/utils/convertSeriesToTimeseries';
 import {usePageFilterChartParams} from 'sentry/views/insights/pages/platform/laravel/utils';
 import {WidgetVisualizationStates} from 'sentry/views/insights/pages/platform/laravel/widgetVisualizationStates';
@@ -42,7 +42,7 @@ export function BaseTrafficWidget({
 
   const theme = useTheme();
 
-  const {data, isLoading, error} = useEAPSeries(
+  const {data, isLoading, error} = useSpanSeries(
     {
       ...pageFilterChartParams,
       search: query,

--- a/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
+++ b/static/app/views/insights/pages/platform/shared/table/useTableData.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 
 import {useLocation} from 'sentry/utils/useLocation';
 import {useTableSortParams} from 'sentry/views/insights/agentMonitoring/components/headSortCell';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useTransactionNameQuery} from 'sentry/views/insights/pages/platform/shared/useTransactionNameQuery';
 import type {EAPSpanProperty} from 'sentry/views/insights/types';
 
@@ -23,7 +23,7 @@ export function useTableData<Fields extends EAPSpanProperty>({
   const {query} = useTransactionNameQuery();
   const {sortField, sortOrder} = useTableSortParams();
 
-  return useEAPSpans(
+  return useSpans(
     {
       search: `${baseQuery ?? ''} ${query}`.trim(),
       sorts: [{field: sortField, kind: sortOrder}],
@@ -63,7 +63,7 @@ export function useTableDataWithController<Fields extends EAPSpanProperty>({
   }, [transactionsRequest.data]);
 
   // The controller name is available in the span.description field on the `span.op:http.route` span in the same transaction
-  const routeControllersRequest = useEAPSpans(
+  const routeControllersRequest = useSpans(
     {
       search: `transaction.op:http.server span.op:http.route transaction:[${
         transactionPaths.map(transactions => `"${transactions}"`).join(',') || '""'

--- a/static/app/views/performance/otlp/overviewSpansTable.tsx
+++ b/static/app/views/performance/otlp/overviewSpansTable.tsx
@@ -20,7 +20,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {renderHeadCell} from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {ModuleName} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
@@ -58,7 +58,7 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
   countQuery.addFilterValue('is_transaction', '1');
   countQuery.addFilterValue('transaction', transactionName);
 
-  const {data: numEvents, error: numEventsError} = useEAPSpans(
+  const {data: numEvents, error: numEventsError} = useSpans(
     {
       search: countQuery,
       fields: ['count()'],

--- a/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
+++ b/static/app/views/performance/otlp/useServiceEntrySpansQuery.tsx
@@ -3,7 +3,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {type EAPSpanProperty, SpanIndexedField} from 'sentry/views/insights/types';
 import {SERVICE_ENTRY_SPANS_CURSOR_NAME} from 'sentry/views/performance/transactionSummary/transactionOverview/content';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
@@ -127,7 +127,7 @@ function useSingleQuery(options: UseSingleQueryOptions) {
     newQuery.removeFilter('span.category');
   }
 
-  const {data, isLoading, pageLinks, meta, error} = useEAPSpans(
+  const {data, isLoading, pageLinks, meta, error} = useSpans(
     {
       search: newQuery,
       fields: FIELDS,
@@ -180,7 +180,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
     data: categorizedSpanIds,
     isLoading: isCategorizedSpanIdsLoading,
     error: categorizedSpanIdsError,
-  } = useEAPSpans(
+  } = useSpans(
     {
       search: categorizedSpansQuery,
       fields: ['transaction.span_id', 'sum(span.self_time)'],
@@ -213,7 +213,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
     pageLinks: categorizedSpansPageLinks,
     meta: categorizedSpansMeta,
     error: categorizedSpansError,
-  } = useEAPSpans(
+  } = useSpans(
     {
       search: specificSpansQuery,
       fields: FIELDS,

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -13,7 +13,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/useCompactSelectOptionsCache';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 
@@ -44,7 +44,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const query = new MutableSearch('');
   query.addFilterValue('transaction', serviceEntrySpanName);
 
-  const {data, isError} = useEAPSpans(
+  const {data, isError} = useSpans(
     {
       limit: LIMIT,
       fields: [SpanIndexedField.SPAN_CATEGORY, 'count()'],

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -11,8 +11,8 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
 import {eapSeriesDataToTimeSeries} from 'sentry/views/performance/transactionSummary/transactionOverview/utils';
 
@@ -51,7 +51,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     data: failureRateSeriesData,
     isPending: isFailureRateSeriesPending,
     isError: isFailureRateSeriesError,
-  } = useEAPSeries(
+  } = useSpanSeries(
     {
       search: new MutableSearch(`transaction:${transactionName}`),
       yAxis: ['failure_rate()'],
@@ -63,7 +63,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     data: failureRateValue,
     isPending: isFailureRateValuePending,
     isError: isFailureRateValueError,
-  } = useEAPSpans(
+  } = useSpans(
     {
       search: new MutableSearch(`transaction:${transactionName}`),
       fields: ['failure_rate()'],

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -7,8 +7,8 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
-import {useEAPSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useEAPSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import {useSpanSeries} from 'sentry/views/insights/common/queries/useDiscoverSeries';
 import {SpanIndexedField} from 'sentry/views/insights/types';
 import {
   filterToColor,
@@ -100,7 +100,7 @@ function useDurationBreakdownVisualization({
     data: spanSeriesData,
     isPending: isSpanSeriesPending,
     isError: isSpanSeriesError,
-  } = useEAPSeries(
+  } = useSpanSeries(
     {
       yAxis: [
         'avg(span.duration)',
@@ -165,7 +165,7 @@ function useDurationPercentilesVisualization({
     data: durationPercentilesData,
     isPending: isDurationPercentilesPending,
     isError: isDurationPercentilesError,
-  } = useEAPSpans(
+  } = useSpans(
     {
       fields: [
         'p50(span.duration)',


### PR DESCRIPTION
Renames `useEAPSpans` to `useSpans` and `useEapSeries` to `useSpanSeries`

 There's no reason to distinguish this as the eap hook now that there is only one dataset being used. At the end of the day this is the hook you use to fetch spans, no need to expose underlying details here.