### PR TITLE
ref(replay): update experimental tooltip

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -25,7 +25,11 @@ function getReplayTabs({
     [TabKey.AI]: organization.features.includes('replay-ai-summaries') ? (
       <Flex align="center" gap={space(0.75)}>
         {t('Summary')}
-        <Tooltip title={t('experimental')}>
+        <Tooltip
+          title={t(
+            'This feature is experimental! Try it out and let us know what you think. No promises!'
+          )}
+        >
           <IconLab isSolid />
         </Tooltip>
       </Flex>


### PR DESCRIPTION
<img width="284" height="145" alt="SCR-20250714-ksyi" src="https://github.com/user-attachments/assets/aac378c9-4159-436b-8248-2b4e857bc0dc" />

match the wording to the experimental badge that's used across sentry