### PR TITLE
feat(upsampling) - Organization Events API error upsampling support

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -341,6 +341,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             meta = results.get("meta", {})
             fields_meta = meta.get("fields", {})
 
+            self.handle_error_upsampling(project_ids, results)
+
             if standard_meta:
                 isMetricsData = meta.pop("isMetricsData", False)
                 isMetricsExtractedData = meta.pop("isMetricsExtractedData", False)
@@ -413,8 +415,27 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         if "device" in fields and request.GET.get("readable"):
             self.handle_readable_device(results, project_ids, organization)
 
+        if not ("project.id" in first_row or "projectid" in first_row):
+            return results
+
+        for result in results:
+            for key in ("projectid", "project.id"):
+                if key in result and key not in fields:
+                    del result[key]
+
+        return results
+
+    def handle_error_upsampling(self, project_ids: Sequence[int], results: dict[str, Any]):
+        """
+        If the query is for error upsampled projects, we need to rename the fields to include the ()
+        and update the meta fields to reflect the new field names. This works around a limitation in
+        how aliases are handled in the SnQL parser.
+        """
         if are_all_projects_error_upsampled(project_ids):
-            for result in results:
+            data = results.get("data", [])
+            fields_meta = results.get("meta", {}).get("fields", {})
+
+            for result in data:
                 if "count" in result:
                     result["count()"] = result["count"]
                     del result["count"]
@@ -425,15 +446,15 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     result["epm()"] = result["epm"]
                     del result["epm"]
 
