### PR TITLE
fix(billing): Correct crons warning for enterprise customers

### DIFF
--- a/static/gsApp/components/cronsOnDemandStepWarning.spec.tsx
+++ b/static/gsApp/components/cronsOnDemandStepWarning.spec.tsx
@@ -101,7 +101,7 @@ describe('CronsOnDemandStepWarning', function () {
 
     expect(
       screen.queryByText(
-        "These changes will take effect at the start of your next billing cycle. Heads up that you're currently using $4.00 of Cron Monitors. These monitors will be turned off at the start of your next billing cycle unless you increase your on-demand budget."
+        "These changes will take effect at the start of your next billing cycle. Heads up that you're currently using $4 of Cron Monitors. These monitors will be turned off at the start of your next billing cycle unless you increase your on-demand budget."
       )
     ).not.toBeInTheDocument();
   });

--- a/static/gsApp/components/cronsOnDemandStepWarning.tsx
+++ b/static/gsApp/components/cronsOnDemandStepWarning.tsx
@@ -25,14 +25,14 @@ export function CronsOnDemandStepWarning({
 }: Props) {
   const cronCategoryName = DATA_CATEGORY_INFO[DataCategoryExact.MONITOR_SEAT].plural;
   const cronsBucket = activePlan.planCategories[cronCategoryName]?.[0];
-  let reserved: number | undefined;
-  let cronsPrice: number | undefined;
+  let reserved: number | null | undefined;
+  let cronsPrice: number | null | undefined;
   if (isEnterprise(activePlan.id)) {
     // this can only be reached for enterprise customers with invoiced on-demand
     // we want to make sure we use their actual reserved amount and not the minimum
     // for enterprise plans
-    reserved = subscription.categories[cronCategoryName]?.reserved ?? 0;
-    cronsPrice = subscription.categories[cronCategoryName]?.paygCpe ?? 0;
+    reserved = subscription.categories[cronCategoryName]?.reserved;
+    cronsPrice = subscription.categories[cronCategoryName]?.paygCpe;
   } else {
     reserved = cronsBucket?.events;
     cronsPrice = cronsBucket?.onDemandPrice;
@@ -43,7 +43,7 @@ export function CronsOnDemandStepWarning({
     staleTime: 0,
   });
 
-  if (isPending || !data || !cronsPrice || !reserved) {
+  if (isPending || !data || !cronsPrice || reserved === undefined || reserved === null) {
     return null;
   }
 


### PR DESCRIPTION
Fixes an issue where the crons on-demand step warning is incorrect for enterprise customers with manually invoiced on-demand. 

The rendering logic assumed that the customer would always have the first reserved tier for crons, which is true for self-serve customers. For enterprise customers, the first tier is `-2` so the rendering logic would incorrectly identify a customer without any monitors as having spent $1.56 on cron monitors in that period.