### PR TITLE
fix(explore): Only permit span.duration for eap count

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -857,11 +857,12 @@ const SPAN_AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
       {
         name: 'column',
         kind: 'column',
-        columnTypes: validateForNumericAggregate([
-          FieldValueType.DURATION,
-          FieldValueType.NUMBER,
-          FieldValueType.PERCENTAGE,
-        ]),
+        columnTypes: function ({key, valueType}) {
+          return (
+            key === SpanIndexedField.SPAN_DURATION &&
+            (valueType === FieldValueType.DURATION || valueType === FieldValueType.NUMBER)
+          );
+        },
         defaultValue: 'span.duration',
         required: false,
       },


### PR DESCRIPTION
Only permit span.duration as the argument to eap spans count.