-        if not ("project.id" in first_row or "projectid" in first_row):
-            return results
-
-        for result in results:
-            for key in ("projectid", "project.id"):
-                if key in result and key not in fields:
-                    del result[key]
-
-        return results
+            if "count" in fields_meta:
+                fields_meta["count()"] = fields_meta["count"]
+                del fields_meta["count"]
+            if "eps" in fields_meta:
+                fields_meta["eps()"] = fields_meta["eps"]
+                del fields_meta["eps"]
+            if "epm" in fields_meta:
+                fields_meta["epm()"] = fields_meta["epm"]
+                del fields_meta["epm"]
 
     def handle_issues(
         self, results: Sequence[Any], project_ids: Sequence[int], organization: Organization

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -322,9 +322,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             transform_alias_to_input_format = True
             selected_columns = self.get_field_list(organization, request)
             if are_all_projects_error_upsampled(snuba_params.project_ids):
-                selected_columns = transform_query_columns_for_error_upsampling(
-                    selected_columns, True
-                )
+                selected_columns = transform_query_columns_for_error_upsampling(selected_columns)
                 transform_alias_to_input_format = False
             query_source = self.get_request_source(request)
             return dataset_query(

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -14,7 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.helpers.error_upsampling import (
-    are_all_projects_error_upsampled,
+    is_errors_query_for_error_upsampled_projects,
     transform_query_columns_for_error_upsampling,
 )
 from sentry.api.paginator import GenericOffsetPaginator
@@ -321,7 +321,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         ):
             transform_alias_to_input_format = True
             selected_columns = self.get_field_list(organization, request)
-            if are_all_projects_error_upsampled(snuba_params.project_ids):
+            if is_errors_query_for_error_upsampled_projects(
+                snuba_params, organization, dataset, request
+            ):
                 selected_columns = transform_query_columns_for_error_upsampling(selected_columns)
                 transform_alias_to_input_format = False
             query_source = self.get_request_source(request)

--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -46,19 +46,27 @@ def are_all_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
 
 def transform_query_columns_for_error_upsampling(
     query_columns: Sequence[str],
+    alias_with_parenthesis: bool = False,
 ) -> list[str]:
     """
     Transform aggregation functions to use sum(sample_weight) instead of count()
-    for error upsampling. Only called when all projects are allowlisted.
+    for error upsampling.
     """
     transformed_columns = []
     for column in query_columns:
         column_lower = column.lower().strip()
 
         if column_lower == "count()":
-            # Simple count becomes sum of sample weights
-            transformed_columns.append("upsampled_count() as count")
+            alias = "count()" if alias_with_parenthesis else "count"
+            transformed_columns.append(f"upsampled_count() as {alias}")
 
+        elif column_lower == "eps()":
+            alias = "eps()" if alias_with_parenthesis else "eps"
+            transformed_columns.append(f"upsampled_eps() as {alias}")
+
+        elif column_lower == "epm()":
+            alias = "epm()" if alias_with_parenthesis else "epm"
+            transformed_columns.append(f"upsampled_epm() as {alias}")
         else:
             transformed_columns.append(column)
 

--- a/src/sentry/api/helpers/error_upsampling.py
+++ b/src/sentry/api/helpers/error_upsampling.py
@@ -44,10 +44,7 @@ def are_all_projects_error_upsampled(project_ids: Sequence[int]) -> bool:
     return result
 
 
-def transform_query_columns_for_error_upsampling(
-    query_columns: Sequence[str],
-    alias_with_parenthesis: bool = False,
-) -> list[str]:
+def transform_query_columns_for_error_upsampling(query_columns: Sequence[str]) -> list[str]:
     """
     Transform aggregation functions to use sum(sample_weight) instead of count()
     for error upsampling.
@@ -57,16 +54,13 @@ def transform_query_columns_for_error_upsampling(
         column_lower = column.lower().strip()
 
         if column_lower == "count()":
-            alias = "count()" if alias_with_parenthesis else "count"
-            transformed_columns.append(f"upsampled_count() as {alias}")
+            transformed_columns.append("upsampled_count() as count")
 
         elif column_lower == "eps()":
-            alias = "eps()" if alias_with_parenthesis else "eps"
-            transformed_columns.append(f"upsampled_eps() as {alias}")
+            transformed_columns.append("upsampled_eps() as eps")
 
         elif column_lower == "epm()":
-            alias = "epm()" if alias_with_parenthesis else "epm"
-            transformed_columns.append(f"upsampled_epm() as {alias}")
+            transformed_columns.append("upsampled_epm() as epm")
         else:
             transformed_columns.append(column)
 

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -125,16 +125,16 @@ TYPED_TAG_KEY_RE = re.compile(
 # Based on general/src/protocol/tags.rs in relay
 VALID_FIELD_PATTERN = re.compile(r"^[a-zA-Z0-9_.:-]*$")
 
-# The regex for alias here is to match any word, but exclude anything that is only digits
-# eg. 123 doesn't match, but test_123 will match
-ALIAS_REGEX = r"(\w+)?(?!\d+)\w+"
+# The regex for alias here is to match any word characters and parentheses, but exclude anything that is only digits
+# eg. 123 doesn't match, but test_123 will match, and count() will match
+ALIAS_REGEX = r"(?=.*[a-zA-Z_])[\w()]+"
 
 MISERY_ALPHA = 5.8875
 MISERY_BETA = 111.8625
 
 ALIAS_PATTERN = re.compile(rf"{ALIAS_REGEX}$")
 FUNCTION_PATTERN = re.compile(
-    rf"^(?P<function>[^\(]+)\((?P<columns>.*)\)( (as|AS) (?P<alias>{ALIAS_REGEX}))?$"
+    rf"^(?P<function>[^\(]+)\((?P<columns>.*?)\)( (as|AS) (?P<alias>{ALIAS_REGEX}))?$"
 )
 
 DURATION_PATTERN = re.compile(r"(\d+\.?\d?)(\D{1,3})")

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -125,16 +125,16 @@ TYPED_TAG_KEY_RE = re.compile(
 # Based on general/src/protocol/tags.rs in relay
 VALID_FIELD_PATTERN = re.compile(r"^[a-zA-Z0-9_.:-]*$")
 
-# The regex for alias here is to match any word characters and parentheses, but exclude anything that is only digits
-# eg. 123 doesn't match, but test_123 will match, and count() will match
-ALIAS_REGEX = r"(?=.*[a-zA-Z_])[\w()]+"
+# The regex for alias here is to match any word, but exclude anything that is only digits
+# eg. 123 doesn't match, but test_123 will match
+ALIAS_REGEX = r"(\w+)?(?!\d+)\w+"
 
 MISERY_ALPHA = 5.8875
 MISERY_BETA = 111.8625
 
 ALIAS_PATTERN = re.compile(rf"{ALIAS_REGEX}$")
 FUNCTION_PATTERN = re.compile(
-    rf"^(?P<function>[^\(]+)\((?P<columns>.*?)\)( (as|AS) (?P<alias>{ALIAS_REGEX}))?$"
+    rf"^(?P<function>[^\(]+)\((?P<columns>.*)\)( (as|AS) (?P<alias>{ALIAS_REGEX}))?$"
 )
 
 DURATION_PATTERN = re.compile(r"(\d+\.?\d?)(\D{1,3})")

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1042,7 +1042,9 @@ class DiscoverDatasetConfig(DatasetConfig):
                     "upsampled_count",
                     required_args=[],
                     snql_aggregate=lambda args, alias: Function(
-                        "sum", [Function("ifNull", [Column("sample_weight"), 1])], alias
+                        "toInt64",
+                        [Function("sum", [Function("ifNull", [Column("sample_weight"), 1])])],
+                        alias,
                     ),
                     default_result_type="integer",
                 ),

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -1042,11 +1042,25 @@ class DiscoverDatasetConfig(DatasetConfig):
                     "upsampled_count",
                     required_args=[],
                     snql_aggregate=lambda args, alias: Function(
-                        "toInt64",
-                        [Function("sum", [Function("ifNull", [Column("sample_weight"), 1])])],
-                        alias,
+                        "sum", [Function("ifNull", [Column("sample_weight"), 1])], alias
                     ),
-                    default_result_type="number",
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "upsampled_eps",
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_upsampled_eps(
+                        args, alias, self.builder
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="rate",
+                ),
+                SnQLFunction(
+                    "upsampled_epm",
+                    snql_aggregate=lambda args, alias: function_aliases.resolve_upsampled_epm(
+                        args, alias, self.builder
+                    ),
+                    optional_args=[IntervalDefault("interval", 1, None)],
+                    default_result_type="rate",
                 ),
             ]
         }

--- a/src/sentry/search/events/datasets/function_aliases.py
+++ b/src/sentry/search/events/datasets/function_aliases.py
@@ -379,6 +379,18 @@ def resolve_eps(
     return Function("divide", [Function("count", []), interval], alias)
 
 
+def resolve_upsampled_eps(
+    args: Mapping[str, str | Column | SelectType | int | float],
+    alias: str,
+    builder: BaseQueryBuilder,
+) -> SelectType:
+    if hasattr(builder, "interval"):
+        interval = builder.interval
+    else:
+        interval = args["interval"]
+    return Function("divide", [Function("sum", [Column("sample_weight")]), interval], alias)
+
+
 def resolve_epm(
     args: Mapping[str, str | Column | SelectType | int | float],
     alias: str,
@@ -391,5 +403,21 @@ def resolve_epm(
     return Function(
         "divide",
         [Function("count", []), Function("divide", [interval, 60])],
+        alias,
+    )
+
+
+def resolve_upsampled_epm(
+    args: Mapping[str, str | Column | SelectType | int | float],
+    alias: str,
+    builder: BaseQueryBuilder,
+) -> SelectType:
+    if hasattr(builder, "interval"):
+        interval = builder.interval
+    else:
+        interval = args["interval"]
+    return Function(
+        "divide",
+        [Function("sum", [Column("sample_weight")]), Function("divide", [interval, 60])],
         alias,
     )

--- a/src/sentry/search/events/datasets/function_aliases.py
+++ b/src/sentry/search/events/datasets/function_aliases.py
@@ -388,7 +388,11 @@ def resolve_upsampled_eps(
         interval = builder.interval
     else:
         interval = args["interval"]
-    return Function("divide", [Function("sum", [Column("sample_weight")]), interval], alias)
+    return Function(
+        "divide",
+        [Function("sum", [Function("ifNull", [Column("sample_weight"), 1])]), interval],
+        alias,
+    )
 
 
 def resolve_epm(
@@ -418,6 +422,9 @@ def resolve_upsampled_epm(
         interval = args["interval"]
     return Function(
         "divide",
-        [Function("sum", [Column("sample_weight")]), Function("divide", [interval, 60])],
+        [
+            Function("sum", [Function("ifNull", [Column("sample_weight"), 1])]),
+            Function("divide", [interval, 60]),
+        ],
         alias,
     )

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6635,6 +6635,12 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             # Expect the count to be upsampled (1 event / 0.1 = 10) + 1 event with no sampling = 11
             assert response.data["data"][0]["count()"] == 11
 
+            # Check meta information
+            meta = response.data["meta"]
+            assert "fields" in meta
+            assert "count()" in meta["fields"]
+            assert meta["fields"]["count()"] == "integer"
+
     def test_error_upsampling_eps_with_allowlisted_project(self):
         """Test that eps() is upsampled for allowlisted projects when querying error events."""
         # Set up allowlisted project
@@ -6681,6 +6687,12 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             actual_eps = response.data["data"][0]["eps()"]
             assert abs(actual_eps - expected_eps) < 0.0001  # Allow small rounding differences
 
+            # Check meta information
+            meta = response.data["meta"]
+            assert "fields" in meta
+            assert "eps()" in meta["fields"]
+            assert meta["fields"]["eps()"] == "rate"
+
     def test_error_upsampling_epm_with_allowlisted_project(self):
         """Test that epm() is upsampled for allowlisted projects when querying error events."""
         # Set up allowlisted project
@@ -6726,6 +6738,12 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
             expected_epm = 11 / 120
             actual_epm = response.data["data"][0]["epm()"]
             assert abs(actual_epm - expected_epm) < 0.001  # Allow small rounding differences
+
+            # Check meta information
+            meta = response.data["meta"]
+            assert "fields" in meta
+            assert "epm()" in meta["fields"]
+            assert meta["fields"]["epm()"] == "rate"
 
     def test_error_upsampling_with_no_allowlist(self):
         """Test that count() is not upsampled when project is not allowlisted."""


### PR DESCRIPTION
Support projects with error upsampling in Organization Events API, supporting count(), eps() and epm() columns. 

Edit: I have decided to not do the Function and Alias parsing change to support parentheses on aliases, while I believe it would have worked and possibly an improvement, after some thought and a conversation with @wmak I decided to do the simple less risky thing and manipulate the response in the APIs `handle_data` method ad-hoc. This makes sense especially since this change is for a very specific use case.

initial old approach
```
Required some basic but fundamental changes to our SNQL function parsing, specifically:
- allow "()" at the end of aliases
- when parsing function columns, match the first closing ")", matching the minimum instead of the last and matching the maximum
```