### PR TITLE
:wrench: chore(aci): update `send_activity_notification` to not send notifications for metric alert resolutions

### DIFF
--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -777,18 +777,14 @@ class TestSlackServiceMethods(TestCase):
         )
 
         with mock.patch.object(self.service, "_logger") as mock_logger:
-            result = self.service.notify_all_threads_for_activity(activity=activity)
+            self.service.notify_all_threads_for_activity(activity=activity)
 
-            # Verify the debug log was called with the expected message
             mock_logger.info.assert_called_with(
                 "metric resolved notification, will be sent via action.trigger - nothing to do here",
                 extra={
                     "activity_id": activity.id,
                     "project_id": activity.project.id,
-                    "group_id": activity.group.id,
+                    "group_id": metric_group.id,
                     "organization_id": self.organization.id,
                 },
             )
-
-            # Verify the method returns None (early exit)
-            assert result is None


### PR DESCRIPTION
Following up https://github.com/getsentry/sentry/pull/95475

Once we build out the ability for the NOA to send Metric Issue Resolution notifications, we want to make sure we don't double notify and send an activity notification as well.

For slack, it is not powered by `activity.send_notification` rather a receiver on the `Activity` model, so I need to separate case it as well.

I also updated the check from `group_category` to `type_id` since the `group_category` is mainly for the FE and can change.