### PR TITLE
feat(dashboards): Expose lastVisited through dashboards list API

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -222,7 +222,14 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 else:
                     dashboards.append(item)
 
-            serialized.extend(serialize(dashboards, request.user, serializer=list_serializer))
+            serialized.extend(
+                serialize(
+                    dashboards,
+                    request.user,
+                    serializer=list_serializer,
+                    context={"organization": organization},
+                )
+            )
             return serialized
 
         render_pre_built_dashboard = True

--- a/src/sentry/api/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/api/endpoints/organization_dashboards_starred.py
@@ -62,7 +62,12 @@ class OrganizationDashboardsStarredEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             paginator=GenericOffsetPaginator(data_fn=data_fn),
-            on_results=lambda x: serialize(x, request.user, serializer=DashboardListSerializer()),
+            on_results=lambda x: serialize(
+                x,
+                request.user,
+                serializer=DashboardListSerializer(),
+                context={"organization": organization},
+            ),
             default_per_page=25,
         )
 

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -212,7 +212,7 @@ class _Widget(TypedDict):
     projects: list[int]
     environment: list[str]
     filters: DashboardFilters
-    last_visited: datetime | None
+    last_visited: str | None
 
 
 class PageFiltersOptional(TypedDict, total=False):

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -212,6 +212,7 @@ class _Widget(TypedDict):
     projects: list[int]
     environment: list[str]
     filters: DashboardFilters
+    last_visited: datetime | None
 
 
 class PageFiltersOptional(TypedDict, total=False):

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -4,7 +4,6 @@ DASHBOARD_OBJECT = {
     "id": "1",
     "title": "Dashboard",
     "dateCreated": "2024-06-20T14:38:03.498574Z",
-    "lastVisited": "2024-06-20T14:38:03.498574Z",
     "createdBy": {
         "id": "1",
         "name": "Admin",
@@ -123,6 +122,7 @@ DASHBOARDS_OBJECT = [
         "id": "2",
         "title": "Dashboard",
         "dateCreated": "2024-06-20T14:38:03.498574Z",
+        "lastVisited": "2024-06-20T14:38:03.498574Z",
         "projects": [],
         "environment": ["alpha"],
         "filters": {

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -81,6 +81,7 @@ DASHBOARDS_OBJECT = [
         "id": "1",
         "title": "Dashboard",
         "dateCreated": "2024-06-20T14:38:03.498574Z",
+        "lastVisited": "2024-06-20T14:38:03.498574Z",
         "projects": [1],
         "environment": ["alpha"],
         "filters": {

--- a/src/sentry/apidocs/examples/dashboard_examples.py
+++ b/src/sentry/apidocs/examples/dashboard_examples.py
@@ -4,6 +4,7 @@ DASHBOARD_OBJECT = {
     "id": "1",
     "title": "Dashboard",
     "dateCreated": "2024-06-20T14:38:03.498574Z",
+    "lastVisited": "2024-06-20T14:38:03.498574Z",
     "createdBy": {
         "id": "1",
         "name": "Admin",

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -5,12 +5,18 @@ from typing import Any
 
 from django.urls import reverse
 
-from sentry.models.dashboard import Dashboard, DashboardFavoriteUser, DashboardTombstone
+from sentry.models.dashboard import (
+    Dashboard,
+    DashboardFavoriteUser,
+    DashboardLastVisited,
+    DashboardTombstone,
+)
 from sentry.models.dashboard_widget import (
     DashboardWidget,
     DashboardWidgetDisplayTypes,
     DashboardWidgetTypes,
 )
+from sentry.models.organizationmember import OrganizationMember
 from sentry.testutils.cases import OrganizationDashboardWidgetTestCase
 from sentry.testutils.helpers.datetime import before_now
 


### PR DESCRIPTION
For each dashboard in the list endpoint, fetch the last visited object and expose when the user last visited the dashboard through the endpoint for rendering in the frontend.