### PR TITLE
chore(billing): Add tally type info + checkout PAYG categories

### DIFF
--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -59,6 +59,7 @@ Object.entries(DEFAULT_BILLED_DATA_CATEGORY_INFO).forEach(
       feature: null,
       hasSpikeProtection: false,
       reservedVolumeTooltip: null,
+      tallyType: 'usage',
     };
   }
 );
@@ -73,7 +74,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.ERROR]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.ERROR],
     canAllocate: true,
-    canProductTrial: false,
     maxAdminGift: 10_000_000,
     freeEventsMultiple: 1_000,
     hasSpikeProtection: true,
@@ -96,7 +96,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.ATTACHMENT]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.ATTACHMENT],
     canAllocate: true,
-    canProductTrial: false,
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'event-attachments',
@@ -107,7 +106,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.REPLAY]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.REPLAY],
-    canAllocate: false,
     canProductTrial: true,
     maxAdminGift: 1_000_000,
     freeEventsMultiple: 1,
@@ -118,7 +116,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.SPAN]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SPAN],
-    canAllocate: false,
     canProductTrial: true,
     maxAdminGift: 1_000_000_000,
     freeEventsMultiple: 100_000,
@@ -130,7 +127,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.SPAN_INDEXED]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SPAN_INDEXED],
-    canAllocate: false,
     canProductTrial: true,
     maxAdminGift: 1_000_000_000,
     freeEventsMultiple: 100_000,
@@ -138,50 +134,37 @@ export const BILLED_DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.MONITOR_SEAT]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.MONITOR_SEAT],
-    canAllocate: false,
-    canProductTrial: false,
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'monitor-seat-billing',
+    tallyType: 'seat',
   },
   [DataCategoryExact.UPTIME]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.UPTIME],
-    canAllocate: false,
-    canProductTrial: false,
     maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'uptime-billing',
+    tallyType: 'seat',
   },
   [DataCategoryExact.PROFILE_DURATION]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PROFILE_DURATION],
-    canAllocate: false,
     canProductTrial: true,
     maxAdminGift: 10_000,
     freeEventsMultiple: 1, // in hours
-    feature: null,
   },
   [DataCategoryExact.PROFILE_DURATION_UI]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PROFILE_DURATION_UI],
-    canAllocate: false,
     canProductTrial: true,
     maxAdminGift: 10_000,
     freeEventsMultiple: 1, // in hours
-    feature: null,
   },
+  // Seer categories have product trials through ReservedBudgetCategoryType.SEER, not as individual categories
   [DataCategoryExact.SEER_AUTOFIX]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_AUTOFIX],
-    canAllocate: false,
-    canProductTrial: false,
-    maxAdminGift: 0,
-    freeEventsMultiple: 0,
     feature: 'seer-billing',
   },
   [DataCategoryExact.SEER_SCANNER]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_SCANNER],
-    canAllocate: false,
-    canProductTrial: false,
-    maxAdminGift: 0,
-    freeEventsMultiple: 0,
     feature: 'seer-billing',
   },
 } as const satisfies Record<DataCategoryExact, BilledDataCategoryInfo>;

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -1030,4 +1030,8 @@ export interface BilledDataCategoryInfo extends DataCategoryInfo {
    * The tooltip text for the checkout page
    */
   reservedVolumeTooltip: string | null;
+  /**
+   * How usage is tallied for the category
+   */
+  tallyType: 'usage' | 'seat';
 }

--- a/static/gsApp/views/amCheckout/checkoutOverviewV2.tsx
+++ b/static/gsApp/views/amCheckout/checkoutOverviewV2.tsx
@@ -191,12 +191,9 @@ function CheckoutOverviewV2({activePlan, formData, onUpdate: _onUpdate}: Props) 
   };
 
   const renderObservabilityProductBreakdown = () => {
-    const paygCategories = [
-      DataCategory.MONITOR_SEATS,
-      DataCategory.PROFILE_DURATION,
-      DataCategory.PROFILE_DURATION_UI,
-      DataCategory.UPTIME,
-    ];
+    const paygCategories = activePlan.onDemandCategories.filter(
+      category => activePlan.planCategories[category]?.length === 1
+    );
 
     const budgetCategories = Object.values(
       activePlan.availableReservedBudgetTypes

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -226,7 +226,8 @@ function Overview({location, subscription, promotionData}: Props) {
 
             const categoryTotals: BillingStatTotal =
               categoryInfo?.tallyType === 'usage'
-                ? {
+                ? usageData.totals[category]!
+                : {
                     accepted: monitor_usage ?? 0,
                     dropped: 0,
                     droppedOther: 0,
@@ -234,12 +235,11 @@ function Overview({location, subscription, promotionData}: Props) {
                     droppedSpikeProtection: 0,
                     filtered: 0,
                     projected: 0,
-                  }
-                : usageData.totals[category]!;
+                  };
             const eventTotals =
               categoryInfo?.tallyType === 'usage'
-                ? undefined
-                : usageData.eventTotals?.[category];
+                ? usageData.eventTotals?.[category]
+                : undefined;
 
             const showEventBreakdown =
               organization.features.includes('profiling-billing') &&


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-951/dont-explicitly-define-payg-categories-for-checkout
Closes https://linear.app/getsentry/issue/BIL-953/add-tally-type-information-to-the-frontend