### PR TITLE
:wrench: chore(aci): pass evidence data to activity model for notifications

### DIFF
--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -67,6 +67,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             status=new_status,
             substatus=new_substatus,
             activity_type=activity_type,
+            activity_data=status_change.get("activity_data"),
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
         kick_off_status_syncs.apply_async(
@@ -90,6 +91,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             status=new_status,
             substatus=new_substatus,
             activity_type=activity_type,
+            activity_data=status_change.get("activity_data"),
         )
         remove_group_from_inbox(group, action=GroupInboxRemoveAction.IGNORED)
         kick_off_status_syncs.apply_async(
@@ -127,6 +129,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             substatus=new_substatus,
             activity_type=activity_type,
             from_substatus=group.substatus,
+            activity_data=status_change.get("activity_data"),
         )
         add_group_to_inbox(group, group_inbox_reason)
         kick_off_status_syncs.apply_async(
@@ -164,7 +167,7 @@ def get_group_from_fingerprint(project_id: int, fingerprint: Sequence[str]) -> G
 
 
 def bulk_get_groups_from_fingerprints(
-    project_fingerprint_pairs: Iterable[tuple[int, Sequence[str]]]
+    project_fingerprint_pairs: Iterable[tuple[int, Sequence[str]]],
 ) -> dict[tuple[int, tuple[str, ...]], Group]:
     """
     Returns a map of (project, fingerprint) to the group.

--- a/src/sentry/issues/status_change_message.py
+++ b/src/sentry/issues/status_change_message.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import Any, TypedDict
 from uuid import uuid4
 
 
@@ -13,6 +13,7 @@ class StatusChangeMessageData(TypedDict):
     new_substatus: int | None
     id: str
     detector_id: int | None
+    activity_data: dict[str, Any] | None
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,7 @@ class StatusChangeMessage:
     new_status: int
     new_substatus: int | None
     detector_id: int | None = None
+    activity_data: dict[str, Any] | None = None
     id: str = field(default_factory=lambda: uuid4().hex)
 
     def to_dict(
@@ -33,5 +35,6 @@ class StatusChangeMessage:
             "new_status": self.new_status,
             "new_substatus": self.new_substatus,
             "detector_id": self.detector_id,
+            "activity_data": self.activity_data,
             "id": self.id,
         }

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -30,6 +30,7 @@ def get_test_message_status_change(
         "new_substatus": new_substatus,
         "payload_type": "status_change",
         "detector_id": detector_id,
+        "activity_data": {"test": "test"},
     }
 
     return payload
@@ -373,6 +374,7 @@ class TestStatusChangeRegistry(IssueOccurrenceTestBase):
             new_status=status_change["new_status"],
             new_substatus=status_change.get("new_substatus"),
             detector_id=status_change.get("detector_id"),
+            activity_data=status_change.get("activity_data"),
         )
 
     def get_latest_activity(self, activity_type: ActivityType) -> Activity:
@@ -398,6 +400,8 @@ class TestStatusChangeRegistry(IssueOccurrenceTestBase):
 
             update_status(self.group, self.message)
             latest_activity = self.get_latest_activity(ActivityType.SET_RESOLVED)
+
+            assert latest_activity.data == {"test": "test"}
 
             mock_handler.assert_called_once_with(self.group, self.message, latest_activity)
 
@@ -431,6 +435,9 @@ class TestStatusChangeRegistry(IssueOccurrenceTestBase):
 
             update_status(self.group, self.message)
             latest_activity = self.get_latest_activity(ActivityType.AUTO_SET_ONGOING)
+
+            assert latest_activity.data == {"test": "test"}
+
             mock_handler.assert_called_once_with(self.group, self.message, latest_activity)
 
     def test_handler_is_called__unresolved_regressed(self) -> None:
@@ -447,6 +454,9 @@ class TestStatusChangeRegistry(IssueOccurrenceTestBase):
 
             update_status(self.group, self.message)
             latest_activity = self.get_latest_activity(ActivityType.SET_REGRESSION)
+
+            assert latest_activity.data == {"test": "test"}
+
             mock_handler.assert_called_once_with(self.group, self.message, latest_activity)
 
     def test_handler_is_called__ignored(self) -> None:
@@ -463,4 +473,7 @@ class TestStatusChangeRegistry(IssueOccurrenceTestBase):
 
             update_status(self.group, self.message)
             latest_activity = self.get_latest_activity(ActivityType.SET_IGNORED)
+
+            assert latest_activity.data == {"test": "test"}
+
             mock_handler.assert_called_once_with(self.group, self.message, latest_activity)

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -95,6 +95,7 @@ class StatusChangeTestMixin:
             "new_status": 1,
             "new_substatus": 1,
             "detector_id": None,
+            "activity_data": {"test": "test"},
         }
         kwargs.update(overrides)  # type: ignore[typeddict-item]
 

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -58,6 +58,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
             new_substatus=None,
             fingerprint=["test_fingerprint"],
             detector_id=None,  # No detector_id provided
+            activity_data=None,
         )
 
         with mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr") as mock_incr:
@@ -80,6 +81,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
             new_substatus=None,
             fingerprint=["test_fingerprint"],
             detector_id=detector.id,
+            activity_data={"test": "test"},
         )
 
         with mock.patch(
@@ -105,6 +107,7 @@ class WorkflowStatusUpdateHandlerTests(TestCase):
             new_substatus=None,
             fingerprint=["test_fingerprint"],
             detector_id=detector.id,
+            activity_data={"test": "test"},
         )
 
         with mock.patch(

--- a/tests/sentry/workflow_engine/test_task_integration.py
+++ b/tests/sentry/workflow_engine/test_task_integration.py
@@ -62,6 +62,7 @@ class IssuePlatformIntegrationTests(TestCase):
             new_substatus=None,
             fingerprint=[self.fingerprint],
             detector_id=self.detector.id,
+            activity_data={"test": "test"},
         )
 
         with mock.patch("sentry.workflow_engine.tasks.workflows.metrics.incr") as mock_incr:


### PR DESCRIPTION
Continuing work for  https://www.notion.so/sentry/Workflow-Status-Changes-1fa8b10e4b5d80a48acddb95d160da1f?source=copy_link#1fa8b10e4b5d80e6bb1aef39cab2c6dc

Following up: https://github.com/getsentry/sentry/pull/93522

This PR adds support for passing evidence data from workflow engine detectors to activity records when status changes occur.
* Refactored Stateful Detector to decompose `fetch_evidence_data`
* Added `activity_data` field to `StatusChangeMessage` and `StatusChangeMessageData` classes
* Modified status change consumer to pass through evidence data when updating group status


A followup PR will use the data saved on the `Activity` to send notifications.
